### PR TITLE
fix: resolve uvx absolute path for non-interactive shell contexts

### DIFF
--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -23,6 +23,7 @@ import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js
 import { USER_SETTINGS_PATH } from '../../shared/paths.js';
 import { sanitizeEnv } from '../../supervisor/env-sanitizer.js';
 import { getSupervisor } from '../../supervisor/index.js';
+import { getUvxPath } from '../../utils/uvx-path.js';
 
 const CHROMA_MCP_CLIENT_NAME = 'claude-mem-chroma';
 const CHROMA_MCP_CLIENT_VERSION = '1.0.0';
@@ -112,7 +113,12 @@ export class ChromaMcpManager {
     // This also fixes Git Bash compatibility (#1062) since cmd.exe handles
     // Windows-native command resolution regardless of the calling shell.
     const isWindows = process.platform === 'win32';
-    const uvxSpawnCommand = isWindows ? (process.env.ComSpec || 'cmd.exe') : 'uvx';
+    // On non-Windows, resolve uvx absolute path so the worker can find it when
+    // started from non-interactive contexts (launchd, cron, nohup) where
+    // ~/.local/bin is not in PATH. Falls back to 'uvx' if not found (allows
+    // a clear error message rather than silent failure).
+    const resolvedUvxPath = !isWindows ? (getUvxPath() ?? 'uvx') : 'uvx';
+    const uvxSpawnCommand = isWindows ? (process.env.ComSpec || 'cmd.exe') : resolvedUvxPath;
     const uvxSpawnArgs = isWindows ? ['/c', 'uvx', ...commandArgs] : commandArgs;
 
     logger.info('CHROMA_MCP', 'Connecting to chroma-mcp via MCP stdio', {

--- a/src/utils/uvx-path.ts
+++ b/src/utils/uvx-path.ts
@@ -1,0 +1,69 @@
+/**
+ * Uvx Path Utility
+ *
+ * Resolves the uvx executable path for environments where uvx is not in PATH
+ * (e.g., launchd, cron, nohup contexts where ~/.local/bin is not included).
+ */
+
+import { spawnSync } from 'child_process';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { logger } from './logger.js';
+
+/**
+ * Get the uvx executable path.
+ * Tries PATH first, then checks common installation locations.
+ * Returns absolute path if found, null otherwise.
+ */
+export function getUvxPath(): string | null {
+  // Try PATH first
+  try {
+    const result = spawnSync('uvx', ['--version'], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      shell: false
+    });
+    if (result.status === 0) {
+      return 'uvx'; // Available in PATH
+    }
+  } catch (e) {
+    logger.debug('SYSTEM', 'uvx not found in PATH, checking common installation locations', {
+      error: e instanceof Error ? e.message : String(e)
+    });
+  }
+
+  // Check common installation paths
+  const uvxPaths = [
+    join(homedir(), '.local', 'bin', 'uvx'),   // Default uv/uvx install on Linux/macOS
+    join(homedir(), '.cargo', 'bin', 'uvx'),    // Cargo-based install
+    '/opt/homebrew/bin/uvx',                    // Homebrew on Apple Silicon
+    '/usr/local/bin/uvx',                       // Homebrew on Intel / manual install
+    '/usr/bin/uvx',
+  ];
+
+  for (const uvxPath of uvxPaths) {
+    if (existsSync(uvxPath)) {
+      logger.debug('SYSTEM', 'Found uvx at known location', { path: uvxPath });
+      return uvxPath;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Get the uvx executable path or throw an error.
+ * Use this when uvx is required for operation.
+ */
+export function getUvxPathOrThrow(): string {
+  const uvxPath = getUvxPath();
+  if (!uvxPath) {
+    throw new Error(
+      'uvx is required but not found in PATH or common locations.\n' +
+      'Install it with: curl -LsSf https://astral.sh/uv/install.sh | sh\n' +
+      'Then ensure ~/.local/bin is in your PATH.'
+    );
+  }
+  return uvxPath;
+}


### PR DESCRIPTION
Fixes #1644

## Problem

`ChromaMcpManager` spawns `uvx` by bare name on non-Windows platforms:

```typescript
const uvxSpawnCommand = isWindows ? (process.env.ComSpec || 'cmd.exe') : 'uvx';
```

When the worker daemon is started from a non-interactive context (launchd, cron, nohup), `~/.local/bin` is not included in `PATH`, so `uvx` cannot be found. ChromaDB silently fails, the generator crash-loops, and observations stop recording — with no user-visible indication:

```
[WARN] [CHROMA_MCP] Connection failed, killing subprocess to prevent zombie {error=Executable not found in $PATH: "uvx"}
[ERROR] [SESSION] Generator failed {provider=claude, error=Claude executable not found.}
```

## Solution

Add a `getUvxPath()` utility (modeled after the existing `getBunPath()` pattern) that:
1. Tries `uvx` via `spawnSync` first (respects PATH if set correctly)
2. Falls back to checking common installation locations:
   - `~/.local/bin/uvx` (default `uv` install)
   - `~/.cargo/bin/uvx` (cargo-based install)
   - `/opt/homebrew/bin/uvx` (Apple Silicon Homebrew)
   - `/usr/local/bin/uvx` (Intel macOS / manual)
   - `/usr/bin/uvx`

Use the resolved absolute path when spawning `uvx` on non-Windows. Falls back to bare `'uvx'` if nothing is found, preserving the existing error rather than adding a new failure mode.

## Files Changed

- `src/utils/uvx-path.ts` — new utility following the `bun-path.ts` pattern
- `src/services/sync/ChromaMcpManager.ts` — use `getUvxPath()` to resolve the spawn command

## Testing

Verified that `getUvxPath()` resolves `~/.local/bin/uvx` when that path exists and `uvx` is not in `PATH`.