### PR TITLE
fix: add content-hash dedup to batch observation store methods

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -1659,15 +1659,23 @@ export class SessionStore {
     const storeTx = this.db.transaction(() => {
       const observationIds: number[] = [];
 
-      // 1. Store all observations
+      // 1. Store all observations (with content-hash deduplication)
       const obsStmt = this.db.prepare(`
         INSERT INTO observations
         (memory_session_id, project, type, title, subtitle, facts, narrative, concepts,
-         files_read, files_modified, prompt_number, discovery_tokens, created_at, created_at_epoch)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         files_read, files_modified, prompt_number, discovery_tokens, content_hash, created_at, created_at_epoch)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
 
       for (const observation of observations) {
+        // Content-hash deduplication (same logic as storeObservation singular)
+        const contentHash = computeObservationContentHash(memorySessionId, observation.title, observation.narrative);
+        const existing = findDuplicateObservation(this.db, contentHash, timestampEpoch);
+        if (existing) {
+          observationIds.push(existing.id);
+          continue;
+        }
+
         const result = obsStmt.run(
           memorySessionId,
           project,
@@ -1681,6 +1689,7 @@ export class SessionStore {
           JSON.stringify(observation.files_modified),
           promptNumber || null,
           discoveryTokens,
+          contentHash,
           timestampIso,
           timestampEpoch
         );
@@ -1779,15 +1788,23 @@ export class SessionStore {
     const storeAndMarkTx = this.db.transaction(() => {
       const observationIds: number[] = [];
 
-      // 1. Store all observations
+      // 1. Store all observations (with content-hash deduplication)
       const obsStmt = this.db.prepare(`
         INSERT INTO observations
         (memory_session_id, project, type, title, subtitle, facts, narrative, concepts,
-         files_read, files_modified, prompt_number, discovery_tokens, created_at, created_at_epoch)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         files_read, files_modified, prompt_number, discovery_tokens, content_hash, created_at, created_at_epoch)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
 
       for (const observation of observations) {
+        // Content-hash deduplication (same logic as storeObservation singular)
+        const contentHash = computeObservationContentHash(memorySessionId, observation.title, observation.narrative);
+        const existing = findDuplicateObservation(this.db, contentHash, timestampEpoch);
+        if (existing) {
+          observationIds.push(existing.id);
+          continue;
+        }
+
         const result = obsStmt.run(
           memorySessionId,
           project,
@@ -1801,6 +1818,7 @@ export class SessionStore {
           JSON.stringify(observation.files_modified),
           promptNumber || null,
           discoveryTokens,
+          contentHash,
           timestampIso,
           timestampEpoch
         );


### PR DESCRIPTION
## Problem

`storeObservations()` and `storeObservationsAndMarkComplete()` are missing the content-hash deduplication that `storeObservation()` (singular) already has via `computeObservationContentHash()` and `findDuplicateObservation()`.

This causes providers that return multiple observations per response (confirmed with Gemini, likely affects others) to insert **2-10x duplicate rows per tool use**. The batch methods insert unconditionally without checking `content_hash`.

### Root cause

`storeObservation()` (singular, line 1503) correctly:
1. Computes `contentHash` via `computeObservationContentHash()`
2. Checks for duplicates via `findDuplicateObservation()` (30s window)
3. Returns early if duplicate found
4. Includes `content_hash` in the INSERT

`storeObservations()` (plural, line 1629) and `storeObservationsAndMarkComplete()` (line 1747) do **none of this** — no hash computation, no duplicate check, no `content_hash` column in INSERT.

The main code path (`ei()` / `ResponseProcessor`) calls `storeObservations` (plural), so the dedup in the singular method is never reached.

### Fix

Added the same dedup pattern to both batch methods:
1. Compute content hash via `computeObservationContentHash()`
2. Check for existing observation within 30s window via `findDuplicateObservation()`
3. Skip insert and reuse existing ID if duplicate found
4. Include `content_hash` column in INSERT statement

### Testing

Tested locally with Gemini provider (`gemini-2.5-flash-lite`) on v10.5.2:
- **Before patch**: Every observation inserted 2-3x (new) or 10-30x (backlog processing)
- **After patch**: Zero duplicates across 11 test observations, all with unique `content_hash` values

### Related

Fixes #1158