### PR TITLE
fix: gracefully handle empty prompts in session-init hook

### DIFF
--- a/src/cli/handlers/session-init.ts
+++ b/src/cli/handlers/session-init.ts
@@ -16,8 +16,9 @@ export const sessionInitHandler: EventHandler = {
 
     const { sessionId, cwd, prompt } = input;
 
-    if (!prompt) {
-      throw new Error('sessionInitHandler requires prompt');
+    // Gracefully handle empty prompts (user submitted blank input)
+    if (!prompt || !prompt.trim()) {
+      return { continue: true, suppressOutput: true };
     }
 
     const project = getProjectName(cwd);


### PR DESCRIPTION
## Summary

- Fix UserPromptSubmit hook blocking when user submits empty/whitespace-only prompt
- Return early with `{ continue: true }` instead of throwing error

## Problem

When a user submits an empty prompt (or whitespace-only) to Claude Code, the session-init handler throws:

```
UserPromptSubmit operation blocked by hook:
Hook error: Error: sessionInitHandler requires prompt
```

This blocks the entire operation instead of gracefully continuing.

## Solution

Changed the prompt validation from throwing an error to returning early:

```typescript
// Before (blocking)
if (!prompt) {
  throw new Error('sessionInitHandler requires prompt');
}

// After (graceful)
if (!prompt || !prompt.trim()) {
  return { continue: true, suppressOutput: true };
}
```

## Test plan

- [ ] Submit empty prompt in Claude Code - should not throw error
- [ ] Submit whitespace-only prompt - should not throw error
- [ ] Submit normal prompt - should initialize session as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)