### PR TITLE
feat: Chroma health watchdog + isConnected() accessor

### DIFF
--- a/src/services/sync/ChromaSync.ts
+++ b/src/services/sync/ChromaSync.ts
@@ -188,6 +188,13 @@ export class ChromaSync {
   }
 
   /**
+   * Check if Chroma MCP client is currently connected
+   */
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  /**
    * Ensure MCP client is connected to Chroma server
    * Throws error if connection fails
    */


### PR DESCRIPTION
## Summary

Adds proactive Chroma connection monitoring to detect and recover from silent connection failures.

- New `isConnected()` accessor on ChromaSync for health checking
- Worker checks Chroma connection every 5 min via watchdog timer
- If connection lost, closes transport so it reconnects on next use
- Timer uses `unref()` to not keep process alive
- Properly cleaned up on shutdown

**Note**: Removed stale session recovery from this PR — upstream PR #741 already handles this via `processPendingQueues()`.

## Files changed (2)
- `src/services/sync/ChromaSync.ts` — `isConnected()` accessor
- `src/services/worker-service.ts` — Chroma watchdog timer

## Test plan
- [ ] Start worker, verify "Started Chroma watchdog" log
- [ ] Kill Chroma process, wait 5 min, verify watchdog logs "connection lost"
- [ ] Next search should trigger automatic reconnection

🤖 Generated with [Claude Code](https://claude.ai/code)