### PR TITLE
docs: align session ID architecture guide with current runtime semantics

### DIFF
--- a/docs/SESSION_ID_ARCHITECTURE.md
+++ b/docs/SESSION_ID_ARCHITECTURE.md
@@ -30,7 +30,7 @@ Claude-mem uses **two distinct session IDs** to track conversations and memory:
                            ↓
 ┌─────────────────────────────────────────────────────────────┐
 │ 3. First SDK message arrives with session_id                │
-│    updateMemorySessionId(sessionDbId, "sdk-gen-abc123")     │
+│    ensureMemorySessionIdRegistered(sessionDbId, "sdk-gen-abc123") │
 │                                                              │
 │    Database state:                                          │
 │    ├─ content_session_id: "user-session-123"               │
@@ -73,8 +73,8 @@ This is why `SDKAgent` persists the SDK-returned `session_id` immediately throug
 const hasRealMemorySessionId = !!session.memorySessionId;
 ```
 
-- When `memorySessionId === null` → Not yet captured
-- When `memorySessionId !== null` → Real SDK session captured
+- When `memorySessionId` is falsy → Not yet captured
+- When `memorySessionId` is truthy → Real SDK session captured
 
 ### 2. Resume Safety
 


### PR DESCRIPTION
## Summary
- correct the architecture guide to say observations are keyed by the real `memory_session_id`, not `contentSessionId`
- document the current resume gate: `memorySessionId`, `lastPromptNumber > 1`, and `!forceInit`
- update the pitfalls and usage examples so future contributors do not reintroduce the older placeholder model

## Validation
- `git diff --check`
- unable to run `bun test tests/session_id_usage_validation.test.ts` in this environment because `bun` is not installed