### PR TITLE
feat: interactive feed setup wizard and standalone daemon

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.76",
+    "@clack/prompts": "^1.0.1",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "ansi-to-html": "^0.7.2",
     "dompurify": "^3.3.1",

--- a/src/cli/feed-setup/feed-setup-wizard.ts
+++ b/src/cli/feed-setup/feed-setup-wizard.ts
@@ -1,0 +1,118 @@
+/**
+ * Feed Setup Wizard Orchestrator
+ *
+ * Guides users through the full Telegram feed setup in 6 steps:
+ * 1. Create Telegram bot (BotFather)
+ * 2. Create/select group
+ * 3. Detect chat ID
+ * 4. Send test message
+ * 5. Save configuration
+ * 6. Verify live feed
+ *
+ * Supports --non-interactive mode for CI/Docker with --bot-token and --chat-id flags.
+ */
+
+import * as p from '@clack/prompts';
+import { loadFeedConfig, isFeedConfigured } from '../../services/feed/FeedConfig.js';
+import { createBotStep } from './steps/create-bot.js';
+import { createGroupStep } from './steps/create-group.js';
+import { detectChatIdStep } from './steps/detect-chat-id.js';
+import { testMessageStep } from './steps/test-message.js';
+import { saveConfigStep } from './steps/save-config.js';
+import { verifyFeedStep } from './steps/verify-feed.js';
+
+export interface WizardOptions {
+  nonInteractive?: boolean;
+  botToken?: string;
+  chatId?: string;
+}
+
+export async function runFeedSetupWizard(options: WizardOptions = {}): Promise<void> {
+  const { nonInteractive = false, botToken: presetToken, chatId: presetChatId } = options;
+
+  p.intro('\u{1F9E0} Claude-Mem Feed Setup');
+
+  // Non-interactive mode requires both --bot-token and --chat-id
+  if (nonInteractive && (!presetToken || !presetChatId)) {
+    p.log.error('Non-interactive mode requires --bot-token=TOKEN and --chat-id=ID');
+    p.outro('Setup failed');
+    return;
+  }
+
+  // Pre-flight: check existing configuration
+  const existing = loadFeedConfig();
+  if (isFeedConfigured(existing) && !nonInteractive) {
+    const maskedToken = existing.botToken.slice(0, 8) + '...' + existing.botToken.slice(-4);
+    p.note(
+      `Enabled: ${existing.enabled}\n` +
+      `Token: ${maskedToken}\n` +
+      `Chat ID: ${existing.chatId}`,
+      'Feed is already configured'
+    );
+
+    const action = await p.select({
+      message: 'What would you like to do?',
+      options: [
+        { value: 'reconfigure', label: 'Reconfigure' },
+        { value: 'test', label: 'Send test message' },
+        { value: 'exit', label: 'Exit' },
+      ],
+    });
+
+    if (p.isCancel(action) || action === 'exit') {
+      p.outro('Done');
+      return;
+    }
+
+    if (action === 'test') {
+      await testMessageStep(existing.botToken, existing.chatId, true);
+      p.outro('Done');
+      return;
+    }
+    // action === 'reconfigure' -> continue with wizard
+  }
+
+  // Step 1: Create bot
+  const botResult = await createBotStep(presetToken);
+  if (p.isCancel(botResult)) {
+    p.outro('Setup cancelled');
+    return;
+  }
+  const { botToken, botUsername } = botResult;
+
+  // Step 2: Create group (skip in non-interactive mode)
+  if (!nonInteractive) {
+    const groupResult = await createGroupStep(botUsername);
+    if (p.isCancel(groupResult)) {
+      p.outro('Setup cancelled');
+      return;
+    }
+  }
+
+  // Step 3: Detect chat ID
+  const chatResult = await detectChatIdStep(botToken, presetChatId);
+  if (p.isCancel(chatResult)) {
+    p.outro('Setup cancelled');
+    return;
+  }
+  const { chatId, chatTitle } = chatResult;
+
+  // Step 4: Test message
+  const testResult = await testMessageStep(botToken, chatId, nonInteractive);
+  if (p.isCancel(testResult)) {
+    p.outro('Setup cancelled');
+    return;
+  }
+
+  // Step 5: Save config
+  const saveResult = await saveConfigStep(botToken, botUsername, chatId, chatTitle, nonInteractive);
+  if (p.isCancel(saveResult) || !saveResult) {
+    p.outro('Setup cancelled');
+    return;
+  }
+
+  // Step 6: Verify live feed
+  await verifyFeedStep(nonInteractive);
+
+  p.outro('\u{1F980} Feed setup complete! Observations will stream to your Telegram group.');
+}

