### PR TITLE
fix: replace non-existent setup.sh with smart-install.js in Setup hook

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; \"$_R/scripts/setup.sh\"",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/smart-install.js\"",
             "timeout": 300
           }
         ]


### PR DESCRIPTION
## Summary

- Replace `setup.sh` with `smart-install.js` in the Setup hook configuration

## Problem

The Setup hook in `plugin/hooks/hooks.json` references a non-existent script:

```json
"command": "... \"$_R/scripts/setup.sh\""
```

However, `scripts/setup.sh` does not exist in the repository. This causes:
- `SessionStart:startup hook error` on first launch
- Potential incomplete plugin initialization

## Solution

Changed the Setup hook to call `smart-install.js` instead, which:
- ✅ Actually exists in the repository
- ✅ Handles Bun runtime installation
- ✅ Handles uv (Python package manager) installation  
- ✅ Manages dependency installation

This aligns with the SessionStart hook which also calls `smart-install.js`.

## Files Changed

- `plugin/hooks/hooks.json`: Updated Setup hook command from `setup.sh` to `node smart-install.js`

🤖 Generated with [Claude Code](https://claude.ai/code)