### PR TITLE
fix(sdk-agent): remove invalid resume parameter causing session failures

### DIFF
--- a/src/services/worker/SDKAgent.ts
+++ b/src/services/worker/SDKAgent.ts
@@ -67,16 +67,18 @@ export class SDKAgent {
       logger.info('SDK', 'Starting SDK query', {
         sessionDbId: session.sessionDbId,
         claudeSessionId: session.claudeSessionId,
-        resume_parameter: session.claudeSessionId,
         lastPromptNumber: session.lastPromptNumber
       });
 
       // Run Agent SDK query loop
+      // NOTE: Do NOT use 'resume' parameter - it expects an SDK session ID, not a Claude Code session ID
+      // The claudeSessionId from hooks is the user's Claude Code session, not an SDK-created session
+      // Using it with 'resume' causes "Claude Code process exited with code 1" errors
+      // Each SDK agent call starts fresh for observation processing, which is correct
       const queryResult = query({
         prompt: messageGenerator,
         options: {
           model: modelId,
-          resume: session.claudeSessionId,
           disallowedTools,
           abortController: session.abortController,
           pathToClaudeCodeExecutable: claudePath


### PR DESCRIPTION
## Summary
- Remove invalid `resume` parameter from SDK `query()` options that was using user's Claude Code session ID instead of SDK session ID
- This was causing "Claude Code process exited with code 1" errors and preventing observations from being recorded

## Problem
The `resume` parameter in `SDKAgent.ts` was set to `session.claudeSessionId`, which is the user's active Claude Code session ID (passed from hooks). However, the `resume` option expects an **SDK-created session ID**, not a user session ID.

When the SDK tried to resume with this invalid ID, Claude Code CLI would exit with code 1, causing all observation processing to fail silently.

## Solution
Remove the `resume` parameter entirely. Each SDK observation-processing call now starts fresh, which is the correct behavior for this use case since we're spawning a separate agent to analyze and record observations.

## Test plan
- [x] Verified observations are now being recorded after the fix
- [x] Confirmed no more "Claude Code process exited with code 1" errors in logs
- [x] Tested with multiple tool uses to ensure observations are captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)