### PR TITLE
fix: prevent LLM from using <observation> tags in summary responses

### DIFF
--- a/src/sdk/parser.ts
+++ b/src/sdk/parser.ts
@@ -120,6 +120,11 @@ export function parseSummary(text: string, sessionId?: number): ParsedSummary | 
   const summaryMatch = summaryRegex.exec(text);
 
   if (!summaryMatch) {
+    // Log when the response contains <observation> instead of <summary>
+    // to help diagnose prompt conditioning issues (see #1312)
+    if (/<observation>/.test(text)) {
+      logger.warn('PARSER', 'Summary response contained <observation> tags instead of <summary> — prompt conditioning may need strengthening', { sessionId });
+    }
     return null;
   }
 

--- a/src/sdk/prompts.ts
+++ b/src/sdk/prompts.ts
@@ -130,7 +130,11 @@ export function buildSummaryPrompt(session: SDKSession, mode: ModeConfig): strin
     return '';
   })();
 
-  return `${mode.prompts.header_summary_checkpoint}
+  return `--- MODE SWITCH: PROGRESS SUMMARY ---
+Do NOT output <observation> tags. This is a summary request, not an observation request.
+Your response MUST use <summary> tags ONLY. Any <observation> output will be discarded.
+
+${mode.prompts.header_summary_checkpoint}
 ${mode.prompts.summary_instruction}
 
 ${mode.prompts.summary_context_label}


### PR DESCRIPTION
## Problem

When the SDK agent processes a `summarize` message, the LLM sometimes responds with `<observation>` XML tags instead of the expected `<summary>` tags. `parseSummary()` finds no `<summary>` block, returns `null`, and the summary is silently lost. The stop hook reports "Summary completed" (false positive) because the pending queue is empty.

## Root Cause

The SDK session conversation history is heavily biased toward `<observation>` output:
- The system/init prompt provides a detailed `<observation>` XML template
- Every previous assistant response uses `<observation>` tags
- By the time the summarize prompt arrives, in-context conditioning toward `<observation>` overwhelms the `<summary>` format instruction

## Fix

**Prompt-level fix** (as recommended in the issue — parser fallback was explicitly ruled out to avoid spurious summaries):

1. **`buildSummaryPrompt()`** now prepends explicit mode-switch instructions:
   ```
   --- MODE SWITCH: PROGRESS SUMMARY ---
   Do NOT output <observation> tags. This is a summary request, not an observation request.
   Your response MUST use <summary> tags ONLY. Any <observation> output will be discarded.
   ```

2. **`parseSummary()`** now logs a warning when `<observation>` tags are found in a response that has no `<summary>` block, making the issue visible in logs instead of silently discarding.

## Why Not a Parser Fallback?

As the issue reporter noted, `parseSummary()` is called on **every** agent response (not just summarize). A fallback that converts `<observation>` → `<summary>` would cause every normal observation to also generate a spurious summary record.

Fixes #1312