### PR TITLE
feat: universalize observation feed emojis

### DIFF
--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -63,7 +63,7 @@
               "claudeCodeLabel": {
                 "type": "string",
                 "default": "Claude Code Session",
-                "description": "Display label for Claude Code sessions in the feed"
+                "description": "Display label prefix for Claude Code sessions in the feed (project identifier is appended automatically)"
               },
               "default": {
                 "type": "string",

--- a/openclaw/src/index.ts
+++ b/openclaw/src/index.ts
@@ -227,8 +227,13 @@ function buildGetSourceLabel(
     if (project === "openclaw") {
       return `${primary} openclaw`;
     }
-    // Everything else is a Claude Code session
-    return `${claudeCode} ${claudeCodeLabel}`;
+    // Everything else is a Claude Code session. Keep the project identifier
+    // visible so concurrent sessions can be distinguished in the feed.
+    const trimmedLabel = claudeCodeLabel.trim();
+    if (!trimmedLabel) {
+      return `${claudeCode} ${project}`;
+    }
+    return `${claudeCode} ${trimmedLabel} (${project})`;
   };
 }
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `AGENT_EMOJI_MAP` with a config-driven emoji system via `observationFeed.emojis`
- Deterministic auto-assign from a 20-emoji pool using agentId hash (same agent = same emoji, no state needed)
- User can pin specific agent emojis, customize the primary/fallback/Claude Code emojis, or change nothing (all have sensible defaults)
- Claude Code sessions now display "Claude Code Session" instead of the working directory name
- All settings exposed in `openclaw.plugin.json` configSchema so the onboarding wizard AI discovers them automatically

## Config Example

```json
{
  "observationFeed": {
    "emojis": {
      "primary": "🦞",
      "claudeCode": "⌨️",
      "claudeCodeLabel": "Claude Code Session",
      "default": "🦀",
      "agents": { "devops": "🔧", "researcher": "🔍" }
    }
  }
}
```

Users who don't configure anything get auto-assigned emojis out of the box.

## Test plan

- [ ] Build passes (`cd openclaw && npm run build`)
- [ ] Verify zero-config: no `emojis` block → agents get deterministic pool emojis, Claude Code shows "Claude Code Session"
- [ ] Verify pinned agents: add `emojis.agents` entries → those agents use pinned emoji, others use pool
- [ ] Verify primary/fallback customization works
- [ ] Verify edge case: `project = "openclaw-"` (empty agentId) falls back to primary emoji

🤖 Generated with [Claude Code](https://claude.com/claude-code)