### PR TITLE
feat: add folder exclude setting for CLAUDE.md generation

### DIFF
--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -50,6 +50,8 @@ export interface SettingsDefaults {
   // Feature Toggles
   CLAUDE_MEM_CONTEXT_SHOW_LAST_SUMMARY: string;
   CLAUDE_MEM_CONTEXT_SHOW_LAST_MESSAGE: string;
+  // Folder CLAUDE.md Generation
+  CLAUDE_MEM_FOLDER_MD_EXCLUDE: string;  // JSON array of folder paths to exclude from CLAUDE.md generation
 }
 
 export class SettingsDefaultsManager {
@@ -94,6 +96,8 @@ export class SettingsDefaultsManager {
     // Feature Toggles
     CLAUDE_MEM_CONTEXT_SHOW_LAST_SUMMARY: 'true',
     CLAUDE_MEM_CONTEXT_SHOW_LAST_MESSAGE: 'false',
+    // Folder CLAUDE.md Generation
+    CLAUDE_MEM_FOLDER_MD_EXCLUDE: '[]',  // Empty array by default
   };
 
   /**


### PR DESCRIPTION
## Summary
- Add `CLAUDE_MEM_FOLDER_MD_EXCLUDE` setting to exclude specific folders from CLAUDE.md generation
- Useful for SwiftUI/Xcode projects where duplicate filenames cause build conflicts

## Usage
```json
// ~/.claude-mem/settings.json
{
  "CLAUDE_MEM_FOLDER_MD_EXCLUDE": ["/path/to/swift/project"]
}
```
