### PR TITLE
fix(windows): enable worker logging on Windows

### DIFF
--- a/src/services/process/ProcessManager.ts
+++ b/src/services/process/ProcessManager.ts
@@ -99,8 +99,9 @@ export class ProcessManager {
         const escapedBunPath = this.escapePowerShellString(bunPath);
         const escapedScript = this.escapePowerShellString(script);
         const escapedWorkDir = this.escapePowerShellString(MARKETPLACE_ROOT);
+        const escapedLogFile = this.escapePowerShellString(logFile);
         const envVars = `$env:CLAUDE_MEM_WORKER_PORT='${port}'`;
-        const psCommand = `${envVars}; Start-Process -FilePath '${escapedBunPath}' -ArgumentList '${escapedScript}' -WorkingDirectory '${escapedWorkDir}' -WindowStyle Hidden -PassThru | Select-Object -ExpandProperty Id`;
+        const psCommand = `${envVars}; Start-Process -FilePath '${escapedBunPath}' -ArgumentList '${escapedScript}' -WorkingDirectory '${escapedWorkDir}' -WindowStyle Hidden -RedirectStandardOutput '${escapedLogFile}' -RedirectStandardError '${escapedLogFile}.err' -PassThru | Select-Object -ExpandProperty Id`;
 
         const result = spawnSync('powershell', ['-Command', psCommand], {
           stdio: 'pipe',


### PR DESCRIPTION
## Summary
- Adds `-RedirectStandardOutput` and `-RedirectStandardError` to the PowerShell `Start-Process` command when starting the worker on Windows
- Worker logs now go to `~/.claude-mem/logs/worker-YYYY-MM-DD.log` and `~/.claude-mem/logs/worker-YYYY-MM-DD.log.err`
- Previously, Windows worker startup did not redirect stdout/stderr, making debugging startup failures impossible

## Test plan
- [x] Build and sync to marketplace
- [x] Restart worker via `npm run worker:restart`
- [x] Verify log files are created in `~/.claude-mem/logs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)