### PR TITLE
fix: respect dateStart/dateEnd filters in Chroma search path

### DIFF
--- a/src/services/worker/SearchManager.ts
+++ b/src/services/worker/SearchManager.ts
@@ -180,15 +180,37 @@ export class SearchManager {
       logger.debug('SEARCH', 'ChromaDB returned semantic matches', { matchCount: chromaResults.ids.length });
 
       if (chromaResults.ids.length > 0) {
-        // Step 2: Filter by recency (90 days)
-        const ninetyDaysAgo = Date.now() - SEARCH_CONSTANTS.RECENCY_WINDOW_MS;
+        // Step 2: Filter by date range
+        // Use user-provided dateRange if available, otherwise fall back to 90-day recency window
+        const { dateRange } = options;
+        let startEpoch: number | undefined;
+        let endEpoch: number | undefined;
+
+        if (dateRange) {
+          if (dateRange.start) {
+            startEpoch = typeof dateRange.start === 'number'
+              ? dateRange.start
+              : new Date(dateRange.start).getTime();
+          }
+          if (dateRange.end) {
+            endEpoch = typeof dateRange.end === 'number'
+              ? dateRange.end
+              : new Date(dateRange.end).getTime();
+          }
+        } else {
+          // Default: 90-day recency window
+          startEpoch = Date.now() - SEARCH_CONSTANTS.RECENCY_WINDOW_MS;
+        }
+
         const recentMetadata = chromaResults.metadatas.map((meta, idx) => ({
           id: chromaResults.ids[idx],
           meta,
-          isRecent: meta && meta.created_at_epoch > ninetyDaysAgo
+          isRecent: meta && meta.created_at_epoch != null
+            && (!startEpoch || meta.created_at_epoch >= startEpoch)
+            && (!endEpoch || meta.created_at_epoch <= endEpoch)
         })).filter(item => item.isRecent);
 
-        logger.debug('SEARCH', 'Results within 90-day window', { count: recentMetadata.length });
+        logger.debug('SEARCH', dateRange ? 'Results within user date range' : 'Results within 90-day window', { count: recentMetadata.length });
 
         // Step 3: Categorize IDs by document type
         const obsIds: number[] = [];


### PR DESCRIPTION
## Problem

The MCP `search` tool's `dateStart`/`dateEnd` parameters are ignored when a query string is provided. The Chroma semantic search path (PATH 2 in `SearchManager.search()`) only applies a hardcoded 90-day recency window — it never checks the user-provided `dateRange` from the normalized parameters.

## Root Cause

In `SearchManager.ts` line ~186, the Chroma path filters results using:
```typescript
const ninetyDaysAgo = Date.now() - SEARCH_CONSTANTS.RECENCY_WINDOW_MS;
```
The `options.dateRange` (populated from `dateStart`/`dateEnd` by `normalizeParams()`) is never referenced in this code path, even though the filter-only path (PATH 1, no query) correctly passes it through to SQLite.

## Fix

Replace the hardcoded 90-day window with a check for user-provided `dateRange`. When `dateStart`/`dateEnd` are specified, those bounds are used. When no date filter is specified, the 90-day default is preserved for backward compatibility.

## Testing

The existing `normalizeParams` test confirms `dateStart`/`dateEnd` are correctly flattened into `dateRange`. The SQLite-level `SessionSearch` already handles `dateRange` filtering correctly — this fix ensures the Chroma path respects it too.

Fixes #1324