### PR TITLE
Prevent CLAUDE.md generation in Android res/ and other unsafe directories

### DIFF
--- a/src/utils/claude-md-utils.ts
+++ b/src/utils/claude-md-utils.ts
@@ -240,6 +240,27 @@ export function formatTimelineForClaudeMd(timelineText: string): string {
 }
 
 /**
+ * Built-in directory names where CLAUDE.md generation is unsafe or undesirable.
+ * e.g. Android res/ is compiler-strict (non-XML breaks build); .git, build, node_modules are tooling-owned.
+ */
+const EXCLUDED_UNSAFE_DIRECTORIES = new Set([
+  'res',
+  '.git',
+  'build',
+  'node_modules',
+  '__pycache__'
+]);
+
+/**
+ * Returns true if folder path contains any excluded segment (e.g. .../res/..., .../node_modules/...).
+ */
+function isExcludedUnsafeDirectory(folderPath: string): boolean {
+  const normalized = path.normalize(folderPath);
+  const segments = normalized.split(path.sep);
+  return segments.some(seg => EXCLUDED_UNSAFE_DIRECTORIES.has(seg));
+}
+
+/**
  * Check if a folder is a project root (contains .git directory).
  * Project root CLAUDE.md files should remain user-managed, not auto-updated.
  */
@@ -291,6 +312,11 @@ export async function updateFolderClaudeMdFiles(
       // Skip project root - root CLAUDE.md should remain user-managed
       if (isProjectRoot(folderPath)) {
         logger.debug('FOLDER_INDEX', 'Skipping project root CLAUDE.md', { folderPath });
+        continue;
+      }
+      // Skip known-unsafe directories (e.g. Android res/, .git, build, node_modules)
+      if (isExcludedUnsafeDirectory(folderPath)) {
+        logger.debug('FOLDER_INDEX', 'Skipping unsafe directory for CLAUDE.md', { folderPath });
         continue;
       }
       folderPaths.add(folderPath);


### PR DESCRIPTION
## Summary

This PR prevents folder-level `CLAUDE.md` generation in directories that
are known to break toolchains, including Android `res/` folders.

## Details

Android's resource compiler (`aapt2`) treats all files under `res/`
as resources, and the presence of a Markdown file causes build failures.

This change adds a small built-in exclusion list for directories where
`CLAUDE.md` generation is unsafe or undesirable, including:

- `res/`
- `.git/`
- `build/`
- `node_modules/`
- `__pycache__/`

This avoids breaking builds while preserving folder-level context
generation elsewhere.

## Related Issues

Closes #912
