### PR TITLE
docs: add Windows setup note for npm not recognized error

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,17 @@ See **[Beta Features Documentation](https://docs.claude-mem.ai/beta-features)** 
 - **SQLite 3**: For persistent storage (bundled)
 
 ---
+### Windows Setup Notes
+
+If you see an error like:
+
+```powershell
+npm : The term 'npm' is not recognized as the name of a cmdlet
+```
+
+Make sure Node.js and npm are installed and added to your PATH. Download the latest Node.js installer from https://nodejs.org and restart your terminal after installation.
+
+---
 
 ## Configuration
 


### PR DESCRIPTION
Fixes #908

This PR adds a Windows setup note to the README.md, explaining how to resolve the "npm is not recognized as the name of a cmdlet" error during development setup. The note guides users to install Node.js and ensure npm is added to their PATH.
