### PR TITLE
fix: auto-install bun when not found in PATH

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -12,17 +12,17 @@
           },
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" hook claude-code context",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" hook claude-code context",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" hook claude-code user-message",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" hook claude-code user-message",
             "timeout": 60
           }
         ]
@@ -33,12 +33,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" hook claude-code session-init",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" hook claude-code session-init",
             "timeout": 60
           }
         ]
@@ -50,12 +50,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" hook claude-code observation",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" hook claude-code observation",
             "timeout": 120
           }
         ]
@@ -66,12 +66,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" hook claude-code summarize",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.sh\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" hook claude-code summarize",
             "timeout": 120
           }
         ]

--- a/plugin/scripts/bun-runner.sh
+++ b/plugin/scripts/bun-runner.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Bun runner script - finds and runs bun even if not in PATH
+# This handles the case where bun was just installed but PATH isn't updated yet
+
+# Try bun in PATH first
+if command -v bun &> /dev/null; then
+    exec bun "$@"
+fi
+
+# Check common installation paths
+BUN_PATHS=(
+    "$HOME/.bun/bin/bun"
+    "/usr/local/bin/bun"
+    "/opt/homebrew/bin/bun"
+)
+
+for BUN_PATH in "${BUN_PATHS[@]}"; do
+    if [ -x "$BUN_PATH" ]; then
+        exec "$BUN_PATH" "$@"
+    fi
+done
+
+# Bun not found - try to install it
+echo "🔧 Bun not found. Installing..." >&2
+curl -fsSL https://bun.sh/install | bash >&2
+
+# Try again after installation
+if [ -x "$HOME/.bun/bin/bun" ]; then
+    exec "$HOME/.bun/bin/bun" "$@"
+fi
+
+echo "❌ Failed to find or install bun. Please install manually: curl -fsSL https://bun.sh/install | bash" >&2
+exit 1


### PR DESCRIPTION
## Summary
- Adds `bun-runner.sh` wrapper script that finds bun even when not in PATH
- Updates all hooks to use the wrapper instead of calling `bun` directly
- Auto-installs bun if not found anywhere

## Problem
Users who don't have bun installed get errors like `bun: command not found` when the plugin hooks run. Even though `smart-install.js` installs bun, the PATH isn't updated until terminal restart, causing all subsequent hooks to fail.

## Solution
The new `bun-runner.sh` wrapper:
1. Tries `bun` in PATH first
2. Falls back to common installation paths (`~/.bun/bin/bun`, `/usr/local/bin/bun`, `/opt/homebrew/bin/bun`)
3. Auto-installs bun via curl if not found anywhere
4. Executes the command with the found/installed bun

## Test plan
- [ ] Test on fresh macOS system without bun installed
- [ ] Test on system with bun installed but not in PATH
- [ ] Test on system with bun in PATH (no change in behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)