### PR TITLE
fix(windows): isMainModule CJS branch fails on Bun — add CLAUDE_MEM_MANAGED fallback

### DIFF
--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -1307,8 +1307,10 @@ async function main() {
 }
 
 // Check if running as main module in both ESM and CommonJS
+// The CLAUDE_MEM_MANAGED check handles Bun on Windows where require.main !== module
+// in CJS mode despite being the entry point (see #1450)
 const isMainModule = typeof require !== 'undefined' && typeof module !== 'undefined'
-  ? require.main === module || !module.parent
+  ? require.main === module || !module.parent || process.env.CLAUDE_MEM_MANAGED === 'true'
   : import.meta.url === `file://${process.argv[1]}`
     || process.argv[1]?.endsWith('worker-service')
     || process.argv[1]?.endsWith('worker-service.cjs')


### PR DESCRIPTION
## Summary

- On Bun/Windows, `require.main !== module` in CJS mode causes the worker to exit silently with code 0, preventing the worker daemon from starting
- The wrapper already sets `CLAUDE_MEM_MANAGED=true` when spawning the inner worker — this PR adds it as a fallback check in the CJS branch of `isMainModule`
- 1-line change in `src/services/worker-service.ts`, does not affect standalone or ESM execution

## Root Cause

PR #1518 fixed the ESM path checks for `isMainModule` but the CJS branch was left unchanged:

```typescript
// CJS branch — Bun fails here:
require.main === module || !module.parent
```

In Bun's CJS runtime on Windows, `require.main !== module` and `module.parent` is truthy, so `isMainModule` evaluates to `false`. The worker exits with code 0 — no error, no log.

## Evidence

```
[wrapper] Spawning inner worker: ...\worker-service.cjs
[wrapper] Inner exited with code=0, signal=null
[wrapper] Inner exited unexpectedly, wrapper exiting
```

With the fix:
```bash
CLAUDE_MEM_MANAGED=true bun worker-service.cjs  # stays alive ✓
```

## Test plan

- [x] Verified worker starts and stays alive on Windows 11 + Bun 1.3.11
- [x] Verified `CLAUDE_MEM_MANAGED` is already set by `worker-wrapper.cjs` spawn env
- [x] Verified standalone execution (`bun worker-service.cjs` without env var) still uses the original `require.main === module` check

Ref #1450

🤖 Generated with [Claude Code](https://claude.com/claude-code)