--- a/src/cli/feed-setup/steps/create-bot.ts
+++ b/src/cli/feed-setup/steps/create-bot.ts
@@ -1,0 +1,63 @@
+/**
+ * Step 1: Create Telegram Bot
+ *
+ * Shows BotFather instructions, collects bot token, validates via getMe.
+ */
+
+import * as p from '@clack/prompts';
+import { TelegramClient } from '../../../services/feed/TelegramClient.js';
+import { validateBotToken } from '../../../services/feed/FeedConfig.js';
+
+export interface CreateBotResult {
+  botToken: string;
+  botUsername: string;
+}
+
+export async function createBotStep(presetToken?: string): Promise<CreateBotResult | symbol> {
+  p.note(
+    `To set up the feed, you need a Telegram bot.\n\n` +
+    `1. Open Telegram and search for @BotFather\n` +
+    `2. Send /newbot\n` +
+    `3. Choose a name (e.g. "Claude-Mem Feed")\n` +
+    `4. Choose a username (e.g. "claudemem_feed_bot")\n` +
+    `5. Copy the bot token BotFather gives you`,
+    'Create a Telegram Bot'
+  );
+
+  let botToken = presetToken || '';
+  let botUsername = '';
+
+  while (true) {
+    if (!botToken) {
+      const tokenInput = await p.text({
+        message: 'Paste your bot token:',
+        placeholder: '123456789:ABCdefGHIjklMNOpqrsTUVwxyz1234567890',
+        validate: (value) => {
+          if (!validateBotToken(value)) {
+            return 'Invalid token format. Should look like: 123456789:ABCdefGHI...';
+          }
+        },
+      });
+
+      if (p.isCancel(tokenInput)) return tokenInput;
+      botToken = (tokenInput as string).trim();
+    }
+
+    const s = p.spinner();
+    s.start('Verifying bot token...');
+
+    try {
+      const client = new TelegramClient(botToken);
+      const me = await client.getMe();
+      botUsername = me.username;
+      s.stop(`Bot verified: @${botUsername}`);
+      break;
+    } catch (err) {
+      s.stop('Token verification failed');
+      p.log.error(`Could not verify token: ${(err as Error).message}`);
+      botToken = ''; // Reset to ask again
+    }
+  }
+
+  return { botToken, botUsername };
+}

--- a/src/cli/feed-setup/steps/create-group.ts
+++ b/src/cli/feed-setup/steps/create-group.ts
@@ -1,0 +1,24 @@
+/**
+ * Step 2: Create/Select Group
+ *
+ * Instructs user to create a Telegram group and add the bot.
+ */
+
+import * as p from '@clack/prompts';
+
+export async function createGroupStep(botUsername: string): Promise<boolean | symbol> {
+  p.note(
+    `Now create a Telegram group for your feed:\n\n` +
+    `1. Open Telegram and create a new group\n` +
+    `2. Name it (e.g. "Claude-Mem Feed")\n` +
+    `3. Add @${botUsername} to the group\n` +
+    `4. Send any message in the group (so the bot can detect it)`,
+    'Create a Telegram Group'
+  );
+
+  const done = await p.confirm({
+    message: 'Done? (bot added to group and message sent)',
+  });
+
+  return done;
+}

--- a/src/cli/feed-setup/steps/detect-chat-id.ts
+++ b/src/cli/feed-setup/steps/detect-chat-id.ts
@@ -1,0 +1,99 @@
+/**
+ * Step 3: Detect Chat ID
+ *
+ * Auto-detects group chat ID via getUpdates. Falls back to manual input.
+ */
+
+import * as p from '@clack/prompts';
+import { TelegramClient, type TelegramChat } from '../../../services/feed/TelegramClient.js';
+
+export interface DetectChatIdResult {
+  chatId: string;
+  chatTitle: string;
+}
+
+export async function detectChatIdStep(
+  botToken: string,
+  presetChatId?: string
+): Promise<DetectChatIdResult | symbol> {
+  if (presetChatId) {
+    // Non-interactive: validate the provided chat ID
+    const client = new TelegramClient(botToken);
+    try {
+      const chatInfo = await client.getChat(presetChatId);
+      return { chatId: presetChatId, chatTitle: chatInfo.title };
+    } catch {
+      throw new Error(`Invalid chat ID: ${presetChatId}`);
+    }
+  }
+
+  const s = p.spinner();
+  s.start('Looking for groups with your bot...');
+
+  const client = new TelegramClient(botToken);
+  let chats: TelegramChat[] = [];
+
+  try {
+    chats = await client.getUpdates();
+    // Filter to groups/supergroups
+    chats = chats.filter(c => c.chatType === 'group' || c.chatType === 'supergroup');
+  } catch (err) {
+    s.stop('Could not fetch updates');
+    p.log.warn(`getUpdates failed: ${(err as Error).message}`);
+  }
+
+  if (chats.length === 1) {
+    s.stop(`Found group: ${chats[0].chatTitle}`);
+
+    const confirm = await p.confirm({
+      message: `Use "${chats[0].chatTitle}" (${chats[0].chatId})?`,
+    });
+    if (p.isCancel(confirm)) return confirm;
+
+    if (confirm) {
+      return { chatId: chats[0].chatId, chatTitle: chats[0].chatTitle };
+    }
+  } else if (chats.length > 1) {
+    s.stop(`Found ${chats.length} groups`);
+
+    const selected = await p.select({
+      message: 'Which group should receive the feed?',
+      options: chats.map(c => ({
+        value: c.chatId,
+        label: `${c.chatTitle} (${c.chatId})`,
+      })),
+    });
+    if (p.isCancel(selected)) return selected;
+
+    const chat = chats.find(c => c.chatId === selected)!;
+    return { chatId: chat.chatId, chatTitle: chat.chatTitle };
+  } else {
+    s.stop('No groups found');
+    p.log.info('Make sure you added the bot to a group and sent a message.');
+  }
+
+  // Manual fallback
+  const manualId = await p.text({
+    message: 'Enter the chat ID manually:',
+    placeholder: '-1001234567890',
+    validate: (value) => {
+      if (!value.trim()) return 'Chat ID is required';
+      if (!/^-?\d+$/.test(value.trim())) return 'Chat ID should be a number';
+    },
+  });
+  if (p.isCancel(manualId)) return manualId;
+
+  const chatId = (manualId as string).trim();
+
+  // Validate via getChat
+  const vs = p.spinner();
+  vs.start('Validating chat ID...');
+  try {
+    const info = await client.getChat(chatId);
+    vs.stop(`Validated: ${info.title} (${info.type})`);
+    return { chatId, chatTitle: info.title };
+  } catch (err) {
+    vs.stop('Validation failed');
+    throw new Error(`Invalid chat ID: ${(err as Error).message}`);
+  }
+}

