### PR TITLE
feat: persist ANTHROPIC_BASE_URL in ~/.claude-mem/.env for custom gateway support

### DIFF
--- a/docs/public/configuration.mdx
+++ b/docs/public/configuration.mdx
@@ -52,6 +52,23 @@ See [OpenRouter Provider](usage/openrouter-provider) for detailed configuration,
 | `CLAUDE_MEM_PYTHON_VERSION`   | `3.13`                          | Python version for chroma-mcp         |
 | `CLAUDE_CODE_PATH`            | _(auto-detect)_                 | Path to Claude Code CLI (for Windows) |
 
+## Custom Gateway / Proxy Configuration
+
+Corporate environments commonly route Anthropic API calls through an internal LLM gateway or proxy. Claude-mem supports this via `ANTHROPIC_BASE_URL` in `~/.claude-mem/.env`.
+
+Edit `~/.claude-mem/.env`:
+
+```bash
+ANTHROPIC_API_KEY=your-gateway-api-key
+ANTHROPIC_BASE_URL=https://your-gateway.example.com/v1
+```
+
+Both values are persisted in this file so they survive worker daemon restarts, regardless of which shell context started the daemon. The gateway must be compatible with the Anthropic Messages API format (`POST /v1/messages`).
+
+<Note>
+`ANTHROPIC_BASE_URL` also passes through from the shell environment, but persisting it in `~/.claude-mem/.env` is more reliable for long-running worker daemons that may outlive the original shell session.
+</Note>
+
 ## Model Configuration
 
 Configure which AI model processes your observations.

--- a/src/shared/EnvManager.ts
+++ b/src/shared/EnvManager.ts
@@ -42,6 +42,8 @@ export interface ClaudeMemEnv {
   ANTHROPIC_API_KEY?: string;
   GEMINI_API_KEY?: string;
   OPENROUTER_API_KEY?: string;
+  // Configuration (optional - for corporate LLM gateways and custom endpoints)
+  ANTHROPIC_BASE_URL?: string;
 }
 
 /**
@@ -82,9 +84,10 @@ function parseEnvFile(content: string): Record<string, string> {
  */
 function serializeEnvFile(env: Record<string, string>): string {
   const lines: string[] = [
-    '# claude-mem credentials',
-    '# This file stores API keys for claude-mem memory agent',
+    '# claude-mem credentials and configuration',
+    '# This file stores API keys and endpoint settings for claude-mem',
     '# Edit this file or use claude-mem settings to configure',
+    '# Set ANTHROPIC_BASE_URL here if using a corporate LLM gateway or proxy',
     '',
   ];
 
@@ -112,11 +115,12 @@ export function loadClaudeMemEnv(): ClaudeMemEnv {
     const content = readFileSync(ENV_FILE_PATH, 'utf-8');
     const parsed = parseEnvFile(content);
 
-    // Only return managed credential keys
+    // Only return managed keys (credentials + configuration)
     const result: ClaudeMemEnv = {};
     if (parsed.ANTHROPIC_API_KEY) result.ANTHROPIC_API_KEY = parsed.ANTHROPIC_API_KEY;
     if (parsed.GEMINI_API_KEY) result.GEMINI_API_KEY = parsed.GEMINI_API_KEY;
     if (parsed.OPENROUTER_API_KEY) result.OPENROUTER_API_KEY = parsed.OPENROUTER_API_KEY;
+    if (parsed.ANTHROPIC_BASE_URL) result.ANTHROPIC_BASE_URL = parsed.ANTHROPIC_BASE_URL;
 
     return result;
   } catch (error) {
@@ -163,6 +167,13 @@ export function saveClaudeMemEnv(env: ClaudeMemEnv): void {
         updated.OPENROUTER_API_KEY = env.OPENROUTER_API_KEY;
       } else {
         delete updated.OPENROUTER_API_KEY;
+      }
+    }
+    if (env.ANTHROPIC_BASE_URL !== undefined) {
+      if (env.ANTHROPIC_BASE_URL) {
+        updated.ANTHROPIC_BASE_URL = env.ANTHROPIC_BASE_URL;
+      } else {
+        delete updated.ANTHROPIC_BASE_URL;
       }
     }
 
@@ -219,7 +230,17 @@ export function buildIsolatedEnv(includeCredentials: boolean = true): Record<str
       isolatedEnv.OPENROUTER_API_KEY = credentials.OPENROUTER_API_KEY;
     }
 
-    // 4. Pass through Claude CLI's OAuth token if available (fallback for CLI subscription billing)
+    // 4. Re-inject ANTHROPIC_BASE_URL from managed .env if configured.
+    // Corporate environments commonly route API calls through an LLM gateway
+    // or proxy, requiring a custom base URL. While ANTHROPIC_BASE_URL passes
+    // through from process.env (it's not in BLOCKED_ENV_VARS), the worker
+    // daemon may have been started in a shell context that lacked this variable.
+    // Persisting it in ~/.claude-mem/.env ensures it survives daemon restarts.
+    if (credentials.ANTHROPIC_BASE_URL) {
+      isolatedEnv.ANTHROPIC_BASE_URL = credentials.ANTHROPIC_BASE_URL;
+    }
+
+    // 5. Pass through Claude CLI's OAuth token if available (fallback for CLI subscription billing)
     // When no ANTHROPIC_API_KEY is configured, the spawned CLI uses subscription billing
     // which requires either ~/.claude/.credentials.json or CLAUDE_CODE_OAUTH_TOKEN.
     // The worker inherits this token from the Claude Code session that started it.


### PR DESCRIPTION
## Problem

Corporate environments commonly route Anthropic API calls through an internal LLM gateway or proxy (e.g., AWS API Gateway, custom Bedrock proxies, on-prem endpoints). This requires setting `ANTHROPIC_BASE_URL` alongside `ANTHROPIC_API_KEY`.

Currently, `ANTHROPIC_BASE_URL` passes through from `process.env` (it's not in `BLOCKED_ENV_VARS`), but the worker daemon may have been started in a shell context that lacked this variable, or may outlive the shell session that originally set it. When the base URL is lost, the SDK subprocess silently fails with "Not logged in" because it falls back to Anthropic's default endpoint where the gateway API key is not recognized.

This is a real-world issue: corporate users configure both `ANTHROPIC_API_KEY` and `ANTHROPIC_BASE_URL` in their shell profile, but only `ANTHROPIC_API_KEY` gets persisted (via `~/.claude-mem/.env`), while `ANTHROPIC_BASE_URL` is lost on daemon restart.

## Solution

Extend `~/.claude-mem/.env` to also manage `ANTHROPIC_BASE_URL`, following the same pattern used for API keys:

- Add `ANTHROPIC_BASE_URL` to `ClaudeMemEnv` interface
- Read/write it in `loadClaudeMemEnv()` / `saveClaudeMemEnv()`
- Re-inject it in `buildIsolatedEnv()` so subprocess always gets the configured endpoint
- Document custom gateway configuration in `docs/configuration.mdx`

## Changes

- `src/shared/EnvManager.ts`: 4 surgical additions following existing credential patterns
- `docs/public/configuration.mdx`: new "Custom Gateway / Proxy Configuration" section

## Testing

Verified manually in a corporate environment using an Anthropic-compatible LLM gateway. Before this change, the worker would fail with "Not logged in" after daemon restart. After adding `ANTHROPIC_BASE_URL` to `~/.claude-mem/.env`, the worker correctly routes requests through the gateway across restarts.