### PR TITLE
fix: export/import scripts now use API instead of direct DB access

### DIFF
--- a/scripts/import-memories.ts
+++ b/scripts/import-memories.ts
@@ -3,34 +3,18 @@
  * Import memories from a JSON export file with duplicate prevention
  * Usage: npx tsx scripts/import-memories.ts <input-file>
  * Example: npx tsx scripts/import-memories.ts windows-memories.json
+ *
+ * This script uses the worker API instead of direct database access.
  */
 
-import Database from 'better-sqlite3';
 import { existsSync, readFileSync } from 'fs';
-import { homedir } from 'os';
-import { join } from 'path';
 
-interface ImportStats {
-  sessionsImported: number;
-  sessionsSkipped: number;
-  summariesImported: number;
-  summariesSkipped: number;
-  observationsImported: number;
-  observationsSkipped: number;
-  promptsImported: number;
-  promptsSkipped: number;
-}
+const WORKER_PORT = process.env.CLAUDE_MEM_WORKER_PORT || 37777;
+const WORKER_URL = `http://127.0.0.1:${WORKER_PORT}`;
 
-function importMemories(inputFile: string) {
+async function importMemories(inputFile: string) {
   if (!existsSync(inputFile)) {
     console.error(`❌ Input file not found: ${inputFile}`);
-    process.exit(1);
-  }
-
-  const dbPath = join(homedir(), '.claude-mem', 'claude-mem.db');
-
-  if (!existsSync(dbPath)) {
-    console.error(`❌ Database not found at: ${dbPath}`);
     process.exit(1);
   }
 
@@ -47,190 +31,50 @@ function importMemories(inputFile: string) {
   console.log(`   • ${exportData.totalPrompts} prompts`);
   console.log('');
 
-  const db = new Database(dbPath);
-  const stats: ImportStats = {
-    sessionsImported: 0,
-    sessionsSkipped: 0,
-    summariesImported: 0,
-    summariesSkipped: 0,
-    observationsImported: 0,
-    observationsSkipped: 0,
-    promptsImported: 0,
-    promptsSkipped: 0
-  };
-
+  // Check if worker is running
   try {
-    // Prepare statements for duplicate checking
-    const checkSession = db.prepare('SELECT id FROM sdk_sessions WHERE claude_session_id = ?');
-    const checkSummary = db.prepare('SELECT id FROM session_summaries WHERE sdk_session_id = ?');
-    const checkObservation = db.prepare(`
-      SELECT id FROM observations
-      WHERE sdk_session_id = ?
-        AND title = ?
-        AND created_at_epoch = ?
-    `);
-    const checkPrompt = db.prepare(`
-      SELECT id FROM user_prompts
-      WHERE claude_session_id = ?
-        AND prompt_number = ?
-    `);
-
-    // Prepare insert statements
-    const insertSession = db.prepare(`
-      INSERT INTO sdk_sessions (
-        claude_session_id, sdk_session_id, project, user_prompt,
-        started_at, started_at_epoch, completed_at, completed_at_epoch,
-        status
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `);
-
-    const insertSummary = db.prepare(`
-      INSERT INTO session_summaries (
-        sdk_session_id, project, request, investigated, learned,
-        completed, next_steps, files_read, files_edited, notes,
-        prompt_number, discovery_tokens, created_at, created_at_epoch
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `);
-
-    const insertObservation = db.prepare(`
-      INSERT INTO observations (
-        sdk_session_id, project, text, type, title, subtitle,
-        facts, narrative, concepts, files_read, files_modified,
-        prompt_number, discovery_tokens, created_at, created_at_epoch
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `);
-
-    const insertPrompt = db.prepare(`
-      INSERT INTO user_prompts (
-        claude_session_id, prompt_number, prompt_text,
-        created_at, created_at_epoch
-      ) VALUES (?, ?, ?, ?, ?)
-    `);
-
-    // Import in transaction
-    db.transaction(() => {
-      // 1. Import sessions first (dependency for everything else)
-      console.log('🔄 Importing sessions...');
-      for (const session of exportData.sessions) {
-        const exists = checkSession.get(session.claude_session_id);
-        if (exists) {
-          stats.sessionsSkipped++;
-          continue;
-        }
-
-        insertSession.run(
-          session.claude_session_id,
-          session.sdk_session_id,
-          session.project,
-          session.user_prompt,
-          session.started_at,
-          session.started_at_epoch,
-          session.completed_at,
-          session.completed_at_epoch,
-          session.status
-        );
-        stats.sessionsImported++;
-      }
-      console.log(`   ✅ Imported: ${stats.sessionsImported}, Skipped: ${stats.sessionsSkipped}`);
-
-      // 2. Import summaries (depends on sessions)
-      console.log('🔄 Importing summaries...');
-      for (const summary of exportData.summaries) {
-        const exists = checkSummary.get(summary.sdk_session_id);
-        if (exists) {
-          stats.summariesSkipped++;
-          continue;
-        }
-
-        insertSummary.run(
-          summary.sdk_session_id,
-          summary.project,
-          summary.request,
-          summary.investigated,
-          summary.learned,
-          summary.completed,
-          summary.next_steps,
-          summary.files_read,
-          summary.files_edited,
-          summary.notes,
-          summary.prompt_number,
-          summary.discovery_tokens || 0,
-          summary.created_at,
-          summary.created_at_epoch
-        );
-        stats.summariesImported++;
-      }
-      console.log(`   ✅ Imported: ${stats.summariesImported}, Skipped: ${stats.summariesSkipped}`);
-
-      // 3. Import observations (depends on sessions)
-      console.log('🔄 Importing observations...');
-      for (const obs of exportData.observations) {
-        const exists = checkObservation.get(
-          obs.sdk_session_id,
-          obs.title,
-          obs.created_at_epoch
-        );
-        if (exists) {
-          stats.observationsSkipped++;
-          continue;
-        }
-
-        insertObservation.run(
-          obs.sdk_session_id,
-          obs.project,
-          obs.text,
-          obs.type,
-          obs.title,
-          obs.subtitle,
-          obs.facts,
-          obs.narrative,
-          obs.concepts,
-          obs.files_read,
-          obs.files_modified,
-          obs.prompt_number,
-          obs.discovery_tokens || 0,
-          obs.created_at,
-          obs.created_at_epoch
-        );
-        stats.observationsImported++;
-      }
-      console.log(`   ✅ Imported: ${stats.observationsImported}, Skipped: ${stats.observationsSkipped}`);
-
-      // 4. Import prompts (depends on sessions)
-      console.log('🔄 Importing prompts...');
-      for (const prompt of exportData.prompts) {
-        const exists = checkPrompt.get(
-          prompt.claude_session_id,
-          prompt.prompt_number
-        );
-        if (exists) {
-          stats.promptsSkipped++;
-          continue;
-        }
-
-        insertPrompt.run(
-          prompt.claude_session_id,
-          prompt.prompt_number,
-          prompt.prompt_text,
-          prompt.created_at,
-          prompt.created_at_epoch
-        );
-        stats.promptsImported++;
-      }
-      console.log(`   ✅ Imported: ${stats.promptsImported}, Skipped: ${stats.promptsSkipped}`);
-
-    })();
-
-    console.log('\n✅ Import complete!');
-    console.log('📊 Summary:');
-    console.log(`   Sessions:     ${stats.sessionsImported} imported, ${stats.sessionsSkipped} skipped`);
-    console.log(`   Summaries:    ${stats.summariesImported} imported, ${stats.summariesSkipped} skipped`);
-    console.log(`   Observations: ${stats.observationsImported} imported, ${stats.observationsSkipped} skipped`);
-    console.log(`   Prompts:      ${stats.promptsImported} imported, ${stats.promptsSkipped} skipped`);
-
-  } finally {
-    db.close();
+    const healthCheck = await fetch(`${WORKER_URL}/api/stats`);
+    if (!healthCheck.ok) {
+      throw new Error('Worker not responding');
+    }
+  } catch (error) {
+    console.error(`❌ Worker not running at ${WORKER_URL}`);
+    console.error('   Please ensure the claude-mem worker is running.');
+    process.exit(1);
   }
+
+  console.log('🔄 Importing via worker API...');
+
+  // Send import request to worker
+  const response = await fetch(`${WORKER_URL}/api/import`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      sessions: exportData.sessions || [],
+      summaries: exportData.summaries || [],
+      observations: exportData.observations || [],
+      prompts: exportData.prompts || []
+    })
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error(`❌ Import failed: ${response.status} ${response.statusText}`);
+    console.error(`   ${errorText}`);
+    process.exit(1);
+  }
+
+  const result = await response.json();
+  const stats = result.stats;
+
+  console.log('\n✅ Import complete!');
+  console.log('📊 Summary:');
+  console.log(`   Sessions:     ${stats.sessionsImported} imported, ${stats.sessionsSkipped} skipped`);
+  console.log(`   Summaries:    ${stats.summariesImported} imported, ${stats.summariesSkipped} skipped`);
+  console.log(`   Observations: ${stats.observationsImported} imported, ${stats.observationsSkipped} skipped`);
+  console.log(`   Prompts:      ${stats.promptsImported} imported, ${stats.promptsSkipped} skipped`);
 }
 
 // CLI interface

