### PR TITLE
fix: clarify observation ID in context footer and index (#1339)

### DIFF
--- a/src/services/context/formatters/ColorFormatter.ts
+++ b/src/services/context/formatters/ColorFormatter.ts
@@ -74,7 +74,7 @@ export function renderColorContextIndex(): string[] {
     `${colors.dim}Context Index: This semantic index (titles, types, files, tokens) is usually sufficient to understand past work.${colors.reset}`,
     '',
     `${colors.dim}When you need implementation details, rationale, or debugging context:${colors.reset}`,
-    `${colors.dim}  - Fetch by ID: get_observations([IDs]) for observations visible in this index${colors.reset}`,
+    `${colors.dim}  - Fetch by ID: get_observations([observation IDs]) for observations visible in this index${colors.reset}`,
     `${colors.dim}  - Search history: Use the mem-search skill for past decisions, bugs, and deeper research${colors.reset}`,
     `${colors.dim}  - Trust this index over re-reading code for past decisions and learnings${colors.reset}`,
     ''
@@ -226,7 +226,7 @@ export function renderColorFooter(totalDiscoveryTokens: number, totalReadTokens:
   const workTokensK = Math.round(totalDiscoveryTokens / 1000);
   return [
     '',
-    `${colors.dim}Access ${workTokensK}k tokens of past research & decisions for just ${totalReadTokens.toLocaleString()}t. Use the claude-mem skill to access memories by ID.${colors.reset}`
+    `${colors.dim}Access ${workTokensK}k tokens of past research & decisions for just ${totalReadTokens.toLocaleString()}t. Use the claude-mem skill to access memories by observation ID (the #N numbers in the index above).${colors.reset}`
   ];
 }
 

--- a/src/services/context/formatters/MarkdownFormatter.ts
+++ b/src/services/context/formatters/MarkdownFormatter.ts
@@ -72,7 +72,7 @@ export function renderMarkdownContextIndex(): string[] {
     `**Context Index:** This semantic index (titles, types, files, tokens) is usually sufficient to understand past work.`,
     '',
     `When you need implementation details, rationale, or debugging context:`,
-    `- Fetch by ID: get_observations([IDs]) for observations visible in this index`,
+    `- Fetch by ID: get_observations([observation IDs]) for observations visible in this index`,
     `- Search history: Use the mem-search skill for past decisions, bugs, and deeper research`,
     `- Trust this index over re-reading code for past decisions and learnings`,
     ''
@@ -229,7 +229,7 @@ export function renderMarkdownFooter(totalDiscoveryTokens: number, totalReadToke
   const workTokensK = Math.round(totalDiscoveryTokens / 1000);
   return [
     '',
-    `Access ${workTokensK}k tokens of past research & decisions for just ${totalReadTokens.toLocaleString()}t. Use the claude-mem skill to access memories by ID.`
+    `Access ${workTokensK}k tokens of past research & decisions for just ${totalReadTokens.toLocaleString()}t. Use the claude-mem skill to access memories by observation ID (the #N numbers in the index above).`
   ];
 }
 

--- a/tests/context/formatters/color-formatter.test.ts
+++ b/tests/context/formatters/color-formatter.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, mock } from 'bun:test';
+
+// Mock the ModeManager before importing the formatter
+mock.module('../../../src/services/domain/ModeManager.js', () => ({
+  ModeManager: {
+    getInstance: () => ({
+      getActiveMode: () => ({
+        name: 'code',
+        prompts: {},
+        observation_types: [
+          { id: 'decision', emoji: 'D' },
+          { id: 'bugfix', emoji: 'B' },
+          { id: 'discovery', emoji: 'I' },
+        ],
+        observation_concepts: [],
+      }),
+      getTypeIcon: (type: string) => {
+        const icons: Record<string, string> = { decision: 'D', bugfix: 'B', discovery: 'I' };
+        return icons[type] || '?';
+      },
+      getWorkEmoji: () => 'W',
+    }),
+  },
+}));
+
+import {
+  renderColorFooter,
+} from '../../../src/services/context/formatters/ColorFormatter.js';
+
+describe('renderColorFooter', () => {
+  it('should include token amounts', () => {
+    const result = renderColorFooter(10000, 500);
+    const joined = result.join('\n');
+
+    expect(joined).toContain('10k');
+    expect(joined).toContain('500');
+  });
+
+  it('should mention claude-mem skill', () => {
+    const result = renderColorFooter(5000, 100);
+    const joined = result.join('\n');
+
+    expect(joined).toContain('claude-mem');
+  });
+
+  it('should clarify observation ID to avoid confusion with user_prompts IDs (#1339)', () => {
+    const result = renderColorFooter(5000, 100);
+    const joined = result.join('\n');
+
+    // Must say "observation ID" to distinguish from user_prompts/session_summaries IDs
+    expect(joined).toContain('observation ID');
+  });
+});

--- a/tests/context/formatters/markdown-formatter.test.ts
+++ b/tests/context/formatters/markdown-formatter.test.ts
@@ -495,6 +495,14 @@ describe('MarkdownFormatter', () => {
       expect(joined).toContain('claude-mem');
     });
 
+    it('should clarify observation ID to avoid confusion with user_prompts IDs (#1339)', () => {
+      const result = renderMarkdownFooter(5000, 100);
+      const joined = result.join('\n');
+
+      // Must say "observation ID" to distinguish from user_prompts/session_summaries IDs
+      expect(joined).toContain('observation ID');
+    });
+
     it('should round work tokens to nearest thousand', () => {
       const result = renderMarkdownFooter(15500, 100);
       const joined = result.join('\n');


### PR DESCRIPTION
## Summary

Fixes #1339

- Changed "access memories by ID" → "access memories by **observation ID** (the #N numbers in the index above)" in both `ColorFormatter` and `MarkdownFormatter` footer text
- Updated the context-index bullet from `get_observations([IDs])` → `get_observations([observation IDs])` for consistency
- Added `tests/context/formatters/color-formatter.test.ts` (was missing entirely) and a regression test in the existing markdown formatter test

The old text was ambiguous: the web UI displays IDs from three tables (`observations`, `user_prompts`, `session_summaries`), all with the same `#N` format. Users would look up `#439` in the web UI (a prompt record), pass it to `get_observations(ids=[439])`, and receive observation #439 — a completely different record.

## Verification

- [x] Baseline tests: 1106 pass, 0 pre-existing failures
- [x] Post-fix tests: 1110 pass, 0 regressions, +4 new tests
- [x] New tests: 4 added (ColorFormatter test file + regression test in both formatters)
- [x] Review agent: issue alignment verified

## Files changed

| File | Change |
|------|--------|
| `src/services/context/formatters/MarkdownFormatter.ts` | Clarify "ID" → "observation ID" in footer and context-index bullet |
| `src/services/context/formatters/ColorFormatter.ts` | Same copy change |
| `tests/context/formatters/markdown-formatter.test.ts` | Add `observation ID` regression test |
| `tests/context/formatters/color-formatter.test.ts` | New file — `renderColorFooter` tests |

Generated by Claude Code
Vibe coded by ousamabenyounes