### PR TITLE
fix: prevent shell injection in summary workflow (#1285)

### DIFF
--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Comment with AI summary
         run: |
-          gh issue comment $ISSUE_NUMBER --body '${{ steps.inference.outputs.response }}'
+          gh issue comment "$ISSUE_NUMBER" --body "$RESPONSE"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
## Summary

- The `gh issue comment` command was interpolating LLM output via `${{ steps.inference.outputs.response }}` directly in the shell with single-quotes
- If the response contains a `'`, it breaks out of shell quoting — potential command injection and `GITHUB_TOKEN` leakage
- `RESPONSE` was already declared as an `env:` var on line 34 but never used — now using it

## Fix

```diff
- gh issue comment $ISSUE_NUMBER --body '${{ steps.inference.outputs.response }}'
+ gh issue comment "$ISSUE_NUMBER" --body "$RESPONSE"
```

Passing values through `env:` variables is the [GitHub-recommended approach](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections) to prevent script injection.

## Test plan

- [x] `grep -n '\${{' .github/workflows/summary.yml` returns 0 matches inside `run:` blocks
- [x] Full test suite: 1106 pass, 0 fail

Closes #1285

🤖 Generated with [Claude Code](https://claude.com/claude-code)