### PR TITLE
fix: strip persisted-output tags from memory

### DIFF
--- a/src/utils/tag-stripping.ts
+++ b/src/utils/tag-stripping.ts
@@ -31,7 +31,8 @@ function countTags(content: string): number {
   const contextCount = (content.match(/<claude-mem-context>/g) || []).length;
   const systemInstructionCount = (content.match(/<system_instruction>/g) || []).length;
   const systemInstructionHyphenCount = (content.match(/<system-instruction>/g) || []).length;
-  return privateCount + contextCount + systemInstructionCount + systemInstructionHyphenCount;
+  const persistedOutputCount = (content.match(/<persisted-output>/g) || []).length;
+  return privateCount + contextCount + systemInstructionCount + systemInstructionHyphenCount + persistedOutputCount;
 }
 
 /**
@@ -55,6 +56,7 @@ function stripTagsInternal(content: string): string {
     .replace(/<private>[\s\S]*?<\/private>/g, '')
     .replace(/<system_instruction>[\s\S]*?<\/system_instruction>/g, '')
     .replace(/<system-instruction>[\s\S]*?<\/system-instruction>/g, '')
+    .replace(/<persisted-output>[\s\S]*?<\/persisted-output>/g, '')
     .trim();
 }
 

--- a/tests/utils/tag-stripping.test.ts
+++ b/tests/utils/tag-stripping.test.ts
@@ -49,6 +49,12 @@ describe('Tag Stripping Utilities', () => {
         const result = stripMemoryTagsFromPrompt(input);
         expect(result).toBe('public  end');
       });
+
+      it('should strip <persisted-output> tags', () => {
+        const input = 'public <persisted-output>large output</persisted-output> after';
+        const result = stripMemoryTagsFromPrompt(input);
+        expect(result).toBe('public  after');
+      });
     });
 
     describe('multiple tags handling', () => {
@@ -229,6 +235,15 @@ finish`;
         const result = stripMemoryTagsFromJson(JSON.stringify(toolResponse));
         const parsed = JSON.parse(result);
         expect(parsed.output).toBe('result ');
+      });
+
+      it('should strip persisted-output tags from JSON', () => {
+        const jsonContent = JSON.stringify({
+          output: '<persisted-output>big output</persisted-output> keep'
+        });
+        const result = stripMemoryTagsFromJson(jsonContent);
+        const parsed = JSON.parse(result);
+        expect(parsed.output).toBe(' keep');
       });
     });
 


### PR DESCRIPTION
## Summary
- strip <persisted-output> tags alongside existing privacy/system tags
- include persisted-output in tag count for ReDoS guard
- add test coverage for prompt + JSON stripping

## Testing
- not run (bun not available in this environment)