--- a/src/cli/feed-setup/steps/save-config.ts
+++ b/src/cli/feed-setup/steps/save-config.ts
@@ -1,0 +1,45 @@
+/**
+ * Step 5: Save Config
+ *
+ * Shows summary and saves feed configuration to settings.json.
+ */
+
+import * as p from '@clack/prompts';
+import { saveFeedConfig } from '../../../services/feed/FeedConfig.js';
+
+export async function saveConfigStep(
+  botToken: string,
+  botUsername: string,
+  chatId: string,
+  chatTitle: string,
+  nonInteractive: boolean = false
+): Promise<boolean | symbol> {
+  // Mask the token for display
+  const maskedToken = botToken.slice(0, 8) + '...' + botToken.slice(-4);
+
+  p.note(
+    `Bot: @${botUsername}\n` +
+    `Token: ${maskedToken}\n` +
+    `Group: ${chatTitle}\n` +
+    `Chat ID: ${chatId}`,
+    'Configuration Summary'
+  );
+
+  if (!nonInteractive) {
+    const confirm = await p.confirm({
+      message: 'Save this configuration?',
+    });
+    if (p.isCancel(confirm)) return confirm;
+    if (!confirm) return false;
+  }
+
+  saveFeedConfig({
+    enabled: true,
+    channel: 'telegram',
+    botToken,
+    chatId,
+  });
+
+  p.log.success('Configuration saved to ~/.claude-mem/settings.json');
+  return true;
+}

--- a/src/cli/feed-setup/steps/test-message.ts
+++ b/src/cli/feed-setup/steps/test-message.ts
@@ -1,0 +1,38 @@
+/**
+ * Step 4: Test Message
+ *
+ * Sends a test message to the configured group to verify connectivity.
+ */
+
+import * as p from '@clack/prompts';
+import { TelegramClient } from '../../../services/feed/TelegramClient.js';
+
+export async function testMessageStep(
+  botToken: string,
+  chatId: string,
+  nonInteractive: boolean = false
+): Promise<boolean | symbol> {
+  const s = p.spinner();
+  s.start('Sending test message...');
+
+  try {
+    const client = new TelegramClient(botToken);
+    await client.sendMessage(
+      chatId,
+      '\u{1F9E0} Claude-Mem Feed connected! Session observations will appear here.'
+    );
+    s.stop('Test message sent!');
+  } catch (err) {
+    s.stop('Failed to send test message');
+    p.log.error((err as Error).message);
+    return false;
+  }
+
+  if (nonInteractive) return true;
+
+  const confirmed = await p.confirm({
+    message: 'Did you see the message in your Telegram group?',
+  });
+
+  return confirmed;
+}

--- a/src/cli/feed-setup/steps/verify-feed.ts
+++ b/src/cli/feed-setup/steps/verify-feed.ts
@@ -1,0 +1,70 @@
+/**
+ * Step 6: Verify Live Feed
+ *
+ * Starts/restarts the feed daemon via the worker HTTP API and optionally
+ * waits for the first observation to come through.
+ */
+
+import * as p from '@clack/prompts';
+import { getWorkerPort } from '../../../shared/worker-utils.js';
+
+export async function verifyFeedStep(nonInteractive: boolean = false): Promise<void> {
+  const port = getWorkerPort();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  const s = p.spinner();
+  s.start('Starting feed daemon...');
+
+  try {
+    const res = await fetch(`${baseUrl}/api/feed/start`, { method: 'POST' });
+    const data = await res.json() as Record<string, unknown>;
+
+    if (!data.success) {
+      s.stop('Feed daemon failed to start');
+      p.log.warn(data.message as string || 'Unknown error');
+      return;
+    }
+
+    s.stop('Feed daemon started');
+  } catch (err) {
+    s.stop('Could not reach worker');
+    p.log.warn(
+      'Worker service is not running. The feed will start automatically on next worker boot.'
+    );
+    return;
+  }
+
+  if (nonInteractive) return;
+
+  // Wait for first observation (optional, 30s timeout)
+  const s2 = p.spinner();
+  s2.start('Waiting for first observation (30s timeout)...');
+
+  const timeout = 30_000;
+  const start = Date.now();
+  let receivedObservation = false;
+
+  while (Date.now() - start < timeout) {
+    try {
+      const statusRes = await fetch(`${baseUrl}/api/feed/status`);
+      const statusData = await statusRes.json() as Record<string, unknown>;
+      if ((statusData.lastMessageTime as number) > start) {
+        receivedObservation = true;
+        break;
+      }
+    } catch {
+      // Worker may not be reachable yet
+    }
+    await new Promise(resolve => setTimeout(resolve, 2000));
+  }
+
+  if (receivedObservation) {
+    s2.stop('First observation sent to Telegram!');
+  } else {
+    s2.stop('No observations received yet');
+    p.log.info(
+      'This is normal if no Claude Code sessions are active.\n' +
+      'Observations will appear in your Telegram group when you use Claude Code.'
+    );
+  }
+}

