### PR TITLE
Fix worker URL construction for custom hosts

### DIFF
--- a/src/cli/handlers/context.ts
+++ b/src/cli/handlers/context.ts
@@ -6,7 +6,7 @@
  */
 
 import type { EventHandler, NormalizedHookInput, HookResult } from '../types.js';
-import { ensureWorkerRunning, getWorkerPort } from '../../shared/worker-utils.js';
+import { buildWorkerUrl, ensureWorkerRunning, getWorkerPort } from '../../shared/worker-utils.js';
 import { getProjectContext } from '../../utils/project-name.js';
 
 export const contextHandler: EventHandler = {
@@ -20,7 +20,7 @@ export const contextHandler: EventHandler = {
 
     // Pass all projects (parent + worktree if applicable) for unified timeline
     const projectsParam = context.allProjects.join(',');
-    const url = `http://127.0.0.1:${port}/api/context/inject?projects=${encodeURIComponent(projectsParam)}`;
+    const url = buildWorkerUrl(`/api/context/inject?projects=${encodeURIComponent(projectsParam)}`, port);
 
     // Note: Removed AbortSignal.timeout due to Windows Bun cleanup issue (libuv assertion)
     // Worker service has its own timeouts, so client-side timeout is redundant

--- a/src/cli/handlers/file-edit.ts
+++ b/src/cli/handlers/file-edit.ts
@@ -6,7 +6,7 @@
  */
 
 import type { EventHandler, NormalizedHookInput, HookResult } from '../types.js';
-import { ensureWorkerRunning, getWorkerPort } from '../../shared/worker-utils.js';
+import { buildWorkerUrl, ensureWorkerRunning, getWorkerPort } from '../../shared/worker-utils.js';
 import { logger } from '../../utils/logger.js';
 
 export const fileEditHandler: EventHandler = {
@@ -34,7 +34,7 @@ export const fileEditHandler: EventHandler = {
 
     // Send to worker as an observation with file edit metadata
     // The observation handler on the worker will process this appropriately
-    const response = await fetch(`http://127.0.0.1:${port}/api/sessions/observations`, {
+    const response = await fetch(buildWorkerUrl('/api/sessions/observations', port), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/src/cli/handlers/observation.ts
+++ b/src/cli/handlers/observation.ts
@@ -5,7 +5,7 @@
  */
 
 import type { EventHandler, NormalizedHookInput, HookResult } from '../types.js';
-import { ensureWorkerRunning, getWorkerPort } from '../../shared/worker-utils.js';
+import { buildWorkerUrl, ensureWorkerRunning, getWorkerPort } from '../../shared/worker-utils.js';
 import { logger } from '../../utils/logger.js';
 
 export const observationHandler: EventHandler = {
@@ -33,7 +33,7 @@ export const observationHandler: EventHandler = {
     }
 
     // Send to worker - worker handles privacy check and database operations
-    const response = await fetch(`http://127.0.0.1:${port}/api/sessions/observations`, {
+    const response = await fetch(buildWorkerUrl('/api/sessions/observations', port), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/src/cli/handlers/session-init.ts
+++ b/src/cli/handlers/session-init.ts
@@ -5,7 +5,7 @@
  */
 
 import type { EventHandler, NormalizedHookInput, HookResult } from '../types.js';
-import { ensureWorkerRunning, getWorkerPort } from '../../shared/worker-utils.js';
+import { buildWorkerUrl, ensureWorkerRunning, getWorkerPort } from '../../shared/worker-utils.js';
 import { getProjectName } from '../../utils/project-name.js';
 import { logger } from '../../utils/logger.js';
 
@@ -26,7 +26,7 @@ export const sessionInitHandler: EventHandler = {
     logger.debug('HOOK', 'session-init: Calling /api/sessions/init', { contentSessionId: sessionId, project });
 
     // Initialize session via HTTP - handles DB operations and privacy checks
-    const initResponse = await fetch(`http://127.0.0.1:${port}/api/sessions/init`, {
+    const initResponse = await fetch(buildWorkerUrl('/api/sessions/init', port), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -73,7 +73,7 @@ export const sessionInitHandler: EventHandler = {
       logger.debug('HOOK', 'session-init: Calling /sessions/{sessionDbId}/init', { sessionDbId, promptNumber });
 
       // Initialize SDK agent session via HTTP (starts the agent!)
-      const response = await fetch(`http://127.0.0.1:${port}/sessions/${sessionDbId}/init`, {
+      const response = await fetch(buildWorkerUrl(`/sessions/${sessionDbId}/init`, port), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ userPrompt: cleanedPrompt, promptNumber })

--- a/src/cli/handlers/summarize.ts
+++ b/src/cli/handlers/summarize.ts
@@ -7,7 +7,7 @@
  */
 
 import type { EventHandler, NormalizedHookInput, HookResult } from '../types.js';
-import { ensureWorkerRunning, getWorkerPort } from '../../shared/worker-utils.js';
+import { buildWorkerUrl, ensureWorkerRunning, getWorkerPort } from '../../shared/worker-utils.js';
 import { logger } from '../../utils/logger.js';
 import { extractLastMessage } from '../../shared/transcript-parser.js';
 
@@ -36,7 +36,7 @@ export const summarizeHandler: EventHandler = {
     });
 
     // Send to worker - worker handles privacy check and database operations
-    const response = await fetch(`http://127.0.0.1:${port}/api/sessions/summarize`, {
+    const response = await fetch(buildWorkerUrl('/api/sessions/summarize', port), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/src/cli/handlers/user-message.ts
+++ b/src/cli/handlers/user-message.ts
@@ -7,7 +7,7 @@
 
 import { basename } from 'path';
 import type { EventHandler, NormalizedHookInput, HookResult } from '../types.js';
-import { ensureWorkerRunning, getWorkerPort } from '../../shared/worker-utils.js';
+import { buildWorkerUrl, ensureWorkerRunning, getWorkerBaseUrl, getWorkerPort } from '../../shared/worker-utils.js';
 import { HOOK_EXIT_CODES } from '../../shared/hook-constants.js';
 
 export const userMessageHandler: EventHandler = {
@@ -21,7 +21,7 @@ export const userMessageHandler: EventHandler = {
     // Fetch formatted context directly from worker API
     // Note: Removed AbortSignal.timeout to avoid Windows Bun cleanup issue (libuv assertion)
     const response = await fetch(
-      `http://127.0.0.1:${port}/api/context/inject?project=${encodeURIComponent(project)}&colors=true`,
+      buildWorkerUrl(`/api/context/inject?project=${encodeURIComponent(project)}&colors=true`, port),
       { method: 'GET' }
     );
 
@@ -38,7 +38,7 @@ export const userMessageHandler: EventHandler = {
       output +
       "\n\n" + String.fromCodePoint(0x1F4A1) + " New! Wrap all or part of any message with <private> ... </private> to prevent storing sensitive information in your observation history.\n" +
       "\n" + String.fromCodePoint(0x1F4AC) + " Community https://discord.gg/J4wttp9vDu" +
-      `\n` + String.fromCodePoint(0x1F4FA) + ` Watch live in browser http://localhost:${port}/\n`
+      `\n` + String.fromCodePoint(0x1F4FA) + ` Watch live in browser ${getWorkerBaseUrl(port)}/\n`
     );
 
     return { exitCode: HOOK_EXIT_CODES.USER_MESSAGE_ONLY };

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -27,14 +27,15 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { getWorkerPort, getWorkerHost } from '../shared/worker-utils.js';
+import { getWorkerBaseUrl } from '../shared/worker-utils.js';
+import { fetchWithTimeout } from '../shared/http.js';
+import { HOOK_TIMEOUTS, getTimeout } from '../shared/hook-constants.js';
 
 /**
  * Worker HTTP API configuration
  */
-const WORKER_PORT = getWorkerPort();
-const WORKER_HOST = getWorkerHost();
-const WORKER_BASE_URL = `http://${WORKER_HOST}:${WORKER_PORT}`;
+const WORKER_BASE_URL = getWorkerBaseUrl();
+const HEALTH_REQUEST_TIMEOUT_MS = getTimeout(HOOK_TIMEOUTS.HEALTH_REQUEST);
 
 /**
  * Map tool names to Worker HTTP endpoints
@@ -141,7 +142,11 @@ async function callWorkerAPIPost(
  */
 async function verifyWorkerConnection(): Promise<boolean> {
   try {
-    const response = await fetch(`${WORKER_BASE_URL}/api/health`);
+    const response = await fetchWithTimeout(
+      `${WORKER_BASE_URL}/api/health`,
+      {},
+      HEALTH_REQUEST_TIMEOUT_MS
+    );
     return response.ok;
   } catch (error) {
     // Expected during worker startup or if worker is down

--- a/src/services/worker/http/routes/SettingsRoutes.ts
+++ b/src/services/worker/http/routes/SettingsRoutes.ts
@@ -267,9 +267,9 @@ export class SettingsRoutes extends BaseRouteHandler {
     if (settings.CLAUDE_MEM_WORKER_HOST) {
       const host = settings.CLAUDE_MEM_WORKER_HOST;
       // Allow localhost variants and valid IP patterns
-      const validHostPattern = /^(127\.0\.0\.1|0\.0\.0\.0|localhost|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/;
+      const validHostPattern = /^(127\.0\.0\.1|0\.0\.0\.0|localhost|::1|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/;
       if (!validHostPattern.test(host)) {
-        return { valid: false, error: 'CLAUDE_MEM_WORKER_HOST must be a valid IP address (e.g., 127.0.0.1, 0.0.0.0)' };
+        return { valid: false, error: 'CLAUDE_MEM_WORKER_HOST must be a valid host (e.g., 127.0.0.1, 0.0.0.0, ::1, localhost)' };
       }
     }
 

--- a/src/shared/hook-constants.ts
+++ b/src/shared/hook-constants.ts
@@ -1,6 +1,7 @@
 export const HOOK_TIMEOUTS = {
   DEFAULT: 300000,            // Standard HTTP timeout (5 min for slow systems)
   HEALTH_CHECK: 30000,        // Worker health check (30s for slow systems)
+  HEALTH_REQUEST: 2000,       // Per-request timeout for local health/readiness checks
   WORKER_STARTUP_WAIT: 1000,
   WORKER_STARTUP_RETRIES: 300,
   PRE_RESTART_SETTLE_DELAY: 2000,  // Give files time to sync before restart

--- a/src/shared/http.ts
+++ b/src/shared/http.ts
@@ -1,0 +1,53 @@
+/**
+ * HTTP utilities with safe timeouts for local worker requests.
+ *
+ * Windows: avoid AbortController-based timeouts due to Bun cleanup issues.
+ * Non-Windows: abort the request to prevent hung sockets.
+ */
+
+function fetchWithTimeoutNoAbort(
+  url: string,
+  options: RequestInit,
+  timeoutMs: number
+): Promise<Response> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Request timed out after ${timeoutMs}ms: ${url}`));
+    }, timeoutMs);
+
+    fetch(url, options).then(
+      (response) => {
+        clearTimeout(timer);
+        resolve(response);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+}
+
+export async function fetchWithTimeout(
+  url: string,
+  options: RequestInit = {},
+  timeoutMs: number
+): Promise<Response> {
+  if (!timeoutMs || timeoutMs <= 0) {
+    return fetch(url, options);
+  }
+
+  const isWindows = process.platform === 'win32';
+  if (isWindows || options.signal) {
+    return fetchWithTimeoutNoAbort(url, options, timeoutMs);
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}


### PR DESCRIPTION
## Summary
- honor `CLAUDE_MEM_WORKER_HOST` everywhere worker URLs are built (IPv6-safe `::1` bracket handling)
- add short per-request timeouts for local health/readiness checks to avoid hangs
- allow `::1` in settings validation and update viewer URL output

## Details
- new `buildWorkerUrl`/`getWorkerBaseUrl` helpers centralize host+port formatting
- new `fetchWithTimeout` helper for health/readiness checks (no Abort on Windows)
- update CLI handlers, MCP server, Cursor hooks installer, and `HealthMonitor` to use the helpers
- tests updated to use the new URL helper

## Testing
- `bun test tests/infrastructure/health-monitor.test.ts`

Closes #725
