### PR TITLE
fix: bump plugin/.claude-plugin/plugin.json version to 10.4.1

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "10.4.0",
+  "version": "10.4.1",
   "description": "Persistent memory system for Claude Code - seamlessly preserve context across sessions",
   "author": {
     "name": "Alex Newman"


### PR DESCRIPTION
## Problem

The plugin manifest at `plugin/.claude-plugin/plugin.json` was still at version `10.4.0` while `package.json` had already been bumped to `10.4.1`.

Claude Code's plugin caching system uses the manifest `version` field as a cache key. This mismatch means users who already had `10.4.0` cached would pull the new `10.4.1` source files but continue serving them under the stale `10.4.0` cache entry — they would never pick up the new version.

## Root Cause

Version was bumped in `package.json` and the root-level `.claude-plugin/plugin.json` but missed in `plugin/.claude-plugin/plugin.json`.

## Fix

Bump `plugin/.claude-plugin/plugin.json` version from `10.4.0` → `10.4.1` to match `package.json`.

## Change

```diff
- "version": "10.4.0",
+ "version": "10.4.1",
```

Closes #1219