### PR TITLE
fix: use nullish coalescing for promptNumber to preserve zero values

### DIFF
--- a/src/services/sqlite/PendingMessageStore.ts
+++ b/src/services/sqlite/PendingMessageStore.ts
@@ -69,7 +69,7 @@ export class PendingMessageStore {
       message.tool_response ? JSON.stringify(message.tool_response) : null,
       message.cwd || null,
       message.last_assistant_message || null,
-      message.prompt_number || null,
+      message.prompt_number ?? null,
       now
     );
 
@@ -444,7 +444,7 @@ export class PendingMessageStore {
       tool_name: persistent.tool_name || undefined,
       tool_input: persistent.tool_input ? JSON.parse(persistent.tool_input) : undefined,
       tool_response: persistent.tool_response ? JSON.parse(persistent.tool_response) : undefined,
-      prompt_number: persistent.prompt_number || undefined,
+      prompt_number: persistent.prompt_number ?? undefined,
       cwd: persistent.cwd || undefined,
       last_assistant_message: persistent.last_assistant_message || undefined
     };

--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -1481,7 +1481,7 @@ export class SessionStore {
       JSON.stringify(observation.concepts),
       JSON.stringify(observation.files_read),
       JSON.stringify(observation.files_modified),
-      promptNumber || null,
+      promptNumber ?? null,
       discoveryTokens,
       timestampIso,
       timestampEpoch
@@ -1532,7 +1532,7 @@ export class SessionStore {
       summary.completed,
       summary.next_steps,
       summary.notes,
-      promptNumber || null,
+      promptNumber ?? null,
       discoveryTokens,
       timestampIso,
       timestampEpoch
@@ -1613,7 +1613,7 @@ export class SessionStore {
           JSON.stringify(observation.concepts),
           JSON.stringify(observation.files_read),
           JSON.stringify(observation.files_modified),
-          promptNumber || null,
+          promptNumber ?? null,
           discoveryTokens,
           timestampIso,
           timestampEpoch
@@ -1640,7 +1640,7 @@ export class SessionStore {
           summary.completed,
           summary.next_steps,
           summary.notes,
-          promptNumber || null,
+          promptNumber ?? null,
           discoveryTokens,
           timestampIso,
           timestampEpoch
@@ -1733,7 +1733,7 @@ export class SessionStore {
           JSON.stringify(observation.concepts),
           JSON.stringify(observation.files_read),
           JSON.stringify(observation.files_modified),
-          promptNumber || null,
+          promptNumber ?? null,
           discoveryTokens,
           timestampIso,
           timestampEpoch
@@ -1760,7 +1760,7 @@ export class SessionStore {
           summary.completed,
           summary.next_steps,
           summary.notes,
-          promptNumber || null,
+          promptNumber ?? null,
           discoveryTokens,
           timestampIso,
           timestampEpoch

--- a/src/services/sqlite/observations/store.ts
+++ b/src/services/sqlite/observations/store.ts
@@ -42,7 +42,7 @@ export function storeObservation(
     JSON.stringify(observation.concepts),
     JSON.stringify(observation.files_read),
     JSON.stringify(observation.files_modified),
-    promptNumber || null,
+    promptNumber ?? null,
     discoveryTokens,
     timestampIso,
     timestampEpoch

--- a/src/services/sqlite/summaries/store.ts
+++ b/src/services/sqlite/summaries/store.ts
@@ -46,7 +46,7 @@ export function storeSummary(
     summary.completed,
     summary.next_steps,
     summary.notes,
-    promptNumber || null,
+    promptNumber ?? null,
     discoveryTokens,
     timestampIso,
     timestampEpoch

--- a/src/services/sqlite/transactions.ts
+++ b/src/services/sqlite/transactions.ts
@@ -83,7 +83,7 @@ export function storeObservationsAndMarkComplete(
         JSON.stringify(observation.concepts),
         JSON.stringify(observation.files_read),
         JSON.stringify(observation.files_modified),
-        promptNumber || null,
+        promptNumber ?? null,
         discoveryTokens,
         timestampIso,
         timestampEpoch
@@ -110,7 +110,7 @@ export function storeObservationsAndMarkComplete(
         summary.completed,
         summary.next_steps,
         summary.notes,
-        promptNumber || null,
+        promptNumber ?? null,
         discoveryTokens,
         timestampIso,
         timestampEpoch
@@ -194,7 +194,7 @@ export function storeObservations(
         JSON.stringify(observation.concepts),
         JSON.stringify(observation.files_read),
         JSON.stringify(observation.files_modified),
-        promptNumber || null,
+        promptNumber ?? null,
         discoveryTokens,
         timestampIso,
         timestampEpoch
@@ -221,7 +221,7 @@ export function storeObservations(
         summary.completed,
         summary.next_steps,
         summary.notes,
-        promptNumber || null,
+        promptNumber ?? null,
         discoveryTokens,
         timestampIso,
         timestampEpoch

--- a/tests/sqlite/observations.test.ts
+++ b/tests/sqlite/observations.test.ts
@@ -133,6 +133,17 @@ describe('Observations Module', () => {
       expect(result.createdAtEpoch).toBeLessThanOrEqual(after);
     });
 
+    it('should store prompt_number=0 as 0 (not NULL)', () => {
+      const memorySessionId = createSessionWithMemoryId('content-zero', 'session-zero');
+      const observation = createObservationInput();
+
+      const result = storeObservation(db, memorySessionId, 'test-project', observation, 0);
+      const stored = getObservationById(db, result.id);
+
+      expect(stored).not.toBeNull();
+      expect(stored!.prompt_number).toBe(0);
+    });
+
     it('should handle null subtitle and narrative', () => {
       const memorySessionId = createSessionWithMemoryId('content-null', 'session-null');
       const observation = createObservationInput({

--- a/tests/sqlite/summaries.test.ts
+++ b/tests/sqlite/summaries.test.ts
@@ -128,6 +128,17 @@ describe('Summaries Module', () => {
       expect(result.createdAtEpoch).toBeLessThanOrEqual(after);
     });
 
+    it('should store prompt_number=0 as 0 (not NULL)', () => {
+      const memorySessionId = createSessionWithMemoryId('content-sum-zero', 'session-sum-zero');
+      const summary = createSummaryInput();
+
+      storeSummary(db, memorySessionId, 'test-project', summary, 0);
+      const stored = getSummaryForSession(db, memorySessionId);
+
+      expect(stored).not.toBeNull();
+      expect(stored!.prompt_number).toBe(0);
+    });
+
     it('should handle null notes', () => {
       const memorySessionId = createSessionWithMemoryId('content-sum-null', 'session-sum-null');
       const summary = createSummaryInput({ notes: null });


### PR DESCRIPTION
## Summary

- `promptNumber || null` treats `0` as falsy, so the first prompt in a session (prompt number 0) is stored as `NULL` instead of `0`
- Replace all `promptNumber || null` with `promptNumber ?? null` across 5 source files (observations, summaries, transactions, SessionStore, PendingMessageStore)
- Also fix `prompt_number || undefined` in `PendingMessageStore.toPendingMessage()` which drops zero values during deserialization

**Files changed:** `observations/store.ts`, `summaries/store.ts`, `transactions.ts`, `SessionStore.ts`, `PendingMessageStore.ts`

## Test plan

- [x] Add test: `storeObservation` with `promptNumber=0` stores `0` (not NULL)
- [x] Add test: `storeSummary` with `promptNumber=0` stores `0` (not NULL)
- [x] All 22 existing observation/summary tests still pass
- [x] Verified no remaining `promptNumber || null` patterns in `src/`