### PR TITLE
fix: auto-detect Cursor context from cursor_version in hook input

### DIFF
--- a/src/cli/hook-command.ts
+++ b/src/cli/hook-command.ts
@@ -73,12 +73,16 @@ export async function hookCommand(platform: string, event: string, options: Hook
   process.stderr.write = (() => true) as typeof process.stderr.write;
 
   try {
-    const adapter = getPlatformAdapter(platform);
     const handler = getEventHandler(event);
 
     const rawInput = await readJsonFromStdin();
+    // Auto-detect Cursor: when Claude Code plugins run inside Cursor, the raw input
+    // contains cursor_version even though the CLI arg says 'claude-code'. Use the
+    // cursor adapter so SDK agent init is skipped for hooks running in Cursor context.
+    const effectivePlatform = (rawInput as any)?.cursor_version ? 'cursor' : platform;
+    const adapter = getPlatformAdapter(effectivePlatform);
     const input = adapter.normalizeInput(rawInput);
-    input.platform = platform;  // Inject platform for handler-level decisions
+    input.platform = effectivePlatform;  // Inject platform for handler-level decisions
     const result = await handler.execute(input);
     const output = adapter.formatOutput(result);
 


### PR DESCRIPTION
## Problem

When Claude Code plugins run inside Cursor, hooks are invoked with `hook claude-code <event>` as the CLI command (because Cursor reads Claude Code plugin hook configs directly). But the stdin payload Cursor provides always contains `cursor_version` — a Cursor-specific field not present in Claude Code payloads.

This caused `hookCommand` to use the `claude-code` adapter and set `input.platform = 'claude-code'`, bypassing the Cursor platform guard in `session-init` that skips SDK agent init:

```ts
if (input.platform !== 'cursor' && sessionDbId) {
  // SDK agent init — attempts Claude API call
}
```

The SDK agent init then attempts a Claude API call, which fails with 400 (no credentials available in the Cursor subprocess environment). In older plugin versions (e.g. 9.0.12), this threw an error that propagated to `hookCommand`'s catch block, which classified the `4xx` message as a client bug and exited with code 2 — blocking every Cursor prompt.

## Fix

Check `cursor_version` in the raw stdin before selecting the adapter. If present, use the cursor adapter and `effectivePlatform = 'cursor'`, which routes through the Cursor code path and skips SDK agent init.

```ts
const effectivePlatform = (rawInput as any)?.cursor_version ? 'cursor' : platform;
const adapter = getPlatformAdapter(effectivePlatform);
const input = adapter.normalizeInput(rawInput);
input.platform = effectivePlatform;
```

## Root cause trace

1. Cursor reads `~/.claude/plugins/cache/.../hooks/hooks.json` and runs `hook claude-code session-init`
2. `hookCommand` sets `platform = 'claude-code'` from CLI arg, ignoring `cursor_version` in stdin
3. `session-init` handler sees `platform !== 'cursor'` → attempts SDK agent init
4. SDK agent init hits Claude API → 400 → blocks prompt

## Testing

After this fix, hooks invoked from Cursor with `hook claude-code session-init` will detect `cursor_version` in the payload and automatically use the cursor adapter, skipping SDK agent init — same behavior as if the hook had been registered as `hook cursor session-init`.