### PR TITLE
fix: add AbortSignal.timeout to isPortInUse on non-Windows platforms

### DIFF
--- a/src/services/infrastructure/HealthMonitor.ts
+++ b/src/services/infrastructure/HealthMonitor.ts
@@ -39,10 +39,15 @@ async function httpRequestToWorker(
  */
 export async function isPortInUse(port: number): Promise<boolean> {
   try {
-    // Note: Removed AbortSignal.timeout to avoid Windows Bun cleanup issue (libuv assertion)
-    const response = await fetch(`http://127.0.0.1:${port}/api/health`);
+    // AbortSignal.timeout is skipped on Windows to avoid a Bun libuv assertion crash.
+    // On Linux/macOS, fetch() to a closed port may hang forever (Bun 1.3.11+), so
+    // we apply a 2s timeout to prevent daemon startup from blocking indefinitely.
+    const options: RequestInit = process.platform !== 'win32'
+      ? { signal: AbortSignal.timeout(2000) }
+      : {};
+    const response = await fetch(`http://127.0.0.1:${port}/api/health`, options);
     return response.ok;
-  } catch (error) {
+  } catch {
     // [ANTI-PATTERN IGNORED]: Health check polls every 500ms, logging would flood
     return false;
   }


### PR DESCRIPTION
Fixes #1587

## Problem

On Bun 1.3.11 (Linux/WSL2), `fetch()` to a closed port hangs indefinitely instead of rejecting with `ECONNREFUSED`. The `AbortSignal.timeout` was previously removed from `isPortInUse()` to avoid a Windows Bun libuv assertion crash, but this caused the daemon startup to block forever on Linux when no worker was running.

## Solution

Add a platform guard: apply a 2-second `AbortSignal.timeout` on Linux/macOS only, and keep the bare `fetch()` on Windows where the timeout causes a libuv assertion failure. This restores the timeout for the platform that needs it without regressing Windows.

```typescript
const options: RequestInit = process.platform !== 'win32'
  ? { signal: AbortSignal.timeout(2000) }
  : {};
const response = await fetch(`http://127.0.0.1:${port}/api/health`, options);
```

## Testing

Verified that on Linux (WSL2), `fetch()` without a timeout to a port with nothing listening hangs indefinitely, while `fetch()` with `AbortSignal.timeout(2000)` correctly throws a timeout error after 2 seconds, allowing `isPortInUse()` to return `false` and daemon startup to proceed normally.