### PR TITLE
fix: remove Setup hook referencing deleted setup.sh

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,18 +1,6 @@
 {
   "description": "Claude-mem memory system hooks",
   "hooks": {
-    "Setup": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; \"$_R/scripts/setup.sh\"",
-            "timeout": 300
-          }
-        ]
-      }
-    ],
     "SessionStart": [
       {
         "matcher": "startup|clear|compact",


### PR DESCRIPTION
## Summary
- Remove the `Setup` hook block from `plugin/hooks/hooks.json` that references the nonexistent `scripts/setup.sh`

## Why
`setup.sh` was intentionally deleted in v10.5.0 ("Removed legacy setup.sh script"). When v10.5.1 restored hooks.json to a pre-smart-explore configuration, the Setup hook definition came back but the script it points to was never re-created. This causes exit code 127 on every session start.

The `SessionStart` hook already runs `smart-install.js` which handles installation and setup, making the `Setup` hook redundant.

## How
Removed the `Setup` event handler block entirely from hooks.json.

Closes #1396

🤖 Generated with [Claude Code](https://claude.com/claude-code)