### PR TITLE
fix(chroma): close transport before nulling to prevent subprocess leak

### DIFF
--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -252,9 +252,17 @@ export class ChromaMcpManager {
       // Transport error: chroma-mcp subprocess likely died (e.g., killed by orphan reaper,
       // HNSW index corruption). Mark connection dead and retry once after reconnect (#1131).
       // Without this retry, callers see a one-shot error even though reconnect would succeed.
+      //
+      // CRITICAL: Close the transport before nulling to kill the subprocess (#1369).
+      // If we null this.transport first, connectInternal() sees transport === null,
+      // skips cleanup, and spawns a new subprocess, orphaning the old one.
       this.connected = false;
+      const staleTransport = this.transport;
       this.client = null;
       this.transport = null;
+      if (staleTransport) {
+        try { await staleTransport.close(); } catch { /* subprocess may already be dead */ }
+      }
 
       logger.warn('CHROMA_MCP', `Transport error during "${toolName}", reconnecting and retrying once`, {
         error: transportError instanceof Error ? transportError.message : String(transportError)
@@ -267,7 +275,14 @@ export class ChromaMcpManager {
           arguments: toolArguments
         });
       } catch (retryError) {
+        // Retry also failed. Close transport to prevent another orphan.
         this.connected = false;
+        const retryTransport = this.transport;
+        this.client = null;
+        this.transport = null;
+        if (retryTransport) {
+          try { await retryTransport.close(); } catch { /* subprocess may already be dead */ }
+        }
         throw new Error(`chroma-mcp transport error during "${toolName}" (retry failed): ${retryError instanceof Error ? retryError.message : String(retryError)}`);
       }
     }


### PR DESCRIPTION
## Summary

Fixes #1369

`callTool()` sets `this.transport = null` without calling `transport.close()` first. When `connectInternal()` runs next, it sees `transport === null`, skips cleanup, and spawns a new `chroma-mcp` subprocess while the old one is still alive. Over time this leaks dozens of orphaned `uvx`/`chroma-mcp` processes, each loading a 79MB ONNX model, exhausting RAM and causing MCP search timeouts.

## Root Cause

Two code paths in `callTool()` drop the transport reference without closing it:

1. **Initial catch block** (transport error) - nulls `this.transport`, then calls `ensureConnected()` which spawns a new subprocess
2. **Retry catch block** - only sets `this.connected = false` without cleaning up transport/client at all

Meanwhile, `connectInternal()` tries to close the old transport:
```js
if (this.transport) try { await this.transport.close() } catch {}
```
But since `callTool()` already nulled it, this guard is always false, and the old subprocess lives on.

## Fix

Save a reference to the stale transport before nulling the instance field, then close the saved reference:

```js
const staleTransport = this.transport;
this.client = null;
this.transport = null;
if (staleTransport) {
  try { await staleTransport.close(); } catch { /* subprocess may already be dead */ }
}
```

Applied to both the initial catch and retry catch blocks.

## Impact

Without fix: each transport error accumulates an orphaned `chroma-mcp` process. In production we observed 25+ leaked processes consuming several GB of RAM.

With fix: `transport.close()` sends SIGTERM to the subprocess before a replacement is spawned.

## Test plan

- [x] Verified fix on local machine: transport errors no longer accumulate orphaned processes
- [x] Existing SSL test suite unaffected (tests mock transport)