### PR TITLE
fix: resolve bun.exe when npm shim is in PATH

### DIFF
--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -55,14 +55,54 @@ function findBun() {
   });
 
   if (pathCheck.status === 0 && pathCheck.stdout.trim()) {
-    return 'bun'; // Found in PATH
+    if (!IS_WINDOWS) {
+      return 'bun'; // Found in PATH
+    }
+
+    const candidates = pathCheck.stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    const exeCandidate = candidates.find((candidate) =>
+      candidate.toLowerCase().endsWith('.exe') && existsSync(candidate)
+    );
+    if (exeCandidate) {
+      return exeCandidate;
+    }
+
+    const plainCandidate = candidates.find((candidate) =>
+      !candidate.match(/\.(cmd|bat)$/i) && existsSync(candidate)
+    );
+    if (plainCandidate) {
+      return plainCandidate;
+    }
+
+    const cmdCandidate = candidates.find((candidate) => candidate.match(/\.(cmd|bat)$/i));
+    if (cmdCandidate) {
+      const cmdDir = dirname(cmdCandidate);
+      const exeSibling = cmdCandidate.replace(/\.(cmd|bat)$/i, '.exe');
+      const npmBunExe = join(cmdDir, 'node_modules', 'bun', 'bin', 'bun.exe');
+
+      if (existsSync(exeSibling)) {
+        return exeSibling;
+      }
+
+      if (existsSync(npmBunExe)) {
+        return npmBunExe;
+      }
+    }
   }
 
   // Check common installation paths (handles fresh installs before PATH reload)
   // Windows: Bun installs to ~/.bun/bin/bun.exe (same as smart-install.js)
   // Unix: Check default location plus common package manager paths
+  const windowsAppData = process.env.APPDATA || join(homedir(), 'AppData', 'Roaming');
   const bunPaths = IS_WINDOWS
-    ? [join(homedir(), '.bun', 'bin', 'bun.exe')]
+    ? [
+        join(homedir(), '.bun', 'bin', 'bun.exe'),
+        join(windowsAppData, 'npm', 'node_modules', 'bun', 'bin', 'bun.exe')
+      ]
     : [
         join(homedir(), '.bun', 'bin', 'bun'),
         '/usr/local/bin/bun',

--- a/src/npx-cli/utils/bun-resolver.ts
+++ b/src/npx-cli/utils/bun-resolver.ts
@@ -9,7 +9,7 @@
 import { spawnSync } from 'child_process';
 import { existsSync } from 'fs';
 import { homedir } from 'os';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { IS_WINDOWS } from './paths.js';
 
 /**
@@ -18,9 +18,11 @@ import { IS_WINDOWS } from './paths.js';
  */
 function bunCandidatePaths(): string[] {
   if (IS_WINDOWS) {
+    const appData = process.env.APPDATA || join(homedir(), 'AppData', 'Roaming');
     return [
       join(homedir(), '.bun', 'bin', 'bun.exe'),
       join(process.env.USERPROFILE || homedir(), '.bun', 'bin', 'bun.exe'),
+      join(appData, 'npm', 'node_modules', 'bun', 'bin', 'bun.exe'),
     ];
   }
 
@@ -51,7 +53,43 @@ export function resolveBunBinaryPath(): string | null {
   });
 
   if (pathCheck.status === 0 && pathCheck.stdout.trim()) {
-    return 'bun'; // Available in PATH — use short name
+    if (!IS_WINDOWS) {
+      return 'bun';
+    }
+
+    const candidates = pathCheck.stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    const exeCandidate = candidates.find((candidate) =>
+      candidate.toLowerCase().endsWith('.exe') && existsSync(candidate)
+    );
+    if (exeCandidate) {
+      return exeCandidate;
+    }
+
+    const plainCandidate = candidates.find((candidate) =>
+      !candidate.match(/\.(cmd|bat)$/i) && existsSync(candidate)
+    );
+    if (plainCandidate) {
+      return plainCandidate;
+    }
+
+    const cmdCandidate = candidates.find((candidate) => candidate.match(/\.(cmd|bat)$/i));
+    if (cmdCandidate) {
+      const cmdDir = dirname(cmdCandidate);
+      const exeSibling = cmdCandidate.replace(/\.(cmd|bat)$/i, '.exe');
+      const npmBunExe = join(cmdDir, 'node_modules', 'bun', 'bin', 'bun.exe');
+
+      if (existsSync(exeSibling)) {
+        return exeSibling;
+      }
+
+      if (existsSync(npmBunExe)) {
+        return npmBunExe;
+      }
+    }
   }
 
   // Probe known install locations


### PR DESCRIPTION
## Summary
- avoid returning "bun" on Windows when "where bun" only finds bun.cmd
- resolve bun.exe from the shim location or npm global install dir
- keep bun resolver in sync for the NPX CLI

## Testing
- not run (path resolution change only)
