### PR TITLE
fix: resolve UserPromptSubmit hook error on new session startup

### DIFF
--- a/src/cli/handlers/session-init.ts
+++ b/src/cli/handlers/session-init.ts
@@ -13,12 +13,34 @@ import { isProjectExcluded } from '../../utils/project-filter.js';
 import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js';
 import { USER_SETTINGS_PATH } from '../../shared/paths.js';
 
+/**
+ * Wait for the worker to become available, retrying with backoff.
+ * Covers the race condition where SessionStart is still starting the worker
+ * when the first UserPromptSubmit fires (fixes #XXXX).
+ *
+ * @param timeoutMs Maximum time to wait for the worker (default: 10s)
+ * @param intervalMs Polling interval (default: 500ms)
+ */
+async function waitForWorkerWithRetry(timeoutMs: number = 10000, intervalMs: number = 500): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await ensureWorkerRunning()) {
+      return true;
+    }
+    await new Promise(r => setTimeout(r, intervalMs));
+  }
+  return false;
+}
+
 export const sessionInitHandler: EventHandler = {
   async execute(input: NormalizedHookInput): Promise<HookResult> {
-    // Ensure worker is running before any other logic
-    const workerReady = await ensureWorkerRunning();
+    // Wait for worker with retry — SessionStart may still be starting the worker
+    // when the first UserPromptSubmit arrives (race condition on new sessions).
+    // Single-shot check was insufficient; polling for up to 10s covers the startup window.
+    const workerReady = await waitForWorkerWithRetry();
     if (!workerReady) {
-      // Worker not available - skip session init gracefully
+      // Worker not available after retries - skip session init gracefully
+      logger.info('HOOK', 'session-init: Worker not available after retry, skipping gracefully');
       return { continue: true, suppressOutput: true, exitCode: HOOK_EXIT_CODES.SUCCESS };
     }
 

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -1122,13 +1122,6 @@ async function main() {
     }
 
     case 'hook': {
-      // Auto-start worker if not running
-      const workerReady = await ensureWorkerStarted(port);
-      if (!workerReady) {
-        logger.warn('SYSTEM', 'Worker failed to start before hook, handler will retry');
-      }
-
-      // Existing logic unchanged
       const platform = process.argv[3];
       const event = process.argv[4];
       if (!platform || !event) {
@@ -1138,26 +1131,44 @@ async function main() {
         process.exit(1);
       }
 
-      // Check if worker is already running on port
-      const portInUse = await isPortInUse(port);
       let startedWorkerInProcess = false;
 
-      if (!portInUse) {
-        // Port free - start worker IN THIS PROCESS (no spawn!)
-        // This process becomes the worker and stays alive
-        try {
-          logger.info('SYSTEM', 'Starting worker in-process for hook', { event });
-          const worker = new WorkerService();
-          await worker.start();
-          startedWorkerInProcess = true;
-          // Worker is now running in this process on the port
-        } catch (error) {
-          logger.failure('SYSTEM', 'Worker failed to start in hook', {}, error as Error);
-          removePidFile();
-          process.exit(0);
+      try {
+        // Auto-start worker if not running
+        const workerReady = await ensureWorkerStarted(port);
+        if (!workerReady) {
+          logger.warn('SYSTEM', 'Worker failed to start before hook, handler will retry');
         }
+
+        // Check if worker is already running on port
+        const portInUse = await isPortInUse(port);
+
+        if (!portInUse) {
+          // Port free - start worker IN THIS PROCESS (no spawn!)
+          // This process becomes the worker and stays alive
+          try {
+            logger.info('SYSTEM', 'Starting worker in-process for hook', { event });
+            const worker = new WorkerService();
+            await worker.start();
+            startedWorkerInProcess = true;
+            // Worker is now running in this process on the port
+          } catch (error) {
+            logger.failure('SYSTEM', 'Worker failed to start in hook', {}, error as Error);
+            removePidFile();
+            // Don't exit here - fall through to hookCommand which will degrade gracefully
+          }
+        }
+        // If port in use, we'll use HTTP to the existing worker
+      } catch (error) {
+        // Defensive: any unexpected error during worker startup should not
+        // prevent the hook from completing. The handler will degrade gracefully
+        // if the worker is unavailable. Fixes race condition where SessionStart
+        // and UserPromptSubmit hooks compete to start the worker.
+        logger.warn('SYSTEM', 'Unexpected error during hook worker startup, proceeding to handler', {
+          event,
+          error: error instanceof Error ? error.message : String(error)
+        });
       }
-      // If port in use, we'll use HTTP to the existing worker
 
       const { hookCommand } = await import('../cli/hook-command.js');
       // If we started the worker in this process, skip process.exit() so we stay alive as the worker


### PR DESCRIPTION
## Problem

When starting a new Claude Code session, users see a `UserPromptSubmit hook error` on their first prompt. This happens because the `UserPromptSubmit` hook fires before `SessionStart` has finished starting the worker daemon, causing a race condition.

**Reproduction steps:**
1. Start a new Claude Code session
2. Type any prompt (e.g., "hola que tal?")
3. Observe `UserPromptSubmit hook error` in the output

The session still works after this error (graceful degradation catches most paths), but the error message is confusing and unnecessary.

## Root Cause

Two issues combine to produce the error:

1. **`session-init.ts`**: `ensureWorkerRunning()` does a **single health check** with no retry. If the worker is still starting up (SessionStart is running `smart-install.js` + `worker-service start`), this check fails immediately.

2. **`worker-service.ts` `case 'hook'`**: The worker startup logic (`ensureWorkerStarted()` + in-process worker start) runs without a top-level try-catch. If `ensureWorkerStarted` spawns a competing daemon while SessionStart is already spawning one, unexpected errors can propagate to `main().catch()` or cause the hook to exit with a non-zero code.

## Fix

### `src/cli/handlers/session-init.ts`

Replace the single-shot `ensureWorkerRunning()` call with `waitForWorkerWithRetry()` — a polling loop that checks worker health every 500ms for up to 10 seconds. This covers the typical SessionStart startup window without adding significant latency when the worker is already running (returns on first successful check).

### `src/services/worker-service.ts`

Wrap the entire worker startup logic in the `case 'hook'` block with a defensive try-catch. If any unexpected error occurs during daemon startup (port conflicts, PID file races, etc.), the code now falls through to `hookCommand()` which handles worker unavailability gracefully via `isWorkerUnavailableError()`. Also removed the premature `process.exit(0)` on in-process worker start failure — letting `hookCommand` handle it ensures consistent output formatting.

## Testing

- Verified TypeScript compiles without new errors (pre-existing errors in the project are unrelated)
- Manually tested `worker-service.cjs hook claude-code session-init` — returns `{"continue":true,"suppressOutput":true}` correctly
- The retry loop gracefully degrades: if the worker never starts, the handler returns `{continue: true, suppressOutput: true, exitCode: 0}` after 10 seconds

## Risk Assessment

**Low risk.** Both changes are defensive:
- The retry loop only adds latency when the worker is genuinely starting up (otherwise returns on first check)
- The try-catch wrapper doesn't change any success paths — it only catches errors that previously would propagate as unhandled
- No changes to the hook JSON contract or exit code semantics