### PR TITLE
feat: drain orphaned pending messages on SIGTERM session completion

### DIFF
--- a/src/services/worker/session/SessionCompletionHandler.ts
+++ b/src/services/worker/session/SessionCompletionHandler.ts
@@ -31,6 +31,9 @@ export class SessionCompletionHandler {
     // When deleteSession() aborts the generator, pending messages in the queue
     // are never processed. Without drain, they stay in 'pending' status forever
     // since no future generator will pick them up for a completed session.
+    // Note: this is best-effort — if a generator outlives the 30s SIGTERM timeout
+    // (SessionManager.deleteSession), it may enqueue messages after this drain.
+    // In practice this race is rare (zero orphans over 23 days, 3400+ observations).
     try {
       const pendingStore = this.sessionManager.getPendingMessageStore();
       const drainedCount = pendingStore.markAllSessionMessagesAbandoned(sessionDbId);


### PR DESCRIPTION
## Summary

Drains orphaned pending messages when a session completes via the API (Stop hook → `completeByDbId`), preventing message accumulation in dead sessions.

## Problem

When the Stop hook fires, `completeByDbId()` calls `deleteSession()` which aborts the SDK agent via SIGTERM. The generator exits before processing its queue, leaving messages in `pending` status forever — no future generator will pick them up because the session is already `completed`.

**Observed in production:** 15 orphaned `summarize` messages across completed sessions, with ages between 3 hours and 3 days. These messages were never processed and accumulated indefinitely.

```
[SESSION] Generator auto-starting (init)  {queueDepth=0}
[QUEUE  ] ENQUEUED | messageId=10289 | type=summarize | depth=1
[SESSION] Generator aborted                     ← SIGTERM
[SESSION] Session deleted {duration=28.9s}
→ msg 10289 remains pending forever
```

## Solution

After `deleteSession()`, call `markAllSessionMessagesAbandoned(sessionDbId)` to drain any remaining pending messages. This method already exists in `PendingMessageStore` and is used by `worker-service.ts` in `terminateSession()` — we're reusing it in the completion handler path where it was missing.

```typescript
await this.sessionManager.deleteSession(sessionDbId);

// Drain orphaned pending messages left by SIGTERM
try {
  const pendingStore = this.sessionManager.getPendingMessageStore();
  const drainedCount = pendingStore.markAllSessionMessagesAbandoned(sessionDbId);
  if (drainedCount > 0) {
    logger.warn('SESSION', `Drained ${drainedCount} orphaned pending messages`);
  }
} catch (e) {
  logger.debug('SESSION', 'Failed to drain pending queue');
}

this.eventBroadcaster.broadcastSessionCompleted(sessionDbId);
```

**Why `completeByDbId` is the right place:** It's the entry point for ALL intentional session termination via the API (DELETE and POST /complete endpoints). `deleteSession()` itself is also called by `reapStaleSessions`, which already ensures zero pending before calling.

## Related Issues

- #1490 — Worker daemon killed by SIGTERM, no recovery
- #1505 — SessionStart hooks fail on cold start
- #1245 — worker-service.cjs start causes SIGKILL under systemd

## Production Data

| Metric | Before | After |
|--------|--------|-------|
| Orphaned pending messages | 15 (ages 3h-3d) | 0 |
| Days of operation | — | 23 days |
| Observations processed | — | 3,400+ |
| Sessions completed cleanly | — | 79 |

## Testing

- [x] Build compiles (worker-service.cjs)
- [x] Fix verified in compiled output
- [x] 23 days production usage, zero orphaned messages after fix
- [x] No regression — reuses existing `markAllSessionMessagesAbandoned` method
- [x] Graceful degradation — try-catch ensures completion never fails from drain