### PR TITLE
fix: salvage summary data when Claude returns observation tags instead of summary tags

### DIFF
--- a/src/sdk/parser.ts
+++ b/src/sdk/parser.ts
@@ -120,10 +120,31 @@ export function parseSummary(text: string, sessionId?: number): ParsedSummary | 
   const summaryMatch = summaryRegex.exec(text);
 
   if (!summaryMatch) {
-    // Log when the response contains <observation> instead of <summary>
-    // to help diagnose prompt conditioning issues (see #1312)
+    // When response contains <observation> instead of <summary>, attempt to salvage
+    // summary data from the observation fields rather than discarding it (see #1546)
     if (/<observation>/.test(text)) {
-      logger.warn('PARSER', 'Summary response contained <observation> tags instead of <summary> — prompt conditioning may need strengthening', { sessionId });
+      logger.warn('PARSER', 'Summary response contained <observation> tags instead of <summary> — attempting to salvage summary data', { sessionId });
+
+      const obsContentMatch = /<observation>([\s\S]*?)<\/observation>/.exec(text);
+      if (obsContentMatch) {
+        const obsContent = obsContentMatch[1];
+        const title = extractField(obsContent, 'title');
+        const narrative = extractField(obsContent, 'narrative');
+        const facts = extractArrayElements(obsContent, 'facts', 'fact');
+        const learned = narrative || (facts.length > 0 ? facts.join('; ') : null);
+
+        if (title || learned) {
+          logger.info('PARSER', 'Salvaged summary from observation tags', { sessionId, hasTitle: !!title, hasLearned: !!learned });
+          return {
+            request: null,
+            investigated: null,
+            learned,
+            completed: title,
+            next_steps: null,
+            notes: null
+          };
+        }
+      }
     }
     return null;
   }

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+
+// Mock dependencies before importing parser
+mock.module('../src/utils/logger', () => ({
+  logger: {
+    info: () => {},
+    warn: () => {},
+    error: () => {}
+  }
+}));
+
+mock.module('../src/services/domain/ModeManager', () => ({
+  ModeManager: {
+    getInstance: () => ({
+      getActiveMode: () => ({
+        observation_types: [{ id: 'observation' }, { id: 'decision' }],
+        prompts: {}
+      })
+    })
+  }
+}));
+
+import { parseSummary, parseObservations } from '../src/sdk/parser';
+
+describe('parseSummary', () => {
+  it('returns null when no summary or observation tags present', () => {
+    const result = parseSummary('some random text');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when skip_summary tag is present', () => {
+    const result = parseSummary('<skip_summary reason="no work done" />');
+    expect(result).toBeNull();
+  });
+
+  it('parses a valid summary block', () => {
+    const text = `
+<summary>
+  <request>Fix the bug</request>
+  <investigated>Found root cause in parser.ts</investigated>
+  <learned>The regex was greedy</learned>
+  <completed>Fixed the regex</completed>
+  <next_steps>Add tests</next_steps>
+  <notes>Low risk change</notes>
+</summary>
+    `;
+    const result = parseSummary(text);
+    expect(result).not.toBeNull();
+    expect(result?.request).toBe('Fix the bug');
+    expect(result?.investigated).toBe('Found root cause in parser.ts');
+    expect(result?.learned).toBe('The regex was greedy');
+    expect(result?.completed).toBe('Fixed the regex');
+    expect(result?.next_steps).toBe('Add tests');
+    expect(result?.notes).toBe('Low risk change');
+  });
+
+  it('salvages summary from observation tags when summary tag is absent (issue #1546)', () => {
+    const text = `
+<observation>
+  <type>observation</type>
+  <title>Fixed authentication bug in login handler</title>
+  <narrative>The root cause was a missing null check in the token validation logic. Added guard clause to prevent NPE.</narrative>
+  <facts>
+    <fact>Token validation was missing null check</fact>
+    <fact>Added guard clause in auth.ts line 42</fact>
+  </facts>
+</observation>
+    `;
+    const result = parseSummary(text);
+    expect(result).not.toBeNull();
+    expect(result?.completed).toBe('Fixed authentication bug in login handler');
+    expect(result?.learned).toBe('The root cause was a missing null check in the token validation logic. Added guard clause to prevent NPE.');
+    expect(result?.request).toBeNull();
+    expect(result?.investigated).toBeNull();
+    expect(result?.next_steps).toBeNull();
+  });
+
+  it('salvages summary using facts when observation has no narrative (issue #1546)', () => {
+    const text = `
+<observation>
+  <type>decision</type>
+  <title>Chose SQLite over PostgreSQL</title>
+  <facts>
+    <fact>SQLite has zero configuration</fact>
+    <fact>PostgreSQL requires a running server</fact>
+  </facts>
+</observation>
+    `;
+    const result = parseSummary(text);
+    expect(result).not.toBeNull();
+    expect(result?.completed).toBe('Chose SQLite over PostgreSQL');
+    expect(result?.learned).toBe('SQLite has zero configuration; PostgreSQL requires a running server');
+  });
+
+  it('returns null when observation tags present but no useful data', () => {
+    const text = '<observation><type>observation</type></observation>';
+    const result = parseSummary(text);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #1546

## Problem

When Claude responds to a summarize prompt with `<observation>` tags instead of `<summary>` tags (occurring ~72% of the time per the issue report), `parseSummary` logs a warning and returns `null`, discarding all the data Claude generated.

## Solution

Instead of immediately returning `null` when `<summary>` is absent but `<observation>` is present, the parser now attempts to salvage useful data from the first observation block:

- Maps `<title>` → `completed`
- Maps `<narrative>` → `learned` (falls back to joining `<fact>` elements if narrative is absent)
- Returns a minimal `ParsedSummary` with the salvaged fields, leaving unresolvable fields (`request`, `investigated`, `next_steps`) as `null`

If neither title nor learned data can be extracted, the function still returns `null` as before.

## Testing

Added `tests/parser.test.ts` with 6 test cases covering:
- Normal summary parsing
- `skip_summary` tag handling
- Salvage path: observation with title + narrative → minimal summary
- Salvage path: observation with title + facts (no narrative) → joined facts as `learned`
- No-op when observation tags contain no useful data
- Returns `null` when neither summary nor observation tags present

All 6 tests pass. Pre-existing test suite unaffected.