### PR TITLE
fix: Reset AbortController before starting generator to prevent infinite abort loop

### DIFF
--- a/src/services/worker/http/routes/SessionRoutes.ts
+++ b/src/services/worker/http/routes/SessionRoutes.ts
@@ -122,6 +122,16 @@ export class SessionRoutes extends BaseRouteHandler {
   ): void {
     if (!session) return;
 
+    // Reset AbortController if it was previously aborted
+    // This fixes the bug where a session gets stuck in an infinite "Generator aborted" loop
+    // after its AbortController was aborted (e.g., from a previous generator exit)
+    if (session.abortController.signal.aborted) {
+      logger.debug('SESSION', 'Resetting aborted AbortController before starting generator', {
+        sessionId: session.sessionDbId
+      });
+      session.abortController = new AbortController();
+    }
+
     const agent = provider === 'openrouter' ? this.openRouterAgent : (provider === 'gemini' ? this.geminiAgent : this.sdkAgent);
     const agentName = provider === 'openrouter' ? 'OpenRouter' : (provider === 'gemini' ? 'Gemini' : 'Claude SDK');
 


### PR DESCRIPTION
## Problem

Sessions can get stuck in an infinite "Generator aborted" loop, preventing any observation processing.

### Root Cause

When a generator exits with `wasAborted=true`, the cleanup in `startGeneratorWithProvider()` correctly sets:
- `generatorPromise = null` ✓
- `currentProvider = null` ✓

But it does **NOT** reset the `AbortController`, leaving `signal.aborted = true`.

When new observations arrive:
1. `ensureGeneratorRunning()` sees `generatorPromise = null`
2. Attempts to start a new generator via `startGeneratorWithProvider()`
3. New generator immediately detects `signal.aborted = true`
4. Generator exits with "Generator aborted" message
5. Loop repeats infinitely

### Reproduction

1. Start a session and process some observations
2. Abort the generator (e.g., session timeout, crash recovery)
3. Send new observations to the same session
4. Observe infinite "Generator aborted" messages in logs
5. Observations queue grows but never gets processed

## Solution

Add a check at the beginning of `startGeneratorWithProvider()` to detect if the session's AbortController signal is already aborted. If so, create a fresh AbortController instance before proceeding.

```typescript
if (session.abortController.signal.aborted) {
  logger.debug('SESSION', 'Resetting aborted AbortController before starting generator', {
    sessionId: session.sessionDbId
  });
  session.abortController = new AbortController();
}
```

This mirrors the existing crash recovery logic (line 192) but applies it universally to all generator starts.

## Testing

- [x] Verified fix resolves stuck sessions
- [x] Confirmed new generators start successfully after AbortController reset
- [x] Observation processing resumes normally

## Impact

Low risk - only affects sessions that were previously stuck. Normal session flow unchanged.