### PR TITLE
Fix formatting in README for plugin commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@
 Start a new Claude Code session in the terminal and enter the following commands:
 
 ```
-> /plugin marketplace add thedotmack/claude-mem
+/plugin marketplace add thedotmack/claude-mem
 
-> /plugin install claude-mem
+/plugin install claude-mem
 ```
 
 Restart Claude Code. Context from previous sessions will automatically appear in new sessions.


### PR DESCRIPTION
The ">" character prevent the command to run