### PR TITLE
fix: prevent infinite restart loop on FK constraint errors

### DIFF
--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -561,6 +561,7 @@ export class WorkerService {
           'ENOENT',
           'spawn',
           'Invalid API key',
+          'FOREIGN KEY constraint failed',
         ];
         if (unrecoverablePatterns.some(pattern => errorMessage.includes(pattern))) {
           hadUnrecoverableError = true;
@@ -659,16 +660,35 @@ export class WorkerService {
 
         // Check if there's pending work that needs processing with a fresh AbortController
         const pendingCount = pendingStore.getPendingCount(session.sessionDbId);
+        const MAX_PENDING_RESTARTS = 3;
 
         if (pendingCount > 0) {
+          // Track consecutive pending-work restarts to prevent infinite loops (e.g. FK errors)
+          session.consecutiveRestarts = (session.consecutiveRestarts || 0) + 1;
+
+          if (session.consecutiveRestarts > MAX_PENDING_RESTARTS) {
+            logger.error('SYSTEM', 'Exceeded max pending-work restarts, stopping to prevent infinite loop', {
+              sessionId: session.sessionDbId,
+              pendingCount,
+              consecutiveRestarts: session.consecutiveRestarts
+            });
+            session.consecutiveRestarts = 0;
+            this.broadcastProcessingStatus();
+            return;
+          }
+
           logger.info('SYSTEM', 'Pending work remains after generator exit, restarting with fresh AbortController', {
             sessionId: session.sessionDbId,
-            pendingCount
+            pendingCount,
+            attempt: session.consecutiveRestarts
           });
           // Reset AbortController for restart
           session.abortController = new AbortController();
           // Restart processor
           this.startSessionProcessor(session, 'pending-work-restart');
+        } else {
+          // Successful completion with no pending work — reset counter
+          session.consecutiveRestarts = 0;
         }
 
         this.broadcastProcessingStatus();


### PR DESCRIPTION
## Summary
- Add `FOREIGN KEY constraint failed` to unrecoverable error patterns so the session generator stops immediately instead of endlessly retrying
- Add `MAX_PENDING_RESTARTS` (3) safety limit to `pending-work-restart` path to prevent infinite loops from any future unhandled persistent errors

## Problem
When pending messages reference deleted FK records, the session generator throws `FOREIGN KEY constraint failed`. This error was not in the unrecoverable patterns list, so it fell through to the `pending-work-restart` logic which unconditionally restarts when `pendingCount > 0` — creating an infinite loop.

Observed impact: **2,228 error log entries** in a single session, worker eventually killed by SIGTERM, unable to auto-restart afterward.

## Test plan
- [ ] Verify worker starts normally after fix
- [ ] Confirm FK errors no longer trigger restart loop (check logs for `Exceeded max pending-work restarts` or `Unrecoverable generator error`)
- [ ] Verify normal pending-work-restart still works (counter resets on success)

🤖 Generated with [Claude Code](https://claude.com/claude-code)