### PR TITLE
fix: add resume to SessionStart hook matcher

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -3,7 +3,7 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup|clear|compact",
+        "matcher": "startup|clear|compact|resume",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary

Fixed SessionStart hook error when Claude Code resumes a previous session.

## Problem

The SessionStart hook matcher was `"startup|clear|compact"`, missing the `resume` event type. This caused hook errors when:
- Continuing a previous conversation
- Resuming after context limit reached
- Any session resume scenario

## Solution

Added `resume` to the matcher: `"startup|clear|compact|resume"`

## Test Plan

- [x] Restart Claude Code and verify no "SessionStart:resume hook error"
- [x] Verify hooks still work for startup, clear, and compact events

🤖 Generated with [Claude Code](https://claude.com/claude-code)