### PR TITLE
fix: update default model to claude-sonnet-4-6 (#1390)

### DIFF
--- a/docs/context/agent-sdk-v2-preview.md
+++ b/docs/context/agent-sdk-v2-preview.md
@@ -32,7 +32,7 @@ For simple single-turn queries where you don't need to maintain a session, use `
 import { unstable_v2_prompt } from '@anthropic-ai/claude-agent-sdk'
 
 const result = await unstable_v2_prompt('What is 2 + 2?', {
-  model: 'claude-sonnet-4-5-20250929'
+  model: 'claude-sonnet-4-6-20250929'
 })
 console.log(result.result)
 ```
@@ -45,7 +45,7 @@ import { query } from '@anthropic-ai/claude-agent-sdk'
 
 const q = query({
   prompt: 'What is 2 + 2?',
-  options: { model: 'claude-sonnet-4-5-20250929' }
+  options: { model: 'claude-sonnet-4-6-20250929' }
 })
 
 for await (const msg of q) {
@@ -71,7 +71,7 @@ The example below creates a session, sends "Hello!" to Claude, and prints the te
 import { unstable_v2_createSession } from '@anthropic-ai/claude-agent-sdk'
 
 await using session = unstable_v2_createSession({
-  model: 'claude-sonnet-4-5-20250929'
+  model: 'claude-sonnet-4-6-20250929'
 })
 
 await session.send('Hello!')
@@ -97,7 +97,7 @@ import { query } from '@anthropic-ai/claude-agent-sdk'
 
 const q = query({
   prompt: 'Hello!',
-  options: { model: 'claude-sonnet-4-5-20250929' }
+  options: { model: 'claude-sonnet-4-6-20250929' }
 })
 
 for await (const msg of q) {
@@ -123,7 +123,7 @@ This example asks a math question, then asks a follow-up that references the pre
 import { unstable_v2_createSession } from '@anthropic-ai/claude-agent-sdk'
 
 await using session = unstable_v2_createSession({
-  model: 'claude-sonnet-4-5-20250929'
+  model: 'claude-sonnet-4-6-20250929'
 })
 
 // Turn 1
@@ -177,7 +177,7 @@ async function* createInputStream() {
 
 const q = query({
   prompt: createInputStream(),
-  options: { model: 'claude-sonnet-4-5-20250929' }
+  options: { model: 'claude-sonnet-4-6-20250929' }
 })
 
 for await (const msg of q) {
@@ -217,7 +217,7 @@ function getAssistantText(msg: SDKMessage): string | null {
 
 // Create initial session and have a conversation
 const session = unstable_v2_createSession({
-  model: 'claude-sonnet-4-5-20250929'
+  model: 'claude-sonnet-4-6-20250929'
 })
 
 await session.send('Remember this number: 42')
@@ -235,7 +235,7 @@ session.close()
 
 // Later: resume the session using the stored ID
 await using resumedSession = unstable_v2_resumeSession(sessionId!, {
-  model: 'claude-sonnet-4-5-20250929'
+  model: 'claude-sonnet-4-6-20250929'
 })
 
 await resumedSession.send('What number did I ask you to remember?')
@@ -254,7 +254,7 @@ import { query } from '@anthropic-ai/claude-agent-sdk'
 // Create initial session
 const initialQuery = query({
   prompt: 'Remember this number: 42',
-  options: { model: 'claude-sonnet-4-5-20250929' }
+  options: { model: 'claude-sonnet-4-6-20250929' }
 })
 
 // Get session ID from any message
@@ -276,7 +276,7 @@ console.log('Session ID:', sessionId)
 const resumedQuery = query({
   prompt: 'What number did I ask you to remember?',
   options: {
-    model: 'claude-sonnet-4-5-20250929',
+    model: 'claude-sonnet-4-6-20250929',
     resume: sessionId
   }
 })
@@ -304,7 +304,7 @@ Sessions can be closed manually or automatically using [`await using`](https://w
 import { unstable_v2_createSession } from '@anthropic-ai/claude-agent-sdk'
 
 await using session = unstable_v2_createSession({
-  model: 'claude-sonnet-4-5-20250929'
+  model: 'claude-sonnet-4-6-20250929'
 })
 // Session closes automatically when the block exits
 ```
@@ -315,7 +315,7 @@ await using session = unstable_v2_createSession({
 import { unstable_v2_createSession } from '@anthropic-ai/claude-agent-sdk'
 
 const session = unstable_v2_createSession({
-  model: 'claude-sonnet-4-5-20250929'
+  model: 'claude-sonnet-4-6-20250929'
 })
 // ... use the session ...
 session.close()

--- a/docs/public/architecture/hooks.mdx
+++ b/docs/public/architecture/hooks.mdx
@@ -860,7 +860,7 @@ async startSession(session: ActiveSession, worker?: any) {
   const queryResult = query({
     prompt: messageGenerator,
     options: {
-      model: 'claude-sonnet-4-5',
+      model: 'claude-sonnet-4-6',
       disallowedTools: ['Bash', 'Read', 'Write', ...],  // Observer-only
       abortController: session.abortController
     }

--- a/docs/public/platform-integration.mdx
+++ b/docs/public/platform-integration.mdx
@@ -46,7 +46,7 @@ GET /api/context/recent?project=my-project&limit=3
 ### Environment Variables
 
 ```bash
-CLAUDE_MEM_MODEL=claude-sonnet-4-5          # Model for observations/summaries
+CLAUDE_MEM_MODEL=claude-sonnet-4-6          # Model for observations/summaries
 CLAUDE_MEM_CONTEXT_OBSERVATIONS=50          # Observations injected at SessionStart
 CLAUDE_MEM_WORKER_PORT=37777                # Worker service port
 CLAUDE_MEM_PYTHON_VERSION=3.13              # Python version for chroma-mcp

--- a/openclaw/install.sh
+++ b/openclaw/install.sh
@@ -1101,7 +1101,7 @@ write_settings() {
 
     // All defaults from SettingsDefaultsManager.ts
     const defaults = {
-      CLAUDE_MEM_MODEL: 'claude-sonnet-4-5',
+      CLAUDE_MEM_MODEL: 'claude-sonnet-4-6',
       CLAUDE_MEM_CONTEXT_OBSERVATIONS: '50',
       CLAUDE_MEM_WORKER_PORT: '37777',
       CLAUDE_MEM_WORKER_HOST: '127.0.0.1',

--- a/openclaw/test-install.sh
+++ b/openclaw/test-install.sh
@@ -643,7 +643,7 @@ test_write_settings_new_file() {
 
   local model
   model="$(node -e "const s = JSON.parse(require('fs').readFileSync('${settings_file}','utf8')); console.log(s.CLAUDE_MEM_MODEL);")"
-  assert_eq "claude-sonnet-4-5" "$model" "CLAUDE_MEM_MODEL defaults to claude-sonnet-4-5"
+  assert_eq "claude-sonnet-4-6" "$model" "CLAUDE_MEM_MODEL defaults to claude-sonnet-4-6"
 
   HOME="$ORIGINAL_HOME"
   rm -rf "$fake_home"

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -71,7 +71,7 @@ export class SettingsDefaultsManager {
    * Default values for all settings
    */
   private static readonly DEFAULTS: SettingsDefaults = {
-    CLAUDE_MEM_MODEL: 'claude-sonnet-4-5',
+    CLAUDE_MEM_MODEL: 'claude-sonnet-4-6',
     CLAUDE_MEM_CONTEXT_OBSERVATIONS: '50',
     CLAUDE_MEM_WORKER_PORT: '37777',
     CLAUDE_MEM_WORKER_HOST: '127.0.0.1',

--- a/src/ui/viewer/constants/settings.ts
+++ b/src/ui/viewer/constants/settings.ts
@@ -3,7 +3,7 @@
  * Shared across UI components and hooks
  */
 export const DEFAULT_SETTINGS = {
-  CLAUDE_MEM_MODEL: 'claude-sonnet-4-5',
+  CLAUDE_MEM_MODEL: 'claude-sonnet-4-6',
   CLAUDE_MEM_CONTEXT_OBSERVATIONS: '50',
   CLAUDE_MEM_WORKER_PORT: '37777',
   CLAUDE_MEM_WORKER_HOST: '127.0.0.1',

--- a/tests/shared/settings-defaults-manager.test.ts
+++ b/tests/shared/settings-defaults-manager.test.ts
@@ -309,7 +309,7 @@ describe('SettingsDefaultsManager', () => {
 
   describe('get', () => {
     it('should return default value for key', () => {
-      expect(SettingsDefaultsManager.get('CLAUDE_MEM_MODEL')).toBe('claude-sonnet-4-5');
+      expect(SettingsDefaultsManager.get('CLAUDE_MEM_MODEL')).toBe('claude-sonnet-4-6');
       expect(SettingsDefaultsManager.get('CLAUDE_MEM_WORKER_PORT')).toBe('37777');
     });
   });


### PR DESCRIPTION
## Summary

- Updates `CLAUDE_MEM_MODEL` default from deprecated `claude-sonnet-4-5` to `claude-sonnet-4-6` across all source files, installer, tests, and documentation
- Fixes silent use of outdated model for all new installs without explicit user configuration

## Files changed (8)

| File | Change |
|------|--------|
| `src/shared/SettingsDefaultsManager.ts` | Default constant |
| `src/ui/viewer/constants/settings.ts` | Viewer default |
| `openclaw/install.sh` | Installer default |
| `openclaw/test-install.sh` | Test assertion |
| `docs/public/platform-integration.mdx` | Doc example |
| `docs/public/architecture/hooks.mdx` | Doc example |
| `docs/context/agent-sdk-v2-preview.md` | 12 SDK refs |
| `tests/shared/settings-defaults-manager.test.ts` | Test assertion |

## Test plan

- [x] Full test suite: 1106 pass, 0 fail
- [x] `grep -r "claude-sonnet-4-5" src/ openclaw/ docs/public/ tests/` returns 0 matches
- [x] Settings default manager test passes with new value

Closes #1390

🤖 Generated with [Claude Code](https://claude.com/claude-code)