### PR TITLE
feat: add CLAUDE_MEM_DISABLED env var for headless sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,21 @@ Settings are managed in `~/.claude-mem/settings.json` (auto-created with default
 
 See the **[Configuration Guide](https://docs.claude-mem.ai/configuration)** for all available settings and examples.
 
+### Disabling for Headless/Agent Sessions
+
+If you run Claude Code in headless or multi-agent setups (e.g. Paperclip, CI pipelines), you can disable claude-mem per-session with an environment variable:
+
+```bash
+CLAUDE_MEM_DISABLED=1 claude --print "your prompt here"
+```
+
+This is useful when:
+- Agent sessions should not inject or record observations
+- You want to avoid token waste from context injection in automated pipelines
+- Cross-contamination between agent and user sessions is a concern
+
+Unlike `CLAUDE_CONFIG_DIR` overrides, this does not break OAuth authentication.
+
 ---
 
 ## Development

--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -79,6 +79,13 @@ function findBun() {
   return null;
 }
 
+// Early exit if disabled via environment variable (#1484).
+// Allows orchestration platforms (e.g. Paperclip) to disable claude-mem
+// per-session without affecting auth or global plugin state.
+if (process.env.CLAUDE_MEM_DISABLED === '1') {
+  process.exit(0);
+}
+
 // Early exit if plugin is disabled in Claude Code settings (#781).
 // Sync read + JSON parse — fastest possible check before spawning Bun.
 function isPluginDisabledInClaudeSettings() {

--- a/src/shared/plugin-state.ts
+++ b/src/shared/plugin-state.ts
@@ -10,6 +10,15 @@ import { homedir } from 'os';
 const PLUGIN_SETTINGS_KEY = 'claude-mem@thedotmack';
 
 /**
+ * Check if claude-mem is disabled via CLAUDE_MEM_DISABLED env var (#1484).
+ * Intended for orchestration platforms (e.g. Paperclip) that need to disable
+ * claude-mem per-session without affecting auth or global plugin state.
+ */
+export function isDisabledByEnvVar(): boolean {
+  return process.env.CLAUDE_MEM_DISABLED === '1';
+}
+
+/**
  * Check if claude-mem is disabled in Claude Code's settings (#781).
  * Sync read + JSON parse for speed — called before any async work.
  * Returns true only if the plugin is explicitly disabled (enabledPlugins[key] === false).

--- a/tests/infrastructure/plugin-disabled-check.test.ts
+++ b/tests/infrastructure/plugin-disabled-check.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { isPluginDisabledInClaudeSettings } from '../../src/shared/plugin-state.js';
+import { isPluginDisabledInClaudeSettings, isDisabledByEnvVar } from '../../src/shared/plugin-state.js';
 
 /**
  * Tests for isPluginDisabledInClaudeSettings() (#781).
@@ -87,5 +87,46 @@ describe('isPluginDisabledInClaudeSettings (#781)', () => {
   it('should return false when settings.json is empty', () => {
     writeFileSync(join(tempDir, 'settings.json'), '');
     expect(isPluginDisabledInClaudeSettings()).toBe(false);
+  });
+});
+
+describe('isDisabledByEnvVar (#1484)', () => {
+  let originalValue: string | undefined;
+
+  beforeEach(() => {
+    originalValue = process.env.CLAUDE_MEM_DISABLED;
+  });
+
+  afterEach(() => {
+    if (originalValue !== undefined) {
+      process.env.CLAUDE_MEM_DISABLED = originalValue;
+    } else {
+      delete process.env.CLAUDE_MEM_DISABLED;
+    }
+  });
+
+  it('should return true when CLAUDE_MEM_DISABLED is "1"', () => {
+    process.env.CLAUDE_MEM_DISABLED = '1';
+    expect(isDisabledByEnvVar()).toBe(true);
+  });
+
+  it('should return false when CLAUDE_MEM_DISABLED is not set', () => {
+    delete process.env.CLAUDE_MEM_DISABLED;
+    expect(isDisabledByEnvVar()).toBe(false);
+  });
+
+  it('should return false when CLAUDE_MEM_DISABLED is "0"', () => {
+    process.env.CLAUDE_MEM_DISABLED = '0';
+    expect(isDisabledByEnvVar()).toBe(false);
+  });
+
+  it('should return false when CLAUDE_MEM_DISABLED is "true"', () => {
+    process.env.CLAUDE_MEM_DISABLED = 'true';
+    expect(isDisabledByEnvVar()).toBe(false);
+  });
+
+  it('should return false when CLAUDE_MEM_DISABLED is empty string', () => {
+    process.env.CLAUDE_MEM_DISABLED = '';
+    expect(isDisabledByEnvVar()).toBe(false);
   });
 });


### PR DESCRIPTION
## What this does

Adding support for `CLAUDE_MEM_DISABLED=1` environment variable so you can turn off claude-mem in specific sessions without touching global settings or breaking auth.

I was running into this problem when using multi-agent setup with Paperclip - all my agent sessions were getting context injected (wasting tokens) and recording observations from different domains into same database (making context messy for unrelated sessions).

## Changes

- `plugin/scripts/bun-runner.js` - env var check before anything else runs, so it exits fast with code 0
- `src/shared/plugin-state.ts` - exported `isDisabledByEnvVar()` helper so other entry points can also use this check
- `tests/infrastructure/plugin-disabled-check.test.ts` - tests covering the new function (true only for exact "1" value)
- `README.md` - documented the env var under Configuration section

## Why not use existing disable methods

Like the issue author mentioned:
- `CLAUDE_CONFIG_DIR` override breaks OAuth because macOS Keychain is tied to the config dir path
- `--bare` mode needs `ANTHROPIC_API_KEY`, doesnt work for OAuth-only setups
- Project-level settings affect interactive sessions too

The env var approach is cleanest - just set it per-process and everything else stays untouched.

## How to use

```bash
CLAUDE_MEM_DISABLED=1 claude --print "do something"
```

Or in orchestration config (like Paperclip's adapterConfig.env).

## Testing

Added 5 test cases to existing test file - checks that only exact value "1" triggers disable, other values like "0", "true", empty string are all treated as not disabled.

Closes #1484