### PR TITLE
fix: terminate session on prompt-too-long instead of retrying indefinitely

### DIFF
--- a/src/services/worker/SDKAgent.ts
+++ b/src/services/worker/SDKAgent.ts
@@ -200,6 +200,11 @@ export class SDKAgent {
           }, truncatedResponse);
         }
 
+        // Detect fatal context overflow and terminate gracefully (issue #870)
+        if (typeof textContent === 'string' && textContent.includes('Prompt is too long')) {
+          throw new Error('Claude session context overflow: prompt is too long');
+        }
+
         // Parse and process response using shared ResponseProcessor
         await processAgentResponse(
           textContent,


### PR DESCRIPTION
## Summary

This PR fixes an infinite retry loop that occurs when Claude returns
“Prompt is too long” due to excessive context size.

## Details

Previously, the worker treated the “Prompt is too long” response as a
successful SDK response and continued processing, resulting in an
infinite retry loop with runaway CPU usage.

This change detects the context overflow response and treats it as a
fatal error, allowing the session to terminate and clean up gracefully.

## Impact

- Prevents infinite CPU loops
- Avoids runaway claude processes
- Handles context overflow as a terminal condition

## Related Issue

Closes #870
