### PR TITLE
openclaw: convert make-plan and do-plan commands to skills

### DIFF
--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -6,6 +6,7 @@
   "version": "1.0.0",
   "author": "thedotmack",
   "homepage": "https://claude-mem.com",
+  "skills": ["skills/make-plan", "skills/do-plan"],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/openclaw/skills/do-plan/SKILL.md
+++ b/openclaw/skills/do-plan/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: do-plan
+description: Execute a phased implementation plan using subagents. Use when asked to execute, run, or carry out a plan — especially one created by make-plan.
+---
+
+# Do Plan
+
+You are an ORCHESTRATOR. Deploy subagents to execute *all* work. Do not do the work yourself except to coordinate, route context, and verify that each subagent completed its assigned checklist.
+
+## Execution Protocol
+
+### Rules
+
+- Each phase uses fresh subagents where noted (or when context is large/unclear)
+- Assign one clear objective per subagent and require evidence (commands run, outputs, files changed)
+- Do not advance to the next step until the assigned subagent reports completion and the orchestrator confirms it matches the plan
+
+### During Each Phase
+
+Deploy an "Implementation" subagent to:
+1. Execute the implementation as specified
+2. COPY patterns from documentation, don't invent
+3. Cite documentation sources in code comments when using unfamiliar APIs
+4. If an API seems missing, STOP and verify — don't assume it exists
+
+### After Each Phase
+
+Deploy subagents for each post-phase responsibility:
+1. **Run verification checklist** — Deploy a "Verification" subagent to prove the phase worked
+2. **Anti-pattern check** — Deploy an "Anti-pattern" subagent to grep for known bad patterns from the plan
+3. **Code quality review** — Deploy a "Code Quality" subagent to review changes
+4. **Commit only if verified** — Deploy a "Commit" subagent *only after* verification passes; otherwise, do not commit
+
+### Between Phases
+
+Deploy a "Branch/Sync" subagent to:
+- Push to working branch after each verified phase
+- Prepare the next phase handoff so the next phase's subagents start fresh but have plan context
+
+## Failure Modes to Prevent
+
+- Don't invent APIs that "should" exist — verify against docs
+- Don't add undocumented parameters — copy exact signatures
+- Don't skip verification — deploy a verification subagent and run the checklist
+- Don't commit before verification passes (or without explicit orchestrator approval)

--- a/openclaw/skills/make-plan/SKILL.md
+++ b/openclaw/skills/make-plan/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: make-plan
+description: Create a detailed, phased implementation plan with documentation discovery. Use when asked to plan a feature, task, or multi-step implementation — especially before executing with do-plan.
+---
+
+# Make Plan
+
+You are an ORCHESTRATOR. Create an LLM-friendly plan in phases that can be executed consecutively in new chat contexts.
+
+## Delegation Model
+
+Use subagents for *fact gathering and extraction* (docs, examples, signatures, grep results). Keep *synthesis and plan authoring* with the orchestrator (phase boundaries, task framing, final wording). If a subagent report is incomplete or lacks evidence, re-check with targeted reads/greps before finalizing.
+
+### Subagent Reporting Contract (MANDATORY)
+
+Each subagent response must include:
+1. Sources consulted (files/URLs) and what was read
+2. Concrete findings (exact API names/signatures; exact file paths/locations)
+3. Copy-ready snippet locations (example files/sections to copy)
+4. "Confidence" note + known gaps (what might still be missing)
+
+Reject and redeploy the subagent if it reports conclusions without sources.
+
+## Plan Structure
+
+### Phase 0: Documentation Discovery (ALWAYS FIRST)
+
+Before planning implementation, deploy "Documentation Discovery" subagents to:
+1. Search for and read relevant documentation, examples, and existing patterns
+2. Identify the actual APIs, methods, and signatures available (not assumed)
+3. Create a brief "Allowed APIs" list citing specific documentation sources
+4. Note any anti-patterns to avoid (methods that DON'T exist, deprecated parameters)
+
+The orchestrator consolidates findings into a single Phase 0 output.
+
+### Each Implementation Phase Must Include
+
+1. **What to implement** — Frame tasks to COPY from docs, not transform existing code
+   - Good: "Copy the V2 session pattern from docs/examples.ts:45-60"
+   - Bad: "Migrate the existing code to V2"
+2. **Documentation references** — Cite specific files/lines for patterns to follow
+3. **Verification checklist** — How to prove this phase worked (tests, grep checks)
+4. **Anti-pattern guards** — What NOT to do (invented APIs, undocumented params)
+
+### Final Phase: Verification
+
+1. Verify all implementations match documentation
+2. Check for anti-patterns (grep for known bad patterns)
+3. Run tests to confirm functionality
+
+## Key Principles
+
+- Documentation Availability ≠ Usage: Explicitly require reading docs
+- Task Framing Matters: Direct agents to docs, not just outcomes
+- Verify > Assume: Require proof, not assumptions about APIs
+- Session Boundaries: Each phase should be self-contained with its own doc references
+
+## Anti-Patterns to Prevent
+
+- Inventing API methods that "should" exist
+- Adding parameters not in documentation
+- Skipping verification steps
+- Assuming structure without checking examples


### PR DESCRIPTION
## Summary

Convert the `/make-plan` and `/do` slash commands from `plugin/commands/` into OpenClaw skills under `openclaw/skills/`.

## Why

OpenClaw skills are auto-discovered by the agent via SKILL.md frontmatter description matching and loaded on-demand. This is more context-efficient than always-loaded slash commands — the skill body only enters context when the agent determines it's relevant.

## Changes

- `openclaw/skills/make-plan/SKILL.md` — phased implementation planning with doc discovery
- `openclaw/skills/do-plan/SKILL.md` — subagent-driven plan execution
- `openclaw/openclaw.plugin.json` — register skill directories via `skills` array

## Notes

- Content adapted from `plugin/commands/make-plan.md` and `plugin/commands/do.md`
- Original commands left in place (no breaking change)