### PR TITLE
fix(ui): include SSE live data when project filter is active

### DIFF
--- a/src/ui/viewer/App.tsx
+++ b/src/ui/viewer/App.tsx
@@ -25,29 +25,26 @@ export function App() {
   const { preference, resolvedTheme, setThemePreference } = useTheme();
   const pagination = usePagination(currentFilter);
 
-  // When filtering by project: ONLY use paginated data (API-filtered)
-  // When showing all projects: merge SSE live data with paginated data
+  // Merge SSE live data with paginated data, filtering by project when active
   const allObservations = useMemo(() => {
-    if (currentFilter) {
-      // Project filter active: API handles filtering, ignore SSE items
-      return paginatedObservations;
-    }
-    // No filter: merge SSE + paginated, deduplicate by ID
-    return mergeAndDeduplicateByProject(observations, paginatedObservations);
+    const live = currentFilter
+      ? observations.filter(o => o.project === currentFilter)
+      : observations;
+    return mergeAndDeduplicateByProject(live, paginatedObservations);
   }, [observations, paginatedObservations, currentFilter]);
 
   const allSummaries = useMemo(() => {
-    if (currentFilter) {
-      return paginatedSummaries;
-    }
-    return mergeAndDeduplicateByProject(summaries, paginatedSummaries);
+    const live = currentFilter
+      ? summaries.filter(s => s.project === currentFilter)
+      : summaries;
+    return mergeAndDeduplicateByProject(live, paginatedSummaries);
   }, [summaries, paginatedSummaries, currentFilter]);
 
   const allPrompts = useMemo(() => {
-    if (currentFilter) {
-      return paginatedPrompts;
-    }
-    return mergeAndDeduplicateByProject(prompts, paginatedPrompts);
+    const live = currentFilter
+      ? prompts.filter(p => p.project === currentFilter)
+      : prompts;
+    return mergeAndDeduplicateByProject(live, paginatedPrompts);
   }, [prompts, paginatedPrompts, currentFilter]);
 
   // Toggle context preview modal

--- a/src/ui/viewer/utils/data.ts
+++ b/src/ui/viewer/utils/data.ts
@@ -5,10 +5,9 @@
 
 /**
  * Merge real-time SSE items with paginated items, removing duplicates by ID
- * NOTE: This should ONLY be used when no project filter is active.
- * When filtering, use ONLY paginated data (API-filtered).
+ * Callers should pre-filter liveItems by project when a filter is active.
  *
- * @param liveItems - Items from SSE stream (unfiltered)
+ * @param liveItems - Items from SSE stream (pre-filtered if needed)
  * @param paginatedItems - Items from pagination API
  * @returns Merged and deduplicated array
  */


### PR DESCRIPTION
## Summary

- Fix SSE live data being discarded when a project filter is selected in the Web UI
- New observations, summaries, and prompts now appear in real-time regardless of filter state

## Problem

When `currentFilter` is set (user selects a project from dropdown), `App.tsx` ignores all SSE data and only shows paginated API data. This means new `new_summary`, `new_observation`, and `new_prompt` SSE events are invisible until the user refreshes the page.

**Before:** SSE live data discarded → no real-time updates when filtered
**After:** SSE live data filtered by project → real-time updates work with any filter

## Changes

- `src/ui/viewer/App.tsx`: Filter SSE data by project before merging with paginated data (instead of discarding it)
- `src/ui/viewer/utils/data.ts`: Update JSDoc to reflect new caller responsibility

## Test plan

- [ ] Open Web UI at localhost:37777, select a specific project filter
- [ ] Trigger tool use in Claude Code → verify new observation card appears in real-time
- [ ] Wait for Stop hook to fire → verify SESSION SUMMARY card appears
- [ ] Switch to "All Projects" → verify data still merges correctly
- [ ] Verify no duplicate cards appear when switching filters

Fixes #1313

🤖 Generated with [Claude Code](https://claude.com/claude-code)