### PR TITLE
fix: use Gemini v1 API endpoint instead of v1beta

### DIFF
--- a/src/services/worker/GeminiAgent.ts
+++ b/src/services/worker/GeminiAgent.ts
@@ -28,8 +28,9 @@ import {
   type FallbackAgent
 } from './agents/index.js';
 
-// Gemini API endpoint
-const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models';
+// Gemini API endpoint — use v1 (stable), not v1beta.
+// v1beta does not support newer models like gemini-3-flash.
+const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1/models';
 
 // Gemini model types (available via API)
 export type GeminiModel =
@@ -38,6 +39,7 @@ export type GeminiModel =
   | 'gemini-2.5-pro'
   | 'gemini-2.0-flash'
   | 'gemini-2.0-flash-lite'
+  | 'gemini-3-flash'
   | 'gemini-3-flash-preview';
 
 // Free tier RPM limits by model (requests per minute)
@@ -47,6 +49,7 @@ const GEMINI_RPM_LIMITS: Record<GeminiModel, number> = {
   'gemini-2.5-pro': 5,
   'gemini-2.0-flash': 15,
   'gemini-2.0-flash-lite': 30,
+  'gemini-3-flash': 10,
   'gemini-3-flash-preview': 5,
 };
 

--- a/tests/gemini_agent.test.ts
+++ b/tests/gemini_agent.test.ts
@@ -168,7 +168,7 @@ describe('GeminiAgent', () => {
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
     const url = (global.fetch as any).mock.calls[0][0];
-    expect(url).toContain('https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent');
+    expect(url).toContain('https://generativelanguage.googleapis.com/v1/models/gemini-2.5-flash-lite:generateContent');
     expect(url).toContain('key=test-api-key');
   });
 


### PR DESCRIPTION
## Problem

The Gemini API URL is hardcoded to `v1beta/models`, but newer models like `gemini-3-flash` are only available on the `v1` endpoint. This causes a **silent failure**: every observation request returns HTTP 404, the queue backs up indefinitely, and zero observations are stored — with no user-visible error.

I discovered this after my queue grew to 2,779 items over a full day with no observations captured. The only clue was buried in the worker log:

```
models/gemini-3-flash is not found for API version v1beta
```

## Root Cause

`GeminiAgent.ts:32` hardcodes `v1beta`:
```typescript
const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models';
```

The `generateContent` endpoint works identically on `v1` and `v1beta` — there's no beta-specific feature being used.

## Fix

- Change API URL from `v1beta/models` to `v1/models`
- Add `gemini-3-flash` to `GeminiModel` type union and RPM limits map
- Update test expectation to match new endpoint

## Impact

Anyone using `CLAUDE_MEM_GEMINI_MODEL=gemini-3-flash` (or future v1-only models) gets broken memory with no warning. The plugin's own RPM limit map already includes `gemini-3-flash-preview` at 5 RPM, suggesting this model family was intended to be supported.

## Testing

- Verified `generateContent` works on `v1` for all listed models
- Updated existing test to reflect endpoint change