### PR TITLE
feat: support CLAUDE_PLUGIN_ROOT for local plugin installs

### DIFF
--- a/src/services/infrastructure/HealthMonitor.ts
+++ b/src/services/infrastructure/HealthMonitor.ts
@@ -92,12 +92,15 @@ export async function httpShutdown(port: number): Promise<boolean> {
 }
 
 /**
- * Get the plugin version from the installed marketplace package.json
+ * Get the plugin version from the installed plugin's package.json
  * This is the "expected" version that should be running
+ * Supports both --plugin-dir (CLAUDE_PLUGIN_ROOT) and marketplace installs
  */
 export function getInstalledPluginVersion(): string {
-  const marketplaceRoot = path.join(homedir(), '.claude', 'plugins', 'marketplaces', 'thedotmack');
-  const packageJsonPath = path.join(marketplaceRoot, 'package.json');
+  // Prefer CLAUDE_PLUGIN_ROOT for --plugin-dir installs
+  const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT
+    || path.join(homedir(), '.claude', 'plugins', 'marketplaces', 'thedotmack');
+  const packageJsonPath = path.join(pluginRoot, 'package.json');
   const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
   return packageJson.version;
 }

--- a/src/services/worker/BranchManager.ts
+++ b/src/services/worker/BranchManager.ts
@@ -11,7 +11,7 @@ import { homedir } from 'os';
 import { join } from 'path';
 import { logger } from '../../utils/logger.js';
 
-const INSTALLED_PLUGIN_PATH = join(homedir(), '.claude', 'plugins', 'marketplaces', 'thedotmack');
+const INSTALLED_PLUGIN_PATH = process.env.CLAUDE_PLUGIN_ROOT || join(homedir(), '.claude', 'plugins', 'marketplaces', 'thedotmack');
 
 /**
  * Validate branch name to prevent command injection

--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -6,7 +6,9 @@ import { HOOK_TIMEOUTS, getTimeout } from "./hook-constants.js";
 import { SettingsDefaultsManager } from "./SettingsDefaultsManager.js";
 import { getWorkerRestartInstructions } from "../utils/error-messages.js";
 
-const MARKETPLACE_ROOT = path.join(homedir(), '.claude', 'plugins', 'marketplaces', 'thedotmack');
+// Support --plugin-dir installs via CLAUDE_PLUGIN_ROOT, fallback to marketplace
+const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT
+  || path.join(homedir(), '.claude', 'plugins', 'marketplaces', 'thedotmack');
 
 // Named constants for health checks
 const HEALTH_CHECK_TIMEOUT_MS = getTimeout(HOOK_TIMEOUTS.HEALTH_CHECK);
@@ -71,7 +73,7 @@ async function isWorkerHealthy(): Promise<boolean> {
  * Get the current plugin version from package.json
  */
 function getPluginVersion(): string {
-  const packageJsonPath = path.join(MARKETPLACE_ROOT, 'package.json');
+  const packageJsonPath = path.join(PLUGIN_ROOT, 'package.json');
   const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
   return packageJson.version;
 }


### PR DESCRIPTION
Use CLAUDE_PLUGIN_ROOT environment variable when available, with fallback to marketplace path. This enables running from local source via marketplace install instead of hardcoded paths.