### PR TITLE
fix: remove non-existent columns from getSessionSummaryById query

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -2094,7 +2094,7 @@ export class SessionStore {
   }
 
   /**
-   * Get full session summary by ID (includes request_summary and learned_summary)
+   * Get full session summary by ID
    */
   getSessionSummaryById(id: number): {
     id: number;
@@ -2102,11 +2102,9 @@ export class SessionStore {
     content_session_id: string;
     project: string;
     user_prompt: string;
-    request_summary: string | null;
-    learned_summary: string | null;
     status: string;
-    created_at: string;
-    created_at_epoch: number;
+    started_at: string;
+    started_at_epoch: number;
   } | null {
     const stmt = this.db.prepare(`
       SELECT
@@ -2115,11 +2113,9 @@ export class SessionStore {
         content_session_id,
         project,
         user_prompt,
-        request_summary,
-        learned_summary,
         status,
-        created_at,
-        created_at_epoch
+        started_at,
+        started_at_epoch
       FROM sdk_sessions
       WHERE id = ?
       LIMIT 1

--- a/src/services/sqlite/sessions/get.ts
+++ b/src/services/sqlite/sessions/get.ts
@@ -80,7 +80,7 @@ export function getRecentSessionsWithStatus(
 }
 
 /**
- * Get full session summary by ID (includes request_summary and learned_summary)
+ * Get full session summary by ID
  */
 export function getSessionSummaryById(
   db: Database,
@@ -93,11 +93,9 @@ export function getSessionSummaryById(
       content_session_id,
       project,
       user_prompt,
-      request_summary,
-      learned_summary,
       status,
-      created_at,
-      created_at_epoch
+      started_at,
+      started_at_epoch
     FROM sdk_sessions
     WHERE id = ?
     LIMIT 1

--- a/src/services/sqlite/sessions/types.ts
+++ b/src/services/sqlite/sessions/types.ts
@@ -51,9 +51,7 @@ export interface SessionSummaryDetail {
   content_session_id: string;
   project: string;
   user_prompt: string;
-  request_summary: string | null;
-  learned_summary: string | null;
   status: string;
-  created_at: string;
-  created_at_epoch: number;
+  started_at: string;
+  started_at_epoch: number;
 }

--- a/tests/sqlite/sessions.test.ts
+++ b/tests/sqlite/sessions.test.ts
@@ -13,6 +13,7 @@ import { ClaudeMemDatabase } from '../../src/services/sqlite/Database.js';
 import {
   createSDKSession,
   getSessionById,
+  getSessionSummaryById,
   updateMemorySessionId,
 } from '../../src/services/sqlite/Sessions.js';
 import type { Database } from 'bun:sqlite';
@@ -81,6 +82,28 @@ describe('Sessions Module', () => {
       const session = getSessionById(db, 99999);
 
       expect(session).toBeNull();
+    });
+  });
+
+  describe('getSessionSummaryById', () => {
+    it('should retrieve session summary with all expected fields', () => {
+      const sessionId = createSDKSession(db, 'content-summary-1', 'test-project', 'test prompt');
+
+      const summary = getSessionSummaryById(db, sessionId);
+
+      expect(summary).not.toBeNull();
+      expect(summary?.id).toBe(sessionId);
+      expect(summary?.project).toBe('test-project');
+      expect(summary?.user_prompt).toBe('test prompt');
+      expect(summary).toHaveProperty('status');
+      expect(summary).toHaveProperty('started_at');
+      expect(summary).toHaveProperty('started_at_epoch');
+    });
+
+    it('should return null for non-existent session', () => {
+      const summary = getSessionSummaryById(db, 99999);
+
+      expect(summary).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
- `getSessionSummaryById` in both `sessions/get.ts` and `SessionStore.ts` queries `request_summary` and `learned_summary` columns that were never added to the `sdk_sessions` table via any migration, causing a runtime `SQLiteError: no such column` when called
- The query also referenced `created_at`/`created_at_epoch` instead of the actual column names `started_at`/`started_at_epoch`
- Removed the phantom columns from the SQL query and type definition, and corrected the timestamp column names to match the schema

## Test plan
- [x] Added `getSessionSummaryById` tests to `tests/sqlite/sessions.test.ts` following existing patterns
- [x] Verified the function retrieves session data with all expected fields
- [x] Verified null return for non-existent sessions
- [x] All 193 tests pass across the full test suite