### PR TITLE
fix: use bun to run mcp-server.cjs instead of node shebang

### DIFF
--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,7 +2,8 @@
   "mcpServers": {
     "mcp-search": {
       "type": "stdio",
-      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/mcp-server.cjs"
+      "command": "bun",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/mcp-server.cjs"]
     }
   }
 }


### PR DESCRIPTION
Fixes #1648

## Problem

`plugin/.mcp.json` specifies `mcp-server.cjs` as the command directly:

```json
{
  "mcpServers": {
    "mcp-search": {
      "type": "stdio",
      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/mcp-server.cjs"
    }
  }
}
```

When Claude Code spawns this, the OS resolves the `#!/usr/bin/env node` shebang and runs the script with Node.js. However, `mcp-server.cjs` depends on `bun:sqlite`, a Bun-specific built-in that doesn't exist in Node.js, causing:

```
Error: Cannot find module 'bun:sqlite'
```

The MCP server fails to start, and Claude Code reports `Failed to reconnect to plugin:claude-mem:mcp-search`.

## Solution

Explicitly invoke `bun` as the command and pass the script as an argument, bypassing the shebang entirely:

```json
{
  "mcpServers": {
    "mcp-search": {
      "type": "stdio",
      "command": "bun",
      "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/mcp-server.cjs"]
    }
  }
}
```

Since `bun:sqlite` already requires Bun to be installed, this adds no new dependency.

## Testing

Verified that `plugin/.mcp.json` now specifies `bun` as the command with the script path in `args`.