### PR TITLE
Rename Telegram bot commands from hyphens to underscores

### DIFF
--- a/docs/public/openclaw-integration.mdx
+++ b/docs/public/openclaw-integration.mdx
@@ -235,7 +235,7 @@ After starting the gateway, check that the feed is connected:
    [claude-mem] Connected to SSE stream
    ```
 
-2. **Use the status command** — Run `/claude-mem-feed` in any OpenClaw chat to see:
+2. **Use the status command** — Run `/claude_mem_feed` in any OpenClaw chat to see:
    ```
    Claude-Mem Observation Feed
    Enabled: yes
@@ -340,22 +340,22 @@ The claude-mem worker service must be running on the same machine as the OpenCla
 
 ## Commands
 
-### /claude-mem-feed
+### /claude_mem_feed
 
 Show or toggle the observation feed status.
 
 ```
-/claude-mem-feed        # Show current status
-/claude-mem-feed on     # Request enable
-/claude-mem-feed off    # Request disable
+/claude_mem_feed        # Show current status
+/claude_mem_feed on     # Request enable
+/claude_mem_feed off    # Request disable
 ```
 
-### /claude-mem-status
+### /claude_mem_status
 
 Check worker health and session status.
 
 ```
-/claude-mem-status
+/claude_mem_status
 ```
 
 Returns worker status, port, active session count, and observation feed connection state.

--- a/openclaw/SKILL.md
+++ b/openclaw/SKILL.md
@@ -152,7 +152,7 @@ Restart your OpenClaw gateway so it picks up the new plugin configuration. After
 [claude-mem] OpenClaw plugin loaded — v1.0.0 (worker: 127.0.0.1:37777)
 ```
 
-If you see this, the plugin is loaded. You can also verify by running `/claude-mem-status` in any OpenClaw chat:
+If you see this, the plugin is loaded. You can also verify by running `/claude_mem_status` in any OpenClaw chat:
 
 ```
 Claude-Mem Worker Status
@@ -324,7 +324,7 @@ Restart the gateway. Check the logs for these three lines in order:
 [claude-mem] Connected to SSE stream
 ```
 
-Then run `/claude-mem-feed` in any OpenClaw chat:
+Then run `/claude_mem_feed` in any OpenClaw chat:
 
 ```
 Claude-Mem Observation Feed
@@ -340,12 +340,12 @@ If `Connection` shows `connected`, you're done. Have an agent do some work and w
 
 The plugin registers two commands:
 
-### /claude-mem-status
+### /claude_mem_status
 
 Reports worker health and current session state.
 
 ```
-/claude-mem-status
+/claude_mem_status
 ```
 
 Output:
@@ -357,14 +357,14 @@ Active sessions: 2
 Observation feed: connected
 ```
 
-### /claude-mem-feed
+### /claude_mem_feed
 
 Shows observation feed status. Accepts optional `on`/`off` argument.
 
 ```
-/claude-mem-feed          — show status
-/claude-mem-feed on       — request enable (update config to persist)
-/claude-mem-feed off      — request disable (update config to persist)
+/claude_mem_feed          — show status
+/claude_mem_feed on       — request enable (update config to persist)
+/claude_mem_feed off      — request disable (update config to persist)
 ```
 
 ## How It All Works

--- a/openclaw/src/index.ts
+++ b/openclaw/src/index.ts
@@ -806,10 +806,10 @@ export default function claudeMemPlugin(api: OpenClawPluginApi): void {
   }
 
   // ------------------------------------------------------------------
-  // Command: /claude-mem-feed — status & toggle
+  // Command: /claude_mem_feed — status & toggle
   // ------------------------------------------------------------------
   api.registerCommand({
-    name: "claude-mem-feed",
+    name: "claude_mem_feed",
     description: "Show or toggle Claude-Mem observation feed status",
     acceptsArgs: true,
     handler: async (ctx) => {
@@ -977,10 +977,10 @@ export default function claudeMemPlugin(api: OpenClawPluginApi): void {
   });
 
   // ------------------------------------------------------------------
-  // Command: /claude-mem-status — worker health check
+  // Command: /claude_mem_status — worker health check
   // ------------------------------------------------------------------
   api.registerCommand({
-    name: "claude-mem-status",
+    name: "claude_mem_status",
     description: "Check Claude-Mem worker health and session status",
     handler: async () => {
       const healthText = await workerGetText(workerPort, "/api/health", api.logger);


### PR DESCRIPTION
Rebased version of #1114 to resolve conflicts with #1115. Original author: @Manantra