### PR TITLE
feat: add GitHub Copilot provider

### DIFF
--- a/docs/public/configuration.mdx
+++ b/docs/public/configuration.mdx
@@ -14,7 +14,7 @@ Settings are managed in `~/.claude-mem/settings.json`. The file is auto-created 
 | Setting                       | Default                         | Description                           |
 |-------------------------------|---------------------------------|---------------------------------------|
 | `CLAUDE_MEM_MODEL`            | `sonnet`                        | AI model for processing observations (when using Claude) |
-| `CLAUDE_MEM_PROVIDER`         | `claude`                        | AI provider: `claude`, `gemini`, or `openrouter` |
+| `CLAUDE_MEM_PROVIDER`         | `claude`                        | AI provider: `claude`, `gemini`, `openrouter`, or `github-copilot` |
 | `CLAUDE_MEM_MODE`             | `code`                          | Active mode profile (e.g., `code--es`, `email-investigation`) |
 | `CLAUDE_MEM_CONTEXT_OBSERVATIONS` | `50`                        | Number of observations to inject      |
 | `CLAUDE_MEM_WORKER_PORT`      | `37777`                         | Worker service port                   |
@@ -42,6 +42,19 @@ See [Gemini Provider](usage/gemini-provider) for detailed configuration and free
 | `CLAUDE_MEM_OPENROUTER_APP_NAME`             | `claude-mem`                | Optional: App name for analytics      |
 
 See [OpenRouter Provider](usage/openrouter-provider) for detailed configuration, free model list, and usage guide.
+
+### GitHub Copilot Provider Settings
+
+| Setting                          | Default   | Description |
+|----------------------------------|-----------|-------------|
+| `CLAUDE_MEM_COPILOT_MODEL`       | `gpt-4.1` | Model identifier to request from GitHub Copilot |
+| `CLAUDE_MEM_COPILOT_TOKEN_FILE`  | `~/.openclaw/credentials/github-copilot.token.json` | Path to a JSON token file containing `token` and `expiresAt` |
+
+If you are using OpenClaw, you can generate/refresh this token with:
+
+```bash
+openclaw models auth login-github-copilot
+```
 
 ### System Configuration
 

--- a/docs/public/usage/gemini-provider.mdx
+++ b/docs/public/usage/gemini-provider.mdx
@@ -37,7 +37,7 @@ Claude-mem supports Google's Gemini API as an alternative to the Claude Agent SD
 
 | Setting | Values | Default | Description |
 |---------|--------|---------|-------------|
-| `CLAUDE_MEM_PROVIDER` | `claude`, `gemini` | `claude` | AI provider for observation extraction |
+| `CLAUDE_MEM_PROVIDER` | `claude`, `gemini`, `github-copilot` | `claude` | AI provider for observation extraction |
 | `CLAUDE_MEM_GEMINI_API_KEY` | string | — | Your Gemini API key |
 | `CLAUDE_MEM_GEMINI_MODEL` | `gemini-2.5-flash-lite`, `gemini-2.5-flash`, `gemini-3-flash-preview` | `gemini-2.5-flash-lite` | Gemini model to use |
 | `CLAUDE_MEM_GEMINI_BILLING_ENABLED` | `true`, `false` | `false` | Skip rate limiting if billing is enabled on Google Cloud |

--- a/docs/public/usage/openrouter-provider.mdx
+++ b/docs/public/usage/openrouter-provider.mdx
@@ -71,7 +71,7 @@ All free models support:
 
 | Setting | Values | Default | Description |
 |---------|--------|---------|-------------|
-| `CLAUDE_MEM_PROVIDER` | `claude`, `gemini`, `openrouter` | `claude` | AI provider for observation extraction |
+| `CLAUDE_MEM_PROVIDER` | `claude`, `gemini`, `openrouter`, `github-copilot` | `claude` | AI provider for observation extraction |
 | `CLAUDE_MEM_OPENROUTER_API_KEY` | string | — | Your OpenRouter API key |
 | `CLAUDE_MEM_OPENROUTER_MODEL` | string | `xiaomi/mimo-v2-flash:free` | Model identifier (see list above) |
 | `CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES` | number | `20` | Max messages in conversation history |

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -101,6 +101,7 @@ import { SSEBroadcaster } from './worker/SSEBroadcaster.js';
 import { SDKAgent } from './worker/SDKAgent.js';
 import { GeminiAgent, isGeminiSelected, isGeminiAvailable } from './worker/GeminiAgent.js';
 import { OpenRouterAgent, isOpenRouterSelected, isOpenRouterAvailable } from './worker/OpenRouterAgent.js';
