### PR TITLE
fix: resolve duplicate assistant messages in OpenRouter agent

### DIFF
--- a/src/services/worker/OpenRouterAgent.ts
+++ b/src/services/worker/OpenRouterAgent.ts
@@ -11,21 +11,21 @@
  * - Support dynamic model selection across providers
  */
 
-import { DatabaseManager } from './DatabaseManager.js';
-import { SessionManager } from './SessionManager.js';
-import { logger } from '../../utils/logger.js';
-import { buildInitPrompt, buildObservationPrompt, buildSummaryPrompt, buildContinuationPrompt } from '../../sdk/prompts.js';
+import { buildContinuationPrompt, buildInitPrompt, buildObservationPrompt, buildSummaryPrompt } from '../../sdk/prompts.js';
+import { getCredential } from '../../shared/EnvManager.js';
 import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js';
 import { USER_SETTINGS_PATH } from '../../shared/paths.js';
-import { getCredential } from '../../shared/EnvManager.js';
-import type { ActiveSession, ConversationMessage } from '../worker-types.js';
+import { logger } from '../../utils/logger.js';
 import { ModeManager } from '../domain/ModeManager.js';
+import type { ActiveSession, ConversationMessage } from '../worker-types.js';
+import { DatabaseManager } from './DatabaseManager.js';
+import { SessionManager } from './SessionManager.js';
 import {
+  isAbortError,
   processAgentResponse,
   shouldFallbackToClaude,
-  isAbortError,
-  type WorkerRef,
-  type FallbackAgent
+  type FallbackAgent,
+  type WorkerRef
 } from './agents/index.js';
 
 // OpenRouter API endpoint
@@ -114,7 +114,7 @@ export class OpenRouterAgent {
 
       if (initResponse.content) {
         // Add response to conversation history
-        session.conversationHistory.push({ role: 'assistant', content: initResponse.content });
+        // session.conversationHistory.push({ role: 'assistant', content: initResponse.content });
 
         // Track token usage
         const tokensUsed = initResponse.tokensUsed || 0;
@@ -185,7 +185,7 @@ export class OpenRouterAgent {
           let tokensUsed = 0;
           if (obsResponse.content) {
             // Add response to conversation history
-            session.conversationHistory.push({ role: 'assistant', content: obsResponse.content });
+            // session.conversationHistory.push({ role: 'assistant', content: obsResponse.content });
 
             tokensUsed = obsResponse.tokensUsed || 0;
             session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
@@ -227,7 +227,7 @@ export class OpenRouterAgent {
           let tokensUsed = 0;
           if (summaryResponse.content) {
             // Add response to conversation history
-            session.conversationHistory.push({ role: 'assistant', content: summaryResponse.content });
+            // session.conversationHistory.push({ role: 'assistant', content: summaryResponse.content });
 
             tokensUsed = summaryResponse.tokensUsed || 0;
             session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);


### PR DESCRIPTION
This commit addresses the issue of duplicate assistant messages appearing in the conversation history by commenting out the lines that were unnecessarily pushing assistant responses to the conversationHistory array.

The processAgentResponse function already handles adding assistant messages to the conversation history, so these additional pushes were causing duplicate entries.

Changes made:
- Commented out session.conversationHistory.push calls for assistant responses in three locations within OpenRouterAgent.ts:
  1. In the init response handling (around line 117)
  2. In the observation response handling (around line 188)
  3. In the summary response handling (around line 230)

This ensures that assistant messages are only added once to the conversation history, preventing duplication while maintaining the intended functionality.