### PR TITLE
docs: add cmux Claude executable troubleshooting note

### DIFF
--- a/docs/public/troubleshooting.mdx
+++ b/docs/public/troubleshooting.mdx
@@ -221,9 +221,9 @@ The skill includes comprehensive diagnostics, automated repair sequences, and de
    }
    ```
 
-2. Verify the path exists:
+2. Verify the path exists and is executable:
    ```bash
-   ls -l /Users/<username>/.local/bin/claude
+   test -x /Users/<username>/.local/bin/claude && echo "OK: executable"
    ```
 
 3. Restart Claude Code after saving the setting.


### PR DESCRIPTION
Fixes #1544

cmux.app users can land on the wrapper `claude` binary instead of the real Claude executable, which makes SDK agent startup fail with "Claude executable not found". This PR adds a focused troubleshooting note explaining the cmux-specific symptom and the `CLAUDE_CODE_PATH` workaround.