--- a/src/services/feed/FeedConfig.ts
+++ b/src/services/feed/FeedConfig.ts
@@ -1,0 +1,69 @@
+/**
+ * FeedConfig
+ *
+ * Configuration types, loading, saving, and validation for the Claude-mem feed.
+ * Feed settings are stored in ~/.claude-mem/settings.json alongside other settings.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync } from 'fs';
+import { dirname } from 'path';
+import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js';
+import { USER_SETTINGS_PATH } from '../../shared/paths.js';
+
+export interface FeedConfig {
+  enabled: boolean;
+  channel: string;
+  botToken: string;
+  chatId: string;
+}
+
+const BOT_TOKEN_REGEX = /^\d+:[A-Za-z0-9_-]{35,}$/;
+
+export function validateBotToken(token: string): boolean {
+  return BOT_TOKEN_REGEX.test(token.trim());
+}
+
+export function loadFeedConfig(): FeedConfig {
+  const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+  return {
+    enabled: settings.CLAUDE_MEM_FEED_ENABLED === 'true',
+    channel: settings.CLAUDE_MEM_FEED_CHANNEL || 'telegram',
+    botToken: settings.CLAUDE_MEM_FEED_BOT_TOKEN || '',
+    chatId: settings.CLAUDE_MEM_FEED_CHAT_ID || '',
+  };
+}
+
+export function isFeedConfigured(config: FeedConfig): boolean {
+  return config.botToken !== '' && config.chatId !== '';
+}
+
+export function saveFeedConfig(config: FeedConfig): void {
+  let existing: Record<string, unknown> = {};
+
+  if (existsSync(USER_SETTINGS_PATH)) {
+    try {
+      existing = JSON.parse(readFileSync(USER_SETTINGS_PATH, 'utf-8'));
+    } catch {
+      existing = {};
+    }
+  } else {
+    const dir = dirname(USER_SETTINGS_PATH);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+  }
+
+  existing.CLAUDE_MEM_FEED_ENABLED = config.enabled ? 'true' : 'false';
+  existing.CLAUDE_MEM_FEED_CHANNEL = config.channel;
+  existing.CLAUDE_MEM_FEED_BOT_TOKEN = config.botToken;
+  existing.CLAUDE_MEM_FEED_CHAT_ID = config.chatId;
+
+  writeFileSync(USER_SETTINGS_PATH, JSON.stringify(existing, null, 2), 'utf-8');
+
+  // Settings file contains bot token — restrict to owner-only
+  try {
+    chmodSync(USER_SETTINGS_PATH, 0o600);
+  } catch {
+    // Best-effort: Windows doesn't support Unix permissions
+  }
+}

--- a/src/services/feed/FeedDaemon.ts
+++ b/src/services/feed/FeedDaemon.ts
@@ -1,0 +1,236 @@
+/**
+ * FeedDaemon
+ *
+ * Lives inside the worker process. Listens for SSE broadcast events
+ * (new_observation, new_summary) via SSEBroadcaster.onBroadcast() and
+ * sends formatted messages to Telegram.
+ *
+ * No HTTP loopback - uses internal listener API directly.
+ * Uses HTML parse mode to avoid Markdown escaping issues with code symbols.
+ */
+
+import { TelegramClient } from './TelegramClient.js';
+import { loadFeedConfig, isFeedConfigured, type FeedConfig } from './FeedConfig.js';
+import type { SSEBroadcaster } from '../worker/SSEBroadcaster.js';
+import { logger } from '../../utils/logger.js';
+
+// Emoji for observation types
+const TYPE_EMOJI: Record<string, string> = {
+  discovery: '\u{1F535}',        // blue circle
+  bugfix: '\u{1F534}',           // red circle
+  change: '\u{2705}',            // check mark
+  decision: '\u{2696}\u{FE0F}',  // balance scale
+  refactor: '\u{1F504}',         // arrows counterclockwise
+  feature: '\u{1F7E3}',          // purple circle
+};
+const DEFAULT_EMOJI = '\u{1F4DD}'; // memo
+
+// Failure backoff: mute sends after consecutive failures
+const MAX_CONSECUTIVE_FAILURES = 5;
+const MUTE_DURATION_MS = 60_000;
+
+/**
+ * Escape HTML special characters for Telegram HTML parse mode.
+ */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+export class FeedDaemon {
+  private client: TelegramClient | null = null;
+  private unsubscribe: (() => void) | null = null;
+  private config: FeedConfig | null = null;
+  private lastMessageTime: number = 0;
+  private _running: boolean = false;
+  private consecutiveFailures: number = 0;
+  private mutedUntil: number = 0;
+
+  get running(): boolean {
+    return this._running;
+  }
+
+  /**
+   * Start the feed daemon. Loads config, creates Telegram client,
+   * subscribes to SSE broadcasts.
+   */
+  start(broadcaster: SSEBroadcaster): boolean {
+    if (this._running) {
+      logger.warn('FEED', 'Feed daemon already running');
+      return true;
+    }
+
+    this.config = loadFeedConfig();
+
+    if (!this.config.enabled || !isFeedConfigured(this.config)) {
+      logger.debug('FEED', 'Feed not configured or disabled, skipping start');
+      return false;
+    }
+
+    this.client = new TelegramClient(this.config.botToken);
+    this.consecutiveFailures = 0;
+    this.mutedUntil = 0;
+
+    this.unsubscribe = broadcaster.onBroadcast((event) => {
+      this.handleEvent(event);
+    });
+
+    this._running = true;
+    logger.info('FEED', 'Feed daemon started', { chatId: this.config.chatId });
+    return true;
+  }
+
+  /**
+   * Stop the feed daemon. Unsubscribes from broadcasts.
+   */
+  stop(): void {
+    if (this.unsubscribe) {
+      this.unsubscribe();
+      this.unsubscribe = null;
+    }
+    this.client = null;
+    this._running = false;
+    logger.info('FEED', 'Feed daemon stopped');
+  }
+
+  /**
+   * Reload config and restart if needed.
+   */
+  restart(broadcaster: SSEBroadcaster): boolean {
+    this.stop();
+    return this.start(broadcaster);
+  }
+
+  /**
+   * Send a test message to verify the connection.
+   */
+  async sendTestMessage(): Promise<void> {
+    const config = this.config ?? loadFeedConfig();
+    if (!isFeedConfigured(config)) {
+      throw new Error('Feed not configured');
+    }
+    const client = this.client ?? new TelegramClient(config.botToken);
+    await client.sendMessage(
+      config.chatId,
+      '\u{1F9E0} Claude-Mem Feed connected! Session observations will appear here.'
+    );
+  }
+
+  getStatus(): {
+    running: boolean;
+    enabled: boolean;
+    configured: boolean;
+    chatId: string;
+    lastMessageTime: number;
+  } {
+    const config = this.config ?? loadFeedConfig();
+    return {
+      running: this._running,
+      enabled: config.enabled,
+      configured: isFeedConfigured(config),
+      chatId: config.chatId,
+      lastMessageTime: this.lastMessageTime,
+    };
+  }
+
+  private handleEvent(event: Record<string, unknown>): void {
+    const type = event.type as string;
+
+    if (type === 'new_observation' && event.observation) {
+      this.sendObservation(event.observation as Record<string, unknown>);
+    } else if (type === 'new_summary' && event.summary) {
+      this.sendSummary(event.summary as Record<string, unknown>);
+    }
+  }
+
+  /**
+   * Check if currently muted due to consecutive failures.
+   */
+  private isMuted(): boolean {
+    if (this.mutedUntil > 0 && Date.now() < this.mutedUntil) {
+      return true;
+    }
+    if (this.mutedUntil > 0 && Date.now() >= this.mutedUntil) {
+      // Mute period expired, reset
+      this.mutedUntil = 0;
+      this.consecutiveFailures = 0;
+      logger.info('FEED', 'Mute period expired, resuming sends');
+    }
+    return false;
+  }
+
+  /**
+   * Record a send failure. After MAX_CONSECUTIVE_FAILURES, mute for MUTE_DURATION_MS.
+   */
+  private recordFailure(err: Error): void {
+    this.consecutiveFailures++;
+    if (this.consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+      this.mutedUntil = Date.now() + MUTE_DURATION_MS;
+      logger.warn('FEED', `Muting feed for ${MUTE_DURATION_MS / 1000}s after ${this.consecutiveFailures} consecutive failures`, {
+        lastError: err.message,
+      });
+    } else {
+      logger.error('FEED', 'Failed to send to Telegram', {
+        consecutiveFailures: this.consecutiveFailures,
+      }, err);
+    }
+  }
+
+  private recordSuccess(): void {
+    this.consecutiveFailures = 0;
+    this.lastMessageTime = Date.now();
+  }
+
+  private sendObservation(obs: Record<string, unknown>): void {
+    if (!this.client || !this.config || this.isMuted()) return;
+
+    const obsType = (obs.type as string) || 'unknown';
+    const emoji = TYPE_EMOJI[obsType] || DEFAULT_EMOJI;
+    const title = escapeHtml((obs.title as string) || 'Untitled');
+    const project = (obs.project as string) || '';
+    const narrative = (obs.narrative as string) || (obs.text as string) || '';
+
+    const projectLabel = project ? `[${escapeHtml(project.split('/').pop()!)}]` : '';
+    const lines = [
+      `${emoji} <b>${title}</b> ${projectLabel}`,
+    ];
+
+    if (narrative) {
+      const maxLen = 500;
+      const truncated = narrative.length > maxLen
+        ? narrative.slice(0, maxLen) + '...'
+        : narrative;
+      lines.push(escapeHtml(truncated));
+    }
+
+    const text = lines.join('\n');
+    this.client.sendMessage(this.config.chatId, text, 'HTML').then(
+      () => this.recordSuccess(),
+      (err) => this.recordFailure(err as Error),
+    );
+  }
+
+  private sendSummary(summary: Record<string, unknown>): void {
+    if (!this.client || !this.config || this.isMuted()) return;
+
+    const project = (summary.project as string) || '';
+    const projectLabel = project ? `[${escapeHtml(project.split('/').pop()!)}]` : '';
+    const request = (summary.request as string) || '';
+    const completed = (summary.completed as string) || '';
+
+    const lines = [
+      `\u{1F4CB} <b>Session Summary</b> ${projectLabel}`,
+    ];
+
+    if (request) lines.push(`<b>Request:</b> ${escapeHtml(request)}`);
+    if (completed) lines.push(`<b>Completed:</b> ${escapeHtml(completed)}`);
+
+    const text = lines.join('\n');
+    this.client.sendMessage(this.config.chatId, text, 'HTML').then(
+      () => this.recordSuccess(),
+      (err) => this.recordFailure(err as Error),
+    );
+  }
+}

