### PR TITLE
fix: include project in ChromaDB where clause for vector search

### DIFF
--- a/src/services/worker/SearchManager.ts
+++ b/src/services/worker/SearchManager.ts
@@ -154,7 +154,7 @@ export class SearchManager {
       let chromaSucceeded = false;
       logger.debug('SEARCH', 'Using ChromaDB semantic search', { typeFilter: type || 'all' });
 
-      // Build Chroma where filter for doc_type
+      // Build Chroma where filter for doc_type and project
       let whereFilter: Record<string, any> | undefined;
       if (type === 'observations') {
         whereFilter = { doc_type: 'observation' };
@@ -164,7 +164,17 @@ export class SearchManager {
         whereFilter = { doc_type: 'user_prompt' };
       }
 
-      // Step 1: Chroma semantic search with optional type filter
+      // Include project in the Chroma where clause to scope vector search.
+      // Without this, larger projects dominate the top-N results and smaller
+      // projects get crowded out before the post-hoc SQLite filter.
+      if (options.project) {
+        const projectFilter = { project: options.project };
+        whereFilter = whereFilter
+          ? { $and: [whereFilter, projectFilter] }
+          : projectFilter;
+      }
+
+      // Step 1: Chroma semantic search with optional type + project filter
       const chromaResults = await this.queryChroma(query, 100, whereFilter);
       chromaSucceeded = true; // Chroma didn't throw error
       logger.debug('SEARCH', 'ChromaDB returned semantic matches', { matchCount: chromaResults.ids.length });

--- a/tests/worker/search/strategies/chroma-search-strategy.test.ts
+++ b/tests/worker/search/strategies/chroma-search-strategy.test.ts
@@ -213,6 +213,52 @@ describe('ChromaSearchStrategy', () => {
       );
     });
 
+    it('should include project in Chroma where clause when specified', async () => {
+      const options: StrategySearchOptions = {
+        query: 'test query',
+        project: 'my-project'
+      };
+
+      await strategy.search(options);
+
+      expect(mockChromaSync.queryChroma).toHaveBeenCalledWith(
+        'test query',
+        100,
+        { project: 'my-project' }
+      );
+    });
+
+    it('should combine doc_type and project with $and when both specified', async () => {
+      const options: StrategySearchOptions = {
+        query: 'test query',
+        searchType: 'observations',
+        project: 'my-project'
+      };
+
+      await strategy.search(options);
+
+      expect(mockChromaSync.queryChroma).toHaveBeenCalledWith(
+        'test query',
+        100,
+        { $and: [{ doc_type: 'observation' }, { project: 'my-project' }] }
+      );
+    });
+
+    it('should not include project filter when project is not specified', async () => {
+      const options: StrategySearchOptions = {
+        query: 'test query',
+        searchType: 'observations'
+      };
+
+      await strategy.search(options);
+
+      expect(mockChromaSync.queryChroma).toHaveBeenCalledWith(
+        'test query',
+        100,
+        { doc_type: 'observation' }
+      );
+    });
+
     it('should return empty result when no query provided', async () => {
       const options: StrategySearchOptions = {
         query: undefined


### PR DESCRIPTION
## Summary

When searching with a `project` parameter, the ChromaDB vector query did not filter by project — it only filtered by `doc_type`. This caused larger projects to dominate the top-N results returned by ChromaDB, effectively crowding out results from smaller projects before the post-hoc SQLite project filter could take effect.

**Example:** With project A having 19,551 embeddings and project B having 705:
- Search scoped to project B → ChromaDB returns 100 results, ~97 from project A
- SQLite filters by project B → only 1-3 results survive instead of 20+

## Changes

- **`ChromaSearchStrategy.buildWhereFilter()`** — accepts optional `project` param, composes `$and` filter with `{project}` when both `doc_type` and `project` are specified
- **`SearchManager.search()`** — includes `options.project` in the ChromaDB `where` clause using the same `$and` composition
- **Tests** — 3 new test cases covering project-only filter, combined `$and` filter, and no-project backward compatibility

## Related

- Closes #714 (search with project returns no results despite data existing)
- Same architectural pattern as #679 (date filters not passed to Chroma)

## Test plan

- [ ] Existing tests pass (no regressions for searches without project)
- [ ] New tests verify project filter is included in ChromaDB where clause
- [ ] Manual verification: multi-project database returns correct results when searching with project param