### PR TITLE
fix: provide empty JSON fallback when stdin is not piped

### DIFF
--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -155,14 +155,17 @@ const stdinData = await collectStdin();
 // Note: Don't use shell mode on Windows - it breaks paths with spaces in usernames
 // Use windowsHide to prevent a visible console window from spawning on Windows
 const child = spawn(bunPath, args, {
-  stdio: [stdinData ? 'pipe' : 'ignore', 'inherit', 'inherit'],
+  stdio: ['pipe', 'inherit', 'inherit'],
   windowsHide: true,
   env: process.env
 });
 
-// Write buffered stdin to child's pipe, then close it so the child sees EOF
-if (stdinData && child.stdin) {
-  child.stdin.write(stdinData);
+// Write buffered stdin to child's pipe, then close it so the child sees EOF.
+// Fall back to '{}' when no stdin data is available so worker-service.cjs
+// always receives valid JSON input even when Claude Code doesn't pipe stdin
+// (e.g. during SessionStart on some platforms). Fixes #1560.
+if (child.stdin) {
+  child.stdin.write(stdinData || '{}');
   child.stdin.end();
 }
 


### PR DESCRIPTION
Fixes #1560

## Problem
The `bun-runner.js` SessionStart hook fails with exit code 1 when Claude Code doesn't provide stdin data to the hook process. In `collectStdin()`, if no stdin is piped (non-TTY but empty stdin), it returns `null`. The child process was then spawned with `stdio: ['ignore', ...]`, meaning `worker-service.cjs` received no input at all and failed because it expects to read JSON from stdin.

## Solution
Always use `'pipe'` for the child's stdin and fall back to `'{}'` when no stdin data is available:

```js
const child = spawn(bunPath, args, {
  stdio: ['pipe', 'inherit', 'inherit'],  // was: stdinData ? 'pipe' : 'ignore'
  ...
});

if (child.stdin) {
  child.stdin.write(stdinData || '{}');   // was: only written if stdinData non-null
  child.stdin.end();
}
```

This ensures `worker-service.cjs start` always receives valid JSON input, matching the behaviour of passing `echo '{}' | node bun-runner.js ...` (which worked per the issue repro steps).

## Testing
Verified by reviewing the `collectStdin()` logic and the worker-service startup contract. The fix mirrors the suggested fix in the issue.