### PR TITLE
fix: add explicit inputSchema properties for search and timeline MCP tools

### DIFF
--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -188,7 +188,17 @@ NEVER fetch full details without filtering first. 10x token savings.`,
     description: 'Step 1: Search memory. Returns index with IDs. Params: query, limit, project, type, obs_type, dateStart, dateEnd, offset, orderBy',
     inputSchema: {
       type: 'object',
-      properties: {},
+      properties: {
+        query: { type: 'string', description: 'Search term' },
+        limit: { type: 'number', description: 'Max results (default 20, max 100)' },
+        project: { type: 'string', description: 'Project name filter' },
+        type: { type: 'string', description: 'observations, sessions, or prompts' },
+        obs_type: { type: 'string', description: 'Comma-separated: bugfix, feature, decision, discovery, change' },
+        dateStart: { type: 'string', description: 'YYYY-MM-DD or epoch ms' },
+        dateEnd: { type: 'string', description: 'YYYY-MM-DD or epoch ms' },
+        offset: { type: 'number', description: 'Skip N results' },
+        orderBy: { type: 'string', description: 'date_desc (default), date_asc, relevance' }
+      },
       additionalProperties: true
     },
     handler: async (args: any) => {
@@ -201,7 +211,13 @@ NEVER fetch full details without filtering first. 10x token savings.`,
     description: 'Step 2: Get context around results. Params: anchor (observation ID) OR query (finds anchor automatically), depth_before, depth_after, project',
     inputSchema: {
       type: 'object',
-      properties: {},
+      properties: {
+        anchor: { type: 'number', description: 'Observation ID to center around' },
+        query: { type: 'string', description: 'Find anchor automatically if anchor not provided' },
+        depth_before: { type: 'number', description: 'Items before anchor (default 5, max 20)' },
+        depth_after: { type: 'number', description: 'Items after anchor (default 5, max 20)' },
+        project: { type: 'string', description: 'Project name filter' }
+      },
       additionalProperties: true
     },
     handler: async (args: any) => {


### PR DESCRIPTION
## Problem

The `search` and `timeline` tools in `mcp-server.ts` declare their `inputSchema` with empty `properties: {}` and rely on `additionalProperties: true` to accept parameters:

```typescript
inputSchema: {
  type: 'object',
  properties: {},           // empty
  additionalProperties: true
}
```

Claude Code (and potentially other MCP clients that strictly follow JSON Schema) only recognizes parameters explicitly defined in `properties`. It does not infer accepted parameters from `additionalProperties: true`. As a result, clients cannot pass `query`, `limit`, `anchor`, etc., causing server-side errors:

```
Worker API error (500): Either query or filters required for search
```

This has been reported and worked around via manual patching of the compiled `.cjs` output. See also the tool `description` strings which already document the accepted parameters — they just aren't reflected in the schema.

## Fix

Add explicit property definitions (with types and descriptions) to `inputSchema.properties` for:

- **`search`**: `query`, `limit`, `project`, `type`, `obs_type`, `dateStart`, `dateEnd`, `offset`, `orderBy`
- **`timeline`**: `anchor`, `query`, `depth_before`, `depth_after`, `project`

`additionalProperties: true` is preserved for forward compatibility.

No parameters are marked `required` since both tools support flexible query patterns (e.g., `search` can use `query` alone or filters alone).

## Test plan

- [ ] Verify `tools/list` response includes the new properties in `inputSchema`
- [ ] Verify Claude Code can call `search(query="test")` and `timeline(anchor=123)` without errors
- [ ] Verify existing functionality is not broken (all params still pass through to Worker API)