### PR TITLE
refactor: use bun instead of node for all hook commands

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/smart-install.js\"",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/smart-install.js\"",
             "timeout": 300
           },
           {
@@ -17,12 +17,12 @@
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/context-hook.js\"",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/context-hook.js\"",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/user-message-hook.js\"",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/user-message-hook.js\"",
             "timeout": 60
           }
         ]
@@ -38,7 +38,7 @@
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/new-hook.js\"",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/new-hook.js\"",
             "timeout": 60
           }
         ]
@@ -55,7 +55,7 @@
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/save-hook.js\"",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/save-hook.js\"",
             "timeout": 120
           }
         ]
@@ -71,7 +71,7 @@
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/summary-hook.js\"",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/summary-hook.js\"",
             "timeout": 120
           }
         ]


### PR DESCRIPTION
claude-mem uses bun exclusively. This change ensures consistency by running all hook scripts with bun instead of node.