### PR TITLE
feat: Endless Mode V2 — session-cycling orchestrator

### DIFF
--- a/plugin/skills/endless/SKILL.md
+++ b/plugin/skills/endless/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: endless
+description: Run a task in endless mode — automatically cycles Claude Code sessions to avoid context window limits. Your work is preserved across cycles via claude-mem observations.
+---
+
+# Endless Mode
+
+Run a long-running task that automatically cycles Claude Code sessions when context fills up. Claude-mem's observation system captures your work, and each new session starts with compressed context from previous cycles.
+
+## Usage
+
+The user provides a task description. This skill sends it to the worker's endless mode endpoint.
+
+## Steps
+
+1. Confirm the task with the user
+2. Call `POST http://localhost:37777/api/endless/run` with:
+   ```json
+   {
+     "task": "<the user's task description>",
+     "project": "<current project name>",
+     "cwd": "<current working directory>"
+   }
+   ```
+3. Report that the task has started
+4. The user can check status with `GET http://localhost:37777/api/endless/status`
+
+## Important
+
+- Only one endless mode task can run at a time
+- The task runs in the background on the worker — it survives if the user's session ends
+- Each cycle spawns a full Claude Code instance with all tools available
+- Context continuity comes from claude-mem's SessionStart observation injection
+- The task cycles when the observer stores an observation (indicating meaningful work was captured)
+- Natural completion (agent finishes the task) stops the loop automatically
+- Safety valve: maximum 100 cycles

--- a/src/services/sqlite/PendingMessageStore.ts
+++ b/src/services/sqlite/PendingMessageStore.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'events';
 import { Database } from './sqlite-compat.js';
 import type { PendingMessage } from '../worker-types.js';
 import { logger } from '../../utils/logger.js';
