### PR TITLE
feat: add git-aware project identity for worktree support

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,27 @@ Settings are managed in `~/.claude-mem/settings.json` (auto-created with default
 
 See the **[Configuration Guide](https://docs.claude-mem.ai/configuration)** for all available settings and examples.
 
+### Git Worktree Support
+
+Claude-mem automatically identifies projects by git repository, so **all worktrees of the same repo share memory**. Project identity is determined by (in order of priority):
+
+1. **`.claude-mem` config file** in repo root (explicit override)
+2. **Git remote origin URL** (normalized, e.g., `github.com/user/repo`)
+3. **Git repo root basename** (for local repos without remotes)
+4. **Folder basename** (fallback for non-git directories)
+
+To explicitly set a project name, create `.claude-mem` in your repo root:
+```json
+{
+  "projectName": "my-project"
+}
+```
+
+To reset the database and start fresh with the new identity system:
+```bash
+npm run db:reset
+```
+
 ---
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "queue:clear": "bun scripts/clear-failed-queue.ts --all --force",
     "claude-md:regenerate": "bun scripts/regenerate-claude-md.ts",
     "claude-md:dry-run": "bun scripts/regenerate-claude-md.ts --dry-run",
+    "db:reset": "node -e \"const fs=require('fs'),p=require('path').join(require('os').homedir(),'.claude-mem','claude-mem.db');fs.existsSync(p)?(fs.unlinkSync(p),console.log('Database deleted:',p)):console.log('No database found at:',p)\"",
     "translate-readme": "bun scripts/translate-readme/cli.ts -v -o docs/i18n README.md",
     "translate:tier1": "npm run translate-readme -- zh ja pt-br ko es de fr",
     "translate:tier2": "npm run translate-readme -- he ar ru pl cs nl tr uk",

--- a/src/hooks/context-hook.ts
+++ b/src/hooks/context-hook.ts
@@ -9,7 +9,7 @@
 import { stdin } from "process";
 import { ensureWorkerRunning, getWorkerPort } from "../shared/worker-utils.js";
 import { HOOK_TIMEOUTS } from "../shared/hook-constants.js";
-import { getProjectContext } from "../utils/project-name.js";
+import { getProjectName } from "../utils/project-name.js";
 import { logger } from "../utils/logger.js";
 
 export interface SessionStartInput {
@@ -24,12 +24,10 @@ async function contextHook(input?: SessionStartInput): Promise<string> {
   await ensureWorkerRunning();
 
   const cwd = input?.cwd ?? process.cwd();
-  const context = getProjectContext(cwd);
+  const project = getProjectName(cwd);
   const port = getWorkerPort();
 
-  // Pass all projects (parent + worktree if applicable) for unified timeline
-  const projectsParam = context.allProjects.join(',');
-  const url = `http://127.0.0.1:${port}/api/context/inject?projects=${encodeURIComponent(projectsParam)}`;
+  const url = `http://127.0.0.1:${port}/api/context/inject?project=${encodeURIComponent(project)}`;
 
   // Note: Removed AbortSignal.timeout due to Windows Bun cleanup issue (libuv assertion)
   // Worker service has its own timeouts, so client-side timeout is redundant

--- a/src/utils/git-project-identity.ts
+++ b/src/utils/git-project-identity.ts
@@ -1,0 +1,218 @@
+/**
+ * Git-aware project identity resolution
+ *
+ * Resolves project identity using a cascade:
+ * 1. .claude-mem config file in repo root (explicit override)
+ * 2. Git remote origin URL (normalized)
+ * 3. Git repo root basename
+ * 4. Folder basename (fallback for non-git directories)
+ */
+
+import path from 'path';
+import { spawnSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import { logger } from './logger.js';
+
+const GIT_COMMAND_TIMEOUT_MS = 5000;
+
+export interface ProjectIdentity {
+  name: string;
+  source: 'config' | 'remote' | 'git-root' | 'folder';
+  cwd: string;
+}
+
+// Module-level cache (per-process, no TTL needed)
+const identityCache = new Map<string, ProjectIdentity>();
+
+/**
+ * Execute git command safely with argument array
+ * Returns null on any failure (graceful degradation)
+ */
+function execGit(args: string[], cwd: string): string | null {
+  try {
+    const result = spawnSync('git', args, {
+      cwd,
+      encoding: 'utf-8',
+      timeout: GIT_COMMAND_TIMEOUT_MS,
+      windowsHide: true,
+      shell: false, // CRITICAL: Never use shell
+      stdio: ['pipe', 'pipe', 'ignore'], // Suppress stderr
+    });
+
+    if (result.error || result.status !== 0) {
+      return null;
+    }
+
+    return result.stdout.trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get git repository root for a directory
+ * Returns null if not a git repo or git not available
+ */
+export function getGitRoot(cwd: string): string | null {
+  return execGit(['rev-parse', '--show-toplevel'], cwd);
+}
+
+/**
+ * Get git remote origin URL
+ * Returns null if no remote or git not available
+ */
+export function getGitRemoteOrigin(cwd: string): string | null {
+  return execGit(['remote', 'get-url', 'origin'], cwd);
+}
+
+/**
+ * Normalize git remote URL to a consistent project identity
+ *
+ * Examples:
+ * - https://github.com/user/repo.git -> github.com/user/repo
+ * - git@github.com:user/repo.git -> github.com/user/repo
+ * - ssh://git@github.com/user/repo.git -> github.com/user/repo
+ */
+export function normalizeRemoteUrl(url: string): string {
+  // Remove trailing .git suffix
+  let normalized = url.replace(/\.git$/, '');
+
+  // Handle SSH format: git@github.com:user/repo
+  const sshMatch = normalized.match(/^git@([^:]+):(.+)$/);
+  if (sshMatch) {
+    return `${sshMatch[1]}/${sshMatch[2]}`;
+  }
+
+  // Handle HTTPS format: https://github.com/user/repo
+  const httpsMatch = normalized.match(/^https?:\/\/([^/]+)\/(.+)$/);
+  if (httpsMatch) {
+    return `${httpsMatch[1]}/${httpsMatch[2]}`;
+  }
+
+  // Handle SSH URL format: ssh://git@github.com/user/repo
+  const sshUrlMatch = normalized.match(/^ssh:\/\/[^@]+@([^/]+)\/(.+)$/);
+  if (sshUrlMatch) {
+    return `${sshUrlMatch[1]}/${sshUrlMatch[2]}`;
+  }
+
+  // Fallback: return as-is (rare edge case)
+  return normalized;
+}
+
+/**
+ * Read .claude-mem config from repo root
+ * Returns project name if configured, null otherwise
+ */
+export function getConfigProjectName(gitRoot: string): string | null {
+  const configPath = path.join(gitRoot, '.claude-mem');
+
+  if (!existsSync(configPath)) {
+    return null;
+  }
+
+  try {
+    const content = readFileSync(configPath, 'utf-8');
+    const config = JSON.parse(content);
+
+    if (typeof config.projectName === 'string' && config.projectName.trim()) {
+      return config.projectName.trim();
+    }
+
+    return null;
+  } catch (error) {
+    // Invalid JSON or read error - silently fall through to next cascade level
+    logger.debug('GIT_IDENTITY', 'Failed to read .claude-mem config', { gitRoot }, error as Error);
+    return null;
+  }
+}
+
+/**
+ * Get folder basename (original fallback logic)
+ */
+function getFolderBasename(cwd: string): string {
+  const basename = path.basename(cwd);
+
+  // Edge case: Drive roots on Windows (C:\) or Unix root (/)
+  if (basename === '') {
+    const isWindows = process.platform === 'win32';
+    if (isWindows) {
+      const driveMatch = cwd.match(/^([A-Z]):\\/i);
+      if (driveMatch) {
+        return `drive-${driveMatch[1].toUpperCase()}`;
+      }
+    }
+    return 'unknown-project';
+  }
+
+  return basename;
+}
+
+/**
+ * Resolve project identity using the cascade (uncached)
+ */
+function resolveIdentityUncached(cwd: string): ProjectIdentity {
+  // Try git-based identity first
+  const gitRoot = getGitRoot(cwd);
+
+  if (gitRoot) {
+    // 1. Check for .claude-mem config
+    const configName = getConfigProjectName(gitRoot);
+    if (configName) {
+      return { name: configName, source: 'config', cwd };
+    }
+
+    // 2. Try git remote origin
+    const remoteUrl = getGitRemoteOrigin(cwd);
+    if (remoteUrl) {
+      const normalized = normalizeRemoteUrl(remoteUrl);
+      return { name: normalized, source: 'remote', cwd };
+    }
+
+    // 3. Use git root basename
+    const gitRootBasename = path.basename(gitRoot);
+    if (gitRootBasename) {
+      return { name: gitRootBasename, source: 'git-root', cwd };
+    }
+  }
+
+  // 4. Fallback to folder basename
+  return { name: getFolderBasename(cwd), source: 'folder', cwd };
+}
+
+/**
+ * Resolve project identity using the cascade (cached)
+ *
+ * Priority:
+ * 1. .claude-mem config file in repo root
+ * 2. Git remote origin URL (normalized)
+ * 3. Git repo root basename
+ * 4. Folder basename (fallback)
+ */
+export function resolveProjectIdentity(cwd: string): ProjectIdentity {
+  // Check cache first
+  const cached = identityCache.get(cwd);
+  if (cached) {
+    return cached;
+  }
+
+  // Resolve identity using cascade
+  const identity = resolveIdentityUncached(cwd);
+
+  // Cache the result
+  identityCache.set(cwd, identity);
+
+  logger.debug('GIT_IDENTITY', 'Resolved project identity', {
+    cwd,
+    name: identity.name,
+    source: identity.source,
+  });
+
+  return identity;
+}
+
+/**
+ * Clear the identity cache (for testing)
+ */
+export function clearIdentityCache(): void {
+  identityCache.clear();
+}

--- a/src/utils/project-name.ts
+++ b/src/utils/project-name.ts
@@ -1,10 +1,15 @@
 import path from 'path';
 import { logger } from './logger.js';
-import { detectWorktree } from './worktree.js';
+import { resolveProjectIdentity } from './git-project-identity.js';
 
 /**
  * Extract project name from working directory path
- * Handles edge cases: null/undefined cwd, drive roots, trailing slashes
+ *
+ * Uses git-aware identity cascade:
+ * 1. .claude-mem config file in repo root (explicit override)
+ * 2. Git remote origin URL (normalized)
+ * 3. Git repo root basename
+ * 4. Folder basename (fallback for non-git directories)
  *
  * @param cwd - Current working directory (absolute path)
  * @returns Project name or "unknown-project" if extraction fails
@@ -15,71 +20,34 @@ export function getProjectName(cwd: string | null | undefined): string {
     return 'unknown-project';
   }
 
-  // Extract basename (handles trailing slashes automatically)
+  return resolveProjectIdentity(cwd).name;
+}
+
+/**
+ * Get folder basename only (legacy behavior)
+ * Use this when git-aware identity is explicitly not wanted
+ *
+ * @param cwd - Current working directory (absolute path)
+ * @returns Folder basename or "unknown-project" if extraction fails
+ */
+export function getFolderBasename(cwd: string | null | undefined): string {
+  if (!cwd || cwd.trim() === '') {
+    return 'unknown-project';
+  }
+
   const basename = path.basename(cwd);
 
   // Edge case: Drive roots on Windows (C:\, J:\) or Unix root (/)
-  // path.basename('C:\') returns '' (empty string)
   if (basename === '') {
-    // Extract drive letter on Windows, or use 'root' on Unix
     const isWindows = process.platform === 'win32';
     if (isWindows) {
       const driveMatch = cwd.match(/^([A-Z]):\\/i);
       if (driveMatch) {
-        const driveLetter = driveMatch[1].toUpperCase();
-        const projectName = `drive-${driveLetter}`;
-        logger.info('PROJECT_NAME', 'Drive root detected', { cwd, projectName });
-        return projectName;
+        return `drive-${driveMatch[1].toUpperCase()}`;
       }
     }
-    logger.warn('PROJECT_NAME', 'Root directory detected, using fallback', { cwd });
     return 'unknown-project';
   }
 
   return basename;
-}
-
-/**
- * Project context with worktree awareness
- */
-export interface ProjectContext {
-  /** The current project name (worktree or main repo) */
-  primary: string;
-  /** Parent project name if in a worktree, null otherwise */
-  parent: string | null;
-  /** True if currently in a worktree */
-  isWorktree: boolean;
-  /** All projects to query: [primary] for main repo, [parent, primary] for worktree */
-  allProjects: string[];
-}
-
-/**
- * Get project context with worktree detection.
- *
- * When in a worktree, returns both the worktree project name and parent project name
- * for unified timeline queries.
- *
- * @param cwd - Current working directory (absolute path)
- * @returns ProjectContext with worktree info
- */
-export function getProjectContext(cwd: string | null | undefined): ProjectContext {
-  const primary = getProjectName(cwd);
-
-  if (!cwd) {
-    return { primary, parent: null, isWorktree: false, allProjects: [primary] };
-  }
-
-  const worktreeInfo = detectWorktree(cwd);
-
-  if (worktreeInfo.isWorktree && worktreeInfo.parentProjectName) {
-    // In a worktree: include parent first for chronological ordering
-    return {
-      primary,
-      parent: worktreeInfo.parentProjectName,
-      isWorktree: true,
-      allProjects: [worktreeInfo.parentProjectName, primary]
-    };
-  }
-
-  return { primary, parent: null, isWorktree: false, allProjects: [primary] };
 }

--- a/tests/utils/git-project-identity.test.ts
+++ b/tests/utils/git-project-identity.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import * as child_process from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  normalizeRemoteUrl,
+  resolveProjectIdentity,
+  clearIdentityCache,
+  getGitRoot,
+  getGitRemoteOrigin,
+  getConfigProjectName,
+} from '../../src/utils/git-project-identity.js';
+
+describe('git-project-identity', () => {
+  beforeEach(() => {
+    clearIdentityCache();
+  });
+
+  describe('normalizeRemoteUrl', () => {
+    it('should normalize HTTPS URLs', () => {
+      expect(normalizeRemoteUrl('https://github.com/user/repo.git')).toBe('github.com/user/repo');
+      expect(normalizeRemoteUrl('https://github.com/user/repo')).toBe('github.com/user/repo');
+    });
+
+    it('should normalize SSH URLs (git@host:path format)', () => {
+      expect(normalizeRemoteUrl('git@github.com:user/repo.git')).toBe('github.com/user/repo');
+      expect(normalizeRemoteUrl('git@github.com:user/repo')).toBe('github.com/user/repo');
+    });
+
+    it('should normalize SSH URLs (ssh:// format)', () => {
+      expect(normalizeRemoteUrl('ssh://git@github.com/user/repo.git')).toBe('github.com/user/repo');
+      expect(normalizeRemoteUrl('ssh://git@github.com/user/repo')).toBe('github.com/user/repo');
+    });
+
+    it('should handle GitLab subgroups', () => {
+      expect(normalizeRemoteUrl('https://gitlab.com/group/subgroup/repo.git')).toBe(
+        'gitlab.com/group/subgroup/repo'
+      );
+      expect(normalizeRemoteUrl('git@gitlab.com:group/subgroup/repo.git')).toBe(
+        'gitlab.com/group/subgroup/repo'
+      );
+    });
+
+    it('should handle self-hosted GitLab', () => {
+      expect(normalizeRemoteUrl('https://gitlab.company.com/team/project.git')).toBe(
+        'gitlab.company.com/team/project'
+      );
+    });
+
+    it('should handle Bitbucket URLs', () => {
+      expect(normalizeRemoteUrl('git@bitbucket.org:team/repo.git')).toBe('bitbucket.org/team/repo');
+    });
+
+    it('should strip .git suffix only once', () => {
+      expect(normalizeRemoteUrl('https://github.com/user/repo.git.git')).toBe(
+        'github.com/user/repo.git'
+      );
+    });
+
+    it('should return as-is for unrecognized formats', () => {
+      expect(normalizeRemoteUrl('file:///path/to/repo')).toBe('file:///path/to/repo');
+    });
+  });
+
+  describe('resolveProjectIdentity', () => {
+    describe('with real git repo (integration)', () => {
+      it('should resolve identity for current working directory', () => {
+        // This test runs in the claude-mem repo itself
+        const identity = resolveProjectIdentity(process.cwd());
+
+        // Should return a valid identity
+        expect(identity.name).toBeTruthy();
+        expect(identity.cwd).toBe(process.cwd());
+        expect(['config', 'remote', 'git-root', 'folder']).toContain(identity.source);
+      });
+    });
+
+    describe('cache behavior', () => {
+      it('should cache resolved identities', () => {
+        const cwd = process.cwd();
+
+        // First call
+        const identity1 = resolveProjectIdentity(cwd);
+
+        // Second call should return cached result
+        const identity2 = resolveProjectIdentity(cwd);
+
+        expect(identity1).toBe(identity2); // Same object reference
+      });
+
+      it('should clear cache with clearIdentityCache()', () => {
+        const cwd = process.cwd();
+
+        const identity1 = resolveProjectIdentity(cwd);
+        clearIdentityCache();
+        const identity2 = resolveProjectIdentity(cwd);
+
+        // Different object (not cached), but same values
+        expect(identity1).not.toBe(identity2);
+        expect(identity1.name).toBe(identity2.name);
+        expect(identity1.source).toBe(identity2.source);
+      });
+    });
+
+    describe('fallback to folder name', () => {
+      it('should use folder basename for non-git directories', () => {
+        // Use a temp directory path that definitely isn't a git repo
+        const tempPath =
+          process.platform === 'win32' ? 'C:\\Windows\\Temp\\not-a-repo' : '/tmp/not-a-repo';
+
+        const identity = resolveProjectIdentity(tempPath);
+
+        expect(identity.name).toBe('not-a-repo');
+        expect(identity.source).toBe('folder');
+      });
+
+      it('should handle Windows drive roots', () => {
+        if (process.platform !== 'win32') return;
+
+        const identity = resolveProjectIdentity('C:\\');
+
+        expect(identity.name).toBe('drive-C');
+        expect(identity.source).toBe('folder');
+      });
+    });
+  });
+
+  describe('getConfigProjectName', () => {
+    const testDir = path.join(
+      process.platform === 'win32' ? 'C:\\Temp' : '/tmp',
+      'git-identity-test-' + Date.now()
+    );
+    const configPath = path.join(testDir, '.claude-mem');
+
+    beforeEach(() => {
+      try {
+        fs.mkdirSync(testDir, { recursive: true });
+      } catch {
+        // Directory might already exist
+      }
+    });
+
+    afterEach(() => {
+      try {
+        fs.unlinkSync(configPath);
+      } catch {
+        // File might not exist
+      }
+      try {
+        fs.rmdirSync(testDir);
+      } catch {
+        // Directory might not be empty or not exist
+      }
+    });
+
+    it('should return null if config file does not exist', () => {
+      const result = getConfigProjectName(testDir);
+      expect(result).toBeNull();
+    });
+
+    it('should return projectName from valid config', () => {
+      fs.writeFileSync(configPath, JSON.stringify({ projectName: 'my-custom-project' }));
+
+      const result = getConfigProjectName(testDir);
+      expect(result).toBe('my-custom-project');
+    });
+
+    it('should trim whitespace from projectName', () => {
+      fs.writeFileSync(configPath, JSON.stringify({ projectName: '  trimmed-name  ' }));
+
+      const result = getConfigProjectName(testDir);
+      expect(result).toBe('trimmed-name');
+    });
+
+    it('should return null for empty projectName', () => {
+      fs.writeFileSync(configPath, JSON.stringify({ projectName: '' }));
+
+      const result = getConfigProjectName(testDir);
+      expect(result).toBeNull();
+    });
+
+    it('should return null for whitespace-only projectName', () => {
+      fs.writeFileSync(configPath, JSON.stringify({ projectName: '   ' }));
+
+      const result = getConfigProjectName(testDir);
+      expect(result).toBeNull();
+    });
+
+    it('should return null for invalid JSON', () => {
+      fs.writeFileSync(configPath, 'not valid json');
+
+      const result = getConfigProjectName(testDir);
+      expect(result).toBeNull();
+    });
+
+    it('should return null if projectName is not a string', () => {
+      fs.writeFileSync(configPath, JSON.stringify({ projectName: 123 }));
+
+      const result = getConfigProjectName(testDir);
+      expect(result).toBeNull();
+    });
+
+    it('should return null if projectName key is missing', () => {
+      fs.writeFileSync(configPath, JSON.stringify({ otherKey: 'value' }));
+
+      const result = getConfigProjectName(testDir);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getGitRoot', () => {
+    it('should return git root or null for current directory', () => {
+      // This test runs in the claude-mem repo (or installed plugin)
+      const root = getGitRoot(process.cwd());
+
+      // If it's a git repo, should return a path
+      // If not (e.g., installed plugin), returns null - both are valid
+      if (root) {
+        expect(typeof root).toBe('string');
+        expect(root.length).toBeGreaterThan(0);
+      } else {
+        expect(root).toBeNull();
+      }
+    });
+
+    it('should return null for non-git directory', () => {
+      const tempPath = process.platform === 'win32' ? 'C:\\Windows\\Temp' : '/tmp';
+      const root = getGitRoot(tempPath);
+
+      expect(root).toBeNull();
+    });
+  });
+
+  describe('getGitRemoteOrigin', () => {
+    it('should return remote URL or null for current repo', () => {
+      // This test runs in the claude-mem repo (or installed plugin)
+      const remote = getGitRemoteOrigin(process.cwd());
+
+      // Remote could be null if:
+      // - Not a git repo (installed plugin)
+      // - Git repo without remotes (local-only)
+      // Both are valid cases
+      if (remote) {
+        expect(typeof remote).toBe('string');
+        expect(remote.length).toBeGreaterThan(0);
+      } else {
+        expect(remote).toBeNull();
+      }
+    });
+
+    it('should return null for non-git directory', () => {
+      const tempPath = process.platform === 'win32' ? 'C:\\Windows\\Temp' : '/tmp';
+      const remote = getGitRemoteOrigin(tempPath);
+
+      expect(remote).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Projects are now identified by git repository instead of folder name
- **All worktrees of the same repo automatically share memory**
- Identity cascade: `.claude-mem` config → git remote URL → git root basename → folder name
- Added `npm run db:reset` to clear database
- Replaces incomplete `getProjectContext` approach with simpler single-ID solution

## Changes

- `src/utils/git-project-identity.ts` - new identity resolution with caching
- `src/utils/project-name.ts` - delegates to new cascade  
- `src/hooks/context-hook.ts` - uses `getProjectName` instead of removed `getProjectContext`
- `tests/utils/git-project-identity.test.ts` - 25 unit tests
- `README.md` - documented git worktree support

## Test plan

- [x] Unit tests pass (25 tests)
- [ ] Manual test with multiple worktrees
- [ ] Verify fallback works for non-git directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)