### PR TITLE
feat(provider): add OpenAI Codex OAuth provider for observation extraction

### DIFF
--- a/docs/public/configuration.mdx
+++ b/docs/public/configuration.mdx
@@ -14,7 +14,7 @@ Settings are managed in `~/.claude-mem/settings.json`. The file is auto-created 
 | Setting                       | Default                         | Description                           |
 |-------------------------------|---------------------------------|---------------------------------------|
 | `CLAUDE_MEM_MODEL`            | `sonnet`                        | AI model for processing observations (when using Claude) |
-| `CLAUDE_MEM_PROVIDER`         | `claude`                        | AI provider: `claude`, `gemini`, or `openrouter` |
+| `CLAUDE_MEM_PROVIDER`         | `claude`                        | AI provider: `claude`, `gemini`, `openrouter`, or `openai-codex` |
 | `CLAUDE_MEM_MODE`             | `code`                          | Active mode profile (e.g., `code--es`, `email-investigation`) |
 | `CLAUDE_MEM_CONTEXT_OBSERVATIONS` | `50`                        | Number of observations to inject      |
 | `CLAUDE_MEM_WORKER_PORT`      | `37777`                         | Worker service port                   |
@@ -42,6 +42,19 @@ See [Gemini Provider](usage/gemini-provider) for detailed configuration and free
 | `CLAUDE_MEM_OPENROUTER_APP_NAME`             | `claude-mem`                | Optional: App name for analytics      |
 
 See [OpenRouter Provider](usage/openrouter-provider) for detailed configuration, free model list, and usage guide.
+
+### OpenAI Codex Provider Settings
+
+| Setting                              | Default         | Description                           |
+|--------------------------------------|-----------------|---------------------------------------|
+| `CLAUDE_MEM_OPENAI_CODEX_MODEL`      | `gpt-4o`        | Model for observation extraction (`gpt-4o`, `gpt-4o-mini`, `gpt-5.3-codex`) |
+| `CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR`  | _(auto-detect)_ | Path to dir containing `auth-profiles.json`. Leave empty to auto-detect from OpenClaw. |
+
+See [OpenAI Codex Provider](usage/openai-codex-provider) for OAuth setup, credential discovery, and migration guide.
+
+<Warning>
+**OpenClaw users**: Anthropic's Terms of Service (updated February 2026) prohibit using Claude OAuth tokens in third-party apps outside of Claude Code. If you run claude-mem through OpenClaw, use `openai-codex`, `gemini`, or `openrouter` as your provider instead of `claude`.
+</Warning>
 
 ### System Configuration
 

--- a/docs/public/docs.json
+++ b/docs/public/docs.json
@@ -38,6 +38,7 @@
           "usage/getting-started",
           "usage/openrouter-provider",
           "usage/gemini-provider",
+          "usage/openai-codex-provider",
           "usage/search-tools",
           "usage/claude-desktop",
           "usage/private-tags",

