### PR TITLE
fix(openclaw): fix worker startup race condition in installer

### DIFF
--- a/openclaw/install.sh
+++ b/openclaw/install.sh
@@ -1265,8 +1265,22 @@ start_worker() {
   fi
 
   # Remove stale PID files to prevent the worker from detecting its own PID
-  # as an existing instance and refusing to start (self-duplicate detection bug)
-  rm -f "${HOME}/.claude-mem/worker.pid" "${HOME}/.claude-mem/worker-37777.pid" 2>/dev/null
+  # as an existing instance and refusing to start (self-duplicate detection bug).
+  # Only remove if the PID inside is dead — a live worker means we should skip restart.
+  for _pidfile in "${HOME}/.claude-mem/worker.pid" "${HOME}/.claude-mem/worker-37777.pid"; do
+    if [[ -f "$_pidfile" ]]; then
+      _old_pid=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('$_pidfile','utf8')).pid)}catch{}" 2>/dev/null)
+      if [[ -n "$_old_pid" ]] && kill -0 "$_old_pid" 2>/dev/null; then
+        # Verify it's actually a worker process, not a recycled PID
+        if ps -p "$_old_pid" -o args= 2>/dev/null | grep -q "worker-service"; then
+          info "Worker already running (PID: $_old_pid) — skipping start"
+          return 0
+        fi
+      fi
+      # PID is dead or not a worker process — safe to remove stale file
+      rm -f "$_pidfile" 2>/dev/null
+    fi
+  done
 
   # Start worker in background with nohup using --daemon flag.
   # The --daemon flag triggers the worker's default code path which starts

--- a/openclaw/test-install.sh
+++ b/openclaw/test-install.sh
@@ -2324,6 +2324,92 @@ test_skill_md_documents_options() {
 test_skill_md_documents_options
 
 ###############################################################################
+# Worker PID file handling tests
+###############################################################################
+
+test_worker_stale_pid_cleanup() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local fake_home="$tmpdir/fakehome"
+  mkdir -p "$fake_home/.claude-mem"
+
+  # Write a PID file with a dead PID (99999999 should not exist)
+  cat > "$fake_home/.claude-mem/worker.pid" <<'EOF'
+{"pid":99999999,"port":37777,"startedAt":"2026-01-01T00:00:00.000Z","version":"installer"}
+EOF
+
+  # Source the relevant function and check that the stale file gets removed
+  # We test the logic inline since start_worker has other dependencies
+  local _pidfile="$fake_home/.claude-mem/worker.pid"
+  local _old_pid
+  _old_pid=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('$_pidfile','utf8')).pid)}catch{}" 2>/dev/null)
+
+  if [[ -n "$_old_pid" ]] && ! kill -0 "$_old_pid" 2>/dev/null; then
+    rm -f "$_pidfile" 2>/dev/null
+  fi
+
+  if [[ ! -f "$_pidfile" ]]; then
+    test_pass "Stale PID file (dead process) is removed"
+  else
+    test_fail "Stale PID file was not removed"
+  fi
+
+  rm -rf "$tmpdir"
+}
+
+test_worker_live_pid_preserved() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local fake_home="$tmpdir/fakehome"
+  mkdir -p "$fake_home/.claude-mem"
+
+  # Write a PID file with our own PID (guaranteed alive, but not a worker)
+  cat > "$fake_home/.claude-mem/worker.pid" <<EOF
+{"pid":$$,"port":37777,"startedAt":"2026-01-01T00:00:00.000Z","version":"installer"}
+EOF
+
+  local _pidfile="$fake_home/.claude-mem/worker.pid"
+  local _old_pid
+  _old_pid=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync('$_pidfile','utf8')).pid)}catch{}" 2>/dev/null)
+
+  local should_remove=true
+  if [[ -n "$_old_pid" ]] && kill -0 "$_old_pid" 2>/dev/null; then
+    # PID is alive — check if it's actually a worker process
+    if ps -p "$_old_pid" -o args= 2>/dev/null | grep -q "worker-service"; then
+      should_remove=false
+    fi
+    # PID alive but not a worker → still remove (recycled PID)
+  fi
+
+  if [[ "$should_remove" == "true" ]]; then
+    rm -f "$_pidfile" 2>/dev/null
+  fi
+
+  # Our PID is alive but NOT a worker-service process, so the file should be removed
+  if [[ ! -f "$_pidfile" ]]; then
+    test_pass "PID file with live non-worker PID is removed (recycled PID)"
+  else
+    test_fail "PID file with live non-worker PID was preserved incorrectly"
+  fi
+
+  rm -rf "$tmpdir"
+}
+
+test_worker_daemon_flag_present() {
+  # Verify install.sh passes --daemon to worker-service
+  if grep -q 'worker_script.*--daemon' "$INSTALL_SCRIPT" || \
+     grep -q '"$worker_script" --daemon' "$INSTALL_SCRIPT"; then
+    test_pass "install.sh passes --daemon flag to worker-service"
+  else
+    test_fail "install.sh does not pass --daemon flag to worker-service"
+  fi
+}
+
+test_worker_stale_pid_cleanup
+test_worker_live_pid_preserved
+test_worker_daemon_flag_present
+
+###############################################################################
 # Summary
 ###############################################################################
 


### PR DESCRIPTION
## Problem

The OpenClaw installer's `start_worker()` function silently fails to start the worker — the process spawns, immediately exits with code 0, and the health check times out after 30 attempts.

This affects both Linux and macOS installations via `bash <(curl -fsSL https://install.cmem.ai/openclaw.sh)`.

## Root Cause

Two bugs in `openclaw/install.sh`:

### 1. PID file race condition (self-duplicate detection)

The installer writes a PID file containing the worker's own PID **before** the worker starts:

```bash
nohup "$BUN_PATH" "$worker_script" >> "$log_file" 2>&1 &
WORKER_PID=$!
# Writes {pid: WORKER_PID} to worker.pid immediately
```

When `worker-service.cjs` starts and hits the `default` code path, it reads this PID file, finds the PID alive (it's checking itself), concludes another instance is already running, and exits:

```js
// In worker-service.cjs default path:
let i = Rf();  // reads PID file → finds own PID
i && xw(i.pid) && process.exit(0);  // alive check → true → exit
```

### 2. Missing `--daemon` flag

Without passing `--daemon` as `argv[2]`, the worker falls into the `default` switch case which includes the duplicate instance detection. The `--daemon` flag triggers the correct startup path.

## Fix

- Remove stale PID files before starting the worker
- Pass `--daemon` flag to `worker-service.cjs`
- Let the worker manage its own PID file internally (written after successful server startup)

## Testing

Tested on:
- **Linux** (Arch Linux x64, Bun 1.3.10)
- **macOS** (Mac mini, Bun 1.3.10)

Both confirmed worker starts successfully and responds to health checks after the fix.