### PR TITLE
fix: add PHP grammar support to smart-file-read parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "tree-sitter-go": "^0.25.0",
     "tree-sitter-java": "^0.23.5",
     "tree-sitter-javascript": "^0.25.0",
+    "tree-sitter-php": "^0.24.2",
     "tree-sitter-python": "^0.25.0",
     "tree-sitter-ruby": "^0.23.1",
     "tree-sitter-rust": "^0.24.0",

--- a/src/services/smart-file-read/parser.ts
+++ b/src/services/smart-file-read/parser.ts
@@ -3,7 +3,7 @@
  *
  * No native bindings. No WASM. Just the CLI binary + query patterns.
  *
- * Supported: JS, TS, Python, Go, Rust, Ruby, Java, C, C++
+ * Supported: JS, TS, Python, Go, Rust, Ruby, Java, C, C++, PHP
  *
  * by Copter Labs
  */
@@ -66,6 +66,7 @@ const LANG_MAP: Record<string, string> = {
   ".cxx": "cpp",
   ".hpp": "cpp",
   ".hh": "cpp",
+  ".php": "php",
 };
 
 export function detectLanguage(filePath: string): string {
@@ -86,6 +87,7 @@ const GRAMMAR_PACKAGES: Record<string, string> = {
   java: "tree-sitter-java",
   c: "tree-sitter-c",
   cpp: "tree-sitter-cpp",
+  php: "tree-sitter-php/php",
 };
 
 function resolveGrammarPath(language: string): string | null {
@@ -160,6 +162,15 @@ const QUERIES: Record<string, string> = {
 (import_statement) @imp
 (import_declaration) @imp
 `,
+
+  php: `
+(function_definition name: (name) @name) @func
+(method_declaration name: (name) @name) @method
+(class_declaration name: (name) @name) @cls
+(interface_declaration name: (name) @name) @iface
+(trait_declaration name: (name) @name) @trait_def
+(namespace_use_declaration) @imp
+`,
 };
 
 function getQueryKey(language: string): string {
@@ -173,6 +184,7 @@ function getQueryKey(language: string): string {
     case "rust": return "rust";
     case "ruby": return "ruby";
     case "java": return "java";
+    case "php": return "php";
     default: return "generic";
   }
 }


### PR DESCRIPTION
Fixes #1617

## Problem

PHP was listed as a supported language in the CHANGELOG and `.php` files were being scanned by `search.ts`, but `parser.ts` was missing several entries needed for PHP symbol extraction:

1. `.php` was not in `LANG_MAP` — `detectLanguage()` returned `'unknown'` for PHP files
2. `'php'` was not in `GRAMMAR_PACKAGES` — no grammar path could be resolved
3. No PHP query patterns existed in `QUERIES`
4. No `'php'` case in `getQueryKey()`

As a result, `smart_search`, `smart_outline`, and `smart_unfold` would scan PHP files but extract **0 symbols**.

## Solution

- Added `'.php': 'php'` to `LANG_MAP`
- Added `'php': 'tree-sitter-php/php'` to `GRAMMAR_PACKAGES`
- Added PHP tree-sitter query patterns covering functions, methods, classes, interfaces, traits, and `use` statements
- Added `case 'php'` to `getQueryKey()`
- Added `tree-sitter-php ^0.24.2` to `devDependencies`

## Testing

With these changes, `smart_search` on a Laravel/PHP codebase should correctly extract and return PHP symbols (classes, methods, functions) instead of returning 0 results.