### PR TITLE
fix: expand tilde (~) to home directory in project resolver

### DIFF
--- a/src/utils/project-name.ts
+++ b/src/utils/project-name.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { homedir } from 'os';
 import { logger } from './logger.js';
 import { detectWorktree } from './worktree.js';
 
@@ -15,8 +16,13 @@ export function getProjectName(cwd: string | null | undefined): string {
     return 'unknown-project';
   }
 
+  // Expand ~ to home directory (some terminals report cwd as literal ~)
+  const resolvedCwd = (cwd === '~' || cwd.startsWith('~/'))
+    ? cwd.replace('~', homedir())
+    : cwd;
+
   // Extract basename (handles trailing slashes automatically)
-  const basename = path.basename(cwd);
+  const basename = path.basename(resolvedCwd);
 
   // Edge case: Drive roots on Windows (C:\, J:\) or Unix root (/)
   // path.basename('C:\') returns '' (empty string)


### PR DESCRIPTION
## Summary
- Expand literal `~` and `~/...` to the actual home directory path in `getProjectName()` before resolution
- Prevents fallback to `unknown-project` when terminals report cwd as unexpanded tilde

## Details
Some terminals report `cwd` as the literal string `~` instead of the full path (e.g., `/Users/logan`). The project name resolver didn't handle this, causing it to fall through to `unknown-project`.

The fix adds a simple tilde expansion using `os.homedir()` at the start of `getProjectName()`, before any other resolution logic runs.

Fixes #1478

## Test plan
- [ ] Verify `getProjectName('~')` returns the home directory basename (e.g., `logan`)
- [ ] Verify `getProjectName('~/projects/my-app')` returns `my-app`
- [ ] Verify existing paths without `~` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)