@@ -47,10 +48,19 @@ export interface PersistentPendingMessage {
 export class PendingMessageStore {
   private db: Database;
   private maxRetries: number;
+  private events: EventEmitter;
 
   constructor(db: Database, maxRetries: number = 3) {
     this.db = db;
     this.maxRetries = maxRetries;
+    this.events = new EventEmitter();
+  }
+
+  /**
+   * Get the EventEmitter for subscribing to queue events (e.g., queue-empty:{sessionDbId})
+   */
+  getEvents(): EventEmitter {
+    return this.events;
   }
 
   /**
@@ -144,10 +154,27 @@ export class PendingMessageStore {
    * This prevents message loss on generator crash.
    */
   confirmProcessed(messageId: number): void {
+    // Look up session_db_id before deleting so we can check queue emptiness after
+    const lookupStmt = this.db.prepare('SELECT session_db_id FROM pending_messages WHERE id = ?');
+    const row = lookupStmt.get(messageId) as { session_db_id: number } | undefined;
+
     const stmt = this.db.prepare('DELETE FROM pending_messages WHERE id = ?');
     const result = stmt.run(messageId);
     if (result.changes > 0) {
       logger.debug('QUEUE', `CONFIRMED | messageId=${messageId} | deleted from queue`);
+
+      if (row) {
+        // Global event: any observation confirmed (for EndlessRunner cycle detection)
+        this.events.emit('observation-confirmed', row.session_db_id);
+
+        // Session-scoped event: queue fully drained (for EndlessRunner queue drain)
+        const remaining = this.getPendingCount(row.session_db_id);
+        if (remaining === 0) {
+          const eventName = `queue-empty:${row.session_db_id}`;
+          logger.debug('QUEUE', `QUEUE_EMPTY | sessionDbId=${row.session_db_id} | emitting ${eventName}`);
+          this.events.emit(eventName);
+        }
+      }
     }
   }
 

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -124,6 +124,8 @@ import { SearchRoutes } from './worker/http/routes/SearchRoutes.js';
 import { SettingsRoutes } from './worker/http/routes/SettingsRoutes.js';
 import { LogsRoutes } from './worker/http/routes/LogsRoutes.js';
 import { MemoryRoutes } from './worker/http/routes/MemoryRoutes.js';
+import { EndlessRoutes } from './worker/http/routes/EndlessRoutes.js';
+import { EndlessRunner } from './worker/EndlessRunner.js';
 
 // Process management for zombie cleanup (Issue #737)
 import { startOrphanReaper, reapOrphanedProcesses, getProcessBySession, ensureProcessExit } from './worker/ProcessRegistry.js';
@@ -173,6 +175,9 @@ export class WorkerService {
   private settingsManager: SettingsManager;
   private sessionEventBroadcaster: SessionEventBroadcaster;
 
+  // Endless mode orchestrator
+  private endlessRunner: EndlessRunner;
+
   // Route handlers
   private searchRoutes: SearchRoutes | null = null;
 
@@ -211,6 +216,7 @@ export class WorkerService {
     this.geminiAgent = new GeminiAgent(this.dbManager, this.sessionManager);
     this.openRouterAgent = new OpenRouterAgent(this.dbManager, this.sessionManager);
 
+    this.endlessRunner = new EndlessRunner(this.sessionManager, this.dbManager);
     this.paginationHelper = new PaginationHelper(this.dbManager);
     this.settingsManager = new SettingsManager(this.dbManager);
     this.sessionEventBroadcaster = new SessionEventBroadcaster(this.sseBroadcaster, this);
@@ -320,6 +326,7 @@ export class WorkerService {
     this.server.registerRoutes(new SettingsRoutes(this.settingsManager));
     this.server.registerRoutes(new LogsRoutes());
     this.server.registerRoutes(new MemoryRoutes(this.dbManager, 'claude-mem'));
+    this.server.registerRoutes(new EndlessRoutes(this.endlessRunner));
   }
 
   /**

--- a/src/services/worker/EndlessRunner.ts
+++ b/src/services/worker/EndlessRunner.ts
@@ -1,0 +1,263 @@
+/**
+ * EndlessRunner: Session-cycling orchestrator for Endless Mode V2
+ *
+ * Spawns Claude Code sessions via Agent SDK query(), cycles them when
+ * observations arrive (indicating context is being consumed). Claude-mem's
+ * existing SessionStart hook injects compressed observations from previous
+ * cycles, providing continuity across session boundaries.
+ *
+ * Cycle lifecycle:
+ * 1. Spawn a Claude Code process via SDK query()
+ * 2. Monitor for observation storage (via queue-empty event on PendingMessageStore)
+ * 3. When an observation arrives, abort the current SDK session
+ * 4. Wait for the observer queue to drain
+ * 5. Clean up the old transcript
+ * 6. Start a new cycle with a continuation prompt
+ */
+
+import { unlinkSync, existsSync } from 'fs';
+import { logger } from '../../utils/logger.js';
+import { findClaudeExecutable, getModelId } from './agent-utils.js';
+import { buildIsolatedEnv } from '../../shared/EnvManager.js';
+import { OBSERVER_SESSIONS_DIR, ensureDir } from '../../shared/paths.js';
+import { sanitizeEnv } from '../../supervisor/env-sanitizer.js';
+import { SessionManager } from './SessionManager.js';
+import { DatabaseManager } from './DatabaseManager.js';
+
+// @ts-ignore - Agent SDK types may not be available
+import { query } from '@anthropic-ai/claude-agent-sdk';
+
+const MAX_CYCLES = 100;
+
+export type EndlessTaskStatus = 'running' | 'completed' | 'max_cycles_reached' | 'error';
+
+export interface EndlessTaskState {
+  taskId: string;
+  task: string;
+  project: string;
+  cwd: string;
+  status: EndlessTaskStatus;
+  currentCycle: number;
+  maxCycles: number;
+  startedAt: number;
+  completedAt: number | null;
+  error: string | null;
+}
+
+export class EndlessRunner {
+  private sessionManager: SessionManager;
+  private dbManager: DatabaseManager;
+  private currentTask: EndlessTaskState | null = null;
+
+  constructor(sessionManager: SessionManager, dbManager: DatabaseManager) {
+    this.sessionManager = sessionManager;
+    this.dbManager = dbManager;
+  }
+
+  /**
+   * Get current task state (for status endpoint)
+   */
+  getTaskState(): EndlessTaskState | null {
+    return this.currentTask;
+  }
+
+  /**
+   * Run the endless mode orchestrator loop.
+   *
+   * Spawns consecutive Claude Code sessions via SDK query(). Each session
+   * runs until an observation is stored (signaling context consumption),
+   * then the session is aborted, the queue is drained, and a new cycle
+   * begins with a continuation prompt. Claude-mem's SessionStart hook
+   * automatically injects compressed prior context into each new session.
+   */
+  async run(task: string, project: string, cwd: string): Promise<EndlessTaskState> {
+    if (this.currentTask && this.currentTask.status === 'running') {
+      throw new Error('An endless mode task is already running');
+    }
+
+    const taskId = `endless-${Date.now()}`;
+    this.currentTask = {
+      taskId,
+      task,
+      project,
+      cwd,
+      status: 'running',
+      currentCycle: 0,
+      maxCycles: MAX_CYCLES,
+      startedAt: Date.now(),
+      completedAt: null,
+      error: null,
+    };
+
+    logger.info('ENDLESS', 'Starting endless mode', {
+      taskId,
+      task: task.substring(0, 100),
+      project,
+      cwd,
+    });
+
+    try {
+      const result = await this.orchestratorLoop(task, project, cwd);
+      this.currentTask.status = result;
+      this.currentTask.completedAt = Date.now();
+
+      logger.info('ENDLESS', 'Endless mode completed', {
+        taskId,
+        status: result,
+        cycles: this.currentTask.currentCycle,
+        durationMs: Date.now() - this.currentTask.startedAt,
+      });
+
+      return this.currentTask;
+    } catch (error) {
+      this.currentTask.status = 'error';
+      this.currentTask.error = (error as Error).message;
+      this.currentTask.completedAt = Date.now();
+
+      logger.error('ENDLESS', 'Endless mode failed', { taskId }, error as Error);
+      return this.currentTask;
+    }
+  }
+
+  /**
+   * Core orchestrator loop.
+   *
+   * For each cycle:
+   * 1. Create a fresh AbortController
+   * 2. Listen for the global `observation-confirmed` event on PendingMessageStore
+   * 3. Call query() with the task prompt (cycle 1) or continuation prompt (cycle 2+)
+   * 4. Iterate SDK messages; when observation-confirmed fires, abort the session
+   * 5. After the SDK finishes, drain the observer queue using the real sessionDbId
+   * 6. Clean up the transcript file
+   * 7. If the agent finished naturally (no observation triggered abort), the task is complete
+   *
+   * Session ID mapping: The spawned Claude Code process generates its own
+   * contentSessionId. Plugin hooks use that ID when POSTing to the worker.
+   * The worker creates a DB session for it. We learn the real sessionDbId
+   * from the `observation-confirmed` event (which includes sessionDbId).
+   */
+  private async orchestratorLoop(
+    task: string,
+    project: string,
+    taskCwd: string
+  ): Promise<'completed' | 'max_cycles_reached'> {
+    const claudePath = findClaudeExecutable();
+    const modelId = getModelId();
+    const isolatedEnv = sanitizeEnv(buildIsolatedEnv());
+    ensureDir(OBSERVER_SESSIONS_DIR);
+
+    for (let cycle = 1; cycle <= MAX_CYCLES; cycle++) {
+      this.currentTask!.currentCycle = cycle;
+
+      logger.info('ENDLESS', `Starting cycle ${cycle}/${MAX_CYCLES}`, {
+        taskId: this.currentTask!.taskId,
+        cycle,
+      });
+
+      // Build prompt for this cycle
+      const prompt =
+        cycle === 1
+          ? task
+          : `Continue working on: ${task}\n\nYou have context from previous work sessions injected above. Pick up where you left off.`;
+
+      // Create a fresh AbortController for this cycle
+      const abortController = new AbortController();
+
+      // Closure-scoped state for this cycle
+      let observationTriggeredAbort = false;
+      let realSessionDbId: number | null = null;
+
+      // Listen for the global observation-confirmed event.
+      // The spawned Claude Code process has its own contentSessionId (assigned by
+      // Claude Code, not by us). Plugin hooks POST observations to the worker using
+      // that ID. The worker creates a DB session and queues the observation. When the
+      // observer finishes processing and confirmProcessed() fires, PendingMessageStore
+      // emits 'observation-confirmed' with the sessionDbId.
+      //
+      // Since the plan says "one at a time is MVP", any observation-confirmed event
+      // during this cycle is from our spawned active agent.
+      const pendingStore = this.sessionManager.getPendingMessageStore();
+      const observationListener = (sessionDbId: number) => {
+        if (!abortController.signal.aborted) {
+          realSessionDbId = sessionDbId;
+          observationTriggeredAbort = true;
+          logger.info('ENDLESS', 'Observation confirmed, aborting current cycle', {
+            cycle,
+            sessionDbId,
+          });
+          abortController.abort();
+        }
+      };
+      pendingStore.getEvents().on('observation-confirmed', observationListener);
+
+      // Track transcript path for cleanup
+      let transcriptPath: string | null = null;
+
+      try {
+        // Spawn active agent via SDK query()
+        const queryResult = query({
+          prompt,
+          options: {
+            model: modelId,
+            cwd: taskCwd,
+            abortController,
+            pathToClaudeCodeExecutable: claudePath,
+            env: isolatedEnv,
+          },
+        });
+
+        // Iterate SDK messages
+        for await (const message of queryResult) {
+          // Capture transcript path from result messages for cleanup
+          if (message.type === 'result') {
+            if (message.transcript_path) {
+              transcriptPath = message.transcript_path;
+            }
+
+            // Agent finished — check WHY
+            if (!observationTriggeredAbort) {
+              // Agent finished naturally — task is complete
+              logger.info('ENDLESS', 'Agent finished naturally, task complete', {
+                cycle,
+              });
+              return 'completed';
+            }
+            // Observation triggered abort — continue to drain + next cycle
+            break;
+          }
+        }
+      } finally {
+        // Always clean up the observation listener
+        pendingStore.getEvents().removeListener('observation-confirmed', observationListener);
+      }
+
+      // Drain observer queue — wait for all pending tool uses to be processed
+      // Uses the real sessionDbId captured from the observation-confirmed event
+      if (realSessionDbId !== null) {
+        logger.info('ENDLESS', 'Waiting for observer queue to drain', {
+          cycle,
+          sessionDbId: realSessionDbId,
+        });
+        await this.sessionManager.waitForQueueEmpty(realSessionDbId);
+        logger.info('ENDLESS', 'Observer queue drained', { cycle, sessionDbId: realSessionDbId });
+      }
+
+      // Clean up transcript file to free disk space
+      if (transcriptPath && existsSync(transcriptPath)) {
+        try {
+          unlinkSync(transcriptPath);
+          logger.debug('ENDLESS', 'Transcript cleaned up', { transcriptPath });
+        } catch (error) {
+          logger.warn('ENDLESS', 'Failed to clean transcript', { transcriptPath }, error as Error);
+        }
+      }
+
+      logger.info('ENDLESS', `Cycle ${cycle} complete, starting next cycle`, {
+        taskId: this.currentTask!.taskId,
+        cycle,
+      });
+    }
+
+    return 'max_cycles_reached';
+  }
+}

--- a/src/services/worker/SDKAgent.ts
+++ b/src/services/worker/SDKAgent.ts
@@ -8,9 +8,6 @@
  * - Sync to database and Chroma
  */
 
-import { execSync } from 'child_process';
-import { homedir } from 'os';
-import path from 'path';
 import { DatabaseManager } from './DatabaseManager.js';
 import { SessionManager } from './SessionManager.js';
 import { logger } from '../../utils/logger.js';
@@ -23,6 +20,7 @@ import { ModeManager } from '../domain/ModeManager.js';
 import { processAgentResponse, type WorkerRef } from './agents/index.js';
 import { createPidCapturingSpawn, getProcessBySession, ensureProcessExit, waitForSlot } from './ProcessRegistry.js';
 import { sanitizeEnv } from '../../supervisor/env-sanitizer.js';
+import { findClaudeExecutable, getModelId } from './agent-utils.js';
 
 // Import Agent SDK (assumes it's installed)
 // @ts-ignore - Agent SDK types may not be available
@@ -47,10 +45,10 @@ export class SDKAgent {
     const cwdTracker = { lastCwd: undefined as string | undefined };
 
     // Find Claude executable
-    const claudePath = this.findClaudeExecutable();
+    const claudePath = findClaudeExecutable();
 
     // Get model ID and disallowed tools
-    const modelId = this.getModelId();
+    const modelId = getModelId();
     // Memory agent is OBSERVER ONLY - no tools allowed
     const disallowedTools = [
       'Bash',           // Prevent infinite loops
@@ -432,58 +430,4 @@ export class SDKAgent {
     }
   }
 
-  // ============================================================================
-  // Configuration Helpers
-  // ============================================================================
-
-  /**
-   * Find Claude executable (inline, called once per session)
-   */
-  private findClaudeExecutable(): string {
-    const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
-
-    // 1. Check configured path
-    if (settings.CLAUDE_CODE_PATH) {
-      // Lazy load fs to keep startup fast
-      const { existsSync } = require('fs');
-      if (!existsSync(settings.CLAUDE_CODE_PATH)) {
-        throw new Error(`CLAUDE_CODE_PATH is set to "${settings.CLAUDE_CODE_PATH}" but the file does not exist.`);
-      }
-      return settings.CLAUDE_CODE_PATH;
-    }
-
-    // 2. On Windows, prefer "claude.cmd" via PATH to avoid spawn issues with spaces in paths
-    if (process.platform === 'win32') {
-      try {
-        execSync('where claude.cmd', { encoding: 'utf8', windowsHide: true, stdio: ['ignore', 'pipe', 'ignore'] });
-        return 'claude.cmd'; // Let Windows resolve via PATHEXT
-      } catch {
-        // Fall through to generic error
-      }
-    }
-
-    // 3. Try auto-detection for non-Windows platforms
-    try {
-      const claudePath = execSync(
-        process.platform === 'win32' ? 'where claude' : 'which claude',
-        { encoding: 'utf8', windowsHide: true, stdio: ['ignore', 'pipe', 'ignore'] }
-      ).trim().split('\n')[0].trim();
-
-      if (claudePath) return claudePath;
-    } catch (error) {
-      // [ANTI-PATTERN IGNORED]: Fallback behavior - which/where failed, continue to throw clear error
-      logger.debug('SDK', 'Claude executable auto-detection failed', {}, error as Error);
-    }
-
-    throw new Error('Claude executable not found. Please either:\n1. Add "claude" to your system PATH, or\n2. Set CLAUDE_CODE_PATH in ~/.claude-mem/settings.json');
-  }
-
-  /**
-   * Get model ID from settings or environment
-   */
-  private getModelId(): string {
-    const settingsPath = path.join(homedir(), '.claude-mem', 'settings.json');
-    const settings = SettingsDefaultsManager.loadFromFile(settingsPath);
-    return settings.CLAUDE_MEM_MODEL;
-  }
 }

--- a/src/services/worker/SessionManager.ts
+++ b/src/services/worker/SessionManager.ts
@@ -500,4 +500,33 @@ export class SessionManager {
   getPendingMessageStore(): PendingMessageStore {
     return this.getPendingStore();
   }
+
+  /**
+   * Wait for all pending messages to be processed for a session.
+   * Resolves immediately if count is already 0.
+   * Event-driven — no polling.
+   */
+  async waitForQueueEmpty(sessionDbId: number): Promise<void> {
+    const pendingStore = this.getPendingStore();
+
+    // Already empty?
+    if (pendingStore.getPendingCount(sessionDbId) === 0) {
+      return;
+    }
+
+    // Wait for event
+    return new Promise<void>((resolve) => {
+      const eventName = `queue-empty:${sessionDbId}`;
+      const handler = () => {
+        resolve();
+      };
+      pendingStore.getEvents().once(eventName, handler);
+
+      // Double-check after subscribing (race condition guard)
+      if (pendingStore.getPendingCount(sessionDbId) === 0) {
+        pendingStore.getEvents().removeListener(eventName, handler);
+        resolve();
+      }
+    });
+  }
 }

--- a/src/services/worker/agent-utils.ts
+++ b/src/services/worker/agent-utils.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared utility functions for agent implementations
+ *
+ * Extracted from SDKAgent to allow reuse across SDKAgent, EndlessRunner,
+ * and other agent implementations that need Claude executable discovery
+ * and model configuration.
+ */
+
+import { execSync } from 'child_process';
+import { homedir } from 'os';
+import path from 'path';
+import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js';
+import { USER_SETTINGS_PATH } from '../../shared/paths.js';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Find Claude executable (checks settings, then PATH)
+ */
+export function findClaudeExecutable(): string {
+  const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+
+  // 1. Check configured path
+  if (settings.CLAUDE_CODE_PATH) {
+    // Lazy load fs to keep startup fast
+    const { existsSync } = require('fs');
+    if (!existsSync(settings.CLAUDE_CODE_PATH)) {
+      throw new Error(`CLAUDE_CODE_PATH is set to "${settings.CLAUDE_CODE_PATH}" but the file does not exist.`);
+    }
+    return settings.CLAUDE_CODE_PATH;
+  }
+
+  // 2. On Windows, prefer "claude.cmd" via PATH to avoid spawn issues with spaces in paths
+  if (process.platform === 'win32') {
+    try {
+      execSync('where claude.cmd', { encoding: 'utf8', windowsHide: true, stdio: ['ignore', 'pipe', 'ignore'] });
+      return 'claude.cmd'; // Let Windows resolve via PATHEXT
+    } catch {
+      // Fall through to generic error
+    }
+  }
+
+  // 3. Try auto-detection for non-Windows platforms
+  try {
+    const claudePath = execSync(
+      process.platform === 'win32' ? 'where claude' : 'which claude',
+      { encoding: 'utf8', windowsHide: true, stdio: ['ignore', 'pipe', 'ignore'] }
+    ).trim().split('\n')[0].trim();
+
+    if (claudePath) return claudePath;
+  } catch (error) {
+    // [ANTI-PATTERN IGNORED]: Fallback behavior - which/where failed, continue to throw clear error
+    logger.debug('SDK', 'Claude executable auto-detection failed', {}, error as Error);
+  }
+
+  throw new Error('Claude executable not found. Please either:\n1. Add "claude" to your system PATH, or\n2. Set CLAUDE_CODE_PATH in ~/.claude-mem/settings.json');
+}
+
+/**
+ * Get model ID from settings or environment
+ */
+export function getModelId(): string {
+  const settingsPath = path.join(homedir(), '.claude-mem', 'settings.json');
+  const settings = SettingsDefaultsManager.loadFromFile(settingsPath);
+  return settings.CLAUDE_MEM_MODEL;
+}

--- a/src/services/worker/http/routes/EndlessRoutes.ts
+++ b/src/services/worker/http/routes/EndlessRoutes.ts
@@ -1,0 +1,70 @@
+/**
+ * Endless Mode Routes
+ *
+ * Handles endless mode task lifecycle: starting runs and checking status.
+ * POST /api/endless/run — Start an endless mode task
+ * GET /api/endless/status — Get current task status
+ */
+
+import express, { Request, Response } from 'express';
+import { logger } from '../../../../utils/logger.js';
+import { BaseRouteHandler } from '../BaseRouteHandler.js';
+import { EndlessRunner } from '../../EndlessRunner.js';
+
+export class EndlessRoutes extends BaseRouteHandler {
+  constructor(
+    private endlessRunner: EndlessRunner
+  ) {
+    super();
+  }
+
+  setupRoutes(app: express.Application): void {
+    app.post('/api/endless/run', this.handleRun.bind(this));
+    app.get('/api/endless/status', this.handleStatus.bind(this));
+  }
+
+  /**
+   * Start an endless mode task
+   * POST /api/endless/run
+   * Body: { task: string, project: string, cwd: string }
+   */
+  private handleRun = this.wrapHandler(async (req: Request, res: Response): Promise<void> => {
+    const { task, project, cwd } = req.body;
+
+    if (!this.validateRequired(req, res, ['task', 'project', 'cwd'])) {
+      return;
+    }
+
+    logger.info('HTTP', '→ POST /api/endless/run', {
+      task: task.substring(0, 100),
+      project,
+      cwd,
+    });
+
+    // Start the run in the background — don't block the HTTP response
+    // The caller polls GET /api/endless/status for progress
+    this.endlessRunner.run(task, project, cwd).catch((error) => {
+      logger.error('ENDLESS', 'Endless run failed', {}, error as Error);
+    });
+
+    res.json({
+      status: 'started',
+      taskId: this.endlessRunner.getTaskState()?.taskId,
+    });
+  });
+
+  /**
+   * Get current endless mode task status
+   * GET /api/endless/status
+   */
+  private handleStatus = this.wrapHandler((req: Request, res: Response): void => {
+    const state = this.endlessRunner.getTaskState();
+
+    if (!state) {
+      res.json({ status: 'idle', task: null });
+      return;
+    }
+
+    res.json(state);
+  });
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -15,7 +15,7 @@ export enum LogLevel {
   SILENT = 4
 }
 
-export type Component = 'HOOK' | 'WORKER' | 'SDK' | 'PARSER' | 'DB' | 'SYSTEM' | 'HTTP' | 'SESSION' | 'CHROMA' | 'CHROMA_MCP' | 'CHROMA_SYNC' | 'FOLDER_INDEX' | 'CLAUDE_MD' | 'QUEUE';
+export type Component = 'HOOK' | 'WORKER' | 'SDK' | 'PARSER' | 'DB' | 'SYSTEM' | 'HTTP' | 'SESSION' | 'CHROMA' | 'CHROMA_MCP' | 'CHROMA_SYNC' | 'FOLDER_INDEX' | 'CLAUDE_MD' | 'QUEUE' | 'ENDLESS';
 
 interface LogContext {
   sessionId?: number;


### PR DESCRIPTION
## Summary

- Adds an orchestrator loop (`EndlessRunner`) that automatically cycles Claude Code sessions when context fills up, using observation storage as the cycle trigger
- Extracts shared agent utilities (`findClaudeExecutable`, `getModelId`) from `SDKAgent` into `agent-utils.ts` for reuse
- Adds event-driven queue drain (`waitForQueueEmpty`) to `SessionManager` via new `EventEmitter` on `PendingMessageStore`
- Exposes `POST /api/endless/run` and `GET /api/endless/status` endpoints + `/endless` skill

## How it works

1. User invokes `/endless "Refactor auth to JWT"`
2. Skill POSTs to worker's `/api/endless/run`
3. `EndlessRunner` spawns a Claude Code process via SDK `query()`
4. When the observer stores an observation (meaning work was captured), the session is aborted
5. Observer queue drains, transcript is cleaned up
6. New cycle starts with continuation prompt — SessionStart hook injects compressed prior context
7. Loop exits when the agent finishes naturally (task complete) or hits 100-cycle safety valve

## New files

| File | Purpose |
|------|---------|
| `src/services/worker/EndlessRunner.ts` | Core orchestrator loop |
| `src/services/worker/agent-utils.ts` | Shared claude path + model ID utilities |
| `src/services/worker/http/routes/EndlessRoutes.ts` | HTTP endpoints |
| `plugin/skills/endless/SKILL.md` | User-facing skill |

## Modified files

| File | Change |
|------|--------|
| `PendingMessageStore.ts` | Added EventEmitter, `observation-confirmed` + `queue-empty` events |
| `SessionManager.ts` | Added `waitForQueueEmpty()` with race condition guard |
| `SDKAgent.ts` | Extracted utilities to `agent-utils.ts` |
| `worker-service.ts` | Registered `EndlessRunner` + `EndlessRoutes` |
| `logger.ts` | Added `'ENDLESS'` to Component type |

## Test plan

- [ ] Verify `POST /api/endless/run` starts a task and returns immediately
- [ ] Verify `GET /api/endless/status` reports running task state
- [ ] Verify cycle triggers when observer stores first observation
- [ ] Verify natural completion exits the loop (agent finishes task)
- [ ] Verify queue drain waits for all pending messages before cycling
- [ ] Verify only one task can run at a time (concurrent run returns error)
- [ ] Verify existing observation pipeline (PostToolUse → observer → DB) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)