### PR TITLE
fix: prevent duplicate generator spawns in handleSessionInit

### DIFF
--- a/src/services/worker/http/routes/SessionRoutes.ts
+++ b/src/services/worker/http/routes/SessionRoutes.ts
@@ -291,8 +291,8 @@ export class SessionRoutes extends BaseRouteHandler {
       });
     }
 
-    // Start agent in background using the helper method
-    this.startGeneratorWithProvider(session, this.getSelectedProvider(), 'init');
+    // Idempotent: ensure generator is running (matches handleObservations / handleSummarize)
+    this.ensureGeneratorRunning(sessionDbId, 'init');
 
     // Broadcast session started event
     this.eventBroadcaster.broadcastSessionStarted(sessionDbId, session.project);


### PR DESCRIPTION
## Summary

This PR fixes a bug where `handleSessionInit` unconditionally spawned a new
generator on every `UserPromptSubmit`, leading to multiple generators per
session.

## Details

Previously, `handleSessionInit` called `startGeneratorWithProvider()` on every
prompt, even when a generator was already running. This caused generator
duplication, fragmented observation history, and unbounded process/memory
growth.

This change switches `handleSessionInit` to use the existing idempotent helper
`ensureGeneratorRunning()`, matching the behavior already used in
`handleObservations`.

## Impact

- Prevents multiple generators from being spawned per session
- Avoids competing generators and partial history
- Eliminates a major source of memory/process leaks

## Related Issue

Closes #915
