### PR TITLE
fix: make privacy tag stripping case-insensitive

### DIFF
--- a/src/utils/tag-stripping.ts
+++ b/src/utils/tag-stripping.ts
@@ -25,8 +25,8 @@ const MAX_TAG_COUNT = 100;
  * Used for ReDoS protection before regex processing
  */
 function countTags(content: string): number {
-  const privateCount = (content.match(/<private>/g) || []).length;
-  const contextCount = (content.match(/<claude-mem-context>/g) || []).length;
+  const privateCount = (content.match(/<private>/gi) || []).length;
+  const contextCount = (content.match(/<claude-mem-context>/gi) || []).length;
   return privateCount + contextCount;
 }
 
@@ -47,8 +47,8 @@ function stripTagsInternal(content: string): string {
   }
 
   return content
-    .replace(/<claude-mem-context>[\s\S]*?<\/claude-mem-context>/g, '')
-    .replace(/<private>[\s\S]*?<\/private>/g, '')
+    .replace(/<claude-mem-context>[\s\S]*?<\/claude-mem-context>/gi, '')
+    .replace(/<private>[\s\S]*?<\/private>/gi, '')
     .trim();
 }
 

--- a/tests/utils/tag-stripping.test.ts
+++ b/tests/utils/tag-stripping.test.ts
@@ -51,6 +51,28 @@ describe('Tag Stripping Utilities', () => {
       });
     });
 
+    describe('case-insensitive tag matching', () => {
+      it('should strip uppercase <PRIVATE> tags', () => {
+        const input = 'public <PRIVATE>secret</PRIVATE> end';
+        expect(stripMemoryTagsFromPrompt(input)).toBe('public  end');
+      });
+
+      it('should strip mixed-case <Private> tags', () => {
+        const input = 'public <Private>secret</Private> end';
+        expect(stripMemoryTagsFromPrompt(input)).toBe('public  end');
+      });
+
+      it('should strip uppercase <CLAUDE-MEM-CONTEXT> tags', () => {
+        const input = 'public <CLAUDE-MEM-CONTEXT>context</CLAUDE-MEM-CONTEXT> end';
+        expect(stripMemoryTagsFromPrompt(input)).toBe('public  end');
+      });
+
+      it('should strip mixed case and lowercase tags together', () => {
+        const input = '<PRIVATE>secret1</PRIVATE> middle <private>secret2</private> end';
+        expect(stripMemoryTagsFromPrompt(input)).toBe('middle  end');
+      });
+    });
+
     describe('multiple tags handling', () => {
       it('should strip multiple <private> blocks', () => {
         const input = '<private>first secret</private> middle <private>second secret</private> end';


### PR DESCRIPTION
## Summary
- The regex patterns used to strip `<private>` and `<claude-mem-context>` tags were missing the case-insensitive (`i`) flag
- Uppercase or mixed-case variants (e.g., `<PRIVATE>`, `<Private>`, `<CLAUDE-MEM-CONTEXT>`) bypassed the privacy filter entirely, allowing content meant to be excluded from memory to be stored in the database
- Added the `i` flag to all four regex patterns in `countTags` and `stripTagsInternal` in `src/utils/tag-stripping.ts`

## Test plan
- [x] Added test cases for uppercase `<PRIVATE>` tags
- [x] Added test cases for mixed-case `<Private>` tags
- [x] Added test cases for uppercase `<CLAUDE-MEM-CONTEXT>` tags
- [x] Added test cases for mixed case tags combined with lowercase tags
- [x] All 31 tag-stripping tests pass