### PR TITLE
fix: add 400/401 to FALLBACK_ERROR_PATTERNS to prevent retry loop on auth errors

### DIFF
--- a/src/services/worker/agents/FallbackErrorHandler.ts
+++ b/src/services/worker/agents/FallbackErrorHandler.ts
@@ -13,6 +13,8 @@ import { logger } from '../../../utils/logger.js';
  * Check if an error should trigger fallback to Claude SDK
  *
  * Errors that trigger fallback:
+ * - 400: Bad request / API_KEY_INVALID (permanent failure, skip retries)
+ * - 401: Unauthorized (invalid credentials, skip retries)
  * - 429: Rate limit exceeded
  * - 500/502/503: Server errors
  * - ECONNREFUSED: Connection refused (server down)

--- a/src/services/worker/agents/types.ts
+++ b/src/services/worker/agents/types.ts
@@ -123,6 +123,8 @@ export interface BaseAgentConfig {
  * Error codes that should trigger fallback to Claude
  */
 export const FALLBACK_ERROR_PATTERNS = [
+  '400',           // Bad request (e.g. API_KEY_INVALID — permanent failure, no point retrying)
+  '401',           // Unauthorized — invalid or missing credentials
   '429',           // Rate limit
   '500',           // Internal server error
   '502',           // Bad gateway


### PR DESCRIPTION
Fixes #1614

## Problem

When Gemini returns `400 API_KEY_INVALID`, the `shouldFallbackToClaude()` function returns `false` because `'400'` was not in `FALLBACK_ERROR_PATTERNS`. This causes the crash-recovery loop to retry 3 times before giving up, resulting in a ~2-minute delay in the stop hook.

## Solution

Added `'400'` and `'401'` to `FALLBACK_ERROR_PATTERNS` in `src/services/worker/agents/types.ts`.

Auth errors are **permanent failures** — retrying with the same credentials will always fail. Triggering the Claude SDK fallback immediately (same as rate-limit/network errors) avoids the 3-restart retry loop.

## Testing

- Verified `shouldFallbackToClaude()` uses `FALLBACK_ERROR_PATTERNS.some(pattern => message.includes(pattern))`, so adding `'400'`/`'401'` will match error messages containing those status codes.
- Existing behavior for transient errors (429, 5xx, network) is unchanged.