### PR TITLE
fix: unset CLAUDECODE env var when spawning worker daemon from hooks

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -12,7 +12,7 @@
           },
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
+            "command": "env -u CLAUDECODE bun \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
             "timeout": 60
           },
           {
@@ -33,7 +33,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
+            "command": "env -u CLAUDECODE bun \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
             "timeout": 60
           },
           {
@@ -50,7 +50,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
+            "command": "env -u CLAUDECODE bun \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
             "timeout": 60
           },
           {
@@ -66,7 +66,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
+            "command": "env -u CLAUDECODE bun \"${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs\" start",
             "timeout": 60
           },
           {


### PR DESCRIPTION
## Summary

- Wraps all 4 `worker-service.cjs start` hook commands with `env -u CLAUDECODE` to prevent the worker daemon from inheriting the Claude Code session environment variable

## Problem

Hook commands run inside Claude Code's process tree, so `bun worker-service.cjs start` inherits the `CLAUDECODE` environment variable. This causes the worker daemon to behave as if it's running inside a Claude Code session, interfering with subprocess spawning in nested environments.

Related: #1163 (broader env-leaking issue with `CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, proxy vars)

## Test plan

- [ ] Start a Claude Code session, verify `worker-service.cjs` spawns
- [ ] Check the worker process environment: `cat /proc/<pid>/environ | tr '\0' '\n' | grep CLAUDE` — verify `CLAUDECODE` is not set
- [ ] Verify worker functionality is unaffected (search, observations, etc.)

Fixes #1352

🤖 Generated with [Claude Code](https://claude.com/claude-code)