### PR TITLE
fix: remove dead USER_MESSAGE_ONLY exit code causing SessionStart hook errors

### DIFF
--- a/src/shared/hook-constants.ts
+++ b/src/shared/hook-constants.ts
@@ -1,13 +1,13 @@
 export const HOOK_TIMEOUTS = {
-  DEFAULT: 300000,            // Standard HTTP timeout (5 min for slow systems)
-  HEALTH_CHECK: 3000,         // Worker health check (3s — healthy worker responds in <100ms)
-  POST_SPAWN_WAIT: 5000,      // Wait for daemon to start after spawn (starts in <1s on Linux)
-  READINESS_WAIT: 30000,      // Wait for DB + search init after spawn (typically <5s)
-  PORT_IN_USE_WAIT: 3000,     // Wait when port occupied but health failing
+  DEFAULT: 300000, // Standard HTTP timeout (5 min for slow systems)
+  HEALTH_CHECK: 3000, // Worker health check (3s — healthy worker responds in <100ms)
+  POST_SPAWN_WAIT: 5000, // Wait for daemon to start after spawn (starts in <1s on Linux)
+  READINESS_WAIT: 30000, // Wait for DB + search init after spawn (typically <5s)
+  PORT_IN_USE_WAIT: 3000, // Wait when port occupied but health failing
   WORKER_STARTUP_WAIT: 1000,
-  PRE_RESTART_SETTLE_DELAY: 2000,  // Give files time to sync before restart
-  POWERSHELL_COMMAND: 10000,     // PowerShell process enumeration (10s - typically completes in <1s)
-  WINDOWS_MULTIPLIER: 1.5     // Platform-specific adjustment for hook-side operations
+  PRE_RESTART_SETTLE_DELAY: 2000, // Give files time to sync before restart
+  POWERSHELL_COMMAND: 10000, // PowerShell process enumeration (10s - typically completes in <1s)
+  WINDOWS_MULTIPLIER: 1.5, // Platform-specific adjustment for hook-side operations
 } as const;
 
 /**
@@ -16,19 +16,21 @@ export const HOOK_TIMEOUTS = {
  * Exit code behavior per Claude Code docs:
  * - 0: Success. For SessionStart/UserPromptSubmit, stdout added to context.
  * - 2: Blocking error. For SessionStart, stderr shown to user only.
- * - Other non-zero: stderr shown in verbose mode only.
+ * - Other non-zero: treated as hook error (stderr shown in verbose mode only).
+ *
+ * IMPORTANT: Only exit codes 0 and 2 are recognized by Claude Code.
+ * Any other non-zero exit code (including 1, 3, etc.) is treated as a
+ * hook failure and triggers the "hook error" UI message on every session start.
  */
 export const HOOK_EXIT_CODES = {
   SUCCESS: 0,
   FAILURE: 1,
   /** Blocking error - for SessionStart, shows stderr to user only */
   BLOCKING_ERROR: 2,
-  /** Show stderr to user only, don't inject into context. Used by user-message handler (Cursor). */
-  USER_MESSAGE_ONLY: 3,
 } as const;
 
 export function getTimeout(baseTimeout: number): number {
-  return process.platform === 'win32'
+  return process.platform === "win32"
     ? Math.round(baseTimeout * HOOK_TIMEOUTS.WINDOWS_MULTIPLIER)
     : baseTimeout;
 }


### PR DESCRIPTION
## Summary

- Removes the unused `USER_MESSAGE_ONLY: 3` exit code constant from `hook-constants.ts`
- Improves exit code documentation to clarify Claude Code's hook protocol

## Problem

In v8.x, the `user-message-hook.js` called `process.exit(3)` using `HOOK_EXIT_CODES.USER_MESSAGE_ONLY`. Claude Code only recognizes exit codes 0 (success) and 2 (blocking error) — any other non-zero exit code is treated as a hook failure. This caused the `SessionStart:startup hook error` message on every session start for all users.

The v10.x refactor removed `user-message-hook.js` and replaced it with the worker-service hook command architecture, which correctly uses only exit codes 0 and 2. However, the dead `USER_MESSAGE_ONLY: 3` constant was left behind, which could lead to reintroduction of the bug.

## Changes

1. Removed `USER_MESSAGE_ONLY: 3` from `HOOK_EXIT_CODES` (dead code — no references in current codebase)
2. Added explicit documentation warning that only exit codes 0 and 2 are valid

## Test plan

- [x] Grep confirms `USER_MESSAGE_ONLY` has zero references outside the constant definition
- [x] Existing hook-command.ts only uses `SUCCESS` (0) and `BLOCKING_ERROR` (2)
- [x] No behavioral change — purely dead code removal + documentation improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)