### PR TITLE
fix: detect auth errors and prevent infinite retry loops

### DIFF
--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -587,8 +587,6 @@ export class WorkerService {
           'Invalid API key',
           'FOREIGN KEY constraint failed',
           'Authentication failed',       // Thrown by SDKAgent after refresh attempt fails
-          'authentication_error',        // Raw API 401 response pattern
-          'Failed to authenticate',      // Claude Code SDK auth failure message
         ];
         if (unrecoverablePatterns.some(pattern => errorMessage.includes(pattern))) {
           hadUnrecoverableError = true;

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -16,7 +16,7 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { getWorkerPort, getWorkerHost } from '../shared/worker-utils.js';
 import { HOOK_TIMEOUTS } from '../shared/hook-constants.js';
 import { SettingsDefaultsManager } from '../shared/SettingsDefaultsManager.js';
-import { getAuthMethodDescription } from '../shared/EnvManager.js';
+import { getAuthMethodDescription, checkOAuthTokenStatus } from '../shared/EnvManager.js';
 import { logger } from '../utils/logger.js';
 import { ChromaMcpManager } from './sync/ChromaMcpManager.js';
 import { ChromaSync } from './sync/ChromaSync.js';
@@ -239,6 +239,10 @@ export class WorkerService {
         let provider = 'claude';
         if (isOpenRouterSelected() && isOpenRouterAvailable()) provider = 'openrouter';
         else if (isGeminiSelected() && isGeminiAvailable()) provider = 'gemini';
+
+        // Check OAuth token health for proactive monitoring
+        const tokenStatus = checkOAuthTokenStatus();
+
         return {
           provider,
           authMethod: getAuthMethodDescription(),
@@ -249,6 +253,9 @@ export class WorkerService {
                 ...(this.lastAiInteraction.error && { error: this.lastAiInteraction.error }),
               }
             : null,
+          ...(tokenStatus.expired && { tokenExpired: true }),
+          ...(tokenStatus.expiringSoon && { tokenExpiringSoon: true }),
+          ...(tokenStatus.expiresAt && { tokenExpiresAt: tokenStatus.expiresAt }),
         };
       },
     });
