### PR TITLE
fix: Windows paths with spaces crash worker startup and chroma-mcp connection

### DIFF
--- a/scripts/smart-install.js
+++ b/scripts/smart-install.js
@@ -191,35 +191,6 @@ function installBun() {
 }
 
 /**
- * Get the uvx executable path on Windows (.exe or .cmd)
- */
-function getUvxPath() {
-  const UVX_COMMON_PATHS_WIN = [
-    join(homedir(), '.local', 'bin', 'uvx.exe'),
-    join(homedir(), '.cargo', 'bin', 'uvx.exe')
-  ];
-  return UVX_COMMON_PATHS_WIN.find(existsSync) || null;
-}
-
-/**
- * On Windows, the native uv installer creates uvx.exe but some tools expect uvx.cmd.
- * Create a uvx.cmd shim in the same directory as uvx.exe if it doesn't already exist.
- */
-function ensureUvxCmd() {
-  if (!IS_WINDOWS) return;
-
-  const uvxExePath = getUvxPath();
-  if (!uvxExePath) return;
-
-  const uvxCmdPath = uvxExePath.replace(/uvx\.exe$/i, 'uvx.cmd');
-  if (existsSync(uvxCmdPath)) return;
-
-  const cmdContent = `@echo off\r\n"${uvxExePath}" %*\r\n`;
-  writeFileSync(uvxCmdPath, cmdContent, 'utf-8');
-  console.error(`✅ Created uvx.cmd shim at ${uvxCmdPath}`);
-}
-
-/**
  * Install uv automatically based on platform
  */
 function installUv() {
@@ -308,7 +279,6 @@ function installDeps() {
 try {
   if (!isBunInstalled()) installBun();
   if (!isUvInstalled()) installUv();
-  ensureUvxCmd();
   if (needsInstall()) {
     installDeps();
     console.error('✅ Dependencies installed');

--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -103,7 +103,7 @@ export class ChromaMcpManager {
     const spawnEnvironment = this.getSpawnEnv();
 
     const isWindows = process.platform === 'win32';
-    const uvxCommand = isWindows ? this.resolveWindowsUvxCommand() : 'uvx';
+    const uvxCommand = isWindows ? 'uvx.cmd' : 'uvx';
 
     logger.info('CHROMA_MCP', 'Connecting to chroma-mcp via MCP stdio', {
       command: uvxCommand,
@@ -167,21 +167,6 @@ export class ChromaMcpManager {
       this.transport = null;
       this.lastConnectionFailureTimestamp = Date.now();
     };
-  }
-
-  /**
-   * Resolve the uvx command on Windows.
-   * Native uv installer creates uvx.exe; npm/pipx creates uvx.cmd.
-   * Prefer uvx.exe if found, fall back to uvx.cmd.
-   */
-  private resolveWindowsUvxCommand(): string {
-    const pathDirs = (process.env.PATH || '').split(';');
-    for (const dir of pathDirs) {
-      if (fs.existsSync(path.join(dir, 'uvx.exe'))) {
-        return path.join(dir, 'uvx.exe');
-      }
-    }
-    return 'uvx.cmd';
   }
 
   /**


### PR DESCRIPTION
## Problem

  On Windows, when the user profile path contains spaces (e.g.
  `C:\Users\Jan Rutger Voorhorst\`), claude-mem fails to start in two ways:

  ### 1. Worker fails to start (`Module not found "C:\Users\Jan"`)
  `worker-cli.js` uses PowerShell `Start-Process -ArgumentList '${scriptPath}'`.
  PowerShell parses the `-ArgumentList` string by spaces, so
  `C:\Users\Jan Rutger Voorhorst\...\worker-wrapper.cjs` is split into
  multiple arguments and Bun receives only `C:\Users\Jan` as the script path.

  ### 2. chroma-mcp fails to connect (`MCP error -32000: Connection closed`)
  `ChromaMcpManager` always uses `uvx.cmd` on Windows. However, the native
  [astral-sh/uv](https://github.com/astral-sh/uv) installer creates `uvx.exe`,
  not `uvx.cmd`. The `.cmd` wrapper is only created when installed via npm/pipx.
  This causes the chroma-mcp subprocess to fail immediately.

  ## Fix

  ### `plugin/scripts/worker-cli.js`
  Wrap the script path in double-quotes inside the PowerShell single-quoted
  string so spaces are preserved:
  -ArgumentList '"${a}"'   // was: '${a}'

  ### `src/services/sync/ChromaMcpManager.ts`
  Add `resolveWindowsUvxCommand()` that searches PATH for `uvx.exe` first,
  falling back to `uvx.cmd` for npm/pipx installs.

  ### `scripts/smart-install.js`
  Add `ensureUvxCmd()` that creates a `uvx.cmd` shim next to `uvx.exe` after
  installation, so both lookup strategies work going forward.

  ## Testing
  Verified working on Windows 10 with:
  - User profile path containing spaces
  - `uv` installed via native astral-sh installer (creates `uvx.exe` only)
  - Norton antivirus (requires exclusions for `~/.local/share/uv/`)