### PR TITLE
fix: remove user-message hook from SessionStart to prevent startup error

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -19,11 +19,6 @@
             "type": "command",
             "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" hook claude-code context",
             "timeout": 60
-          },
-          {
-            "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" hook claude-code user-message",
-            "timeout": 60
           }
         ]
       }


### PR DESCRIPTION
## Summary

Removes the `user-message` hook from SessionStart hooks to fix the "SessionStart:startup hook error" message that appears on every Claude Code session start.

## Problem

The `user-message` hook handler exits with code 3 (`USER_MESSAGE_ONLY`) which is intentional for terminal-only output, but Claude Code interprets any non-zero exit code as a failure and displays an error message.

**Exit code definitions in the codebase:**
```javascript
var d = {
  SUCCESS: 0,        // Hook ran successfully
  FAILURE: 1,        // Hook failed with error  
  USER_MESSAGE_ONLY: 3  // Output to terminal only, don't inject
};
```

## Solution

Remove the `user-message` hook from SessionStart because:
1. The `context` hook already handles injecting context into the conversation (exits 0)
2. The `user-message` hook's terminal output is redundant for SessionStart since the context is already displayed
3. This aligns with the existing fix in the `bugfix/exit-code-fix` branch

## Testing

- Before: "SessionStart:startup hook error" appears on every session start
- After: No error message, context injection still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)