### PR TITLE
fix: use stdout + exit code 0 for informational messages

### DIFF
--- a/src/hooks/user-message-hook.ts
+++ b/src/hooks/user-message-hook.ts
@@ -1,10 +1,10 @@
 /**
  * User Message Hook - SessionStart
- * Displays context information to the user via stderr
+ * Displays context information to the user via stdout
  *
  * This hook runs in parallel with context-hook to show users what context
- * has been loaded into their session. Uses stderr as the communication channel
- * since it's currently the only way to display messages in Claude Code UI.
+ * has been loaded into their session. Uses stdout with exit code 0 as per
+ * Claude Code's hooks documentation for informational messages.
  */
 import { basename } from "path";
 import { ensureWorkerRunning, getWorkerPort } from "../shared/worker-utils.js";
@@ -30,13 +30,12 @@ if (!response.ok) {
 
 const output = await response.text();
 
-console.error(
-  "\n\n📝 Claude-Mem Context Loaded\n" +
-  "   ℹ️  Note: This appears as stderr but is informational only\n\n" +
+console.log(
+  "\n\n📝 Claude-Mem Context Loaded\n\n" +
   output +
   "\n\n💡 New! Wrap all or part of any message with <private> ... </private> to prevent storing sensitive information in your observation history.\n" +
   "\n💬 Community https://discord.gg/J4wttp9vDu" +
   `\n📺 Watch live in browser http://localhost:${port}/\n`
 );
 
-process.exit(HOOK_EXIT_CODES.USER_MESSAGE_ONLY);
+process.exit(HOOK_EXIT_CODES.SUCCESS);

--- a/src/shared/hook-constants.ts
+++ b/src/shared/hook-constants.ts
@@ -13,7 +13,11 @@ export const HOOK_TIMEOUTS = {
 export const HOOK_EXIT_CODES = {
   SUCCESS: 0,
   FAILURE: 1,
-  /** Show user message that Claude does NOT receive as context */
+  /**
+   * @deprecated Exit code 3 is not documented in Claude Code's hooks API.
+   * Use SUCCESS (0) with stdout for informational messages instead.
+   * See: https://docs.anthropic.com/en/docs/claude-code/hooks
+   */
   USER_MESSAGE_ONLY: 3,
 } as const;
 


### PR DESCRIPTION
## Summary

Fixes #508

This PR fixes the "Plugin hook error:" labeling issue by using Claude Code's documented approach for informational messages.

## Problem

The `user-message-hook.ts` was using `stderr` + exit code 3 (`USER_MESSAGE_ONLY`) to display messages. This caused Claude Code to label the output as an error:

```
SessionStart:startup says: Plugin hook error: 📝 Claude-Mem Context Loaded
       ℹ️  Note: This appears as stderr but is informational only
```

## Root Cause

According to [Claude Code's hooks documentation](https://docs.anthropic.com/en/docs/claude-code/hooks):

- Exit code 3 is **not documented** — Claude Code only recognizes 0 (success), 2 (blocking error), and treats all others as "non-blocking errors"
- `stderr` output from non-zero exits is displayed with error formatting
- Informational messages should use **exit code 0 + stdout**

## Changes

1. **`src/hooks/user-message-hook.ts`**
   - Changed `console.error` → `console.log` (write to stdout instead of stderr)
   - Changed exit code from `USER_MESSAGE_ONLY` (3) → `SUCCESS` (0)
   - Updated header comments to reflect the correct approach
   - Removed the "Note: This appears as stderr..." message (no longer needed)

2. **`src/shared/hook-constants.ts`**
   - Added `@deprecated` JSDoc to `USER_MESSAGE_ONLY` constant with explanation

## Expected Result

After this fix:
```
SessionStart:Callback hook success: 📝 Claude-Mem Context Loaded
```

## Testing

- [ ] Verified message appears without "error" labeling
- [ ] Verified context is still displayed correctly
- [ ] Verified exit code 0 doesn't affect hook behavior