### PR TITLE
fix: gracefully handle missing input fields in hook handlers

### DIFF
--- a/src/cli/handlers/observation.ts
+++ b/src/cli/handlers/observation.ts
@@ -24,7 +24,8 @@ export const observationHandler: EventHandler = {
     const { sessionId, cwd, toolName, toolInput, toolResponse } = input;
 
     if (!toolName) {
-      throw new Error('observationHandler requires toolName');
+      // No tool name provided - skip observation gracefully
+      return { continue: true, suppressOutput: true, exitCode: HOOK_EXIT_CODES.SUCCESS };
     }
 
     const port = getWorkerPort();

--- a/src/cli/handlers/summarize.ts
+++ b/src/cli/handlers/summarize.ts
@@ -29,7 +29,9 @@ export const summarizeHandler: EventHandler = {
 
     // Validate required fields before processing
     if (!transcriptPath) {
-      throw new Error(`Missing transcriptPath in Stop hook input for session ${sessionId}`);
+      // No transcript available - skip summary gracefully (not an error)
+      logger.debug('HOOK', `No transcriptPath in Stop hook input for session ${sessionId} - skipping summary`);
+      return { continue: true, suppressOutput: true, exitCode: HOOK_EXIT_CODES.SUCCESS };
     }
 
     // Extract last assistant message from transcript (the work Claude did)


### PR DESCRIPTION
## Summary

- **summarize** (Stop hook) and **observation** (PostToolUse hook) handlers throw blocking errors (exit code 2) when optional input fields (`transcriptPath`, `toolName`, `cwd`) are missing
- Replace `throw new Error(...)` with graceful returns (`{ continue: true, suppressOutput: true, exitCode: SUCCESS }`) matching the existing pattern used for worker-unavailable checks
- Affects every session stop and many tool uses, causing visible "Hook error" messages

## Changes

- `src/cli/handlers/summarize.ts:31` — return gracefully when `transcriptPath` is missing instead of throwing
- `src/cli/handlers/observation.ts:26` — return gracefully when `toolName` is missing instead of throwing

## Test plan

- [x] Verified `hook claude-code summarize` returns `{"continue":true,"suppressOutput":true}` without stdin (previously threw `Missing transcriptPath`)
- [x] Verified `hook claude-code observation` returns `{"continue":true,"suppressOutput":true}` without stdin (previously threw `observationHandler requires toolName`)
- [x] Normal operation unaffected — fields are still used when present

🤖 Generated with [Claude Code](https://claude.com/claude-code)