### PR TITLE
fix: prevent cold start hook errors from aggressiveStartupCleanup killing parent process

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,18 +1,6 @@
 {
   "description": "Claude-mem memory system hooks",
   "hooks": {
-    "Setup": [
-      {
-        "matcher": "*",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; \"$_R/scripts/setup.sh\"",
-            "timeout": 300
-          }
-        ]
-      }
-    ],
     "SessionStart": [
       {
         "matcher": "startup|clear|compact",
@@ -21,11 +9,6 @@
             "type": "command",
             "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/smart-install.js\"",
             "timeout": 300
-          },
-          {
-            "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" start",
-            "timeout": 60
           },
           {
             "type": "command",

--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -139,12 +139,12 @@ function collectStdin() {
       resolve(null);
     });
 
-    // Safety: if no data arrives within 5s, proceed without stdin
+    // Safety: if no data arrives within 500ms, proceed without stdin
     setTimeout(() => {
       process.stdin.removeAllListeners();
       process.stdin.pause();
       resolve(chunks.length > 0 ? Buffer.concat(chunks) : null);
-    }, 5000);
+    }, 500);
   });
 }
 

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -438,9 +438,7 @@ async function main() {
   setTimeout(async () => {
     const workerAvailable = await verifyWorkerConnection();
     if (!workerAvailable) {
-      logger.error('SYSTEM', 'Worker not available', undefined, {});
-      logger.error('SYSTEM', 'Tools will fail until Worker is started');
-      logger.error('SYSTEM', 'Start Worker with: npm run worker:restart');
+      logger.info('SYSTEM', 'Worker not yet available, will connect when ready', undefined, {});
     } else {
       logger.info('SYSTEM', 'Worker available', undefined, {});
     }

--- a/src/services/infrastructure/ProcessManager.ts
+++ b/src/services/infrastructure/ProcessManager.ts
@@ -475,7 +475,7 @@ export async function aggressiveStartupCleanup(): Promise<void> {
 
       for (const proc of processList) {
         const pid = proc.ProcessId;
-        if (!Number.isInteger(pid) || pid <= 0 || pid === currentPid) continue;
+        if (!Number.isInteger(pid) || pid <= 0 || pid === currentPid || pid === process.ppid) continue;
 
         const commandLine = proc.CommandLine || '';
         const isAggressive = AGGRESSIVE_CLEANUP_PATTERNS.some(p => commandLine.includes(p));
@@ -518,7 +518,7 @@ export async function aggressiveStartupCleanup(): Promise<void> {
         const etime = match[2];
         const command = match[3];
 
-        if (!Number.isInteger(pid) || pid <= 0 || pid === currentPid) continue;
+        if (!Number.isInteger(pid) || pid <= 0 || pid === currentPid || pid === process.ppid) continue;
 
         const isAggressive = AGGRESSIVE_CLEANUP_PATTERNS.some(p => command.includes(p));
 

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -1164,10 +1164,8 @@ async function main() {
       // sandbox kills. Instead, ensureWorkerStarted() spawns a fully detached
       // daemon (detached: true, stdio: 'ignore', child.unref()) that survives
       // the hook process's exit and is invisible to Claude Code's sandbox.
-      const workerReady = await ensureWorkerStarted(port);
-      if (!workerReady) {
-        logger.warn('SYSTEM', 'Worker failed to start before hook, handler will proceed gracefully');
-      }
+      await ensureWorkerStarted(port) || logger.warn("SYSTEM", "Worker failed to start...");
+      await waitForReadiness(port, getPlatformTimeout(HOOK_TIMEOUTS.READINESS_WAIT)) || logger.warn("SYSTEM", "Worker readiness timed out before hook, proceeding anyway");
 
       const { hookCommand } = await import('../cli/hook-command.js');
       await hookCommand(platform, event);


### PR DESCRIPTION
## Summary

Fixes multiple cold start issues that cause "SessionStart:startup hook error" and missing context banner on first launch after reboot.

## Root Cause

`aggressiveStartupCleanup()` in `ProcessManager.ts` SIGKILLs all processes whose command line matches `worker-service.cjs`, including the hook process that spawned the daemon. The daemon kills its own parent before the hook can return output.

Introduced in commit `d333c7d` (v9.1.0). Was masked by the in-process worker fallback until v10.5.6 removed it (PR #1370).

## Changes

| File | Change | Why |
|------|--------|-----|
| `ProcessManager.ts` | Add `process.ppid` to PID exclusion list | Prevents daemon from killing the hook that spawned it |
| `hooks.json` | Remove stale `Setup` hook | `setup.sh` was deleted in v10.5.0 but hook entry remained |
| `hooks.json` | Remove redundant `start` hook from SessionStart | `context` hook already calls `ensureWorkerStarted()` internally; parallel execution causes "port in use" race |
| `bun-runner.js` | Reduce `collectStdin` timeout from 5s to 500ms | SessionStart hooks don't receive stdin; 5s delay wastes startup time |
| `worker-service.ts` | Add `waitForReadiness()` in hook handler | Ensures DB is initialized before fetching context, preventing empty banner |
| `mcp-server.ts` | Downgrade cold-start worker check from `error` to `info` | Prevents stderr output from being surfaced as hook error by Claude Code |

## Testing

Verified on macOS ARM64 (Apple Silicon) with Claude Code 2.1.80 and claude-mem v10.6.1:
- Before: "SessionStart:startup hook error" on every cold boot, no context banner, requires restart
- After: Clean startup, context banner shows immediately, no errors

Note: `plugin/scripts/worker-service.cjs` and `plugin/scripts/mcp-server.cjs` are bundled outputs and not modified here. They will need to be rebuilt from the updated source.

## Related Issues

Fixes #1426
Related: #1423 #1419 #1410 #1395


🤖 Generated with [Claude Code](https://claude.com/claude-code)