--- a/src/services/feed/TelegramClient.ts
+++ b/src/services/feed/TelegramClient.ts
@@ -1,0 +1,119 @@
+/**
+ * TelegramClient
+ *
+ * Minimal Telegram Bot API client for the Claude-mem feed.
+ * Supports getMe, getUpdates, getChat, sendMessage.
+ * Base URL is overridable for testing with a mock server.
+ */
+
+import { logger } from '../../utils/logger.js';
+
+const REQUEST_TIMEOUT_MS = 10_000;
+
+export interface TelegramUser {
+  username: string;
+  firstName: string;
+}
+
+export interface TelegramChat {
+  chatId: string;
+  chatTitle: string;
+  chatType: string;
+}
+
+export interface TelegramChatInfo {
+  title: string;
+  type: string;
+}
+
+export class TelegramClient {
+  private botToken: string;
+  private baseUrl: string;
+
+  constructor(botToken: string, baseUrl?: string) {
+    this.botToken = botToken;
+    this.baseUrl = baseUrl || process.env.TELEGRAM_API_BASE || 'https://api.telegram.org';
+  }
+
+  private async request<T>(method: string, params?: Record<string, unknown>): Promise<T> {
+    const url = `${this.baseUrl}/bot${this.botToken}/${method}`;
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: params ? JSON.stringify(params) : undefined,
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`Telegram API error ${response.status}: ${text}`);
+      }
+
+      const data = await response.json() as { ok: boolean; result: T; description?: string };
+      if (!data.ok) {
+        throw new Error(`Telegram API returned error: ${data.description || 'Unknown error'}`);
+      }
+
+      return data.result;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async getMe(): Promise<TelegramUser> {
+    const result = await this.request<{ username: string; first_name: string }>('getMe');
+    return {
+      username: result.username,
+      firstName: result.first_name,
+    };
+  }
+
+  async getUpdates(): Promise<TelegramChat[]> {
+    const updates = await this.request<Array<{
+      message?: {
+        chat: { id: number; title?: string; type: string };
+      };
+    }>>('getUpdates');
+
+    const seen = new Map<string, TelegramChat>();
+    for (const update of updates) {
+      if (update.message?.chat) {
+        const chat = update.message.chat;
+        const chatId = String(chat.id);
+        if (!seen.has(chatId)) {
+          seen.set(chatId, {
+            chatId,
+            chatTitle: chat.title || `Private chat ${chatId}`,
+            chatType: chat.type,
+          });
+        }
+      }
+    }
+
+    return Array.from(seen.values());
+  }
+
+  async getChat(chatId: string): Promise<TelegramChatInfo> {
+    const result = await this.request<{ title?: string; type: string }>('getChat', {
+      chat_id: chatId,
+    });
+    return {
+      title: result.title || 'Private chat',
+      type: result.type,
+    };
+  }
+
+  async sendMessage(chatId: string, text: string, parseMode?: string): Promise<void> {
+    await this.request('sendMessage', {
+      chat_id: chatId,
+      text,
+      ...(parseMode && { parse_mode: parseMode }),
+    });
+    logger.debug('FEED', 'Message sent to Telegram', { chatId });
+  }
+}

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -124,6 +124,10 @@ import { SearchRoutes } from './worker/http/routes/SearchRoutes.js';
 import { SettingsRoutes } from './worker/http/routes/SettingsRoutes.js';
 import { LogsRoutes } from './worker/http/routes/LogsRoutes.js';
 import { MemoryRoutes } from './worker/http/routes/MemoryRoutes.js';