--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -984,6 +984,36 @@ export class SessionStore {
   }
 
   /**
+   * Get SDK sessions by SDK session IDs
+   * Used for exporting session metadata
+   */
+  getSdkSessionsBySessionIds(sdkSessionIds: string[]): {
+    id: number;
+    claude_session_id: string;
+    sdk_session_id: string;
+    project: string;
+    user_prompt: string;
+    started_at: string;
+    started_at_epoch: number;
+    completed_at: string | null;
+    completed_at_epoch: number | null;
+    status: string;
+  }[] {
+    if (sdkSessionIds.length === 0) return [];
+
+    const placeholders = sdkSessionIds.map(() => '?').join(',');
+    const stmt = this.db.prepare(`
+      SELECT id, claude_session_id, sdk_session_id, project, user_prompt,
+             started_at, started_at_epoch, completed_at, completed_at_epoch, status
+      FROM sdk_sessions
+      WHERE sdk_session_id IN (${placeholders})
+      ORDER BY started_at_epoch DESC
+    `);
+
+    return stmt.all(...sdkSessionIds) as any[];
+  }
+
+  /**
    * Find active SDK session for a Claude session
    */
   findActiveSDKSession(claudeSessionId: string): {
@@ -1738,5 +1768,213 @@ export class SessionStore {
    */
   close(): void {
     this.db.close();
+  }
+
+  // ===========================================
+  // Import Methods (for import-memories script)
+  // ===========================================
+
+  /**
+   * Import SDK session with duplicate checking
+   * Returns: { imported: boolean, id: number }
+   */
+  importSdkSession(session: {
+    claude_session_id: string;
+    sdk_session_id: string;
+    project: string;
+    user_prompt: string;
+    started_at: string;
+    started_at_epoch: number;
+    completed_at: string | null;
+    completed_at_epoch: number | null;
+    status: string;
+  }): { imported: boolean; id: number } {
+    // Check if session already exists
+    const existing = this.db.prepare(
+      'SELECT id FROM sdk_sessions WHERE claude_session_id = ?'
+    ).get(session.claude_session_id) as { id: number } | undefined;
+
+    if (existing) {
+      return { imported: false, id: existing.id };
+    }
+
+    const stmt = this.db.prepare(`
+      INSERT INTO sdk_sessions (
+        claude_session_id, sdk_session_id, project, user_prompt,
+        started_at, started_at_epoch, completed_at, completed_at_epoch, status
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    const result = stmt.run(
+      session.claude_session_id,
+      session.sdk_session_id,
+      session.project,
+      session.user_prompt,
+      session.started_at,
+      session.started_at_epoch,
+      session.completed_at,
+      session.completed_at_epoch,
+      session.status
+    );
+
+    return { imported: true, id: result.lastInsertRowid as number };
+  }
+
+  /**
+   * Import session summary with duplicate checking
+   * Returns: { imported: boolean, id: number }
+   */
+  importSessionSummary(summary: {
+    sdk_session_id: string;
+    project: string;
+    request: string | null;
+    investigated: string | null;
+    learned: string | null;
+    completed: string | null;
+    next_steps: string | null;
+    files_read: string | null;
+    files_edited: string | null;
+    notes: string | null;
+    prompt_number: number | null;
+    discovery_tokens: number;
+    created_at: string;
+    created_at_epoch: number;
+  }): { imported: boolean; id: number } {
+    // Check if summary already exists for this session
+    const existing = this.db.prepare(
+      'SELECT id FROM session_summaries WHERE sdk_session_id = ?'
+    ).get(summary.sdk_session_id) as { id: number } | undefined;
+
+    if (existing) {
+      return { imported: false, id: existing.id };
+    }
+
+    const stmt = this.db.prepare(`
+      INSERT INTO session_summaries (
+        sdk_session_id, project, request, investigated, learned,
+        completed, next_steps, files_read, files_edited, notes,
+        prompt_number, discovery_tokens, created_at, created_at_epoch
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    const result = stmt.run(
+      summary.sdk_session_id,
+      summary.project,
+      summary.request,
+      summary.investigated,
+      summary.learned,
+      summary.completed,
+      summary.next_steps,
+      summary.files_read,
+      summary.files_edited,
+      summary.notes,
+      summary.prompt_number,
+      summary.discovery_tokens || 0,
+      summary.created_at,
+      summary.created_at_epoch
+    );
+
+    return { imported: true, id: result.lastInsertRowid as number };
+  }
+
+  /**
+   * Import observation with duplicate checking
+   * Duplicates are identified by sdk_session_id + title + created_at_epoch
+   * Returns: { imported: boolean, id: number }
+   */
+  importObservation(obs: {
+    sdk_session_id: string;
+    project: string;
+    text: string | null;
+    type: string;
+    title: string | null;
+    subtitle: string | null;
+    facts: string | null;
+    narrative: string | null;
+    concepts: string | null;
+    files_read: string | null;
+    files_modified: string | null;
+    prompt_number: number | null;
+    discovery_tokens: number;
+    created_at: string;
+    created_at_epoch: number;
+  }): { imported: boolean; id: number } {
+    // Check if observation already exists
+    const existing = this.db.prepare(`
+      SELECT id FROM observations
+      WHERE sdk_session_id = ? AND title = ? AND created_at_epoch = ?
+    `).get(obs.sdk_session_id, obs.title, obs.created_at_epoch) as { id: number } | undefined;
+
+    if (existing) {
+      return { imported: false, id: existing.id };
+    }
+
+    const stmt = this.db.prepare(`
+      INSERT INTO observations (
+        sdk_session_id, project, text, type, title, subtitle,
+        facts, narrative, concepts, files_read, files_modified,
+        prompt_number, discovery_tokens, created_at, created_at_epoch
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    const result = stmt.run(
+      obs.sdk_session_id,
+      obs.project,
+      obs.text,
+      obs.type,
+      obs.title,
+      obs.subtitle,
+      obs.facts,
+      obs.narrative,
+      obs.concepts,
+      obs.files_read,
+      obs.files_modified,
+      obs.prompt_number,
+      obs.discovery_tokens || 0,
+      obs.created_at,
+      obs.created_at_epoch
+    );
+
+    return { imported: true, id: result.lastInsertRowid as number };
+  }
+
+  /**
+   * Import user prompt with duplicate checking
+   * Duplicates are identified by claude_session_id + prompt_number
+   * Returns: { imported: boolean, id: number }
+   */
+  importUserPrompt(prompt: {
+    claude_session_id: string;
+    prompt_number: number;
+    prompt_text: string;
+    created_at: string;
+    created_at_epoch: number;
+  }): { imported: boolean; id: number } {
+    // Check if prompt already exists
+    const existing = this.db.prepare(`
+      SELECT id FROM user_prompts
+      WHERE claude_session_id = ? AND prompt_number = ?
+    `).get(prompt.claude_session_id, prompt.prompt_number) as { id: number } | undefined;
+
+    if (existing) {
+      return { imported: false, id: existing.id };
+    }
+
+    const stmt = this.db.prepare(`
+      INSERT INTO user_prompts (
+        claude_session_id, prompt_number, prompt_text,
+        created_at, created_at_epoch
+      ) VALUES (?, ?, ?, ?, ?)
+    `);
+
+    const result = stmt.run(
+      prompt.claude_session_id,
+      prompt.prompt_number,
+      prompt.prompt_text,
+      prompt.created_at,
+      prompt.created_at_epoch
+    );
+
+    return { imported: true, id: result.lastInsertRowid as number };
   }
 }

--- a/src/services/worker/SearchManager.ts
+++ b/src/services/worker/SearchManager.ts
@@ -87,7 +87,7 @@ export class SearchManager {
       try {
         // Normalize URL-friendly params to internal format
         const normalized = this.normalizeParams(args);
-        const { query, type, obs_type, concepts, files, ...options } = normalized;
+        const { query, type, obs_type, concepts, files, format, ...options } = normalized;
         let observations: ObservationSearchResult[] = [];
         let sessions: SessionSummarySearchResult[] = [];
         let prompts: UserPromptSearchResult[] = [];
@@ -199,6 +199,17 @@ export class SearchManager {
         }
 
         const totalResults = observations.length + sessions.length + prompts.length;
+
+        // JSON format: return raw data for programmatic access (e.g., export scripts)
+        if (format === 'json') {
+          return {
+            observations,
+            sessions,
+            prompts,
+            totalResults,
+            query: query || ''
+          };
+        }
 
         if (totalResults === 0) {
           return {


### PR DESCRIPTION
## Summary

- Fixed `export-memories.ts` - was failing to export memories with project filter
- Fixed `import-memories.ts` - refactored to use API for consistency
- Added JSON format support to SearchManager for raw data output
- Added batch SDK sessions API endpoint (`POST /api/sdk-sessions/batch`)
- Added import API endpoint (`POST /api/import`) with duplicate detection

## Problem

The export/import scripts were using direct database access via `better-sqlite3`, which caused issues:
- Export script returned zero results when filtering by project (empty query bug)
- SearchManager always returned formatted text instead of raw JSON data

## Solution

Refactored both scripts to use the worker HTTP API, which:
1. Properly handles project filtering
2. Returns raw JSON data for export
3. Provides consistent behavior with the rest of the plugin

## Test plan

- [x] Test export script with project filter - now returns correct results
- [x] Test import script with test data
- [x] Verify duplicate detection works (re-importing skips existing records)

🤖 Generated with [Claude Code](https://claude.com/claude-code)