### PR TITLE
fix: rebuild FTS5 index after bulk observation import

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -2418,6 +2418,23 @@ export class SessionStore {
   }
 
   /**
+   * Rebuild the FTS5 index for observations.
+   * Should be called after bulk imports to ensure imported rows are searchable.
+   * No-op if observations_fts table does not exist.
+   */
+  rebuildObservationsFTSIndex(): void {
+    const hasFTS = (this.db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='observations_fts'"
+    ).all() as { name: string }[]).length > 0;
+
+    if (!hasFTS) {
+      return;
+    }
+
+    this.db.run("INSERT INTO observations_fts(observations_fts) VALUES('rebuild')");
+  }
+
+  /**
    * Import user prompt with duplicate checking
    * Duplicates are identified by content_session_id + prompt_number
    * Returns: { imported: boolean, id: number }

--- a/src/services/worker/http/routes/DataRoutes.ts
+++ b/src/services/worker/http/routes/DataRoutes.ts
@@ -362,6 +362,13 @@ export class DataRoutes extends BaseRouteHandler {
           stats.observationsSkipped++;
         }
       }
+
+      // Rebuild FTS index so imported observations are immediately searchable.
+      // The FTS5 content table relies on triggers for incremental updates, but
+      // those triggers may not have fired correctly for all import paths.
+      if (stats.observationsImported > 0) {
+        store.rebuildObservationsFTSIndex();
+      }
     }
 
     // Import prompts (depends on sessions)


### PR DESCRIPTION
Fixes #1631

## Problem

Observations imported via `POST /api/import` were not appearing in MCP `search` results. The `observations_fts` FTS5 content table relies on SQLite triggers to stay in sync with the `observations` table. These triggers may not fire correctly for all import paths, leaving imported rows invisible to full-text search.

## Solution

After a bulk import that inserts at least one new observation, the handler now calls `store.rebuildObservationsFTSIndex()`, which runs:

```sql
INSERT INTO observations_fts(observations_fts) VALUES('rebuild');
```

This is the standard FTS5 rebuild command for external-content tables and guarantees the index is consistent regardless of whether the triggers fired.

A new `SessionStore.rebuildObservationsFTSIndex()` method encapsulates this logic:
- Checks whether `observations_fts` exists before running (no-op when FTS5 is unavailable, e.g. Windows)
- Only called when `observationsImported > 0` to avoid unnecessary rebuilds on no-op imports

## Testing

1. Export a valid memory JSON file
2. Import via `curl -X POST http://127.0.0.1:37777/api/import -H "Content-Type: application/json" -d @file.json`
3. Verify imported observations appear in MCP `search` results immediately (no manual rebuild required)