### PR TITLE
fix: merge SessionStart hooks to run sequentially

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -21,12 +21,7 @@
             "type": "command",
             "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/smart-install.js\"",
             "timeout": 300
-          }
-        ]
-      },
-      {
-        "matcher": "startup|clear|compact",
-        "hooks": [
+          },
           {
             "type": "command",
             "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" start",


### PR DESCRIPTION
## Summary

The SessionStart hook was incorrectly split into two separate matchers with the same pattern `"startup|clear|compact"`, causing them to run in **parallel** per Claude Code's hook execution model.

## Problem

This resulted in a race condition where both hooks tried to bind to port 37777 simultaneously, causing `"Is port 37777 in use?"` errors on first startup. The error disappears on subsequent startups because the worker service is already running.

## Root Cause

Per Claude Code documentation:
> All matching hooks run in parallel: hooks don't see each other's output, non-deterministic ordering, design for independence

Having two matchers with the same pattern causes them to execute in parallel, which breaks the worker startup logic that depends on sequential execution.

## Fix

Consolidate all SessionStart commands into a single matcher, ensuring they execute sequentially.

This is a regression introduced in commit `d93bde0`.

## Test plan

- [ ] Start Claude Code fresh (no worker running)
- [ ] Verify no "port in use" error on first startup
- [ ] Verify worker starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)