### PR TITLE
fix: gracefully handle missing transcript files in worktree sessions

### DIFF
--- a/src/shared/transcript-parser.ts
+++ b/src/shared/transcript-parser.ts
@@ -13,12 +13,14 @@ export function extractLastMessage(
   stripSystemReminders: boolean = false
 ): string {
   if (!transcriptPath || !existsSync(transcriptPath)) {
-    throw new Error(`Transcript path missing or file does not exist: ${transcriptPath}`);
+    logger.warn('PARSER', `Transcript path missing or file does not exist: ${transcriptPath}`);
+    return '';
   }
 
   const content = readFileSync(transcriptPath, 'utf-8').trim();
   if (!content) {
-    throw new Error(`Transcript file exists but is empty: ${transcriptPath}`);
+    logger.warn('PARSER', `Transcript file exists but is empty: ${transcriptPath}`);
+    return '';
   }
 
   const lines = content.split('\n');


### PR DESCRIPTION
## Summary

- **Bug**: When Claude Code runs sessions in ephemeral worktrees (via Agent tool with `isolation: "worktree"`), the Stop hook's summarize handler crashes because `extractLastMessage()` throws when the transcript file no longer exists after worktree cleanup
- **Impact**: Each throw triggers a Claude response → another Stop hook → another throw, creating an infinite error loop that spams the session with hundreds of identical errors
- **Fix**: Changed `extractLastMessage()` to log a warning and return `''` instead of throwing when the transcript file is missing or empty. The summarize handler already handles empty messages gracefully — it just sends an empty summary to the worker

## Root Cause

The transcript path for worktree sessions (e.g. `-Users-j-GitHub-documenters--claude-worktrees-upgrade-posthog-python/`) is derived from the worktree directory. When the worktree is cleaned up after the Agent completes, that project directory and its `.jsonl` transcript no longer exist. But Claude Code continues to fire Stop hooks for the session, causing `extractLastMessage()` to throw on every turn-end.

## Changes

`src/shared/transcript-parser.ts`:
- File not found: `throw` → `logger.warn()` + `return ''`
- Empty file: `throw` → `logger.warn()` + `return ''`

## Test plan

- [ ] Run a session using Agent tool with `isolation: "worktree"` — verify Stop hook completes without errors after worktree cleanup
- [ ] Run a normal session — verify summary still works correctly (transcript exists and is readable)
- [ ] Verify worker logs show WARN instead of ERROR for missing transcripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)