### PR TITLE
feat: parent heartbeat for MCP server orphan prevention

### DIFF
--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -331,8 +331,9 @@ function startParentHeartbeat() {
   if (heartbeatTimer.unref) heartbeatTimer.unref();
 }
 
-// Cleanup function
-async function cleanup() {
+// Cleanup function — synchronous to ensure consistent behavior whether called
+// from signal handlers, heartbeat interval, or awaited in async context
+function cleanup() {
   if (heartbeatTimer) clearInterval(heartbeatTimer);
   logger.info('SYSTEM', 'MCP server shutting down');
   process.exit(0);


### PR DESCRIPTION
## Summary

- MCP server monitors parent process every 30s via ppid check
- Self-exits when parent dies (ppid changes to 1 on Unix) to prevent orphaned node processes
- Timer uses `unref()` to not keep the process alive artificially
- Unix-only — ppid=1 detection doesn't apply on Windows

## Scope

Only touches 1 file:
- `src/servers/mcp-server.ts` — heartbeat interval + cleanup integration

## Test plan

- [x] Server starts normally and heartbeat begins
- [x] Server self-exits when parent process is killed
- [x] Timer doesn't prevent natural process exit
- [x] No effect on Windows (heartbeat skipped)
- [x] No merge conflicts with current main

Split from #830 per review feedback (scope reduction).

---

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)