### PR TITLE
feat: add Claude model selection to installer + update default to Sonnet 4.6

### DIFF
--- a/installer/src/steps/complete.ts
+++ b/installer/src/steps/complete.ts
@@ -6,8 +6,11 @@ import type { IDE } from './ide-selection.js';
 
 function getProviderLabel(config: ProviderConfig): string {
   switch (config.provider) {
-    case 'claude':
-      return config.claudeAuthMethod === 'api' ? 'Claude (API Key)' : 'Claude (CLI subscription)';
+    case 'claude': {
+      const auth = config.claudeAuthMethod === 'api' ? 'API Key' : 'CLI subscription';
+      const model = config.model ?? 'claude-sonnet-4-6';
+      return `Claude ${model} (${auth})`;
+    }
     case 'gemini':
       return `Gemini (${config.model ?? 'gemini-2.5-flash-lite'})`;
     case 'openrouter':

--- a/installer/src/steps/provider.ts
+++ b/installer/src/steps/provider.ts
@@ -45,6 +45,22 @@ export async function runProviderConfiguration(): Promise<ProviderConfig> {
 
     config.claudeAuthMethod = authMethod;
 
+    const model = await p.select({
+      message: 'Which Claude model for memory observations?',
+      options: [
+        { value: 'claude-sonnet-4-6' as const, label: 'Claude Sonnet 4.6', hint: 'recommended — best balance of quality and speed' },
+        { value: 'claude-sonnet-4-5' as const, label: 'Claude Sonnet 4.5', hint: 'previous generation' },
+        { value: 'claude-haiku-3-5' as const, label: 'Claude Haiku 3.5', hint: 'fastest, lowest cost' },
+      ],
+    });
+
+    if (p.isCancel(model)) {
+      p.cancel('Installation cancelled.');
+      process.exit(0);
+    }
+
+    config.model = model;
+
     if (authMethod === 'api') {
       const apiKey = await p.password({
         message: 'Enter your Anthropic API key:',

--- a/installer/src/steps/provider.ts
+++ b/installer/src/steps/provider.ts
@@ -48,10 +48,11 @@ export async function runProviderConfiguration(): Promise<ProviderConfig> {
     const model = await p.select({
       message: 'Which Claude model for memory observations?',
       options: [
+        { value: 'claude-opus-4-6' as const, label: 'Claude Opus 4.6', hint: 'highest quality, slower' },
         { value: 'claude-sonnet-4-6' as const, label: 'Claude Sonnet 4.6', hint: 'recommended — best balance of quality and speed' },
-        { value: 'claude-sonnet-4-5' as const, label: 'Claude Sonnet 4.5', hint: 'previous generation' },
-        { value: 'claude-haiku-3-5' as const, label: 'Claude Haiku 3.5', hint: 'fastest, lowest cost' },
+        { value: 'claude-haiku-4-5' as const, label: 'Claude Haiku 4.5', hint: 'fastest, lowest cost' },
       ],
+      initialValue: 'claude-sonnet-4-6',
     });
 
     if (p.isCancel(model)) {

--- a/installer/src/utils/settings-writer.ts
+++ b/installer/src/utils/settings-writer.ts
@@ -28,6 +28,7 @@ export function buildSettingsObject(
   // Provider-specific settings
   if (providerConfig.provider === 'claude') {
     settings.CLAUDE_MEM_CLAUDE_AUTH_METHOD = providerConfig.claudeAuthMethod ?? 'cli';
+    if (providerConfig.model) settings.CLAUDE_MEM_MODEL = providerConfig.model;
   }
 
   if (providerConfig.provider === 'gemini') {

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -71,7 +71,7 @@ export class SettingsDefaultsManager {
    * Default values for all settings
    */
   private static readonly DEFAULTS: SettingsDefaults = {
-    CLAUDE_MEM_MODEL: 'claude-sonnet-4-5',
+    CLAUDE_MEM_MODEL: 'claude-sonnet-4-6',
     CLAUDE_MEM_CONTEXT_OBSERVATIONS: '50',
     CLAUDE_MEM_WORKER_PORT: '37777',
     CLAUDE_MEM_WORKER_HOST: '127.0.0.1',


### PR DESCRIPTION
## Problem

When selecting Claude as the AI provider during `claude-mem` installation, users cannot choose which Claude model to use for memory observations. Gemini and OpenRouter both have model selection — Claude should too.

Additionally, the default model is still `claude-sonnet-4-5` when `claude-sonnet-4-6` is available.

## Solution

### Model selection during install
Added a model picker to the Claude provider flow in the installer:

```
Which Claude model for memory observations?
● Claude Sonnet 4.6  (recommended — best balance of quality and speed)
○ Claude Sonnet 4.5  (previous generation)
○ Claude Haiku 3.5   (fastest, lowest cost)
```

### Updated default
Changed `CLAUDE_MEM_MODEL` default from `claude-sonnet-4-5` to `claude-sonnet-4-6` in SettingsDefaultsManager.

### Configuration summary
The completion step now shows the selected model:
```
Provider: Claude claude-sonnet-4-6 (CLI subscription)
```

## Files changed (23 lines)
- `installer/src/steps/provider.ts` — model selection prompt
- `installer/src/utils/settings-writer.ts` — persist model to settings
- `installer/src/steps/complete.ts` — show model in summary
- `src/shared/SettingsDefaultsManager.ts` — default 4.5 → 4.6