### PR TITLE
Fix path traversal vulnerability in /api/instructions endpoint

### DIFF
--- a/src/services/server/Server.ts
+++ b/src/services/server/Server.ts
@@ -186,6 +186,10 @@ export class Server {
         let content: string;
 
         if (operation) {
+          if (!/^[a-zA-Z0-9_-]+$/.test(operation)) {
+            res.status(400).json({ error: 'Invalid operation name' });
+            return;
+          }
           const operationPath = path.join(__dirname, '../skills/mem-search/operations', `${operation}.md`);
           content = await fs.promises.readFile(operationPath, 'utf-8');
         } else {


### PR DESCRIPTION
## Summary
- Validates the `operation` query parameter in `/api/instructions` against `/^[a-zA-Z0-9_-]+$/` before using it in a file path, preventing directory traversal via `../` sequences
- Rewrites CLAUDE.md with improved architecture docs, build/test commands, and data flow diagram

## Test plan
- [ ] Verify `/api/instructions?operation=valid-name` still works
- [ ] Verify `/api/instructions?operation=../../etc/passwd` returns 400
- [ ] Verify `/api/instructions` without operation param still loads SKILL.md sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)