### PR TITLE
Use CLAUDE_MEM_WORKER_HOST for health checks, skip local spawn for remote workers

### DIFF
--- a/src/cli/handlers/context.ts
+++ b/src/cli/handlers/context.ts
@@ -6,7 +6,7 @@
  */
 
 import type { EventHandler, NormalizedHookInput, HookResult } from '../types.js';
-import { ensureWorkerRunning, getWorkerPort, workerHttpRequest } from '../../shared/worker-utils.js';
+import { ensureWorkerRunning, getWorkerPort, getWorkerHost, workerHttpRequest } from '../../shared/worker-utils.js';
 import { getProjectContext } from '../../utils/project-name.js';
 import { HOOK_EXIT_CODES } from '../../shared/hook-constants.js';
 import { logger } from '../../utils/logger.js';
@@ -67,8 +67,10 @@ export const contextHandler: EventHandler = {
       const additionalContext = contextResult.trim();
       const coloredTimeline = colorResult.trim();
 
+      const host = getWorkerHost();
+      const displayHost = (host === '0.0.0.0' || host === '127.0.0.1') ? 'localhost' : host;
       const systemMessage = showTerminalOutput && coloredTimeline
-        ? `${coloredTimeline}\n\nView Observations Live @ http://localhost:${port}`
+        ? `${coloredTimeline}\n\nView Observations Live @ http://${displayHost}:${port}`
         : undefined;
 
       return {

--- a/src/services/infrastructure/HealthMonitor.ts
+++ b/src/services/infrastructure/HealthMonitor.ts
@@ -13,9 +13,11 @@ import path from 'path';
 import { readFileSync } from 'fs';
 import { logger } from '../../utils/logger.js';
 import { MARKETPLACE_ROOT } from '../../shared/paths.js';
+import { getWorkerHost } from '../../shared/worker-utils.js';
 
 /**
  * Make an HTTP request to the worker via TCP.
+ * Uses the configured CLAUDE_MEM_WORKER_HOST (defaults to 127.0.0.1).
  * Returns { ok, statusCode, body } or throws on transport error.
  */
 async function httpRequestToWorker(
@@ -23,7 +25,8 @@ async function httpRequestToWorker(
   endpointPath: string,
   method: string = 'GET'
 ): Promise<{ ok: boolean; statusCode: number; body: string }> {
-  const response = await fetch(`http://127.0.0.1:${port}${endpointPath}`, { method });
+  const host = getWorkerHost();
+  const response = await fetch(`http://${host}:${port}${endpointPath}`, { method });
   // Gracefully handle cases where response body isn't available (e.g., test mocks)
   let body = '';
   try {
@@ -40,7 +43,8 @@ async function httpRequestToWorker(
 export async function isPortInUse(port: number): Promise<boolean> {
   try {
     // Note: Removed AbortSignal.timeout to avoid Windows Bun cleanup issue (libuv assertion)
-    const response = await fetch(`http://127.0.0.1:${port}/api/health`);
+    const host = getWorkerHost();
+    const response = await fetch(`http://${host}:${port}/api/health`);
     return response.ok;
   } catch (error) {
     // [ANTI-PATTERN IGNORED]: Health check polls every 500ms, logging would flood

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -13,7 +13,7 @@ import path from 'path';
 import { existsSync, writeFileSync, unlinkSync, statSync } from 'fs';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { getWorkerPort, getWorkerHost } from '../shared/worker-utils.js';
+import { getWorkerPort, getWorkerHost, isWorkerLocal } from '../shared/worker-utils.js';
 import { HOOK_TIMEOUTS } from '../shared/hook-constants.js';
 import { SettingsDefaultsManager } from '../shared/SettingsDefaultsManager.js';
 import { getAuthMethodDescription } from '../shared/EnvManager.js';
@@ -937,6 +937,18 @@ export class WorkerService {
  * @returns true if worker is healthy (existing or newly started), false on failure
  */
 async function ensureWorkerStarted(port: number): Promise<boolean> {
+  // When CLAUDE_MEM_WORKER_HOST points to a remote address, do not spawn
+  // a local daemon. Just check if the remote worker is healthy.
+  if (!isWorkerLocal()) {
+    const healthy = await waitForHealth(port, 1000);
+    if (healthy) {
+      logger.info('SYSTEM', 'Remote worker is healthy', { host: getWorkerHost() });
+      return true;
+    }
+    logger.warn('SYSTEM', 'Remote worker not reachable, skipping local daemon spawn', { host: getWorkerHost() });
+    return false;
+  }
+
   // Clean stale PID file first (cheap: 1 fs read + 1 signal-0 check)
   const pidFileStatus = cleanStalePidFile();
   if (pidFileStatus === 'alive') {

--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -78,6 +78,16 @@ export function getWorkerHost(): string {
 }
 
 /**
+ * Check if the configured worker host is a local address.
+ * Returns false for remote hosts, meaning the worker daemon should not
+ * be spawned locally — health checks should target the remote host instead.
+ */
+export function isWorkerLocal(): boolean {
+  const host = getWorkerHost();
+  return host === '127.0.0.1' || host === 'localhost' || host === '0.0.0.0' || host === '::1';
+}
+
+/**
  * Clear the cached port and host values.
  * Call this when settings are updated to force re-reading from file.
  */


### PR DESCRIPTION
## Summary

`CLAUDE_MEM_WORKER_HOST` is configurable via `settings.json`, and `getWorkerHost()` + `buildWorkerUrl()` in `worker-utils.ts` already respect it. However, `HealthMonitor.ts` hardcodes `127.0.0.1` for all HTTP requests (health checks, port-in-use detection, shutdown, version checks). This causes `ensureWorkerStarted()` to always find nothing on localhost and spawn a local daemon — even when the configured host points to a remote worker that is healthy and reachable.

**Result:** `CLAUDE_MEM_WORKER_HOST` is effectively a no-op for the worker lifecycle. The local daemon shadows the remote worker on the same port.

## Changes

- **`HealthMonitor.ts`**: `httpRequestToWorker()` and `isPortInUse()` now call `getWorkerHost()` instead of hardcoding `127.0.0.1`
- **`worker-utils.ts`**: Added `isWorkerLocal()` helper — returns `false` for non-local hosts (`127.0.0.1`, `localhost`, `0.0.0.0`, `::1`)
- **`worker-service.ts`**: `ensureWorkerStarted()` checks `isWorkerLocal()` first. For remote hosts, it only does a health check and skips PID file management and daemon spawn entirely
- **`context.ts`**: Status line now shows the configured host instead of hardcoded `localhost`

## Use case

Running claude-mem as a standalone Docker container on a remote VPS, accessed over a VPN. The local machine acts as a thin client — hooks send data to the remote worker via `CLAUDE_MEM_WORKER_HOST`, no local daemon needed.

## Test plan

- [ ] Verify default behavior unchanged: `CLAUDE_MEM_WORKER_HOST=127.0.0.1` still spawns local daemon as before
- [ ] Set `CLAUDE_MEM_WORKER_HOST` to a remote address with a healthy worker → no local daemon spawned, hooks communicate with remote
- [ ] Set `CLAUDE_MEM_WORKER_HOST` to a remote address with no worker → graceful failure, no local spawn attempted
- [ ] Status line shows correct host in viewer URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)