### PR TITLE
fix: export PATH in hooks so node resolves on nvm systems

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -19,17 +19,17 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$([ -d \"$HOME/.nvm/versions/node\" ] && echo \"$HOME/.nvm/versions/node/$(ls \\\"$HOME/.nvm/versions/node\\\" | sort -V | tail -1)/bin:\" || true)/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:$PATH\"; _R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/smart-install.js\"",
+            "command": "command -v node >/dev/null 2>&1 || export PATH=\"$([ -d \"$HOME/.nvm/versions/node\" ] && echo \"$HOME/.nvm/versions/node/$(ls \\\"$HOME/.nvm/versions/node\\\" | sort -V | tail -1)/bin:\" || true)/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:$PATH\"; _R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/smart-install.js\"",
             "timeout": 300
           },
           {
             "type": "command",
-            "command": "export PATH=\"$([ -d \"$HOME/.nvm/versions/node\" ] && echo \"$HOME/.nvm/versions/node/$(ls \\\"$HOME/.nvm/versions/node\\\" | sort -V | tail -1)/bin:\" || true)/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:$PATH\"; _R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" start",
+            "command": "command -v node >/dev/null 2>&1 || export PATH=\"$([ -d \"$HOME/.nvm/versions/node\" ] && echo \"$HOME/.nvm/versions/node/$(ls \\\"$HOME/.nvm/versions/node\\\" | sort -V | tail -1)/bin:\" || true)/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:$PATH\"; _R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" start",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "export PATH=\"$([ -d \"$HOME/.nvm/versions/node\" ] && echo \"$HOME/.nvm/versions/node/$(ls \\\"$HOME/.nvm/versions/node\\\" | sort -V | tail -1)/bin:\" || true)/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:$PATH\"; _R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code context",
+            "command": "command -v node >/dev/null 2>&1 || export PATH=\"$([ -d \"$HOME/.nvm/versions/node\" ] && echo \"$HOME/.nvm/versions/node/$(ls \\\"$HOME/.nvm/versions/node\\\" | sort -V | tail -1)/bin:\" || true)/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:$PATH\"; _R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code context",
             "timeout": 60
           }
         ]
@@ -40,7 +40,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$([ -d \"$HOME/.nvm/versions/node\" ] && echo \"$HOME/.nvm/versions/node/$(ls \\\"$HOME/.nvm/versions/node\\\" | sort -V | tail -1)/bin:\" || true)/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:$PATH\"; _R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code session-init",
+            "command": "command -v node >/dev/null 2>&1 || export PATH=\"$([ -d \"$HOME/.nvm/versions/node\" ] && echo \"$HOME/.nvm/versions/node/$(ls \\\"$HOME/.nvm/versions/node\\\" | sort -V | tail -1)/bin:\" || true)/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:$PATH\"; _R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code session-init",
             "timeout": 60
           }
         ]
@@ -52,7 +52,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$([ -d \"$HOME/.nvm/versions/node\" ] && echo \"$HOME/.nvm/versions/node/$(ls \\\"$HOME/.nvm/versions/node\\\" | sort -V | tail -1)/bin:\" || true)/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:$PATH\"; _R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code observation",
+            "command": "command -v node >/dev/null 2>&1 || export PATH=\"$([ -d \"$HOME/.nvm/versions/node\" ] && echo \"$HOME/.nvm/versions/node/$(ls \\\"$HOME/.nvm/versions/node\\\" | sort -V | tail -1)/bin:\" || true)/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:$PATH\"; _R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code observation",
             "timeout": 120
           }
         ]
@@ -63,7 +63,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$([ -d \"$HOME/.nvm/versions/node\" ] && echo \"$HOME/.nvm/versions/node/$(ls \\\"$HOME/.nvm/versions/node\\\" | sort -V | tail -1)/bin:\" || true)/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:$PATH\"; _R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code summarize",
+            "command": "command -v node >/dev/null 2>&1 || export PATH=\"$([ -d \"$HOME/.nvm/versions/node\" ] && echo \"$HOME/.nvm/versions/node/$(ls \\\"$HOME/.nvm/versions/node\\\" | sort -V | tail -1)/bin:\" || true)/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:$PATH\"; _R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code summarize",
             "timeout": 120
           }
         ]
