### PR TITLE
fix: use 'uvx' instead of 'uvx.cmd' for chroma-mcp spawn on Windows

### DIFF
--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -102,8 +102,7 @@ export class ChromaMcpManager {
     const commandArgs = this.buildCommandArgs();
     const spawnEnvironment = this.getSpawnEnv();
 
-    const isWindows = process.platform === 'win32';
-    const uvxCommand = isWindows ? 'uvx.cmd' : 'uvx';
+    const uvxCommand = 'uvx';
 
     logger.info('CHROMA_MCP', 'Connecting to chroma-mcp via MCP stdio', {
       command: uvxCommand,


### PR DESCRIPTION
## Summary

- Replaces `'uvx.cmd'` with `'uvx'` in `ChromaMcpManager.connectInternal()` to fix chroma-mcp spawn failure on Windows

## Root Cause

On Windows systems where `uv` is installed via the standalone installer (the recommended method), only `uvx.exe` is created — no `uvx.cmd` wrapper exists. The hardcoded `'uvx.cmd'` causes `StdioClientTransport` (via bundled `cross-spawn`) to run `cmd.exe /c "uvx.cmd chroma-mcp ..."`, which fails because `uvx.cmd` isn't found, producing `MCP error -32000: Connection closed`.

Using plain `'uvx'` works on **all platforms** because `cross-spawn` resolves it correctly:
- **Windows:** finds `uvx.exe` via `PATHEXT` resolution
- **macOS/Linux:** finds `uvx` via `PATH`

The platform-specific ternary was unnecessary — `cross-spawn` already handles this.

## Test plan

- [x] Verified `uvx.cmd` does not exist on Windows standalone install (`ls ~/.local/bin/ | grep uvx` → only `uvx.exe`)
- [x] Confirmed `spawn('uvx.cmd', ...)` throws `EINVAL` on Node.js v24 / exits code 1 via `cmd.exe`
- [x] Confirmed `spawn('uvx', ...)` resolves to `uvx.exe` and starts `chroma-mcp` successfully
- [x] Patched `worker-service.cjs` locally and verified search MCP tool returns results

Fixes #1190

🤖 Generated with [Claude Code](https://claude.com/claude-code)