### PR TITLE
fix: detect parent process death via stdin EOF to prevent MCP server leaks

### DIFF
--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -282,20 +282,33 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 });
 
-// Cleanup function
-async function cleanup() {
-  logger.info('SYSTEM', 'MCP server shutting down');
+// Cleanup function - guard against double-exit
+let isShuttingDown = false;
+async function cleanup(reason?: string) {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+  logger.info('SYSTEM', `MCP server shutting down${reason ? ` (${reason})` : ''}`);
   process.exit(0);
 }
 
 // Register cleanup handlers for graceful shutdown
-process.on('SIGTERM', cleanup);
-process.on('SIGINT', cleanup);
+process.on('SIGTERM', () => cleanup('SIGTERM'));
+process.on('SIGINT', () => cleanup('SIGINT'));
+
+// Detect parent process death: when the parent (Claude Code) exits or crashes,
+// stdin gets EOF/close. The MCP SDK's StdioServerTransport does NOT listen for
+// these events, so without this handler the process leaks indefinitely.
+process.stdin.on('end', () => cleanup('stdin end'));
+process.stdin.on('close', () => cleanup('stdin close'));
 
 // Start the server
 async function main() {
   // Start the MCP server
   const transport = new StdioServerTransport();
+
+  // Also handle transport-level close (fires if server.close() is called)
+  transport.onclose = () => cleanup('transport close');
+
   await server.connect(transport);
   logger.info('SYSTEM', 'Claude-mem search server started');
 


### PR DESCRIPTION
## Summary

- Adds `process.stdin.on('end'/'close')` handlers to detect when the parent Claude Code process exits, triggering graceful shutdown
- Adds `transport.onclose` callback as a secondary detection path
- Adds `isShuttingDown` re-entrancy guard to prevent double-exit races when multiple shutdown events fire simultaneously
- Adds `reason` parameter to `cleanup()` for diagnostic logging

## Problem

When a Claude Code session ends (terminal close, crash, network disconnect), the spawned `mcp-server.cjs` process leaks indefinitely because:

1. **MCP SDK gap**: `StdioServerTransport` only listens for `data` and `error` on stdin — never `end` or `close`
2. **Signal-only cleanup**: The server only registered `SIGTERM`/`SIGINT` handlers, which don't fire on abrupt session drops

Processes accumulate without bound — I found an orphaned instance from 2 days prior still running.

## Test plan

- [ ] Start a Claude Code session, verify `mcp-server.cjs` spawns
- [ ] Close the terminal window — verify the MCP server process exits (check `ps aux | grep mcp-server`)
- [ ] Kill the Claude Code process with `kill -9` — verify the MCP server still exits via stdin EOF
- [ ] Normal `SIGTERM`/`SIGINT` shutdown still works as before

Fixes #1351

🤖 Generated with [Claude Code](https://claude.com/claude-code)