@@ -579,6 +586,9 @@ export class WorkerService {
           'spawn',
           'Invalid API key',
           'FOREIGN KEY constraint failed',
+          'Authentication failed',       // Thrown by SDKAgent after refresh attempt fails
+          'authentication_error',        // Raw API 401 response pattern
+          'Failed to authenticate',      // Claude Code SDK auth failure message
         ];
         if (unrecoverablePatterns.some(pattern => errorMessage.includes(pattern))) {
           hadUnrecoverableError = true;

--- a/src/services/worker/SDKAgent.ts
+++ b/src/services/worker/SDKAgent.ts
@@ -263,24 +263,29 @@ export class SDKAgent {
           // Detect authentication errors (e.g., expired OAuth token).
           // The SDK returns 401 errors as response text, not exceptions.
           // Without this check, the worker retries infinitely on expired tokens.
+          // Use structured patterns to avoid false positives (e.g., Claude discussing auth errors).
           if (typeof textContent === 'string' && (
-            textContent.includes('authentication_error') ||
-            textContent.includes('Failed to authenticate') ||
-            textContent.includes('API Error: 401')
+            textContent.includes('"type":"authentication_error"') ||
+            textContent.includes('Failed to authenticate. API Error: 401')
           )) {
-            // If using CLI subscription billing, attempt auto-refresh before giving up
-            if (!hasAnthropicApiKey()) {
+            // Only attempt refresh for CLI subscription billing path.
+            // Parent OAuth token (CLAUDE_CODE_OAUTH_TOKEN) can't be refreshed by us —
+            // it's the parent process's responsibility.
+            const usingParentOAuthToken = !!process.env.CLAUDE_CODE_OAUTH_TOKEN;
+            if (!hasAnthropicApiKey() && !usingParentOAuthToken) {
               logger.warn('SDK', 'Authentication error detected, attempting OAuth token refresh...', {
                 sessionId: session.sessionDbId,
                 authMethod
               });
               const refreshed = await attemptOAuthTokenRefresh();
               if (refreshed) {
-                logger.info('SDK', 'OAuth token refreshed successfully — retrying will use new token', {
+                logger.info('SDK', 'OAuth token refreshed — aborting session for clean retry', {
                   sessionId: session.sessionDbId
                 });
-                // Don't throw — let the generator exit normally so the retry logic
-                // picks up with the fresh token
+                // Abort the current session so the pending-work-restart path fires
+                // immediately with the fresh token, instead of waiting for the 60s
+                // stale message reclaim in PendingMessageStore.
+                session.abortController.abort();
                 return;
               }
             }

--- a/src/services/worker/SDKAgent.ts
+++ b/src/services/worker/SDKAgent.ts
@@ -17,7 +17,7 @@ import { logger } from '../../utils/logger.js';
 import { buildInitPrompt, buildObservationPrompt, buildSummaryPrompt, buildContinuationPrompt } from '../../sdk/prompts.js';
 import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js';
 import { USER_SETTINGS_PATH, OBSERVER_SESSIONS_DIR, ensureDir } from '../../shared/paths.js';
-import { buildIsolatedEnv, getAuthMethodDescription } from '../../shared/EnvManager.js';
+import { buildIsolatedEnv, getAuthMethodDescription, attemptOAuthTokenRefresh, hasAnthropicApiKey } from '../../shared/EnvManager.js';
 import type { ActiveSession, SDKUserMessage } from '../worker-types.js';
 import { ModeManager } from '../domain/ModeManager.js';
 import { processAgentResponse, type WorkerRef } from './agents/index.js';
@@ -258,6 +258,36 @@ export class SDKAgent {
           // Throw so it surfaces in health endpoint and prevents silent failures.
           if (typeof textContent === 'string' && textContent.includes('Invalid API key')) {
             throw new Error('Invalid API key: check your API key configuration in ~/.claude-mem/settings.json or ~/.claude-mem/.env');
+          }
+
+          // Detect authentication errors (e.g., expired OAuth token).
+          // The SDK returns 401 errors as response text, not exceptions.
+          // Without this check, the worker retries infinitely on expired tokens.
+          if (typeof textContent === 'string' && (
+            textContent.includes('authentication_error') ||
+            textContent.includes('Failed to authenticate') ||
+            textContent.includes('API Error: 401')
+          )) {
+            // If using CLI subscription billing, attempt auto-refresh before giving up
+            if (!hasAnthropicApiKey()) {
+              logger.warn('SDK', 'Authentication error detected, attempting OAuth token refresh...', {
+                sessionId: session.sessionDbId,
+                authMethod
+              });
+              const refreshed = await attemptOAuthTokenRefresh();
+              if (refreshed) {
+                logger.info('SDK', 'OAuth token refreshed successfully — retrying will use new token', {
+                  sessionId: session.sessionDbId
+                });
+                // Don't throw — let the generator exit normally so the retry logic
+                // picks up with the fresh token
+                return;
+              }
+            }
+            throw new Error(
+              'Authentication failed: OAuth token may be expired. ' +
+              'Run "claude" to refresh the token, or configure an API key in ~/.claude-mem/settings.json'
+            );
           }
 
           // Parse and process response using shared ResponseProcessor


### PR DESCRIPTION
## Problem

When the Claude Code OAuth token expires, the SDK returns 401 errors as response text (not exceptions). The worker treats these as normal responses, fails to extract observations, then retries — creating an infinite loop that burns CPU and fills logs for hours/days.

**Impact:** Worker silently blocked for 57+ hours. All observation processing stopped, feed went dark.

**Log pattern:**
```
[SDK] ← Response received (234 chars) {promptNumber=1} Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error",...
```

## Solution

### 1. Auth error detection (SDKAgent.ts)
Detects `authentication_error`, `Failed to authenticate`, and `API Error: 401` in SDK response text.

### 2. Auto-refresh before giving up
When using CLI subscription billing, attempts to refresh the OAuth token via `claude --version`. If refresh succeeds, retries with fresh token. If fails, marks unrecoverable.

### 3. Unrecoverable error patterns (worker-service.ts)
Added auth patterns to prevent infinite restart loops.

### 4. Health endpoint (worker-service.ts)
Reports `tokenExpired`, `tokenExpiringSoon`, and `tokenExpiresAt` in `/api/health`.

### 5. New utilities (EnvManager.ts)
`checkOAuthTokenStatus()` and `attemptOAuthTokenRefresh()`.

## Files changed (147 lines added)
- `src/services/worker/SDKAgent.ts`
- `src/services/worker-service.ts`
- `src/shared/EnvManager.ts`