### PR TITLE
fix(openclaw): fix MEMORY.md project query mismatch and add feed botToken support

### DIFF
--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "claude-mem",
   "name": "Claude-Mem (Persistent Memory)",
   "description": "Official OpenClaw plugin for Claude-Mem. Records observations from embedded runner sessions and streams them to messaging channels.",
-  "kind": "integration",
+  "kind": "memory",
   "version": "1.0.0",
   "author": "thedotmack",
   "homepage": "https://claude-mem.com",
@@ -41,6 +41,10 @@
           "to": {
             "type": "string",
             "description": "Target chat/user ID to send observations to"
+          },
+          "botToken": {
+            "type": "string",
+            "description": "Optional dedicated Telegram bot token for the feed (bypasses gateway channel)"
           }
         }
       }


### PR DESCRIPTION
## Summary

Three fixes for the OpenClaw plugin:

### 1. Fix MEMORY.md sync returning empty content (bug)
`syncMemoryToWorkspace()` was querying `basename(workspaceDir)` as the project name (e.g. `"workspace"`), but observations are stored under agent-scoped names like `"openclaw-main"` (because `getProjectName(ctx)` prepends `openclaw-` when `ctx.agentId` exists). This meant MEMORY.md always came back with "No previous sessions found."

**Fix:** Query both the base project name AND the agent-scoped project name. Pass `EventContext` through to `syncMemoryToWorkspace()` so the correct project can be derived.

### 2. Add dedicated botToken support for observation feed (feature)
New optional `botToken` field in `observationFeed` config. When set, observations are sent directly via the Telegram Bot API instead of routing through the gateway's channel plugin. This allows using a separate bot for the observation stream without interfering with the main bot.

### 3. Fix plugin kind for memory slot compatibility (bug)
Changed plugin kind from `"integration"` to `"memory"` in `openclaw.plugin.json`. This fixes the `memory slot plugin not found or not marked as memory: claude-mem` warning when `plugins.slots.memory = "claude-mem"` is configured in OpenClaw.

## Testing
- Verified MEMORY.md now populates with observations after gateway restart
- Verified observation feed sends via dedicated bot token
- Verified no more duplicate plugin or memory slot warnings in gateway logs