### PR TITLE
docs: clarify that npm global install is SDK-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Start a new Claude Code session in the terminal and enter the following commands
 
 Restart Claude Code. Context from previous sessions will automatically appear in new sessions.
 
+> **Note:** Claude-Mem is also published on npm, but `npm install -g claude-mem` installs the **SDK/library only** — it does not register the plugin hooks or set up the worker service. To use Claude-Mem as a plugin, always install via the `/plugin` commands above.
+
 ### 🦞 OpenClaw Gateway
 
 Install claude-mem as a persistent memory plugin on [OpenClaw](https://openclaw.ai) gateways with a single command:

--- a/docs/public/installation.mdx
+++ b/docs/public/installation.mdx
@@ -22,6 +22,10 @@ That's it! The plugin will automatically:
 
 Start a new Claude Code session and you'll see context from previous sessions automatically loaded.
 
+> **Important:** Claude-Mem is published on npm, but running `npm install -g claude-mem` installs the
+> **SDK/library only**. It does **not** register plugin hooks or start the worker service.
+> To use Claude-Mem as a persistent memory plugin, always install via the `/plugin` commands above.
+
 ## System Requirements
 
 - **Node.js**: 18.0.0 or higher


### PR DESCRIPTION
## Summary
- Added a note to **README.md** and **docs/public/installation.mdx** clarifying that `npm install -g claude-mem` installs the SDK/library only and does **not** register plugin hooks or start the worker service
- Users who discover the package on npm may reasonably try a global install and expect the plugin to work — this note redirects them to the correct `/plugin` commands

## Test plan
- [ ] Verify the note renders correctly on GitHub (README.md)
- [ ] Verify the note renders correctly on docs site (installation.mdx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)