### PR TITLE
fix: resolve plugin root for all hooks without CLAUDE_PLUGIN_ROOT

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/smart-install.js\"",
+            "command": "bash \"$HOME/.claude-mem/hook-launcher.sh\" smart-install",
             "timeout": 300
           }
         ]
@@ -29,12 +29,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.js\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
+            "command": "bash \"$HOME/.claude-mem/hook-launcher.sh\" start",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.js\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" hook claude-code context",
+            "command": "bash \"$HOME/.claude-mem/hook-launcher.sh\" hook claude-code context",
             "timeout": 60
           }
         ]
@@ -45,12 +45,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.js\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
+            "command": "bash \"$HOME/.claude-mem/hook-launcher.sh\" start < /dev/null",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.js\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" hook claude-code session-init",
+            "command": "bash \"$HOME/.claude-mem/hook-launcher.sh\" hook claude-code session-init",
             "timeout": 60
           }
         ]
@@ -62,12 +62,12 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.js\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
+            "command": "bash \"$HOME/.claude-mem/hook-launcher.sh\" start < /dev/null",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.js\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" hook claude-code observation",
+            "command": "bash \"$HOME/.claude-mem/hook-launcher.sh\" hook claude-code observation",
             "timeout": 120
           }
         ]
@@ -78,17 +78,17 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.js\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
+            "command": "bash \"$HOME/.claude-mem/hook-launcher.sh\" start < /dev/null",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.js\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" hook claude-code summarize",
+            "command": "bash \"$HOME/.claude-mem/hook-launcher.sh\" hook claude-code summarize",
             "timeout": 120
           },
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bun-runner.js\" \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" hook claude-code session-complete",
+            "command": "bash \"$HOME/.claude-mem/hook-launcher.sh\" hook claude-code session-complete",
             "timeout": 30
           }
         ]

--- a/plugin/scripts/hook-launcher.sh
+++ b/plugin/scripts/hook-launcher.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# claude-mem Hook Launcher
+#
+# Resolves the plugin root without depending on ${CLAUDE_PLUGIN_ROOT} being
+# injected by Claude Code's hook executor. Works around:
+#   - anthropics/claude-code#24529 (all hooks on Linux)
+#   - thedotmack/claude-mem#1215 (Stop hooks on macOS)
+#
+# Usage (from hooks.json):
+#   bash "$HOME/.claude-mem/hook-launcher.sh" start
+#   bash "$HOME/.claude-mem/hook-launcher.sh" hook claude-code context
+#   bash "$HOME/.claude-mem/hook-launcher.sh" smart-install
+#
+
+set -euo pipefail
+
+# 1. Use CLAUDE_PLUGIN_ROOT if Claude Code set it (forward-compatible)
+ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+
+# 2. Fall back to .plugin-root written by setup.sh
+if [[ -z "$ROOT" ]]; then
+  ROOTFILE="${CLAUDE_MEM_DATA_DIR:-$HOME/.claude-mem}/.plugin-root"
+  if [[ -f "$ROOTFILE" ]]; then
+    ROOT="$(head -1 "$ROOTFILE" | tr -d '[:space:]')"
+  fi
+fi
+
+# 3. Cannot resolve — exit gracefully (non-blocking)
+if [[ -z "$ROOT" || ! -d "$ROOT" ]]; then
+  exit 0
+fi
+
+export CLAUDE_PLUGIN_ROOT="$ROOT"
+
+case "${1:-}" in
+  smart-install)
+    exec node "$ROOT/scripts/smart-install.js"
+    ;;
+  *)
+    exec node "$ROOT/scripts/bun-runner.js" "$ROOT/scripts/worker-service.cjs" "$@"
+    ;;
+esac

--- a/plugin/scripts/setup.sh
+++ b/plugin/scripts/setup.sh
@@ -17,6 +17,18 @@ fi
 MARKER="$ROOT/.install-version"
 PKG_JSON="$ROOT/package.json"
 
+# Write plugin root and deploy hook launcher for non-Setup hooks.
+# Workaround for anthropics/claude-code#24529: ${CLAUDE_PLUGIN_ROOT} is not
+# injected by the hook executor on Linux (all hooks) and macOS (Stop hooks).
+# The launcher reads this file to resolve the plugin root at runtime.
+CLAUDE_MEM_DIR="${CLAUDE_MEM_DATA_DIR:-$HOME/.claude-mem}"
+mkdir -p "$CLAUDE_MEM_DIR"
+echo "$ROOT" > "$CLAUDE_MEM_DIR/.plugin-root"
+if [[ -f "$ROOT/scripts/hook-launcher.sh" ]]; then
+  cp "$ROOT/scripts/hook-launcher.sh" "$CLAUDE_MEM_DIR/hook-launcher.sh"
+  chmod +x "$CLAUDE_MEM_DIR/hook-launcher.sh"
+fi
+
 # Colors (when terminal supports it)
 if [[ -t 2 ]]; then
   RED='\033[0;31m'