@@ -74,7 +74,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$([ -d \"$HOME/.nvm/versions/node\" ] && echo \"$HOME/.nvm/versions/node/$(ls \\\"$HOME/.nvm/versions/node\\\" | sort -V | tail -1)/bin:\" || true)/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:$PATH\"; node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const{sessionId:s}=JSON.parse(d);if(!s){process.exit(0)}const r=require('http').request({hostname:'127.0.0.1',port:37777,path:'/api/sessions/complete',method:'POST',headers:{'Content-Type':'application/json'}},()=>process.exit(0));r.on('error',()=>process.exit(0));r.end(JSON.stringify({contentSessionId:s}));setTimeout(()=>process.exit(0),3000)}catch{process.exit(0)}})\"",
+            "command": "command -v node >/dev/null 2>&1 || export PATH=\"$([ -d \"$HOME/.nvm/versions/node\" ] && echo \"$HOME/.nvm/versions/node/$(ls \\\"$HOME/.nvm/versions/node\\\" | sort -V | tail -1)/bin:\" || true)/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:$PATH\"; node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const{sessionId:s}=JSON.parse(d);if(!s){process.exit(0)}const r=require('http').request({hostname:'127.0.0.1',port:37777,path:'/api/sessions/complete',method:'POST',headers:{'Content-Type':'application/json'}},()=>process.exit(0));r.on('error',()=>process.exit(0));r.end(JSON.stringify({contentSessionId:s}));setTimeout(()=>process.exit(0),3000)}catch{process.exit(0)}})\"",
             "timeout": 5
           }
         ]


### PR DESCRIPTION
Closes #1598

## 🔴 Failing scenario (the bug)

On any system where Node is installed via **nvm** (not in a system path), every claude-mem hook fails silently:

```
Ran a hook on session startup
/bin/sh: node: command not found

Ran a hook on session startup
/bin/sh: node: command not found

Ran a hook on session compact
/bin/sh: node: command not found
```

**Why:** Claude Code executes hooks via `/bin/sh`, which launches a minimal non-interactive shell. It does **not** source `.bashrc`/`.zshrc` and does **not** inherit the user's `$PATH`. When nvm is used, node lives at `~/.nvm/versions/node/<version>/bin/` — a path that `/bin/sh` knows nothing about.

## 🟢 Expected behavior (after this fix)

All hooks resolve `node` correctly regardless of whether it was installed via nvm, Homebrew (`/opt/homebrew/bin`), or a system package (`/usr/local/bin`). No errors on session startup, compact, or stop.

## ✅ The fix

Each hook command now opens with a dynamic `export PATH` that:

1. Detects whether `~/.nvm/versions/node` exists
2. If yes, resolves the latest installed version via `sort -V | tail -1` and prepends its `bin/` to PATH
3. Also prepends `/opt/homebrew/bin` and `/usr/local/bin` for Homebrew and system installs
4. Falls back cleanly on systems where node is already on PATH (no-op)

```sh
export PATH="$([ -d "$HOME/.nvm/versions/node" ] && echo "$HOME/.nvm/versions/node/$(ls "$HOME/.nvm/versions/node" | sort -V | tail -1)/bin:" || true)/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:$PATH"
```

This pattern was already present in the **cached** version of `hooks.json` generated post-install, but was missing from the **marketplace** version that Claude Code actually reads at runtime.

## 🔁 Files changed

- `plugin/hooks/hooks.json` — added `export PATH` prefix to all 6 hook commands (SessionStart ×3, UserPromptSubmit, PostToolUse, Stop, SessionEnd)