### PR TITLE
fix: null guard getChromaSync() when Chroma disabled

### DIFF
--- a/src/services/worker/SearchManager.ts
+++ b/src/services/worker/SearchManager.ts
@@ -61,6 +61,9 @@ export class SearchManager {
     limit: number,
     whereFilter?: Record<string, any>
   ): Promise<{ ids: number[]; distances: number[]; metadatas: any[] }> {
+    if (!this.chromaSync) {
+      return { ids: [], distances: [], metadatas: [] };
+    }
     return await this.chromaSync.queryChroma(query, limit, whereFilter);
   }
 

--- a/src/services/worker/http/routes/SessionRoutes.ts
+++ b/src/services/worker/http/routes/SessionRoutes.ts
@@ -356,7 +356,7 @@ export class SessionRoutes extends BaseRouteHandler {
       // Sync user prompt to Chroma
       const chromaStart = Date.now();
       const promptText = latestPrompt.prompt_text;
-      this.dbManager.getChromaSync().syncUserPrompt(
+      this.dbManager.getChromaSync()?.syncUserPrompt(
         latestPrompt.id,
         latestPrompt.memory_session_id,
         latestPrompt.project,


### PR DESCRIPTION
## Summary

Fixes #1294 — `null is not an object (evaluating 'this.dbManager.getChromaSync().syncUserPrompt')` when `CLAUDE_MEM_CHROMA_ENABLED=false`.

**Root cause:** `getChromaSync()` returns `null` when Chroma is disabled, but two call sites called methods on it without null guards:

- **`SessionRoutes.ts:359`** — `getChromaSync().syncUserPrompt(...)` → added optional chaining `?.`
- **`SearchManager.ts:64`** — `this.chromaSync.queryChroma(...)` → added null guard returning empty results

## Changes

- `src/services/worker/http/routes/SessionRoutes.ts`: Added `?.` optional chaining on `getChromaSync()?.syncUserPrompt(...)` so the call is silently skipped when Chroma is disabled
- `src/services/worker/SearchManager.ts`: Added early return with empty results `{ ids: [], distances: [], metadatas: [] }` in `queryChroma()` when `this.chromaSync` is null

## Test plan

- [ ] Set `CLAUDE_MEM_CHROMA_ENABLED=false` in `~/.claude-mem/settings.json`
- [ ] Kill chroma-mcp processes and restart worker
- [ ] Verify no more `null is not an object` errors in logs on `UserPromptSubmit`
- [ ] Verify session init succeeds and falls back to SQLite-only operation
- [ ] Verify search still works (returns SQLite-only results without Chroma)

Vibe-coded by **Ousama Ben Younes** 🎧
🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 4.6)