### PR DESCRIPTION
## Problem

Claude Code's hook executor does not inject `${CLAUDE_PLUGIN_ROOT}` in all contexts:
- **macOS:** Stop hooks only (#1215)
- **Linux:** ALL hooks — SessionStart, UserPromptSubmit, PostToolUse, Stop (anthropics/claude-code#24529)

When `${CLAUDE_PLUGIN_ROOT}` is not expanded, hook commands resolve to `node "/scripts/bun-runner.js"` which doesn't exist, causing every hook to fail silently.

Additionally, the `start` command in `worker-service.cjs` crashes (exit 1, no output) when it receives stdin data that Claude Code pipes to UserPromptSubmit, PostToolUse, and Stop hooks (#1220 Bug 1).

## Root Cause

1. **Path resolution:** Claude Code's template engine should expand `${CLAUDE_PLUGIN_ROOT}` before executing hook commands, but doesn't do so reliably across all platforms and hook types (anthropics/claude-code#24529).
2. **stdin crash:** The `start` subcommand doesn't consume stdin, but crashes when data is piped to it.

## Fix

Three-part change:

### 1. `plugin/scripts/hook-launcher.sh` (new file)
A stable entry point deployed to `~/.claude-mem/hook-launcher.sh` that resolves the plugin root without relying on `${CLAUDE_PLUGIN_ROOT}`:
- Uses `CLAUDE_PLUGIN_ROOT` env var when available (forward-compatible with a future Claude Code fix)
- Falls back to `~/.claude-mem/.plugin-root` (written by setup.sh)
- Exits gracefully (exit 0) if neither is available
- Handles both `smart-install` and `bun-runner.js → worker-service.cjs` commands

### 2. `plugin/scripts/setup.sh` (+12 lines)
After resolving `ROOT` (Setup hooks always receive `CLAUDE_PLUGIN_ROOT` correctly, and the script self-resolves via `BASH_SOURCE[0]` as a fallback):
- Writes `ROOT` to `~/.claude-mem/.plugin-root`
- Copies `hook-launcher.sh` from plugin scripts to `~/.claude-mem/hook-launcher.sh`

### 3. `plugin/hooks/hooks.json`
All non-Setup hook commands now call:
```
bash "$HOME/.claude-mem/hook-launcher.sh" <subcommand> [args...]
```

The `start` subcommand in UserPromptSubmit, PostToolUse, and Stop hooks additionally redirects stdin:
```
bash "$HOME/.claude-mem/hook-launcher.sh" start < /dev/null
```

Setup hook is unchanged — it already self-resolves and `${CLAUDE_PLUGIN_ROOT}` is reliably injected for Setup.

## Design Rationale

- **No hardcoded user paths:** The launcher reads the root from `~/.claude-mem/.plugin-root`, written at setup time
- **Forward-compatible:** If Claude Code fixes #24529, `CLAUDE_PLUGIN_ROOT` will be set and the launcher uses it directly
- **Graceful degradation:** Missing `.plugin-root` → exit 0 (non-blocking hook)
- **Respects `CLAUDE_MEM_DATA_DIR`:** Users with custom data directories are supported
- **Comprehensive:** Fixes ALL hooks on ALL platforms, not just Stop on macOS

## Testing

Verified on Linux (Ubuntu, Claude Code v2.1.52) with `CLAUDE_PLUGIN_ROOT` unset:

| Hook Command | Result |
|---|---|
| `start` (via launcher, `< /dev/null`) | Exit 0, worker started |
| `hook claude-code context` | Exit 0, 35KB context returned |
| `smart-install` | Exit 0 |
| `hook claude-code session-init` | Exit 0 |
| `start` (missing `.plugin-root`) | Exit 0, graceful no-op |

## Related Issues & PRs

- Fixes #1215 (Stop hooks fail on macOS)
- Fixes #1220 (Bug 1: `start` crashes on stdin)
- Related: anthropics/claude-code#24529 (root cause — `CLAUDE_PLUGIN_ROOT` not injected)
- Supersedes #1222 (stdin fix only, `start` commands only)
- Supersedes #1223 (Stop hooks only, same approach but limited scope)
- Related: #1221 (version mismatch in plugin.json — separate issue)