### PR TITLE
fix: handle missing assistant messages gracefully in transcript parser

### DIFF
--- a/src/shared/transcript-parser.ts
+++ b/src/shared/transcript-parser.ts
@@ -58,7 +58,7 @@ export function extractLastMessage(
 
   // If we searched the whole transcript and didn't find any message of this role
   if (!foundMatchingRole) {
-    throw new Error(`No message found for role '${role}' in transcript: ${transcriptPath}`);
+    return '';
   }
 
   return '';


### PR DESCRIPTION
## Summary
- Fix crash when user exits Claude Code before any assistant response is generated
- Return empty string instead of throwing error in `extractLastMessage()` when no message of requested role is found
- Consistent with existing behavior (function already returns `''` in other edge cases)

## Problem
When the summarize Stop hook runs on sessions without assistant messages, it crashes with:
```
[bun ".../worker-service.cjs" hook claude-code summarize]: Hook error:
Error: No message found for role 'assistant' in transcript: .../session.jsonl
```

This happens when:
- User exits before Claude responds (Ctrl+C early)
- Very short sessions with only user/tool interactions

## Solution
Changed `extractLastMessage()` to return `''` instead of throwing when no message is found. The summarize handler already handles empty strings gracefully (logs `hasLastAssistantMessage: false` and continues).

## Test plan
- [ ] Start a new Claude Code session
- [ ] Exit immediately (Ctrl+C before any assistant response)
- [ ] Verify no error message appears
- [ ] Start another session with normal conversation, exit, verify summarization still works

🤖 Generated with [Claude Code](https://claude.ai/code)