### PR TITLE
fix: add PRAGMA foreign_keys to cleanup-duplicates.ts

### DIFF
--- a/scripts/cleanup-duplicates.ts
+++ b/scripts/cleanup-duplicates.ts
@@ -80,6 +80,11 @@ function main() {
     ? new Database(DB_PATH, { readonly: true })
     : new Database(DB_PATH);
 
+  // Enable foreign keys for CASCADE DELETE to work (Issue #716)
+  if (!dryRun) {
+    db.run('PRAGMA foreign_keys = ON');
+  }
+
   // Get total observation count
   const totalCount = db.prepare('SELECT COUNT(*) as count FROM observations').get() as { count: number };
   console.log(`Total observations in database: ${totalCount.count}`);


### PR DESCRIPTION
## Summary

The `scripts/cleanup-duplicates.ts` script was missing `PRAGMA foreign_keys = ON` after creating the database connection. This caused CASCADE DELETE to not trigger when deleting duplicate observations, leaving orphan records in `observation_files` and `observation_concepts` tables.

## Root Cause

SQLite defaults to `foreign_keys = OFF`. Without explicitly enabling it, the `ON DELETE CASCADE` constraints don't fire, leaving orphaned child records.

## Changes

Added `PRAGMA foreign_keys = ON` after database connection (only in write mode, not dry-run):

```typescript
if (!dryRun) {
  db.run('PRAGMA foreign_keys = ON');
}
```

## Impact

Users who ran the cleanup script previously may have orphaned records causing "FOREIGN KEY constraint failed" errors. They can clean these manually:

```sql
DELETE FROM observation_files WHERE observation_id NOT IN (SELECT id FROM observations);
DELETE FROM observation_concepts WHERE observation_id NOT IN (SELECT id FROM observations);
```

## Test plan

- [x] Build succeeds
- [ ] Run cleanup script in dry-run mode
- [ ] Run cleanup script in execute mode, verify no orphan records remain

Fixes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)