### PR TITLE
Fix: Allow image-only prompts in session-init handler

### DIFF
--- a/src/cli/handlers/session-init.ts
+++ b/src/cli/handlers/session-init.ts
@@ -14,11 +14,10 @@ export const sessionInitHandler: EventHandler = {
     // Ensure worker is running before any other logic
     await ensureWorkerRunning();
 
-    const { sessionId, cwd, prompt } = input;
+    const { sessionId, cwd, prompt: rawPrompt } = input;
 
-    if (!prompt) {
-      throw new Error('sessionInitHandler requires prompt');
-    }
+    // Handle image-only prompts (where text prompt is empty/undefined)
+    const prompt = rawPrompt || '[media prompt]';
 
     const project = getProjectName(cwd);
     const port = getWorkerPort();


### PR DESCRIPTION
## Summary
- When users submit prompts containing only images (no text), the `prompt` field is empty/undefined
- The session-init handler was throwing an error instead of handling this gracefully
- This PR uses a placeholder `[media prompt]` to allow sessions to initialize normally

## Test plan
- [ ] Submit an image-only prompt (no text)
- [ ] Verify session initializes without error
- [ ] Verify memory tracking still works for the session

Fixes #927