### PR TITLE
fix: redirect stdin from /dev/null for 'start' hook commands

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -45,7 +45,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.js\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.js\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start < /dev/null",
             "timeout": 60
           },
           {
@@ -62,7 +62,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.js\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.js\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start < /dev/null",
             "timeout": 60
           },
           {
@@ -78,7 +78,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.js\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.js\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start < /dev/null",
             "timeout": 60
           },
           {


### PR DESCRIPTION
## Problem (Bug 1 from #1220)

The `worker-service.cjs start` command does not consume or expect stdin input. However, Claude Code pipes JSON data (containing `tool_name`, `tool_response`, etc.) to all **PostToolUse** hooks, and JSON data to **UserPromptSubmit** and **Stop** hooks as well.

When `start` receives any stdin data, it crashes with exit code 1 and no stdout/stderr output, which Claude Code surfaces as a hook error on every tool call:

```
PostToolUse:<tool> hook error: Failed with non-blocking status code: No stderr output
```

**Reproduction:**
```bash
# Fails (exit 1, silent)
echo '{"tool_name":"Read","tool_response":"test"}' | bun worker-service.cjs start

# Works (exit 0)
bun worker-service.cjs start < /dev/null
```

## Root Cause

`worker-service.cjs start` attempts to parse stdin when it receives data, but the startup command has no use for the hook payload. Any stdin content causes it to fail.

## Fix

Add `< /dev/null` to the `start` command in the three hook contexts that pipe stdin to hooks:
- `UserPromptSubmit`
- `PostToolUse`  
- `Stop`

The `SessionStart` `start` command is left unchanged as it does not receive stdin payloads from Claude Code.

## Change

```diff
- "command": "node \"...\"/bun-runner.js \"...\"/worker-service.cjs start"
+ "command": "node \"...\"/bun-runner.js \"...\"/worker-service.cjs start < /dev/null"
```

Closes #1220 (Bug 1)