### PR TITLE
feat(session-registry): add registry UI and raw multi-provider session browsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,13 @@ src/ui/viewer.html
 .mcp.json
 .cursor/
 
+# Prevent literal tilde directories (path validation bug artifacts)
+~*/
+
+# Prevent other malformed path directories (at root level only)
+/http*/
+/https*/
+
 # Ignore WebStorm project files (for dinosaur IDE users)
 .idea/
 
@@ -36,3 +43,7 @@ src/ui/viewer.html
 .claude/session-intent.md
 .claude/session-plan.md
 .octo/
+
+# Archived perf-comparison artifacts (moved to ../CC-sesh-master/legada)
+docs/ui-parallel-performance-playbook.md
+scripts/perf/

--- a/installer/src/utils/settings-writer.ts
+++ b/installer/src/utils/settings-writer.ts
@@ -41,6 +41,18 @@ export function buildSettingsObject(
     if (providerConfig.model) settings.CLAUDE_MEM_OPENROUTER_MODEL = providerConfig.model;
   }
 
+  // OpenClaw-specific provider override
+  if (providerConfig.openclawProvider && providerConfig.openclawProvider !== providerConfig.provider) {
+    settings.CLAUDE_MEM_OPENCLAW_PROVIDER = providerConfig.openclawProvider;
+    // Write OpenClaw-specific API key if it's a different provider that needs one
+    if (providerConfig.openclawProvider === 'gemini' && providerConfig.openclawApiKey) {
+      if (!settings.CLAUDE_MEM_GEMINI_API_KEY) settings.CLAUDE_MEM_GEMINI_API_KEY = providerConfig.openclawApiKey;
+    } else if (providerConfig.openclawProvider === 'openrouter' && providerConfig.openclawApiKey) {
+      if (!settings.CLAUDE_MEM_OPENROUTER_API_KEY) settings.CLAUDE_MEM_OPENROUTER_API_KEY = providerConfig.openclawApiKey;
+    }
+    // openai-codex: credentials managed by OpenClaw OAuth — nothing to write here
+  }
+
   // Chroma settings
   if (settingsConfig.chromaEnabled) {
     settings.CLAUDE_MEM_CHROMA_MODE = settingsConfig.chromaMode ?? 'local';

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.76",
+    "@mariozechner/pi-ai": "^0.53.0",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "ansi-to-html": "^0.7.2",
     "dompurify": "^3.3.1",

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -109,6 +109,7 @@ import { SSEBroadcaster } from './worker/SSEBroadcaster.js';
 import { SDKAgent } from './worker/SDKAgent.js';
 import { GeminiAgent, isGeminiSelected, isGeminiAvailable } from './worker/GeminiAgent.js';
 import { OpenRouterAgent, isOpenRouterSelected, isOpenRouterAvailable } from './worker/OpenRouterAgent.js';
+import { OpenAICodexAgent, isOpenAICodexSelected, isOpenAICodexAvailable } from './worker/OpenAICodexAgent.js';
 import { PaginationHelper } from './worker/PaginationHelper.js';
 import { SettingsManager } from './worker/SettingsManager.js';
 import { SearchManager } from './worker/SearchManager.js';
@@ -124,6 +125,7 @@ import { SearchRoutes } from './worker/http/routes/SearchRoutes.js';
 import { SettingsRoutes } from './worker/http/routes/SettingsRoutes.js';
 import { LogsRoutes } from './worker/http/routes/LogsRoutes.js';
 import { MemoryRoutes } from './worker/http/routes/MemoryRoutes.js';
+import { SessionRegistryRoutes } from './worker/http/routes/SessionRegistryRoutes.js';
 
 // Process management for zombie cleanup (Issue #737)
 import { startOrphanReaper, reapOrphanedProcesses, getProcessBySession, ensureProcessExit } from './worker/ProcessRegistry.js';
@@ -169,6 +171,7 @@ export class WorkerService {
   private sdkAgent: SDKAgent;
   private geminiAgent: GeminiAgent;
   private openRouterAgent: OpenRouterAgent;
+  private openAICodexAgent: OpenAICodexAgent;
   private paginationHelper: PaginationHelper;
   private settingsManager: SettingsManager;
   private sessionEventBroadcaster: SessionEventBroadcaster;
@@ -210,6 +213,14 @@ export class WorkerService {
     this.sdkAgent = new SDKAgent(this.dbManager, this.sessionManager);
     this.geminiAgent = new GeminiAgent(this.dbManager, this.sessionManager);
     this.openRouterAgent = new OpenRouterAgent(this.dbManager, this.sessionManager);
+    this.openAICodexAgent = new OpenAICodexAgent(this.dbManager, this.sessionManager);
+
+    // Configure fallback chain for non-Claude providers.
+    // If provider-specific API calls fail with transient/recoverable errors,
+    // the request can continue via the Claude SDK agent.
+    this.geminiAgent.setFallbackAgent(this.sdkAgent);
+    this.openRouterAgent.setFallbackAgent(this.sdkAgent);
+    this.openAICodexAgent.setFallbackAgent(this.sdkAgent);
 
     this.paginationHelper = new PaginationHelper(this.dbManager);
     this.settingsManager = new SettingsManager(this.dbManager);
@@ -315,11 +326,12 @@ export class WorkerService {
 
     // Standard routes (registered AFTER guard middleware)
     this.server.registerRoutes(new ViewerRoutes(this.sseBroadcaster, this.dbManager, this.sessionManager));
-    this.server.registerRoutes(new SessionRoutes(this.sessionManager, this.dbManager, this.sdkAgent, this.geminiAgent, this.openRouterAgent, this.sessionEventBroadcaster, this));
+    this.server.registerRoutes(new SessionRoutes(this.sessionManager, this.dbManager, this.sdkAgent, this.geminiAgent, this.openRouterAgent, this.openAICodexAgent, this.sessionEventBroadcaster, this));
     this.server.registerRoutes(new DataRoutes(this.paginationHelper, this.dbManager, this.sessionManager, this.sseBroadcaster, this, this.startTime));
     this.server.registerRoutes(new SettingsRoutes(this.settingsManager));
     this.server.registerRoutes(new LogsRoutes());
     this.server.registerRoutes(new MemoryRoutes(this.dbManager, 'claude-mem'));
+    this.server.registerRoutes(new SessionRegistryRoutes());
   }
 
   /**
@@ -523,13 +535,26 @@ export class WorkerService {
    * Get the appropriate agent based on provider settings.
    * Same logic as SessionRoutes.getActiveAgent() for consistency.
    */
-  private getActiveAgent(): SDKAgent | GeminiAgent | OpenRouterAgent {
-    if (isOpenRouterSelected() && isOpenRouterAvailable()) {
-      return this.openRouterAgent;
+  /**
+   * Resolve the effective provider for a session.
+   * OpenClaw sessions (contentSessionId starts with 'openclaw-') use
+   * CLAUDE_MEM_OPENCLAW_PROVIDER if configured; otherwise fall back to
+   * the global CLAUDE_MEM_PROVIDER.
+   */
+  private resolveProviderForSession(contentSessionId?: string): string {
+    const { USER_SETTINGS_PATH } = require('../shared/paths.js');
+    const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+    if (contentSessionId?.startsWith('openclaw-') && settings.CLAUDE_MEM_OPENCLAW_PROVIDER) {
+      return settings.CLAUDE_MEM_OPENCLAW_PROVIDER;
     }
-    if (isGeminiSelected() && isGeminiAvailable()) {
-      return this.geminiAgent;
-    }
+    return settings.CLAUDE_MEM_PROVIDER || 'claude';
+  }
+
+  private getActiveAgent(contentSessionId?: string): SDKAgent | GeminiAgent | OpenRouterAgent | OpenAICodexAgent {
+    const provider = this.resolveProviderForSession(contentSessionId);
+    if (provider === 'openai-codex' && isOpenAICodexAvailable()) return this.openAICodexAgent;
+    if (provider === 'openrouter' && isOpenRouterAvailable()) return this.openRouterAgent;
+    if (provider === 'gemini' && isGeminiAvailable()) return this.geminiAgent;
     return this.sdkAgent;
   }
 
@@ -545,7 +570,7 @@ export class WorkerService {
     if (!session) return;
 
     const sid = session.sessionDbId;
-    const agent = this.getActiveAgent();
+    const agent = this.getActiveAgent(session.contentSessionId);
     const providerName = agent.constructor.name;
 
     // Before starting generator, check if AbortController is already aborted

--- a/src/services/worker-types.ts
+++ b/src/services/worker-types.ts
@@ -32,7 +32,7 @@ export interface ActiveSession {
   cumulativeOutputTokens: number;  // Track output tokens for discovery cost
   earliestPendingTimestamp: number | null;  // Original timestamp of earliest pending message (for accurate observation timestamps)
   conversationHistory: ConversationMessage[];  // Shared conversation history for provider switching
-  currentProvider: 'claude' | 'gemini' | 'openrouter' | null;  // Track which provider is currently running
+  currentProvider: 'claude' | 'gemini' | 'openrouter' | 'openai-codex' | null;  // Track which provider is currently running
   consecutiveRestarts: number;  // Track consecutive restart attempts to prevent infinite loops
   forceInit?: boolean;  // Force fresh SDK session (skip resume)
   idleTimedOut?: boolean;  // Set when session exits due to idle timeout (prevents restart loop)

--- a/src/services/worker/MoonshotAgent.ts
+++ b/src/services/worker/MoonshotAgent.ts
@@ -1,0 +1,464 @@
+/**
+ * MoonshotAgent: Moonshot AI (Kimi) based observation extraction
+ *
+ * Alternative to SDKAgent that uses Moonshot AI's OpenAI-compatible API
+ * for accessing Kimi K2.5 and other Moonshot models.
+ *
+ * Responsibility:
+ * - Call Moonshot AI REST API for observation extraction
+ * - Parse XML responses (same format as Claude/Gemini)
+ * - Sync to database and Chroma
+ * - Support dynamic model selection
+ */
+
+import { buildContinuationPrompt, buildInitPrompt, buildObservationPrompt, buildSummaryPrompt } from '../../sdk/prompts.js';
+import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js';
+import { USER_SETTINGS_PATH } from '../../shared/paths.js';
+import { logger } from '../../utils/logger.js';
+import { ModeManager } from '../domain/ModeManager.js';
+import type { ActiveSession, ConversationMessage } from '../worker-types.js';
+import { DatabaseManager } from './DatabaseManager.js';
+import { SessionManager } from './SessionManager.js';
+import {
+  isAbortError,
+  processAgentResponse,
+  shouldFallbackToClaude,
+  type FallbackAgent,
+  type WorkerRef
+} from './agents/index.js';
+
+// Moonshot API endpoint
+const MOONSHOT_API_URL = 'https://api.moonshot.ai/v1/chat/completions';
+
+// Context window management constants
+const DEFAULT_MAX_CONTEXT_MESSAGES = 50;  // Kimi K2.5 supports 256k context
+const DEFAULT_MAX_ESTIMATED_TOKENS = 250000;  // ~250k tokens max context (conservative for 256k limit)
+const CHARS_PER_TOKEN_ESTIMATE = 4;  // Conservative estimate: 1 token = 4 chars
+const API_TIMEOUT_MS = 30000;  // 30 second timeout for API calls
+
+// OpenAI-compatible message format
+interface OpenAIMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+interface MoonshotResponse {
+  choices?: Array<{
+    message?: {
+      role?: string;
+      content?: string;
+    };
+    finish_reason?: string;
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+  };
+  error?: {
+    message?: string;
+    code?: string;
+  };
+}
+
+export class MoonshotAgent {
+  private dbManager: DatabaseManager;
+  private sessionManager: SessionManager;
+  private fallbackAgent: FallbackAgent | null = null;
+
+  constructor(dbManager: DatabaseManager, sessionManager: SessionManager) {
+    this.dbManager = dbManager;
+    this.sessionManager = sessionManager;
+  }
+
+  /**
+   * Set the fallback agent (Claude SDK) for when Moonshot API fails
+   * Must be set after construction to avoid circular dependency
+   */
+  setFallbackAgent(agent: FallbackAgent): void {
+    this.fallbackAgent = agent;
+  }
+
+  /**
+   * Start Moonshot agent for a session
+   * Uses multi-turn conversation to maintain context across messages
+   */
+  async startSession(session: ActiveSession, worker?: WorkerRef): Promise<void> {
+    try {
+      // Get Moonshot configuration
+      const { apiKey, model, baseUrl } = this.getMoonshotConfig();
+
+      if (!apiKey) {
+        throw new Error('Moonshot API key not configured. Set CLAUDE_MEM_MOONSHOT_API_KEY in settings or MOONSHOT_API_KEY environment variable.');
+      }
+
+      // Generate synthetic memorySessionId (Moonshot is stateless, doesn't return session IDs)
+      if (!session.memorySessionId) {
+        const syntheticMemorySessionId = `moonshot-${session.contentSessionId}-${Date.now()}`;
+        session.memorySessionId = syntheticMemorySessionId;
+        this.dbManager.getSessionStore().updateMemorySessionId(session.sessionDbId, syntheticMemorySessionId);
+        logger.info('SESSION', `MEMORY_ID_GENERATED | sessionDbId=${session.sessionDbId} | provider=Moonshot`);
+      }
+
+      // Load active mode
+      const mode = ModeManager.getInstance().getActiveMode();
+
+      // Build initial prompt
+      const initPrompt = session.lastPromptNumber === 1
+        ? buildInitPrompt(session.project, session.contentSessionId, session.userPrompt, mode)
+        : buildContinuationPrompt(session.userPrompt, session.lastPromptNumber, session.contentSessionId, mode);
+
+      // Add to conversation history and query Moonshot with full context
+      session.conversationHistory.push({ role: 'user', content: initPrompt });
+      const initResponse = await this.queryMoonshotMultiTurn(session.conversationHistory, apiKey, model, baseUrl);
+
+      if (initResponse.content) {
+        // Track token usage
+        const tokensUsed = initResponse.tokensUsed || 0;
+        session.cumulativeInputTokens += initResponse.inputTokens || Math.floor(tokensUsed * 0.7);
+        session.cumulativeOutputTokens += initResponse.outputTokens || Math.floor(tokensUsed * 0.3);
+
+        // Process response using shared ResponseProcessor
+        await processAgentResponse(
+          initResponse.content,
+          session,
+          this.dbManager,
+          this.sessionManager,
+          worker,
+          tokensUsed,
+          null,
+          'Moonshot',
+          undefined
+        );
+      } else {
+        logger.error('SDK', 'Empty Moonshot init response - session may lack context', {
+          sessionId: session.sessionDbId,
+          model
+        });
+      }
+
+      // Track lastCwd from messages for CLAUDE.md generation
+      let lastCwd: string | undefined;
+
+      // Process pending messages
+      for await (const message of this.sessionManager.getMessageIterator(session.sessionDbId)) {
+        // CLAIM-CONFIRM: Track message ID for confirmProcessed() after successful storage
+        session.processingMessageIds.push(message._persistentId);
+
+        // Update lastCwd if message has cwd
+        if (message.cwd) {
+          lastCwd = message.cwd;
+        }
+
+        // Load active mode (may have changed)
+        const currentMode = ModeManager.getInstance().getActiveMode();
+
+        // Build observation prompt
+        const obsPrompt = buildObservationPrompt(
+          message.tool_name,
+          message.tool_input,
+          message.tool_output,
+          session.contentSessionId,
+          currentMode
+        );
+
+        // Add to conversation history and query with full context
+        session.conversationHistory.push({ role: 'user', content: obsPrompt });
+        const response = await this.queryMoonshotMultiTurn(
+          session.conversationHistory,
+          apiKey,
+          model,
+          baseUrl
+        );
+
+        if (response.content) {
+          // Track token usage
+          const tokensUsed = response.tokensUsed || 0;
+          session.cumulativeInputTokens += response.inputTokens || Math.floor(tokensUsed * 0.7);
+          session.cumulativeOutputTokens += response.outputTokens || Math.floor(tokensUsed * 0.3);
+
+          // Process response
+          await processAgentResponse(
+            response.content,
+            session,
+            this.dbManager,
+            this.sessionManager,
+            worker,
+            tokensUsed,
+            message.timestamp,
+            'Moonshot',
+            lastCwd
+          );
+        } else {
+          logger.warn('SDK', 'Empty Moonshot response for observation', {
+            sessionId: session.sessionDbId,
+            messageId: message._persistentId,
+            tool: message.tool_name
+          });
+        }
+
+        // Update last activity timestamp
+        session.lastGeneratorActivity = Date.now();
+      }
+
+      // Check if summarization is needed
+      const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+      const contextObservations = parseInt(settings.CLAUDE_MEM_CONTEXT_OBSERVATIONS, 10) || 50;
+
+      // Get observation count from database
+      const observationCount = this.dbManager.getSessionStore().getObservationCount(session.sessionDbId);
+
+      if (observationCount >= contextObservations) {
+        logger.info('SESSION', `Triggering summarization | count=${observationCount} | threshold=${contextObservations}`, {
+          sessionId: session.sessionDbId
+        });
+
+        // Get last assistant message for context
+        const lastAssistantMessage = session.conversationHistory
+          .filter(m => m.role === 'assistant')
+          .pop()?.content || '';
+
+        // Build summary prompt
+        const summaryPrompt = buildSummaryPrompt({
+          id: session.sessionDbId,
+          memory_session_id: session.memorySessionId,
+          project: session.project,
+          user_prompt: session.userPrompt,
+          last_assistant_message: lastAssistantMessage
+        }, currentMode);
+
+        // Add to conversation history and query
+        session.conversationHistory.push({ role: 'user', content: summaryPrompt });
+        const summaryResponse = await this.queryMoonshotMultiTurn(
+          session.conversationHistory,
+          apiKey,
+          model,
+          baseUrl
+        );
+
+        if (summaryResponse.content) {
+          // Track token usage
+          const tokensUsed = summaryResponse.tokensUsed || 0;
+          session.cumulativeInputTokens += summaryResponse.inputTokens || Math.floor(tokensUsed * 0.7);
+          session.cumulativeOutputTokens += summaryResponse.outputTokens || Math.floor(tokensUsed * 0.3);
+
+          // Process summary response
+          await processAgentResponse(
+            summaryResponse.content,
+            session,
+            this.dbManager,
+            this.sessionManager,
+            worker,
+            tokensUsed,
+            null,
+            'Moonshot',
+            lastCwd
+          );
+        }
+      }
+
+      // Mark session complete
+      const sessionDuration = Date.now() - session.startTime;
+      logger.success('SDK', 'Moonshot agent completed', {
+        sessionId: session.sessionDbId,
+        duration: `${(sessionDuration / 1000).toFixed(1)}s`,
+        totalTokens: session.cumulativeInputTokens + session.cumulativeOutputTokens
+      });
+
+    } catch (error) {
+      // Check if this is a fatal error or if we should fallback
+      if (shouldFallbackToClaude(error) && this.fallbackAgent) {
+        logger.warn('SDK', 'Moonshot failed, falling back to Claude', {
+          sessionId: session.sessionDbId,
+          error: error instanceof Error ? error.message : String(error)
+        });
+        await this.fallbackAgent.startSession(session, worker);
+        return;
+      }
+
+      // Check for abort errors (user cancelled)
+      if (isAbortError(error)) {
+        logger.info('SESSION', 'Moonshot session aborted by user', {
+          sessionId: session.sessionDbId
+        });
+        throw error;
+      }
+
+      // Log and re-throw other errors
+      logger.error('SESSION', 'Moonshot session failed', {
+        sessionId: session.sessionDbId,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Query Moonshot API with multi-turn conversation context
+   */
+  private async queryMoonshotMultiTurn(
+    conversationHistory: ConversationMessage[],
+    apiKey: string,
+    model: string,
+    baseUrl: string
+  ): Promise<{ content: string; tokensUsed: number; inputTokens?: number; outputTokens?: number }> {
+    // Build messages array from conversation history
+    const messages: OpenAIMessage[] = conversationHistory.map(msg => ({
+      role: msg.role as 'user' | 'assistant' | 'system',
+      content: msg.content
+    }));
+
+    // Truncate if needed to fit context window
+    const { maxContextMessages, maxEstimatedTokens } = this.getContextLimits();
+    const truncatedMessages = this.truncateMessages(messages, maxContextMessages, maxEstimatedTokens);
+
+    const requestBody = {
+      model,
+      messages: truncatedMessages,
+      temperature: 0.1,  // Low temperature for consistent observation extraction
+      max_tokens: 8192   // Kimi K2.5 supports up to 8192 output tokens
+    };
+
+    // Create abort controller for timeout
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(`${baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${apiKey}`
+        },
+        body: JSON.stringify(requestBody),
+        signal: controller.signal
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        let errorMessage = `Moonshot API error: ${response.status} - ${errorText}`;
+
+        try {
+          const errorJson = JSON.parse(errorText);
+          if (errorJson.error?.message) {
+            errorMessage = `Moonshot API error: ${errorJson.error.message}`;
+          }
+        } catch {
+          // Use raw error text if JSON parsing fails
+        }
+
+        throw new Error(errorMessage);
+      }
+
+      const data: MoonshotResponse = await response.json();
+
+      if (data.error?.message) {
+        throw new Error(`Moonshot API error: ${data.error.message}`);
+      }
+
+      const content = data.choices?.[0]?.message?.content || '';
+      const inputTokens = data.usage?.prompt_tokens || 0;
+      const outputTokens = data.usage?.completion_tokens || 0;
+      const totalTokens = data.usage?.total_tokens || (inputTokens + outputTokens);
+
+      return {
+        content,
+        tokensUsed: totalTokens,
+        inputTokens,
+        outputTokens
+      };
+    } catch (error) {
+      clearTimeout(timeoutId);
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new Error(`Moonshot API timeout after ${API_TIMEOUT_MS}ms`);
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Truncate messages to fit within context window limits
+   */
+  private truncateMessages(
+    messages: OpenAIMessage[],
+    maxMessages: number,
+    maxEstimatedTokens: number
+  ): OpenAIMessage[] {
+    // First limit by message count
+    let truncated = messages;
+    if (messages.length > maxMessages) {
+      // Keep first message (init prompt) and most recent messages
+      const firstMessage = messages[0];
+      const recentMessages = messages.slice(-(maxMessages - 1));
+      truncated = [firstMessage, ...recentMessages];
+      logger.debug('SDK', `Truncated conversation history to ${maxMessages} messages`, {
+        originalCount: messages.length,
+        truncatedCount: truncated.length
+      });
+    }
+
+    // Then limit by estimated tokens
+    let totalChars = truncated.reduce((sum, msg) => sum + msg.content.length, 0);
+    const estimatedTokens = totalChars / CHARS_PER_TOKEN_ESTIMATE;
+
+    if (estimatedTokens > maxEstimatedTokens) {
+      // Keep removing oldest messages (except first) until we fit
+      while (truncated.length > 1 && totalChars > maxEstimatedTokens * CHARS_PER_TOKEN_ESTIMATE) {
+        const removed = truncated.splice(1, 1)[0];
+        totalChars -= removed.content.length;
+      }
+      logger.debug('SDK', `Truncated conversation history to fit token limit`, {
+        messages: truncated.length,
+        estimatedTokens: Math.ceil(totalChars / CHARS_PER_TOKEN_ESTIMATE)
+      });
+    }
+
+    return truncated;
+  }
+
+  /**
+   * Get context window limits from settings
+   */
+  private getContextLimits(): { maxContextMessages: number; maxEstimatedTokens: number } {
+    const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+    return {
+      maxContextMessages: parseInt(settings.CLAUDE_MEM_MOONSHOT_MAX_CONTEXT_MESSAGES, 10) || DEFAULT_MAX_CONTEXT_MESSAGES,
+      maxEstimatedTokens: parseInt(settings.CLAUDE_MEM_MOONSHOT_MAX_TOKENS, 10) || DEFAULT_MAX_ESTIMATED_TOKENS
+    };
+  }
+
+  /**
+   * Get Moonshot configuration from settings
+   */
+  private getMoonshotConfig(): { apiKey: string; model: string; baseUrl: string } {
+    const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+
+    // Check for API key in settings or environment
+    const apiKey = settings.CLAUDE_MEM_MOONSHOT_API_KEY || process.env.MOONSHOT_API_KEY || '';
+    const model = settings.CLAUDE_MEM_MOONSHOT_MODEL || 'kimi-k2.5';
+    const baseUrl = settings.CLAUDE_MEM_MOONSHOT_BASE_URL || MOONSHOT_API_URL;
+
+    return { apiKey, model, baseUrl };
+  }
+}
+
+/**
+ * Check if Moonshot is the selected provider
+ */
+export function isMoonshotSelected(): boolean {
+  const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+  return settings.CLAUDE_MEM_PROVIDER === 'moonshot' ||
+         settings.CLAUDE_MEM_PROVIDER === 'kimi' ||
+         settings.CLAUDE_MEM_PROVIDER === 'moonshot-ai';
+}
+
+/**
+ * Check if Moonshot is available (has API key configured)
+ */
+export function isMoonshotAvailable(): boolean {
+  const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+  const apiKey = settings.CLAUDE_MEM_MOONSHOT_API_KEY || process.env.MOONSHOT_API_KEY;
+  return !!apiKey;
+}

--- a/src/services/worker/OpenAICodexAgent.ts
+++ b/src/services/worker/OpenAICodexAgent.ts
@@ -1,0 +1,579 @@
+/**
+ * OpenAICodexAgent: OpenAI Codex (ChatGPT Plus/Pro OAuth) observation extraction
+ *
+ * Allows claude-mem to extract observations using a ChatGPT Plus/Pro subscription
+ * via OAuth, without requiring an Anthropic API key or Claude Code context.
+ *
+ * This is the recommended provider for OpenClaw users, since Anthropic's ToS
+ * prohibits using Claude OAuth tokens in third-party apps (as of Feb 2026).
+ *
+ * Credential discovery order:
+ *   1. CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR setting (explicit override)
+ *   2. OPENCLAW_AGENT_DIR env var (set automatically by OpenClaw at runtime)
+ *   3. ~/.openclaw/agents/default/agent/auth-profiles.json (OpenClaw default)
+ *   4. ~/.claude-mem/auth-profiles.json (standalone fallback)
+ *
+ * Responsibility:
+ * - Read OpenAI Codex OAuth credentials from auth-profiles.json
+ * - Auto-refresh expired tokens via pi-ai's refreshOpenAICodexToken
+ * - Call OpenAI Codex responses API for observation extraction
+ * - Parse XML responses (same format as Claude/Gemini/OpenRouter agents)
+ * - Sync to database and Chroma
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import { DatabaseManager } from './DatabaseManager.js';
+import { SessionManager } from './SessionManager.js';
+import { logger } from '../../utils/logger.js';
+import {
+  buildInitPrompt,
+  buildObservationPrompt,
+  buildSummaryPrompt,
+  buildContinuationPrompt,
+} from '../../sdk/prompts.js';
+import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js';
+import { USER_SETTINGS_PATH } from '../../shared/paths.js';
+import type { ActiveSession, ConversationMessage } from '../worker-types.js';
+import { ModeManager } from '../domain/ModeManager.js';
+import {
+  processAgentResponse,
+  shouldFallbackToClaude,
+  isAbortError,
+  type WorkerRef,
+  type FallbackAgent,
+} from './agents/index.js';
+
+// OpenAI Codex OAuth endpoint (ChatGPT backend responses API)
+const OPENAI_CODEX_API_URL = 'https://chatgpt.com/backend-api/codex/responses';
+
+// Codex responses require stream=true and store=false.
+const CODEX_STREAM = true;
+const CODEX_STORE = false;
+
+// Codex endpoint currently requires explicit instructions.
+const CODEX_INSTRUCTIONS =
+  'You are Claude-Mem observation extraction assistant. Follow the prompt exactly and output only the requested content.';
+
+// Default model for OpenAI Codex OAuth (GPT-5.x Codex series)
+const DEFAULT_CODEX_MODEL = 'gpt-5.3-codex';
+
+// Context window limits (same as OpenRouterAgent)
+const DEFAULT_MAX_CONTEXT_MESSAGES = 20;
+const DEFAULT_MAX_ESTIMATED_TOKENS = 100_000;
+const CHARS_PER_TOKEN_ESTIMATE = 4;
+
+// Auth profile store schema (subset — mirrors OpenClaw's auth-profiles.json)
+interface AuthProfile {
+  type: 'oauth' | 'api_key';
+  provider: string;
+  refresh?: string;
+  access?: string;
+  expires?: number;
+  [key: string]: unknown;
+}
+interface AuthProfileStore {
+  version: number;
+  profiles: Record<string, AuthProfile>;
+}
+
+// Codex responses input format
+interface CodexInputMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface CodexStreamEvent {
+  type?: string;
+  delta?: string;
+  text?: string;
+  response?: {
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      total_tokens?: number;
+    };
+    output?: Array<{
+      type?: string;
+      content?: Array<{ type?: string; text?: string }>;
+    }>;
+    error?: { message?: string; code?: string };
+  };
+  error?: { message?: string; code?: string };
+}
+
+// ─────────────────────────────────────────────────────────────
+// Token cache (process-lifetime, keyed by authDir)
+// ─────────────────────────────────────────────────────────────
+
+interface CachedToken {
+  access: string;
+  expires: number;  // epoch ms
+}
+const tokenCache = new Map<string, CachedToken>();
+
+// ─────────────────────────────────────────────────────────────
+// Credential helpers
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the directory that contains auth-profiles.json.
+ * Preference order: explicit setting → OPENCLAW_AGENT_DIR env → OpenClaw default → claude-mem fallback.
+ */
+function resolveAuthDir(): string {
+  const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+  if (settings.CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR) {
+    return settings.CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR;
+  }
+  if (process.env.OPENCLAW_AGENT_DIR) {
+    return process.env.OPENCLAW_AGENT_DIR;
+  }
+  // OpenClaw default: ~/.openclaw/agents/default/agent
+  const openclawDefault = join(homedir(), '.openclaw', 'agents', 'default', 'agent');
+  if (existsSync(join(openclawDefault, 'auth-profiles.json'))) {
+    return openclawDefault;
+  }
+  // Standalone fallback: ~/.claude-mem
+  return join(homedir(), '.claude-mem');
+}
+
+/**
+ * Load the auth-profiles.json store from the resolved auth directory.
+ */
+function loadAuthStore(authDir: string): AuthProfileStore | null {
+  const path = join(authDir, 'auth-profiles.json');
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as AuthProfileStore;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find the first OpenAI Codex OAuth profile in the store.
+ */
+function findCodexProfile(store: AuthProfileStore): AuthProfile | null {
+  for (const [id, profile] of Object.entries(store.profiles)) {
+    if (id.startsWith('openai-codex:') && profile.type === 'oauth') {
+      return profile;
+    }
+  }
+  return null;
+}
+
+/**
+ * Persist updated credentials back to auth-profiles.json.
+ * Only updates the matching profile — leaves everything else untouched.
+ */
+function saveCodexProfile(authDir: string, store: AuthProfileStore, updated: AuthProfile): void {
+  const filePath = join(authDir, 'auth-profiles.json');
+  for (const [id, profile] of Object.entries(store.profiles)) {
+    if (id.startsWith('openai-codex:') && profile.type === 'oauth') {
+      store.profiles[id] = { ...profile, ...updated };
+      break;
+    }
+  }
+  writeFileSync(filePath, JSON.stringify(store, null, 2), 'utf-8');
+}
+
+/**
+ * Get a valid access token, refreshing it if expired.
+ * Requires pi-ai to be installed as a dependency of claude-mem.
+ */
+async function getAccessToken(): Promise<string> {
+  const authDir = resolveAuthDir();
+  const bufferMs = 5 * 60 * 1000;
+
+  // Fast path: in-memory cache (avoids disk read on every query)
+  const cached = tokenCache.get(authDir);
+  if (cached && Date.now() < (cached.expires - bufferMs)) {
+    return cached.access;
+  }
+
+  // Load from disk to check / get refresh token
+  const store = loadAuthStore(authDir);
+
+  if (!store) {
+    throw new Error(
+      `OpenAI Codex OAuth: no auth-profiles.json found in ${authDir}.\n` +
+      `Run 'openclaw auth' (or 'npx @mariozechner/pi-ai login openai-codex') to authenticate.`
+    );
+  }
+
+  const profile = findCodexProfile(store);
+  if (!profile || !profile.refresh) {
+    throw new Error(
+      `OpenAI Codex OAuth: no openai-codex profile found in ${authDir}/auth-profiles.json.\n` +
+      `Run 'openclaw auth' to add OpenAI Codex authentication.`
+    );
+  }
+
+  // Token on disk still valid — populate cache and return
+  if (profile.access && profile.expires && Date.now() < (profile.expires - bufferMs)) {
+    tokenCache.set(authDir, { access: profile.access, expires: profile.expires });
+    return profile.access;
+  }
+
+  // Token expired — refresh it
+  logger.info('SDK', 'OpenAI Codex token expired, refreshing…');
+  try {
+    // Dynamic import so claude-mem can work without pi-ai if provider is not 'openai-codex'
+    // @ts-ignore — dynamic import; pi-ai must be a dependency of claude-mem
+    const { refreshOpenAICodexToken } = await import('@mariozechner/pi-ai') as any;
+    const refreshed = await refreshOpenAICodexToken(profile.refresh);
+    saveCodexProfile(authDir, store, refreshed);
+    // Update in-memory cache
+    tokenCache.set(authDir, { access: refreshed.access, expires: refreshed.expires });
+    logger.info('SDK', 'OpenAI Codex token refreshed successfully');
+    return refreshed.access;
+  } catch (err) {
+    throw new Error(
+      `OpenAI Codex OAuth: token refresh failed — ${err instanceof Error ? err.message : String(err)}.\n` +
+      `Re-authenticate with 'openclaw auth'.`
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Agent class
+// ─────────────────────────────────────────────────────────────
+
+export class OpenAICodexAgent {
+  private dbManager: DatabaseManager;
+  private sessionManager: SessionManager;
+  private fallbackAgent: FallbackAgent | null = null;
+
+  constructor(dbManager: DatabaseManager, sessionManager: SessionManager) {
+    this.dbManager = dbManager;
+    this.sessionManager = sessionManager;
+  }
+
+  setFallbackAgent(agent: FallbackAgent): void {
+    this.fallbackAgent = agent;
+  }
+
+  async startSession(session: ActiveSession, worker?: WorkerRef): Promise<void> {
+    try {
+      const model = this.getModel();
+
+      // Generate synthetic memorySessionId (stateless REST API)
+      if (!session.memorySessionId) {
+        const id = `openai-codex-${session.contentSessionId}-${Date.now()}`;
+        session.memorySessionId = id;
+        this.dbManager.getSessionStore().updateMemorySessionId(session.sessionDbId, id);
+        logger.info('SESSION', `MEMORY_ID_GENERATED | sessionDbId=${session.sessionDbId} | provider=OpenAICodex`);
+      }
+
+      const mode = ModeManager.getInstance().getActiveMode();
+
+      // Init prompt
+      const initPrompt =
+        session.lastPromptNumber === 1
+          ? buildInitPrompt(session.project, session.contentSessionId, session.userPrompt, mode)
+          : buildContinuationPrompt(session.userPrompt, session.lastPromptNumber, session.contentSessionId, mode);
+
+      session.conversationHistory.push({ role: 'user', content: initPrompt });
+      const initResponse = await this.query(session.conversationHistory, model);
+
+      if (initResponse.content) {
+        const tokensUsed = initResponse.tokensUsed || 0;
+        session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
+        session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
+        await processAgentResponse(
+          initResponse.content,
+          session,
+          this.dbManager,
+          this.sessionManager,
+          worker,
+          tokensUsed,
+          null,
+          'OpenAICodex',
+          undefined
+        );
+      }
+
+      let lastCwd: string | undefined;
+
+      // Process pending messages
+      for await (const message of this.sessionManager.getMessageIterator(session.sessionDbId)) {
+        session.processingMessageIds.push(message._persistentId);
+        if (message.cwd) lastCwd = message.cwd;
+        const originalTimestamp = session.earliestPendingTimestamp;
+
+        if (message.type === 'observation') {
+          if (message.prompt_number !== undefined) {
+            session.lastPromptNumber = message.prompt_number;
+          }
+          if (!session.memorySessionId) {
+            throw new Error('Cannot process observations: memorySessionId not captured.');
+          }
+
+          const observationPrompt = buildObservationPrompt({
+            id: 0,
+            tool_name: message.tool_name!,
+            tool_input: JSON.stringify(message.tool_input),
+            tool_output: JSON.stringify(message.tool_response),
+            created_at_epoch: originalTimestamp ?? Date.now(),
+            cwd: message.cwd,
+          });
+
+          session.conversationHistory.push({ role: 'user', content: observationPrompt });
+          const obsResponse = await this.query(session.conversationHistory, model);
+
+          const tokensUsed = obsResponse.tokensUsed || 0;
+          session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
+          session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
+
+          await processAgentResponse(
+            obsResponse.content || '',
+            session,
+            this.dbManager,
+            this.sessionManager,
+            worker,
+            tokensUsed,
+            originalTimestamp,
+            'OpenAICodex',
+            lastCwd
+          );
+
+        } else if (message.type === 'summarize') {
+          if (!session.memorySessionId) {
+            throw new Error('Cannot process summary: memorySessionId not captured.');
+          }
+
+          const summaryPrompt = buildSummaryPrompt({
+            id: session.sessionDbId,
+            memory_session_id: session.memorySessionId,
+            project: session.project,
+            user_prompt: session.userPrompt,
+            last_assistant_message: message.last_assistant_message || '',
+          }, mode);
+
+          session.conversationHistory.push({ role: 'user', content: summaryPrompt });
+          const sumResponse = await this.query(session.conversationHistory, model);
+
+          const tokensUsed = sumResponse.tokensUsed || 0;
+          session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
+          session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
+
+          await processAgentResponse(
+            sumResponse.content || '',
+            session,
+            this.dbManager,
+            this.sessionManager,
+            worker,
+            tokensUsed,
+            originalTimestamp,
+            'OpenAICodex',
+            lastCwd
+          );
+        }
+      }
+
+      logger.success('SDK', 'OpenAI Codex agent completed', {
+        sessionId: session.sessionDbId,
+        model,
+        duration: `${((Date.now() - session.startTime) / 1000).toFixed(1)}s`,
+      });
+
+    } catch (error: unknown) {
+      if (isAbortError(error)) {
+        logger.warn('SDK', 'OpenAI Codex agent aborted', { sessionId: session.sessionDbId });
+        throw error;
+      }
+
+      if (shouldFallbackToClaude(error) && this.fallbackAgent) {
+        logger.warn('SDK', 'OpenAI Codex API failed, falling back to Claude SDK', {
+          sessionDbId: session.sessionDbId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return this.fallbackAgent.startSession(session, worker);
+      }
+
+      logger.failure('SDK', 'OpenAI Codex agent error', { sessionDbId: session.sessionDbId }, error as Error);
+      throw error;
+    }
+  }
+
+  // ── Private helpers ────────────────────────────────────────
+
+  private getModel(): string {
+    const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+    return settings.CLAUDE_MEM_OPENAI_CODEX_MODEL || DEFAULT_CODEX_MODEL;
+  }
+
+  private estimateTokens(text: string): number {
+    return Math.ceil(text.length / CHARS_PER_TOKEN_ESTIMATE);
+  }
+
+  private truncateHistory(history: ConversationMessage[]): ConversationMessage[] {
+    // Re-use OpenRouter context settings as general limits (same defaults apply)
+    const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+    const MAX_MESSAGES = parseInt(settings.CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES) || DEFAULT_MAX_CONTEXT_MESSAGES;
+    const MAX_TOKENS = parseInt(settings.CLAUDE_MEM_OPENROUTER_MAX_TOKENS) || DEFAULT_MAX_ESTIMATED_TOKENS;
+    // Note: these settings will be renamed to CLAUDE_MEM_CONTEXT_MAX_* in a future refactor
+
+    if (history.length <= MAX_MESSAGES) {
+      const totalTokens = history.reduce((s, m) => s + this.estimateTokens(m.content), 0);
+      if (totalTokens <= MAX_TOKENS) return history;
+    }
+
+    const truncated: ConversationMessage[] = [];
+    let tokenCount = 0;
+    for (let i = history.length - 1; i >= 0; i--) {
+      const msg = history[i];
+      const t = this.estimateTokens(msg.content);
+      if (truncated.length >= MAX_MESSAGES || tokenCount + t > MAX_TOKENS) break;
+      truncated.unshift(msg);
+      tokenCount += t;
+    }
+    return truncated;
+  }
+
+  private toCodexInput(history: ConversationMessage[]): CodexInputMessage[] {
+    return history.map(m => ({
+      role: m.role === 'assistant' ? 'assistant' : 'user',
+      content: m.content,
+    }));
+  }
+
+  /**
+   * Call OpenAI Codex responses endpoint with OAuth Bearer token.
+   * Token is refreshed automatically if expired.
+   */
+  private async query(
+    history: ConversationMessage[],
+    model: string,
+  ): Promise<{ content: string; tokensUsed?: number }> {
+    const accessToken = await getAccessToken();
+    const input = this.toCodexInput(this.truncateHistory(history));
+
+    logger.debug('SDK', `Querying OpenAI Codex (${model})`, { turns: input.length });
+
+    const response = await fetch(OPENAI_CODEX_API_URL, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+        'Accept': 'text/event-stream',
+      },
+      body: JSON.stringify({
+        model,
+        instructions: CODEX_INSTRUCTIONS,
+        input,
+        stream: CODEX_STREAM,
+        store: CODEX_STORE,
+      }),
+    });
+
+    const rawBody = await response.text();
+    if (!response.ok) {
+      throw new Error(`OpenAI Codex API error: ${response.status} — ${rawBody}`);
+    }
+
+    let accumulatedText = '';
+    let completedText = '';
+    let tokensUsed: number | undefined;
+    let inputTokens: number | undefined;
+    let outputTokens: number | undefined;
+
+    const lines = rawBody.split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith('data:')) continue;
+
+      const payload = trimmed.slice(5).trim();
+      if (!payload || payload === '[DONE]') continue;
+
+      let event: CodexStreamEvent;
+      try {
+        event = JSON.parse(payload) as CodexStreamEvent;
+      } catch {
+        continue;
+      }
+
+      if (event.error?.message) {
+        throw new Error(`OpenAI Codex API error: ${event.error.code ?? 'unknown'} — ${event.error.message}`);
+      }
+
+      switch (event.type) {
+        case 'response.output_text.delta':
+          if (typeof event.delta === 'string') {
+            accumulatedText += event.delta;
+          }
+          break;
+        case 'response.output_text.done':
+          if (typeof event.text === 'string') {
+            completedText = event.text;
+          }
+          break;
+        case 'response.completed': {
+          const usage = event.response?.usage;
+          tokensUsed = usage?.total_tokens;
+          inputTokens = usage?.input_tokens;
+          outputTokens = usage?.output_tokens;
+
+          const output = event.response?.output;
+          if (Array.isArray(output)) {
+            const parts: string[] = [];
+            for (const item of output) {
+              if (item?.type !== 'message' || !Array.isArray(item.content)) continue;
+              for (const part of item.content) {
+                if (part?.type === 'output_text' && typeof part.text === 'string') {
+                  parts.push(part.text);
+                }
+              }
+            }
+            if (parts.length > 0) {
+              completedText = parts.join('');
+            }
+          }
+
+          if (event.response?.error?.message) {
+            throw new Error(
+              `OpenAI Codex API error: ${event.response.error.code ?? 'unknown'} — ${event.response.error.message}`,
+            );
+          }
+          break;
+        }
+      }
+    }
+
+    const content = completedText || accumulatedText;
+    if (!content) {
+      logger.error('SDK', 'Empty response from OpenAI Codex');
+      return { content: '' };
+    }
+
+    if (tokensUsed) {
+      logger.info('SDK', 'OpenAI Codex API usage', {
+        model,
+        inputTokens,
+        outputTokens,
+        totalTokens: tokensUsed,
+      });
+    }
+
+    return { content, tokensUsed };
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Provider detection helpers (mirrors OpenRouterAgent pattern)
+// ─────────────────────────────────────────────────────────────
+
+/** Returns true if a valid openai-codex OAuth profile exists on disk. */
+export function isOpenAICodexAvailable(): boolean {
+  const authDir = resolveAuthDir();
+  const store = loadAuthStore(authDir);
+  if (!store) return false;
+  return !!findCodexProfile(store);
+}
+
+/** Returns true if CLAUDE_MEM_PROVIDER is set to 'openai-codex'. */
+export function isOpenAICodexSelected(): boolean {
+  const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+  return settings.CLAUDE_MEM_PROVIDER === 'openai-codex';
+}

--- a/src/services/worker/http/routes/SessionRegistryRoutes.ts
+++ b/src/services/worker/http/routes/SessionRegistryRoutes.ts
@@ -1,0 +1,1263 @@
+/**
+ * Session Registry Routes
+ *
+ * Provides API endpoints for browsing raw JSONL session files:
+ *   GET /api/session-registry/list                      – list sessions (with filters)
+ *   GET /api/session-registry/:id/events                – read session events
+ *   GET /api/session-registry/:id/stats                 – aggregate token/tool stats
+ *   GET /api/session-registry/:id/subagents             – subagent list for a session
+ *   GET /api/session-registry/:id/raw-event/:eventId    – single raw JSONL record
+ *
+ * Sources scanned:
+ *   ~/.claude/projects (Claude Code sessions)
+ *   ~/.openclaw/agents (OpenClaw sessions)
+ *   ~/.codex/sessions (Codex sessions)
+ *
+ * Ported from CC-sesh-master/serve-dashboard.py (Python → TypeScript).
+ */
+
+import express, { Request, Response } from 'express';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { BaseRouteHandler } from '../BaseRouteHandler.js';
+import { logger } from '../../../../utils/logger.js';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const HOME_DIR = os.homedir();
+const PROJECTS_DIR = path.join(HOME_DIR, '.claude', 'projects');
+const OPENCLAW_DIR = path.join(HOME_DIR, '.openclaw', 'agents');
+const CODEX_DIR = path.join(HOME_DIR, '.codex', 'sessions');
+
+const MAX_TOOL_RESULT_LEN = 2048;
+const MAX_TOOL_INPUT_LEN = 1024;
+const MAX_TEXT_LEN = 10240;
+const TAIL_READ_BYTES = 512 * 1024; // 512 KB
+const REBUILD_INTERVAL_MS = 30_000;
+const MODEL_CONTEXT_DEFAULT = 200_000;
+const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+  'opus-4': 200_000,
+  'sonnet-4': 200_000,
+  'haiku-4': 200_000,
+  'sonnet-3': 200_000,
+  'haiku-3': 200_000,
+  'opus-3': 200_000,
+  'o3': 200_000,
+  'o4-mini': 200_000,
+  'gpt-4.1': 1_047_576,
+  'gpt-4o': 128_000,
+  'gpt-5': 200_000,
+};
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SAFE_ID_RE = /^[a-zA-Z0-9_-]+$/;
+
+// ─── Shared types ─────────────────────────────────────────────────────────────
+
+export interface RegistrySession {
+  sessionId: string;
+  project: string;
+  source: 'claude' | 'openclaw' | 'codex';
+  slug: string;
+  status: 'active' | 'completed';
+  model: string;
+  version: string;
+  mtime: number;
+  size: number;
+  eventCount: number;
+  cwd: string;
+  gitBranch: string;
+  subagentCount: number;
+  duration: number;
+  contextPct: number;
+  _path?: string;
+}
+
+export interface RegistrySubagent {
+  id: string;
+  parentId: string;
+  agentType: string;
+  slug: string;
+  model: string;
+  status: 'active' | 'completed';
+  mtime: number;
+  size?: number;
+  eventCount?: number;
+  filename?: string;
+  ephemeral?: boolean;
+  spawnStatus?: string;
+  runId?: string;
+  childSessionKey?: string;
+  timestamp?: string;
+}
+
+export interface RegistryEvent {
+  type: string;
+  uuid: string;
+  timestamp: string;
+  [key: string]: unknown;
+}
+
+// ─── Helper: read tail of a file ─────────────────────────────────────────────
+
+function readTailLines(filePath: string, bytes: number): string[] {
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    const stat = fs.fstatSync(fd);
+    const size = stat.size;
+    const readBytes = Math.min(size, bytes);
+    const buf = Buffer.alloc(readBytes);
+    fs.readSync(fd, buf, 0, readBytes, Math.max(0, size - readBytes));
+    const text = buf.toString('utf-8');
+    const lines = text.split('\n');
+    // Discard first line if we didn't start at position 0 (may be partial)
+    if (size > bytes) lines.shift();
+    return lines;
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+// ─── Helper: read head of a file ─────────────────────────────────────────────
+
+const HEAD_READ_BYTES = 8192; // 8 KB – enough for ~8 typical JSONL lines
+
+function readHeadLines(filePath: string, size: number, bytes: number = HEAD_READ_BYTES): string[] {
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    const readBytes = Math.min(size, bytes);
+    const buf = Buffer.alloc(readBytes);
+    fs.readSync(fd, buf, 0, readBytes, 0);
+    const text = buf.toString('utf-8');
+    const lines = text.split('\n');
+    // If we didn't read the whole file the last line may be partial – drop it
+    if (size > bytes && lines.length > 0) lines.pop();
+    return lines;
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function parseTimestampSec(ts: unknown): number | null {
+  if (typeof ts === 'number' && Number.isFinite(ts)) {
+    return ts > 1e12 ? ts / 1000 : ts;
+  }
+  if (typeof ts !== 'string' || !ts) return null;
+  const parsedMs = Date.parse(ts);
+  if (Number.isNaN(parsedMs)) return null;
+  return parsedMs / 1000;
+}
+
+function asNum(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function extractContextInputTokens(usage: unknown): number {
+  if (!usage || typeof usage !== 'object') return 0;
+  const u = usage as Record<string, unknown>;
+  return (
+    asNum(u.input_tokens) +
+    asNum(u.input) +
+    asNum(u.cache_read_input_tokens) +
+    asNum(u.cache_creation_input_tokens) +
+    asNum(u.cached_input_tokens) +
+    asNum(u.cacheRead) +
+    asNum(u.cacheWrite)
+  );
+}
+
+function getContextSize(model: string): number {
+  if (!model) return MODEL_CONTEXT_DEFAULT;
+  const lower = model.toLowerCase();
+  for (const [key, size] of Object.entries(MODEL_CONTEXT_WINDOWS)) {
+    if (lower.includes(key)) return size;
+  }
+  return MODEL_CONTEXT_DEFAULT;
+}
+
+function getContextPct(model: string, inputTokens: number): number {
+  if (!inputTokens) return 0;
+  const contextSize = getContextSize(model);
+  if (!contextSize) return 0;
+  return Math.round((inputTokens / contextSize) * 100);
+}
+
+// ─── SessionIndex ─────────────────────────────────────────────────────────────
+
+class SessionIndex {
+  private sessions: Map<string, RegistrySession & { _path: string }> = new Map();
+  private subagents: Map<string, RegistrySubagent[]> = new Map();
+  private subagentPaths: Map<string, string> = new Map();
+  private projects: Set<string> = new Set();
+  private lastRebuild = 0;
+  private rebuilding = false;
+
+  needsRebuild(): boolean {
+    return Date.now() - this.lastRebuild > REBUILD_INTERVAL_MS;
+  }
+
+  ensureFresh(): void {
+    if (this.needsRebuild() && !this.rebuilding) {
+      this.rebuild();
+    }
+  }
+
+  rebuild(): void {
+    this.rebuilding = true;
+    try {
+      const sessions = new Map<string, RegistrySession & { _path: string }>();
+      const subagents = new Map<string, RegistrySubagent[]>();
+      const subagentPaths = new Map<string, string>();
+      const projects = new Set<string>();
+
+      // ── ~/.claude/projects/ ──────────────────────────────────────
+      if (fs.existsSync(PROJECTS_DIR)) {
+        for (const projName of fs.readdirSync(PROJECTS_DIR)) {
+          const projDir = path.join(PROJECTS_DIR, projName);
+          if (!fs.statSync(projDir).isDirectory()) continue;
+          if (projName.toLowerCase().includes('observer')) continue;
+
+          let display = projName;
+          if (display.startsWith('-home-dev-')) display = display.slice(10);
+          else if (display.startsWith('-home-dev')) display = display.slice(9) || 'home';
+          display = display.replace(/-/g, '/') || 'home';
+
+          this.scanSessionDir(projDir, display, 'claude', sessions, subagents, subagentPaths, projects);
+        }
+      }
+
+      // ── ~/.openclaw/agents/*/sessions/ ──────────────────────────
+      if (fs.existsSync(OPENCLAW_DIR)) {
+        for (const agentName of fs.readdirSync(OPENCLAW_DIR)) {
+          const sessDir = path.join(OPENCLAW_DIR, agentName, 'sessions');
+          if (!fs.existsSync(sessDir) || !fs.statSync(sessDir).isDirectory()) continue;
+          const display = 'openclaw/' + agentName;
+          this.scanSessionDir(sessDir, display, 'openclaw', sessions, subagents, subagentPaths, projects);
+        }
+      }
+
+      // ── ~/.codex/sessions/ ──────────────────────────────────────
+      if (fs.existsSync(CODEX_DIR)) {
+        this.scanCodexSessions(CODEX_DIR, sessions, projects);
+      }
+
+      this.sessions = sessions;
+      this.subagents = subagents;
+      this.subagentPaths = subagentPaths;
+      this.projects = projects;
+      this.lastRebuild = Date.now();
+    } finally {
+      this.rebuilding = false;
+    }
+  }
+
+  private scanSessionDir(
+    dir: string,
+    display: string,
+    source: 'claude' | 'openclaw',
+    sessions: Map<string, RegistrySession & { _path: string }>,
+    subagents: Map<string, RegistrySubagent[]>,
+    subagentPaths: Map<string, string>,
+    projects: Set<string>,
+  ): void {
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(dir);
+    } catch { return; }
+
+    for (const fname of entries) {
+      if (!fname.endsWith('.jsonl')) continue;
+      const sid = fname.slice(0, -6);
+      if (!UUID_RE.test(sid)) continue;
+
+      const filePath = path.join(dir, fname);
+      let stat: fs.Stats;
+      try { stat = fs.statSync(filePath); } catch { continue; }
+
+      if (stat.size === 0) continue;
+
+      const meta = this.extractMetadata(filePath, stat.size);
+      if (!meta) continue;
+
+      projects.add(display);
+      const ageSec = (Date.now() - stat.mtimeMs) / 1000;
+      const active = ageSec < 120 && !meta.hasStop;
+
+      // On-disk subagents
+      const subDir = path.join(dir, sid, 'subagents');
+      const subList: RegistrySubagent[] = [];
+      if (fs.existsSync(subDir)) {
+        for (const sf of fs.readdirSync(subDir)) {
+          if (!sf.endsWith('.jsonl')) continue;
+          const saPath = path.join(subDir, sf);
+          const sa = this.extractSubagentInfo(saPath, sid);
+          if (sa) {
+            subList.push(sa);
+            subagentPaths.set(sf.slice(0, -6), saPath);
+          }
+        }
+        subList.sort((a, b) => b.mtime - a.mtime);
+      }
+      if (subList.length) subagents.set(sid, subList);
+
+      sessions.set(sid, {
+        sessionId: sid,
+        project: display,
+        source,
+        slug: meta.slug,
+        status: active ? 'active' : 'completed',
+        model: meta.model,
+        version: meta.version,
+        mtime: stat.mtimeMs / 1000,
+        size: stat.size,
+        eventCount: meta.eventCount,
+        cwd: meta.cwd,
+        gitBranch: meta.gitBranch,
+        subagentCount: subList.length + (meta.inlineSubagentCount || 0),
+        duration: meta.firstTs ? Math.max(0, Math.round(stat.mtimeMs / 1000 - meta.firstTs)) : 0,
+        contextPct: getContextPct(meta.model, meta.lastInputTokens),
+        _path: filePath,
+      });
+    }
+  }
+
+  private extractMetadata(filePath: string, size: number): {
+    slug: string; model: string; version: string; cwd: string;
+    gitBranch: string; hasStop: boolean; eventCount: number;
+    inlineSubagentCount: number;
+    firstTs: number;
+    lastInputTokens: number;
+  } | null {
+    const result = {
+      slug: '', model: '', version: '', cwd: '', gitBranch: '',
+      hasStop: false, eventCount: Math.max(1, Math.floor(size / 500)),
+      inlineSubagentCount: 0,
+      firstTs: 0,
+      lastInputTokens: 0,
+    };
+
+    let isOpenclaw = false;
+
+    try {
+      // Head scan: read first HEAD_READ_BYTES only (avoids full-file read)
+      const headLines = readHeadLines(filePath, size).filter(l => l.trim());
+
+      for (let i = 0; i < Math.min(8, headLines.length); i++) {
+        try {
+          const obj = JSON.parse(headLines[i]);
+          const t = obj.type || '';
+          if (!result.firstTs) {
+            const ts = parseTimestampSec(obj.timestamp);
+            if (ts) result.firstTs = ts;
+          }
+          if (!result.slug) result.slug = obj.slug || '';
+          if (!result.cwd) result.cwd = obj.cwd || '';
+          if (!result.gitBranch) result.gitBranch = obj.gitBranch || '';
+          if (t === 'assistant' && !result.model) result.model = obj.message?.model || '';
+          if (t === 'session') {
+            if (!result.cwd) result.cwd = obj.cwd || '';
+            if (!result.version) result.version = String(obj.version || '');
+            isOpenclaw = true;
+          }
+          if (t === 'message') {
+            const msg = obj.message || {};
+            if (msg.role === 'assistant' && !result.model) {
+              const m = msg.model || '';
+              if (m && m !== 'delivery-mirror') result.model = m;
+            }
+          }
+          if (!result.version && typeof obj.version === 'string') result.version = obj.version;
+        } catch { /* skip invalid JSON */ }
+      }
+
+      // Tail scan: read last TAIL_READ_BYTES only
+      const tailAllLines = size > HEAD_READ_BYTES
+        ? readTailLines(filePath, TAIL_READ_BYTES)
+        : headLines;
+      const tailLines = tailAllLines.filter(l => l.trim());
+      for (let i = tailLines.length - 1; i >= Math.max(0, tailLines.length - 16); i--) {
+        try {
+          const obj = JSON.parse(tailLines[i]);
+          const t = obj.type || '';
+          if (t === 'system' && obj.subtype === 'stop_hook_summary') result.hasStop = true;
+          if (!result.lastInputTokens) {
+            let usage: unknown;
+            if (t === 'assistant') {
+              usage = obj.message?.usage;
+            } else if (t === 'message') {
+              const msg = obj.message || {};
+              if (msg.role === 'assistant') usage = msg.usage;
+            }
+            const inputTokens = extractContextInputTokens(usage);
+            if (inputTokens > 0) result.lastInputTokens = inputTokens;
+          }
+          if (!result.model) {
+            if (t === 'assistant') result.model = obj.message?.model || '';
+            else if (t === 'message') {
+              const m = (obj.message || {}).model || '';
+              if (m && m !== 'delivery-mirror') result.model = m;
+            }
+          }
+          if (!result.slug && obj.slug) result.slug = obj.slug;
+          if (result.lastInputTokens && (result.model || result.slug)) break;
+        } catch { /* skip */ }
+      }
+
+      // Count inline subagents for openclaw sessions (requires full scan)
+      if (isOpenclaw) {
+        let count = 0;
+        const fullText = fs.readFileSync(filePath, 'utf-8');
+        for (const line of fullText.split('\n')) {
+          if (line.includes('sessions_spawn') && line.includes('"accepted"')) count++;
+        }
+        result.inlineSubagentCount = count;
+      }
+
+    } catch {
+      return null;
+    }
+
+    return result;
+  }
+
+  private extractSubagentInfo(filePath: string, parentId: string): RegistrySubagent | null {
+    let stat: fs.Stats;
+    try { stat = fs.statSync(filePath); } catch { return null; }
+    if (stat.size === 0) return null;
+
+    const fname = path.basename(filePath, '.jsonl');
+    let agentType = 'task-agent';
+    if (fname.includes('prompt_suggestion')) agentType = 'prompt_suggestion';
+    else if (fname.includes('compact')) agentType = 'compact';
+
+    const info: RegistrySubagent = {
+      id: fname, parentId, agentType,
+      slug: '', model: '',
+      status: (Date.now() - stat.mtimeMs) / 1000 < 120 ? 'active' : 'completed',
+      mtime: stat.mtimeMs / 1000,
+      size: stat.size,
+      eventCount: Math.max(1, Math.floor(stat.size / 500)),
+      filename: path.basename(filePath),
+    };
+
+    try {
+      // Only need first 5 lines – read a small head portion
+      const headLines = readHeadLines(filePath, stat.size).filter(l => l.trim());
+      for (let i = 0; i < Math.min(5, headLines.length); i++) {
+        try {
+          const obj = JSON.parse(headLines[i]);
+          if (!info.slug) info.slug = obj.slug || '';
+          if (!info.model && obj.type === 'assistant') info.model = obj.message?.model || '';
+        } catch { /* skip */ }
+      }
+    } catch { /* ignore */ }
+
+    return info;
+  }
+
+  private scanCodexSessions(
+    baseDir: string,
+    sessions: Map<string, RegistrySession & { _path: string }>,
+    projects: Set<string>,
+  ): void {
+    const walkDir = (dir: string): void => {
+      let entries: string[];
+      try { entries = fs.readdirSync(dir); } catch { return; }
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry);
+        let stat: fs.Stats;
+        try { stat = fs.statSync(fullPath); } catch { continue; }
+        if (stat.isDirectory()) {
+          walkDir(fullPath);
+        } else if (entry.startsWith('rollout-') && entry.endsWith('.jsonl')) {
+          if (stat.size === 0) continue;
+          const meta = this.extractCodexMetadata(fullPath, stat.size);
+          if (!meta) continue;
+
+          const sid = 'codex-' + (meta.id || path.basename(fullPath, '.jsonl'));
+          const cwd = meta.cwd || '';
+          const homePrefix = HOME_DIR + '/';
+          const rel = cwd.startsWith(homePrefix) ? cwd.slice(homePrefix.length).replace(/\/$/, '') : '';
+          const display = rel ? 'codex/' + rel : 'codex';
+          projects.add(display);
+
+          const ageSec = (Date.now() - stat.mtimeMs) / 1000;
+          const active = ageSec < 120 && !meta.hasComplete;
+
+          sessions.set(sid, {
+            sessionId: sid,
+            project: display,
+            source: 'codex',
+            slug: meta.slug,
+            status: active ? 'active' : 'completed',
+            model: meta.model,
+            version: meta.version,
+            mtime: stat.mtimeMs / 1000,
+            size: stat.size,
+            eventCount: meta.eventCount,
+            cwd,
+            gitBranch: meta.gitBranch,
+            subagentCount: 0,
+            duration: meta.firstTs ? Math.max(0, Math.round(stat.mtimeMs / 1000 - meta.firstTs)) : 0,
+            contextPct: getContextPct(meta.model, meta.lastInputTokens),
+            _path: fullPath,
+          });
+        }
+      }
+    };
+    walkDir(baseDir);
+  }
+
+  private extractCodexMetadata(filePath: string, size: number): {
+    id: string; slug: string; model: string; version: string;
+    cwd: string; gitBranch: string; hasComplete: boolean;
+    eventCount: number;
+    firstTs: number;
+    lastInputTokens: number;
+  } | null {
+    const result = {
+      id: '', slug: '', model: '', version: '', cwd: '', gitBranch: '',
+      hasComplete: false, eventCount: Math.max(1, Math.floor(size / 500)),
+      firstTs: 0,
+      lastInputTokens: 0,
+    };
+
+    // 16 KB is generous for 30 typical Codex JSONL lines
+    const HEAD_CODEX_BYTES = 16384;
+
+    try {
+      // Head scan: read first HEAD_CODEX_BYTES only
+      const headLines = readHeadLines(filePath, size, HEAD_CODEX_BYTES).filter(l => l.trim());
+
+      for (let i = 0; i < Math.min(30, headLines.length); i++) {
+        try {
+          const obj = JSON.parse(headLines[i]);
+          const t = obj.type || '';
+          const payload = obj.payload || {};
+          if (!result.firstTs) {
+            const ts = parseTimestampSec(obj.timestamp);
+            if (ts) result.firstTs = ts;
+          }
+          if (typeof payload !== 'object') continue;
+          const pt = payload.type || '';
+
+          if (t === 'session_meta') {
+            result.id = payload.id || '';
+            result.cwd = payload.cwd || '';
+            result.version = payload.cli_version || '';
+            const git = payload.git || {};
+            if (typeof git === 'object') result.gitBranch = git.branch || '';
+          } else if (t === 'turn_context' && !result.model) {
+            result.model = payload.model || '';
+          } else if (t === 'event_msg' && pt === 'user_message' && !result.slug) {
+            const text2 = (payload.message || '').trim();
+            if (text2) result.slug = text2.slice(0, 80).replace(/\n/g, ' ').trim();
+          } else if (t === 'response_item' && pt === 'message' && payload.role === 'user' && !result.slug) {
+            const content = Array.isArray(payload.content) ? payload.content : [];
+            for (const block of content) {
+              if (block?.type === 'input_text') {
+                const txt = (block.text || '').trim();
+                if (txt && !txt.startsWith('#') && !txt.startsWith('<') && txt.length <= 500) {
+                  result.slug = txt.slice(0, 80).replace(/\n/g, ' ').trim();
+                  break;
+                }
+              }
+            }
+          }
+        } catch { /* skip */ }
+      }
+
+      // Tail scan: read last TAIL_READ_BYTES only
+      const tailAllLines = size > HEAD_CODEX_BYTES
+        ? readTailLines(filePath, TAIL_READ_BYTES)
+        : headLines;
+      const tailLines = tailAllLines.filter(l => l.trim());
+      for (let i = tailLines.length - 1; i >= Math.max(0, tailLines.length - 16); i--) {
+        try {
+          const obj = JSON.parse(tailLines[i]);
+          const payload = obj.payload || {};
+          const payloadType = payload?.type;
+          if (obj.type === 'event_msg' && payloadType === 'task_complete') result.hasComplete = true;
+          if (!result.model && obj.type === 'turn_context') result.model = payload?.model || '';
+          if (!result.lastInputTokens) {
+            if (obj.type === 'turn_context') {
+              const inputTokens = extractContextInputTokens(payload?.total_token_usage);
+              if (inputTokens > 0) result.lastInputTokens = inputTokens;
+            } else if (obj.type === 'event_msg' && payloadType === 'token_count') {
+              const inputTokens = extractContextInputTokens(payload?.info?.total_token_usage);
+              if (inputTokens > 0) result.lastInputTokens = inputTokens;
+            }
+          }
+          if (result.hasComplete && result.model && result.lastInputTokens) break;
+        } catch { /* skip */ }
+      }
+
+    } catch { return null; }
+
+    return result;
+  }
+
+  // ── Query interface ─────────────────────────────────────────────────────────
+
+  getSessions(opts: {
+    project?: string; status?: string; search?: string;
+    source?: string; offset?: number; limit?: number;
+  }): {
+    sessions: Omit<RegistrySession, '_path'>[];
+    total: number; projects: string[]; sources: string[];
+    offset: number; limit: number;
+  } {
+    this.ensureFresh();
+
+    let items = Array.from(this.sessions.values()) as (RegistrySession & { _path: string })[];
+
+    const allProjects = Array.from(this.projects).sort();
+    const sources = [...new Set(items.map(s => s.source))].sort();
+
+    if (opts.source) items = items.filter(s => s.source === opts.source);
+    if (opts.project) items = items.filter(s => s.project === opts.project);
+    if (opts.status && opts.status !== 'all') items = items.filter(s => s.status === opts.status);
+    if (opts.search) {
+      const q = opts.search.toLowerCase();
+      items = items.filter(s =>
+        s.slug.toLowerCase().includes(q) ||
+        s.project.toLowerCase().includes(q) ||
+        s.sessionId.toLowerCase().includes(q)
+      );
+    }
+
+    items.sort((a, b) => b.mtime - a.mtime);
+    const total = items.length;
+    const offset = opts.offset ?? 0;
+    const limit = Math.min(opts.limit ?? 50, 200);
+    const page = items.slice(offset, offset + limit);
+
+    const sessions = page.map(({ _path: _p, ...rest }) => rest);
+    return { sessions, total, projects: allProjects, sources, offset, limit };
+  }
+
+  getSessionPath(sessionId: string): string | null {
+    this.ensureFresh();
+    const s = this.sessions.get(sessionId);
+    if (s) return s._path;
+
+    const saPath = this.subagentPaths.get(sessionId);
+    if (saPath) return saPath;
+
+    // Filesystem fallback for claude sessions
+    if (!SAFE_ID_RE.test(sessionId)) return null;
+    if (fs.existsSync(PROJECTS_DIR)) {
+      for (const d of fs.readdirSync(PROJECTS_DIR)) {
+        const candidate = path.resolve(PROJECTS_DIR, d, sessionId + '.jsonl');
+        if (candidate.startsWith(path.resolve(PROJECTS_DIR) + path.sep) && fs.existsSync(candidate)) {
+          return candidate;
+        }
+      }
+    }
+    return null;
+  }
+
+  getSubagents(sessionId: string): RegistrySubagent[] {
+    this.ensureFresh();
+    return this.subagents.get(sessionId) ?? [];
+  }
+}
+
+// ─── SessionEventReader ────────────────────────────────────────────────────────
+
+const SKIP_TYPES = new Set([
+  'file-history-snapshot', 'queue-operation',
+  'session', 'thinking_level_change', 'custom',
+]);
+
+function isCodexPath(p: string): boolean {
+  return p.startsWith(CODEX_DIR);
+}
+
+function parseEvent(line: string): RegistryEvent | null {
+  if (!line.trim()) return null;
+  let raw: Record<string, unknown>;
+  try { raw = JSON.parse(line); } catch { return null; }
+
+  const t = raw.type as string;
+  if (!t || SKIP_TYPES.has(t)) return null;
+
+  // OpenClaw type="message" format
+  if (t === 'message') {
+    const msg = (raw.message || {}) as Record<string, unknown>;
+    const role = msg.role as string;
+    const roleMap: Record<string, string> = { user: 'user', assistant: 'assistant', toolResult: 'user' };
+    const mapped = roleMap[role];
+    if (!mapped) return null;
+
+    const result: RegistryEvent = {
+      type: mapped,
+      uuid: (raw.id as string) || '',
+      timestamp: (raw.timestamp as string) || '',
+    };
+
+    if (role === 'user') {
+      result.userType = 'external';
+      const content = msg.content;
+      if (typeof content === 'string') {
+        result.text = content.slice(0, MAX_TEXT_LEN);
+        result.truncated = content.length > MAX_TEXT_LEN;
+      } else if (Array.isArray(content)) {
+        const texts = content.filter((b: unknown) => (b as Record<string,unknown>)?.type === 'text')
+          .map((b: unknown) => ((b as Record<string,unknown>).text as string || '').slice(0, MAX_TEXT_LEN));
+        if (texts.length) {
+          const joined = texts.join('\n');
+          result.text = joined.slice(0, MAX_TEXT_LEN);
+          result.truncated = joined.length > MAX_TEXT_LEN;
+        }
+      }
+    } else if (role === 'toolResult') {
+      result.userType = 'external';
+      const content = msg.content;
+      let full = '';
+      if (Array.isArray(content)) full = content.filter((b: unknown) => (b as Record<string,unknown>)?.type === 'text').map((b: unknown) => (b as Record<string,unknown>).text as string).join('\n');
+      else if (typeof content === 'string') full = content;
+      const details = (msg.details || {}) as Record<string, unknown>;
+      const isErr = (details.exitCode as number) !== 0 && details.exitCode !== undefined;
+      result.tool_results = [{
+        tool_use_id: msg.toolCallId as string || '',
+        type: 'tool_result',
+        content: full.slice(0, MAX_TOOL_RESULT_LEN),
+        truncated: full.length > MAX_TOOL_RESULT_LEN,
+        ...(isErr ? { is_error: true } : {}),
+      }];
+    } else if (role === 'assistant') {
+      let model = (msg.model as string) || '';
+      if (model === 'delivery-mirror') model = '';
+      result.model = model;
+      result.usage = msg.usage || {};
+      result.stop_reason = msg.stop_reason || '';
+      const texts: string[] = [];
+      const toolUses: unknown[] = [];
+      const content = msg.content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          const b = block as Record<string, unknown>;
+          if (b.type === 'text') texts.push((b.text as string || '').slice(0, MAX_TEXT_LEN));
+          else if (b.type === 'toolCall') {
+            const inp = JSON.stringify(b.arguments || {});
+            toolUses.push({ type: 'tool_use', id: b.id, name: b.name, input: inp.slice(0, MAX_TOOL_INPUT_LEN), truncated: inp.length > MAX_TOOL_INPUT_LEN });
+          } else if (b.type === 'thinking') result.hasThinking = true;
+        }
+      }
+      if (texts.length) result.text = texts.join('\n');
+      if (toolUses.length) result.tool_uses = toolUses;
+    }
+    return result;
+  }
+
+  // Claude Code native format
+  const result: RegistryEvent = {
+    type: t,
+    uuid: (raw.uuid as string) || '',
+    timestamp: (raw.timestamp as string) || '',
+  };
+
+  if (t === 'user') {
+    const msg = (raw.message || {}) as Record<string, unknown>;
+    const content = msg.content;
+    result.userType = raw.userType || 'external';
+    if (typeof content === 'string') {
+      result.text = content.slice(0, MAX_TEXT_LEN);
+      result.truncated = content.length > MAX_TEXT_LEN;
+    } else if (Array.isArray(content)) {
+      const texts: string[] = [];
+      const toolResults: unknown[] = [];
+      for (const block of content) {
+        const b = block as Record<string, unknown>;
+        if (b.type === 'text') texts.push((b.text as string || '').slice(0, MAX_TEXT_LEN));
+        else if (b.type === 'tool_result') {
+          const rc = b.content;
+          let full = '';
+          if (Array.isArray(rc)) full = rc.filter((i: unknown) => (i as Record<string,unknown>)?.type === 'text').map((i: unknown) => (i as Record<string,unknown>).text as string).join('\n');
+          else if (typeof rc === 'string') full = rc;
+          toolResults.push({
+            tool_use_id: b.tool_use_id || '',
+            type: 'tool_result',
+            content: full.slice(0, MAX_TOOL_RESULT_LEN),
+            truncated: full.length > MAX_TOOL_RESULT_LEN,
+            ...(b.is_error ? { is_error: true } : {}),
+          });
+        }
+      }
+      if (texts.length) { const j = texts.join('\n'); result.text = j.slice(0, MAX_TEXT_LEN); result.truncated = j.length > MAX_TEXT_LEN; }
+      if (toolResults.length) result.tool_results = toolResults;
+    }
+  } else if (t === 'assistant') {
+    const msg = (raw.message || {}) as Record<string, unknown>;
+    result.model = msg.model || '';
+    result.usage = msg.usage || {};
+    result.stop_reason = msg.stop_reason || '';
+    const texts: string[] = [];
+    const toolUses: unknown[] = [];
+    for (const block of (msg.content as unknown[] || [])) {
+      const b = block as Record<string, unknown>;
+      if (b.type === 'text') texts.push((b.text as string || '').slice(0, MAX_TEXT_LEN));
+      else if (b.type === 'tool_use') {
+        const inp = JSON.stringify(b.input || {});
+        toolUses.push({ type: 'tool_use', id: b.id, name: b.name, input: inp.slice(0, MAX_TOOL_INPUT_LEN), truncated: inp.length > MAX_TOOL_INPUT_LEN });
+      } else if (b.type === 'thinking') result.hasThinking = true;
+    }
+    if (texts.length) result.text = texts.join('\n');
+    if (toolUses.length) result.tool_uses = toolUses;
+  } else if (t === 'system') {
+    result.subtype = raw.subtype || '';
+    result.level = raw.level || '';
+  } else if (t === 'progress') {
+    const data = (raw.data || {}) as Record<string, unknown>;
+    result.progress = { type: data.type || '', content: String(data.content || '').slice(0, 200) };
+  }
+
+  return result;
+}
+
+function parseCodexEvent(line: string, lineNum: number): RegistryEvent | null {
+  let raw: Record<string, unknown>;
+  try { raw = JSON.parse(line); } catch { return null; }
+
+  const t = raw.type as string;
+  const payload = (raw.payload || {}) as Record<string, unknown>;
+  if (typeof payload !== 'object') return null;
+  const pt = payload.type as string;
+  const ts = (raw.timestamp as string) || '';
+  const uuid = `codex-${lineNum}`;
+
+  if (t === 'session_meta' || t === 'turn_context') return null;
+  if (t === 'event_msg' && ['token_count', 'agent_reasoning', 'agent_message', 'user_message', 'context_compacted'].includes(pt)) return null;
+
+  if (t === 'event_msg') {
+    if (pt === 'task_started' || pt === 'task_complete') {
+      return { type: 'system', uuid, timestamp: ts, subtype: pt, level: '' };
+    }
+    return null;
+  }
+
+  if (t === 'response_item') {
+    const role = payload.role as string;
+    const content = payload.content as unknown[];
+
+    if (pt === 'message' && role === 'user') {
+      const texts: string[] = [];
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          const b = block as Record<string, unknown>;
+          if (b.type === 'input_text') texts.push((b.text as string || '').slice(0, MAX_TEXT_LEN));
+        }
+      }
+      if (!texts.length) return null;
+      const firstText = texts[0];
+      if (firstText.startsWith('# AGENTS.md') || firstText.startsWith('# Collaboration Mode') || firstText.startsWith('<environment_context>')) return null;
+      const joined = texts.join('\n');
+      return { type: 'user', uuid, timestamp: ts, userType: 'external', text: joined.slice(0, MAX_TEXT_LEN), truncated: joined.length > MAX_TEXT_LEN };
+    }
+    if (pt === 'message' && role === 'developer') return null;
+    if (pt === 'message' && role === 'assistant') {
+      const texts = Array.isArray(content) ? content.filter((b: unknown) => (b as Record<string,unknown>)?.type === 'output_text').map((b: unknown) => ((b as Record<string,unknown>).text as string || '').slice(0, MAX_TEXT_LEN)) : [];
+      const ev: RegistryEvent = { type: 'assistant', uuid, timestamp: ts, model: '', usage: {}, stop_reason: '' };
+      if (texts.length) ev.text = texts.join('\n');
+      return ev;
+    }
+    if (pt === 'function_call') {
+      const args = payload.arguments as string || '{}';
+      const trunc = typeof args === 'string' && args.length > MAX_TOOL_INPUT_LEN;
+      return { type: 'assistant', uuid, timestamp: ts, model: '', usage: {}, stop_reason: '', tool_uses: [{ type: 'tool_use', id: payload.call_id || '', name: payload.name || '', input: (typeof args === 'string' ? args : JSON.stringify(args)).slice(0, MAX_TOOL_INPUT_LEN), truncated: trunc }] };
+    }
+    if (pt === 'function_call_output') {
+      const output = (payload.output as string) || '';
+      return { type: 'user', uuid, timestamp: ts, userType: 'tool_result', tool_results: [{ tool_use_id: payload.call_id || '', type: 'tool_result', content: output.slice(0, MAX_TOOL_RESULT_LEN), truncated: output.length > MAX_TOOL_RESULT_LEN }] };
+    }
+    if (pt === 'custom_tool_call') {
+      const inp = (payload.input as string) || '';
+      return { type: 'assistant', uuid, timestamp: ts, model: '', usage: {}, stop_reason: '', tool_uses: [{ type: 'tool_use', id: payload.call_id || '', name: payload.name || '', input: inp.slice(0, MAX_TOOL_INPUT_LEN), truncated: inp.length > MAX_TOOL_INPUT_LEN }] };
+    }
+    if (pt === 'custom_tool_call_output') {
+      const output = (payload.output as string) || '';
+      return { type: 'user', uuid, timestamp: ts, userType: 'tool_result', tool_results: [{ tool_use_id: payload.call_id || '', type: 'tool_result', content: output.slice(0, MAX_TOOL_RESULT_LEN), truncated: output.length > MAX_TOOL_RESULT_LEN }] };
+    }
+    if (pt === 'reasoning') {
+      const summary = Array.isArray(payload.summary) ? payload.summary : [];
+      const summaryText = summary.filter((i: unknown) => (i as Record<string,unknown>)?.type === 'summary_text').map((i: unknown) => (i as Record<string,unknown>).text as string).join('\n');
+      const ev: RegistryEvent = { type: 'assistant', uuid, timestamp: ts, model: '', usage: {}, stop_reason: '', hasThinking: true };
+      if (summaryText) ev.text = summaryText.slice(0, MAX_TEXT_LEN);
+      return ev;
+    }
+  }
+
+  return null;
+}
+
+function readEvents(filePath: string, after?: string, limit = 100): RegistryEvent[] {
+  let size: number;
+  try { size = fs.statSync(filePath).size; } catch { return []; }
+
+  const isCodex = isCodexPath(filePath);
+
+  if (isCodex) return readCodexEvents(filePath, size, after, limit);
+  if (after) return readAfterCursor(filePath, size, after, limit);
+  return readTail(filePath, size, limit);
+}
+
+function readTail(filePath: string, size: number, limit: number): RegistryEvent[] {
+  const events: RegistryEvent[] = [];
+  try {
+    const text = size > TAIL_READ_BYTES
+      ? readTailLines(filePath, TAIL_READ_BYTES).join('\n')
+      : fs.readFileSync(filePath, 'utf-8');
+    for (const line of text.split('\n')) {
+      const ev = parseEvent(line.trim());
+      if (ev && !SKIP_TYPES.has(ev.type)) events.push(ev);
+    }
+  } catch (e) {
+    logger.error('SESSION_REGISTRY', 'Error reading tail', {}, e as Error);
+  }
+  return events.slice(-limit);
+}
+
+function readAfterCursor(filePath: string, size: number, after: string, limit: number): RegistryEvent[] {
+  const events: RegistryEvent[] = [];
+  let found = false;
+
+  const processLines = (lines: string[]): boolean => {
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      if (!found) {
+        try {
+          const obj = JSON.parse(line);
+          if (obj.uuid === after || obj.id === after) { found = true; }
+        } catch { /* skip */ }
+        continue;
+      }
+      const ev = parseEvent(line.trim());
+      if (ev && !SKIP_TYPES.has(ev.type)) {
+        events.push(ev);
+        if (events.length >= limit) return true;
+      }
+    }
+    return false;
+  };
+
+  try {
+    if (size > TAIL_READ_BYTES) {
+      const tailLines = readTailLines(filePath, TAIL_READ_BYTES);
+      if (processLines(tailLines) || found) return events;
+    }
+    // Full scan
+    const text = fs.readFileSync(filePath, 'utf-8');
+    found = false;
+    events.length = 0;
+    processLines(text.split('\n'));
+  } catch (e) {
+    logger.error('SESSION_REGISTRY', 'Error reading after cursor', {}, e as Error);
+  }
+  return events;
+}
+
+function readCodexEvents(filePath: string, size: number, after?: string, limit = 100): RegistryEvent[] {
+  const events: RegistryEvent[] = [];
+
+  if (after && after.startsWith('codex-')) {
+    const afterLine = parseInt(after.split('-')[1] ?? '-1', 10);
+    let found = false;
+    try {
+      const lines = fs.readFileSync(filePath, 'utf-8').split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        if (!found) { if (i === afterLine) found = true; continue; }
+        const ev = parseCodexEvent(lines[i].trim(), i);
+        if (ev && !SKIP_TYPES.has(ev.type)) { events.push(ev); if (events.length >= limit) break; }
+      }
+    } catch { /* ignore */ }
+    return events;
+  }
+
+  try {
+    // Always perform a full read so that cursor IDs (codex-<lineNum>) are stable
+    // absolute line numbers regardless of file size. This ensures after=codex-N
+    // pagination is always correct.
+    const text = fs.readFileSync(filePath, 'utf-8');
+    const lines = text.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      if (!lines[i].trim()) continue;
+      const ev = parseCodexEvent(lines[i].trim(), i);
+      if (ev && !SKIP_TYPES.has(ev.type)) events.push(ev);
+    }
+  } catch { /* ignore */ }
+
+  return events.slice(-limit);
+}
+
+function getRawEvent(filePath: string, eventUuid: string): unknown | null {
+  try {
+    if (eventUuid.startsWith('codex-')) {
+      const targetLine = parseInt(eventUuid.split('-')[1] ?? '-1', 10);
+      const lines = fs.readFileSync(filePath, 'utf-8').split('\n');
+      if (targetLine >= 0 && targetLine < lines.length) {
+        return JSON.parse(lines[targetLine].trim());
+      }
+      return null;
+    }
+    const size = fs.statSync(filePath).size;
+    const checkLines = (lines: string[]): unknown | null => {
+      for (const line of lines) {
+        try {
+          const obj = JSON.parse(line.trim());
+          if (obj.uuid === eventUuid || obj.id === eventUuid) return obj;
+        } catch { /* skip */ }
+      }
+      return null;
+    };
+    if (size > TAIL_READ_BYTES) {
+      const result = checkLines(readTailLines(filePath, TAIL_READ_BYTES));
+      if (result) return result;
+    }
+    return checkLines(fs.readFileSync(filePath, 'utf-8').split('\n'));
+  } catch { return null; }
+}
+
+function getStats(filePath: string): Record<string, unknown> {
+  const stats: Record<string, unknown> = {
+    model: '', version: '', cwd: '', gitBranch: '',
+    tokens: { input: 0, output: 0, cache_read: 0, cache_creation: 0 },
+    tool_calls: {} as Record<string, number>,
+    event_counts: {} as Record<string, number>,
+    first_timestamp: '', last_timestamp: '', duration_seconds: 0,
+  };
+  const tokens = stats.tokens as Record<string, number>;
+  const toolCalls = stats.tool_calls as Record<string, number>;
+  const eventCounts = stats.event_counts as Record<string, number>;
+
+  let firstTs = '', lastTs = '';
+
+  try {
+    const text = fs.readFileSync(filePath, 'utf-8');
+    for (const line of text.split('\n')) {
+      if (!line.trim()) continue;
+      let raw: Record<string, unknown>;
+      try { raw = JSON.parse(line); } catch { continue; }
+
+      const et = raw.type as string;
+      if (!et) continue;
+      eventCounts[et] = (eventCounts[et] || 0) + 1;
+
+      let ts = raw.timestamp as string | number;
+      if (ts) {
+        if (typeof ts === 'number') {
+          ts = new Date(ts > 1e12 ? ts : ts * 1000).toISOString();
+        }
+        if (!firstTs) firstTs = ts as string;
+        lastTs = ts as string;
+      }
+
+      if (!stats.cwd && raw.cwd) stats.cwd = raw.cwd;
+      if (!stats.gitBranch && raw.gitBranch) stats.gitBranch = raw.gitBranch;
+      if (!stats.version && typeof raw.version === 'string') stats.version = raw.version;
+
+      const msg = (raw.message || {}) as Record<string, unknown>;
+
+      if (et === 'assistant') {
+        if (!stats.model && msg.model) stats.model = msg.model;
+        const usage = (msg.usage || {}) as Record<string, number>;
+        tokens.input += usage.input_tokens || 0;
+        tokens.output += usage.output_tokens || 0;
+        tokens.cache_read += usage.cache_read_input_tokens || 0;
+        tokens.cache_creation += usage.cache_creation_input_tokens || 0;
+        for (const block of (msg.content as unknown[] || [])) {
+          const b = block as Record<string, unknown>;
+          if (b.type === 'tool_use') { const n = (b.name as string) || 'unknown'; toolCalls[n] = (toolCalls[n] || 0) + 1; }
+        }
+      } else if (et === 'message') {
+        const role = msg.role as string;
+        if (role === 'assistant') {
+          const m = msg.model as string || '';
+          if (!stats.model && m && m !== 'delivery-mirror') stats.model = m;
+          const usage = (msg.usage || {}) as Record<string, number>;
+          tokens.input += usage.input_tokens || usage.input || 0;
+          tokens.output += usage.output_tokens || usage.output || 0;
+          tokens.cache_read += usage.cache_read_input_tokens || usage.cacheRead || 0;
+          tokens.cache_creation += usage.cache_creation_input_tokens || usage.cacheWrite || 0;
+          for (const block of (msg.content as unknown[] || [])) {
+            const b = block as Record<string, unknown>;
+            if (b.type === 'toolCall') { const n = (b.name as string) || 'unknown'; toolCalls[n] = (toolCalls[n] || 0) + 1; }
+          }
+        }
+      } else if (['session_meta', 'turn_context', 'response_item', 'event_msg'].includes(et)) {
+        const payload = (raw.payload || {}) as Record<string, unknown>;
+        const pt = payload.type as string;
+        if (et === 'session_meta') {
+          if (!stats.cwd) stats.cwd = payload.cwd || '';
+          if (!stats.version) stats.version = payload.cli_version || '';
+          const git = (payload.git || {}) as Record<string, string>;
+          if (!stats.gitBranch) stats.gitBranch = git.branch || '';
+        } else if (et === 'turn_context' && !stats.model) {
+          stats.model = payload.model || '';
+        } else if (et === 'event_msg' && pt === 'token_count') {
+          const info = (payload.info || {}) as Record<string, unknown>;
+          const usage = (info.total_token_usage || {}) as Record<string, number>;
+          if (usage.input_tokens) tokens.input = usage.input_tokens;
+          if (usage.output_tokens) tokens.output = usage.output_tokens + (usage.reasoning_output_tokens || 0);
+          if (usage.cached_input_tokens) tokens.cache_read = usage.cached_input_tokens;
+        } else if (et === 'response_item' && (pt === 'function_call' || pt === 'custom_tool_call')) {
+          const n = (payload.name as string) || 'unknown';
+          toolCalls[n] = (toolCalls[n] || 0) + 1;
+        }
+      }
+    }
+  } catch (e) {
+    logger.error('SESSION_REGISTRY', 'Error reading stats', {}, e as Error);
+  }
+
+  stats.first_timestamp = firstTs;
+  stats.last_timestamp = lastTs;
+  if (firstTs && lastTs) {
+    try {
+      const t1 = new Date(firstTs).getTime();
+      const t2 = new Date(lastTs).getTime();
+      stats.duration_seconds = Math.max(0, Math.round((t2 - t1) / 1000));
+    } catch { /* ignore */ }
+  }
+
+  return stats;
+}
+
+function scanInlineSubagents(filePath: string, sessionId: string): RegistrySubagent[] {
+  const calls = new Map<string, Record<string, unknown>>();
+  const results = new Map<string, Record<string, unknown>>();
+
+  try {
+    const text = fs.readFileSync(filePath, 'utf-8');
+    for (const line of text.split('\n')) {
+      if (!line.includes('sessions_spawn')) continue;
+      let raw: Record<string, unknown>;
+      try { raw = JSON.parse(line); } catch { continue; }
+
+      const msg = (raw.message || {}) as Record<string, unknown>;
+      const role = msg.role as string;
+      const content = msg.content as unknown[];
+      const ts = (raw.timestamp as string) || '';
+
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          const b = block as Record<string, unknown>;
+          if (b.type === 'toolCall' && b.name === 'sessions_spawn') {
+            const cid = (b.id as string) || '';
+            const args = (b.arguments || {}) as Record<string, unknown>;
+            calls.set(cid, { task: args.task || '', model: args.model || '', mode: args.mode || 'run', timestamp: ts });
+          }
+        }
+      }
+      if (role === 'toolResult' && msg.toolName === 'sessions_spawn') {
+        const tcid = (msg.toolCallId as string) || '';
+        let rc = '';
+        if (Array.isArray(content)) rc = content.filter((b: unknown) => (b as Record<string,unknown>)?.type === 'text').map((b: unknown) => (b as Record<string,unknown>).text as string).join('');
+        else if (typeof content === 'string') rc = content;
+        if (rc) {
+          try {
+            const parsed = JSON.parse(rc);
+            results.set(tcid, { status: parsed.status || '', childSessionKey: parsed.childSessionKey || '', runId: parsed.runId || '', error: parsed.error || '' });
+          } catch { /* ignore */ }
+        }
+      }
+    }
+  } catch { return []; }
+
+  const subagents: RegistrySubagent[] = [];
+  for (const [tcid, result] of results) {
+    if (result.status !== 'accepted') continue;
+    const call = calls.get(tcid) || {};
+    const childKey = (result.childSessionKey as string) || '';
+    const parts = childKey.split(':');
+    const saId = parts.length >= 4 ? parts[parts.length - 1] : childKey;
+    const task = (call.task as string) || '';
+    const slug = task.slice(0, 60).replace(/\n/g, ' ').trim() + (task.length > 60 ? '...' : '');
+    subagents.push({
+      id: 'oc-spawn-' + saId.slice(0, 12),
+      parentId: sessionId,
+      agentType: 'openclaw-spawn',
+      slug,
+      model: (call.model as string) || '',
+      status: 'completed',
+      mtime: 0,
+      ephemeral: true,
+      spawnStatus: result.status as string,
+      runId: result.runId as string || '',
+      childSessionKey: childKey,
+      timestamp: (call.timestamp as string) || '',
+    });
+  }
+  return subagents;
+}
+
+// ─── Global index instance ────────────────────────────────────────────────────
+
+const sessionIndex = new SessionIndex();
+
+// ─── Route handler class ──────────────────────────────────────────────────────
+
+export class SessionRegistryRoutes extends BaseRouteHandler {
+  setupRoutes(app: express.Application): void {
+    app.get('/api/session-registry/list', this.wrapHandler(this.handleList.bind(this)));
+    app.get('/api/session-registry/:id/events', this.wrapHandler(this.handleEvents.bind(this)));
+    app.get('/api/session-registry/:id/stats', this.wrapHandler(this.handleStats.bind(this)));
+    app.get('/api/session-registry/:id/subagents', this.wrapHandler(this.handleSubagents.bind(this)));
+    app.get('/api/session-registry/:id/raw-event/:eventId', this.wrapHandler(this.handleRawEvent.bind(this)));
+  }
+
+  private handleList(req: Request, res: Response): void {
+    const { project, status, search, source, offset, limit } = req.query;
+    const data = sessionIndex.getSessions({
+      project: project as string | undefined,
+      status: status as string | undefined,
+      search: search as string | undefined,
+      source: source as string | undefined,
+      offset: offset ? parseInt(offset as string, 10) : 0,
+      limit: limit ? parseInt(limit as string, 10) : 50,
+    });
+    res.json(data);
+  }
+
+  private handleEvents(req: Request, res: Response): void {
+    const { id } = req.params;
+    const filePath = sessionIndex.getSessionPath(id);
+    if (!filePath) { this.notFound(res, 'Session not found'); return; }
+    const { after, limit } = req.query;
+    const rawLimit = limit ? parseInt(limit as string, 10) : 100;
+    const clampedLimit = (!Number.isFinite(rawLimit) || rawLimit < 1) ? 100 : Math.min(rawLimit, 500);
+    const events = readEvents(filePath, after as string | undefined, clampedLimit);
+    res.json({ events, sessionId: id });
+  }
+
+  private handleStats(req: Request, res: Response): void {
+    const { id } = req.params;
+    const filePath = sessionIndex.getSessionPath(id);
+    if (!filePath) { this.notFound(res, 'Session not found'); return; }
+    res.json(getStats(filePath));
+  }
+
+  private handleSubagents(req: Request, res: Response): void {
+    const { id } = req.params;
+    const diskSubagents = sessionIndex.getSubagents(id);
+    const filePath = sessionIndex.getSessionPath(id);
+    const inline = filePath ? scanInlineSubagents(filePath, id) : [];
+    const all = [...diskSubagents, ...inline];
+    res.json({ sessionId: id, subagents: all, total: all.length });
+  }
+
+  private handleRawEvent(req: Request, res: Response): void {
+    const { id, eventId } = req.params;
+    const filePath = sessionIndex.getSessionPath(id);
+    if (!filePath) { this.notFound(res, 'Session not found'); return; }
+    const event = getRawEvent(filePath, eventId);
+    if (!event) { this.notFound(res, 'Event not found'); return; }
+    res.json(event);
+  }
+}

--- a/src/services/worker/http/routes/SessionRegistryRoutes.ts
+++ b/src/services/worker/http/routes/SessionRegistryRoutes.ts
@@ -554,11 +554,14 @@ class SessionIndex {
           const pt = payload.type || '';
 
           if (t === 'session_meta') {
-            result.id = payload.id || '';
-            result.cwd = payload.cwd || '';
-            result.version = payload.cli_version || '';
+            // Only use the FIRST session_meta — Codex subagent files
+            // include the parent's session_meta as line 1, which would
+            // overwrite the subagent's own id and shadow the parent session.
+            if (!result.id) result.id = payload.id || '';
+            if (!result.cwd) result.cwd = payload.cwd || '';
+            if (!result.version) result.version = payload.cli_version || '';
             const git = payload.git || {};
-            if (typeof git === 'object') result.gitBranch = git.branch || '';
+            if (typeof git === 'object' && !result.gitBranch) result.gitBranch = git.branch || '';
           } else if (t === 'turn_context' && !result.model) {
             result.model = payload.model || '';
           } else if (t === 'event_msg' && pt === 'user_message' && !result.slug) {

--- a/src/services/worker/http/routes/SessionRegistryRoutes.ts
+++ b/src/services/worker/http/routes/SessionRegistryRoutes.ts
@@ -29,6 +29,7 @@ const HOME_DIR = os.homedir();
 const PROJECTS_DIR = path.join(HOME_DIR, '.claude', 'projects');
 const OPENCLAW_DIR = path.join(HOME_DIR, '.openclaw', 'agents');
 const CODEX_DIR = path.join(HOME_DIR, '.codex', 'sessions');
+const KIMI_DIR = path.join(HOME_DIR, '.kimi', 'sessions');
 
 const MAX_TOOL_RESULT_LEN = 2048;
 const MAX_TOOL_INPUT_LEN = 1024;
@@ -58,7 +59,7 @@ const SAFE_ID_RE = /^[a-zA-Z0-9_-]+$/;
 export interface RegistrySession {
   sessionId: string;
   project: string;
-  source: 'claude' | 'openclaw' | 'codex';
+  source: 'claude' | 'openclaw' | 'codex' | 'kimi';
   slug: string;
   status: 'active' | 'completed';
   model: string;
@@ -245,6 +246,11 @@ class SessionIndex {
       // ── ~/.codex/sessions/ ──────────────────────────────────────
       if (fs.existsSync(CODEX_DIR)) {
         this.scanCodexSessions(CODEX_DIR, sessions, projects);
+      }
+
+      // ── ~/.kimi/sessions/ ───────────────────────────────────────
+      if (fs.existsSync(KIMI_DIR)) {
+        this.scanKimiSessions(KIMI_DIR, sessions, projects);
       }
 
       this.sessions = sessions;
@@ -603,6 +609,157 @@ class SessionIndex {
     return result;
   }
 
+  // ── Kimi CLI scanner ────────────────────────────────────────────────────────
+
+  private scanKimiSessions(
+    baseDir: string,
+    sessions: Map<string, RegistrySession & { _path: string }>,
+    projects: Set<string>,
+  ): void {
+    let hashEntries: string[];
+    try { hashEntries = fs.readdirSync(baseDir); } catch { return; }
+
+    for (const hashDir of hashEntries) {
+      const hashPath = path.join(baseDir, hashDir);
+      let hashStat: fs.Stats;
+      try { hashStat = fs.statSync(hashPath); } catch { continue; }
+      if (!hashStat.isDirectory()) continue;
+
+      let uuidEntries: string[];
+      try { uuidEntries = fs.readdirSync(hashPath); } catch { continue; }
+
+      for (const uuidDir of uuidEntries) {
+        const sessionPath = path.join(hashPath, uuidDir);
+        let sessionStat: fs.Stats;
+        try { sessionStat = fs.statSync(sessionPath); } catch { continue; }
+        if (!sessionStat.isDirectory()) continue;
+
+        // Look for context.jsonl or wire.jsonl
+        const contextPath = path.join(sessionPath, 'context.jsonl');
+        const wirePath = path.join(sessionPath, 'wire.jsonl');
+        const statePath = path.join(sessionPath, 'state.json');
+
+        const filePath = fs.existsSync(contextPath) ? contextPath : (fs.existsSync(wirePath) ? wirePath : null);
+        if (!filePath) continue;
+
+        let stat: fs.Stats;
+        try { stat = fs.statSync(filePath); } catch { continue; }
+        if (stat.size === 0) continue;
+
+        const meta = this.extractKimiMetadata(filePath, stat.size, statePath, hashDir);
+        if (!meta) continue;
+
+        const sid = 'kimi-' + uuidDir;
+        // Use cwd basename, or hashDir as fallback, or 'unknown' as last resort
+        const projectName = meta.cwd ? path.basename(meta.cwd) : (hashDir ? hashDir.slice(0, 8) : 'unknown');
+        const display = 'kimi/' + projectName;
+        projects.add(display);
+
+        const ageSec = (Date.now() - stat.mtimeMs) / 1000;
+        const active = ageSec < 120;
+
+        // Calculate duration only if we have a valid firstTs
+        const duration = meta.firstTs && meta.firstTs > 0
+          ? Math.max(0, Math.round(stat.mtimeMs / 1000 - meta.firstTs))
+          : 0;
+
+        sessions.set(sid, {
+          sessionId: sid,
+          project: display,
+          source: 'kimi',
+          slug: meta.slug,
+          status: active ? 'active' : 'completed',
+          model: meta.model,
+          version: meta.version,
+          mtime: stat.mtimeMs / 1000,
+          size: stat.size,
+          eventCount: meta.eventCount,
+          cwd: meta.cwd,
+          gitBranch: '',
+          subagentCount: 0,
+          duration,
+          contextPct: getContextPct(meta.model, meta.lastInputTokens),
+          _path: filePath,
+        });
+      }
+    }
+  }
+
+  private extractKimiMetadata(filePath: string, size: number, statePath: string, hashDir?: string): {
+    slug: string; model: string; version: string; cwd: string;
+    eventCount: number; firstTs: number; lastInputTokens: number;
+  } | null {
+    const result = {
+      slug: '', model: '', version: '', cwd: hashDir ? `kimi-${hashDir.slice(0, 8)}` : '',
+      eventCount: Math.max(1, Math.floor(size / 500)),
+      firstTs: 0, lastInputTokens: 0,
+    };
+
+    try {
+      // Try to read state.json for cwd and model info
+      if (fs.existsSync(statePath)) {
+        try {
+          const stateContent = fs.readFileSync(statePath, 'utf-8');
+          const state = JSON.parse(stateContent);
+          result.cwd = state.cwd || state.project_path || result.cwd;
+          result.model = state.model || '';
+          result.version = state.version || state.cli_version || '';
+        } catch (parseErr) {
+          // Log debug info for troubleshooting
+          logger.debug('SESSION', 'Failed to parse Kimi state.json', {
+            statePath,
+            error: parseErr instanceof Error ? parseErr.message : String(parseErr)
+          });
+        }
+      }
+
+      // Head scan: read first HEAD_READ_BYTES
+      const headLines = readHeadLines(filePath, size).filter(l => l.trim());
+
+      for (let i = 0; i < Math.min(20, headLines.length); i++) {
+        try {
+          const obj = JSON.parse(headLines[i]);
+          if (!result.firstTs) {
+            const ts = parseTimestampSec(obj.timestamp);
+            if (ts) result.firstTs = ts;
+          }
+          // Try to extract user message for slug
+          if (!result.slug && obj.role === 'user' && obj.content) {
+            const content = typeof obj.content === 'string' ? obj.content : JSON.stringify(obj.content);
+            result.slug = content.slice(0, 80).replace(/\n/g, ' ').trim();
+          }
+          if (!result.slug && obj.type === 'user_message' && obj.content) {
+            const content = typeof obj.content === 'string' ? obj.content : JSON.stringify(obj.content);
+            result.slug = content.slice(0, 80).replace(/\n/g, ' ').trim();
+          }
+          // Extract model from metadata
+          if (!result.model && obj.model) result.model = obj.model;
+          if (!result.model && obj.metadata?.model) result.model = obj.metadata.model;
+        } catch { /* skip invalid JSON */ }
+      }
+
+      // Tail scan for recent token usage
+      const tailAllLines = size > HEAD_READ_BYTES
+        ? readTailLines(filePath, TAIL_READ_BYTES)
+        : headLines;
+      const tailLines = tailAllLines.filter(l => l.trim());
+      for (let i = tailLines.length - 1; i >= Math.max(0, tailLines.length - 10); i--) {
+        try {
+          const obj = JSON.parse(tailLines[i]);
+          if (!result.lastInputTokens) {
+            const usage = obj.usage || obj.token_usage || obj.metadata?.usage;
+            const inputTokens = extractContextInputTokens(usage);
+            if (inputTokens > 0) result.lastInputTokens = inputTokens;
+          }
+          if (!result.model && obj.model) result.model = obj.model;
+          if (result.lastInputTokens && result.model) break;
+        } catch { /* skip */ }
+      }
+    } catch { return null; }
+
+    return result;
+  }
+
   // ── Query interface ─────────────────────────────────────────────────────────
 
   getSessions(opts: {
@@ -674,6 +831,7 @@ class SessionIndex {
 const SKIP_TYPES = new Set([
   'file-history-snapshot', 'queue-operation',
   'session', 'thinking_level_change', 'custom',
+  'progress',
 ]);
 
 function isCodexPath(p: string): boolean {

--- a/src/services/worker/http/routes/SettingsRoutes.ts
+++ b/src/services/worker/http/routes/SettingsRoutes.ts
@@ -91,9 +91,13 @@ export class SettingsRoutes extends BaseRouteHandler {
       'CLAUDE_MEM_WORKER_HOST',
       // AI Provider Configuration
       'CLAUDE_MEM_PROVIDER',
+      'CLAUDE_MEM_OPENCLAW_PROVIDER',
       'CLAUDE_MEM_GEMINI_API_KEY',
       'CLAUDE_MEM_GEMINI_MODEL',
       'CLAUDE_MEM_GEMINI_RATE_LIMITING_ENABLED',
+      // OpenAI Codex Configuration
+      'CLAUDE_MEM_OPENAI_CODEX_MODEL',
+      'CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR',
       // OpenRouter Configuration
       'CLAUDE_MEM_OPENROUTER_API_KEY',
       'CLAUDE_MEM_OPENROUTER_MODEL',
@@ -232,12 +236,30 @@ export class SettingsRoutes extends BaseRouteHandler {
    * Validate all settings from request body (single source of truth)
    */
   private validateSettings(settings: any): { valid: boolean; error?: string } {
+    const validProviders = ['claude', 'gemini', 'openrouter', 'openai-codex'];
+
     // Validate CLAUDE_MEM_PROVIDER
     if (settings.CLAUDE_MEM_PROVIDER) {
-    const validProviders = ['claude', 'gemini', 'openrouter'];
-    if (!validProviders.includes(settings.CLAUDE_MEM_PROVIDER)) {
-      return { valid: false, error: 'CLAUDE_MEM_PROVIDER must be "claude", "gemini", or "openrouter"' };
+      if (!validProviders.includes(settings.CLAUDE_MEM_PROVIDER)) {
+        return {
+          valid: false,
+          error:
+            'CLAUDE_MEM_PROVIDER must be "claude", "gemini", "openrouter", or "openai-codex"',
+        };
       }
+    }
+
+    // Validate CLAUDE_MEM_OPENCLAW_PROVIDER (empty string is allowed)
+    if (
+      settings.CLAUDE_MEM_OPENCLAW_PROVIDER !== undefined &&
+      settings.CLAUDE_MEM_OPENCLAW_PROVIDER !== '' &&
+      !validProviders.includes(settings.CLAUDE_MEM_OPENCLAW_PROVIDER)
+    ) {
+      return {
+        valid: false,
+        error:
+          'CLAUDE_MEM_OPENCLAW_PROVIDER must be empty or one of: "claude", "gemini", "openrouter", "openai-codex"',
+      };
     }
 
     // Validate CLAUDE_MEM_GEMINI_MODEL

--- a/src/services/worker/http/routes/ViewerRoutes.ts
+++ b/src/services/worker/http/routes/ViewerRoutes.ts
@@ -31,6 +31,8 @@ export class ViewerRoutes extends BaseRouteHandler {
 
     app.get('/health', this.handleHealth.bind(this));
     app.get('/', this.handleViewerUI.bind(this));
+    // SPA client-side route: serve viewer for /sessions path
+    app.get('/sessions', this.handleViewerUI.bind(this));
     app.get('/stream', this.handleSSEStream.bind(this));
   }
 

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -18,13 +18,17 @@ export interface SettingsDefaults {
   CLAUDE_MEM_WORKER_HOST: string;
   CLAUDE_MEM_SKIP_TOOLS: string;
   // AI Provider Configuration
-  CLAUDE_MEM_PROVIDER: string;  // 'claude' | 'gemini' | 'openrouter'
+  CLAUDE_MEM_PROVIDER: string;          // 'claude' | 'gemini' | 'openrouter' | 'openai-codex'
+  CLAUDE_MEM_OPENCLAW_PROVIDER: string; // Override provider for OpenClaw sessions (empty = use CLAUDE_MEM_PROVIDER)
   CLAUDE_MEM_CLAUDE_AUTH_METHOD: string;  // 'cli' | 'api' - how Claude provider authenticates
   CLAUDE_MEM_GEMINI_API_KEY: string;
   CLAUDE_MEM_GEMINI_MODEL: string;  // 'gemini-2.5-flash-lite' | 'gemini-2.5-flash' | 'gemini-3-flash-preview'
   CLAUDE_MEM_GEMINI_RATE_LIMITING_ENABLED: string;  // 'true' | 'false' - enable rate limiting for free tier
   CLAUDE_MEM_OPENROUTER_API_KEY: string;
   CLAUDE_MEM_OPENROUTER_MODEL: string;
+  // OpenAI Codex OAuth provider
+  CLAUDE_MEM_OPENAI_CODEX_MODEL: string;        // Model to use (default: gpt-4o)
+  CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR: string;    // Override path to auth-profiles.json dir
   CLAUDE_MEM_OPENROUTER_SITE_URL: string;
   CLAUDE_MEM_OPENROUTER_APP_NAME: string;
   CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES: string;
@@ -77,13 +81,16 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_WORKER_HOST: '127.0.0.1',
     CLAUDE_MEM_SKIP_TOOLS: 'ListMcpResourcesTool,SlashCommand,Skill,TodoWrite,AskUserQuestion',
     // AI Provider Configuration
-    CLAUDE_MEM_PROVIDER: 'claude',  // Default to Claude
+    CLAUDE_MEM_PROVIDER: 'claude',          // Default to Claude
+    CLAUDE_MEM_OPENCLAW_PROVIDER: '',       // Empty = use CLAUDE_MEM_PROVIDER for all sessions
     CLAUDE_MEM_CLAUDE_AUTH_METHOD: 'cli',  // Default to CLI subscription billing (not API key)
     CLAUDE_MEM_GEMINI_API_KEY: '',  // Empty by default, can be set via UI or env
     CLAUDE_MEM_GEMINI_MODEL: 'gemini-2.5-flash-lite',  // Default Gemini model (highest free tier RPM)
     CLAUDE_MEM_GEMINI_RATE_LIMITING_ENABLED: 'true',  // Rate limiting ON by default for free tier users
     CLAUDE_MEM_OPENROUTER_API_KEY: '',  // Empty by default, can be set via UI or env
     CLAUDE_MEM_OPENROUTER_MODEL: 'xiaomi/mimo-v2-flash:free',  // Default OpenRouter model (free tier)
+    CLAUDE_MEM_OPENAI_CODEX_MODEL: 'gpt-4o',   // Default Codex model (conservative)
+    CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR: '',      // Empty = auto-detect from OPENCLAW_AGENT_DIR or ~/.openclaw
     CLAUDE_MEM_OPENROUTER_SITE_URL: '',  // Optional: for OpenRouter analytics
     CLAUDE_MEM_OPENROUTER_APP_NAME: 'claude-mem',  // App name for OpenRouter analytics
     CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES: '20',  // Max messages in context window

--- a/src/ui/viewer/App.tsx
+++ b/src/ui/viewer/App.tsx
@@ -3,6 +3,7 @@ import { Header } from './components/Header';
 import { Feed } from './components/Feed';
 import { ContextSettingsModal } from './components/ContextSettingsModal';
 import { LogsDrawer } from './components/LogsModal';
+import { SessionRegistryPage } from './components/SessionRegistryPage';
 import { useSSE } from './hooks/useSSE';
 import { useSettings } from './hooks/useSettings';
 import { useStats } from './hooks/useStats';
@@ -11,10 +12,36 @@ import { useTheme } from './hooks/useTheme';
 import { Observation, Summary, UserPrompt } from './types';
 import { mergeAndDeduplicateByProject } from './utils/data';
 
+type AppPage = 'feed' | 'session-registry';
+
 export function App() {
+  const [currentPage, setCurrentPage] = useState<AppPage>(() => {
+    // Support simple path-based routing
+    if (typeof window !== 'undefined' && window.location.pathname === '/sessions') {
+      return 'session-registry';
+    }
+    return 'feed';
+  });
   const [currentFilter, setCurrentFilter] = useState('');
   const [contextPreviewOpen, setContextPreviewOpen] = useState(false);
   const [logsModalOpen, setLogsModalOpen] = useState(false);
+
+  const navigateTo = useCallback((page: AppPage) => {
+    setCurrentPage(page);
+    if (typeof window !== 'undefined') {
+      window.history.pushState({}, '', page === 'session-registry' ? '/sessions' : '/');
+    }
+  }, []);
+
+  // Handle browser back/forward
+  useEffect(() => {
+    const onPop = () => {
+      const page = window.location.pathname === '/sessions' ? 'session-registry' : 'feed';
+      setCurrentPage(page);
+    };
+    window.addEventListener('popstate', onPop);
+    return () => window.removeEventListener('popstate', onPop);
+  }, []);
   const [paginatedObservations, setPaginatedObservations] = useState<Observation[]>([]);
   const [paginatedSummaries, setPaginatedSummaries] = useState<Summary[]>([]);
   const [paginatedPrompts, setPaginatedPrompts] = useState<UserPrompt[]>([]);
@@ -89,6 +116,10 @@ export function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentFilter]);
 
+  if (currentPage === 'session-registry') {
+    return <SessionRegistryPage onNavigateHome={() => navigateTo('feed')} />;
+  }
+
   return (
     <>
       <Header
@@ -101,6 +132,7 @@ export function App() {
         themePreference={preference}
         onThemeChange={setThemePreference}
         onContextPreviewToggle={toggleContextPreview}
+        onSessionRegistryOpen={() => navigateTo('session-registry')}
       />
 
       <Feed

--- a/src/ui/viewer/components/ContextSettingsModal.tsx
+++ b/src/ui/viewer/components/ContextSettingsModal.tsx
@@ -323,6 +323,7 @@ export function ContextSettingsModal({
                   <option value="claude">Claude (uses your Claude account)</option>
                   <option value="gemini">Gemini (uses API key)</option>
                   <option value="openrouter">OpenRouter (multi-model)</option>
+                  <option value="openai-codex">OpenAI Codex (ChatGPT Plus/Pro OAuth)</option>
                 </select>
               </FormField>
 
@@ -428,6 +429,54 @@ export function ContextSettingsModal({
                   </FormField>
                 </>
               )}
+
+              {formState.CLAUDE_MEM_PROVIDER === 'openai-codex' && (
+                <>
+                  <FormField
+                    label="Model"
+                    tooltip="OpenAI model to use for observation extraction (your ChatGPT Plus/Pro subscription grants access to GPT-5.x Codex models)"
+                  >
+                    <select
+                      value={formState.CLAUDE_MEM_OPENAI_CODEX_MODEL || 'gpt-4o'}
+                      onChange={(e) => updateSetting('CLAUDE_MEM_OPENAI_CODEX_MODEL', e.target.value)}
+                    >
+                      <option value="gpt-4o">gpt-4o (recommended)</option>
+                      <option value="gpt-4o-mini">gpt-4o-mini (faster)</option>
+                      <option value="gpt-5.3-codex">gpt-5.3-codex (latest, Plus/Pro only)</option>
+                    </select>
+                  </FormField>
+                  <FormField
+                    label="Agent Dir (Optional)"
+                    tooltip="Path to the directory containing auth-profiles.json. Leave empty to auto-detect from OpenClaw installation."
+                  >
+                    <input
+                      type="text"
+                      value={formState.CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR || ''}
+                      onChange={(e) => updateSetting('CLAUDE_MEM_OPENAI_CODEX_AGENT_DIR', e.target.value)}
+                      placeholder="Auto-detect from OpenClaw (leave empty)"
+                    />
+                  </FormField>
+                  <div style={{ padding: '8px 0', fontSize: '12px', color: 'var(--text-muted, #888)' }}>
+                    ℹ️ Authentication is managed by OpenClaw. Run <code>openclaw auth</code> to sign in with your ChatGPT account.
+                  </div>
+                </>
+              )}
+
+              <FormField
+                label="OpenClaw Provider Override"
+                tooltip="AI provider used exclusively for sessions originating from OpenClaw. Leave empty to use the global provider above for all sessions. Recommended: openai-codex (uses ChatGPT subscription, avoids Anthropic ToS restriction for third-party apps)."
+              >
+                <select
+                  value={formState.CLAUDE_MEM_OPENCLAW_PROVIDER || ''}
+                  onChange={(e) => updateSetting('CLAUDE_MEM_OPENCLAW_PROVIDER', e.target.value)}
+                >
+                  <option value="">Same as global provider</option>
+                  <option value="claude">Claude (Anthropic OAuth — not recommended for OpenClaw)</option>
+                  <option value="gemini">Gemini</option>
+                  <option value="openrouter">OpenRouter</option>
+                  <option value="openai-codex">OpenAI Codex (ChatGPT Plus/Pro OAuth)</option>
+                </select>
+              </FormField>
 
               <FormField
                 label="Worker Port"

--- a/src/ui/viewer/components/Header.tsx
+++ b/src/ui/viewer/components/Header.tsx
@@ -14,6 +14,7 @@ interface HeaderProps {
   themePreference: ThemePreference;
   onThemeChange: (theme: ThemePreference) => void;
   onContextPreviewToggle: () => void;
+  onSessionRegistryOpen?: () => void;
 }
 
 export function Header({
@@ -25,7 +26,8 @@ export function Header({
   queueDepth,
   themePreference,
   onThemeChange,
-  onContextPreviewToggle
+  onContextPreviewToggle,
+  onSessionRegistryOpen
 }: HeaderProps) {
   useSpinningFavicon(isProcessing);
 
@@ -78,6 +80,23 @@ export function Header({
           </svg>
         </a>
         <GitHubStarsButton username="thedotmack" repo="claude-mem" />
+        {onSessionRegistryOpen && (
+          <button
+            className="settings-btn"
+            onClick={onSessionRegistryOpen}
+            title="Session Registry"
+            style={{ display: 'flex', alignItems: 'center', gap: '4px', fontSize: '12px', fontWeight: 500, padding: '6px 16px', whiteSpace: 'nowrap', minWidth: 'fit-content', overflow: 'visible' }}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+              <polyline points="14 2 14 8 20 8"></polyline>
+              <line x1="16" y1="13" x2="8" y2="13"></line>
+              <line x1="16" y1="17" x2="8" y2="17"></line>
+              <polyline points="10 9 9 9 8 9"></polyline>
+            </svg>
+            Sessions
+          </button>
+        )}
         <select
           value={currentFilter}
           onChange={e => onFilterChange(e.target.value)}

--- a/src/ui/viewer/components/SessionRegistryPage.tsx
+++ b/src/ui/viewer/components/SessionRegistryPage.tsx
@@ -1,0 +1,989 @@
+/**
+ * SessionRegistryPage
+ *
+ * Full-page session registry browser. Shows sessions from:
+ *   - ~/.claude/projects (Claude Code)
+ *   - ~/.openclaw/agents (OpenClaw)
+ *   - ~/.codex/sessions (Codex)
+ *
+ * Features: search, status/source/project filters, event viewer, stats,
+ * subagent list (with drill-down to subagent events).
+ */
+
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface RegistrySession {
+  sessionId: string;
+  project: string;
+  source: 'claude' | 'openclaw' | 'codex';
+  slug: string;
+  status: 'active' | 'completed';
+  model: string;
+  version: string;
+  mtime: number;
+  size: number;
+  eventCount: number;
+  cwd: string;
+  gitBranch: string;
+  subagentCount: number;
+  duration: number;
+  contextPct: number;
+}
+
+interface RegistrySubagent {
+  id: string;
+  parentId: string;
+  agentType: string;
+  slug: string;
+  model: string;
+  status: 'active' | 'completed';
+  mtime: number;
+  size?: number;
+  eventCount?: number;
+  filename?: string;
+  ephemeral?: boolean;
+  spawnStatus?: string;
+  runId?: string;
+  childSessionKey?: string;
+  timestamp?: string;
+}
+
+interface RegistryEvent {
+  type: string;
+  uuid: string;
+  timestamp: string;
+  text?: string;
+  model?: string;
+  userType?: string;
+  subtype?: string;
+  hasThinking?: boolean;
+  truncated?: boolean;
+  tool_uses?: ToolUse[];
+  tool_results?: ToolResult[];
+  usage?: UsageInfo;
+  stop_reason?: string;
+  [key: string]: unknown;
+}
+
+interface ToolUse {
+  id: string;
+  name: string;
+  input: string;
+  type: string;
+  truncated?: boolean;
+}
+
+interface ToolResult {
+  tool_use_id: string;
+  content: string;
+  type: string;
+  is_error?: boolean;
+  truncated?: boolean;
+}
+
+interface UsageInfo {
+  input_tokens?: number;
+  output_tokens?: number;
+}
+
+interface SessionStats {
+  model: string;
+  version: string;
+  cwd: string;
+  gitBranch: string;
+  tokens: { input: number; output: number; cache_read: number; cache_creation: number };
+  tool_calls: Record<string, number>;
+  event_counts: Record<string, number>;
+  first_timestamp: string;
+  last_timestamp: string;
+  duration_seconds: number;
+}
+
+// ─── API helpers ──────────────────────────────────────────────────────────────
+
+const BASE = '/api/session-registry';
+const LIVE_POLL_MS = 5000;
+const LIVE_SSE_DEBOUNCE_MS = 500;
+const LIVE_UPDATE_EVENT_TYPES = new Set([
+  'new_prompt',
+  'new_observation',
+  'new_summary',
+  'session_started',
+  'session_completed',
+  'observation_queued',
+  'processing_status',
+]);
+
+async function apiGet<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json() as Promise<T>;
+}
+
+function useSessionRegistryLiveTick(): number {
+  const [tick, setTick] = useState(0);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    const bump = () => setTick(prev => prev + 1);
+    const scheduleBump = () => {
+      if (debounceTimerRef.current) return;
+      debounceTimerRef.current = setTimeout(() => {
+        debounceTimerRef.current = null;
+        bump();
+      }, LIVE_SSE_DEBOUNCE_MS);
+    };
+
+    const interval = window.setInterval(bump, LIVE_POLL_MS);
+    const eventSource = new EventSource('/stream');
+
+    eventSource.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data) as { type?: string };
+        if (data.type && LIVE_UPDATE_EVENT_TYPES.has(data.type)) {
+          scheduleBump();
+        }
+      } catch {
+        scheduleBump();
+      }
+    };
+
+    const onFocus = () => bump();
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') bump();
+    };
+    window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onVisibility);
+
+    return () => {
+      window.clearInterval(interval);
+      eventSource.close();
+      window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onVisibility);
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    };
+  }, []);
+
+  return tick;
+}
+
+// ─── Formatting helpers ───────────────────────────────────────────────────────
+
+function formatRelTime(epochSec: number): string {
+  const diffSec = Math.floor(Date.now() / 1000 - epochSec);
+  if (diffSec < 60) return `${diffSec}s ago`;
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`;
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`;
+  return `${Math.floor(diffSec / 86400)}d ago`;
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function formatDuration(sec: number): string {
+  if (sec < 60) return `${sec}s`;
+  if (sec < 3600) return `${Math.floor(sec / 60)}m ${sec % 60}s`;
+  return `${Math.floor(sec / 3600)}h ${Math.floor((sec % 3600) / 60)}m`;
+}
+
+function formatDurationCompact(sec: number): string {
+  if (sec < 60) return `${sec}s`;
+  if (sec < 3600) return `${Math.floor(sec / 60)}m`;
+  return `${Math.floor(sec / 3600)}h ${Math.floor((sec % 3600) / 60)}m`;
+}
+
+function formatNum(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+// ─── EventBlock ───────────────────────────────────────────────────────────────
+
+function EventBlock({ event }: { event: RegistryEvent }) {
+  const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
+  const [expandedResults, setExpandedResults] = useState<Set<string>>(new Set());
+
+  const toggleTool = (id: string) => setExpandedTools(prev => {
+    const next = new Set(prev);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    return next;
+  });
+  const toggleResult = (id: string) => setExpandedResults(prev => {
+    const next = new Set(prev);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    return next;
+  });
+
+  const typeLabel = event.type === 'user'
+    ? (event.userType === 'tool_result' ? 'Tool Result' : 'User')
+    : event.type === 'assistant' ? 'Assistant'
+    : event.type === 'system' ? 'System'
+    : event.type;
+
+  const typeColor: Record<string, string> = {
+    user: 'var(--color-accent-prompt)',
+    assistant: 'var(--color-accent-observation)',
+    system: 'var(--color-text-muted)',
+  };
+  const color = typeColor[event.type] || 'var(--color-text-muted)';
+
+  const ts = event.timestamp
+    ? new Date(event.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+    : '';
+
+  return (
+    <div style={{
+      borderLeft: `3px solid ${color}`,
+      paddingLeft: '10px',
+      marginBottom: '10px',
+      opacity: event.type === 'system' ? 0.7 : 1,
+    }}>
+      <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginBottom: '4px' }}>
+        <span style={{ fontSize: '11px', fontWeight: 600, color, textTransform: 'uppercase', letterSpacing: '0.05em' }}>{typeLabel}</span>
+        {event.model && <span style={{ fontSize: '11px', color: 'var(--color-text-muted)' }}>{event.model}</span>}
+        {event.hasThinking && <span style={{ fontSize: '10px', color: 'var(--color-accent-summary)', border: '1px solid var(--color-accent-summary)', borderRadius: '4px', padding: '0 4px' }}>thinking</span>}
+        {ts && <span style={{ fontSize: '11px', color: 'var(--color-text-muted)', marginLeft: 'auto' }}>{ts}</span>}
+        {event.usage && (event.usage.input_tokens || event.usage.output_tokens) ? (
+          <span style={{ fontSize: '10px', color: 'var(--color-text-muted)' }}>
+            ↑{formatNum(event.usage.input_tokens || 0)} ↓{formatNum(event.usage.output_tokens || 0)}
+          </span>
+        ) : null}
+      </div>
+
+      {/* System event subtype */}
+      {event.type === 'system' && event.subtype && (
+        <div style={{ fontSize: '12px', color: 'var(--color-text-muted)', fontStyle: 'italic' }}>{event.subtype}</div>
+      )}
+
+      {/* Text content */}
+      {event.text && (
+        <div style={{
+          fontSize: '13px',
+          lineHeight: '1.5',
+          color: 'var(--color-text-primary)',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+          maxHeight: '300px',
+          overflowY: 'auto',
+        }}>
+          {event.text}
+          {event.truncated && <span style={{ color: 'var(--color-text-muted)' }}> [truncated]</span>}
+        </div>
+      )}
+
+      {/* Tool uses */}
+      {event.tool_uses?.map((tu) => (
+        <div key={tu.id} style={{
+          background: 'var(--color-bg-stat)',
+          border: '1px solid var(--color-border-primary)',
+          borderRadius: '6px',
+          padding: '6px 10px',
+          marginTop: '6px',
+          fontSize: '12px',
+        }}>
+          <div
+            onClick={() => toggleTool(tu.id)}
+            style={{ cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '6px' }}
+          >
+            <span style={{ color: 'var(--color-accent-primary)', fontWeight: 600 }}>🔧 {tu.name}</span>
+            <span style={{ color: 'var(--color-text-muted)', fontSize: '10px' }}>{expandedTools.has(tu.id) ? '▲' : '▼'}</span>
+          </div>
+          {expandedTools.has(tu.id) && (
+            <pre style={{
+              marginTop: '4px', fontSize: '11px', whiteSpace: 'pre-wrap',
+              wordBreak: 'break-all', color: 'var(--color-text-secondary)',
+              maxHeight: '200px', overflowY: 'auto',
+            }}>
+              {tu.input}{tu.truncated ? ' [truncated]' : ''}
+            </pre>
+          )}
+        </div>
+      ))}
+
+      {/* Tool results */}
+      {event.tool_results?.map((tr, i) => {
+        const resultKey = `${tr.tool_use_id || 'tool-result'}-${i}`;
+        const isOpen = expandedResults.has(resultKey);
+        const preview = tr.content.length > 140 ? `${tr.content.slice(0, 140)}…` : tr.content;
+        return (
+          <div key={i} style={{
+            background: tr.is_error ? 'rgba(231,72,86,0.06)' : 'var(--color-bg-stat)',
+            border: `1px solid ${tr.is_error ? 'var(--color-accent-error)' : 'var(--color-border-primary)'}`,
+            borderRadius: '6px',
+            padding: '6px 10px',
+            marginTop: '6px',
+            fontSize: '12px',
+          }}>
+            <div
+              onClick={() => toggleResult(resultKey)}
+              style={{ cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '6px' }}
+            >
+              <span style={{ color: tr.is_error ? 'var(--color-accent-error)' : 'var(--color-text-muted)', fontSize: '10px' }}>
+                {tr.is_error ? '✗ Error' : '✓ Result'} (tool_use_id: {tr.tool_use_id?.slice(-8)})
+              </span>
+              <span style={{ color: 'var(--color-text-muted)', fontSize: '10px' }}>{isOpen ? '▲' : '▼'}</span>
+            </div>
+            {!isOpen && (
+              <div
+                style={{
+                  marginTop: '4px',
+                  fontSize: '11px',
+                  color: 'var(--color-text-muted)',
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {preview}{tr.truncated ? ' [truncated]' : ''}
+              </div>
+            )}
+            {isOpen && (
+              <pre style={{
+                marginTop: '4px', fontSize: '11px', whiteSpace: 'pre-wrap',
+                wordBreak: 'break-all', color: 'var(--color-text-secondary)',
+                maxHeight: '200px', overflowY: 'auto',
+              }}>
+                {tr.content}{tr.truncated ? ' [truncated]' : ''}
+              </pre>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── SessionEventList ─────────────────────────────────────────────────────────
+
+function SessionEventList({ sessionId, liveTick }: { sessionId: string; liveTick: number }) {
+  const [events, setEvents] = useState<RegistryEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const lastUuidRef = useRef<string | null>(null);
+
+  const loadEvents = useCallback(async (after?: string) => {
+    try {
+      const url = after
+        ? `${BASE}/${encodeURIComponent(sessionId)}/events?after=${encodeURIComponent(after)}&limit=100`
+        : `${BASE}/${encodeURIComponent(sessionId)}/events?limit=100`;
+      const data = await apiGet<{ events: RegistryEvent[] }>(url);
+      const evts = data.events || [];
+      if (after) {
+        setEvents(prev => [...prev, ...evts]);
+      } else {
+        setEvents(evts);
+      }
+      setHasMore(evts.length === 100);
+      if (evts.length > 0) {
+        lastUuidRef.current = evts[evts.length - 1].uuid;
+      }
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    setEvents([]);
+    lastUuidRef.current = null;
+    setHasMore(false);
+    loadEvents().finally(() => setLoading(false));
+  }, [sessionId, loadEvents]);
+
+  const loadMore = async () => {
+    if (!lastUuidRef.current || loadingMore) return;
+    setLoadingMore(true);
+    await loadEvents(lastUuidRef.current);
+    setLoadingMore(false);
+  };
+
+  useEffect(() => {
+    if (!liveTick || !lastUuidRef.current) return;
+
+    const after = lastUuidRef.current;
+    const url = `${BASE}/${encodeURIComponent(sessionId)}/events?after=${encodeURIComponent(after)}&limit=100`;
+    apiGet<{ events: RegistryEvent[] }>(url)
+      .then((data) => {
+        const evts = data.events || [];
+        if (evts.length === 0) return;
+        setEvents(prev => [...prev, ...evts]);
+        lastUuidRef.current = evts[evts.length - 1].uuid;
+      })
+      .catch(() => {
+        // Keep UI stable on background refresh failures.
+      });
+  }, [liveTick, sessionId]);
+
+  if (loading) return <div style={{ color: 'var(--color-text-muted)', padding: '20px' }}>Loading events…</div>;
+  if (error) return <div style={{ color: 'var(--color-accent-error)', padding: '20px' }}>Error: {error}</div>;
+  if (!events.length) return <div style={{ color: 'var(--color-text-muted)', padding: '20px' }}>No events found.</div>;
+
+  return (
+    <div>
+      {events.map((ev, i) => (
+        <EventBlock key={ev.uuid || i} event={ev} />
+      ))}
+      {hasMore && (
+        <button
+          onClick={loadMore}
+          disabled={loadingMore}
+          style={{
+            marginTop: '10px', padding: '6px 16px',
+            background: 'var(--color-bg-stat)', border: '1px solid var(--color-border-primary)',
+            borderRadius: '6px', cursor: 'pointer', color: 'var(--color-text-primary)', fontSize: '12px',
+          }}
+        >
+          {loadingMore ? 'Loading…' : 'Load more events'}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ─── SessionStatsPanel ────────────────────────────────────────────────────────
+
+function SessionStatsPanel({ sessionId, liveTick }: { sessionId: string; liveTick: number }) {
+  const [stats, setStats] = useState<SessionStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStats = useCallback((silent: boolean) => {
+    if (!silent) setLoading(true);
+    if (!silent) setError(null);
+    return apiGet<SessionStats>(`${BASE}/${encodeURIComponent(sessionId)}/stats`)
+      .then(setStats)
+      .catch((e) => {
+        if (!silent) setError((e as Error).message);
+      })
+      .finally(() => {
+        if (!silent) setLoading(false);
+      });
+  }, [sessionId]);
+
+  useEffect(() => {
+    fetchStats(false);
+  }, [fetchStats]);
+
+  useEffect(() => {
+    if (!liveTick) return;
+    fetchStats(true);
+  }, [liveTick, fetchStats]);
+
+  if (loading) return <div style={{ color: 'var(--color-text-muted)' }}>Loading stats…</div>;
+  if (error) return <div style={{ color: 'var(--color-accent-error)' }}>Error: {error}</div>;
+  if (!stats) return null;
+
+  const sortedTools = Object.entries(stats.tool_calls).sort((a, b) => b[1] - a[1]);
+  const totalTokens = stats.tokens.input + stats.tokens.output;
+
+  return (
+    <div style={{ fontSize: '13px' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px', marginBottom: '12px' }}>
+        {[
+          ['Model', stats.model || '—'],
+          ['Version', stats.version || '—'],
+          ['Duration', stats.duration_seconds ? formatDuration(stats.duration_seconds) : '—'],
+          ['Total Tokens', formatNum(totalTokens)],
+          ['Input', formatNum(stats.tokens.input)],
+          ['Output', formatNum(stats.tokens.output)],
+          ['Cache Read', formatNum(stats.tokens.cache_read)],
+          ['Cache Write', formatNum(stats.tokens.cache_creation)],
+        ].map(([label, value]) => (
+          <div key={label} style={{ background: 'var(--color-bg-stat)', borderRadius: '6px', padding: '8px 10px', border: '1px solid var(--color-border-primary)' }}>
+            <div style={{ fontSize: '10px', color: 'var(--color-text-muted)', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: '2px' }}>{label}</div>
+            <div style={{ fontWeight: 600, color: 'var(--color-text-primary)' }}>{value}</div>
+          </div>
+        ))}
+      </div>
+      {stats.cwd && (
+        <div style={{ marginBottom: '8px', color: 'var(--color-text-secondary)', fontFamily: 'var(--font-terminal)', fontSize: '11px' }}>
+          📁 {stats.cwd} {stats.gitBranch ? `(${stats.gitBranch})` : ''}
+        </div>
+      )}
+      {sortedTools.length > 0 && (
+        <>
+          <div style={{ fontWeight: 600, marginBottom: '6px', fontSize: '12px', color: 'var(--color-text-secondary)' }}>Tool Calls</div>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
+            {sortedTools.slice(0, 20).map(([name, count]) => (
+              <span key={name} style={{
+                background: 'var(--color-type-badge-bg)', color: 'var(--color-type-badge-text)',
+                borderRadius: '12px', padding: '2px 8px', fontSize: '11px', fontWeight: 500,
+              }}>
+                {name} × {count}
+              </span>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── SubagentList ─────────────────────────────────────────────────────────────
+
+function SubagentList({ sessionId, onSelect }: { sessionId: string; onSelect: (id: string) => void }) {
+  const [subagents, setSubagents] = useState<RegistrySubagent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    apiGet<{ subagents: RegistrySubagent[] }>(`${BASE}/${encodeURIComponent(sessionId)}/subagents`)
+      .then(d => setSubagents(d.subagents || []))
+      .catch(e => setError((e as Error).message))
+      .finally(() => setLoading(false));
+  }, [sessionId]);
+
+  if (loading) return <div style={{ color: 'var(--color-text-muted)' }}>Loading subagents…</div>;
+  if (error) return <div style={{ color: 'var(--color-accent-error)' }}>Error: {error}</div>;
+  if (!subagents.length) return <div style={{ color: 'var(--color-text-muted)' }}>No subagents found.</div>;
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+      {subagents.map(sa => (
+        <div
+          key={sa.id}
+          style={{
+            background: 'var(--color-bg-stat)', border: '1px solid var(--color-border-primary)',
+            borderRadius: '8px', padding: '8px 12px', fontSize: '12px',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '4px' }}>
+            <span style={{ fontWeight: 600, color: 'var(--color-text-primary)' }}>{sa.agentType}</span>
+            <span style={{
+              fontSize: '10px', padding: '1px 6px', borderRadius: '10px',
+              background: sa.status === 'active' ? 'rgba(22,198,12,0.15)' : 'var(--color-bg-tertiary)',
+              color: sa.status === 'active' ? 'var(--color-accent-success)' : 'var(--color-text-muted)',
+            }}>{sa.status}</span>
+            {sa.ephemeral && <span style={{ fontSize: '10px', color: 'var(--color-text-muted)' }}>ephemeral</span>}
+            {sa.mtime > 0 && <span style={{ marginLeft: 'auto', color: 'var(--color-text-muted)', fontSize: '11px' }}>{formatRelTime(sa.mtime)}</span>}
+          </div>
+          {sa.slug && <div style={{ color: 'var(--color-text-secondary)', marginBottom: '4px', fontStyle: 'italic' }}>{sa.slug}</div>}
+          {sa.model && <div style={{ color: 'var(--color-text-muted)', fontSize: '11px' }}>Model: {sa.model}</div>}
+          {sa.childSessionKey && (
+            <div style={{ color: 'var(--color-text-muted)', fontSize: '11px', fontFamily: 'var(--font-terminal)' }}>{sa.childSessionKey}</div>
+          )}
+          {!sa.ephemeral && (
+            <button
+              onClick={() => onSelect(sa.id)}
+              style={{
+                marginTop: '6px', padding: '3px 10px', fontSize: '11px',
+                background: 'var(--color-bg-button)', color: 'var(--color-text-button)',
+                border: 'none', borderRadius: '4px', cursor: 'pointer',
+              }}
+            >
+              View Events
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ─── SessionDetail ────────────────────────────────────────────────────────────
+
+type DetailTab = 'events' | 'stats' | 'subagents';
+
+function SessionDetail({ session, onBack, liveTick }: { session: RegistrySession; onBack: () => void; liveTick: number }) {
+  const [tab, setTab] = useState<DetailTab>('events');
+  const [subagentSessionId, setSubagentSessionId] = useState<string | null>(null);
+
+  const handleSubagentSelect = (id: string) => setSubagentSessionId(id);
+
+  const tabStyle = (t: DetailTab): React.CSSProperties => ({
+    padding: '6px 14px', fontSize: '13px', cursor: 'pointer', border: 'none', borderRadius: '6px',
+    background: tab === t ? 'var(--color-accent-primary)' : 'var(--color-bg-stat)',
+    color: tab === t ? '#fff' : 'var(--color-text-secondary)',
+    fontWeight: tab === t ? 600 : 400,
+  });
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+      {/* Header */}
+      <div style={{
+        display: 'flex', alignItems: 'flex-start', gap: '10px',
+        padding: '12px 16px', borderBottom: '1px solid var(--color-border-primary)',
+        background: 'var(--color-bg-header)', flexShrink: 0,
+      }}>
+        <button
+          onClick={onBack}
+          style={{
+            padding: '4px 10px', fontSize: '12px', cursor: 'pointer',
+            border: '1px solid var(--color-border-primary)', borderRadius: '6px',
+            background: 'var(--color-bg-card)', color: 'var(--color-text-secondary)',
+          }}
+        >← Back</button>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontWeight: 700, color: 'var(--color-text-title)', fontSize: '14px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {session.slug || session.sessionId.slice(0, 24) + '…'}
+          </div>
+          <div style={{ display: 'flex', gap: '8px', marginTop: '3px', flexWrap: 'wrap' }}>
+            <span style={{ fontSize: '11px', color: 'var(--color-text-muted)' }}>{session.project}</span>
+            <span style={{ fontSize: '11px', color: 'var(--color-text-muted)' }}>•</span>
+            <span style={{ fontSize: '11px', color: 'var(--color-text-muted)', fontFamily: 'var(--font-terminal)' }}>{session.source}</span>
+            {session.model && <><span style={{ fontSize: '11px', color: 'var(--color-text-muted)' }}>•</span><span style={{ fontSize: '11px', color: 'var(--color-text-muted)' }}>{session.model}</span></>}
+            <span style={{ fontSize: '11px', color: 'var(--color-text-muted)' }}>•</span>
+            <span style={{ fontSize: '11px', color: 'var(--color-text-muted)' }}>{formatSize(session.size)}</span>
+            <span style={{ fontSize: '11px', color: 'var(--color-text-muted)' }}>•</span>
+            <span style={{ fontSize: '11px', color: 'var(--color-text-muted)' }}>{formatRelTime(session.mtime)}</span>
+          </div>
+        </div>
+        <span style={{
+          padding: '3px 8px', borderRadius: '12px', fontSize: '11px', fontWeight: 600,
+          background: session.status === 'active' ? 'rgba(22,198,12,0.15)' : 'var(--color-bg-tertiary)',
+          color: session.status === 'active' ? 'var(--color-accent-success)' : 'var(--color-text-muted)',
+        }}>{session.status}</span>
+      </div>
+
+      {/* Tabs */}
+      <div style={{ display: 'flex', gap: '6px', padding: '10px 16px', borderBottom: '1px solid var(--color-border-primary)', flexShrink: 0 }}>
+        <button style={tabStyle('events')} onClick={() => { setTab('events'); setSubagentSessionId(null); }}>Events</button>
+        <button style={tabStyle('stats')} onClick={() => setTab('stats')}>Stats</button>
+        <button style={tabStyle('subagents')} onClick={() => setTab('subagents')}>
+          Subagents {session.subagentCount > 0 ? `(${session.subagentCount})` : ''}
+        </button>
+      </div>
+
+      {/* Content */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '16px' }}>
+        {tab === 'events' && !subagentSessionId && (
+          <SessionEventList sessionId={session.sessionId} liveTick={liveTick} />
+        )}
+        {tab === 'events' && subagentSessionId && (
+          <div>
+            <button
+              onClick={() => setSubagentSessionId(null)}
+              style={{
+                marginBottom: '10px', padding: '4px 10px', fontSize: '12px', cursor: 'pointer',
+                border: '1px solid var(--color-border-primary)', borderRadius: '6px',
+                background: 'var(--color-bg-card)', color: 'var(--color-text-secondary)',
+              }}
+            >← Back to parent events</button>
+            <div style={{ fontSize: '12px', color: 'var(--color-text-muted)', marginBottom: '10px' }}>
+              Subagent: <code style={{ fontFamily: 'var(--font-terminal)' }}>{subagentSessionId}</code>
+            </div>
+            <SessionEventList sessionId={subagentSessionId} liveTick={liveTick} />
+          </div>
+        )}
+        {tab === 'stats' && <SessionStatsPanel sessionId={session.sessionId} liveTick={liveTick} />}
+        {tab === 'subagents' && (
+          <SubagentList
+            sessionId={session.sessionId}
+            onSelect={(id) => { setTab('events'); handleSubagentSelect(id); }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+
+function SessionDetailPlaceholder() {
+  return (
+    <div style={{
+      flex: 1,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: '32px',
+      background: 'var(--color-bg-primary)',
+    }}>
+      <div style={{
+        fontSize: '28px',
+        fontWeight: 600,
+        color: 'var(--color-text-muted)',
+        textAlign: 'center',
+        letterSpacing: '0.05em',
+      }}>
+        {'<-- Choose a session to start!'}
+      </div>
+    </div>
+  );
+}
+
+
+// ─── SessionList ──────────────────────────────────────────────────────────────
+
+function SessionList({ onSelect, liveTick }: { onSelect: (s: RegistrySession) => void; liveTick: number }) {
+  const [sessions, setSessions] = useState<RegistrySession[]>([]);
+  const [total, setTotal] = useState(0);
+  const [projects, setProjects] = useState<string[]>([]);
+  const [sources, setSources] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [sourceFilter, setSourceFilter] = useState('');
+  const [projectFilter, setProjectFilter] = useState('');
+
+  const offsetRef = useRef(0);
+  const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const fetchSessions = useCallback(async (opts: { reset?: boolean; searchVal?: string; statusVal?: string; sourceVal?: string; projectVal?: string }) => {
+    const { reset, searchVal, statusVal, sourceVal, projectVal } = opts;
+    const s = searchVal ?? search;
+    const st = statusVal ?? statusFilter;
+    const src = sourceVal ?? sourceFilter;
+    const proj = projectVal ?? projectFilter;
+
+    if (reset) { offsetRef.current = 0; }
+
+    const params = new URLSearchParams({ limit: '50', offset: String(offsetRef.current) });
+    if (s) params.set('search', s);
+    if (st && st !== 'all') params.set('status', st);
+    if (src) params.set('source', src);
+    if (proj) params.set('project', proj);
+
+    try {
+      const data = await apiGet<{ sessions: RegistrySession[]; total: number; projects: string[]; sources: string[] }>(`${BASE}/list?${params}`);
+      if (reset) {
+        setSessions(data.sessions);
+      } else {
+        setSessions(prev => [...prev, ...data.sessions]);
+      }
+      setTotal(data.total);
+      setProjects(data.projects || []);
+      setSources(data.sources || []);
+      offsetRef.current += data.sessions.length;
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  }, [search, statusFilter, sourceFilter, projectFilter]);
+
+  const refresh = useCallback((overrides: { searchVal?: string; statusVal?: string; sourceVal?: string; projectVal?: string } = {}) => {
+    setLoading(true);
+    setError(null);
+    fetchSessions({ reset: true, ...overrides }).finally(() => setLoading(false));
+  }, [fetchSessions]);
+
+  useEffect(() => { refresh(); }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (!liveTick) return;
+    fetchSessions({ reset: true }).catch(() => {
+      // Keep UI stable on background refresh failures.
+    });
+  }, [liveTick, fetchSessions]);
+
+  const handleSearch = (val: string) => {
+    setSearch(val);
+    if (searchTimer.current) clearTimeout(searchTimer.current);
+    searchTimer.current = setTimeout(() => refresh({ searchVal: val }), 400);
+  };
+
+  const handleStatusChange = (val: string) => { setStatusFilter(val); refresh({ statusVal: val }); };
+  const handleSourceChange = (val: string) => { setSourceFilter(val); refresh({ sourceVal: val }); };
+  const handleProjectChange = (val: string) => { setProjectFilter(val); refresh({ projectVal: val }); };
+
+  const loadMore = async () => {
+    setLoadingMore(true);
+    await fetchSessions({});
+    setLoadingMore(false);
+  };
+
+  const inputStyle: React.CSSProperties = {
+    padding: '6px 10px', fontSize: '13px', background: 'var(--color-bg-input)',
+    border: '1px solid var(--color-border-primary)', borderRadius: '6px',
+    color: 'var(--color-text-primary)', outline: 'none',
+  };
+
+  const sourceColors: Record<string, string> = {
+    claude: 'var(--color-accent-observation)',
+    openclaw: 'var(--color-accent-prompt)',
+    codex: 'var(--color-accent-summary)',
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+      {/* Filters */}
+      <div style={{
+        padding: '12px 16px', borderBottom: '1px solid var(--color-border-primary)',
+        background: 'var(--color-bg-header)', display: 'flex', flexWrap: 'wrap', gap: '8px', alignItems: 'center', flexShrink: 0,
+      }}>
+        <input
+          type="text"
+          placeholder="Search sessions…"
+          value={search}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleSearch(e.target.value)}
+          style={{ ...inputStyle, flex: '1 1 200px', minWidth: '120px' }}
+        />
+        <select value={statusFilter} onChange={(e: React.ChangeEvent<HTMLSelectElement>) => handleStatusChange(e.target.value)} style={{ ...inputStyle, cursor: 'pointer' }}>
+          <option value="all">All Status</option>
+          <option value="active">Active</option>
+          <option value="completed">Completed</option>
+        </select>
+        <select value={sourceFilter} onChange={(e: React.ChangeEvent<HTMLSelectElement>) => handleSourceChange(e.target.value)} style={{ ...inputStyle, cursor: 'pointer' }}>
+          <option value="">All Sources</option>
+          {sources.map(s => <option key={s} value={s}>{s}</option>)}
+        </select>
+        <select value={projectFilter} onChange={(e: React.ChangeEvent<HTMLSelectElement>) => handleProjectChange(e.target.value)} style={{ ...inputStyle, cursor: 'pointer' }}>
+          <option value="">All Projects</option>
+          {projects.map(p => <option key={p} value={p}>{p}</option>)}
+        </select>
+        <button
+          onClick={() => refresh()}
+          style={{
+            padding: '6px 12px', fontSize: '12px', cursor: 'pointer',
+            border: '1px solid var(--color-border-primary)', borderRadius: '6px',
+            background: 'var(--color-bg-stat)', color: 'var(--color-text-secondary)',
+          }}
+        >↺ Refresh</button>
+        {total > 0 && <span style={{ fontSize: '12px', color: 'var(--color-text-muted)', marginLeft: 'auto' }}>{total} session{total !== 1 ? 's' : ''}</span>}
+      </div>
+
+      {/* Session items */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '8px' }}>
+        {loading && <div style={{ color: 'var(--color-text-muted)', padding: '20px 12px' }}>Loading sessions…</div>}
+        {error && <div style={{ color: 'var(--color-accent-error)', padding: '12px' }}>Error: {error}</div>}
+        {!loading && !error && sessions.length === 0 && (
+          <div style={{ color: 'var(--color-text-muted)', padding: '20px 12px' }}>No sessions found.</div>
+        )}
+        {sessions.map(s => (
+          <div
+            key={s.sessionId}
+            onClick={() => onSelect(s)}
+            style={{
+              background: 'var(--color-bg-card)', border: '1px solid var(--color-border-primary)',
+              borderRadius: '8px', padding: '10px 14px', marginBottom: '6px',
+              cursor: 'pointer', transition: 'border-color 0.15s',
+            }}
+            onMouseEnter={e => (e.currentTarget.style.borderColor = 'var(--color-border-hover)')}
+            onMouseLeave={e => (e.currentTarget.style.borderColor = 'var(--color-border-primary)')}
+          >
+            <div style={{ display: 'flex', alignItems: 'flex-start', gap: '8px' }}>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{
+                  fontWeight: 600, fontSize: '13px', color: 'var(--color-text-title)',
+                  overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+                }}>
+                  {s.slug || <span style={{ color: 'var(--color-text-muted)' }}>(no description)</span>}
+                </div>
+                <div style={{ display: 'flex', gap: '8px', marginTop: '3px', flexWrap: 'wrap' }}>
+                  <span style={{ fontSize: '11px', color: sourceColors[s.source] || 'var(--color-text-muted)', fontWeight: 600 }}>{s.source}</span>
+                  <span style={{ fontSize: '11px', color: 'var(--color-text-muted)' }}>{s.project}</span>
+                  {s.model && <span style={{ fontSize: '11px', color: 'var(--color-text-muted)' }}>{s.model}</span>}
+                  {s.gitBranch && <span style={{ fontSize: '11px', color: 'var(--color-text-muted)' }}>🌿 {s.gitBranch}</span>}
+                </div>
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: '3px', flexShrink: 0 }}>
+                <span style={{
+                  fontSize: '10px', padding: '2px 7px', borderRadius: '10px', fontWeight: 600,
+                  background: s.status === 'active' ? 'rgba(22,198,12,0.15)' : 'var(--color-bg-tertiary)',
+                  color: s.status === 'active' ? 'var(--color-accent-success)' : 'var(--color-text-muted)',
+                }}>{s.status}</span>
+                <span style={{ fontSize: '11px', color: 'var(--color-text-muted)' }}>{formatRelTime(s.mtime)}</span>
+                {s.duration > 0 && <span style={{ fontSize: '10px', color: 'var(--color-text-muted)' }}>{formatDurationCompact(s.duration)}</span>}
+                {s.contextPct > 0 && <span style={{ fontSize: '10px', color: 'var(--color-accent-summary)', fontWeight: 600 }}>{s.contextPct}% ctx</span>}
+                {s.subagentCount > 0 && <span style={{ fontSize: '10px', color: 'var(--color-accent-prompt)' }}>🤖 {s.subagentCount}</span>}
+              </div>
+            </div>
+          </div>
+        ))}
+        {!loading && sessions.length < total && (
+          <button
+            onClick={loadMore}
+            disabled={loadingMore}
+            style={{
+              display: 'block', width: '100%', padding: '8px', fontSize: '13px',
+              background: 'var(--color-bg-stat)', border: '1px solid var(--color-border-primary)',
+              borderRadius: '8px', cursor: 'pointer', color: 'var(--color-text-secondary)',
+            }}
+          >
+            {loadingMore ? 'Loading…' : `Load more (${total - sessions.length} remaining)`}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── SessionRegistryPage (main export) ───────────────────────────────────────
+
+export function SessionRegistryPage({ onNavigateHome }: { onNavigateHome: () => void }) {
+  const [selected, setSelected] = useState<RegistrySession | null>(null);
+  const liveTick = useSessionRegistryLiveTick();
+  const [isNarrowLayout, setIsNarrowLayout] = useState(() => (
+    typeof window !== 'undefined' ? window.innerWidth < 980 : false
+  ));
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    const handleResize = () => {
+      setIsNarrowLayout(window.innerWidth < 980);
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', overflow: 'hidden' }}>
+      {/* Page header */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: '12px',
+        padding: '10px 16px', background: 'var(--color-bg-header)',
+        borderBottom: '2px solid var(--color-border-primary)', flexShrink: 0,
+      }}>
+        <button
+          onClick={onNavigateHome}
+          style={{
+            padding: '5px 12px', fontSize: '13px', cursor: 'pointer',
+            border: '1px solid var(--color-border-primary)', borderRadius: '6px',
+            background: 'var(--color-bg-card)', color: 'var(--color-text-secondary)',
+            fontWeight: 500,
+          }}
+        >← Feed</button>
+        <h2 style={{ margin: 0, fontSize: '16px', fontWeight: 700, color: 'var(--color-text-title)' }}>
+          Session Registry
+        </h2>
+        <span style={{ fontSize: '12px', color: 'var(--color-text-muted)' }}>
+          Browse raw Claude Code, OpenClaw & Codex sessions
+        </span>
+      </div>
+
+      {/* Body: split or full */}
+      <div style={{ flex: 1, display: 'flex', overflow: 'hidden', flexDirection: isNarrowLayout ? 'column' : 'row' }}>
+        {/* Session list pane */}
+        <div style={{
+          width: isNarrowLayout ? '100%' : '360px',
+          minWidth: isNarrowLayout ? undefined : '280px',
+          height: isNarrowLayout ? '42%' : undefined,
+          minHeight: isNarrowLayout ? '240px' : undefined,
+          flexShrink: 0,
+          borderRight: isNarrowLayout ? 'none' : '1px solid var(--color-border-primary)',
+          borderBottom: isNarrowLayout ? '1px solid var(--color-border-primary)' : 'none',
+          overflow: 'hidden',
+          display: 'flex',
+          flexDirection: 'column',
+        }}>
+          <SessionList onSelect={setSelected} liveTick={liveTick} />
+        </div>
+
+        {/* Detail pane */}
+        <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          {selected ? (
+            <SessionDetail session={selected} onBack={() => setSelected(null)} liveTick={liveTick} />
+          ) : (
+            <SessionDetailPlaceholder />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/viewer/components/SessionRegistryPage.tsx
+++ b/src/ui/viewer/components/SessionRegistryPage.tsx
@@ -171,6 +171,44 @@ function useSessionRegistryLiveTick(): number {
   return tick;
 }
 
+// ─── Provider color helpers ──────────────────────────────────────────────────
+
+const PROVIDER_PALETTE: Record<string, { color: string; bg: string; border: string }> = {
+  claude:    { color: '#d4a27a', bg: 'rgba(212,162,122,0.12)', border: 'rgba(212,162,122,0.25)' },
+  anthropic: { color: '#d4a27a', bg: 'rgba(212,162,122,0.12)', border: 'rgba(212,162,122,0.25)' },
+  openai:    { color: '#74aa9c', bg: 'rgba(116,170,156,0.12)', border: 'rgba(116,170,156,0.25)' },
+  codex:     { color: '#74aa9c', bg: 'rgba(116,170,156,0.12)', border: 'rgba(116,170,156,0.25)' },
+  gpt:       { color: '#74aa9c', bg: 'rgba(116,170,156,0.12)', border: 'rgba(116,170,156,0.25)' },
+  gemini:    { color: '#8ab4f8', bg: 'rgba(138,180,248,0.12)', border: 'rgba(138,180,248,0.25)' },
+  google:    { color: '#8ab4f8', bg: 'rgba(138,180,248,0.12)', border: 'rgba(138,180,248,0.25)' },
+  moonshot:  { color: '#c4b5fd', bg: 'rgba(196,181,253,0.12)', border: 'rgba(196,181,253,0.25)' },
+  kimi:      { color: '#c4b5fd', bg: 'rgba(196,181,253,0.12)', border: 'rgba(196,181,253,0.25)' },
+  openclaw:  { color: '#f87171', bg: 'rgba(248,113,113,0.12)', border: 'rgba(248,113,113,0.25)' },
+  sonnet:    { color: '#d4a27a', bg: 'rgba(212,162,122,0.12)', border: 'rgba(212,162,122,0.25)' },
+  opus:      { color: '#d4a27a', bg: 'rgba(212,162,122,0.12)', border: 'rgba(212,162,122,0.25)' },
+  haiku:     { color: '#d4a27a', bg: 'rgba(212,162,122,0.12)', border: 'rgba(212,162,122,0.25)' },
+};
+
+const DEFAULT_BADGE = { color: 'var(--color-text-secondary)', bg: 'var(--color-bg-tertiary)', border: 'var(--color-border-primary)' };
+
+function getProviderBadge(name: string): { color: string; bg: string; border: string } {
+  const lower = name.toLowerCase();
+  for (const [key, val] of Object.entries(PROVIDER_PALETTE)) {
+    if (lower.includes(key)) return val;
+  }
+  return DEFAULT_BADGE;
+}
+
+function badgeStyle(name: string, extra?: React.CSSProperties): React.CSSProperties {
+  const p = getProviderBadge(name);
+  return {
+    fontSize: '10px', fontWeight: 600, padding: '1px 6px', borderRadius: '4px',
+    color: p.color, background: p.bg, border: `1px solid ${p.border}`,
+    fontFamily: 'var(--font-terminal)',
+    ...extra,
+  };
+}
+
 // ─── Formatting helpers ───────────────────────────────────────────────────────
 
 function formatRelTime(epochSec: number): string {
@@ -431,7 +469,7 @@ function SessionEventList({ sessionId, liveTick }: { sessionId: string; liveTick
 
   return (
     <div>
-      {events.map((ev, i) => (
+      {[...events].reverse().map((ev, i) => (
         <EventBlock key={ev.uuid || i} event={ev} />
       ))}
       {hasMore && (
@@ -550,42 +588,42 @@ function SubagentList({ sessionId, onSelect }: { sessionId: string; onSelect: (i
   if (!subagents.length) return <div style={{ color: 'var(--color-text-muted)' }}>No subagents found.</div>;
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
       {subagents.map(sa => (
         <div
           key={sa.id}
+          onClick={() => !sa.ephemeral && onSelect(sa.id)}
           style={{
             background: 'var(--color-bg-stat)', border: '1px solid var(--color-border-primary)',
-            borderRadius: '8px', padding: '8px 12px', fontSize: '12px',
+            borderRadius: '6px', padding: '6px 10px', fontSize: '12px',
+            cursor: sa.ephemeral ? 'default' : 'pointer',
+            transition: 'border-color 0.15s',
           }}
+          onMouseEnter={e => { if (!sa.ephemeral) e.currentTarget.style.borderColor = 'var(--color-border-hover)'; }}
+          onMouseLeave={e => { e.currentTarget.style.borderColor = 'var(--color-border-primary)'; }}
         >
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '4px' }}>
-            <span style={{ fontWeight: 600, color: 'var(--color-text-primary)' }}>{sa.agentType}</span>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+            <span style={badgeStyle(sa.agentType, { fontSize: '11px', fontWeight: 700 })}>{sa.agentType}</span>
             <span style={{
-              fontSize: '10px', padding: '1px 6px', borderRadius: '10px',
+              fontSize: '10px', fontWeight: 600, padding: '1px 6px', borderRadius: '10px',
               background: sa.status === 'active' ? 'rgba(22,198,12,0.15)' : 'var(--color-bg-tertiary)',
               color: sa.status === 'active' ? 'var(--color-accent-success)' : 'var(--color-text-muted)',
             }}>{sa.status}</span>
-            {sa.ephemeral && <span style={{ fontSize: '10px', color: 'var(--color-text-muted)' }}>ephemeral</span>}
-            {sa.mtime > 0 && <span style={{ marginLeft: 'auto', color: 'var(--color-text-muted)', fontSize: '11px' }}>{formatRelTime(sa.mtime)}</span>}
+            {sa.ephemeral && <span style={{
+              fontSize: '10px', padding: '1px 5px', borderRadius: '4px',
+              background: 'rgba(200,200,200,0.1)', color: 'var(--color-text-muted)', fontStyle: 'italic',
+            }}>ephemeral</span>}
+            {sa.model && <span style={badgeStyle(sa.model)}>{sa.model}</span>}
           </div>
-          {sa.slug && <div style={{ color: 'var(--color-text-secondary)', marginBottom: '4px', fontStyle: 'italic' }}>{sa.slug}</div>}
-          {sa.model && <div style={{ color: 'var(--color-text-muted)', fontSize: '11px' }}>Model: {sa.model}</div>}
-          {sa.childSessionKey && (
-            <div style={{ color: 'var(--color-text-muted)', fontSize: '11px', fontFamily: 'var(--font-terminal)' }}>{sa.childSessionKey}</div>
-          )}
-          {!sa.ephemeral && (
-            <button
-              onClick={() => onSelect(sa.id)}
-              style={{
-                marginTop: '6px', padding: '3px 10px', fontSize: '11px',
-                background: 'var(--color-bg-button)', color: 'var(--color-text-button)',
-                border: 'none', borderRadius: '4px', cursor: 'pointer',
-              }}
-            >
-              View Events
-            </button>
-          )}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', marginTop: '3px' }}>
+            {sa.mtime > 0 && <span style={{ fontSize: '10px', color: 'var(--color-text-muted)' }}>{formatRelTime(sa.mtime)}</span>}
+            {sa.slug && sa.mtime > 0 && <span style={{ fontSize: '10px', color: 'var(--color-text-muted)' }}>·</span>}
+            {sa.slug && (
+              <span style={{ fontSize: '11px', color: 'var(--color-text-secondary)', fontStyle: 'italic', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {sa.slug}
+              </span>
+            )}
+          </div>
         </div>
       ))}
     </div>
@@ -875,7 +913,7 @@ function SessionList({ onSelect, liveTick }: { onSelect: (s: RegistrySession) =>
                 <div style={{ display: 'flex', gap: '8px', marginTop: '3px', flexWrap: 'wrap' }}>
                   <span style={{ fontSize: '11px', color: sourceColors[s.source] || 'var(--color-text-muted)', fontWeight: 600 }}>{s.source}</span>
                   <span style={{ fontSize: '11px', color: 'var(--color-text-muted)' }}>{s.project}</span>
-                  {s.model && <span style={{ fontSize: '11px', color: 'var(--color-text-muted)' }}>{s.model}</span>}
+                  {s.model && <span style={badgeStyle(s.model)}>{s.model}</span>}
                   {s.gitBranch && <span style={{ fontSize: '11px', color: 'var(--color-text-muted)' }}>🌿 {s.gitBranch}</span>}
                 </div>
               </div>
@@ -887,8 +925,12 @@ function SessionList({ onSelect, liveTick }: { onSelect: (s: RegistrySession) =>
                 }}>{s.status}</span>
                 <span style={{ fontSize: '11px', color: 'var(--color-text-muted)' }}>{formatRelTime(s.mtime)}</span>
                 {s.duration > 0 && <span style={{ fontSize: '10px', color: 'var(--color-text-muted)' }}>{formatDurationCompact(s.duration)}</span>}
-                {s.contextPct > 0 && <span style={{ fontSize: '10px', color: 'var(--color-accent-summary)', fontWeight: 600 }}>{s.contextPct}% ctx</span>}
-                {s.subagentCount > 0 && <span style={{ fontSize: '10px', color: 'var(--color-accent-prompt)' }}>🤖 {s.subagentCount}</span>}
+                {(s.contextPct > 0 || s.subagentCount > 0) && (
+                  <span style={{ fontSize: '10px', display: 'flex', gap: '6px', alignItems: 'center' }}>
+                    {s.contextPct > 0 && <span style={{ color: 'var(--color-accent-summary)', fontWeight: 600 }}>{s.contextPct}% ctx</span>}
+                    {s.subagentCount > 0 && <span style={{ color: 'var(--color-accent-prompt)' }}>🤖 {s.subagentCount}</span>}
+                  </span>
+                )}
               </div>
             </div>
           </div>

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -15,7 +15,7 @@ export enum LogLevel {
   SILENT = 4
 }
 
-export type Component = 'HOOK' | 'WORKER' | 'SDK' | 'PARSER' | 'DB' | 'SYSTEM' | 'HTTP' | 'SESSION' | 'CHROMA' | 'CHROMA_MCP' | 'CHROMA_SYNC' | 'FOLDER_INDEX' | 'CLAUDE_MD' | 'QUEUE';
+export type Component = 'HOOK' | 'WORKER' | 'SDK' | 'PARSER' | 'DB' | 'SYSTEM' | 'HTTP' | 'SESSION' | 'CHROMA' | 'CHROMA_MCP' | 'CHROMA_SYNC' | 'FOLDER_INDEX' | 'CLAUDE_MD' | 'QUEUE' | 'SESSION_REGISTRY';
 
 interface LogContext {
   sessionId?: number;


### PR DESCRIPTION
## Summary
- add Session Registry page and navigation entry in the React viewer
- add worker-side Session Registry API route to list/filter raw sessions and fetch detailed session payloads
- support browsing sessions across Claude Code, OpenClaw, and OpenAI Codex sources
- add OpenAI Codex OAuth agent and provider routing/fallback plumbing required to process Codex-origin sessions
- apply final UI polish for session registry: responsive split layout, empty-state placeholder, and improved header CTA sizing

## Key implementation notes
- New backend route: `SessionRegistryRoutes` and viewer route wiring
- New frontend page: `SessionRegistryPage` with source/status/project/search filters and detail pane
- Provider stack updates for `openai-codex` validation and fallback handling in worker service
- Endpoint update for Codex provider to `chatgpt.com/backend-api/codex/responses`

## Validation
- `npm run build`
- manual verification of viewer navigation and session registry rendering/layout on narrow and wide widths

## Context
This branch includes the session registry feature commit plus follow-up bug fixes identified during implementation and review.
