### PR TITLE
fix: update bug and feature request templates to include duplicate check

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,12 @@ assignees: ''
 
 ---
 
+## Before submitting
+
+- [ ] I searched [existing issues](https://github.com/thedotmack/claude-mem/issues) and confirmed this is not a duplicate
+
+---
+
 ## ⚡ Quick Bug Report (Recommended)
 
 **Use the automated bug report generator** for comprehensive diagnostics:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,12 @@ assignees: ''
 
 ---
 
+## Before submitting
+
+- [ ] I searched [existing issues](https://github.com/thedotmack/claude-mem/issues) and confirmed this is not a duplicate
+
+---
+
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ src/ui/viewer.html
 # Prevent other malformed path directories
 http*/
 https*/
+
+# Ignore WebStorm project files (for dinosaur IDE users)
+.idea/


### PR DESCRIPTION
 ## Summary

  - Add "I searched existing issues and confirmed this is not a duplicate" checkbox to bug report and feature request issue templates

  ## Motivation

  The `CLAUDE_MEM_FOLDER_CLAUDEMD_ENABLED` bug currently has [20+ duplicate issues](https://github.com/thedotmack/claude-mem/issues/760) and [7 competing
  fix PRs](https://github.com/thedotmack/claude-mem/pull/589) (0 merged). This creates noise for maintainers and slows down actual bug fixing.

  Adding a duplicate check to the templates is a standard practice in large OSS projects (React, Next.js, VS Code) and helps contributors pause and search
  before filing.

  ## Changes

  - **`.github/ISSUE_TEMPLATE/bug_report.md`** — added duplicate check checkbox
  - **`.github/ISSUE_TEMPLATE/feature_request.md`** — added duplicate check checkbox
