### PR TITLE
Fix Windows path handling for usernames with spaces

### DIFF
--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -72,9 +72,11 @@ if (!bunPath) {
 
 // Spawn Bun with the provided script and args
 // Use spawn (not spawnSync) to properly handle stdio
+// Note: Don't use shell mode on Windows - it breaks paths with spaces in usernames
+// Use windowsHide to prevent a visible console window from spawning on Windows
 const child = spawn(bunPath, args, {
   stdio: 'inherit',
-  shell: IS_WINDOWS,
+  windowsHide: true,
   env: process.env
 });
 


### PR DESCRIPTION
## Summary
- On Windows, `bun-runner.js` fails when the OS username contains spaces (e.g., `C:\Users\Tafari Higgs\...`)
- The `shell: IS_WINDOWS` option in `spawn()` causes cmd.exe to misinterpret the path at the first space, producing: `Syntax Error at C:\Users\Tafari:1:2`
- Fix: remove `shell: true` on Windows since `spawn()` can invoke the Bun binary directly without a shell wrapper

## Root Cause
In `plugin/scripts/bun-runner.js` line 75, `shell: IS_WINDOWS` was set to `true` on Windows. This caused `child_process.spawn()` to route through `cmd.exe`, which splits the path at the space in the username directory and then misinterprets the drive letter colon as a syntax error.

## Test plan
- [x] Tested on Windows 11 with username containing a space ("Tafari Higgs")
- [x] Confirmed the `Syntax Error at C:\Users\Tafari:1:2` error is resolved
- [x] Confirmed bun-runner successfully spawns Bun and runs the worker script

🤖 Generated with [Claude Code](https://claude.com/claude-code)