### PR TITLE
feat: add project-scoped statusline counter utility

### DIFF
--- a/plugin/scripts/statusline-counts.js
+++ b/plugin/scripts/statusline-counts.js
@@ -23,27 +23,29 @@ import { existsSync, readFileSync } from "fs";
 import { homedir } from "os";
 import { join, basename } from "path";
 
+const cwd = process.argv[2] || process.env.CLAUDE_CWD || process.cwd();
+const project = basename(cwd);
+
 try {
-  // Resolve data directory from settings (supports CLAUDE_MEM_DATA_DIR override)
-  let dataDir = join(homedir(), ".claude-mem");
-  const settingsPath = join(dataDir, "settings.json");
-  if (existsSync(settingsPath)) {
-    try {
-      const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
-      if (settings.CLAUDE_MEM_DATA_DIR) dataDir = settings.CLAUDE_MEM_DATA_DIR;
-    } catch { /* use default */ }
+  // Resolve data directory: env var → settings.json → default
+  let dataDir = process.env.CLAUDE_MEM_DATA_DIR || join(homedir(), ".claude-mem");
+  if (!process.env.CLAUDE_MEM_DATA_DIR) {
+    const settingsPath = join(dataDir, "settings.json");
+    if (existsSync(settingsPath)) {
+      try {
+        const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+        if (settings.CLAUDE_MEM_DATA_DIR) dataDir = settings.CLAUDE_MEM_DATA_DIR;
+      } catch { /* use default */ }
+    }
   }
 
   const dbPath = join(dataDir, "claude-mem.db");
   if (!existsSync(dbPath)) {
-    console.log(JSON.stringify({ observations: 0, prompts: 0, project: "" }));
+    console.log(JSON.stringify({ observations: 0, prompts: 0, project }));
     process.exit(0);
   }
 
   const db = new Database(dbPath, { readonly: true });
-
-  const cwd = process.argv[2] || process.env.CLAUDE_CWD || process.cwd();
-  const project = basename(cwd);
 
   const obs = db.query("SELECT COUNT(*) as c FROM observations WHERE project = ?").get(project);
   // user_prompts links to projects through sdk_sessions.content_session_id
@@ -55,5 +57,5 @@ try {
   console.log(JSON.stringify({ observations: obs.c, prompts: prompts.c, project }));
   db.close();
 } catch (e) {
-  console.log(JSON.stringify({ observations: 0, prompts: 0, error: e.message }));
+  console.log(JSON.stringify({ observations: 0, prompts: 0, project, error: e.message }));
 }


### PR DESCRIPTION
## Summary

Adds `plugin/scripts/statusline-counts.js` — a lightweight Bun script that returns project-scoped observation and prompt counts for Claude Code's `statusLineCommand` integration.

### Problem

Without a dedicated counter, statusline implementations must either:
- Hit the worker HTTP API (slow, requires running worker)
- Count all observations globally (inflated count from cross-project data)

### Solution

Direct SQLite read with `WHERE project = ?` scoping:

```bash
$ bun statusline-counts.js /home/user/my-project
{"observations": 42, "prompts": 15, "project": "my-project"}

$ bun statusline-counts.js /tmp/empty-dir
{"observations": 0, "prompts": 0, "project": "empty-dir"}
```

**Performance:** ~15ms (no HTTP, no worker dependency)

### Features

- Project-scoped `WHERE project = ?` filtering for observations
- Prompts counted via `JOIN sdk_sessions` on `content_session_id`
- Respects `CLAUDE_MEM_DATA_DIR` from `settings.json`
- Graceful fallback: returns `{observations: 0, prompts: 0}` on any error
- Zero external dependencies (uses `bun:sqlite` built-in)

### Usage in statusLineCommand

```javascript
const result = execSync(`bun statusline-counts.js "${cwd}"`, {
  encoding: 'utf8', timeout: 3000
}).trim();
const { observations, prompts } = JSON.parse(result);
// Display: "cm:42" in statusline
```

## Test plan
- [x] Returns correct counts for known project (claude-mem: 1 obs, chats: 68 obs)
- [x] Returns zeros for nonexistent project
- [x] Performance: 15ms wall time
- [x] Graceful error handling (missing DB returns zeros)