### PR TITLE
feat: add CLAUDE_MEM_IGNORE_PROMPT_PATTERNS setting to filter noise prompts

### DIFF
--- a/src/services/worker/http/routes/SessionRoutes.ts
+++ b/src/services/worker/http/routes/SessionRoutes.ts
@@ -756,6 +756,27 @@ export class SessionRoutes extends BaseRouteHandler {
       return;
     }
 
+    // Step 4b: Check if prompt matches any ignore patterns
+    const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+    const ignorePatterns = settings.CLAUDE_MEM_IGNORE_PROMPT_PATTERNS;
+    if (ignorePatterns) {
+      const patterns = ignorePatterns.split(',').map((p: string) => p.trim()).filter(Boolean);
+      if (patterns.some((pattern: string) => cleanedPrompt.includes(pattern))) {
+        logger.debug('HOOK', 'Session init - prompt matches ignore pattern, skipping storage', {
+          sessionId: sessionDbId,
+          promptNumber
+        });
+
+        res.json({
+          sessionDbId,
+          promptNumber,
+          skipped: true,
+          reason: 'ignored'
+        });
+        return;
+      }
+    }
+
     // Step 5: Save cleaned user prompt
     store.saveUserPrompt(contentSessionId, promptNumber, cleanedPrompt);
 

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -54,6 +54,8 @@ export interface SettingsDefaults {
   // Exclusion Settings
   CLAUDE_MEM_EXCLUDED_PROJECTS: string;  // Comma-separated glob patterns for excluded project paths
   CLAUDE_MEM_FOLDER_MD_EXCLUDE: string;  // JSON array of folder paths to exclude from CLAUDE.md generation
+  // Prompt Filtering
+  CLAUDE_MEM_IGNORE_PROMPT_PATTERNS: string;  // Comma-separated substrings; prompts containing any are not stored (default: '')
   // Chroma Vector Database Configuration
   CLAUDE_MEM_CHROMA_ENABLED: string;   // 'true' | 'false' - set to 'false' for SQLite-only mode
   CLAUDE_MEM_CHROMA_MODE: string;      // 'local' | 'remote'
@@ -113,6 +115,8 @@ export class SettingsDefaultsManager {
     // Exclusion Settings
     CLAUDE_MEM_EXCLUDED_PROJECTS: '',  // Comma-separated glob patterns for excluded project paths
     CLAUDE_MEM_FOLDER_MD_EXCLUDE: '[]',  // JSON array of folder paths to exclude from CLAUDE.md generation
+    // Prompt Filtering
+    CLAUDE_MEM_IGNORE_PROMPT_PATTERNS: '',     // Empty = no filtering; set to comma-separated substrings to skip storage
     // Chroma Vector Database Configuration
     CLAUDE_MEM_CHROMA_ENABLED: 'true',         // Set to 'false' to disable Chroma and use SQLite-only search
     CLAUDE_MEM_CHROMA_MODE: 'local',           // 'local' uses persistent chroma-mcp via uvx, 'remote' connects to existing server


### PR DESCRIPTION
## Problem

System owners sometimes create automated tooling and shell scripts that routinely inject short prompts into Claude Code sessions to prompt continuous activity -- health checks, inbox monitors, tmux-based injections, periodic pokes, etc. Because they appear as user -submitted prompts, these get stored in the claude-mem database, polluting search results and timeline views with automation noise that has no real value as session memory.

## Solution

A new setting `CLAUDE_MEM_IGNORE_PROMPT_PATTERNS` accepts a comma-separated list of substrings. When a prompt contains any of these substrings (after privacy tag stripping), it is skipped before storage. By default, this setting contains no filter substrings; they may added by the system owner as needed.

## Changes

**`src/shared/SettingsDefaultsManager.ts`**

New setting added to both the interface and DEFAULTS:

```typescript
CLAUDE_MEM_IGNORE_PROMPT_PATTERNS: string  // default: ''
```

**`src/services/worker/http/routes/SessionRoutes.ts`**

After privacy tag stripping (Step 4) and before `saveUserPrompt()` (Step 5), a new check (Step 4b) reads the patterns setting, splits on comma, and tests the cleaned prompt for substring matches. On match, returns:

```json
{"sessionDbId": 123, "promptNumber": 4, "skipped": true, "reason": "ignored"}
```

## Configuration

In `~/.claude-mem/settings.json`:

```json
{
  "CLAUDE_MEM_IGNORE_PROMPT_PATTERNS": "check inbox,heartbeat,poke"
}
```

Or via environment variable:

```bash
export CLAUDE_MEM_IGNORE_PROMPT_PATTERNS="check inbox,heartbeat,poke"
```

## Behavior

- Empty string (default): one falsy check and moves on - no filtering, all prompts stored as before
- Pattern matching is case-sensitive substring match on the cleaned prompt text
- The session record is still created (idempotent `INSERT OR IGNORE`) -- only the user_prompt row is skipped
- Falls through to normal processing if no patterns match

## Relationship to #1169

PR #1169 (session-init dedup) prevents redundant re-initialization when the same session fires multiple hooks. This PR prevents storage of prompts that are automation noise regardless of session state. They address different layers of the same general problem: keeping memory focused on genuine development work.