### PR TITLE
feat: add block-no-verify hook for Claude Code and Cursor

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,5 +6,18 @@
       "Read(./node_modules/**)",
       "Read(./.DS_Store)"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/cursor-hooks/hooks.json
+++ b/cursor-hooks/hooks.json
@@ -1,6 +1,11 @@
 {
   "version": 1,
   "hooks": {
+    "beforeShellExecution": [
+      {
+        "command": "npx block-no-verify@1.1.2"
+      }
+    ],
     "beforeSubmitPrompt": [
       {
         "command": "./cursor-hooks/session-init.sh"


### PR DESCRIPTION
## Before submitting

- [x] I searched existing issues and confirmed this is not a duplicate

---

**Is your feature request related to a problem? Please describe.**

claude-mem captures and preserves session context — but AI agents can silently bypass all git quality gates using the hook-bypass flag, undermining the code quality that context is meant to protect.

**Describe the solution you'd like**

Added `block-no-verify@1.1.2` as a blocking hook in both Claude Code and Cursor configs:

- `.claude/settings.json` — PreToolUse Bash hook running `npx block-no-verify@1.1.2`
- `cursor-hooks/hooks.json` — new `beforeShellExecution` entry running `npx block-no-verify@1.1.2`

**Describe alternatives you've considered**

Inline shell check in settings — the dedicated package handles all flag variants and stays maintained.

**Additional context**

The diff is minimal: 9 lines in `.claude/settings.json` and 5 lines in `cursor-hooks/hooks.json`. No custom scripts.

Closes #1405

---

_Disclosure: I am the author and maintainer of `block-no-verify`._
