### PR TITLE
fix: resolve plugin root for Stop hooks without CLAUDE_PLUGIN_ROOT

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -78,17 +78,17 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.js\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
+            "command": "bash \"$HOME/.claude-mem/stop-hook.sh\" start < /dev/null",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.js\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" hook claude-code summarize",
+            "command": "bash \"$HOME/.claude-mem/stop-hook.sh\" hook claude-code summarize",
             "timeout": 120
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.js\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" hook claude-code session-complete",
+            "command": "bash \"$HOME/.claude-mem/stop-hook.sh\" hook claude-code session-complete",
             "timeout": 30
           }
         ]

--- a/plugin/scripts/setup.sh
+++ b/plugin/scripts/setup.sh
@@ -14,6 +14,14 @@ else
   ROOT="$CLAUDE_PLUGIN_ROOT"
 fi
 
+# Persist the resolved plugin root so Stop hooks can find it without
+# CLAUDE_PLUGIN_ROOT (which Claude Code does not inject in Stop contexts).
+CLAUDE_MEM_DIR="${CLAUDE_MEM_DATA_DIR:-$HOME/.claude-mem}"
+mkdir -p "$CLAUDE_MEM_DIR"
+printf '%s' "$ROOT" > "$CLAUDE_MEM_DIR/.plugin-root"
+cp -f "$ROOT/scripts/stop-hook.sh" "$CLAUDE_MEM_DIR/stop-hook.sh" 2>/dev/null || true
+chmod +x "$CLAUDE_MEM_DIR/stop-hook.sh" 2>/dev/null || true
+
 MARKER="$ROOT/.install-version"
 PKG_JSON="$ROOT/package.json"
 

--- a/plugin/scripts/stop-hook.sh
+++ b/plugin/scripts/stop-hook.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Stop hook wrapper: resolves plugin root without CLAUDE_PLUGIN_ROOT.
+# Claude Code does not inject CLAUDE_PLUGIN_ROOT for Stop hook contexts.
+# setup.sh copies this file to ~/.claude-mem/stop-hook.sh and writes the
+# resolved root to ~/.claude-mem/.plugin-root for fallback use here.
+ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+if [[ -z "$ROOT" ]]; then
+  STORED="${CLAUDE_MEM_DATA_DIR:-$HOME/.claude-mem}/.plugin-root"
+  [[ -f "$STORED" ]] && ROOT="$(cat "$STORED")"
+fi
+[[ -z "$ROOT" ]] && { echo "stop-hook: plugin root unresolvable" >&2; exit 0; }
+exec node "$ROOT/scripts/bun-runner.js" "$ROOT/scripts/worker-service.cjs" "$@"


### PR DESCRIPTION
## Problem

All three Stop hooks fail silently with `No stderr output` because `${CLAUDE_PLUGIN_ROOT}` is **not injected** by Claude Code when executing Stop hooks.

The commands resolve to `node "/scripts/bun-runner.js" ...` (empty path prefix), producing:
```
Stop hook error: Failed with non-blocking status code: No stderr output
```

This means **session-end summarization never runs** — no memory is saved at session completion.

| Hook | Status |
|------|--------|
| SessionStart | ✅ `CLAUDE_PLUGIN_ROOT` injected |
| UserPromptSubmit | ✅ `CLAUDE_PLUGIN_ROOT` injected |
| PostToolUse | ✅ `CLAUDE_PLUGIN_ROOT` injected |
| **Stop** | ❌ `CLAUDE_PLUGIN_ROOT` is **empty** |

## Root Cause

The Claude Code plugin host does not set `CLAUDE_PLUGIN_ROOT` in the environment when running Stop hooks. This is a Claude Code-side limitation. The fix must work without that variable.

## Fix

Three-part change:

### 1. `plugin/scripts/stop-hook.sh` (new file)
A small wrapper that resolves the plugin root without relying on `CLAUDE_PLUGIN_ROOT`:
- Uses `CLAUDE_PLUGIN_ROOT` when available (forward-compatible)
- Falls back to `~/.claude-mem/.plugin-root` (written by setup.sh)

### 2. `plugin/scripts/setup.sh` (+6 lines)
After resolving `ROOT` (the Setup hook always receives `CLAUDE_PLUGIN_ROOT` correctly):
- Writes `ROOT` to `$CLAUDE_MEM_DATA_DIR/.plugin-root`
- Deploys `stop-hook.sh` to `$CLAUDE_MEM_DATA_DIR/stop-hook.sh`

### 3. `plugin/hooks/hooks.json`
Stop hook commands now call:
```
bash "$HOME/.claude-mem/stop-hook.sh" <args>
```
This path is stable and does not depend on `CLAUDE_PLUGIN_ROOT` being injected.

## Design Rationale

- **No hardcoded paths**: `stop-hook.sh` reads the root from `~/.claude-mem/.plugin-root` which setup.sh writes at install/update time.
- **Forward compatible**: If Claude Code ever fixes the injection for Stop hooks, `stop-hook.sh` uses `CLAUDE_PLUGIN_ROOT` first.
- **Graceful failure**: If the file is missing, the hook exits 0 (non-blocking) instead of crashing.

Fixes #1215