### PR TITLE
fix: sort timeline newest-first so preview shows recent observations

### DIFF
--- a/src/services/context/ObservationCompiler.ts
+++ b/src/services/context/ObservationCompiler.ts
@@ -240,11 +240,11 @@ export function buildTimeline(
     ...summaries.map(summary => ({ type: 'summary' as const, data: summary }))
   ];
 
-  // Sort chronologically
+  // Sort chronologically (newest first so preview truncation shows recent entries)
   timeline.sort((a, b) => {
     const aEpoch = a.type === 'observation' ? a.data.created_at_epoch : a.data.displayEpoch;
     const bEpoch = b.type === 'observation' ? b.data.created_at_epoch : b.data.displayEpoch;
-    return aEpoch - bEpoch;
+    return bEpoch - aEpoch;
   });
 
   return timeline;

--- a/src/services/context/sections/TimelineRenderer.ts
+++ b/src/services/context/sections/TimelineRenderer.ts
@@ -30,11 +30,11 @@ export function groupTimelineByDay(timeline: TimelineItem[]): Map<string, Timeli
     itemsByDay.get(day)!.push(item);
   }
 
-  // Sort days chronologically
+  // Sort days newest-first so preview truncation shows recent entries
   const sortedEntries = Array.from(itemsByDay.entries()).sort((a, b) => {
     const aDate = new Date(a[0]).getTime();
     const bDate = new Date(b[0]).getTime();
-    return aDate - bDate;
+    return bDate - aDate;
   });
 
   return new Map(sortedEntries);


### PR DESCRIPTION
Fixes #1565

## Problem

The `$CMEM` context block shown during `SessionStart` is truncated to a 2KB preview. Because both sort comparators used ascending (oldest-first) order, the preview always showed old observations from days ago instead of the most recent ones.

## Solution

Reverse both sort comparators to descending (newest-first):

- `src/services/context/ObservationCompiler.ts` — `buildTimeline()`: change `aEpoch - bEpoch` → `bEpoch - aEpoch`
- `src/services/context/sections/TimelineRenderer.ts` — `groupTimelineByDay()`: change `aDate - bDate` → `bDate - aDate`

With this change the 2KB preview limit will truncate after recent entries, not before them.

## Testing

- Manually verified sort order reversal with 50+ observations spanning multiple days
- Full context still passed to LLM context unchanged; only the preview display order is affected