### PR TITLE
fix(mcp): rename MCP server from mcp-search to claude-mem

### DIFF
--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -239,7 +239,7 @@ NEVER fetch full details without filtering first. 10x token savings.`,
 // Create the MCP server
 const server = new Server(
   {
-    name: 'mcp-search-server',
+    name: 'claude-mem',
     version: packageVersion,
   },
   {


### PR DESCRIPTION
### Summary

This PR renames the MCP server exposed by the claude-mem plugin from
`mcp-search` to `claude-mem` to improve clarity and avoid confusing tool names.

Currently, tools are exposed with names like:

mcp__plugin_claude-mem_mcp-search__save_memory

This reads as if a “search” tool is performing memory operations, which is
misleading and confusing when browsing or invoking MCP tools.

---

### Problem

The server name `mcp-search` no longer reflects the purpose of this plugin:

• The server hosts multiple memory-related tools (save, timeline, observations)
• Most operations are not searches
• Tool names become semantically confusing when composed

This creates unnecessary cognitive overhead for users and tool consumers.

---

### What this PR does

• Renames the MCP server from `mcp-search` → `claude-mem`
• Results in clearer tool names, e.g.:

mcp__plugin_claude-mem_claude-mem__save_memory  
mcp__plugin_claude-mem_claude-mem__search  
mcp__plugin_claude-mem_claude-mem__timeline  

• Improves discoverability and semantic correctness of MCP tooling

---

### What this PR does NOT do

• Does not change tool behavior or APIs
• Does not modify stored data or memory semantics
• Does not affect non-MCP usage paths

---

### Rationale

This is a naming-only fix intended to improve usability and developer
experience without introducing behavioral changes.

---

### Related Issue

Fixes #1005