### PR TITLE
fix: suppress false ERROR when duplicate daemon loses port bind race (#1447)

### DIFF
--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -1200,7 +1200,18 @@ async function main() {
       });
 
       const worker = new WorkerService();
-      worker.start().catch((error) => {
+      worker.start().catch(async (error) => {
+        // Port race: when the MCP server and SessionStart hook both spawn a daemon
+        // concurrently, one will lose the bind race with EADDRINUSE or Bun's equivalent
+        // "port in use" error. If the winner is already healthy, exit cleanly (#1447).
+        const isPortConflict = error instanceof Error && (
+          (error as NodeJS.ErrnoException).code === 'EADDRINUSE' ||
+          /port.*in use|address.*in use/i.test(error.message)
+        );
+        if (isPortConflict && await waitForHealth(port, 3000)) {
+          logger.info('SYSTEM', 'Duplicate daemon exiting — another worker already claimed port', { port });
+          process.exit(0);
+        }
         logger.failure('SYSTEM', 'Worker failed to start', {}, error as Error);
         removePidFile();
         // Exit gracefully: Windows Terminal won't keep tab open on exit 0

--- a/tests/services/worker-daemon-port-race.test.ts
+++ b/tests/services/worker-daemon-port-race.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Source-inspection tests for Issue #1447: Worker startup race condition
+ *
+ * When the MCP server and SessionStart hook both spawn a daemon concurrently,
+ * one daemon loses the port bind race (EADDRINUSE / Bun's "port in use" error).
+ * The loser should detect this, verify the winner is healthy, and exit cleanly
+ * instead of logging an ERROR that clutters the user's session start output.
+ *
+ * These are source-inspection tests because the race is non-deterministic and
+ * requires a real concurrent multi-process scenario to reproduce reliably.
+ */
+
+const WORKER_SERVICE_PATH = join(import.meta.dir, '../../src/services/worker-service.ts');
+const source = readFileSync(WORKER_SERVICE_PATH, 'utf-8');
+
+describe('Worker daemon port-race guard (#1447)', () => {
+  it('detects EADDRINUSE error code in the port-conflict check', () => {
+    expect(source).toContain("code === 'EADDRINUSE'");
+  });
+
+  it('detects Bun port-in-use message via regex in the port-conflict check', () => {
+    expect(source).toContain('/port.*in use|address.*in use/i.test(error.message)');
+  });
+
+  it('calls waitForHealth before exiting on a port conflict', () => {
+    // The guard must verify the winner is actually healthy before exiting,
+    // otherwise a non-worker process on the port would suppress a real error.
+    expect(source).toContain('isPortConflict && await waitForHealth(port,');
+  });
+
+  it('uses async catch handler to allow awaiting waitForHealth', () => {
+    // The .catch() must be async so it can await the health check.
+    expect(source).toContain('worker.start().catch(async (error) =>');
+  });
+
+  it('logs info (not error) when cleanly exiting after port race', () => {
+    // Must not call logger.failure() / logger.error() on the clean exit path.
+    expect(source).toContain("logger.info('SYSTEM', 'Duplicate daemon exiting");
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes the ERROR log `✗ Worker failed to start Failed to start server. Is port 37777 in use?` that appears on every first session start
- Root cause: MCP server and SessionStart hook both spawn a daemon concurrently; the loser detects EADDRINUSE but previously logged it as an ERROR regardless
- Fix: in the daemon's startup catch handler, detect port-conflict errors (EADDRINUSE or Bun's message variant) and do a health check; if the winner is healthy, log INFO and exit cleanly

## Test plan

- [x] Source-inspection tests in `tests/services/worker-daemon-port-race.test.ts` verify the async catch handler, EADDRINUSE detection, Bun message regex, health check call, and INFO-level log
- [x] Full test suite: 1111 pass, 0 fail

Closes #1447

🤖 Generated with [Ora Studio](https://studio.oratelecom.net)