### PR TITLE
docs: add windows note for npm not recongnized error

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,6 @@ If you see an error likes:
 
 ```powershell
 npm : The term 'npm' is not recognized as the name of a cmdlet
-This means Node.js is not installed or not available in your PATH.
 
 ```powershell
 


### PR DESCRIPTION
Adds a short Windows setup note explaining how to resolve
'npm is not recognized' errors during development setup.
