### PR TITLE
fix: generate memorySessionId for non-SDK providers

### DIFF
--- a/src/services/worker/GeminiAgent.ts
+++ b/src/services/worker/GeminiAgent.ts
@@ -145,6 +145,13 @@ export class GeminiAgent {
       session.conversationHistory.push({ role: 'user', content: initPrompt });
       const initResponse = await this.queryGeminiMultiTurn(session.conversationHistory, apiKey, model, rateLimitingEnabled);
 
+      // Gemini doesn't return session_id like Claude SDK, generate one for FK constraint
+      if (!session.memorySessionId) {
+        const syntheticId = `gemini-${session.contentSessionId}-${Date.now()}`;
+        session.memorySessionId = syntheticId;
+        this.dbManager.getSessionStore().updateMemorySessionId(session.sessionDbId, syntheticId);
+      }
+
       if (initResponse.content) {
         // Add response to conversation history
         session.conversationHistory.push({ role: 'assistant', content: initResponse.content });

--- a/src/services/worker/OpenRouterAgent.ts
+++ b/src/services/worker/OpenRouterAgent.ts
@@ -103,6 +103,13 @@ export class OpenRouterAgent {
       session.conversationHistory.push({ role: 'user', content: initPrompt });
       const initResponse = await this.queryOpenRouterMultiTurn(session.conversationHistory, apiKey, model, siteUrl, appName);
 
+      // OpenRouter doesn't return session_id like Claude SDK, generate one for FK constraint
+      if (!session.memorySessionId) {
+        const syntheticId = `openrouter-${session.contentSessionId}-${Date.now()}`;
+        session.memorySessionId = syntheticId;
+        this.dbManager.getSessionStore().updateMemorySessionId(session.sessionDbId, syntheticId);
+      }
+
       if (initResponse.content) {
         // Add response to conversation history
         session.conversationHistory.push({ role: 'assistant', content: initResponse.content });


### PR DESCRIPTION
Fixes #591

OpenRouter/Gemini agents fail because they don't receive session_id from API. Generate synthetic ID before processAgentResponse().