### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 <h1 align="center">
+
+[![gitcgr](https://gitcgr.com/badge/thedotmack/claude-mem.svg)](https://gitcgr.com/thedotmack/claude-mem)
   <br>
   <a href="https://github.com/thedotmack/claude-mem">
     <picture>


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/thedotmack/claude-mem.svg)](https://gitcgr.com/thedotmack/claude-mem)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).