+import { CopilotAgent, isCopilotSelected, isCopilotAvailable } from './worker/CopilotAgent.js';
 import { PaginationHelper } from './worker/PaginationHelper.js';
 import { SettingsManager } from './worker/SettingsManager.js';
 import { SearchManager } from './worker/SearchManager.js';
@@ -161,6 +162,7 @@ export class WorkerService {
   private sdkAgent: SDKAgent;
   private geminiAgent: GeminiAgent;
   private openRouterAgent: OpenRouterAgent;
+  private copilotAgent: CopilotAgent;
   private paginationHelper: PaginationHelper;
   private settingsManager: SettingsManager;
   private sessionEventBroadcaster: SessionEventBroadcaster;
@@ -202,6 +204,12 @@ export class WorkerService {
     this.sdkAgent = new SDKAgent(this.dbManager, this.sessionManager);
     this.geminiAgent = new GeminiAgent(this.dbManager, this.sessionManager);
     this.openRouterAgent = new OpenRouterAgent(this.dbManager, this.sessionManager);
+    this.copilotAgent = new CopilotAgent(this.dbManager, this.sessionManager);
+
+    // Configure fallback: if a REST provider fails, fall back to Claude SDK when appropriate
+    this.geminiAgent.setFallbackAgent(this.sdkAgent);
+    this.openRouterAgent.setFallbackAgent(this.sdkAgent);
+    this.copilotAgent.setFallbackAgent(this.sdkAgent);
 
     this.paginationHelper = new PaginationHelper(this.dbManager);
     this.settingsManager = new SettingsManager(this.dbManager);
@@ -229,7 +237,8 @@ export class WorkerService {
       workerPath: __filename,
       getAiStatus: () => {
         let provider = 'claude';
-        if (isOpenRouterSelected() && isOpenRouterAvailable()) provider = 'openrouter';
+        if (isCopilotSelected() && isCopilotAvailable()) provider = 'github-copilot';
+        else if (isOpenRouterSelected() && isOpenRouterAvailable()) provider = 'openrouter';
         else if (isGeminiSelected() && isGeminiAvailable()) provider = 'gemini';
         return {
           provider,
@@ -330,7 +339,7 @@ export class WorkerService {
 
     // Standard routes (registered AFTER guard middleware)
     this.server.registerRoutes(new ViewerRoutes(this.sseBroadcaster, this.dbManager, this.sessionManager));
-    this.server.registerRoutes(new SessionRoutes(this.sessionManager, this.dbManager, this.sdkAgent, this.geminiAgent, this.openRouterAgent, this.sessionEventBroadcaster, this));
+    this.server.registerRoutes(new SessionRoutes(this.sessionManager, this.dbManager, this.sdkAgent, this.geminiAgent, this.openRouterAgent, this.copilotAgent, this.sessionEventBroadcaster, this));
     this.server.registerRoutes(new DataRoutes(this.paginationHelper, this.dbManager, this.sessionManager, this.sseBroadcaster, this, this.startTime));
     this.server.registerRoutes(new SettingsRoutes(this.settingsManager));
     this.server.registerRoutes(new LogsRoutes());
@@ -491,7 +500,10 @@ export class WorkerService {
    * Get the appropriate agent based on provider settings.
    * Same logic as SessionRoutes.getActiveAgent() for consistency.
    */
-  private getActiveAgent(): SDKAgent | GeminiAgent | OpenRouterAgent {
+  private getActiveAgent(): SDKAgent | GeminiAgent | OpenRouterAgent | CopilotAgent {
+    if (isCopilotSelected() && isCopilotAvailable()) {
+      return this.copilotAgent;
+    }
     if (isOpenRouterSelected() && isOpenRouterAvailable()) {
       return this.openRouterAgent;
     }

--- a/src/services/worker-types.ts
+++ b/src/services/worker-types.ts
@@ -32,7 +32,7 @@ export interface ActiveSession {
   cumulativeOutputTokens: number;  // Track output tokens for discovery cost
   earliestPendingTimestamp: number | null;  // Original timestamp of earliest pending message (for accurate observation timestamps)
   conversationHistory: ConversationMessage[];  // Shared conversation history for provider switching
-  currentProvider: 'claude' | 'gemini' | 'openrouter' | null;  // Track which provider is currently running
+  currentProvider: 'claude' | 'gemini' | 'openrouter' | 'github-copilot' | null;  // Track which provider is currently running
   consecutiveRestarts: number;  // Track consecutive restart attempts to prevent infinite loops
   forceInit?: boolean;  // Force fresh SDK session (skip resume)
   idleTimedOut?: boolean;  // Set when session exits due to idle timeout (prevents restart loop)

--- a/src/services/worker/CopilotAgent.ts
+++ b/src/services/worker/CopilotAgent.ts
@@ -1,0 +1,369 @@
+/**
+ * CopilotAgent: GitHub Copilot-based observation extraction
+ *
+ * Uses GitHub Copilot's OpenAI-compatible chat completions API.
+ *
+ * Token source:
+ * - By default reads token from OpenClaw credentials file:
+ *   ~/.openclaw/credentials/github-copilot.token.json
+ *
+ * IMPORTANT:
+ * - Never log the token.
+ * - If the token is missing/expired, instruct user to run:
+ *   openclaw models auth login-github-copilot
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+import { buildContinuationPrompt, buildInitPrompt, buildObservationPrompt, buildSummaryPrompt } from '../../sdk/prompts.js';
+import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js';
+import { USER_SETTINGS_PATH } from '../../shared/paths.js';
+import { logger } from '../../utils/logger.js';
+import { ModeManager } from '../domain/ModeManager.js';
+import type { ActiveSession, ConversationMessage } from '../worker-types.js';
+
+import { DatabaseManager } from './DatabaseManager.js';
+import { SessionManager } from './SessionManager.js';
+import {
+  isAbortError,
+  processAgentResponse,
+  shouldFallbackToClaude,
+  type FallbackAgent,
+  type WorkerRef
+} from './agents/index.js';
+
+const COPILOT_CHAT_COMPLETIONS_URL = 'https://api.githubcopilot.com/chat/completions';
+
+// OpenAI-compatible message format
+interface OpenAIMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+interface CopilotResponse {
+  choices?: Array<{
+    message?: {
+      role?: string;
+      content?: string;
+    };
+    finish_reason?: string;
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+  };
+  error?: {
+    message?: string;
+    code?: string;
+  };
+}
+
+type CopilotTokenFile = {
+  token?: string;
+  expiresAt?: string | number;
+};
+
+function parseExpiresAt(expiresAt: string | number | undefined): number | null {
+  if (expiresAt === undefined || expiresAt === null) return null;
+  if (typeof expiresAt === 'number') {
+    // Heuristic: seconds vs ms
+    return expiresAt > 1e12 ? expiresAt : expiresAt * 1000;
+  }
+  const d = Date.parse(expiresAt);
+  return Number.isFinite(d) ? d : null;
+}
+
+function readCopilotTokenFromFile(tokenFilePath: string): { token: string; expiresAtMs: number | null } {
+  if (!existsSync(tokenFilePath)) {
+    throw new Error(
+      `GitHub Copilot token file not found at ${tokenFilePath}. ` +
+      `If you use OpenClaw, generate it with: openclaw models auth login-github-copilot (TTY required).`
+    );
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(tokenFilePath, 'utf-8');
+  } catch (err) {
+    throw new Error(
+      `Failed to read GitHub Copilot token file at ${tokenFilePath}. ` +
+      `If you use OpenClaw, regenerate it with: openclaw models auth login-github-copilot (TTY required).`
+    );
+  }
+
+  let parsed: CopilotTokenFile;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `GitHub Copilot token file at ${tokenFilePath} is not valid JSON. ` +
+      `Regenerate it with: openclaw models auth login-github-copilot (TTY required).`
+    );
+  }
+
+  const token = parsed.token;
+  const expiresAtMs = parseExpiresAt(parsed.expiresAt);
+
+  if (!token || typeof token !== 'string') {
+    throw new Error(
+      `GitHub Copilot token file at ${tokenFilePath} is missing a valid "token" field. ` +
+      `Regenerate it with: openclaw models auth login-github-copilot (TTY required).`
+    );
+  }
+
+  // Consider token expired if within 60 seconds of expiry
+  if (expiresAtMs !== null && Date.now() > (expiresAtMs - 60_000)) {
+    throw new Error(
+      `GitHub Copilot token appears to be expired (expiresAt=${parsed.expiresAt}). ` +
+      `Regenerate it with: openclaw models auth login-github-copilot (TTY required).`
+    );
+  }
+
+  return { token, expiresAtMs };
+}
+
+export class CopilotAgent {
+  private dbManager: DatabaseManager;
+  private sessionManager: SessionManager;
+  private fallbackAgent: FallbackAgent | null = null;
+
+  constructor(dbManager: DatabaseManager, sessionManager: SessionManager) {
+    this.dbManager = dbManager;
+    this.sessionManager = sessionManager;
+  }
+
+  setFallbackAgent(agent: FallbackAgent): void {
+    this.fallbackAgent = agent;
+  }
+
+  async startSession(session: ActiveSession, worker?: WorkerRef): Promise<void> {
+    try {
+      const { token, model } = this.getCopilotConfig();
+
+      // Generate synthetic memorySessionId (Copilot is stateless)
+      if (!session.memorySessionId) {
+        const syntheticMemorySessionId = `github-copilot-${session.contentSessionId}-${Date.now()}`;
+        session.memorySessionId = syntheticMemorySessionId;
+        this.dbManager.getSessionStore().updateMemorySessionId(session.sessionDbId, syntheticMemorySessionId);
+        logger.info('SESSION', `MEMORY_ID_GENERATED | sessionDbId=${session.sessionDbId} | provider=GitHubCopilot`);
+      }
+
+      const mode = ModeManager.getInstance().getActiveMode();
+
+      const initPrompt = session.lastPromptNumber === 1
+        ? buildInitPrompt(session.project, session.contentSessionId, session.userPrompt, mode)
+        : buildContinuationPrompt(session.userPrompt, session.lastPromptNumber, session.contentSessionId, mode);
+
+      session.conversationHistory.push({ role: 'user', content: initPrompt });
+      const initResponse = await this.queryCopilotMultiTurn(session.conversationHistory, token, model);
+
+      if (initResponse.content) {
+        const tokensUsed = initResponse.tokensUsed || 0;
+        session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
+        session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
+
+        await processAgentResponse(
+          initResponse.content,
+          session,
+          this.dbManager,
+          this.sessionManager,
+          worker,
+          tokensUsed,
+          null,
+          'GitHubCopilot',
+          undefined
+        );
+      } else {
+        logger.error('SDK', 'Empty Copilot init response - session may lack context', {
+          sessionId: session.sessionDbId,
+          model
+        });
+      }
+
+      let lastCwd: string | undefined;
+
+      for await (const message of this.sessionManager.getMessageIterator(session.sessionDbId)) {
+        session.processingMessageIds.push(message._persistentId);
+
+        if (message.cwd) lastCwd = message.cwd;
+        const originalTimestamp = session.earliestPendingTimestamp;
+
+        if (message.type === 'observation') {
+          if (message.prompt_number !== undefined) session.lastPromptNumber = message.prompt_number;
+          if (!session.memorySessionId) {
+            throw new Error('Cannot process observations: memorySessionId not yet captured. This session may need to be reinitialized.');
+          }
+
+          const obsPrompt = buildObservationPrompt({
+            id: 0,
+            tool_name: message.tool_name!,
+            tool_input: JSON.stringify(message.tool_input),
+            tool_output: JSON.stringify(message.tool_response),
+            created_at_epoch: originalTimestamp ?? Date.now(),
+            cwd: message.cwd
+          });
+
+          session.conversationHistory.push({ role: 'user', content: obsPrompt });
+          const obsResponse = await this.queryCopilotMultiTurn(session.conversationHistory, token, model);
+
+          let tokensUsed = 0;
+          if (obsResponse.content) {
+            tokensUsed = obsResponse.tokensUsed || 0;
+            session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
+            session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
+          }
+
+          await processAgentResponse(
+            obsResponse.content || '',
+            session,
+            this.dbManager,
+            this.sessionManager,
+            worker,
+            tokensUsed,
+            originalTimestamp,
+            'GitHubCopilot',
+            lastCwd
+          );
+
+        } else if (message.type === 'summarize') {
+          if (!session.memorySessionId) {
+            throw new Error('Cannot process summary: memorySessionId not yet captured. This session may need to be reinitialized.');
+          }
+
+          const summaryPrompt = buildSummaryPrompt({
+            id: session.sessionDbId,
+            memory_session_id: session.memorySessionId,
+            project: session.project,
+            user_prompt: session.userPrompt,
+            last_assistant_message: message.last_assistant_message || ''
+          }, mode);
+
+          session.conversationHistory.push({ role: 'user', content: summaryPrompt });
+          const summaryResponse = await this.queryCopilotMultiTurn(session.conversationHistory, token, model);
+
+          let tokensUsed = 0;
+          if (summaryResponse.content) {
+            tokensUsed = summaryResponse.tokensUsed || 0;
+            session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
+            session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
+          }
+
+          await processAgentResponse(
+            summaryResponse.content || '',
+            session,
+            this.dbManager,
+            this.sessionManager,
+            worker,
+            tokensUsed,
+            originalTimestamp,
+            'GitHubCopilot',
+            lastCwd
+          );
+        }
+      }
+
+      const durationMs = Date.now() - session.startTime;
+      logger.success('SDK', 'Copilot agent completed', {
+        sessionId: session.sessionDbId,
+        duration: `${(durationMs / 1000).toFixed(1)}s`,
+        historyLength: session.conversationHistory.length
+      });
+
+    } catch (error) {
+      if (isAbortError(error)) {
+        logger.warn('SDK', 'Copilot agent aborted', { sessionId: session.sessionDbId });
+        throw error;
+      }
+
+      if (shouldFallbackToClaude(error) && this.fallbackAgent) {
+        logger.warn('SDK', 'Copilot request failed, falling back to Claude SDK', {
+          sessionDbId: session.sessionDbId,
+          error: error instanceof Error ? error.message : String(error),
+          historyLength: session.conversationHistory.length
+        });
+        return this.fallbackAgent.startSession(session, worker);
+      }
+
+      logger.failure('SDK', 'Copilot agent error', { sessionDbId: session.sessionDbId }, error);
+      throw error;
+    }
+  }
+
+  private conversationToOpenAIMessages(history: ConversationMessage[]): OpenAIMessage[] {
+    return history.map((m) => ({ role: m.role === 'assistant' ? 'assistant' : 'user', content: m.content }));
+  }
+
+  private async queryCopilotMultiTurn(history: ConversationMessage[], token: string, model: string): Promise<{ content: string; tokensUsed?: number }> {
+    const messages = this.conversationToOpenAIMessages(history);
+    const totalChars = history.reduce((acc, m) => acc + m.content.length, 0);
+
+    logger.debug('SDK', `Querying GitHub Copilot multi-turn (${model})`, {
+      turns: history.length,
+      totalChars
+    });
+
+    const resp = await fetch(COPILOT_CHAT_COMPLETIONS_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        temperature: 0.3,
+        max_tokens: 4096
+      })
+    });
+
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(`GitHub Copilot API error: ${resp.status} - ${text}`);
+    }
+
+    const data = (await resp.json()) as CopilotResponse;
+    if (data.error) {
+      throw new Error(`GitHub Copilot API error: ${data.error.code} - ${data.error.message}`);
+    }
+
+    const content = data.choices?.[0]?.message?.content;
+    if (!content) {
+      logger.error('SDK', 'Empty response from GitHub Copilot');
+      return { content: '' };
+    }
+
+    const tokensUsed = data.usage?.total_tokens;
+    return { content, tokensUsed };
+  }
+
+  private getCopilotConfig(): { token: string; model: string } {
+    const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+
+    const model = settings.CLAUDE_MEM_COPILOT_MODEL || 'gpt-4.1';
+    const tokenFile = settings.CLAUDE_MEM_COPILOT_TOKEN_FILE || join(homedir(), '.openclaw', 'credentials', 'github-copilot.token.json');
+
+    const { token } = readCopilotTokenFromFile(tokenFile);
+    return { token, model };
+  }
+}
+
+export function isCopilotSelected(): boolean {
+  const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+  return settings.CLAUDE_MEM_PROVIDER === 'github-copilot';
+}
+
+export function isCopilotAvailable(): boolean {
+  try {
+    const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+    const tokenFile = settings.CLAUDE_MEM_COPILOT_TOKEN_FILE || join(homedir(), '.openclaw', 'credentials', 'github-copilot.token.json');
+    // Throws if missing/expired
+    readCopilotTokenFromFile(tokenFile);
+    return true;
+  } catch (err) {
+    // Don't spam logs; worker-service will log provider selection.
+    return false;
+  }
+}

--- a/src/services/worker/http/routes/SettingsRoutes.ts
+++ b/src/services/worker/http/routes/SettingsRoutes.ts
@@ -101,6 +101,9 @@ export class SettingsRoutes extends BaseRouteHandler {
       'CLAUDE_MEM_OPENROUTER_APP_NAME',
       'CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES',
       'CLAUDE_MEM_OPENROUTER_MAX_TOKENS',
+      // GitHub Copilot Configuration
+      'CLAUDE_MEM_COPILOT_MODEL',
+      'CLAUDE_MEM_COPILOT_TOKEN_FILE',
       // System Configuration
       'CLAUDE_MEM_DATA_DIR',
       'CLAUDE_MEM_LOG_LEVEL',
@@ -234,9 +237,9 @@ export class SettingsRoutes extends BaseRouteHandler {
   private validateSettings(settings: any): { valid: boolean; error?: string } {
     // Validate CLAUDE_MEM_PROVIDER
     if (settings.CLAUDE_MEM_PROVIDER) {
-    const validProviders = ['claude', 'gemini', 'openrouter'];
-    if (!validProviders.includes(settings.CLAUDE_MEM_PROVIDER)) {
-      return { valid: false, error: 'CLAUDE_MEM_PROVIDER must be "claude", "gemini", or "openrouter"' };
+      const validProviders = ['claude', 'gemini', 'openrouter', 'github-copilot'];
+      if (!validProviders.includes(settings.CLAUDE_MEM_PROVIDER)) {
+        return { valid: false, error: 'CLAUDE_MEM_PROVIDER must be "claude", "gemini", "openrouter", or "github-copilot"' };
       }
     }
 

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -19,7 +19,7 @@ export interface SettingsDefaults {
   CLAUDE_MEM_WORKER_HOST: string;
   CLAUDE_MEM_SKIP_TOOLS: string;
   // AI Provider Configuration
-  CLAUDE_MEM_PROVIDER: string;  // 'claude' | 'gemini' | 'openrouter'
+  CLAUDE_MEM_PROVIDER: string;  // 'claude' | 'gemini' | 'openrouter' | 'github-copilot'
   CLAUDE_MEM_CLAUDE_AUTH_METHOD: string;  // 'cli' | 'api' - how Claude provider authenticates
   CLAUDE_MEM_GEMINI_API_KEY: string;
   CLAUDE_MEM_GEMINI_MODEL: string;  // 'gemini-2.5-flash-lite' | 'gemini-2.5-flash' | 'gemini-3-flash-preview'
@@ -30,6 +30,9 @@ export interface SettingsDefaults {
   CLAUDE_MEM_OPENROUTER_APP_NAME: string;
   CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES: string;
   CLAUDE_MEM_OPENROUTER_MAX_TOKENS: string;
+  // GitHub Copilot Provider
+  CLAUDE_MEM_COPILOT_MODEL: string;
+  CLAUDE_MEM_COPILOT_TOKEN_FILE: string;
   // System Configuration
   CLAUDE_MEM_DATA_DIR: string;
   CLAUDE_MEM_LOG_LEVEL: string;
@@ -90,6 +93,9 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_OPENROUTER_APP_NAME: 'claude-mem',  // App name for OpenRouter analytics
     CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES: '20',  // Max messages in context window
     CLAUDE_MEM_OPENROUTER_MAX_TOKENS: '100000',  // Max estimated tokens (~100k safety limit)
+    // GitHub Copilot Provider
+    CLAUDE_MEM_COPILOT_MODEL: 'gpt-4.1',
+    CLAUDE_MEM_COPILOT_TOKEN_FILE: join(homedir(), '.openclaw', 'credentials', 'github-copilot.token.json'),
     // System Configuration
     CLAUDE_MEM_DATA_DIR: join(homedir(), '.claude-mem'),
     CLAUDE_MEM_LOG_LEVEL: 'INFO',

--- a/src/ui/viewer/components/ContextSettingsModal.tsx
+++ b/src/ui/viewer/components/ContextSettingsModal.tsx
@@ -414,7 +414,7 @@ export function ContextSettingsModal({
             >
               <FormField
                 label="AI Provider"
-                tooltip="Choose between Claude (via Agent SDK) or Gemini (via REST API)"
+                tooltip="Choose the AI provider used for observation extraction"
               >
                 <select
                   value={formState.CLAUDE_MEM_PROVIDER || 'claude'}
@@ -423,6 +423,7 @@ export function ContextSettingsModal({
                   <option value="claude">Claude (uses your Claude account)</option>
                   <option value="gemini">Gemini (uses API key)</option>
                   <option value="openrouter">OpenRouter (multi-model)</option>
+                  <option value="github-copilot">GitHub Copilot</option>
                 </select>
               </FormField>
 
@@ -524,6 +525,33 @@ export function ContextSettingsModal({
                       value={formState.CLAUDE_MEM_OPENROUTER_APP_NAME || 'claude-mem'}
                       onChange={(e) => updateSetting('CLAUDE_MEM_OPENROUTER_APP_NAME', e.target.value)}
                       placeholder="claude-mem"
+                    />
+                  </FormField>
+                </>
+              )}
+
+              {formState.CLAUDE_MEM_PROVIDER === 'github-copilot' && (
+                <>
+                  <FormField
+                    label="Copilot Model"
+                    tooltip="Model identifier to request from GitHub Copilot (default: gpt-4.1)"
+                  >
+                    <input
+                      type="text"
+                      value={formState.CLAUDE_MEM_COPILOT_MODEL || 'gpt-4.1'}
+                      onChange={(e) => updateSetting('CLAUDE_MEM_COPILOT_MODEL', e.target.value)}
+                      placeholder="gpt-4.1"
+                    />
+                  </FormField>
+                  <FormField
+                    label="Copilot Token File"
+                    tooltip="Path to a JSON token file (OpenClaw default: ~/.openclaw/credentials/github-copilot.token.json). Generate/refresh with: openclaw models auth login-github-copilot"
+                  >
+                    <input
+                      type="text"
+                      value={formState.CLAUDE_MEM_COPILOT_TOKEN_FILE || ''}
+                      onChange={(e) => updateSetting('CLAUDE_MEM_COPILOT_TOKEN_FILE', e.target.value)}
+                      placeholder="/home/you/.openclaw/credentials/github-copilot.token.json"
                     />
                   </FormField>
                 </>

--- a/src/ui/viewer/constants/settings.ts
+++ b/src/ui/viewer/constants/settings.ts
@@ -17,6 +17,8 @@ export const DEFAULT_SETTINGS = {
   CLAUDE_MEM_OPENROUTER_SITE_URL: '',
   CLAUDE_MEM_OPENROUTER_APP_NAME: 'claude-mem',
   CLAUDE_MEM_GEMINI_RATE_LIMITING_ENABLED: 'true',
+  CLAUDE_MEM_COPILOT_MODEL: 'gpt-4.1',
+  CLAUDE_MEM_COPILOT_TOKEN_FILE: '',
 
   // Token Economics (all true for backwards compatibility)
   CLAUDE_MEM_CONTEXT_SHOW_READ_TOKENS: 'true',

--- a/src/ui/viewer/types.ts
+++ b/src/ui/viewer/types.ts
@@ -61,7 +61,7 @@ export interface Settings {
   CLAUDE_MEM_WORKER_HOST: string;
 
   // AI Provider Configuration
-  CLAUDE_MEM_PROVIDER?: string;  // 'claude' | 'gemini' | 'openrouter'
+  CLAUDE_MEM_PROVIDER?: string;  // 'claude' | 'gemini' | 'openrouter' | 'github-copilot'
   CLAUDE_MEM_GEMINI_API_KEY?: string;
   CLAUDE_MEM_GEMINI_MODEL?: string;  // 'gemini-2.5-flash-lite' | 'gemini-2.5-flash' | 'gemini-3-flash-preview'
   CLAUDE_MEM_GEMINI_RATE_LIMITING_ENABLED?: string;  // 'true' | 'false'


### PR DESCRIPTION
Adds a new AI provider option: `github-copilot`.

Key points:
- Supports `CLAUDE_MEM_PROVIDER=github-copilot`
- Reads Copilot token from OpenClaw credentials file by default: `~/.openclaw/credentials/github-copilot.token.json`
  - Validates presence + expiry; never logs token
  - If missing/expired, instructs user to run: `openclaw models auth login-github-copilot` (TTY required)
- Adds settings: `CLAUDE_MEM_COPILOT_MODEL` (default `gpt-4.1`), `CLAUDE_MEM_COPILOT_TOKEN_FILE`
- Adds a `CopilotAgent` using Copilot's OpenAI-compatible chat completions endpoint.
- Updates UI settings dropdown and docs.

Notes:
- Token refresh is intentionally out-of-scope for claude-mem; it reuses OpenClaw's auth flow.
