### PR TITLE
fix: Backfill project field on SDK session creation

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -1165,7 +1165,7 @@ export class SessionStore {
     const now = new Date();
     const nowEpoch = now.getTime();
 
-    // Pure INSERT OR IGNORE - no updates, no complexity
+    // INSERT OR IGNORE to create session, then backfill project if it was created empty
     // NOTE: memory_session_id starts as NULL. It is captured by SDKAgent from the first SDK
     // response and stored via updateMemorySessionId(). CRITICAL: memory_session_id must NEVER
     // equal contentSessionId - that would inject memory messages into the user's transcript!
@@ -1174,6 +1174,14 @@ export class SessionStore {
       (content_session_id, memory_session_id, project, user_prompt, started_at, started_at_epoch, status)
       VALUES (?, NULL, ?, ?, ?, ?, 'active')
     `).run(contentSessionId, project, userPrompt, now.toISOString(), nowEpoch);
+
+    // Backfill project if session was created by another hook with empty project
+    if (project) {
+      this.db.prepare(`
+        UPDATE sdk_sessions SET project = ?
+        WHERE content_session_id = ? AND (project IS NULL OR project = '')
+      `).run(project, contentSessionId);
+    }
 
     // Return existing or new ID
     const row = this.db.prepare('SELECT id FROM sdk_sessions WHERE content_session_id = ?')

--- a/src/services/sqlite/sessions/create.ts
+++ b/src/services/sqlite/sessions/create.ts
@@ -30,7 +30,7 @@ export function createSDKSession(
   const now = new Date();
   const nowEpoch = now.getTime();
 
-  // Pure INSERT OR IGNORE - no updates, no complexity
+  // INSERT OR IGNORE to create session, then backfill project if it was created empty
   // NOTE: memory_session_id starts as NULL. It is captured by SDKAgent from the first SDK
   // response and stored via updateMemorySessionId(). CRITICAL: memory_session_id must NEVER
   // equal contentSessionId - that would inject memory messages into the user's transcript!
@@ -39,6 +39,14 @@ export function createSDKSession(
     (content_session_id, memory_session_id, project, user_prompt, started_at, started_at_epoch, status)
     VALUES (?, NULL, ?, ?, ?, ?, 'active')
   `).run(contentSessionId, project, userPrompt, now.toISOString(), nowEpoch);
+
+  // Backfill project if session was created by another hook with empty project
+  if (project) {
+    db.prepare(`
+      UPDATE sdk_sessions SET project = ?
+      WHERE content_session_id = ? AND (project IS NULL OR project = '')
+    `).run(project, contentSessionId);
+  }
 
   // Return existing or new ID
   const row = db.prepare('SELECT id FROM sdk_sessions WHERE content_session_id = ?')


### PR DESCRIPTION
## Summary
- Fixes race condition where `PostToolUse` hook creates the SDK session with an empty project before `UserPromptSubmit`'s session-init sets it
- Adds a backfill `UPDATE` after `INSERT OR IGNORE` in `createSDKSession` to set the project when a later hook provides it
- Applied in both `sessions/create.ts` (functional) and `SessionStore.ts` (class method)

## Test plan
- [ ] Start a new Claude Code conversation in a project directory
- [ ] Use any tool to trigger PostToolUse
- [ ] Verify `sdk_sessions.project` is populated after session-init fires
- [ ] Verify existing sessions with a project set are not overwritten

Closes #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)