### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@
 
 ## Quick Start
 
+[![Run in Smithery](https://smithery.ai/badge/skills/thedotmack)](https://smithery.ai/skills?ns=thedotmack&utm_source=github&utm_medium=badge)
+
+
 Start a new Claude Code session in the terminal and enter the following commands:
 
 ```


### PR DESCRIPTION
## Add skill discoverability badge

Your 6 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Claude Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/thedotmack)](https://smithery.ai/skills?ns=thedotmack&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.