### PR TITLE
fix: FK constraint violations in GeminiAgent, OpenRouterAgent, and ResponseProcessor

### DIFF
--- a/src/services/worker/GeminiAgent.ts
+++ b/src/services/worker/GeminiAgent.ts
@@ -138,8 +138,17 @@ export class GeminiAgent {
       if (!session.memorySessionId) {
         const syntheticMemorySessionId = `gemini-${session.contentSessionId}-${Date.now()}`;
         session.memorySessionId = syntheticMemorySessionId;
-        this.dbManager.getSessionStore().updateMemorySessionId(session.sessionDbId, syntheticMemorySessionId);
-        logger.info('SESSION', `MEMORY_ID_GENERATED | sessionDbId=${session.sessionDbId} | provider=Gemini`);
+
+        // FK_INTEGRITY: Only update database if it doesn't already have a memory_session_id.
+        // After worker restart, existing observations reference the old value. Updating the
+        // parent sdk_sessions.memory_session_id would violate FK constraint (no ON UPDATE CASCADE).
+        const existingDbSession = this.dbManager.getSessionStore().getSessionById(session.sessionDbId);
+        if (!existingDbSession?.memory_session_id) {
+          this.dbManager.getSessionStore().updateMemorySessionId(session.sessionDbId, syntheticMemorySessionId);
+          logger.info('SESSION', `MEMORY_ID_GENERATED | sessionDbId=${session.sessionDbId} | provider=Gemini | persisted=true`);
+        } else {
+          logger.info('SESSION', `MEMORY_ID_GENERATED (in-memory only) | sessionDbId=${session.sessionDbId} | provider=Gemini | dbValue=${existingDbSession.memory_session_id} | reason=FK_INTEGRITY`);
+        }
       }
 
       // Load active mode


### PR DESCRIPTION
## Summary

- **GeminiAgent** and **OpenRouterAgent** unconditionally call `updateMemorySessionId()` after worker restart, which fails because existing observations reference the old `memory_session_id` via FK constraint (no `ON UPDATE CASCADE`)
- **ResponseProcessor** uses the in-memory synthetic `memorySessionId` for observation storage instead of the database's authoritative value, causing INSERT FK violations
- All generators crash-loop until restart limit is reached, stopping all message processing entirely

## Root Cause

The FK_INTEGRITY pattern from SDKAgent (introduced in Issue #817 fix) was not applied to GeminiAgent, OpenRouterAgent, or ResponseProcessor. After worker restart:

1. `SessionManager.initializeSession()` sets `memorySessionId = null` in memory (correct)
2. GeminiAgent/OpenRouterAgent see null → generate new synthetic ID → call `updateMemorySessionId()`
3. SQLite rejects the UPDATE because child rows in `observations` reference the old parent value
4. Even if the UPDATE were skipped, ResponseProcessor would try to INSERT observations with the new synthetic ID that doesn't exist in `sdk_sessions`

## Changes

| File | Fix |
|------|-----|
| `GeminiAgent.ts` | Check DB before `updateMemorySessionId()`; skip if value exists (keep new ID in-memory only) |
| `OpenRouterAgent.ts` | Same fix as GeminiAgent |
| `ResponseProcessor.ts` | Read DB's `memory_session_id` as authoritative value for storage; only use in-memory value when DB is NULL |

## Test plan

- [x] Verified with 3 active sessions (56, 7487, 4099) that were all stuck with FK errors
- [x] After deploying fix, all sessions resumed processing immediately
- [x] Session 56 correctly used old DB value `9757174d-...` (1359 existing observations) instead of new synthetic ID
- [x] No FK constraint errors in logs after fix deployment
- [x] Pending message queue draining normally across all sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)