### PR TITLE
fix: prevent infinite restart loop that causes runaway API costs

### DIFF
--- a/src/services/worker-types.ts
+++ b/src/services/worker-types.ts
@@ -33,6 +33,7 @@ export interface ActiveSession {
   earliestPendingTimestamp: number | null;  // Original timestamp of earliest pending message (for accurate observation timestamps)
   conversationHistory: ConversationMessage[];  // Shared conversation history for provider switching
   currentProvider: 'claude' | 'gemini' | 'openrouter' | null;  // Track which provider is currently running
+  consecutiveRestarts: number;  // Track consecutive restart attempts to prevent infinite loops
 }
 
 export interface PendingMessage {

--- a/src/services/worker/GeminiAgent.ts
+++ b/src/services/worker/GeminiAgent.ts
@@ -184,6 +184,12 @@ export class GeminiAgent {
             session.lastPromptNumber = message.prompt_number;
           }
 
+          // CRITICAL: Check memorySessionId BEFORE making expensive LLM call
+          // This prevents wasting tokens when we won't be able to store the result anyway
+          if (!session.memorySessionId) {
+            throw new Error('Cannot process observations: memorySessionId not yet captured. This session may need to be reinitialized.');
+          }
+
           // Build observation prompt
           const obsPrompt = buildObservationPrompt({
             id: 0,
@@ -221,6 +227,11 @@ export class GeminiAgent {
           );
 
         } else if (message.type === 'summarize') {
+          // CRITICAL: Check memorySessionId BEFORE making expensive LLM call
+          if (!session.memorySessionId) {
+            throw new Error('Cannot process summary: memorySessionId not yet captured. This session may need to be reinitialized.');
+          }
+
           // Build summary prompt
           const summaryPrompt = buildSummaryPrompt({
             id: session.sessionDbId,

--- a/src/services/worker/OpenRouterAgent.ts
+++ b/src/services/worker/OpenRouterAgent.ts
@@ -141,6 +141,12 @@ export class OpenRouterAgent {
             session.lastPromptNumber = message.prompt_number;
           }
 
+          // CRITICAL: Check memorySessionId BEFORE making expensive LLM call
+          // This prevents wasting tokens when we won't be able to store the result anyway
+          if (!session.memorySessionId) {
+            throw new Error('Cannot process observations: memorySessionId not yet captured. This session may need to be reinitialized.');
+          }
+
           // Build observation prompt
           const obsPrompt = buildObservationPrompt({
             id: 0,
@@ -178,6 +184,11 @@ export class OpenRouterAgent {
           );
 
         } else if (message.type === 'summarize') {
+          // CRITICAL: Check memorySessionId BEFORE making expensive LLM call
+          if (!session.memorySessionId) {
+            throw new Error('Cannot process summary: memorySessionId not yet captured. This session may need to be reinitialized.');
+          }
+
           // Build summary prompt
           const summaryPrompt = buildSummaryPrompt({
             id: session.sessionDbId,

--- a/src/services/worker/SessionManager.ts
+++ b/src/services/worker/SessionManager.ts
@@ -139,7 +139,8 @@ export class SessionManager {
       cumulativeOutputTokens: 0,
       earliestPendingTimestamp: null,
       conversationHistory: [],  // Initialize empty - will be populated by agents
-      currentProvider: null  // Will be set when generator starts
+      currentProvider: null,  // Will be set when generator starts
+      consecutiveRestarts: 0  // Track consecutive restart attempts to prevent infinite loops
     };
 
     logger.info('SESSION', 'Creating new session object', {


### PR DESCRIPTION
## Problem

When `memorySessionId` is null (due to a race condition during session initialization), the generator enters an **infinite restart loop**:

1. Generator starts → Calls LLM API ✅ (tokens charged)
2. `processAgentResponse()` → throws "memorySessionId not yet captured" ❌
3. `.finally()` sees `pendingCount > 0` → Restarts generator after 1 second
4. **Go to step 1** (NO RETRY LIMIT!)

### Real-World Impact

I experienced **$402 in wasted API costs** before my OpenRouter key limit stopped it. The logs showed:

```
[ERROR] ✗ OpenRouter agent error - Cannot store observations: memorySessionId not yet captured
[INFO ] Restarting generator after crash/exit with pending work {pendingCount=429}
```

This repeated **24,219 times** in a single day. Each restart made another LLM call that succeeded (cost tokens) but then failed to store the result.

## Solution

### 1. Add Restart Limit (Primary Fix)

```typescript
// SessionRoutes.ts
const MAX_CONSECUTIVE_RESTARTS = 3;

if (session.consecutiveRestarts > MAX_CONSECUTIVE_RESTARTS) {
  logger.error('SESSION', 'CRITICAL: Generator restart limit exceeded - stopping to prevent runaway costs');
  session.abortController.abort();
  return;
}
```

### 2. Add Exponential Backoff

```typescript
// Backoff: 1s → 2s → 4s
const backoffMs = Math.min(1000 * Math.pow(2, session.consecutiveRestarts - 1), 8000);
```

### 3. Fail Fast - Check Before LLM Call (Defensive)

```typescript
// OpenRouterAgent.ts and GeminiAgent.ts
if (!session.memorySessionId) {
  throw new Error('Cannot process observations: memorySessionId not yet captured');
}
// THEN call expensive LLM
await this.queryOpenRouterMultiTurn(...);
```

This check happens **before** the LLM call, preventing token waste.

## Files Changed

| File | Change |
|------|--------|
| `worker-types.ts` | Add `consecutiveRestarts: number` to `ActiveSession` |
| `SessionManager.ts` | Initialize `consecutiveRestarts: 0` |
| `SessionRoutes.ts` | Add restart limit (3), exponential backoff, reset on success |
| `OpenRouterAgent.ts` | Check `memorySessionId` before LLM calls |
| `GeminiAgent.ts` | Same defensive check |

## Testing

1. Build succeeds: `npm run build` ✅
2. Logic verified against original logs showing the infinite loop pattern
3. Fix preserves legitimate crash recovery for transient failures (3 retries)

## Notes

- The root cause (why `memorySessionId` isn't captured in some sessions) may still need investigation
- This fix is a **safety guardrail** to prevent catastrophic costs regardless of root cause
- Consider adding alerting/monitoring for when the restart limit is hit