### PR TITLE
feat: add language setting for observation output

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Settings are managed in `~/.claude-mem/settings.json`. The file is auto-created 
 | `CLAUDE_MEM_PYTHON_VERSION` | `3.13` | Python version for chroma-mcp |
 | `CLAUDE_CODE_PATH` | _(auto-detect)_ | Path to Claude executable |
 | `CLAUDE_MEM_CONTEXT_OBSERVATIONS` | `50` | Number of observations to inject at SessionStart |
+| `CLAUDE_MEM_LANGUAGE` | `en` | Observation output language (en, ja, zh, ko, es, fr, de, pt, ru, ar) |
 
 **Settings Management:**
 
@@ -357,7 +358,8 @@ curl http://localhost:37777/api/settings
 {
   "CLAUDE_MEM_MODEL": "claude-sonnet-4-5",
   "CLAUDE_MEM_WORKER_PORT": "37777",
-  "CLAUDE_MEM_CONTEXT_OBSERVATIONS": "50"
+  "CLAUDE_MEM_CONTEXT_OBSERVATIONS": "50",
+  "CLAUDE_MEM_LANGUAGE": "ja"
 }
 ```
 

--- a/src/services/worker/SDKAgent.ts
+++ b/src/services/worker/SDKAgent.ts
@@ -185,6 +185,9 @@ export class SDKAgent {
    * - We just use the session_id we're given - simple and reliable
    */
   private async *createMessageGenerator(session: ActiveSession): AsyncIterableIterator<SDKUserMessage> {
+    // Get language setting for observation output
+    const language = this.getLanguage();
+
     // Yield initial user prompt with context (or continuation if prompt #2+)
     // CRITICAL: Both paths use session.claudeSessionId from the hook
     yield {
@@ -192,8 +195,8 @@ export class SDKAgent {
       message: {
         role: 'user',
         content: session.lastPromptNumber === 1
-          ? buildInitPrompt(session.project, session.claudeSessionId, session.userPrompt)
-          : buildContinuationPrompt(session.userPrompt, session.lastPromptNumber, session.claudeSessionId)
+          ? buildInitPrompt(session.project, session.claudeSessionId, session.userPrompt, language)
+          : buildContinuationPrompt(session.userPrompt, session.lastPromptNumber, session.claudeSessionId, language)
       },
       session_id: session.claudeSessionId,
       parent_tool_use_id: null,
@@ -237,7 +240,7 @@ export class SDKAgent {
               user_prompt: session.userPrompt,
               last_user_message: message.last_user_message || '',
               last_assistant_message: message.last_assistant_message || ''
-            })
+            }, language)
           },
           session_id: session.claudeSessionId,
           parent_tool_use_id: null,
@@ -462,5 +465,14 @@ export class SDKAgent {
     const settingsPath = path.join(homedir(), '.claude-mem', 'settings.json');
     const settings = SettingsDefaultsManager.loadFromFile(settingsPath);
     return settings.CLAUDE_MEM_MODEL;
+  }
+
+  /**
+   * Get language setting for observation output
+   */
+  private getLanguage(): string {
+    const settingsPath = path.join(homedir(), '.claude-mem', 'settings.json');
+    const settings = SettingsDefaultsManager.loadFromFile(settingsPath);
+    return settings.CLAUDE_MEM_LANGUAGE;
   }
 }

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -37,6 +37,8 @@ export interface SettingsDefaults {
   // Feature Toggles
   CLAUDE_MEM_CONTEXT_SHOW_LAST_SUMMARY: string;
   CLAUDE_MEM_CONTEXT_SHOW_LAST_MESSAGE: string;
+  // Language Configuration
+  CLAUDE_MEM_LANGUAGE: string;
 }
 
 export class SettingsDefaultsManager {
@@ -69,6 +71,8 @@ export class SettingsDefaultsManager {
     // Feature Toggles
     CLAUDE_MEM_CONTEXT_SHOW_LAST_SUMMARY: 'true',
     CLAUDE_MEM_CONTEXT_SHOW_LAST_MESSAGE: 'false',
+    // Language Configuration
+    CLAUDE_MEM_LANGUAGE: 'en', // Observation output language (en, ja, zh, etc.)
   };
 
   /**


### PR DESCRIPTION
## Summary

- Add `CLAUDE_MEM_LANGUAGE` setting to control observation/summary output language
- Supports: en, ja, zh, ko, es, fr, de, pt, ru, ar
- Default: `en` (English) - no behavior change for existing users

## Motivation

Non-English speakers want to have their memory observations written in their native language for better readability and searchability.

## Changes

| File | Change |
|------|--------|
| `src/shared/SettingsDefaultsManager.ts` | Add `CLAUDE_MEM_LANGUAGE` setting |
| `src/sdk/prompts.ts` | Add language instruction generation, pass language to prompts |
| `src/services/worker/SDKAgent.ts` | Read language setting and pass to prompt builders |
| `README.md` | Document new setting |

## Usage

\`\`\`json
// ~/.claude-mem/settings.json
{
  "CLAUDE_MEM_LANGUAGE": "ja"
}
\`\`\`

## Test plan

- [ ] Set \`CLAUDE_MEM_LANGUAGE\` to \`ja\` and verify observations are written in Japanese
- [ ] Verify default (\`en\`) still works as before
- [ ] Verify unsupported language codes fall back gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)