### PR TITLE
fix: prioritize import.meta.url over __dirname in getDirname()

### DIFF
--- a/src/shared/paths.ts
+++ b/src/shared/paths.ts
@@ -6,14 +6,19 @@ import { fileURLToPath } from 'url';
 import { SettingsDefaultsManager } from './SettingsDefaultsManager.js';
 import { logger } from '../utils/logger.js';
 
-// Get __dirname that works in both ESM (hooks) and CJS (worker) contexts
+// Get __dirname that works in both ESM (hooks) and CJS (worker) contexts.
+// import.meta.url is preferred because esbuild inlines __dirname as a static
+// string from the build machine, which breaks path resolution on end-user
+// machines.  The CJS __dirname fallback is kept for environments where
+// import.meta.url is unavailable.
 function getDirname(): string {
-  // CJS context - __dirname exists
+  // Prefer import.meta.url — resolves correctly at runtime on any machine
+  try { return dirname(fileURLToPath(import.meta.url)); } catch {}
+  // CJS context fallback
   if (typeof __dirname !== 'undefined') {
     return __dirname;
   }
-  // ESM context - use import.meta.url
-  return dirname(fileURLToPath(import.meta.url));
+  return process.cwd();
 }
 
 const _dirname = getDirname();


### PR DESCRIPTION
## Summary

- esbuild inlines `__dirname` as a static string from the build machine (`/Users/alexnewman/...`), which shadows Bun's native `__dirname` in the bundled `worker-service.cjs`
- `getDirname()` always takes the `typeof __dirname !== 'undefined'` branch (due to `var` hoisting of the hardcoded value), so the `import.meta.url` fallback is never reached
- This causes `code.json` mode file loading, database initialization, and viewer UI serving to fail on all end-user machines
- Fix: check `import.meta.url` first (resolves correctly at runtime), fall back to `__dirname`, then `process.cwd()`

Fixes #1410, #1419, #1433, #1437

## Test plan

- [ ] Fresh install on a non-dev machine — worker should reach `initialized: true` and `mcpReady: true`
- [ ] `curl http://localhost:37777/api/health` returns `initialized: true`
- [ ] Mode file (`code.json`) loads without error
- [ ] Viewer UI at `http://localhost:37777` serves correctly
- [ ] Verify hooks still work in ESM context (session start/end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)