### PR TITLE
fix: handle missing transcript in git worktrees

### DIFF
--- a/src/shared/transcript-parser.ts
+++ b/src/shared/transcript-parser.ts
@@ -1,5 +1,5 @@
-import { readFileSync, existsSync } from 'fs';
-import { logger } from '../utils/logger.js';
+import { readFileSync, existsSync } from "fs";
+import { logger } from "../utils/logger.js";
 
 /**
  * Extract last message of specified role from transcript JSONL file
@@ -9,19 +9,44 @@ import { logger } from '../utils/logger.js';
  */
 export function extractLastMessage(
   transcriptPath: string,
-  role: 'user' | 'assistant',
-  stripSystemReminders: boolean = false
+  role: "user" | "assistant",
+  stripSystemReminders: boolean = false,
 ): string {
   if (!transcriptPath || !existsSync(transcriptPath)) {
-    throw new Error(`Transcript path missing or file does not exist: ${transcriptPath}`);
+    // When running in a git worktree, Claude Code derives the transcript path
+    // from the worktree CWD, which encodes as a different project directory.
+    // The actual transcript lives under the main project path.
+    // Example: worktree path encodes as -project--claude-worktrees-name/session.jsonl
+    //          but transcript lives at -project/session.jsonl
+    // Try stripping the worktree segment from the encoded path.
+    const worktreeFixed = transcriptPath?.replace(
+      /(\/[^/]+)--claude-worktrees-[^/]+(\/)/,
+      "$1$2",
+    );
+    if (
+      worktreeFixed &&
+      worktreeFixed !== transcriptPath &&
+      existsSync(worktreeFixed)
+    ) {
+      logger.info("PARSER", "Transcript found via worktree path fallback", {
+        original: transcriptPath,
+        resolved: worktreeFixed,
+      });
+      return extractLastMessage(worktreeFixed, role, stripSystemReminders);
+    }
+    // Gracefully return empty instead of throwing — caller handles empty string
+    logger.debug("PARSER", "Transcript not found, returning empty", {
+      path: transcriptPath,
+    });
+    return "";
   }
 
-  const content = readFileSync(transcriptPath, 'utf-8').trim();
+  const content = readFileSync(transcriptPath, "utf-8").trim();
   if (!content) {
     throw new Error(`Transcript file exists but is empty: ${transcriptPath}`);
   }
 
-  const lines = content.split('\n');
+  const lines = content.split("\n");
   let foundMatchingRole = false;
 
   for (let i = lines.length - 1; i >= 0; i--) {
@@ -30,24 +55,29 @@ export function extractLastMessage(
       foundMatchingRole = true;
 
       if (line.message?.content) {
-        let text = '';
+        let text = "";
         const msgContent = line.message.content;
 
-        if (typeof msgContent === 'string') {
+        if (typeof msgContent === "string") {
           text = msgContent;
         } else if (Array.isArray(msgContent)) {
           text = msgContent
-            .filter((c: any) => c.type === 'text')
+            .filter((c: any) => c.type === "text")
             .map((c: any) => c.text)
-            .join('\n');
+            .join("\n");
         } else {
           // Unknown content format - throw error
-          throw new Error(`Unknown message content format in transcript. Type: ${typeof msgContent}`);
+          throw new Error(
+            `Unknown message content format in transcript. Type: ${typeof msgContent}`,
+          );
         }
 
         if (stripSystemReminders) {
-          text = text.replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, '');
-          text = text.replace(/\n{3,}/g, '\n\n').trim();
+          text = text.replace(
+            /<system-reminder>[\s\S]*?<\/system-reminder>/g,
+            "",
+          );
+          text = text.replace(/\n{3,}/g, "\n\n").trim();
         }
 
         // Return text even if empty - caller decides if that's an error
@@ -58,8 +88,8 @@ export function extractLastMessage(
 
   // If we searched the whole transcript and didn't find any message of this role
   if (!foundMatchingRole) {
-    return '';
+    return "";
   }
 
-  return '';
+  return "";
 }


### PR DESCRIPTION
## Summary

Fixes #1234, #1235

When Claude Code runs in a git worktree (via `EnterWorktree` or `Task` with `isolation: "worktree"`), the `transcript_path` passed to the Stop hook is derived from the worktree CWD. This encodes to a different `~/.claude/projects/` directory than where transcripts are actually stored, causing `extractLastMessage()` to throw on every turn.

**Example:**
- Worktree CWD: `/project/.claude/worktrees/my-feature/`
- Encoded path: `~/.claude/projects/-project--claude-worktrees-my-feature/session.jsonl` (doesn't exist)
- Actual path: `~/.claude/projects/-project/session.jsonl`

## Changes

**`src/shared/transcript-parser.ts`:**
1. When transcript path doesn't exist, try stripping `--claude-worktrees-<name>` from the encoded project directory and retry
2. If still not found, return `""` instead of throwing — consistent with how `summarizeHandler` already handles null `transcriptPath`

## Why this approach

- **Minimal change** — single file, single function
- **Uses existing pattern** — the summarize handler already returns gracefully when `transcriptPath` is null; this extends that to the "file not found" case
- **Worktree fallback is additive** — only triggers when the original path fails AND the path contains the worktree encoding pattern
- The existing `detectWorktree()` utility in `src/utils/worktree.ts` detects worktrees from the filesystem, but the transcript path problem occurs in the encoded project directory name, so regex on the path is the right approach here

## Test plan

- [x] Verified regex correctly strips worktree segment from encoded paths
- [x] Tested locally — stop hook no longer errors in worktree sessions
- [x] Non-worktree sessions unaffected (regex doesn't match, original path works)