### PR TITLE
fix: remove unrecognized fields from Claude Code Stop hook output

### DIFF
--- a/src/cli/adapters/claude-code.ts
+++ b/src/cli/adapters/claude-code.ts
@@ -16,20 +16,19 @@ export const claudeCodeAdapter: PlatformAdapter = {
     };
   },
   formatOutput(result) {
-    if (result.hookSpecificOutput) {
+    const r = result ?? ({} as HookResult);
+    if (r.hookSpecificOutput) {
       const output: Record<string, unknown> = { hookSpecificOutput: result.hookSpecificOutput };
-      if (result.systemMessage) {
-        output.systemMessage = result.systemMessage;
+      if (r.systemMessage) {
+        output.systemMessage = r.systemMessage;
       }
       return output;
     }
-    // Return only fields from the Claude Code hook contract.
-    // Stop hooks validate against {decision?, reason?, systemMessage?} and reject
-    // unrecognized fields like `continue` or `suppressOutput` with
-    // "JSON validation failed". An empty object is valid for all hook types.
+    // Only emit fields in the Claude Code hook contract — unrecognized fields
+    // cause "JSON validation failed" in Stop hooks.
     const output: Record<string, unknown> = {};
-    if (result.systemMessage) {
-      output.systemMessage = result.systemMessage;
+    if (r.systemMessage) {
+      output.systemMessage = r.systemMessage;
     }
     return output;
   }

--- a/tests/hook-lifecycle.test.ts
+++ b/tests/hook-lifecycle.test.ts
@@ -256,43 +256,74 @@ describe('Cursor IDE Compatibility (#838, #1049)', () => {
 // --- Platform Adapter Tests ---
 
 describe('Hook Lifecycle - Claude Code Adapter', () => {
-  it('should return empty object for default result (no unrecognized fields)', async () => {
+  const fmt = async (input: any) => {
     const { claudeCodeAdapter } = await import('../src/cli/adapters/claude-code.js');
+    return claudeCodeAdapter.formatOutput(input);
+  };
 
-    // Empty result should produce empty output — Claude Code Stop hooks
-    // reject unrecognized fields like `continue` or `suppressOutput`
-    const output = claudeCodeAdapter.formatOutput({});
-    expect(output).toEqual({});
+  // --- Happy paths ---
+
+  it('should return empty object for empty result', async () => {
+    expect(await fmt({})).toEqual({});
   });
 
-  it('should not include continue or suppressOutput in output', async () => {
-    const { claudeCodeAdapter } = await import('../src/cli/adapters/claude-code.js');
-
-    const output = claudeCodeAdapter.formatOutput({ continue: true, suppressOutput: true }) as Record<string, unknown>;
-    expect(output.continue).toBeUndefined();
-    expect(output.suppressOutput).toBeUndefined();
+  it('should include systemMessage when present', async () => {
+    expect(await fmt({ systemMessage: 'test message' })).toEqual({ systemMessage: 'test message' });
   });
 
-  it('should include systemMessage when present in result', async () => {
-    const { claudeCodeAdapter } = await import('../src/cli/adapters/claude-code.js');
-
-    const output = claudeCodeAdapter.formatOutput({ systemMessage: 'test message' }) as Record<string, unknown>;
-    expect(output.systemMessage).toBe('test message');
-  });
-
-  it('should use hookSpecificOutput format for context injection', async () => {
-    const { claudeCodeAdapter } = await import('../src/cli/adapters/claude-code.js');
-
-    const result = {
+  it('should use hookSpecificOutput format with systemMessage', async () => {
+    const output = await fmt({
       hookSpecificOutput: { hookEventName: 'SessionStart', additionalContext: 'test context' },
       systemMessage: 'test message'
-    };
-    const output = claudeCodeAdapter.formatOutput(result) as Record<string, unknown>;
+    }) as Record<string, unknown>;
     expect(output.hookSpecificOutput).toEqual({ hookEventName: 'SessionStart', additionalContext: 'test context' });
     expect(output.systemMessage).toBe('test message');
-    // Should NOT have continue/suppressOutput when using hookSpecificOutput
-    expect(output.continue).toBeUndefined();
-    expect(output.suppressOutput).toBeUndefined();
+  });
+
+  it('should return hookSpecificOutput without systemMessage when absent', async () => {
+    expect(await fmt({
+      hookSpecificOutput: { hookEventName: 'SessionStart', additionalContext: 'ctx' },
+    })).toEqual({
+      hookSpecificOutput: { hookEventName: 'SessionStart', additionalContext: 'ctx' },
+    });
+  });
+
+  // --- Edge cases / unhappy paths (addresses PR #1291 review) ---
+
+  it('should return empty object for malformed input (undefined/null)', async () => {
+    expect(await fmt(undefined)).toEqual({});
+    expect(await fmt(null)).toEqual({});
+  });
+
+  it('should exclude falsy systemMessage values', async () => {
+    expect(await fmt({ systemMessage: '' })).toEqual({});
+    expect(await fmt({ systemMessage: null })).toEqual({});
+    expect(await fmt({ systemMessage: 0 })).toEqual({});
+  });
+
+  it('should strip all non-contract fields', async () => {
+    expect(await fmt({
+      continue: false,
+      suppressOutput: false,
+      systemMessage: 'msg',
+      exitCode: 2,
+      hookSpecificOutput: undefined,
+    })).toEqual({ systemMessage: 'msg' });
+  });
+
+  it('should only emit keys from the Claude Code hook contract', async () => {
+    const allowedKeys = new Set(['hookSpecificOutput', 'systemMessage', 'decision', 'reason']);
+    const cases = [
+      {},
+      { systemMessage: 'x' },
+      { continue: true, suppressOutput: true, systemMessage: 'x', exitCode: 1 },
+      { hookSpecificOutput: { hookEventName: 'E', additionalContext: 'C' }, systemMessage: 'x' },
+    ];
+    for (const input of cases) {
+      for (const key of Object.keys(await fmt(input) as object)) {
+        expect(allowedKeys.has(key)).toBe(true);
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #1290
Fixes #1288

The Claude Code adapter's `formatOutput()` was returning `{continue: true, suppressOutput: true}` for all hook events. These fields are not part of the Claude Code hook API:
- **`continue: true`** causes Claude Code to re-invoke stop hooks in an infinite loop (#1288)
- **Both fields** fail Stop hook JSON schema validation with "JSON validation failed" (#1290)

## Changes

- **`src/cli/adapters/claude-code.ts`**: Changed `formatOutput()` to return `{}` (empty object) for the default case instead of `{continue, suppressOutput}`. Preserves `systemMessage` when present. Added defensive null guard (`result ?? {}`) matching the existing `normalizeInput` pattern. The `hookSpecificOutput` path (used by SessionStart) is unchanged.
- **`tests/hook-lifecycle.test.ts`**: Updated Claude Code adapter tests to assert the corrected output format. Added unhappy-path edge case tests per review feedback.

## Why this is safe

- `{}` is valid for all Claude Code hook event types (Stop, SessionStart, PostToolUse, etc.)
- The `continue` and `suppressOutput` fields were never part of Claude Code's hook contract — they were silently ignored for non-Stop events
- The `hookSpecificOutput` path used by SessionStart context injection is unaffected
- All 69 existing hook tests pass across 2 test files

## Edge case tests added (per review)

| Test | What it covers |
|------|---------------|
| Malformed input (undefined/null) | `formatOutput(undefined)` and `formatOutput(null)` return `{}` |
| Falsy systemMessage values | Empty string, null, and 0 are excluded from output |
| All HookResult fields populated | Only `systemMessage` survives; `continue`, `suppressOutput`, `exitCode` stripped |
| hookSpecificOutput without systemMessage | Branch A works correctly without optional field |
| Contract key allowlist | Output keys are always a subset of `{hookSpecificOutput, systemMessage, decision, reason}` |

## Verification

Built from source and compared output of the installed (broken) vs built (fixed) plugin:

| Test | Installed v10.5.2 (broken) | Built (fixed) |
|------|--------------------|---------------|
| `summarize` Stop hook | `{"continue":true,"suppressOutput":true}` | `{}` |
| `session-complete` Stop hook | `{"continue":true,"suppressOutput":true}` | `{}` |
| SessionStart `context` hook | `{hookSpecificOutput: ...}` | `{hookSpecificOutput: ...}` (unchanged) |
| Exit code | 0 | 0 |

```
$ bun test tests/hook-lifecycle.test.ts tests/hook-command.test.ts

 69 pass
 0 fail
 107 expect() calls
Ran 69 tests across 2 files.
```

## Test plan

- [x] `bun test tests/hook-lifecycle.test.ts tests/hook-command.test.ts` — 69 tests pass
- [x] Built plugin from source, verified Stop hooks output `{}` instead of `{"continue":true,"suppressOutput":true}`
- [x] Verified `hookSpecificOutput` path still works for SessionStart context injection
- [x] Verified `systemMessage` is preserved when present
- [x] Compared installed v10.5.2 output vs built output side-by-side
- [x] Added unhappy-path tests for malformed input, falsy values, and contract compliance