--- a/docs/public/openclaw-integration.mdx
+++ b/docs/public/openclaw-integration.mdx
@@ -378,8 +378,51 @@ Each OpenClaw agent session gets a unique `contentSessionId` (format: `openclaw-
 
 Both maps are cleared on `gateway_start`.
 
+## AI Provider for OpenClaw Users
+
+<Warning>
+**Important (February 2026)**: Anthropic's Terms of Service now prohibit using Claude OAuth tokens (Free/Pro/Max plans) in third-party apps outside of Claude Code and Claude.ai — including the Agent SDK. If you run claude-mem through OpenClaw, you must configure an alternative provider for observation extraction.
+</Warning>
+
+Claude-mem supports multiple AI providers for extracting observations. When running through OpenClaw, use one of these:
+
+### Recommended: OpenAI Codex (ChatGPT Plus/Pro OAuth)
+
+If you already have a ChatGPT Plus or Pro subscription, this is the simplest migration — no new API key needed. Credentials are shared automatically between OpenClaw and claude-mem.
+
+```json
+{
+  "CLAUDE_MEM_PROVIDER": "openai-codex"
+}
+```
+
+Then run `openclaw auth` and select "OpenAI Codex" if you haven't authenticated yet.
+
+See [OpenAI Codex Provider](usage/openai-codex-provider) for full setup instructions.
+
+### Alternative: Gemini (Free Tier Available)
+
+```json
+{
+  "CLAUDE_MEM_PROVIDER": "gemini",
+  "CLAUDE_MEM_GEMINI_API_KEY": "your-key-from-aistudio.google.com"
+}
+```
+
+### Alternative: OpenRouter (Free Models Available)
+
+```json
+{
+  "CLAUDE_MEM_PROVIDER": "openrouter",
+  "CLAUDE_MEM_OPENROUTER_API_KEY": "your-key-from-openrouter.ai"
+}
+```
+
+Claude Code sessions are unaffected — when claude-mem runs as a Claude Code plugin (not through OpenClaw), the `claude` provider continues to work normally.
+
 ## Requirements
 
 - Claude-mem worker service running on `localhost:37777` (or configured port)
 - OpenClaw gateway with plugin support
 - Network access between gateway and worker (localhost only)
+- An alternative AI provider configured (see above) if running through OpenClaw

--- a/docs/public/usage/openai-codex-provider.mdx
+++ b/docs/public/usage/openai-codex-provider.mdx
@@ -1,0 +1,154 @@
+---
+title: "OpenAI Codex Provider"
+description: "Use your ChatGPT Plus or Pro subscription for observation extraction via OAuth — no separate API key required"
+---
+
+# OpenAI Codex Provider
+
+Claude-mem supports OpenAI Codex (ChatGPT Plus/Pro) as an alternative provider for observation extraction. Authentication uses OAuth, so you can use your existing ChatGPT subscription without needing a separate API key.
+
+<Tip>
+**Recommended for OpenClaw users**: Anthropic's Terms of Service (updated February 2026) prohibit using Claude OAuth tokens in third-party apps. If you run claude-mem through OpenClaw, the OpenAI Codex provider is the cleanest migration path — it reuses your existing ChatGPT subscription with zero extra cost.
+</Tip>
+
+## Why Use OpenAI Codex?
+
+- **No API key needed**: Uses your ChatGPT Plus/Pro subscription via OAuth
+- **Zero extra cost**: Observation extraction runs on your existing subscription
+- **GPT-5.x access**: Plus/Pro subscribers get access to the latest GPT Codex models
+- **Shared credentials**: If you already authenticate via OpenClaw, credentials are reused automatically — no double login
+- **Seamless fallback**: Falls back to Claude if the OAuth token can't be refreshed
+
+## How Authentication Works
+
+Claude-mem reads OAuth credentials from the same `auth-profiles.json` file that OpenClaw writes when you run `openclaw auth`. Token refresh is automatic — when the access token expires, claude-mem uses the stored refresh token to get a new one silently.
+
+### Credential Discovery Order
+
+Claude-mem looks for credentials in this order:
+
+1. `CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR` setting (explicit override)
+2. `OPENCLAW_AGENT_DIR` environment variable (set automatically by OpenClaw at runtime)
+3. `~/.openclaw/agents/default/agent/auth-profiles.json` (OpenClaw default location)
+4. `~/.claude-mem/auth-profiles.json` (standalone fallback)
+
+If you're running claude-mem through OpenClaw, credentials are picked up automatically from step 2 or 3 — no extra configuration required.
+
+## Setup
+
+### Step 1: Authenticate with OpenClaw
+
+If you haven't already, authenticate with your ChatGPT account via OpenClaw:
+
+```bash
+openclaw auth
+# Select "OpenAI Codex" from the provider list
+# Follow the browser OAuth flow
+```
+
+Your credentials are saved to `auth-profiles.json` in your OpenClaw agent directory.
+
+### Step 2: Enable the provider
+
+Edit `~/.claude-mem/settings.json`:
+
+```json
+{
+  "CLAUDE_MEM_PROVIDER": "openai-codex"
+}
+```
+
+Or use the **Settings UI** at http://localhost:37777 → Settings → AI Provider → "OpenAI Codex (ChatGPT Plus/Pro OAuth)".
+
+### Step 3: Restart the worker
+
+```bash
+npm run worker:restart
+```
+
+That's it. Claude-mem will now use your ChatGPT subscription for observation extraction.
+
+## Configuration
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `CLAUDE_MEM_PROVIDER` | `claude` | Set to `openai-codex` to activate this provider |
+| `CLAUDE_MEM_OPENAI_CODEX_MODEL` | `gpt-4o` | Model used for observation extraction |
+| `CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR` | _(auto-detect)_ | Path to directory containing `auth-profiles.json`. Leave empty to auto-detect from OpenClaw. |
+
+### Available Models
+
+| Model | Description |
+|-------|-------------|
+| `gpt-4o` | Recommended — fast, capable, included in Plus/Pro |
+| `gpt-4o-mini` | Faster and lighter; good for high-volume extraction |
+| `gpt-5.3-codex` | Latest Codex model (ChatGPT Plus/Pro only) |
+
+<Note>
+Model availability depends on your ChatGPT subscription tier. `gpt-4o` is available on all paid plans.
+</Note>
+
+### Example Configuration
+
+```json
+{
+  "CLAUDE_MEM_PROVIDER": "openai-codex",
+  "CLAUDE_MEM_OPENAI_CODEX_MODEL": "gpt-4o"
+}
+```
+
+## Standalone Use (Without OpenClaw)
+
+If you're using claude-mem standalone (not through OpenClaw), you can authenticate directly using the `pi-ai` CLI:
+
+```bash
+npx @mariozechner/pi-ai login openai-codex
+```
+
+This saves credentials to `auth.json` in your current directory by default. Point claude-mem to that directory:
+
+```json
+{
+  "CLAUDE_MEM_PROVIDER": "openai-codex",
+  "CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR": "/path/to/directory/containing/auth-profiles.json"
+}
+```
+
+## Troubleshooting
+
+### "No auth-profiles.json found"
+
+Claude-mem can't find your credentials. Either:
+- Run `openclaw auth` to authenticate (if using OpenClaw)
+- Run `npx @mariozechner/pi-ai login openai-codex` and set `CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR`
+
+### "Token refresh failed — Re-authenticate with 'openclaw auth'"
+
+Your refresh token expired or was revoked. Run `openclaw auth` again to get new credentials.
+
+### "No openai-codex profile found"
+
+You have an `auth-profiles.json` but it doesn't contain an OpenAI Codex entry. Run `openclaw auth` and select OpenAI Codex from the provider list.
+
+## Migration from Claude Provider
+
+If you were previously using `CLAUDE_MEM_PROVIDER=claude` (with OAuth) and want to migrate:
+
+1. Run `openclaw auth` to add OpenAI Codex credentials (takes ~1 minute)
+2. Change `CLAUDE_MEM_PROVIDER` to `openai-codex` in `~/.claude-mem/settings.json`
+3. Restart the worker: `npm run worker:restart`
+
+Your memory database, observations, and summaries are unaffected — only the model that extracts new observations changes.
+
+## Comparison with Other Providers
+
+| Provider | Auth | Cost | Best For |
+|----------|------|------|----------|
+| **OpenAI Codex** | OAuth (ChatGPT sub) | Included in subscription | OpenClaw users, ChatGPT subscribers |
+| **Claude** | OAuth (Claude sub) | Included in Claude Code subscription | Claude Code users (not for OpenClaw) |
+| **Gemini** | API key | Free tier available | Cost-conscious users, high volume |
+| **OpenRouter** | API key | Free models available | Multi-model flexibility |
+
+<Warning>
+**Claude provider and OpenClaw**: Using `CLAUDE_MEM_PROVIDER=claude` with OpenClaw violates Anthropic's Terms of Service (updated February 2026), which prohibit using Claude OAuth tokens in third-party apps outside of Claude Code. Switch to `openai-codex`, `gemini`, or `openrouter` when running through OpenClaw.
+</Warning>

--- a/installer/src/steps/provider.ts
+++ b/installer/src/steps/provider.ts
@@ -1,35 +1,99 @@
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 
-export type ProviderType = 'claude' | 'gemini' | 'openrouter';
+export type ProviderType = 'claude' | 'gemini' | 'openrouter' | 'openai-codex';
 export type ClaudeAuthMethod = 'cli' | 'api';
 
 export interface ProviderConfig {
   provider: ProviderType;
+  openclawProvider?: ProviderType;   // OpenClaw-specific override (empty = use global)
   claudeAuthMethod?: ClaudeAuthMethod;
   apiKey?: string;
+  openclawApiKey?: string;
   model?: string;
   rateLimitingEnabled?: boolean;
 }
 
-export async function runProviderConfiguration(): Promise<ProviderConfig> {
+async function askApiKey(prompt: string, hint: string): Promise<string> {
+  const key = await p.password({
+    message: `${prompt} (${hint}):`,
+    validate: (v) => (!v || !v.trim().length ? 'API key is required' : undefined),
+  });
+  if (p.isCancel(key)) { p.cancel('Installation cancelled.'); process.exit(0); }
+  return key;
+}
+
+async function selectProvider(
+  message: string,
+  warnClaudeOAuth = false,
+): Promise<{ provider: ProviderType; apiKey?: string }> {
+  const claudeHint = warnClaudeOAuth
+    ? pc.red('⚠️  Not recommended — Anthropic ToS prohibits Claude OAuth in third-party apps')
+    : 'uses your Anthropic subscription';
+
   const provider = await p.select({
-    message: 'Which AI provider should claude-mem use for memory compression?',
+    message,
     options: [
-      { value: 'claude' as const, label: 'Claude', hint: 'uses your Claude subscription' },
-      { value: 'gemini' as const, label: 'Gemini', hint: 'free tier available' },
-      { value: 'openrouter' as const, label: 'OpenRouter', hint: 'free models available' },
+      {
+        value: 'openai-codex',
+        label: 'OpenAI Codex',
+        hint: 'ChatGPT Plus/Pro OAuth — no extra API key needed',
+      },
+      {
+        value: 'gemini',
+        label: 'Gemini',
+        hint: 'free tier available — requires API key from ai.google.dev',
+      },
+      {
+        value: 'openrouter',
+        label: 'OpenRouter',
+        hint: 'access to 100+ models, free options available',
+      },
+      {
+        value: 'claude',
+        label: 'Claude',
+        hint: claudeHint,
+      },
     ],
   });
 
-  if (p.isCancel(provider)) {
-    p.cancel('Installation cancelled.');
-    process.exit(0);
+  if (p.isCancel(provider)) { p.cancel('Installation cancelled.'); process.exit(0); }
+
+  const selectedProvider = provider as ProviderType;
+  let apiKey: string | undefined;
+  if (selectedProvider === 'gemini') {
+    apiKey = await askApiKey('Enter your Gemini API key', 'https://ai.google.dev');
+  } else if (selectedProvider === 'openrouter') {
+    apiKey = await askApiKey('Enter your OpenRouter API key', 'https://openrouter.ai/keys');
   }
+  // openai-codex: OAuth via `openclaw auth` — no key to collect here
+  // claude: handled separately (auth method selection below)
 
-  const config: ProviderConfig = { provider };
+  return { provider: selectedProvider, apiKey };
+}
 
-  if (provider === 'claude') {
+export async function runProviderConfiguration(): Promise<ProviderConfig> {
+  const config: ProviderConfig = { provider: 'claude' };
+
+  // ── Detect OpenClaw context ───────────────────────────────────────────────
+  // Ask whether the user also runs OpenClaw so we can configure per-origin routing.
+  const usesOpenClaw = await p.confirm({
+    message: 'Do you also use OpenClaw (in addition to Claude Code)?',
+    initialValue: false,
+  });
+  if (p.isCancel(usesOpenClaw)) { p.cancel('Installation cancelled.'); process.exit(0); }
+
+  // ── Claude Code provider ──────────────────────────────────────────────────
+  const ccResult = await selectProvider(
+    usesOpenClaw
+      ? 'Provider for Claude Code sessions:'
+      : 'Which AI provider should claude-mem use for memory compression?',
+    false,
+  );
+  config.provider = ccResult.provider;
+  config.apiKey = ccResult.apiKey;
+
+  if (config.provider === 'claude') {
     const authMethod = await p.select({
       message: 'How should Claude authenticate?',
       options: [
@@ -37,47 +101,23 @@ export async function runProviderConfiguration(): Promise<ProviderConfig> {
         { value: 'api' as const, label: 'API Key', hint: 'uses Anthropic API credits' },
       ],
     });
-
-    if (p.isCancel(authMethod)) {
-      p.cancel('Installation cancelled.');
-      process.exit(0);
-    }
-
+    if (p.isCancel(authMethod)) { p.cancel('Installation cancelled.'); process.exit(0); }
     config.claudeAuthMethod = authMethod;
 
     if (authMethod === 'api') {
       const apiKey = await p.password({
         message: 'Enter your Anthropic API key:',
-        validate: (value) => {
-          if (!value || value.trim().length === 0) return 'API key is required';
-          if (!value.startsWith('sk-ant-')) return 'Anthropic API keys start with sk-ant-';
+        validate: (v) => {
+          if (!v || !v.trim().length) return 'API key is required';
+          if (!v.startsWith('sk-ant-')) return 'Anthropic API keys start with sk-ant-';
         },
       });
-
-      if (p.isCancel(apiKey)) {
-        p.cancel('Installation cancelled.');
-        process.exit(0);
-      }
-
+      if (p.isCancel(apiKey)) { p.cancel('Installation cancelled.'); process.exit(0); }
       config.apiKey = apiKey;
     }
   }
 
-  if (provider === 'gemini') {
-    const apiKey = await p.password({
-      message: 'Enter your Gemini API key:',
-      validate: (value) => {
-        if (!value || value.trim().length === 0) return 'API key is required';
-      },
-    });
-
-    if (p.isCancel(apiKey)) {
-      p.cancel('Installation cancelled.');
-      process.exit(0);
-    }
-
-    config.apiKey = apiKey;
-
+  if (config.provider === 'gemini') {
     const model = await p.select({
       message: 'Which Gemini model?',
       options: [
@@ -86,54 +126,49 @@ export async function runProviderConfiguration(): Promise<ProviderConfig> {
         { value: 'gemini-3-flash-preview' as const, label: 'Gemini 3 Flash Preview', hint: 'latest' },
       ],
     });
-
-    if (p.isCancel(model)) {
-      p.cancel('Installation cancelled.');
-      process.exit(0);
-    }
-
+    if (p.isCancel(model)) { p.cancel('Installation cancelled.'); process.exit(0); }
     config.model = model;
 
     const rateLimiting = await p.confirm({
       message: 'Enable rate limiting? (recommended for free tier)',
       initialValue: true,
     });
-
-    if (p.isCancel(rateLimiting)) {
-      p.cancel('Installation cancelled.');
-      process.exit(0);
-    }
-
+    if (p.isCancel(rateLimiting)) { p.cancel('Installation cancelled.'); process.exit(0); }
     config.rateLimitingEnabled = rateLimiting;
   }
 
-  if (provider === 'openrouter') {
-    const apiKey = await p.password({
-      message: 'Enter your OpenRouter API key:',
-      validate: (value) => {
-        if (!value || value.trim().length === 0) return 'API key is required';
-      },
-    });
-
-    if (p.isCancel(apiKey)) {
-      p.cancel('Installation cancelled.');
-      process.exit(0);
-    }
-
-    config.apiKey = apiKey;
-
+  if (config.provider === 'openrouter') {
     const model = await p.text({
       message: 'Which OpenRouter model?',
       defaultValue: 'xiaomi/mimo-v2-flash:free',
       placeholder: 'xiaomi/mimo-v2-flash:free',
     });
-
-    if (p.isCancel(model)) {
-      p.cancel('Installation cancelled.');
-      process.exit(0);
-    }
-
+    if (p.isCancel(model)) { p.cancel('Installation cancelled.'); process.exit(0); }
     config.model = model;
+  }
+
+  // ── OpenClaw provider (only if user confirmed OpenClaw usage) ─────────────
+  if (usesOpenClaw) {
+    p.note(
+      'Anthropic\'s ToS (Feb 2026) prohibits using Claude OAuth tokens in\n' +
+      'third-party apps like OpenClaw. OpenClaw sessions need a separate provider.',
+      '⚠️  OpenClaw Provider',
+    );
+
+    const ocResult = await selectProvider(
+      'Provider for OpenClaw sessions:',
+      true, // warn about Claude OAuth
+    );
+
+    if (ocResult.provider !== config.provider) {
+      config.openclawProvider = ocResult.provider;
+      config.openclawApiKey = ocResult.apiKey;
+    }
+    // If same as global, leave openclawProvider undefined (means "use global")
+
+    if (ocResult.provider === 'claude') {
+      p.log.warn('⚠️  Using Claude OAuth for OpenClaw sessions may violate Anthropic\'s ToS. Consider switching later.');
+    }
   }
 
   return config;

--- a/installer/src/utils/settings-writer.ts
+++ b/installer/src/utils/settings-writer.ts
@@ -41,6 +41,18 @@ export function buildSettingsObject(
     if (providerConfig.model) settings.CLAUDE_MEM_OPENROUTER_MODEL = providerConfig.model;
   }
 
+  // OpenClaw-specific provider override
+  if (providerConfig.openclawProvider && providerConfig.openclawProvider !== providerConfig.provider) {
+    settings.CLAUDE_MEM_OPENCLAW_PROVIDER = providerConfig.openclawProvider;
+    // Write OpenClaw-specific API key if it's a different provider that needs one
+    if (providerConfig.openclawProvider === 'gemini' && providerConfig.openclawApiKey) {
+      if (!settings.CLAUDE_MEM_GEMINI_API_KEY) settings.CLAUDE_MEM_GEMINI_API_KEY = providerConfig.openclawApiKey;
+    } else if (providerConfig.openclawProvider === 'openrouter' && providerConfig.openclawApiKey) {
+      if (!settings.CLAUDE_MEM_OPENROUTER_API_KEY) settings.CLAUDE_MEM_OPENROUTER_API_KEY = providerConfig.openclawApiKey;
+    }
+    // openai-codex: credentials managed by OpenClaw OAuth — nothing to write here
+  }
+
   // Chroma settings
   if (settingsConfig.chromaEnabled) {
     settings.CLAUDE_MEM_CHROMA_MODE = settingsConfig.chromaMode ?? 'local';

--- a/openclaw/install.sh
+++ b/openclaw/install.sh
@@ -25,6 +25,8 @@ readonly INSTALLER_VERSION="1.0.0"
 NON_INTERACTIVE=""
 CLI_PROVIDER=""
 CLI_API_KEY=""
+CLI_OPENCLAW_PROVIDER=""
+CLI_OPENCLAW_API_KEY=""
 UPGRADE_MODE=""
 CLI_BRANCH=""
 
@@ -54,12 +56,28 @@ while [[ $# -gt 0 ]]; do
       CLI_PROVIDER="${2:-}"
       shift 2
       ;;
+    --openclaw-provider=*)
+      CLI_OPENCLAW_PROVIDER="${1#--openclaw-provider=}"
+      shift
+      ;;
+    --openclaw-provider)
+      CLI_OPENCLAW_PROVIDER="${2:-}"
+      shift 2
+      ;;
     --api-key=*)
       CLI_API_KEY="${1#--api-key=}"
       shift
       ;;
     --api-key)
       CLI_API_KEY="${2:-}"
+      shift 2
+      ;;
+    --openclaw-api-key=*)
+      CLI_OPENCLAW_API_KEY="${1#--openclaw-api-key=}"
+      shift
+      ;;
+    --openclaw-api-key)
+      CLI_OPENCLAW_API_KEY="${2:-}"
       shift 2
       ;;
     *)
@@ -954,8 +972,10 @@ configure_memory_slot() {
 # Reads defaults from SettingsDefaultsManager.ts (single source of truth)
 ###############################################################################
 
-AI_PROVIDER=""
+AI_PROVIDER=""           # Global provider (Claude Code sessions)
 AI_PROVIDER_API_KEY=""
+AI_OPENCLAW_PROVIDER="" # OpenClaw-specific provider (empty = use AI_PROVIDER)
+AI_OPENCLAW_API_KEY=""
 
 mask_api_key() {
   local key="$1"
@@ -972,107 +992,194 @@ mask_api_key() {
   fi
 }
 
-setup_ai_provider() {
+# Ask for API key for a given provider and store in the given variable name.
+# Usage: prompt_api_key <varname> <varname_key>
+# Example: prompt_api_key AI_PROVIDER AI_PROVIDER_API_KEY
+prompt_provider_api_key() {
+  local provider="$1"
+  local keyvar="$2"
+  local url hint
+  case "$provider" in
+    gemini)    url="https://ai.google.dev";   hint="Gemini API key" ;;
+    openrouter) url="https://openrouter.ai"; hint="OpenRouter API key" ;;
+    *)         return 0 ;;  # no API key needed
+  esac
   echo ""
-  info "AI Provider Configuration"
+  prompt_user "Enter your ${hint} (from ${url}):"
+  local key=""
+  read_tty -rs key
   echo ""
+  printf -v "$keyvar" '%s' "$key"
+  if [[ -z "$key" ]]; then
+    warn "No API key provided — add it later in ~/.claude-mem/settings.json"
+  else
+    success "${hint} set ($(mask_api_key "$key"))"
+  fi
+}
 
-  # Handle --provider flag (pre-selected via CLI)
-  if [[ -n "$CLI_PROVIDER" ]]; then
-    case "$CLI_PROVIDER" in
-      claude)
-        AI_PROVIDER="claude"
-        success "Selected via --provider: Claude Max Plan (CLI authentication)"
-        ;;
-      gemini)
-        AI_PROVIDER="gemini"
-        AI_PROVIDER_API_KEY="${CLI_API_KEY}"
-        if [[ -n "$AI_PROVIDER_API_KEY" ]]; then
-          success "Selected via --provider: Gemini (API key set via --api-key)"
-        else
-          warn "Selected via --provider: Gemini (no API key — add later in ~/.claude-mem/settings.json)"
-        fi
-        ;;
-      openrouter)
-        AI_PROVIDER="openrouter"
-        AI_PROVIDER_API_KEY="${CLI_API_KEY}"
-        if [[ -n "$AI_PROVIDER_API_KEY" ]]; then
-          success "Selected via --provider: OpenRouter (API key set via --api-key)"
-        else
-          warn "Selected via --provider: OpenRouter (no API key — add later in ~/.claude-mem/settings.json)"
-        fi
-        ;;
-      *)
-        error "Unknown provider: ${CLI_PROVIDER}"
-        error "Valid providers: claude, gemini, openrouter"
-        exit 1
-        ;;
-    esac
-    return 0
+# Prompt for a provider from a numbered menu.
+# Usage: prompt_provider_menu <result_var> <key_var> <default_num> <skip_claude_warn>
+# Prints menu, reads choice, sets result_var to provider name and key_var to API key.
+prompt_provider_menu() {
+  local result_var="$1"
+  local key_var="$2"
+  local default_num="${3:-1}"
+  local warn_claude="${4:-false}"  # if true, show ToS warning next to Claude option
+
+  local claude_hint="uses your Claude subscription"
+  if [[ "$warn_claude" == "true" ]]; then
+    claude_hint="${COLOR_RED}⚠️  not recommended — Anthropic ToS prohibits Claude OAuth in third-party apps${COLOR_RESET}"
   fi
 
-  # Handle non-interactive mode (no --provider flag)
-  if [[ "$NON_INTERACTIVE" == "true" ]]; then
-    info "Non-interactive mode: defaulting to Claude Max Plan (no API key needed)"
-    AI_PROVIDER="claude"
-    return 0
-  fi
-
-  echo -e "  Choose your AI provider for claude-mem:"
-  echo ""
-  echo -e "  ${COLOR_BOLD}1)${COLOR_RESET} Claude Max Plan ${COLOR_GREEN}(recommended)${COLOR_RESET}"
-  echo -e "     Uses your existing subscription, no API key needed"
+  echo -e "  ${COLOR_BOLD}1)${COLOR_RESET} OpenAI Codex ${COLOR_GREEN}(recommended)${COLOR_RESET}"
+  echo -e "     Uses your ChatGPT Plus/Pro subscription via OAuth — no extra API key"
   echo ""
   echo -e "  ${COLOR_BOLD}2)${COLOR_RESET} Gemini"
   echo -e "     Free tier available — requires API key from ai.google.dev"
   echo ""
   echo -e "  ${COLOR_BOLD}3)${COLOR_RESET} OpenRouter"
-  echo -e "     Pay-per-use — requires API key from openrouter.ai"
+  echo -e "     Access to 100+ models, free options available — requires API key"
+  echo ""
+  echo -e "  ${COLOR_BOLD}4)${COLOR_RESET} Claude — ${claude_hint}"
+  echo -e "     Uses your Anthropic subscription"
   echo ""
 
-  local choice
+  local choice provider=""
   while true; do
-    prompt_user "Enter choice [1/2/3] (default: 1):"
+    prompt_user "Enter choice [1/2/3/4] (default: ${default_num}):"
     read_tty -r choice
-    choice="${choice:-1}"
-
+    choice="${choice:-${default_num}}"
     case "$choice" in
-      1)
-        AI_PROVIDER="claude"
-        success "Selected: Claude Max Plan (CLI authentication)"
-        break
-        ;;
-      2)
-        AI_PROVIDER="gemini"
-        echo ""
-        prompt_user "Enter your Gemini API key (from https://ai.google.dev):"
-        read_tty -rs AI_PROVIDER_API_KEY
-        echo ""
-        if [[ -z "$AI_PROVIDER_API_KEY" ]]; then
-          warn "No API key provided — you can add it later in ~/.claude-mem/settings.json"
-        else
-          success "Gemini API key set ($(mask_api_key "$AI_PROVIDER_API_KEY"))"
-        fi
-        break
-        ;;
-      3)
-        AI_PROVIDER="openrouter"
-        echo ""
-        prompt_user "Enter your OpenRouter API key (from https://openrouter.ai):"
-        read_tty -rs AI_PROVIDER_API_KEY
-        echo ""
-        if [[ -z "$AI_PROVIDER_API_KEY" ]]; then
-          warn "No API key provided — you can add it later in ~/.claude-mem/settings.json"
-        else
-          success "OpenRouter API key set ($(mask_api_key "$AI_PROVIDER_API_KEY"))"
-        fi
-        break
-        ;;
-      *)
-        warn "Invalid choice. Please enter 1, 2, or 3."
-        ;;
+      1) provider="openai-codex" ;;
+      2) provider="gemini"       ;;
+      3) provider="openrouter"   ;;
+      4) provider="claude"       ;;
+      *) warn "Invalid choice. Please enter 1, 2, 3, or 4." ; continue ;;
     esac
+    break
   done
+
+  printf -v "$result_var" '%s' "$provider"
+  local key=""
+  prompt_provider_api_key "$provider" key
+  printf -v "$key_var" '%s' "$key"
+}
+
+setup_ai_provider() {
+  echo ""
+  info "AI Provider Configuration"
+  echo ""
+
+  # ── CLI flags (non-interactive path) ────────────────────────────────────────
+  if [[ -n "$CLI_PROVIDER" || -n "$CLI_OPENCLAW_PROVIDER" ]]; then
+    # Global provider (Claude Code sessions)
+    local global_provider="${CLI_PROVIDER:-claude}"
+    case "$global_provider" in
+      claude|gemini|openrouter|openai-codex) ;;
+      *) error "Unknown --provider: ${global_provider}"; error "Valid: claude, gemini, openrouter, openai-codex"; exit 1 ;;
+    esac
+    AI_PROVIDER="$global_provider"
+    AI_PROVIDER_API_KEY="${CLI_API_KEY:-}"
+    success "Claude Code sessions provider: ${AI_PROVIDER}"
+
+    # OpenClaw-specific provider
+    if [[ -n "$CLI_OPENCLAW_PROVIDER" ]]; then
+      case "$CLI_OPENCLAW_PROVIDER" in
+        claude|gemini|openrouter|openai-codex) ;;
+        *) error "Unknown --openclaw-provider: ${CLI_OPENCLAW_PROVIDER}"; exit 1 ;;
+      esac
+      AI_OPENCLAW_PROVIDER="$CLI_OPENCLAW_PROVIDER"
+      AI_OPENCLAW_API_KEY="${CLI_OPENCLAW_API_KEY:-}"
+    else
+      # Default OpenClaw provider: openai-codex (avoids Anthropic ToS violation)
+      AI_OPENCLAW_PROVIDER="openai-codex"
+    fi
+    if [[ "$AI_OPENCLAW_PROVIDER" != "$AI_PROVIDER" ]]; then
+      success "OpenClaw sessions provider: ${AI_OPENCLAW_PROVIDER}"
+      if [[ "$AI_OPENCLAW_PROVIDER" == "claude" ]]; then
+        warn "⚠️  Using Claude OAuth for OpenClaw sessions may violate Anthropic's ToS (Feb 2026)"
+      fi
+    fi
+    return 0
+  fi
+
+  # ── Non-interactive defaults ─────────────────────────────────────────────────
+  if [[ "$NON_INTERACTIVE" == "true" ]]; then
+    info "Non-interactive mode: Claude Code → claude | OpenClaw → openai-codex"
+    AI_PROVIDER="claude"
+    AI_OPENCLAW_PROVIDER="openai-codex"
+    return 0
+  fi
+
+  # ── Interactive flow ─────────────────────────────────────────────────────────
+  echo -e "  ${COLOR_BOLD}This is an OpenClaw installation.${COLOR_RESET}"
+  echo ""
+  echo -e "  claude-mem can record sessions from two sources simultaneously:"
+  echo -e "  • ${COLOR_BOLD}Claude Code${COLOR_RESET} — as a plugin (standard)"
+  echo -e "  • ${COLOR_BOLD}OpenClaw${COLOR_RESET}     — via this gateway"
+  echo ""
+  echo -e "  ${COLOR_YELLOW}⚠️  Anthropic's ToS (Feb 2026) prohibits using Claude OAuth tokens"
+  echo -e "  in third-party apps like OpenClaw. OpenClaw sessions must use"
+  echo -e "  a different AI provider for observation extraction.${COLOR_RESET}"
+  echo ""
+
+  # Step A: Do you also use Claude Code?
+  local use_claude_code
+  prompt_user "Do you also use Claude Code (in addition to OpenClaw)? [y/N]:"
+  read_tty -r use_claude_code
+  use_claude_code="${use_claude_code:-n}"
+
+  if [[ "$use_claude_code" =~ ^[Yy] ]]; then
+    # Step B: Provider for Claude Code sessions
+    echo ""
+    echo -e "  ${COLOR_BOLD}Provider for Claude Code sessions:${COLOR_RESET}"
+    echo ""
+    echo -e "  ${COLOR_BOLD}1)${COLOR_RESET} Claude Max Plan ${COLOR_GREEN}(recommended)${COLOR_RESET}"
+    echo -e "     Uses your Anthropic subscription — permitted inside Claude Code"
+    echo ""
+    echo -e "  ${COLOR_BOLD}2)${COLOR_RESET} Gemini  — free tier available"
+    echo -e "  ${COLOR_BOLD}3)${COLOR_RESET} OpenRouter — free models available"
+    echo ""
+
+    local cc_choice
+    while true; do
+      prompt_user "Enter choice [1/2/3] (default: 1):"
+      read_tty -r cc_choice
+      cc_choice="${cc_choice:-1}"
+      case "$cc_choice" in
+        1) AI_PROVIDER="claude"      ; break ;;
+        2) AI_PROVIDER="gemini"      ; break ;;
+        3) AI_PROVIDER="openrouter"  ; break ;;
+        *) warn "Invalid choice." ;;
+      esac
+    done
+    prompt_provider_api_key "$AI_PROVIDER" AI_PROVIDER_API_KEY
+    success "Claude Code sessions → ${AI_PROVIDER}"
+  else
+    # Not using Claude Code — global provider will equal OpenClaw provider (set below)
+    AI_PROVIDER=""
+  fi
+
+  # Step C: Provider for OpenClaw sessions
+  echo ""
+  echo -e "  ${COLOR_BOLD}Provider for OpenClaw sessions:${COLOR_RESET}"
+  echo -e "  (must NOT be Claude OAuth — choose one of the alternatives below)"
+  echo ""
+
+  prompt_provider_menu AI_OPENCLAW_PROVIDER AI_OPENCLAW_API_KEY "1" "true"
+  success "OpenClaw sessions → ${AI_OPENCLAW_PROVIDER}"
+
+  # If not using Claude Code, mirror global provider to OpenClaw choice
+  if [[ -z "$AI_PROVIDER" ]]; then
+    AI_PROVIDER="$AI_OPENCLAW_PROVIDER"
+    AI_PROVIDER_API_KEY="$AI_OPENCLAW_API_KEY"
+  fi
+
+  # Warn if user explicitly chose Claude for OpenClaw
+  if [[ "$AI_OPENCLAW_PROVIDER" == "claude" ]]; then
+    warn "⚠️  Claude OAuth for OpenClaw sessions may violate Anthropic's ToS (Feb 2026)."
+    warn "   Consider switching to openai-codex, gemini, or openrouter."
+  fi
 }
 
 ###############################################################################
@@ -1090,6 +1197,8 @@ write_settings() {
   # Pass provider and API key via environment variables to avoid shell-to-JS injection
   INSTALLER_AI_PROVIDER="$AI_PROVIDER" \
   INSTALLER_AI_API_KEY="$AI_PROVIDER_API_KEY" \
+  INSTALLER_AI_OPENCLAW_PROVIDER="$AI_OPENCLAW_PROVIDER" \
+  INSTALLER_AI_OPENCLAW_API_KEY="$AI_OPENCLAW_API_KEY" \
   INSTALLER_SETTINGS_FILE="$settings_file" \
   node -e "
     const fs = require('fs');
@@ -1097,6 +1206,8 @@ write_settings() {
     const homedir = require('os').homedir();
     const provider = process.env.INSTALLER_AI_PROVIDER;
     const apiKey = process.env.INSTALLER_AI_API_KEY || '';
+    const openclawProvider = process.env.INSTALLER_AI_OPENCLAW_PROVIDER || '';
+    const openclawApiKey = process.env.INSTALLER_AI_OPENCLAW_API_KEY || '';
     const settingsPath = process.env.INSTALLER_SETTINGS_FILE;
 
     // All defaults from SettingsDefaultsManager.ts
@@ -1107,6 +1218,7 @@ write_settings() {
       CLAUDE_MEM_WORKER_HOST: '127.0.0.1',
       CLAUDE_MEM_SKIP_TOOLS: 'ListMcpResourcesTool,SlashCommand,Skill,TodoWrite,AskUserQuestion',
       CLAUDE_MEM_PROVIDER: 'claude',
+      CLAUDE_MEM_OPENCLAW_PROVIDER: '',
       CLAUDE_MEM_CLAUDE_AUTH_METHOD: 'cli',
       CLAUDE_MEM_GEMINI_API_KEY: '',
       CLAUDE_MEM_GEMINI_MODEL: 'gemini-2.5-flash-lite',
@@ -1117,6 +1229,8 @@ write_settings() {
       CLAUDE_MEM_OPENROUTER_APP_NAME: 'claude-mem',
       CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES: '20',
       CLAUDE_MEM_OPENROUTER_MAX_TOKENS: '100000',
+      CLAUDE_MEM_OPENAI_CODEX_MODEL: 'gpt-4o',
+      CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR: '',
       CLAUDE_MEM_DATA_DIR: path.join(homedir, '.claude-mem'),
       CLAUDE_MEM_LOG_LEVEL: 'INFO',
       CLAUDE_MEM_PYTHON_VERSION: '3.13',
@@ -1140,6 +1254,8 @@ write_settings() {
 
     // Build provider-specific overrides safely from environment variables
     const overrides = { CLAUDE_MEM_PROVIDER: provider };
+
+    // Global provider settings
     if (provider === 'claude') {
       overrides.CLAUDE_MEM_CLAUDE_AUTH_METHOD = 'cli';
     } else if (provider === 'gemini') {
@@ -1148,6 +1264,18 @@ write_settings() {
     } else if (provider === 'openrouter') {
       overrides.CLAUDE_MEM_OPENROUTER_API_KEY = apiKey;
       overrides.CLAUDE_MEM_OPENROUTER_MODEL = 'xiaomi/mimo-v2-flash:free';
+    }
+
+    // OpenClaw-specific provider (only write if different from global)
+    if (openclawProvider && openclawProvider !== provider) {
+      overrides.CLAUDE_MEM_OPENCLAW_PROVIDER = openclawProvider;
+      if (openclawProvider === 'gemini' && openclawApiKey) {
+        // Note: shares CLAUDE_MEM_GEMINI_API_KEY if not already set by global
+        if (!overrides.CLAUDE_MEM_GEMINI_API_KEY) overrides.CLAUDE_MEM_GEMINI_API_KEY = openclawApiKey;
+      } else if (openclawProvider === 'openrouter' && openclawApiKey) {
+        if (!overrides.CLAUDE_MEM_OPENROUTER_API_KEY) overrides.CLAUDE_MEM_OPENROUTER_API_KEY = openclawApiKey;
+      }
+      // openai-codex uses OAuth — no API key to store
     }
 
     const settings = Object.assign(defaults, overrides);

--- a/openclaw/install.sh
+++ b/openclaw/install.sh
@@ -992,9 +992,9 @@ mask_api_key() {
   fi
 }
 
-# Ask for API key for a given provider and store in the given variable name.
-# Usage: prompt_api_key <varname> <varname_key>
-# Example: prompt_api_key AI_PROVIDER AI_PROVIDER_API_KEY
+# Ask for API key for a given provider and store in the named variable.
+# Usage: prompt_provider_api_key <provider> <keyvar>
+# Example: prompt_provider_api_key gemini AI_PROVIDER_API_KEY
 prompt_provider_api_key() {
   local provider="$1"
   local keyvar="$2"

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.76",
+    "@mariozechner/pi-ai": "^0.53.0",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "ansi-to-html": "^0.7.2",
     "dompurify": "^3.3.1",

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -526,16 +526,26 @@ export class WorkerService {
    * Get the appropriate agent based on provider settings.
    * Same logic as SessionRoutes.getActiveAgent() for consistency.
    */
-  private getActiveAgent(): SDKAgent | GeminiAgent | OpenRouterAgent | OpenAICodexAgent {
-    if (isOpenAICodexSelected() && isOpenAICodexAvailable()) {
-      return this.openAICodexAgent;
+  /**
+   * Resolve the effective provider for a session.
+   * OpenClaw sessions (contentSessionId starts with 'openclaw-') use
+   * CLAUDE_MEM_OPENCLAW_PROVIDER if configured; otherwise fall back to
+   * the global CLAUDE_MEM_PROVIDER.
+   */
+  private resolveProviderForSession(contentSessionId?: string): string {
+    const { USER_SETTINGS_PATH } = require('../shared/paths.js');
+    const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+    if (contentSessionId?.startsWith('openclaw-') && settings.CLAUDE_MEM_OPENCLAW_PROVIDER) {
+      return settings.CLAUDE_MEM_OPENCLAW_PROVIDER;
     }
-    if (isOpenRouterSelected() && isOpenRouterAvailable()) {
-      return this.openRouterAgent;
-    }
-    if (isGeminiSelected() && isGeminiAvailable()) {
-      return this.geminiAgent;
-    }
+    return settings.CLAUDE_MEM_PROVIDER || 'claude';
+  }
+
+  private getActiveAgent(contentSessionId?: string): SDKAgent | GeminiAgent | OpenRouterAgent | OpenAICodexAgent {
+    const provider = this.resolveProviderForSession(contentSessionId);
+    if (provider === 'openai-codex' && isOpenAICodexAvailable()) return this.openAICodexAgent;
+    if (provider === 'openrouter' && isOpenRouterAvailable()) return this.openRouterAgent;
+    if (provider === 'gemini' && isGeminiAvailable()) return this.geminiAgent;
     return this.sdkAgent;
   }
 
@@ -551,7 +561,7 @@ export class WorkerService {
     if (!session) return;
 
     const sid = session.sessionDbId;
-    const agent = this.getActiveAgent();
+    const agent = this.getActiveAgent(session.contentSessionId);
     const providerName = agent.constructor.name;
 
     // Before starting generator, check if AbortController is already aborted

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -214,6 +214,13 @@ export class WorkerService {
     this.openRouterAgent = new OpenRouterAgent(this.dbManager, this.sessionManager);
     this.openAICodexAgent = new OpenAICodexAgent(this.dbManager, this.sessionManager);
 
+    // Configure fallback chain for non-Claude providers.
+    // If provider-specific API calls fail with transient/recoverable errors,
+    // the request can continue via the Claude SDK agent.
+    this.geminiAgent.setFallbackAgent(this.sdkAgent);
+    this.openRouterAgent.setFallbackAgent(this.sdkAgent);
+    this.openAICodexAgent.setFallbackAgent(this.sdkAgent);
+
     this.paginationHelper = new PaginationHelper(this.dbManager);
     this.settingsManager = new SettingsManager(this.dbManager);
     this.sessionEventBroadcaster = new SessionEventBroadcaster(this.sseBroadcaster, this);

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -109,6 +109,7 @@ import { SSEBroadcaster } from './worker/SSEBroadcaster.js';
 import { SDKAgent } from './worker/SDKAgent.js';
 import { GeminiAgent, isGeminiSelected, isGeminiAvailable } from './worker/GeminiAgent.js';
 import { OpenRouterAgent, isOpenRouterSelected, isOpenRouterAvailable } from './worker/OpenRouterAgent.js';
+import { OpenAICodexAgent, isOpenAICodexSelected, isOpenAICodexAvailable } from './worker/OpenAICodexAgent.js';
 import { PaginationHelper } from './worker/PaginationHelper.js';
 import { SettingsManager } from './worker/SettingsManager.js';
 import { SearchManager } from './worker/SearchManager.js';
@@ -169,6 +170,7 @@ export class WorkerService {
   private sdkAgent: SDKAgent;
   private geminiAgent: GeminiAgent;
   private openRouterAgent: OpenRouterAgent;
+  private openAICodexAgent: OpenAICodexAgent;
   private paginationHelper: PaginationHelper;
   private settingsManager: SettingsManager;
   private sessionEventBroadcaster: SessionEventBroadcaster;
@@ -210,6 +212,7 @@ export class WorkerService {
     this.sdkAgent = new SDKAgent(this.dbManager, this.sessionManager);
     this.geminiAgent = new GeminiAgent(this.dbManager, this.sessionManager);
     this.openRouterAgent = new OpenRouterAgent(this.dbManager, this.sessionManager);
+    this.openAICodexAgent = new OpenAICodexAgent(this.dbManager, this.sessionManager);
 
     this.paginationHelper = new PaginationHelper(this.dbManager);
     this.settingsManager = new SettingsManager(this.dbManager);
@@ -315,7 +318,7 @@ export class WorkerService {
 
     // Standard routes (registered AFTER guard middleware)
     this.server.registerRoutes(new ViewerRoutes(this.sseBroadcaster, this.dbManager, this.sessionManager));
-    this.server.registerRoutes(new SessionRoutes(this.sessionManager, this.dbManager, this.sdkAgent, this.geminiAgent, this.openRouterAgent, this.sessionEventBroadcaster, this));
+    this.server.registerRoutes(new SessionRoutes(this.sessionManager, this.dbManager, this.sdkAgent, this.geminiAgent, this.openRouterAgent, this.openAICodexAgent, this.sessionEventBroadcaster, this));
     this.server.registerRoutes(new DataRoutes(this.paginationHelper, this.dbManager, this.sessionManager, this.sseBroadcaster, this, this.startTime));
     this.server.registerRoutes(new SettingsRoutes(this.settingsManager));
     this.server.registerRoutes(new LogsRoutes());
@@ -523,7 +526,10 @@ export class WorkerService {
    * Get the appropriate agent based on provider settings.
    * Same logic as SessionRoutes.getActiveAgent() for consistency.
    */
-  private getActiveAgent(): SDKAgent | GeminiAgent | OpenRouterAgent {
+  private getActiveAgent(): SDKAgent | GeminiAgent | OpenRouterAgent | OpenAICodexAgent {
+    if (isOpenAICodexSelected() && isOpenAICodexAvailable()) {
+      return this.openAICodexAgent;
+    }
     if (isOpenRouterSelected() && isOpenRouterAvailable()) {
       return this.openRouterAgent;
     }

--- a/src/services/worker-types.ts
+++ b/src/services/worker-types.ts
@@ -32,7 +32,7 @@ export interface ActiveSession {
   cumulativeOutputTokens: number;  // Track output tokens for discovery cost
   earliestPendingTimestamp: number | null;  // Original timestamp of earliest pending message (for accurate observation timestamps)
   conversationHistory: ConversationMessage[];  // Shared conversation history for provider switching
-  currentProvider: 'claude' | 'gemini' | 'openrouter' | null;  // Track which provider is currently running
+  currentProvider: 'claude' | 'gemini' | 'openrouter' | 'openai-codex' | null;  // Track which provider is currently running
   consecutiveRestarts: number;  // Track consecutive restart attempts to prevent infinite loops
   forceInit?: boolean;  // Force fresh SDK session (skip resume)
   idleTimedOut?: boolean;  // Set when session exits due to idle timeout (prevents restart loop)

--- a/src/services/worker/OpenAICodexAgent.ts
+++ b/src/services/worker/OpenAICodexAgent.ts
@@ -1,0 +1,479 @@
+/**
+ * OpenAICodexAgent: OpenAI Codex (ChatGPT Plus/Pro OAuth) observation extraction
+ *
+ * Allows claude-mem to extract observations using a ChatGPT Plus/Pro subscription
+ * via OAuth, without requiring an Anthropic API key or Claude Code context.
+ *
+ * This is the recommended provider for OpenClaw users, since Anthropic's ToS
+ * prohibits using Claude OAuth tokens in third-party apps (as of Feb 2026).
+ *
+ * Credential discovery order:
+ *   1. CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR setting (explicit override)
+ *   2. OPENCLAW_AGENT_DIR env var (set automatically by OpenClaw at runtime)
+ *   3. ~/.openclaw/agents/default/agent/auth-profiles.json (OpenClaw default)
+ *   4. ~/.claude-mem/auth-profiles.json (standalone fallback)
+ *
+ * Responsibility:
+ * - Read OpenAI Codex OAuth credentials from auth-profiles.json
+ * - Auto-refresh expired tokens via pi-ai's refreshOpenAICodexToken
+ * - Call OpenAI Chat Completions API for observation extraction
+ * - Parse XML responses (same format as Claude/Gemini/OpenRouter agents)
+ * - Sync to database and Chroma
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import { DatabaseManager } from './DatabaseManager.js';
+import { SessionManager } from './SessionManager.js';
+import { logger } from '../../utils/logger.js';
+import {
+  buildInitPrompt,
+  buildObservationPrompt,
+  buildSummaryPrompt,
+  buildContinuationPrompt,
+} from '../../sdk/prompts.js';
+import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js';
+import { USER_SETTINGS_PATH } from '../../shared/paths.js';
+import type { ActiveSession, ConversationMessage } from '../worker-types.js';
+import { ModeManager } from '../domain/ModeManager.js';
+import {
+  processAgentResponse,
+  shouldFallbackToClaude,
+  isAbortError,
+  type WorkerRef,
+  type FallbackAgent,
+} from './agents/index.js';
+
+// OpenAI Chat Completions endpoint
+const OPENAI_API_URL = 'https://api.openai.com/v1/chat/completions';
+
+// Default model for OpenAI Codex OAuth (GPT-5.x Codex series)
+const DEFAULT_CODEX_MODEL = 'gpt-4o'; // Conservative default; override with CLAUDE_MEM_OPENAI_CODEX_MODEL
+
+// Context window limits (same as OpenRouterAgent)
+const DEFAULT_MAX_CONTEXT_MESSAGES = 20;
+const DEFAULT_MAX_ESTIMATED_TOKENS = 100_000;
+const CHARS_PER_TOKEN_ESTIMATE = 4;
+
+// Auth profile store schema (subset — mirrors OpenClaw's auth-profiles.json)
+interface AuthProfile {
+  type: 'oauth' | 'api_key';
+  provider: string;
+  refresh?: string;
+  access?: string;
+  expires?: number;
+  [key: string]: unknown;
+}
+interface AuthProfileStore {
+  version: number;
+  profiles: Record<string, AuthProfile>;
+}
+
+// OpenAI-compatible message format
+interface OpenAIMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+interface OpenAIResponse {
+  choices?: Array<{
+    message?: { role?: string; content?: string };
+    finish_reason?: string;
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+  };
+  error?: { message?: string; code?: string };
+}
+
+// ─────────────────────────────────────────────────────────────
+// Credential helpers
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the directory that contains auth-profiles.json.
+ * Preference order: explicit setting → OPENCLAW_AGENT_DIR env → OpenClaw default → claude-mem fallback.
+ */
+function resolveAuthDir(): string {
+  const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+  if (settings.CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR) {
+    return settings.CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR;
+  }
+  if (process.env.OPENCLAW_AGENT_DIR) {
+    return process.env.OPENCLAW_AGENT_DIR;
+  }
+  // OpenClaw default: ~/.openclaw/agents/default/agent
+  const openclawDefault = join(homedir(), '.openclaw', 'agents', 'default', 'agent');
+  if (existsSync(join(openclawDefault, 'auth-profiles.json'))) {
+    return openclawDefault;
+  }
+  // Standalone fallback: ~/.claude-mem
+  return join(homedir(), '.claude-mem');
+}
+
+/**
+ * Load the auth-profiles.json store from the resolved auth directory.
+ */
+function loadAuthStore(authDir: string): AuthProfileStore | null {
+  const path = join(authDir, 'auth-profiles.json');
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as AuthProfileStore;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find the first OpenAI Codex OAuth profile in the store.
+ */
+function findCodexProfile(store: AuthProfileStore): AuthProfile | null {
+  for (const [id, profile] of Object.entries(store.profiles)) {
+    if (id.startsWith('openai-codex:') && profile.type === 'oauth') {
+      return profile;
+    }
+  }
+  return null;
+}
+
+/**
+ * Persist updated credentials back to auth-profiles.json.
+ * Only updates the matching profile — leaves everything else untouched.
+ */
+function saveCodexProfile(authDir: string, store: AuthProfileStore, updated: AuthProfile): void {
+  const { writeFileSync } = require('fs');
+  const path = join(authDir, 'auth-profiles.json');
+  for (const [id, profile] of Object.entries(store.profiles)) {
+    if (id.startsWith('openai-codex:') && profile.type === 'oauth') {
+      store.profiles[id] = { ...profile, ...updated };
+      break;
+    }
+  }
+  writeFileSync(path, JSON.stringify(store, null, 2), 'utf-8');
+}
+
+/**
+ * Get a valid access token, refreshing it if expired.
+ * Requires pi-ai to be installed as a dependency of claude-mem.
+ */
+async function getAccessToken(): Promise<string> {
+  const authDir = resolveAuthDir();
+  const store = loadAuthStore(authDir);
+
+  if (!store) {
+    throw new Error(
+      `OpenAI Codex OAuth: no auth-profiles.json found in ${authDir}.\n` +
+      `Run 'openclaw auth' (or 'npx @mariozechner/pi-ai login openai-codex') to authenticate.`
+    );
+  }
+
+  const profile = findCodexProfile(store);
+  if (!profile || !profile.refresh) {
+    throw new Error(
+      `OpenAI Codex OAuth: no openai-codex profile found in ${authDir}/auth-profiles.json.\n` +
+      `Run 'openclaw auth' to add OpenAI Codex authentication.`
+    );
+  }
+
+  // Token is still valid (5-minute buffer)
+  const bufferMs = 5 * 60 * 1000;
+  if (profile.access && profile.expires && Date.now() < (profile.expires - bufferMs)) {
+    return profile.access;
+  }
+
+  // Token expired — refresh it
+  logger.info('SDK', 'OpenAI Codex token expired, refreshing…');
+  try {
+    // Dynamic import so claude-mem can work without pi-ai if provider is not 'openai-codex'
+    // @ts-ignore — dynamic import; pi-ai must be a dependency of claude-mem
+    const { refreshOpenAICodexToken } = await import('@mariozechner/pi-ai') as any;
+    const refreshed = await refreshOpenAICodexToken(profile.refresh);
+    saveCodexProfile(authDir, store, refreshed);
+    logger.info('SDK', 'OpenAI Codex token refreshed successfully');
+    return refreshed.access;
+  } catch (err) {
+    throw new Error(
+      `OpenAI Codex OAuth: token refresh failed — ${err instanceof Error ? err.message : String(err)}.\n` +
+      `Re-authenticate with 'openclaw auth'.`
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Agent class
+// ─────────────────────────────────────────────────────────────
+
+export class OpenAICodexAgent {
+  private dbManager: DatabaseManager;
+  private sessionManager: SessionManager;
+  private fallbackAgent: FallbackAgent | null = null;
+
+  constructor(dbManager: DatabaseManager, sessionManager: SessionManager) {
+    this.dbManager = dbManager;
+    this.sessionManager = sessionManager;
+  }
+
+  setFallbackAgent(agent: FallbackAgent): void {
+    this.fallbackAgent = agent;
+  }
+
+  async startSession(session: ActiveSession, worker?: WorkerRef): Promise<void> {
+    try {
+      const model = this.getModel();
+
+      // Generate synthetic memorySessionId (stateless REST API)
+      if (!session.memorySessionId) {
+        const id = `openai-codex-${session.contentSessionId}-${Date.now()}`;
+        session.memorySessionId = id;
+        this.dbManager.getSessionStore().updateMemorySessionId(session.sessionDbId, id);
+        logger.info('SESSION', `MEMORY_ID_GENERATED | sessionDbId=${session.sessionDbId} | provider=OpenAICodex`);
+      }
+
+      const mode = ModeManager.getInstance().getActiveMode();
+
+      // Init prompt
+      const initPrompt =
+        session.lastPromptNumber === 1
+          ? buildInitPrompt(session.project, session.contentSessionId, session.userPrompt, mode)
+          : buildContinuationPrompt(session.userPrompt, session.lastPromptNumber, session.contentSessionId, mode);
+
+      session.conversationHistory.push({ role: 'user', content: initPrompt });
+      const initResponse = await this.query(session.conversationHistory, model);
+
+      if (initResponse.content) {
+        const tokensUsed = initResponse.tokensUsed || 0;
+        session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
+        session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
+        await processAgentResponse(
+          initResponse.content,
+          session,
+          this.dbManager,
+          this.sessionManager,
+          worker,
+          tokensUsed,
+          null,
+          'OpenAICodex',
+          undefined
+        );
+      }
+
+      let lastCwd: string | undefined;
+
+      // Process pending messages
+      for await (const message of this.sessionManager.getMessageIterator(session.sessionDbId)) {
+        session.processingMessageIds.push(message._persistentId);
+        if (message.cwd) lastCwd = message.cwd;
+        const originalTimestamp = session.earliestPendingTimestamp;
+
+        if (message.type === 'observation') {
+          if (message.prompt_number !== undefined) {
+            session.lastPromptNumber = message.prompt_number;
+          }
+          if (!session.memorySessionId) {
+            throw new Error('Cannot process observations: memorySessionId not captured.');
+          }
+
+          const observationPrompt = buildObservationPrompt({
+            id: 0,
+            tool_name: message.tool_name!,
+            tool_input: JSON.stringify(message.tool_input),
+            tool_output: JSON.stringify(message.tool_response),
+            created_at_epoch: originalTimestamp ?? Date.now(),
+            cwd: message.cwd,
+          });
+
+          session.conversationHistory.push({ role: 'user', content: observationPrompt });
+          const obsResponse = await this.query(session.conversationHistory, model);
+
+          const tokensUsed = obsResponse.tokensUsed || 0;
+          session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
+          session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
+
+          await processAgentResponse(
+            obsResponse.content || '',
+            session,
+            this.dbManager,
+            this.sessionManager,
+            worker,
+            tokensUsed,
+            originalTimestamp,
+            'OpenAICodex',
+            lastCwd
+          );
+
+        } else if (message.type === 'summarize') {
+          if (!session.memorySessionId) {
+            throw new Error('Cannot process summary: memorySessionId not captured.');
+          }
+
+          const summaryPrompt = buildSummaryPrompt({
+            id: session.sessionDbId,
+            memory_session_id: session.memorySessionId,
+            project: session.project,
+            user_prompt: session.userPrompt,
+            last_assistant_message: message.last_assistant_message || '',
+          }, mode);
+
+          session.conversationHistory.push({ role: 'user', content: summaryPrompt });
+          const sumResponse = await this.query(session.conversationHistory, model);
+
+          const tokensUsed = sumResponse.tokensUsed || 0;
+          session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
+          session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
+
+          await processAgentResponse(
+            sumResponse.content || '',
+            session,
+            this.dbManager,
+            this.sessionManager,
+            worker,
+            tokensUsed,
+            originalTimestamp,
+            'OpenAICodex',
+            lastCwd
+          );
+        }
+      }
+
+      logger.success('SDK', 'OpenAI Codex agent completed', {
+        sessionId: session.sessionDbId,
+        model,
+        duration: `${((Date.now() - session.startTime) / 1000).toFixed(1)}s`,
+      });
+
+    } catch (error: unknown) {
+      if (isAbortError(error)) {
+        logger.warn('SDK', 'OpenAI Codex agent aborted', { sessionId: session.sessionDbId });
+        throw error;
+      }
+
+      if (shouldFallbackToClaude(error) && this.fallbackAgent) {
+        logger.warn('SDK', 'OpenAI Codex API failed, falling back to Claude SDK', {
+          sessionDbId: session.sessionDbId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return this.fallbackAgent.startSession(session, worker);
+      }
+
+      logger.failure('SDK', 'OpenAI Codex agent error', { sessionDbId: session.sessionDbId }, error as Error);
+      throw error;
+    }
+  }
+
+  // ── Private helpers ────────────────────────────────────────
+
+  private getModel(): string {
+    const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+    return settings.CLAUDE_MEM_OPENAI_CODEX_MODEL || DEFAULT_CODEX_MODEL;
+  }
+
+  private estimateTokens(text: string): number {
+    return Math.ceil(text.length / CHARS_PER_TOKEN_ESTIMATE);
+  }
+
+  private truncateHistory(history: ConversationMessage[]): ConversationMessage[] {
+    const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+    const MAX_MESSAGES = parseInt(settings.CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES) || DEFAULT_MAX_CONTEXT_MESSAGES;
+    const MAX_TOKENS = parseInt(settings.CLAUDE_MEM_OPENROUTER_MAX_TOKENS) || DEFAULT_MAX_ESTIMATED_TOKENS;
+
+    if (history.length <= MAX_MESSAGES) {
+      const totalTokens = history.reduce((s, m) => s + this.estimateTokens(m.content), 0);
+      if (totalTokens <= MAX_TOKENS) return history;
+    }
+
+    const truncated: ConversationMessage[] = [];
+    let tokenCount = 0;
+    for (let i = history.length - 1; i >= 0; i--) {
+      const msg = history[i];
+      const t = this.estimateTokens(msg.content);
+      if (truncated.length >= MAX_MESSAGES || tokenCount + t > MAX_TOKENS) break;
+      truncated.unshift(msg);
+      tokenCount += t;
+    }
+    return truncated;
+  }
+
+  private toOpenAIMessages(history: ConversationMessage[]): OpenAIMessage[] {
+    return history.map(m => ({
+      role: m.role === 'assistant' ? 'assistant' : 'user',
+      content: m.content,
+    }));
+  }
+
+  /**
+   * Call OpenAI Chat Completions with OAuth Bearer token.
+   * Token is refreshed automatically if expired.
+   */
+  private async query(
+    history: ConversationMessage[],
+    model: string,
+  ): Promise<{ content: string; tokensUsed?: number }> {
+    const accessToken = await getAccessToken();
+    const messages = this.toOpenAIMessages(this.truncateHistory(history));
+
+    logger.debug('SDK', `Querying OpenAI Codex (${model})`, { turns: messages.length });
+
+    const response = await fetch(OPENAI_API_URL, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        temperature: 0.3,
+        max_tokens: 4096,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`OpenAI Codex API error: ${response.status} — ${errorText}`);
+    }
+
+    const data = await response.json() as OpenAIResponse;
+
+    if (data.error) {
+      throw new Error(`OpenAI Codex API error: ${data.error.code} — ${data.error.message}`);
+    }
+
+    if (!data.choices?.[0]?.message?.content) {
+      logger.error('SDK', 'Empty response from OpenAI Codex');
+      return { content: '' };
+    }
+
+    const tokensUsed = data.usage?.total_tokens;
+    if (tokensUsed) {
+      logger.info('SDK', 'OpenAI Codex API usage', {
+        model,
+        inputTokens: data.usage?.prompt_tokens,
+        outputTokens: data.usage?.completion_tokens,
+        totalTokens: tokensUsed,
+      });
+    }
+
+    return { content: data.choices[0].message.content, tokensUsed };
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Provider detection helpers (mirrors OpenRouterAgent pattern)
+// ─────────────────────────────────────────────────────────────
+
+/** Returns true if a valid openai-codex OAuth profile exists on disk. */
+export function isOpenAICodexAvailable(): boolean {
+  const authDir = resolveAuthDir();
+  const store = loadAuthStore(authDir);
+  if (!store) return false;
+  return !!findCodexProfile(store);
+}
+
+/** Returns true if CLAUDE_MEM_PROVIDER is set to 'openai-codex'. */
+export function isOpenAICodexSelected(): boolean {
+  const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+  return settings.CLAUDE_MEM_PROVIDER === 'openai-codex';
+}

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -18,7 +18,8 @@ export interface SettingsDefaults {
   CLAUDE_MEM_WORKER_HOST: string;
   CLAUDE_MEM_SKIP_TOOLS: string;
   // AI Provider Configuration
-  CLAUDE_MEM_PROVIDER: string;  // 'claude' | 'gemini' | 'openrouter' | 'openai-codex'
+  CLAUDE_MEM_PROVIDER: string;          // 'claude' | 'gemini' | 'openrouter' | 'openai-codex'
+  CLAUDE_MEM_OPENCLAW_PROVIDER: string; // Override provider for OpenClaw sessions (empty = use CLAUDE_MEM_PROVIDER)
   CLAUDE_MEM_CLAUDE_AUTH_METHOD: string;  // 'cli' | 'api' - how Claude provider authenticates
   CLAUDE_MEM_GEMINI_API_KEY: string;
   CLAUDE_MEM_GEMINI_MODEL: string;  // 'gemini-2.5-flash-lite' | 'gemini-2.5-flash' | 'gemini-3-flash-preview'
@@ -80,7 +81,8 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_WORKER_HOST: '127.0.0.1',
     CLAUDE_MEM_SKIP_TOOLS: 'ListMcpResourcesTool,SlashCommand,Skill,TodoWrite,AskUserQuestion',
     // AI Provider Configuration
-    CLAUDE_MEM_PROVIDER: 'claude',  // Default to Claude
+    CLAUDE_MEM_PROVIDER: 'claude',          // Default to Claude
+    CLAUDE_MEM_OPENCLAW_PROVIDER: '',       // Empty = use CLAUDE_MEM_PROVIDER for all sessions
     CLAUDE_MEM_CLAUDE_AUTH_METHOD: 'cli',  // Default to CLI subscription billing (not API key)
     CLAUDE_MEM_GEMINI_API_KEY: '',  // Empty by default, can be set via UI or env
     CLAUDE_MEM_GEMINI_MODEL: 'gemini-2.5-flash-lite',  // Default Gemini model (highest free tier RPM)

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -18,13 +18,16 @@ export interface SettingsDefaults {
   CLAUDE_MEM_WORKER_HOST: string;
   CLAUDE_MEM_SKIP_TOOLS: string;
   // AI Provider Configuration
-  CLAUDE_MEM_PROVIDER: string;  // 'claude' | 'gemini' | 'openrouter'
+  CLAUDE_MEM_PROVIDER: string;  // 'claude' | 'gemini' | 'openrouter' | 'openai-codex'
   CLAUDE_MEM_CLAUDE_AUTH_METHOD: string;  // 'cli' | 'api' - how Claude provider authenticates
   CLAUDE_MEM_GEMINI_API_KEY: string;
   CLAUDE_MEM_GEMINI_MODEL: string;  // 'gemini-2.5-flash-lite' | 'gemini-2.5-flash' | 'gemini-3-flash-preview'
   CLAUDE_MEM_GEMINI_RATE_LIMITING_ENABLED: string;  // 'true' | 'false' - enable rate limiting for free tier
   CLAUDE_MEM_OPENROUTER_API_KEY: string;
   CLAUDE_MEM_OPENROUTER_MODEL: string;
+  // OpenAI Codex OAuth provider
+  CLAUDE_MEM_OPENAI_CODEX_MODEL: string;        // Model to use (default: gpt-4o)
+  CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR: string;    // Override path to auth-profiles.json dir
   CLAUDE_MEM_OPENROUTER_SITE_URL: string;
   CLAUDE_MEM_OPENROUTER_APP_NAME: string;
   CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES: string;
@@ -84,6 +87,8 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_GEMINI_RATE_LIMITING_ENABLED: 'true',  // Rate limiting ON by default for free tier users
     CLAUDE_MEM_OPENROUTER_API_KEY: '',  // Empty by default, can be set via UI or env
     CLAUDE_MEM_OPENROUTER_MODEL: 'xiaomi/mimo-v2-flash:free',  // Default OpenRouter model (free tier)
+    CLAUDE_MEM_OPENAI_CODEX_MODEL: 'gpt-4o',   // Default Codex model (conservative)
+    CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR: '',      // Empty = auto-detect from OPENCLAW_AGENT_DIR or ~/.openclaw
     CLAUDE_MEM_OPENROUTER_SITE_URL: '',  // Optional: for OpenRouter analytics
     CLAUDE_MEM_OPENROUTER_APP_NAME: 'claude-mem',  // App name for OpenRouter analytics
     CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES: '20',  // Max messages in context window

--- a/src/ui/viewer/components/ContextSettingsModal.tsx
+++ b/src/ui/viewer/components/ContextSettingsModal.tsx
@@ -463,6 +463,22 @@ export function ContextSettingsModal({
               )}
 
               <FormField
+                label="OpenClaw Provider Override"
+                tooltip="AI provider used exclusively for sessions originating from OpenClaw. Leave empty to use the global provider above for all sessions. Recommended: openai-codex (uses ChatGPT subscription, avoids Anthropic ToS restriction for third-party apps)."
+              >
+                <select
+                  value={formState.CLAUDE_MEM_OPENCLAW_PROVIDER || ''}
+                  onChange={(e) => updateSetting('CLAUDE_MEM_OPENCLAW_PROVIDER', e.target.value)}
+                >
+                  <option value="">Same as global provider</option>
+                  <option value="claude">Claude (Anthropic OAuth — not recommended for OpenClaw)</option>
+                  <option value="gemini">Gemini</option>
+                  <option value="openrouter">OpenRouter</option>
+                  <option value="openai-codex">OpenAI Codex (ChatGPT Plus/Pro OAuth)</option>
+                </select>
+              </FormField>
+
+              <FormField
                 label="Worker Port"
                 tooltip="Port for the background worker service"
               >

--- a/src/ui/viewer/components/ContextSettingsModal.tsx
+++ b/src/ui/viewer/components/ContextSettingsModal.tsx
@@ -323,6 +323,7 @@ export function ContextSettingsModal({
                   <option value="claude">Claude (uses your Claude account)</option>
                   <option value="gemini">Gemini (uses API key)</option>
                   <option value="openrouter">OpenRouter (multi-model)</option>
+                  <option value="openai-codex">OpenAI Codex (ChatGPT Plus/Pro OAuth)</option>
                 </select>
               </FormField>
 
@@ -426,6 +427,38 @@ export function ContextSettingsModal({
                       placeholder="claude-mem"
                     />
                   </FormField>
+                </>
+              )}
+
+              {formState.CLAUDE_MEM_PROVIDER === 'openai-codex' && (
+                <>
+                  <FormField
+                    label="Model"
+                    tooltip="OpenAI model to use for observation extraction (your ChatGPT Plus/Pro subscription grants access to GPT-5.x Codex models)"
+                  >
+                    <select
+                      value={formState.CLAUDE_MEM_OPENAI_CODEX_MODEL || 'gpt-4o'}
+                      onChange={(e) => updateSetting('CLAUDE_MEM_OPENAI_CODEX_MODEL', e.target.value)}
+                    >
+                      <option value="gpt-4o">gpt-4o (recommended)</option>
+                      <option value="gpt-4o-mini">gpt-4o-mini (faster)</option>
+                      <option value="gpt-5.3-codex">gpt-5.3-codex (latest, Plus/Pro only)</option>
+                    </select>
+                  </FormField>
+                  <FormField
+                    label="Agent Dir (Optional)"
+                    tooltip="Path to the directory containing auth-profiles.json. Leave empty to auto-detect from OpenClaw installation."
+                  >
+                    <input
+                      type="text"
+                      value={formState.CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR || ''}
+                      onChange={(e) => updateSetting('CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR', e.target.value)}
+                      placeholder="Auto-detect from OpenClaw (leave empty)"
+                    />
+                  </FormField>
+                  <div style={{ padding: '8px 0', fontSize: '12px', color: 'var(--text-muted, #888)' }}>
+                    ℹ️ Authentication is managed by OpenClaw. Run <code>openclaw auth</code> to sign in with your ChatGPT account.
+                  </div>
                 </>
               )}
 


### PR DESCRIPTION
## Summary

Adds **OpenAI Codex OAuth** as a new provider option for claude-mem, allowing users with ChatGPT Plus/Pro subscriptions to use their existing subscription for observation extraction.

## Motivation

Anthropic's Terms of Service (updated Feb 2026) explicitly prohibit using Claude OAuth tokens in third-party applications outside of Claude Code and Claude.ai — including the Agent SDK. This means OpenClaw users can no longer use `CLAUDE_MEM_PROVIDER=claude` with subscription auth.

This PR adds a clean alternative: authenticate once via `openclaw auth` (OpenAI Codex OAuth), and claude-mem will use that token for all observation extraction.

## What changes

### New file: `OpenAICodexAgent.ts`
- Implements OpenAI Chat Completions API with OAuth Bearer token auth
- Mirrors OpenRouterAgent pattern (same prompt flow, same response parsing)
- Auto-refreshes expired tokens via `@mariozechner/pi-ai` (already a dep of OpenClaw)
- Credential discovery order: explicit setting → OPENCLAW_AGENT_DIR env → ~/.openclaw default → ~/.claude-mem fallback

### Modified files

| File | Change |
|---|---|
| `worker-service.ts` | Import + instantiate + wire into `getActiveAgent()` |
| `SessionRoutes.ts` | Add agent to constructor + routing logic |
| `worker-types.ts` | Extend `currentProvider` union with `'openai-codex'` |
| `SettingsDefaultsManager.ts` | Add `CLAUDE_MEM_OPENAI_CODEX_MODEL` + `CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR` |
| `ContextSettingsModal.tsx` | Add provider option + model selector in UI |
| `package.json` | Add `@mariozechner/pi-ai ^0.53.0` dependency |

## How to use

1. Authenticate: `openclaw auth` → select OpenAI Codex
2. Configure provider in Settings UI or manually:
```json
{ "CLAUDE_MEM_PROVIDER": "openai-codex" }
```

## Backward compatibility

Claude Code + claude-mem users: no change needed. Claude OAuth within Claude Code context remains permitted and fully functional.