### PR TITLE
fix: preserve synthetic memorySessionId for stateless providers across worker restarts

### DIFF
--- a/src/services/worker/SessionManager.ts
+++ b/src/services/worker/SessionManager.ts
@@ -16,6 +16,12 @@ import { PendingMessageStore } from '../sqlite/PendingMessageStore.js';
 import { SessionQueueProcessor } from '../queue/SessionQueueProcessor.js';
 import { getProcessBySession, ensureProcessExit } from './ProcessRegistry.js';
 
+// Stateless provider identifiers for synthetic ID generation
+export const STATELESS_PROVIDERS = {
+  GEMINI: 'gemini',
+  OPENROUTER: 'openrouter'
+} as const;
+
 export class SessionManager {
   private dbManager: DatabaseManager;
   private sessions: Map<number, ActiveSession> = new Map();
@@ -43,6 +49,23 @@ export class SessionManager {
    */
   setOnSessionDeleted(callback: () => void): void {
     this.onSessionDeletedCallback = callback;
+  }
+
+  /**
+   * Check if a memory_session_id is synthetic (from Gemini/OpenRouter) vs SDK UUID
+   * Synthetic ID pattern: provider prefix + dash + contentSessionId (UUID) + dash + timestamp
+   * Examples: gemini-75919a84-1ce3-478f-b36c-91b637310fce-1769797226528
+   *           openrouter-b2fc470f-1ce3-478f-b36c-91b637310fce-1769797226528
+   * contentSessionId must be valid UUID format; suffix is Date.now() timestamp (digits)
+   */
+  private isSyntheticMemorySessionId(memorySessionId: string): boolean {
+    // Strict pattern: provider-(UUID)-(timestamp)
+    // UUID = contentSessionId from Claude Code session
+    // Timestamp = Date.now() at generation time (13+ digit number)
+    const uuidPattern = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+    const providers = Object.values(STATELESS_PROVIDERS).join('|');
+    const syntheticPattern = new RegExp(`^(${providers})-(${uuidPattern})-(\\d+)$`, 'i');
+    return syntheticPattern.test(memorySessionId);
   }
 
   /**
@@ -106,13 +129,28 @@ export class SessionManager {
       memory_session_id: dbSession.memory_session_id
     });
 
-    // Log warning if we're discarding a stale memory_session_id (Issue #817)
-    if (dbSession.memory_session_id) {
-      logger.warn('SESSION', `Discarding stale memory_session_id from previous worker instance (Issue #817)`, {
-        sessionDbId,
-        staleMemorySessionId: dbSession.memory_session_id,
-        reason: 'SDK context lost on worker restart - will capture new ID'
-      });
+    // Handle memory_session_id on restart (Issue #817)
+    // Treat empty string as null for consistency
+    if (dbSession.memory_session_id && dbSession.memory_session_id.trim() !== '') {
+      const isSyntheticId = this.isSyntheticMemorySessionId(dbSession.memory_session_id);
+
+      if (isSyntheticId) {
+        // Preserve synthetic IDs - stateless providers have no server context to lose
+        logger.debug('SESSION', `Preserving synthetic memory_session_id across restart`, {
+          sessionDbId,
+          syntheticMemorySessionId: dbSession.memory_session_id,
+          reason: 'Stateless provider - no server-side state to lose'
+        });
+        // Will be loaded into session.memorySessionId in the session object creation below
+      } else {
+        // Discard SDK UUIDs - SDK context is lost on restart
+        logger.warn('SESSION', `Discarding stale SDK memory_session_id from previous worker instance (Issue #817)`, {
+          sessionDbId,
+          staleMemorySessionId: dbSession.memory_session_id,
+          reason: 'SDK context lost on worker restart - will capture new ID'
+        });
+        dbSession.memory_session_id = null; // Clear for SDK sessions
+      }
     }
 
     // Use currentUserPrompt if provided, otherwise fall back to database (first prompt)
@@ -133,15 +171,16 @@ export class SessionManager {
     }
 
     // Create active session
-    // CRITICAL: Do NOT load memorySessionId from database here (Issue #817)
-    // When creating a new in-memory session, any database memory_session_id is STALE
-    // because the SDK context was lost when the worker restarted. The SDK agent will
-    // capture a new memorySessionId on the first response and persist it.
-    // Loading stale memory_session_id causes "No conversation found" crashes on resume.
+    // CRITICAL: Conditional memorySessionId loading (Issue #817)
+    // - Synthetic IDs (openrouter-*, gemini-*): PRESERVE from database
+    //   Stateless providers have no server context to lose on restart
+    // - SDK UUIDs: DISCARD (set to null)
+    //   SDK conversation context is lost when worker restarts
+    // SDK will capture new ID on first response; stateless providers already generated theirs
     session = {
       sessionDbId,
       contentSessionId: dbSession.content_session_id,
-      memorySessionId: null,  // Always start fresh - SDK will capture new ID
+      memorySessionId: (dbSession.memory_session_id && dbSession.memory_session_id.trim() !== '') ? dbSession.memory_session_id : null,  // Preserve synthetic IDs, null for SDK/empty
       project: dbSession.project,
       userPrompt,
       pendingMessages: [],
@@ -158,11 +197,11 @@ export class SessionManager {
       processingMessageIds: []  // CLAIM-CONFIRM: Track message IDs for confirmProcessed()
     };
 
-    logger.debug('SESSION', 'Creating new session object (memorySessionId cleared to prevent stale resume)', {
+    logger.debug('SESSION', 'Creating new session object (synthetic IDs preserved, SDK UUIDs discarded)', {
       sessionDbId,
       contentSessionId: dbSession.content_session_id,
       dbMemorySessionId: dbSession.memory_session_id || '(none in DB)',
-      memorySessionId: '(cleared - will capture fresh from SDK)',
+      memorySessionId: session.memorySessionId || '(will be generated or captured)',
       lastPromptNumber: promptNumber || this.dbManager.getSessionStore().getPromptNumberFromUserPrompts(dbSession.content_session_id)
     });
 

--- a/tests/session_manager_synthetic_ids.test.ts
+++ b/tests/session_manager_synthetic_ids.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, mock } from 'bun:test';
+import { SessionManager } from '../src/services/worker/SessionManager';
+import { DatabaseManager } from '../src/services/worker/DatabaseManager';
+
+describe('SessionManager - Synthetic ID Handling', () => {
+  let sessionManager: SessionManager;
+  let mockDbManager: DatabaseManager;
+  let mockGetSessionById: any;
+  let mockGetPromptNumberFromUserPrompts: any;
+
+  beforeEach(() => {
+    mockGetPromptNumberFromUserPrompts = mock(() => 1);
+
+    const mockSessionStore = {
+      getPromptNumberFromUserPrompts: mockGetPromptNumberFromUserPrompts,
+      db: {} // Mock db object for PendingMessageStore
+    };
+
+    mockGetSessionById = mock();
+
+    mockDbManager = {
+      getSessionById: mockGetSessionById,
+      getSessionStore: () => mockSessionStore
+    } as unknown as DatabaseManager;
+
+    sessionManager = new SessionManager(mockDbManager);
+  });
+
+  it('should preserve synthetic ID (gemini-*) across restart', () => {
+    // Upstream format: gemini-{contentSessionId}-{Date.now()}
+    const syntheticId = 'gemini-75919a84-1ce3-478f-b36c-91b637310fce-1769797226528';
+
+    mockGetSessionById.mockImplementation(() => ({
+      id: 42,
+      content_session_id: '75919a84-1ce3-478f-b36c-91b637310fce',
+      memory_session_id: syntheticId,
+      project: 'test-project',
+      user_prompt: 'test prompt',
+      created_at: Date.now()
+    }));
+
+    const session = sessionManager.initializeSession(42, 'test prompt', 1);
+
+    // Verify synthetic ID was preserved
+    expect(session.memorySessionId).toBe(syntheticId);
+    expect(session.sessionDbId).toBe(42);
+    expect(session.contentSessionId).toBe('75919a84-1ce3-478f-b36c-91b637310fce');
+  });
+
+  it('should preserve synthetic ID (openrouter-*) across restart', () => {
+    // Upstream format: openrouter-{contentSessionId}-{Date.now()}
+    const syntheticId = 'openrouter-b2fc470f-1ce3-478f-b36c-91b637310fce-1706789012345';
+
+    mockGetSessionById.mockImplementation(() => ({
+      id: 42,
+      content_session_id: 'b2fc470f-1ce3-478f-b36c-91b637310fce',
+      memory_session_id: syntheticId,
+      project: 'test-project',
+      user_prompt: 'test prompt',
+      created_at: Date.now()
+    }));
+
+    const session = sessionManager.initializeSession(42, 'test prompt', 1);
+
+    // Verify synthetic ID was preserved
+    expect(session.memorySessionId).toBe(syntheticId);
+  });
+
+  it('should discard SDK UUID across restart', () => {
+    const sdkUuid = '550e8400-e29b-41d4-a716-446655440000'; // Plain UUID (SDK format)
+
+    mockGetSessionById.mockImplementation(() => ({
+      id: 42,
+      content_session_id: '75919a84-1ce3-478f-b36c-91b637310fce',
+      memory_session_id: sdkUuid,
+      project: 'test-project',
+      user_prompt: 'test prompt',
+      created_at: Date.now()
+    }));
+
+    const session = sessionManager.initializeSession(42, 'test prompt', 1);
+
+    // Verify SDK UUID was discarded (set to null)
+    expect(session.memorySessionId).toBeNull();
+  });
+
+  it('should correctly parse contentSessionId UUID within synthetic ID', () => {
+    // CRITICAL TEST: The contentSessionId is a UUID with dashes embedded in the
+    // synthetic ID string. The regex must correctly isolate the UUID portion from
+    // the provider prefix and timestamp suffix.
+    // Format: openrouter-{8-4-4-4-12 UUID}-{timestamp digits}
+    const syntheticId = 'openrouter-0971eaa4-abcd-4567-8901-234567890abc-1769797226528';
+
+    mockGetSessionById.mockImplementation(() => ({
+      id: 42,
+      content_session_id: '0971eaa4-abcd-4567-8901-234567890abc',
+      memory_session_id: syntheticId,
+      project: 'test-project',
+      user_prompt: 'test prompt',
+      created_at: Date.now()
+    }));
+
+    const session = sessionManager.initializeSession(42, 'test prompt', 1);
+
+    expect(session.memorySessionId).toBe(syntheticId);
+    expect(session.memorySessionId).not.toBeNull();
+  });
+
+  it('should handle empty string memorySessionId as null', () => {
+    mockGetSessionById.mockImplementation(() => ({
+      id: 42,
+      content_session_id: '75919a84-1ce3-478f-b36c-91b637310fce',
+      memory_session_id: '', // Empty string
+      project: 'test-project',
+      user_prompt: 'test prompt',
+      created_at: Date.now()
+    }));
+
+    const session = sessionManager.initializeSession(42, 'test prompt', 1);
+
+    // Empty string should be treated as no ID
+    expect(session.memorySessionId).toBeNull();
+  });
+
+  it('should handle null memorySessionId gracefully', () => {
+    mockGetSessionById.mockImplementation(() => ({
+      id: 42,
+      content_session_id: '75919a84-1ce3-478f-b36c-91b637310fce',
+      memory_session_id: null,
+      project: 'test-project',
+      user_prompt: 'test prompt',
+      created_at: Date.now()
+    }));
+
+    const session = sessionManager.initializeSession(42, 'test prompt', 1);
+
+    // Null should remain null
+    expect(session.memorySessionId).toBeNull();
+  });
+
+  it('should reject malformed synthetic ID with correct prefix but invalid format', () => {
+    // Has synthetic prefix but missing UUID and timestamp portions
+    const malformedId = 'gemini-incomplete';
+
+    mockGetSessionById.mockImplementation(() => ({
+      id: 42,
+      content_session_id: '75919a84-1ce3-478f-b36c-91b637310fce',
+      memory_session_id: malformedId,
+      project: 'test-project',
+      user_prompt: 'test prompt',
+      created_at: Date.now()
+    }));
+
+    const session = sessionManager.initializeSession(42, 'test prompt', 1);
+
+    // Strict regex rejects malformed IDs even with correct prefix
+    expect(session.memorySessionId).toBeNull();
+  });
+
+  it('should reject unknown provider prefix', () => {
+    // Valid format but unrecognized provider
+    const unknownProvider = 'anthropic-75919a84-1ce3-478f-b36c-91b637310fce-1769797226528';
+
+    mockGetSessionById.mockImplementation(() => ({
+      id: 42,
+      content_session_id: '75919a84-1ce3-478f-b36c-91b637310fce',
+      memory_session_id: unknownProvider,
+      project: 'test-project',
+      user_prompt: 'test prompt',
+      created_at: Date.now()
+    }));
+
+    const session = sessionManager.initializeSession(42, 'test prompt', 1);
+
+    // Unknown provider should be treated as SDK UUID and discarded
+    expect(session.memorySessionId).toBeNull();
+  });
+
+  it('should reject synthetic ID with UUID suffix (old format)', () => {
+    // This format was never generated by upstream but tests regex strictness
+    const oldFormatId = 'openrouter-75919a84-1ce3-478f-b36c-91b637310fce-550e8400-e29b-41d4-a716-446655440000';
+
+    mockGetSessionById.mockImplementation(() => ({
+      id: 42,
+      content_session_id: '75919a84-1ce3-478f-b36c-91b637310fce',
+      memory_session_id: oldFormatId,
+      project: 'test-project',
+      user_prompt: 'test prompt',
+      created_at: Date.now()
+    }));
+
+    const session = sessionManager.initializeSession(42, 'test prompt', 1);
+
+    // UUID suffix does not match \\d+ pattern — should be discarded
+    expect(session.memorySessionId).toBeNull();
+  });
+
+  it('should handle concurrent initialization with same sessionDbId', () => {
+    // Simulate: first call sees no memorySessionId, second call returns cached session
+    const syntheticId = 'gemini-75919a84-1ce3-478f-b36c-91b637310fce-1769797226528';
+
+    let callCount = 0;
+    mockGetSessionById.mockImplementation(() => {
+      callCount++;
+      return {
+        id: 42,
+        content_session_id: '75919a84-1ce3-478f-b36c-91b637310fce',
+        memory_session_id: callCount === 1 ? null : syntheticId,
+        project: 'test-project',
+        user_prompt: 'test prompt',
+        created_at: Date.now()
+      };
+    });
+
+    // First initialization — no ID in DB yet
+    const session1 = sessionManager.initializeSession(42, 'test prompt', 1);
+    expect(session1.memorySessionId).toBeNull();
+
+    // Second initialization — returns cached session (doesn't re-read DB)
+    const session2 = sessionManager.initializeSession(42, 'test prompt', 1);
+    expect(session2).toBe(session1);
+  });
+
+  it('should reject non-UUID contentSessionId in synthetic ID', () => {
+    const invalidSyntheticId = 'gemini-NOTAUUID-1769797226528';
+
+    mockGetSessionById.mockImplementation(() => ({
+      id: 42,
+      content_session_id: '75919a84-1ce3-478f-b36c-91b637310fce',
+      memory_session_id: invalidSyntheticId,
+      project: 'test-project',
+      user_prompt: 'test prompt',
+      created_at: Date.now()
+    }));
+
+    const session = sessionManager.initializeSession(42, 'test prompt', 1);
+
+    // Invalid UUID in contentSessionId portion should be rejected
+    expect(session.memorySessionId).toBeNull();
+  });
+
+  it('should handle whitespace-only memorySessionId as null', () => {
+    mockGetSessionById.mockImplementation(() => ({
+      id: 42,
+      content_session_id: '75919a84-1ce3-478f-b36c-91b637310fce',
+      memory_session_id: '   ', // Whitespace only
+      project: 'test-project',
+      user_prompt: 'test prompt',
+      created_at: Date.now()
+    }));
+
+    const session = sessionManager.initializeSession(42, 'test prompt', 1);
+
+    // Whitespace-only should be treated as no ID
+    expect(session.memorySessionId).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

When the worker restarts and recovers sessions via `SessionManager.initializeSession()`,
all `memory_session_id` values are unconditionally set to `null` (Issue #817 fix).

This is correct for SDK UUIDs — the SDK conversation context is lost on restart, so
the old ID causes "No conversation found" crashes on resume.

However, stateless providers (OpenRouter, Gemini) generate synthetic IDs with format
`{provider}-{contentSessionId}-{Date.now()}` that have no server-side state. These
remain valid across restarts and discarding them forces unnecessary ID regeneration.

## Fix

Replaces the unconditional discard in `SessionManager.ts` with conditional logic:

- **Synthetic IDs** (`openrouter-*`, `gemini-*`): Preserved from database
- **SDK UUIDs**: Discarded (existing Issue #817 behavior unchanged)

Detection uses strict regex validation matching the exact format generated by
`OpenRouterAgent.ts` and `GeminiAgent.ts`:

```
^(openrouter|gemini)-([0-9a-f]{8}-[0-9a-f]{4}-...-[0-9a-f]{12})-(\d+)$
```

## Changes

- `src/services/worker/SessionManager.ts` — `STATELESS_PROVIDERS` constant,
  `isSyntheticMemorySessionId()` method, conditional preserve/discard logic
- `tests/session_manager_synthetic_ids.test.ts` — 11 test cases covering
  preserve, discard, edge cases, and regex validation

## Related

- Issue #817 — original unconditional discard fix
- PR #615 — synthetic ID generation in OpenRouterAgent/GeminiAgent