### PR TITLE
feat: share context across all worktrees of the same repo

### DIFF
--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -55,6 +55,8 @@ export interface SettingsDefaults {
   CLAUDE_MEM_EXCLUDED_PROJECTS: string;  // Comma-separated glob patterns for excluded project paths
   CLAUDE_MEM_FOLDER_MD_EXCLUDE: string;  // JSON array of folder paths to exclude from CLAUDE.md generation
   // Chroma Vector Database Configuration
+  // Worktree Settings
+  CLAUDE_MEM_WORKTREE_SHARED_CONTEXT: string;  // 'true' | 'false' - share context across all worktrees of the same repo
   CLAUDE_MEM_CHROMA_ENABLED: string;   // 'true' | 'false' - set to 'false' for SQLite-only mode
   CLAUDE_MEM_CHROMA_MODE: string;      // 'local' | 'remote'
   CLAUDE_MEM_CHROMA_HOST: string;
@@ -113,6 +115,8 @@ export class SettingsDefaultsManager {
     // Exclusion Settings
     CLAUDE_MEM_EXCLUDED_PROJECTS: '',  // Comma-separated glob patterns for excluded project paths
     CLAUDE_MEM_FOLDER_MD_EXCLUDE: '[]',  // JSON array of folder paths to exclude from CLAUDE.md generation
+    // Worktree Settings
+    CLAUDE_MEM_WORKTREE_SHARED_CONTEXT: 'true',  // Share context across all worktrees of the same repo by default
     // Chroma Vector Database Configuration
     CLAUDE_MEM_CHROMA_ENABLED: 'true',         // Set to 'false' to disable Chroma and use SQLite-only search
     CLAUDE_MEM_CHROMA_MODE: 'local',           // 'local' uses persistent chroma-mcp via uvx, 'remote' connects to existing server

--- a/src/utils/project-name.ts
+++ b/src/utils/project-name.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { logger } from './logger.js';
-import { detectWorktree } from './worktree.js';
+import { SettingsDefaultsManager } from '../shared/SettingsDefaultsManager.js';
+import { detectWorktree, discoverAllWorktrees } from './worktree.js';
 
 /**
  * Extract project name from working directory path
@@ -70,9 +71,16 @@ export function getProjectContext(cwd: string | null | undefined): ProjectContex
   }
 
   const worktreeInfo = detectWorktree(cwd);
+  const sharedContext = SettingsDefaultsManager.getBool('CLAUDE_MEM_WORKTREE_SHARED_CONTEXT');
 
-  if (worktreeInfo.isWorktree && worktreeInfo.parentProjectName) {
-    // In a worktree: include parent first for chronological ordering
+  if (worktreeInfo.isWorktree && worktreeInfo.parentProjectName && worktreeInfo.parentRepoPath) {
+    if (sharedContext) {
+      // In a worktree: include parent + all siblings for unified context
+      const worktrees = discoverAllWorktrees(worktreeInfo.parentRepoPath);
+      const allProjects = dedupePreservingOrder([worktreeInfo.parentProjectName, ...worktrees, primary]);
+      return { primary, parent: worktreeInfo.parentProjectName, isWorktree: true, allProjects };
+    }
+    // Original behavior: parent + self only
     return {
       primary,
       parent: worktreeInfo.parentProjectName,
@@ -81,5 +89,21 @@ export function getProjectContext(cwd: string | null | undefined): ProjectContex
     };
   }
 
+  if (sharedContext) {
+    // Main repo: check if it has active worktrees
+    const worktrees = discoverAllWorktrees(cwd);
+    if (worktrees.length > 0) {
+      const allProjects = dedupePreservingOrder([primary, ...worktrees]);
+      return { primary, parent: null, isWorktree: false, allProjects };
+    }
+  }
+
   return { primary, parent: null, isWorktree: false, allProjects: [primary] };
+}
+
+/**
+ * Remove duplicates from an array while preserving insertion order.
+ */
+function dedupePreservingOrder(items: string[]): string[] {
+  return [...new Set(items)];
 }

--- a/src/utils/worktree.ts
+++ b/src/utils/worktree.ts
@@ -8,7 +8,7 @@
  *   gitdir: /path/to/parent/.git/worktrees/<name>
  */
 
-import { statSync, readFileSync } from 'fs';
+import { statSync, readFileSync, readdirSync } from 'fs';
 import path from 'path';
 
 export interface WorktreeInfo {
@@ -81,4 +81,39 @@ export function detectWorktree(cwd: string): WorktreeInfo {
     parentRepoPath,
     parentProjectName
   };
+}
+
+/**
+ * Discover all active worktree project names for a given repository.
+ *
+ * Reads .git/worktrees/ and extracts the basename of each worktree's
+ * actual path from its gitdir file.
+ *
+ * @param repoPath - Absolute path to the repository (main or parent)
+ * @returns Array of worktree project names (basenames of worktree paths)
+ */
+export function discoverAllWorktrees(parentRepoPath: string): string[] {
+  const worktreesDir = path.join(parentRepoPath, '.git', 'worktrees');
+
+  let entries: string[];
+  try {
+    entries = readdirSync(worktreesDir);
+  } catch {
+    return [];
+  }
+
+  const worktrees: string[] = [];
+
+  for (const entry of entries) {
+    const gitdirFile = path.join(worktreesDir, entry, 'gitdir');
+    try {
+      // gitdir file contains the absolute path to the worktree's .git file
+      const worktreePath = path.dirname(readFileSync(gitdirFile, 'utf-8').trim());
+      worktrees.push(path.basename(worktreePath));
+    } catch {
+      // Stale or broken worktree entry — skip
+    }
+  }
+
+  return worktrees;
 }


### PR DESCRIPTION
## Summary

- Adds `discoverAllWorktrees()` to scan `.git/worktrees/` for all active worktree project names
- Updates `getProjectContext()` to include all worktrees in `allProjects` — main repo and worktrees all see each other's observations
- New `CLAUDE_MEM_WORKTREE_SHARED_CONTEXT` setting (default: `true`) to control this behavior

Closes #1582

## How it works

Git stores worktree metadata in `.git/worktrees/<name>/gitdir`, which contains the absolute path to the worktree. `discoverAllWorktrees()` reads these to resolve project names (basenames).

**Before:**
- Main repo → `allProjects: ['my-project']`
- Worktree A → `allProjects: ['my-project', 'feature-a']`
- Worktree B → `allProjects: ['my-project', 'feature-b']`

**After:**
- Main repo → `allProjects: ['my-project', 'feature-a', 'feature-b']`
- Worktree A → `allProjects: ['my-project', 'feature-a', 'feature-b']`
- Worktree B → `allProjects: ['my-project', 'feature-a', 'feature-b']`

## Files changed

| File | Change |
|------|--------|
| `src/utils/worktree.ts` | Added `discoverAllWorktrees()` function |
| `src/utils/project-name.ts` | Updated `getProjectContext()` to use discovery when enabled |
| `src/shared/SettingsDefaultsManager.ts` | Added `CLAUDE_MEM_WORKTREE_SHARED_CONTEXT` setting |

## Test plan

- [ ] Create a main repo with 2+ worktrees, verify `getProjectContext()` returns all in `allProjects`
- [ ] From a worktree, verify parent + all worktrees are included
- [ ] Set `CLAUDE_MEM_WORKTREE_SHARED_CONTEXT=false`, verify original behavior (parent + self only)
- [ ] With stale/broken worktree entries in `.git/worktrees/`, verify they are skipped gracefully
- [ ] Without any worktrees, verify no behavior change