### PR TITLE
fix: respect env vars and settings.json for DATA_DIR resolution

### DIFF
--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -133,10 +133,15 @@ export class SettingsDefaultsManager {
   }
 
   /**
-   * Get a default value from defaults (no environment variable override)
+   * Get a setting value with environment variable override.
+   * Priority: process.env > hardcoded default
+   *
+   * For full priority (env > settings file > default), use loadFromFile().
+   * This method is safe to call at module-load time (no file I/O) and still
+   * respects environment variable overrides that were previously ignored.
    */
   static get(key: keyof SettingsDefaults): string {
-    return this.DEFAULTS[key];
+    return process.env[key] ?? this.DEFAULTS[key];
   }
 
   /**

--- a/src/shared/paths.ts
+++ b/src/shared/paths.ts
@@ -24,7 +24,37 @@ const _dirname = getDirname();
  */
 
 // Base directories
-export const DATA_DIR = SettingsDefaultsManager.get('CLAUDE_MEM_DATA_DIR');
+// Resolve DATA_DIR with full priority: env var > settings.json > default.
+// SettingsDefaultsManager.get() handles env > default. For settings file
+// support, we do a one-time synchronous read of the default settings path
+// to check if the user configured a custom DATA_DIR there.
+function resolveDataDir(): string {
+  // 1. Environment variable (highest priority) — already handled by get()
+  if (process.env.CLAUDE_MEM_DATA_DIR) {
+    return process.env.CLAUDE_MEM_DATA_DIR;
+  }
+
+  // 2. Settings file at the default location
+  const defaultDataDir = join(homedir(), '.claude-mem');
+  const settingsPath = join(defaultDataDir, 'settings.json');
+  try {
+    if (existsSync(settingsPath)) {
+      const { readFileSync } = require('fs');
+      const raw = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      const settings = raw.env ?? raw; // handle legacy nested schema
+      if (settings.CLAUDE_MEM_DATA_DIR) {
+        return settings.CLAUDE_MEM_DATA_DIR;
+      }
+    }
+  } catch {
+    // settings file missing or corrupt — fall through to default
+  }
+
+  // 3. Hardcoded default
+  return defaultDataDir;
+}
+
+export const DATA_DIR = resolveDataDir();
 // Note: CLAUDE_CONFIG_DIR is a Claude Code setting, not claude-mem, so leave as env var
 export const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
 


### PR DESCRIPTION
## Problem

`SettingsDefaultsManager.get()` returns only the hardcoded default value from `DEFAULTS`, ignoring both environment variable overrides and `settings.json` configuration. Since `paths.ts` uses `get('CLAUDE_MEM_DATA_DIR')` to compute `DATA_DIR` at module load time, users who set `CLAUDE_MEM_DATA_DIR` via env var or `settings.json` get no effect — all paths still point to `~/.claude-mem`.

## Root Cause

`get()` was explicitly documented as "no environment variable override" and simply returned `this.DEFAULTS[key]`. The full-priority method `loadFromFile()` exists but requires a file path parameter — creating a circular dependency since that path itself depends on `DATA_DIR`.

## Fix

Two changes:

1. **`SettingsDefaultsManager.get()`** now checks `process.env[key]` before falling back to the default. This is safe for all callers and adds env var support with zero file I/O.

2. **`paths.ts`** uses a new `resolveDataDir()` bootstrap function that checks the full priority chain: env var → `settings.json` at the default location → hardcoded default. The settings file read is synchronous and only happens once at module load, breaking the circular dependency by checking the default path only.

## Priority Order

```
1. CLAUDE_MEM_DATA_DIR env var    (highest)
2. settings.json at ~/.claude-mem  (file override)
3. ~/.claude-mem                   (hardcoded default)
```

Fixes #1303