### PR TITLE
fix: remove SessionStart matcher blocking context injection

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -3,7 +3,6 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup|clear|compact",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
The matcher "startup|clear|compact" was preventing SessionStart hooks from running and injecting context into new sessions. Removing it allows hooks to fire on all session starts.