### PR TITLE
fix: strip hardcoded __dirname/__filename from bundled CJS output

### DIFF
--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -45,17 +45,22 @@ function stripHardcodedDirname(filePath) {
   let content = fs.readFileSync(filePath, 'utf-8');
   const before = content.length;
 
-  // Remove `var __dirname = "...", rest` → `var rest`
-  content = content.replace(/\bvar __dirname\s*=\s*"[^"]*",\s*/g, 'var ');
-  // Remove standalone `var __dirname = "...";`
-  content = content.replace(/\bvar __dirname\s*=\s*"[^"]*";\s*/g, '');
-  // Remove `, __dirname = "..."` from mid/end of var declarations
-  content = content.replace(/,\s*__dirname\s*=\s*"[^"]*"/g, '');
+  // Match both double-quoted and single-quoted string literals.
+  // esbuild currently emits double quotes, but single quotes are handled
+  // defensively in case future versions change quoting style.
+  const str = `(?:"[^"]*"|'[^']*')`;
 
-  // Same for __filename
-  content = content.replace(/\bvar __filename\s*=\s*"[^"]*",\s*/g, 'var ');
-  content = content.replace(/\bvar __filename\s*=\s*"[^"]*";\s*/g, '');
-  content = content.replace(/,\s*__filename\s*=\s*"[^"]*"/g, '');
+  for (const id of ['__dirname', '__filename']) {
+    // Remove `var <id> = "...", rest` → `var rest`
+    content = content.replace(new RegExp(`\\bvar ${id}\\s*=\\s*${str},\\s*`, 'g'), 'var ');
+    // Remove standalone `var <id> = "...";`
+    content = content.replace(new RegExp(`\\bvar ${id}\\s*=\\s*${str};\\s*`, 'g'), '');
+    // Remove `, <id> = "..."` from mid/end of var declarations
+    content = content.replace(new RegExp(`,\\s*${id}\\s*=\\s*${str}`, 'g'), '');
+  }
+
+  // Clean up dangling `var ;` left when __dirname was the sole declarator
+  content = content.replace(/\bvar\s*;/g, '');
 
   const removed = before - content.length;
   if (removed > 0) {


### PR DESCRIPTION
## Summary

Fixes #1410

When esbuild converts ESM TypeScript source to CJS format (`format: 'cjs'`), it inlines `__dirname` and `__filename` as **static strings** based on the source file paths at build time. For example:

```js
var __dirname = "/Users/alexnewman/conductor/workspaces/claude-mem/banjul/src/shared", _dirname, DATA_DIR, ...;
```

These `var` declarations shadow the runtime's native `__dirname` (provided by Bun/Node's CJS module wrapper), causing `getDirname()` → `getPackageRoot()` to resolve to a non-existent directory on end-user machines. This breaks:

- **Viewer UI** — `viewer.html` can't be found (`"Viewer UI not found at any expected location"`)
- **Mode loading** — `code.json` can't be found
- **Database initialization** — `initializeBackground()` crashes
- **Skill file resolution** — mem-search operations/SKILL.md paths fail

## Fix

Adds a `stripHardcodedDirname()` post-build step in `scripts/build-hooks.js` that removes the hardcoded `var __dirname = "..."` and `var __filename = "..."` assignments from all bundled CJS outputs (`worker-service.cjs`, `mcp-server.cjs`, `context-generator.cjs`). This allows the runtime's native `__dirname`/`__filename` globals to work correctly.

The function handles all patterns esbuild produces:
- `var __dirname = "...", rest` → `var rest` (multi-var, leading)
- `var __dirname = "...";` → removed (standalone)
- `..., __dirname = "..."` → removed (mid/end of declaration)

## Test plan

- [x] Run `node scripts/build-hooks.js` and verify the post-build strip message appears
- [x] Verify `plugin/scripts/worker-service.cjs` contains no hardcoded `/Users/` paths in `var __dirname` declarations
- [x] Fresh install: worker starts, `localhost:37777` serves the viewer UI
- [x] Verify `getDirname()` returns the actual script directory at runtime
