### PR TITLE
fix: honor folder CLAUDE.md toggle

### DIFF
--- a/src/services/worker/http/routes/SettingsRoutes.ts
+++ b/src/services/worker/http/routes/SettingsRoutes.ts
@@ -121,6 +121,7 @@ export class SettingsRoutes extends BaseRouteHandler {
       // Feature Toggles
       'CLAUDE_MEM_CONTEXT_SHOW_LAST_SUMMARY',
       'CLAUDE_MEM_CONTEXT_SHOW_LAST_MESSAGE',
+      'CLAUDE_MEM_FOLDER_CLAUDEMD_ENABLED',
     ];
 
     for (const key of settingKeys) {
@@ -297,6 +298,7 @@ export class SettingsRoutes extends BaseRouteHandler {
       'CLAUDE_MEM_CONTEXT_SHOW_SAVINGS_PERCENT',
       'CLAUDE_MEM_CONTEXT_SHOW_LAST_SUMMARY',
       'CLAUDE_MEM_CONTEXT_SHOW_LAST_MESSAGE',
+      'CLAUDE_MEM_FOLDER_CLAUDEMD_ENABLED',
     ];
 
     for (const key of booleanSettings) {

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -50,6 +50,7 @@ export interface SettingsDefaults {
   // Feature Toggles
   CLAUDE_MEM_CONTEXT_SHOW_LAST_SUMMARY: string;
   CLAUDE_MEM_CONTEXT_SHOW_LAST_MESSAGE: string;
+  CLAUDE_MEM_FOLDER_CLAUDEMD_ENABLED: string;
 }
 
 export class SettingsDefaultsManager {
@@ -94,6 +95,7 @@ export class SettingsDefaultsManager {
     // Feature Toggles
     CLAUDE_MEM_CONTEXT_SHOW_LAST_SUMMARY: 'true',
     CLAUDE_MEM_CONTEXT_SHOW_LAST_MESSAGE: 'false',
+    CLAUDE_MEM_FOLDER_CLAUDEMD_ENABLED: 'false',
   };
 
   /**

--- a/src/utils/claude-md-utils.ts
+++ b/src/utils/claude-md-utils.ts
@@ -262,6 +262,10 @@ export async function updateFolderClaudeMdFiles(
 ): Promise<void> {
   // Load settings to get configurable observation limit
   const settings = SettingsDefaultsManager.loadFromFile(SETTINGS_PATH);
+  if (settings.CLAUDE_MEM_FOLDER_CLAUDEMD_ENABLED !== 'true') {
+    logger.debug('FOLDER_INDEX', 'Folder CLAUDE.md generation disabled', { project });
+    return;
+  }
   const limit = parseInt(settings.CLAUDE_MEM_CONTEXT_OBSERVATIONS, 10) || 50;
 
   // Extract unique folder paths from file paths


### PR DESCRIPTION
## Summary
- add `CLAUDE_MEM_FOLDER_CLAUDEMD_ENABLED` to defaults + settings allowlist/validation
- gate folder CLAUDE.md generation unless the setting is "true"

## Context
Fixes #671

## Testing
Not run (settings + early-return change)
