### PR TITLE
feat(openclaw): add workerHost config for Docker deployments

### DIFF
--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -27,6 +27,11 @@
         "default": 37777,
         "description": "Port for Claude-Mem worker service"
       },
+      "workerHost": {
+        "type": "string",
+        "default": "127.0.0.1",
+        "description": "Hostname for Claude-Mem worker service. Set to host.docker.internal when the gateway runs in Docker and the worker runs on the host."
+      },
       "project": {
         "type": "string",
         "default": "openclaw",

--- a/openclaw/src/index.ts
+++ b/openclaw/src/index.ts
@@ -183,6 +183,7 @@ interface ClaudeMemPluginConfig {
   syncMemoryFileExclude?: string[];
   project?: string;
   workerPort?: number;
+  workerHost?: string;
   observationFeed?: {
     enabled?: boolean;
     channel?: string;
@@ -198,6 +199,7 @@ interface ClaudeMemPluginConfig {
 
 const MAX_SSE_BUFFER_SIZE = 1024 * 1024; // 1MB
 const DEFAULT_WORKER_PORT = 37777;
+const DEFAULT_WORKER_HOST = "127.0.0.1";
 
 // Emoji pool for deterministic auto-assignment to unknown agents.
 // Uses a hash of the agentId to pick a consistent emoji — no persistent state needed.
@@ -256,8 +258,10 @@ function buildGetSourceLabel(
 // Worker HTTP Client
 // ============================================================================
 
+let _workerHost = DEFAULT_WORKER_HOST;
+
 function workerBaseUrl(port: number): string {
-  return `http://127.0.0.1:${port}`;
+  return `http://${_workerHost}:${port}`;
 }
 
 async function workerPost(
@@ -533,6 +537,7 @@ async function connectToSSEStream(
 export default function claudeMemPlugin(api: OpenClawPluginApi): void {
   const userConfig = (api.pluginConfig || {}) as ClaudeMemPluginConfig;
   const workerPort = userConfig.workerPort || DEFAULT_WORKER_PORT;
+  _workerHost = userConfig.workerHost || DEFAULT_WORKER_HOST;
   const baseProjectName = userConfig.project || "openclaw";
   const getSourceLabel = buildGetSourceLabel(userConfig.observationFeed?.emojis);
 
@@ -1047,5 +1052,5 @@ export default function claudeMemPlugin(api: OpenClawPluginApi): void {
     },
   });
 
-  api.logger.info(`[claude-mem] OpenClaw plugin loaded — v1.0.0 (worker: 127.0.0.1:${workerPort})`);
+  api.logger.info(`[claude-mem] OpenClaw plugin loaded — v1.0.0 (worker: ${_workerHost}:${workerPort})`);
 }


### PR DESCRIPTION
## Summary

When the OpenClaw gateway runs in Docker and the claude-mem worker runs on the host machine, the plugin cannot reach the worker at `localhost:37777` because `localhost` inside Docker resolves to the container itself, not the host.

This PR adds a `workerHost` configuration option to the OpenClaw plugin, allowing users to override the default `127.0.0.1` with `host.docker.internal` (or any other hostname) for Docker-based deployments.

## Changes

- **`openclaw/src/index.ts`**: Add `workerHost` to `ClaudeMemPluginConfig` interface, read it from plugin config, and use it in `workerBaseUrl()`
- **`openclaw/openclaw.plugin.json`**: Add `workerHost` to the config schema so it passes validation

## Usage

```json
{
  "plugins": {
    "entries": {
      "claude-mem": {
        "enabled": true,
        "config": {
          "workerHost": "host.docker.internal",
          "observationFeed": {
            "enabled": true,
            "channel": "telegram",
            "to": "123456789"
          }
        }
      }
    }
  }
}
```

## Test plan

- [x] TypeScript compiles without errors (`npm run build`)
- [x] Verified on macOS Docker Desktop: gateway connects to worker via `host.docker.internal:37777`
- [x] Default behavior unchanged — omitting `workerHost` still uses `127.0.0.1`