### PR TITLE
fix: harden OpenClaw integration, auth chain, and SSE stability

### DIFF
--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -280,7 +280,8 @@ export class WorkerService {
     this.server.app.get('/api/context/inject', async (req, res, next) => {
       if (!this.initializationCompleteFlag || !this.searchRoutes) {
         logger.warn('SYSTEM', 'Context requested before initialization complete, returning empty');
-        res.status(200).json({ content: [{ type: 'text', text: '' }] });
+        res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+        res.status(200).send('');
         return;
       }
 

--- a/src/services/worker/SSEBroadcaster.ts
+++ b/src/services/worker/SSEBroadcaster.ts
@@ -12,20 +12,40 @@ import type { Response } from 'express';
 import { logger } from '../../utils/logger.js';
 import type { SSEEvent, SSEClient } from '../worker-types.js';
 
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 25000;
+const MIN_HEARTBEAT_INTERVAL_MS = 5000;
+
+function resolveHeartbeatIntervalMs(raw: string | undefined): number {
+  if (!raw || raw.trim() === '') return DEFAULT_HEARTBEAT_INTERVAL_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return DEFAULT_HEARTBEAT_INTERVAL_MS;
+  if (parsed <= 0) return 0; // Explicitly disable heartbeats
+  return Math.max(parsed, MIN_HEARTBEAT_INTERVAL_MS);
+}
+
 export class SSEBroadcaster {
   private sseClients: Set<SSEClient> = new Set();
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    private readonly heartbeatIntervalMs: number = resolveHeartbeatIntervalMs(process.env.CLAUDE_MEM_SSE_HEARTBEAT_MS)
+  ) {}
 
   /**
    * Add a new SSE client connection
    */
   addClient(res: Response): void {
     this.sseClients.add(res);
+    this.startHeartbeatIfNeeded();
     logger.debug('WORKER', 'Client connected', { total: this.sseClients.size });
 
     // Setup cleanup on disconnect
-    res.on('close', () => {
+    const cleanup = () => {
       this.removeClient(res);
-    });
+    };
+    res.on('close', cleanup);
+    res.on('end', cleanup);
+    res.on('error', cleanup);
 
     // Send initial event
     this.sendToClient(res, { type: 'connected', timestamp: Date.now() });
@@ -36,6 +56,9 @@ export class SSEBroadcaster {
    */
   removeClient(res: Response): void {
     this.sseClients.delete(res);
+    if (this.sseClients.size === 0) {
+      this.stopHeartbeat();
+    }
     logger.debug('WORKER', 'Client disconnected', { total: this.sseClients.size });
   }
 
@@ -48,14 +71,13 @@ export class SSEBroadcaster {
       return; // Short-circuit if no clients
     }
 
-    const eventWithTimestamp = { ...event, timestamp: Date.now() };
-    const data = `data: ${JSON.stringify(eventWithTimestamp)}\n\n`;
+    const data = this.serializeEvent(event);
 
     logger.debug('WORKER', 'SSE broadcast sent', { eventType: event.type, clients: this.sseClients.size });
 
     // Single-pass write
     for (const client of this.sseClients) {
-      client.write(data);
+      this.writeToClient(client, data);
     }
   }
 
@@ -69,8 +91,42 @@ export class SSEBroadcaster {
   /**
    * Send event to a specific client
    */
-  private sendToClient(res: Response, event: SSEEvent): void {
-    const data = `data: ${JSON.stringify(event)}\n\n`;
-    res.write(data);
+  sendToClient(res: SSEClient, event: SSEEvent): void {
+    this.writeToClient(res, this.serializeEvent(event));
+  }
+
+  private serializeEvent(event: SSEEvent): string {
+    const eventWithTimestamp = { ...event, timestamp: Date.now() };
+    return `data: ${JSON.stringify(eventWithTimestamp)}\n\n`;
+  }
+
+  private writeToClient(client: SSEClient, payload: string): void {
+    try {
+      client.write(payload);
+    } catch {
+      this.removeClient(client);
+    }
+  }
+
+  private startHeartbeatIfNeeded(): void {
+    if (this.heartbeatIntervalMs <= 0) return;
+    if (this.heartbeatTimer || this.sseClients.size === 0) return;
+
+    this.heartbeatTimer = setInterval(() => {
+      if (this.sseClients.size === 0) return;
+      const keepalive = `: keepalive ${Date.now()}\n\n`;
+      for (const client of this.sseClients) {
+        this.writeToClient(client, keepalive);
+      }
+    }, this.heartbeatIntervalMs);
+
+    // Don't keep process alive only because of heartbeat timer
+    this.heartbeatTimer.unref?.();
+  }
+
+  private stopHeartbeat(): void {
+    if (!this.heartbeatTimer) return;
+    clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = null;
   }
 }

--- a/src/shared/EnvManager.ts
+++ b/src/shared/EnvManager.ts
@@ -229,6 +229,9 @@ export function buildIsolatedEnv(includeCredentials: boolean = true): Record<str
     // If not configured, CLI billing will be used (via ANTHROPIC_AUTH_TOKEN passthrough)
     if (credentials.ANTHROPIC_API_KEY) {
       isolatedEnv.ANTHROPIC_API_KEY = credentials.ANTHROPIC_API_KEY;
+      // Enforce deterministic auth chain: API key mode must not carry OAuth token.
+      // This avoids ambiguous precedence when the parent process exports a token.
+      delete isolatedEnv.CLAUDE_CODE_OAUTH_TOKEN;
     }
     // Note: GEMINI_API_KEY and OPENROUTER_API_KEY pass through from process.env,
     // but claude-mem's .env takes precedence if configured

--- a/tests/integration/context-inject-fail-open.test.ts
+++ b/tests/integration/context-inject-fail-open.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { WorkerService } from '../../src/services/worker-service.js';
+import { logger } from '../../src/utils/logger.js';
+
+describe('WorkerService context inject fail-open', () => {
+  let workerService: WorkerService | null = null;
+  let loggerSpies: ReturnType<typeof spyOn>[] = [];
+
+  beforeEach(() => {
+    loggerSpies = [
+      spyOn(logger, 'info').mockImplementation(() => {}),
+      spyOn(logger, 'debug').mockImplementation(() => {}),
+      spyOn(logger, 'warn').mockImplementation(() => {}),
+      spyOn(logger, 'error').mockImplementation(() => {}),
+    ];
+  });
+
+  afterEach(async () => {
+    loggerSpies.forEach((spy) => spy.mockRestore());
+
+    if (workerService) {
+      const internalServer = (workerService as any).server;
+      if (internalServer?.getHttpServer()) {
+        try {
+          await internalServer.close();
+        } catch {
+          // Best-effort cleanup
+        }
+      }
+    }
+  });
+
+  it('returns empty text/plain before initialization completes', async () => {
+    workerService = new WorkerService();
+    const internalServer = (workerService as any).server;
+    const testPort = 45000 + Math.floor(Math.random() * 10000);
+
+    await internalServer.listen(testPort, '127.0.0.1');
+
+    const response = await fetch(`http://127.0.0.1:${testPort}/api/context/inject?projects=test-project`);
+    const contentType = response.headers.get('content-type');
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(contentType).toContain('text/plain');
+    expect(body).toBe('');
+  });
+});

--- a/tests/shared/env-manager.test.ts
+++ b/tests/shared/env-manager.test.ts
@@ -80,7 +80,7 @@ describe('EnvManager OAuth token resolution', () => {
     expect(isolatedEnv.CLAUDE_CODE_OAUTH_TOKEN).toBe('fallback-token');
   });
 
-  it('should keep API key auth priority when ANTHROPIC_API_KEY is configured', () => {
+  it('should strip OAuth token when ANTHROPIC_API_KEY is configured', () => {
     envFileExists = true;
     envFileContent = 'ANTHROPIC_API_KEY=sk-ant-api-key\n';
     process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-token';
@@ -91,7 +91,7 @@ describe('EnvManager OAuth token resolution', () => {
     const isolatedEnv = buildIsolatedEnv();
 
     expect(isolatedEnv.ANTHROPIC_API_KEY).toBe('sk-ant-api-key');
-    expect(isolatedEnv.CLAUDE_CODE_OAUTH_TOKEN).toBe('oauth-token');
+    expect(isolatedEnv.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
   });
 
   it('should describe auth method as credentials.json token when available', () => {

--- a/tests/shared/env-manager.test.ts
+++ b/tests/shared/env-manager.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+
+const MOCK_HOME = '/tmp/claude-mem-env-test-home';
+let envFileExists = false;
+let envFileContent = '';
+let credentialsFileContent: string | null = null;
+let credentialsReadThrows = false;
+
+mock.module('os', () => ({
+  homedir: () => MOCK_HOME,
+}));
+
+mock.module('fs', () => ({
+  existsSync: (path: string) => {
+    if (path.endsWith('/.claude-mem/.env')) return envFileExists;
+    return false;
+  },
+  readFileSync: (path: string) => {
+    if (path.endsWith('/.claude-mem/.env')) {
+      if (!envFileExists) throw new Error('ENOENT');
+      return envFileContent;
+    }
+    if (path.endsWith('/.claude/.credentials.json')) {
+      if (credentialsReadThrows || !credentialsFileContent) throw new Error('ENOENT');
+      return credentialsFileContent;
+    }
+    throw new Error('ENOENT');
+  },
+  writeFileSync: () => {},
+  mkdirSync: () => {},
+}));
+
+import { buildIsolatedEnv, getAuthMethodDescription } from '../../src/shared/EnvManager.js';
+
+describe('EnvManager OAuth token resolution', () => {
+  const originalOauthToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+  const originalAnthropicKey = process.env.ANTHROPIC_API_KEY;
+
+  beforeEach(() => {
+    envFileExists = false;
+    envFileContent = '';
+    credentialsFileContent = null;
+    credentialsReadThrows = false;
+
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+  });
+
+  afterEach(() => {
+    if (originalOauthToken === undefined) {
+      delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    } else {
+      process.env.CLAUDE_CODE_OAUTH_TOKEN = originalOauthToken;
+    }
+
+    if (originalAnthropicKey === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = originalAnthropicKey;
+    }
+  });
+
+  it('should prefer fresh token from credentials.json over stale env var', () => {
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'stale-token';
+    credentialsFileContent = JSON.stringify({
+      claudeAiOauth: { accessToken: 'fresh-token' },
+    });
+
+    const isolatedEnv = buildIsolatedEnv();
+
+    expect(isolatedEnv.CLAUDE_CODE_OAUTH_TOKEN).toBe('fresh-token');
+  });
+
+  it('should fall back to env var when credentials.json is unavailable', () => {
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'fallback-token';
+    credentialsReadThrows = true;
+
+    const isolatedEnv = buildIsolatedEnv();
+
+    expect(isolatedEnv.CLAUDE_CODE_OAUTH_TOKEN).toBe('fallback-token');
+  });
+
+  it('should keep API key auth priority when ANTHROPIC_API_KEY is configured', () => {
+    envFileExists = true;
+    envFileContent = 'ANTHROPIC_API_KEY=sk-ant-api-key\n';
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-token';
+    credentialsFileContent = JSON.stringify({
+      claudeAiOauth: { accessToken: 'fresh-token' },
+    });
+
+    const isolatedEnv = buildIsolatedEnv();
+
+    expect(isolatedEnv.ANTHROPIC_API_KEY).toBe('sk-ant-api-key');
+    expect(isolatedEnv.CLAUDE_CODE_OAUTH_TOKEN).toBe('oauth-token');
+  });
+
+  it('should describe auth method as credentials.json token when available', () => {
+    credentialsFileContent = JSON.stringify({
+      claudeAiOauth: { accessToken: 'fresh-token' },
+    });
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'stale-token';
+
+    expect(getAuthMethodDescription()).toBe(
+      'Claude Code OAuth token (from ~/.claude/.credentials.json)'
+    );
+  });
+});

--- a/tests/worker/sse-broadcaster.test.ts
+++ b/tests/worker/sse-broadcaster.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'bun:test';
+import { EventEmitter } from 'events';
+import { SSEBroadcaster } from '../../src/services/worker/SSEBroadcaster.js';
+
+type MockSseClient = EventEmitter & {
+  writes: string[];
+  write: (chunk: string) => boolean;
+};
+
+function createMockSseClient(): MockSseClient {
+  const client = new EventEmitter() as MockSseClient;
+  client.writes = [];
+  client.write = (chunk: string) => {
+    client.writes.push(chunk);
+    return true;
+  };
+  return client;
+}
+
+describe('SSEBroadcaster', () => {
+  it('sends connected event when client is added', () => {
+    const broadcaster = new SSEBroadcaster(0);
+    const client = createMockSseClient();
+
+    broadcaster.addClient(client as any);
+
+    expect(client.writes.length).toBe(1);
+    expect(client.writes[0]).toContain('"type":"connected"');
+  });
+
+  it('broadcast sends events to all clients', () => {
+    const broadcaster = new SSEBroadcaster(0);
+    const clientA = createMockSseClient();
+    const clientB = createMockSseClient();
+    broadcaster.addClient(clientA as any);
+    broadcaster.addClient(clientB as any);
+
+    broadcaster.broadcast({
+      type: 'processing_status',
+      isProcessing: true,
+      queueDepth: 2,
+    });
+
+    expect(clientA.writes.some((w) => w.includes('"type":"processing_status"'))).toBe(true);
+    expect(clientB.writes.some((w) => w.includes('"type":"processing_status"'))).toBe(true);
+  });
+
+  it('sendToClient targets only the specified client', () => {
+    const broadcaster = new SSEBroadcaster(0);
+    const clientA = createMockSseClient();
+    const clientB = createMockSseClient();
+    broadcaster.addClient(clientA as any);
+    broadcaster.addClient(clientB as any);
+
+    const clientAInitialWrites = clientA.writes.length;
+    const clientBInitialWrites = clientB.writes.length;
+
+    broadcaster.sendToClient(clientA as any, {
+      type: 'initial_load',
+      projects: ['openclaw', 'openclaw-main'],
+    });
+
+    expect(clientA.writes.length).toBe(clientAInitialWrites + 1);
+    expect(clientB.writes.length).toBe(clientBInitialWrites);
+    expect(clientA.writes[clientA.writes.length - 1]).toContain('"type":"initial_load"');
+  });
+
+  it('sends keepalive heartbeats and stops after disconnect', async () => {
+    const broadcaster = new SSEBroadcaster(10);
+    const client = createMockSseClient();
+    broadcaster.addClient(client as any);
+
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    const heartbeatWrites = client.writes.filter((w) => w.startsWith(': keepalive'));
+    expect(heartbeatWrites.length).toBeGreaterThan(0);
+
+    const writesBeforeClose = client.writes.length;
+    client.emit('close');
+    await new Promise((resolve) => setTimeout(resolve, 35));
+    expect(client.writes.length).toBe(writesBeforeClose);
+  });
+
+  it('removes client on error event', () => {
+    const broadcaster = new SSEBroadcaster(0);
+    const client = createMockSseClient();
+    broadcaster.addClient(client as any);
+
+    expect(broadcaster.getClientCount()).toBe(1);
+    client.emit('error', new Error('socket failed'));
+    expect(broadcaster.getClientCount()).toBe(0);
+  });
+});

--- a/tests/worker/viewer-routes.test.ts
+++ b/tests/worker/viewer-routes.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { ViewerRoutes } from '../../src/services/worker/http/routes/ViewerRoutes.js';
+
+describe('ViewerRoutes SSE stream', () => {
+  it('sends initial events only to the newly connected client', () => {
+    const addClient = mock(() => {});
+    const sendToClient = mock(() => {});
+    const broadcast = mock(() => {});
+
+    const sseBroadcaster = {
+      addClient,
+      sendToClient,
+      broadcast,
+    } as any;
+
+    const dbManager = {
+      getSessionStore: () => ({
+        getAllProjects: () => ['openclaw', 'openclaw-main'],
+      }),
+    } as any;
+
+    const sessionManager = {
+      isAnySessionProcessing: () => true,
+      getTotalActiveWork: () => 3,
+    } as any;
+
+    const routes = new ViewerRoutes(sseBroadcaster, dbManager, sessionManager);
+
+    const req = { path: '/stream' } as any;
+    const setHeader = mock(() => {});
+    const flushHeaders = mock(() => {});
+    const res = {
+      headersSent: false,
+      setHeader,
+      flushHeaders,
+    } as any;
+
+    (routes as any).handleSSEStream(req, res);
+
+    expect(addClient).toHaveBeenCalledTimes(1);
+    expect(addClient).toHaveBeenCalledWith(res);
+    expect(sendToClient).toHaveBeenCalledTimes(2);
+    expect(broadcast).toHaveBeenCalledTimes(0);
+    expect(setHeader).toHaveBeenCalledWith('X-Accel-Buffering', 'no');
+    expect(flushHeaders).toHaveBeenCalledTimes(1);
+
+    const firstEvent = sendToClient.mock.calls[0]?.[1];
+    const secondEvent = sendToClient.mock.calls[1]?.[1];
+    expect(firstEvent.type).toBe('initial_load');
+    expect(firstEvent.projects).toEqual(['openclaw', 'openclaw-main']);
+    expect(secondEvent.type).toBe('processing_status');
+    expect(secondEvent.isProcessing).toBe(true);
+    expect(secondEvent.queueDepth).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- keep OAuth token fresh per session by reading `~/.claude/.credentials.json` in `buildIsolatedEnv()`
- strip `CLAUDE_CODE_OAUTH_TOKEN` when `ANTHROPIC_API_KEY` is configured to avoid ambiguous auth precedence
- harden OpenClaw plugin session scoping (no `default` scope, deterministic scope derivation, TTL/cap pruning, runtime `sessionId` cleanup mapping, global-scope observability warning)
- prevent memory-observation feedback loops by skipping `memory_*` tools and truncating persisted tool responses
- improve SSE stability with worker heartbeats, targeted initial events, proxy buffering disable header, and client cleanup on close/end/error
- standardize context inject fail-open response to empty `text/plain`

## Validation
- `bun test openclaw/src/index.test.ts tests/shared/env-manager.test.ts tests/integration/context-inject-fail-open.test.ts tests/worker/sse-broadcaster.test.ts tests/worker/viewer-routes.test.ts --reporter=dot` (57 pass)

## Related
- Claude Code issue (hooks after compaction): https://github.com/anthropics/claude-code/issues/25655
- OpenClaw logger recursion guard PR: https://github.com/openclaw/openclaw/pull/15948