+import { FeedRoutes } from './worker/http/routes/FeedRoutes.js';
+
+// Feed daemon
+import { FeedDaemon } from './feed/FeedDaemon.js';
 
 // Process management for zombie cleanup (Issue #737)
 import { startOrphanReaper, reapOrphanedProcesses, getProcessBySession, ensureProcessExit } from './worker/ProcessRegistry.js';
@@ -173,6 +177,9 @@ export class WorkerService {
   private settingsManager: SettingsManager;
   private sessionEventBroadcaster: SessionEventBroadcaster;
 
+  // Feed daemon
+  private feedDaemon: FeedDaemon;
+
   // Route handlers
   private searchRoutes: SearchRoutes | null = null;
 
@@ -214,6 +221,7 @@ export class WorkerService {
     this.paginationHelper = new PaginationHelper(this.dbManager);
     this.settingsManager = new SettingsManager(this.dbManager);
     this.sessionEventBroadcaster = new SessionEventBroadcaster(this.sseBroadcaster, this);
+    this.feedDaemon = new FeedDaemon();
 
     // Set callback for when sessions are deleted
     this.sessionManager.setOnSessionDeleted(() => {
@@ -320,6 +328,7 @@ export class WorkerService {
     this.server.registerRoutes(new SettingsRoutes(this.settingsManager));
     this.server.registerRoutes(new LogsRoutes());
     this.server.registerRoutes(new MemoryRoutes(this.dbManager, 'claude-mem'));
+    this.server.registerRoutes(new FeedRoutes(this.feedDaemon, this.sseBroadcaster));
   }
 
   /**
@@ -500,6 +509,11 @@ export class WorkerService {
           logger.error('SYSTEM', 'Stale session reaper error', { error: e instanceof Error ? e.message : String(e) });
         }
       }, 2 * 60 * 1000);
+
+      // Auto-start feed daemon if configured
+      if (this.feedDaemon.start(this.sseBroadcaster)) {
+        logger.info('SYSTEM', 'Feed daemon auto-started');
+      }
 
       // Auto-recover orphaned queues (fire-and-forget with error logging)
       this.processPendingQueues(50).then(result => {
@@ -882,6 +896,9 @@ export class WorkerService {
    * Shutdown the worker service
    */
   async shutdown(): Promise<void> {
+    // Stop feed daemon before shutdown
+    this.feedDaemon.stop();
+
     // Stop orphan reaper before shutdown (Issue #737)
     if (this.stopOrphanReaper) {
       this.stopOrphanReaper();
@@ -1187,6 +1204,68 @@ async function main() {
       const { cleanClaudeMd } = await import('../cli/claude-md-commands.js');
       const result = await cleanClaudeMd(dryRun);
       process.exit(result);
+      break;
+    }
+
+    case 'feed': {
+      const feedSubcommand = process.argv[3];
+      switch (feedSubcommand) {
+        case 'setup': {
+          const nonInteractive = process.argv.includes('--non-interactive');
+          const { runFeedSetupWizard } = await import('../cli/feed-setup/feed-setup-wizard.js');
+          const botToken = process.argv.find(a => a.startsWith('--bot-token='))?.split('=')[1];
+          const chatId = process.argv.find(a => a.startsWith('--chat-id='))?.split('=')[1];
+          await runFeedSetupWizard({ nonInteractive, botToken, chatId });
+          process.exit(0);
+        }
+        case 'start': {
+          // Enable + start via HTTP API
+          const workerReady = await ensureWorkerStarted(port);
+          if (!workerReady) {
+            console.error('Worker not running. Start it first: bun worker-service.cjs start');
+            process.exit(1);
+          }
+          const startRes = await fetch(`http://127.0.0.1:${port}/api/feed/start`, { method: 'POST' });
+          const startData = await startRes.json() as Record<string, unknown>;
+          console.log(startData.message);
+          process.exit(0);
+        }
+        case 'stop': {
+          try {
+            const stopRes = await fetch(`http://127.0.0.1:${port}/api/feed/stop`, { method: 'POST' });
+            const stopData = await stopRes.json() as Record<string, unknown>;
+            console.log(stopData.message);
+          } catch {
+            console.error('Worker not running.');
+          }
+          process.exit(0);
+        }
+        case 'status': {
+          try {
+            const statusRes = await fetch(`http://127.0.0.1:${port}/api/feed/status`);
+            const statusData = await statusRes.json() as Record<string, unknown>;
+            console.log('Feed status:');
+            console.log(`  Running: ${statusData.running}`);
+            console.log(`  Enabled: ${statusData.enabled}`);
+            console.log(`  Configured: ${statusData.configured}`);
+            if (statusData.chatId) console.log(`  Chat ID: ${statusData.chatId}`);
+            if (statusData.lastMessageTime) {
+              console.log(`  Last message: ${new Date(statusData.lastMessageTime as number).toLocaleString()}`);
+            }
+          } catch {
+            console.error('Worker not running. Cannot fetch feed status.');
+          }
+          process.exit(0);
+        }
+        default: {
+          console.log('Usage: feed <setup|start|stop|status>');
+          console.log('  setup   - Interactive setup wizard');
+          console.log('  start   - Enable and start feed daemon');
+          console.log('  stop    - Disable and stop feed daemon');
+          console.log('  status  - Show feed status');
+          process.exit(0);
+        }
+      }
       break;
     }
 

--- a/src/services/worker/SSEBroadcaster.ts
+++ b/src/services/worker/SSEBroadcaster.ts
@@ -14,6 +14,7 @@ import type { SSEEvent, SSEClient } from '../worker-types.js';
 
 export class SSEBroadcaster {
   private sseClients: Set<SSEClient> = new Set();
+  private internalListeners: Set<(event: SSEEvent) => void> = new Set();
 
   /**
    * Add a new SSE client connection
@@ -40,15 +41,30 @@ export class SSEBroadcaster {
   }
 
   /**
-   * Broadcast an event to all connected clients (single-pass)
+   * Register an internal listener that receives all broadcast events without HTTP loopback.
+   * Returns an unsubscribe function.
+   */
+  onBroadcast(cb: (event: SSEEvent) => void): () => void {
+    this.internalListeners.add(cb);
+    return () => { this.internalListeners.delete(cb); };
+  }
+
+  /**
+   * Broadcast an event to all connected clients and internal listeners (single-pass)
    */
   broadcast(event: SSEEvent): void {
-    if (this.sseClients.size === 0) {
-      logger.debug('WORKER', 'SSE broadcast skipped (no clients)', { eventType: event.type });
-      return; // Short-circuit if no clients
+    const eventWithTimestamp = { ...event, timestamp: Date.now() };
+
+    // Notify internal listeners regardless of SSE client count
+    for (const listener of this.internalListeners) {
+      try { listener(eventWithTimestamp); } catch { /* swallow listener errors */ }
     }
 
-    const eventWithTimestamp = { ...event, timestamp: Date.now() };
+    if (this.sseClients.size === 0) {
+      logger.debug('WORKER', 'SSE broadcast skipped (no clients)', { eventType: event.type });
+      return;
+    }
+
     const data = `data: ${JSON.stringify(eventWithTimestamp)}\n\n`;
 
     logger.debug('WORKER', 'SSE broadcast sent', { eventType: event.type, clients: this.sseClients.size });

--- a/src/services/worker/http/routes/FeedRoutes.ts
+++ b/src/services/worker/http/routes/FeedRoutes.ts
@@ -1,0 +1,56 @@
+/**
+ * FeedRoutes
+ *
+ * HTTP endpoints for managing the crab-mem Telegram feed daemon.
+ *   GET  /api/feed/status - Feed status
+ *   POST /api/feed/start  - Start feed daemon
+ *   POST /api/feed/stop   - Stop feed daemon
+ *   POST /api/feed/test   - Send test message
+ */
+
+import express, { Request, Response } from 'express';
+import { BaseRouteHandler } from '../BaseRouteHandler.js';
+import type { FeedDaemon } from '../../../feed/FeedDaemon.js';
+import type { SSEBroadcaster } from '../../SSEBroadcaster.js';
+
+export class FeedRoutes extends BaseRouteHandler {
+  constructor(
+    private feedDaemon: FeedDaemon,
+    private sseBroadcaster: SSEBroadcaster
+  ) {
+    super();
+  }
+
+  setupRoutes(app: express.Application): void {
+    app.get('/api/feed/status', this.handleStatus.bind(this));
+    app.post('/api/feed/start', this.handleStart.bind(this));
+    app.post('/api/feed/stop', this.handleStop.bind(this));
+    app.post('/api/feed/test', this.handleTest.bind(this));
+  }
+
+  private handleStatus = this.wrapHandler((_req: Request, res: Response): void => {
+    res.json(this.feedDaemon.getStatus());
+  });
+
+  private handleStart = this.wrapHandler((_req: Request, res: Response): void => {
+    // Idempotent: start if not running, restart only if already running
+    const started = this.feedDaemon.running
+      ? this.feedDaemon.restart(this.sseBroadcaster)
+      : this.feedDaemon.start(this.sseBroadcaster);
+    res.json({ success: started, message: started ? 'Feed started' : 'Feed not configured or disabled' });
+  });
+
+  private handleStop = this.wrapHandler((_req: Request, res: Response): void => {
+    this.feedDaemon.stop();
+    res.json({ success: true, message: 'Feed stopped' });
+  });
+
+  private handleTest = this.wrapHandler(async (_req: Request, res: Response): Promise<void> => {
+    try {
+      await this.feedDaemon.sendTestMessage();
+      res.json({ success: true, message: 'Test message sent' });
+    } catch (err) {
+      res.status(400).json({ success: false, message: (err as Error).message });
+    }
+  });
+}

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -64,6 +64,11 @@ export interface SettingsDefaults {
   CLAUDE_MEM_CHROMA_API_KEY: string;
   CLAUDE_MEM_CHROMA_TENANT: string;
   CLAUDE_MEM_CHROMA_DATABASE: string;
+  // Feed Settings
+  CLAUDE_MEM_FEED_ENABLED: string;     // 'true' | 'false'
+  CLAUDE_MEM_FEED_CHANNEL: string;     // 'telegram'
+  CLAUDE_MEM_FEED_BOT_TOKEN: string;   // Telegram bot token
+  CLAUDE_MEM_FEED_CHAT_ID: string;     // Telegram chat/group ID
 }
 
 export class SettingsDefaultsManager {
@@ -123,6 +128,11 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_CHROMA_API_KEY: '',
     CLAUDE_MEM_CHROMA_TENANT: 'default_tenant',
     CLAUDE_MEM_CHROMA_DATABASE: 'default_database',
+    // Feed Settings
+    CLAUDE_MEM_FEED_ENABLED: 'false',
+    CLAUDE_MEM_FEED_CHANNEL: 'telegram',
+    CLAUDE_MEM_FEED_BOT_TOKEN: '',
+    CLAUDE_MEM_FEED_CHAT_ID: '',
   };
 
   /**


### PR DESCRIPTION
## Summary

- Adds `claude-mem feed setup` — a 6-step interactive CLI wizard (using @clack/prompts) that guides users through full Telegram feed configuration: create bot via BotFather, create group, auto-detect chat ID, send test message, save config, and verify live feed
- Introduces standalone `FeedDaemon` that runs inside the worker process, listening to `SSEBroadcaster.onBroadcast()` internal events (no HTTP loopback) and forwarding observations + summaries to Telegram
- Adds `TelegramClient` (getMe, getUpdates, getChat, sendMessage) with overridable base URL for mock testing
- Adds `FeedRoutes` HTTP endpoints: GET /api/feed/status, POST /api/feed/start, POST /api/feed/stop, POST /api/feed/test
- Adds CLI subcommands: `feed setup`, `feed start`, `feed stop`, `feed status`
- Supports `--non-interactive --bot-token=TOKEN --chat-id=ID` for CI/Docker

### Code review fixes included
- `chmod 0o600` on settings.json after writing bot token (security hardening)
- Idempotent `/api/feed/start` — uses `start()` when cold, `restart()` only when already running
- Early validation in non-interactive mode when required flags are missing

## Test plan

- [ ] Run `bun plugin/scripts/worker-service.cjs feed setup` interactively — verify all 6 steps complete
- [ ] Run `bun plugin/scripts/worker-service.cjs feed status` — verify status output
- [ ] Run `bun plugin/scripts/worker-service.cjs feed start` / `feed stop` — verify daemon lifecycle
- [ ] Verify non-interactive mode fails early without `--bot-token` and `--chat-id`
- [ ] Verify settings.json has 0600 permissions after saving config
- [ ] Verify feed daemon auto-starts on worker boot when configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)