### PR TITLE
fix(sdk): pass cwd parameter to SDK query to resolve exit code 1

### DIFF
--- a/src/services/sqlite/PendingMessageStore.ts
+++ b/src/services/sqlite/PendingMessageStore.ts
@@ -109,6 +109,20 @@ export class PendingMessageStore {
   }
 
   /**
+   * Peek at the first pending message without removing it
+   * Used to get cwd for SDK query initialization (Issue #467)
+   */
+  peekPending(sessionDbId: number): PersistentPendingMessage | null {
+    const stmt = this.db.prepare(`
+      SELECT * FROM pending_messages
+      WHERE session_db_id = ? AND status = 'pending'
+      ORDER BY id ASC
+      LIMIT 1
+    `);
+    return stmt.get(sessionDbId) as PersistentPendingMessage | null;
+  }
+
+  /**
    * Get all pending messages for session (ordered by creation time)
    */
   getAllPending(sessionDbId: number): PersistentPendingMessage[] {


### PR DESCRIPTION
## Problem

The SDK agent fails with "Claude Code process exited with code 1" when processing observations. This occurs because the `query()` call in SDKAgent.ts is missing the required `cwd` parameter that Claude Code needs to locate session files.

## Root Cause

When Claude Code resumes a session, it requires the working directory to find session files at:
`~/.claude/projects/{cwd-encoded-path}/{session-id}.jsonl`

Without `cwd`, the process fails immediately after starting.

## Solution

1. Add `peekPending()` method to PendingMessageStore to retrieve the cwd from the first pending message without consuming it

2. Pass `cwd` to the SDK query options:
   - Get cwd from first pending message
   - Fallback to process.cwd() if unavailable

## Changes

- `src/services/sqlite/PendingMessageStore.ts`: Add peekPending() method
- `src/services/worker/SDKAgent.ts`: Get cwd and pass to query options

## Testing

1. Clear stale session state
2. Restart worker
3. Verify observations are processed without exit code 1 errors

Fixes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)