### PR TITLE
Allow README translation to reference existing translations

### DIFF
--- a/scripts/translate-readme/README.md
+++ b/scripts/translate-readme/README.md
@@ -43,6 +43,7 @@ translate-readme --list-languages
 | `--no-preserve-code` | Translate code blocks too (not recommended) |
 | `-m, --model <model>` | Claude model to use (default: `sonnet`) |
 | `--max-budget <usd>` | Maximum budget in USD |
+| `--use-existing` | Use existing translation file as a reference |
 | `-v, --verbose` | Show detailed progress |
 | `-h, --help` | Show help message |
 | `--list-languages` | List all supported language codes |
@@ -86,6 +87,9 @@ interface TranslationOptions {
 
   /** Maximum budget in USD */
   maxBudgetUsd?: number;
+
+  /** Use existing translation file (if present) as a reference */
+  useExisting?: boolean;
 
   /** Verbose output */
   verbose?: boolean;

--- a/scripts/translate-readme/cli.ts
+++ b/scripts/translate-readme/cli.ts
@@ -12,6 +12,7 @@ interface CliArgs {
   maxBudget?: number;
   verbose: boolean;
   force: boolean;
+  useExisting: boolean;
   help: boolean;
   listLanguages: boolean;
 }
@@ -39,6 +40,7 @@ OPTIONS:
   --no-preserve-code      Translate code blocks too (not recommended)
   -m, --model <model>     Claude model to use (default: sonnet)
   --max-budget <usd>      Maximum budget in USD
+  --use-existing          Use existing translation file as a reference
   -v, --verbose           Show detailed progress
   -f, --force             Force re-translation ignoring cache
   -h, --help              Show this help message
@@ -126,6 +128,7 @@ function parseArgs(argv: string[]): CliArgs {
     preserveCode: true,
     verbose: false,
     force: false,
+    useExisting: false,
     help: false,
     listLanguages: false,
   };
@@ -151,6 +154,9 @@ function parseArgs(argv: string[]): CliArgs {
       case "-f":
       case "--force":
         args.force = true;
+        break;
+      case "--use-existing":
+        args.useExisting = true;
         break;
       case "--no-preserve-code":
         args.preserveCode = false;
@@ -234,6 +240,7 @@ async function main(): Promise<void> {
       maxBudgetUsd: args.maxBudget,
       verbose: args.verbose,
       force: args.force,
+      useExisting: args.useExisting,
     });
 
     // Exit with error code if any translations failed


### PR DESCRIPTION
Allow reuse of prior translation files as a style and terminology guide when regenerating README i18n files.

GitHub Copilot pull request summary:

> This pull request adds support for using an existing translation file as a reference when generating new translations in the `translate-readme` script. This feature helps preserve manual corrections and maintain consistent style and terminology across translations. The changes include updates to CLI options, internal interfaces, and translation logic.
> 
> Enhancement: Use existing translation as reference
> 
> * Added a `--use-existing` CLI flag and corresponding documentation to allow using the current translation file as a reference for style and terminology. (`scripts/translate-readme/cli.ts`, `scripts/translate-readme/README.md`) [[1]](diffhunk://#diff-d6f1fb1cf38f10f1b1dc0069db1d79953aa4a6fc00787a30afacdad9b7eb486bR43) [[2]](diffhunk://#diff-b0ea780e2ffa4fda63164544c66b6be4d262cadf19fb9bdc4c6f15202f0fd8bcR46)
> * Updated the `CliArgs` and `TranslationOptions` interfaces to include the new `useExisting` option. (`scripts/translate-readme/cli.ts`, `scripts/translate-readme/index.ts`, `scripts/translate-readme/README.md`) [[1]](diffhunk://#diff-d6f1fb1cf38f10f1b1dc0069db1d79953aa4a6fc00787a30afacdad9b7eb486bR15) [[2]](diffhunk://#diff-295c17e11daaebbbdd0830d0a137beeeb3906bbe3d1f8f96a5ca8eb4720950efR52-R53) [[3]](diffhunk://#diff-b0ea780e2ffa4fda63164544c66b6be4d262cadf19fb9bdc4c6f15202f0fd8bcR91-R93)
> * Modified argument parsing and main function logic to support the new flag. (`scripts/translate-readme/cli.ts`) [[1]](diffhunk://#diff-d6f1fb1cf38f10f1b1dc0069db1d79953aa4a6fc00787a30afacdad9b7eb486bR131) [[2]](diffhunk://#diff-d6f1fb1cf38f10f1b1dc0069db1d79953aa4a6fc00787a30afacdad9b7eb486bR158-R160) [[3]](diffhunk://#diff-d6f1fb1cf38f10f1b1dc0069db1d79953aa4a6fc00787a30afacdad9b7eb486bR243)
> * Enhanced the translation pipeline to read the existing translation file (if present and enabled), and pass it to the translation prompt as a reference. (`scripts/translate-readme/index.ts`) [[1]](diffhunk://#diff-295c17e11daaebbbdd0830d0a137beeeb3906bbe3d1f8f96a5ca8eb4720950efR278) [[2]](diffhunk://#diff-295c17e11daaebbbdd0830d0a137beeeb3906bbe3d1f8f96a5ca8eb4720950efR330-R338)
> * Updated the translation prompt to include the reference translation and instructions for the model to use it as a guide for style and terminology, while prioritizing the source content if there are conflicts. (`scripts/translate-readme/index.ts`) [[1]](diffhunk://#diff-295c17e11daaebbbdd0830d0a137beeeb3906bbe3d1f8f96a5ca8eb4720950efL123-R127) [[2]](diffhunk://#diff-295c17e11daaebbbdd0830d0a137beeeb3906bbe3d1f8f96a5ca8eb4720950efR140-R152) [[3]](diffhunk://#diff-295c17e11daaebbbdd0830d0a137beeeb3906bbe3d1f8f96a5ca8eb4720950efR173)