### PR TITLE
fix: isolate observer sessions to prevent polluting claude --resume list

### DIFF
--- a/src/shared/paths.ts
+++ b/src/shared/paths.ts
@@ -38,6 +38,10 @@ export const USER_SETTINGS_PATH = join(DATA_DIR, 'settings.json');
 export const DB_PATH = join(DATA_DIR, 'claude-mem.db');
 export const VECTOR_DB_DIR = join(DATA_DIR, 'vector-db');
 
+// Isolated config directory for observer sessions (Issue #832)
+// This prevents observer sessions from appearing in `claude --resume` list
+export const OBSERVER_CONFIG_DIR = join(DATA_DIR, 'observer-config');
+
 // Claude integration paths
 export const CLAUDE_SETTINGS_PATH = join(CLAUDE_CONFIG_DIR, 'settings.json');
 export const CLAUDE_COMMANDS_DIR = join(CLAUDE_CONFIG_DIR, 'commands');


### PR DESCRIPTION
## Summary

Observer sessions created by claude-mem were appearing in the main Claude Code session picker (`claude --resume`), cluttering the list with internal plugin sessions that users never intend to resume.

**Impact:** In one user's case, 74 observer sessions out of ~220 total sessions (34% noise).

## Root Cause

The SDK agent spawns Claude subprocesses using the default `CLAUDE_CONFIG_DIR` (`~/.claude/`), causing observer session files to be stored alongside user sessions in `~/.claude/projects/*/`.

## Solution

Inject `CLAUDE_CONFIG_DIR=~/.claude-mem/observer-config/` when spawning observer processes via `createPidCapturingSpawn()`.

### Changes

1. **`src/shared/paths.ts`**: Added `OBSERVER_CONFIG_DIR` constant
2. **`src/services/worker/ProcessRegistry.ts`**: Modified spawn to inject isolated config dir

### Result

| Before | After |
|--------|-------|
| Observer sessions in `~/.claude/projects/*/` | Observer sessions in `~/.claude-mem/observer-config/projects/*/` |
| Mixed with user sessions in `claude --resume` | Completely isolated from user sessions |
| 34% noise in resume picker | 0% noise |

## Test plan

- [x] Build succeeds
- [ ] Start session with claude provider, verify observer sessions don't appear in `claude --resume`
- [ ] Verify observer sessions are created in `~/.claude-mem/observer-config/`
- [ ] Verify user sessions still work normally

Fixes #832

🤖 Generated with [Claude Code](https://claude.com/claude-code)