### PR TITLE
fix: skip parseSummary false positives with no sub-tags (#1360)

### DIFF
--- a/src/sdk/parser.ts
+++ b/src/sdk/parser.ts
@@ -133,7 +133,7 @@ export function parseSummary(text: string, sessionId?: number): ParsedSummary | 
   const next_steps = extractField(summaryContent, 'next_steps');
   const notes = extractField(summaryContent, 'notes'); // Optional
 
-  // NOTE FROM THEDOTMACK: 100% of the time we must SAVE the summary, even if fields are missing. 10/24/2025 
+  // NOTE FROM THEDOTMACK: 100% of the time we must SAVE the summary, even if fields are missing. 10/24/2025
   // NEVER DO THIS NONSENSE AGAIN.
 
   // Validate required fields are present (notes is optional)
@@ -148,6 +148,15 @@ export function parseSummary(text: string, sessionId?: number): ParsedSummary | 
   //   });
   //   return null;
   // }
+
+  // Guard: if NO sub-tags matched at all, this is a false positive —
+  // <summary> accidentally appeared inside an <observation> response with no structured content.
+  // This is NOT the same as missing some fields (which we intentionally allow above).
+  // Fix for #1360.
+  if (!request && !investigated && !learned && !completed && !next_steps) {
+    logger.warn('PARSER', 'Summary match has no sub-tags — skipping false positive', { sessionId });
+    return null;
+  }
 
   return {
     request,

--- a/tests/sdk/parse-summary.test.ts
+++ b/tests/sdk/parse-summary.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests for parseSummary (fix for #1360)
+ *
+ * Validates that false-positive summary matches (no sub-tags) are rejected
+ * while real summaries — even with some missing fields — are still saved.
+ */
+import { describe, it, expect } from 'bun:test';
+import { parseSummary } from '../../src/sdk/parser.js';
+
+describe('parseSummary', () => {
+  it('returns null when no <summary> tag present', () => {
+    expect(parseSummary('<observation><title>foo</title></observation>')).toBeNull();
+  });
+
+  it('returns null when <summary> has no sub-tags (false positive — fix for #1360)', () => {
+    // This is the bug: observation response accidentally contains <summary>some text</summary>
+    expect(parseSummary('<observation>done <summary>some content here</summary></observation>')).toBeNull();
+  });
+
+  it('returns null for bare <summary> with only plain text, no sub-tags', () => {
+    expect(parseSummary('<summary>This session was productive.</summary>')).toBeNull();
+  });
+
+  it('returns summary when at least one sub-tag is present (respects maintainer note)', () => {
+    const text = `<summary><request>Fix the bug</request></summary>`;
+    const result = parseSummary(text);
+    expect(result).not.toBeNull();
+    expect(result?.request).toBe('Fix the bug');
+    expect(result?.investigated).toBeNull();
+    expect(result?.learned).toBeNull();
+  });
+
+  it('returns full summary when all fields are present', () => {
+    const text = `<summary>
+      <request>Fix login bug</request>
+      <investigated>Auth flow and JWT expiry</investigated>
+      <learned>Token was expiring too soon</learned>
+      <completed>Extended token TTL to 24h</completed>
+      <next_steps>Monitor error rates</next_steps>
+    </summary>`;
+    const result = parseSummary(text);
+    expect(result).not.toBeNull();
+    expect(result?.request).toBe('Fix login bug');
+    expect(result?.investigated).toBe('Auth flow and JWT expiry');
+    expect(result?.learned).toBe('Token was expiring too soon');
+    expect(result?.completed).toBe('Extended token TTL to 24h');
+    expect(result?.next_steps).toBe('Monitor error rates');
+  });
+
+  it('returns null when skip_summary tag is present', () => {
+    expect(parseSummary('<skip_summary reason="no work done"/>')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- `parseSummary` was called on every LLM response — when an observation response accidentally contained `<summary>some text</summary>` with no structured sub-tags, all fields parsed as `null` → saved as empty strings → empty SESSION SUMMARY card in the UI
- 3+ occurrences confirmed in reporter's DB

## Root cause

```
observation response → parseSummary regex matches <summary> tag
→ extractField returns null for all sub-tags
→ normalizeSummaryForStorage converts null → ""
→ empty record saved to SQLite
→ empty card rendered in viewer
```

## Fix

Add an all-null guard **after** field extraction. If none of the 5 sub-tags (`request`, `investigated`, `learned`, `completed`, `next_steps`) matched, the `<summary>` hit is a false positive:

```ts
if (!request && !investigated && !learned && !completed && !next_steps) {
  logger.warn('PARSER', 'Summary match has no sub-tags — skipping false positive', { sessionId });
  return null;
}
```

**This is explicitly different from the commented-out validation above** (which rejected summaries with *some* fields missing). We only reject when *all* are absent. Partial real summaries are still saved per the maintainer's note.

## Changes

| File | Change |
|------|--------|
| `src/sdk/parser.ts` | Add all-null guard after field extraction |
| `tests/sdk/parse-summary.test.ts` | 6 tests covering false positives, partial summaries, full summaries, skip_summary |

## Test plan

- [x] New tests: 6 pass, 0 fail
- [x] Full suite: 1115 pass, 0 fail
- [x] Rebase on main, 0 conflicts

Closes #1360

🤖 Generated with [Claude Code](https://claude.com/claude-code)