### PR TITLE
fix: move session-complete from Stop to SessionEnd hook

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -70,7 +70,13 @@
             "type": "command",
             "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code summarize",
             "timeout": 120
-          },
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
           {
             "type": "command",
             "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code session-complete",


### PR DESCRIPTION
## Summary

- Move `session-complete` from the `Stop` hook to `SessionEnd` hook
- `Stop` fires every turn (on each Claude response), while `SessionEnd` fires only on actual session termination
- Having `session-complete` in `Stop` kills the SDK agent via SIGTERM every turn, causing the next `summarize` to fail with an empty response

## Root Cause

The `Stop` hook array currently runs both `summarize` and `session-complete` sequentially. Since `session-complete` terminates the SDK agent process, the agent must restart on the next turn. This creates a race condition where `summarize` receives an empty response because the agent hasn't fully restarted.

## Fix

Move `session-complete` to `SessionEnd`, which only fires when the session actually ends (`/quit`, `Ctrl+D`, `/clear`, etc.). This keeps the SDK agent alive between turns so `summarize` can reliably generate summaries.

## Testing

- Verified summaries are generated and stored in `session_summaries` table after each turn
- Verified session summary cards display correctly in the Web UI
- No queue stacking or stuck processing items observed

Fixes #1314

🤖 Generated with [Claude Code](https://claude.com/claude-code)