### PR TITLE
Fix: Replace stderr output with JSON systemMessage to reduce user confusion

### DIFF
--- a/src/hooks/user-message-hook.ts
+++ b/src/hooks/user-message-hook.ts
@@ -1,10 +1,10 @@
 /**
  * User Message Hook - SessionStart
- * Displays context information to the user via stderr
+ * Displays context information to the user via JSON systemMessage
  *
  * This hook runs in parallel with context-hook to show users what context
- * has been loaded into their session. Uses stderr as the communication channel
- * since it's currently the only way to display messages in Claude Code UI.
+ * has been loaded into their session. Uses JSON output with systemMessage
+ * for clean user communication without stderr confusion.
  */
 import { basename } from "path";
 import { ensureWorkerRunning, getWorkerPort } from "../shared/worker-utils.js";
@@ -30,24 +30,18 @@ try {
 
   const output = await response.text();
 
-  console.error(
+  const systemMessage =
     "\n\n📝 Claude-Mem Context Loaded\n" +
-    "   ℹ️  Note: This appears as stderr but is informational only\n\n" +
     output +
     "\n\n💡 New! Wrap all or part of any message with <private> ... </private> to prevent storing sensitive information in your observation history.\n" +
     "\n💬 Community https://discord.gg/J4wttp9vDu" +
-    `\n📺 Watch live in browser http://localhost:${port}/\n`
-  );
+    `\n📺 Watch live in browser http://localhost:${port}/\n`;
+
+  console.log(JSON.stringify({ systemMessage }));
 
 } catch (error) {
   // Context not available yet - likely first run or worker starting up
-  console.error(`
----
-🎉  Note: This appears under Plugin Hook Error, but it's not an error. That's the only option for
-   user messages in Claude Code UI until a better method is provided.
----
-
-⚠️  Claude-Mem: First-Time Setup
+  const systemMessage = `⚠️  Claude-Mem: First-Time Setup
 
 Dependencies are installing in the background. This only happens once.
 
@@ -58,8 +52,9 @@ Dependencies are installing in the background. This only happens once.
 
 Thank you for installing Claude-Mem!
 
-This message was not added to your startup context, so you can continue working as normal.
-`);
+This message was not added to your startup context, so you can continue working as normal.`;
+
+  console.log(JSON.stringify({ systemMessage }));
 }
 
-process.exit(HOOK_EXIT_CODES.USER_MESSAGE_ONLY);
+process.exit(HOOK_EXIT_CODES.SUCCESS);

--- a/src/shared/hook-constants.ts
+++ b/src/shared/hook-constants.ts
@@ -13,8 +13,6 @@ export const HOOK_TIMEOUTS = {
 export const HOOK_EXIT_CODES = {
   SUCCESS: 0,
   FAILURE: 1,
-  /** Show user message that Claude does NOT receive as context */
-  USER_MESSAGE_ONLY: 3,
 } as const;
 
 export function getTimeout(baseTimeout: number): number {


### PR DESCRIPTION
## Summary
This PR addresses a user experience issue where stderr output from the `user-message-hook` was causing "Plugin hook error" messages in the Claude Code UI, leading to user confusion even when the plugin was functioning correctly.

## Problem Description

### Root Cause
The `user-message-hook.ts` was using `console.error()` with exit code 3 (`USER_MESSAGE_ONLY`) to display startup information to users. While this was functionally working, it had several UX problems:
   1. **Confusing Error Messages**: stderr output caused Claude Code to display "Plugin hook error" notifications
   2. **User Anxiety**: Users seeing error messages even when the plugin was working correctly
   3. **Poor Documentation**: stderr approach was not the recommended method according to Claude Code hook documentation

   ## Solution

   ### Changes Made

   1. **Exit Code Update**:
      - Changed from `HOOK_EXIT_CODES.USER_MESSAGE_ONLY` (3) to `HOOK_EXIT_CODES.SUCCESS` (0)
      - Removed the `USER_MESSAGE_ONLY` constant from `hook-constants.ts`

   2. **Output Method**:
      - Replaced `console.error()` with `console.log(JSON.stringify({ systemMessage }))`
      - Used structured JSON output following Claude Code hook documentation best practices

   3. **Content Preservation**:
      - All existing informational content is preserved
      - No changes to the actual messages, only the delivery mechanism
      - Maintains all helpful information about private tags, community links, and browser access

### Visual Comparison
**Before ( stderr approach causing confusion):**
<img width="982" height="648" alt="plugin_error" src="https://github.com/user-attachments/assets/7101e3ed-00bd-47f5-aa8f-a92ecd7b0652" />
 
**After (Clean JSON systemMessage approach):**
<img width="993" height="635" alt="after1" src="https://github.com/user-attachments/assets/70a229d7-d486-4e3c-ad9b-c20af44940cf" />
<img width="1190" height="445" alt="after2" src="https://github.com/user-attachments/assets/f90a946e-13e6-411a-811b-637bae19ea83" />



   ### Technical Details

   **Before:**
   ```javascript
   console.error(
     "\n\n📝 Claude-Mem Context Loaded\n" +
     "   ℹ️  Note: This appears as stderr but is informational only\n\n" +
     output +
     // ... rest of content
   );
   process.exit(HOOK_EXIT_CODES.USER_MESSAGE_ONLY); // exit code 3
   ```

   **After:**
   ```javascript
   const systemMessage =
     "📝 Claude-Mem Context Loaded\n\n" +
     output +
     // ... rest of content
   console.log(JSON.stringify({ systemMessage }));
   process.exit(HOOK_EXIT_CODES.SUCCESS); // exit code 0
   ```

   ## Benefits

   1. **Cleaner UX**: No more confusing error messages in the Claude Code UI
   2. **Better Communication**: Uses the recommended JSON systemMessage approach
   3. **Standards Compliance**: Follows Claude Code hook output documentation
   4. **Zero Functional Loss**: All existing information is preserved and delivered cleanly
   
   
  ## Files Changed

   - `src/hooks/user-message-hook.ts` - Updated output method and exit code
   - `src/shared/hook-constants.ts` - Removed unused `USER_MESSAGE_ONLY` constant

   ## Related Issues

   Resolves the user experience issues discussed in GitHub issue #326 where stderr output was causing unnecessary user confusion.
