### PR TITLE
Fix SessionStart hook error by using documented exit codes

### DIFF
--- a/src/hooks/user-message-hook.ts
+++ b/src/hooks/user-message-hook.ts
@@ -62,4 +62,5 @@ This message was not added to your startup context, so you can continue working 
 `);
 }
 
-process.exit(HOOK_EXIT_CODES.USER_MESSAGE_ONLY);
+// Exit 0 for clean hook completion - stderr output shown in verbose mode (Ctrl+O)
+process.exit(HOOK_EXIT_CODES.SUCCESS);

--- a/src/shared/hook-constants.ts
+++ b/src/shared/hook-constants.ts
@@ -9,12 +9,15 @@ export const HOOK_TIMEOUTS = {
 
 /**
  * Hook exit codes for Claude Code
+ * See: https://code.claude.com/docs/en/hooks.md
  */
 export const HOOK_EXIT_CODES = {
+  /** Success - stdout shown in verbose mode, or added to context for SessionStart/UserPromptSubmit */
   SUCCESS: 0,
+  /** Non-blocking error - stderr shown in verbose mode, execution continues */
   FAILURE: 1,
-  /** Show user message that Claude does NOT receive as context */
-  USER_MESSAGE_ONLY: 3,
+  /** Blocking error - stderr fed back to Claude, may block operations */
+  BLOCKING_ERROR: 2,
 } as const;
 
 export function getTimeout(baseTimeout: number): number {


### PR DESCRIPTION
## Summary
- Fixed "SessionStart:startup hook error" that appeared on every session start
- Changed user-message-hook to exit with code 0 instead of undocumented code 3
- Updated hook-constants.ts to only include officially documented exit codes (0, 1, 2)

## Root Cause
The `user-message-hook.js` was using exit code 3 (`USER_MESSAGE_ONLY`), which is not officially supported by Claude Code. According to the [hooks documentation](https://code.claude.com/docs/en/hooks.md), only exit codes 0 and 2 have special handling - any other code is treated as a non-blocking error.

## Test plan
- [x] Verified hook exits with code 0 when run directly
- [x] Worker service health check passes
- [x] Session starts without "hook error" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)