### PR TITLE
feat: add transcript backfill for historical Claude Code sessions

### DIFF
--- a/src/npx-cli/commands/runtime.ts
+++ b/src/npx-cli/commands/runtime.ts
@@ -148,6 +148,20 @@ export async function runSearchCommand(queryParts: string[]): Promise<void> {
 }
 
 /**
+ * Run a transcript subcommand (init, validate, backfill) via Bun worker-service.
+ */
+export function runTranscriptSubcommand(subcommand: string, extraArgs: string[] = []): void {
+  spawnBunWorkerCommand('transcript', [subcommand, ...extraArgs]);
+}
+
+/**
+ * Run the transcript backfill command via Bun worker-service.
+ */
+export function runTranscriptBackfillCommand(extraArgs: string[] = []): void {
+  spawnBunWorkerCommand('transcript', ['backfill', ...extraArgs]);
+}
+
+/**
  * Start the transcript watcher via Bun.
  */
 export function runTranscriptWatchCommand(): void {

--- a/src/npx-cli/index.ts
+++ b/src/npx-cli/index.ts
@@ -53,6 +53,7 @@ ${pc.bold('Runtime Commands')} (requires Bun, delegates to installed plugin):
   ${pc.cyan('npx claude-mem status')}               Show worker status
   ${pc.cyan('npx claude-mem search <query>')}       Search observations
   ${pc.cyan('npx claude-mem transcript watch')}     Start transcript watcher
+  ${pc.cyan('npx claude-mem transcript backfill')}  Import historical Claude Code sessions
 
 ${pc.bold('IDE Identifiers')}:
   claude-code, cursor, gemini-cli, opencode, openclaw,
@@ -151,9 +152,15 @@ async function main(): Promise<void> {
       if (subCommand === 'watch') {
         const { runTranscriptWatchCommand } = await import('./commands/runtime.js');
         runTranscriptWatchCommand();
+      } else if (subCommand === 'backfill') {
+        const { runTranscriptBackfillCommand } = await import('./commands/runtime.js');
+        runTranscriptBackfillCommand(args.slice(2));
+      } else if (subCommand === 'init' || subCommand === 'validate') {
+        const { runTranscriptSubcommand } = await import('./commands/runtime.js');
+        runTranscriptSubcommand(subCommand, args.slice(2));
       } else {
         console.error(pc.red(`Unknown transcript subcommand: ${subCommand ?? '(none)'}`));
-        console.error(`Usage: npx claude-mem transcript watch`);
+        console.error(`Usage: npx claude-mem transcript <watch|backfill|init|validate>`);
         process.exit(1);
       }
       break;

--- a/src/services/transcripts/backfill.ts
+++ b/src/services/transcripts/backfill.ts
@@ -30,6 +30,7 @@ interface BackfillState {
   lastRun?: string;
 }
 
+/** Options for controlling the transcript backfill process. */
 export interface BackfillOptions {
   path?: string;
   dryRun?: boolean;
@@ -38,6 +39,7 @@ export interface BackfillOptions {
   force?: boolean;
 }
 
+/** Statistics returned after a backfill run completes. */
 export interface BackfillStats {
   filesFound: number;
   filesProcessed: number;
@@ -92,6 +94,7 @@ interface ToolObservation {
 
 const STATE_PATH = join(homedir(), '.claude-mem', 'backfill-state.json');
 
+/** Load persisted backfill state from disk for resume support. */
 function loadBackfillState(): BackfillState {
   if (existsSync(STATE_PATH)) {
     try {
@@ -103,6 +106,7 @@ function loadBackfillState(): BackfillState {
   return { processedFiles: {} };
 }
 
+/** Persist backfill state to disk so interrupted runs can resume. */
 function saveBackfillState(state: BackfillState): void {
   const dir = dirname(STATE_PATH);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
@@ -128,12 +132,14 @@ function parseJsonlFile(filePath: string): ClaudeCodeEvent[] {
   return events;
 }
 
+/** Extract a UUID session ID from a JSONL filename, or null if the name is not a valid UUID. */
 function extractSessionId(filePath: string): string | null {
   const name = basename(filePath, '.jsonl');
   const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
   return uuidPattern.test(name) ? name : null;
 }
 
+/** Extract the working directory from the first event that carries a `cwd` field. */
 function extractCwd(events: ClaudeCodeEvent[]): string {
   for (const event of events) {
     if (event.cwd) return event.cwd;
@@ -141,6 +147,7 @@ function extractCwd(events: ClaudeCodeEvent[]): string {
   return process.cwd();
 }
 
+/** Extract the first non-meta user text prompt from a session's events. */
 function extractFirstUserPrompt(events: ClaudeCodeEvent[]): string | null {
   for (const event of events) {
     if (event.type !== 'user') continue;
@@ -155,6 +162,7 @@ function extractFirstUserPrompt(events: ClaudeCodeEvent[]): string | null {
   return null;
 }
 
+/** Extract the last text block from the final assistant message in the event stream. */
 function extractLastAssistantMessage(events: ClaudeCodeEvent[]): string {
   let lastText = '';
   for (const event of events) {
@@ -169,6 +177,7 @@ function extractLastAssistantMessage(events: ClaudeCodeEvent[]): string {
   return lastText;
 }
 
+/** Pair tool_use requests with their corresponding tool_result responses into observations. */
 function extractToolObservations(events: ClaudeCodeEvent[]): ToolObservation[] {
   const observations: ToolObservation[] = [];
   const pendingTools = new Map<string, { name: string; input: unknown }>();

--- a/src/services/transcripts/backfill.ts
+++ b/src/services/transcripts/backfill.ts
@@ -1,0 +1,371 @@
+/**
+ * Claude Code JSONL Backfill Processor
+ *
+ * Reads historical Claude Code session JSONL files and submits them
+ * through the existing handler pipeline (session-init, observation,
+ * summarize, session-complete).
+ *
+ * Uses a dedicated parser rather than the schema-based transcript watcher
+ * because Claude Code's nested content format (tool_use inside assistant
+ * content arrays, tool_result inside user content arrays) requires native
+ * parsing beyond the schema system's single-path matching.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { homedir } from 'os';
+import { join, basename, dirname } from 'path';
+import { globSync } from 'glob';
+import { sessionInitHandler } from '../../cli/handlers/session-init.js';
+import { observationHandler } from '../../cli/handlers/observation.js';
+import { sessionCompleteHandler } from '../../cli/handlers/session-complete.js';
+import { ensureWorkerRunning, workerHttpRequest } from '../../shared/worker-utils.js';
+import { logger } from '../../utils/logger.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface BackfillState {
+  processedFiles: Record<string, { processedAt: string; observations: number }>;
+  lastRun?: string;
+}
+
+export interface BackfillOptions {
+  path?: string;
+  dryRun?: boolean;
+  limit?: number;
+  delayMs?: number;
+  force?: boolean;
+}
+
+export interface BackfillStats {
+  filesFound: number;
+  filesProcessed: number;
+  filesSkipped: number;
+  sessionsCreated: number;
+  observationsSent: number;
+  errors: number;
+}
+
+interface ContentBlock {
+  type: string;
+  text?: string;
+  thinking?: string;
+  id?: string;
+  name?: string;
+  input?: unknown;
+  content?: string | ContentBlock[];
+  tool_use_id?: string;
+  is_error?: boolean;
+}
+
+interface ClaudeCodeEvent {
+  type: string;
+  sessionId?: string;
+  cwd?: string;
+  uuid?: string;
+  parentUuid?: string | null;
+  timestamp?: string;
+  isMeta?: boolean;
+  message?: {
+    role?: string;
+    model?: string;
+    content?: string | ContentBlock[];
+    stop_reason?: string;
+  };
+  toolUseResult?: {
+    stdout?: string;
+    stderr?: string;
+    interrupted?: boolean;
+  };
+}
+
+interface ToolObservation {
+  toolName: string;
+  toolInput: unknown;
+  toolResponse: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// State persistence (resume support)
+// ---------------------------------------------------------------------------
+
+const STATE_PATH = join(homedir(), '.claude-mem', 'backfill-state.json');
+
+function loadBackfillState(): BackfillState {
+  if (existsSync(STATE_PATH)) {
+    try {
+      return JSON.parse(readFileSync(STATE_PATH, 'utf-8'));
+    } catch {
+      return { processedFiles: {} };
+    }
+  }
+  return { processedFiles: {} };
+}
+
+function saveBackfillState(state: BackfillState): void {
+  const dir = dirname(STATE_PATH);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+}
+
+// ---------------------------------------------------------------------------
+// JSONL parsing helpers
+// ---------------------------------------------------------------------------
+
+function parseJsonlFile(filePath: string): ClaudeCodeEvent[] {
+  const content = readFileSync(filePath, 'utf-8');
+  const events: ClaudeCodeEvent[] = [];
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      events.push(JSON.parse(trimmed));
+    } catch {
+      // Skip malformed lines
+    }
+  }
+  return events;
+}
+
+function extractSessionId(filePath: string): string | null {
+  const name = basename(filePath, '.jsonl');
+  const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  return uuidPattern.test(name) ? name : null;
+}
+
+function extractCwd(events: ClaudeCodeEvent[]): string {
+  for (const event of events) {
+    if (event.cwd) return event.cwd;
+  }
+  return process.cwd();
+}
+
+function extractFirstUserPrompt(events: ClaudeCodeEvent[]): string | null {
+  for (const event of events) {
+    if (event.type !== 'user') continue;
+    if (event.isMeta) continue;
+    if (!event.message?.content) continue;
+    // User text messages have string content; tool results have array content
+    if (typeof event.message.content === 'string') {
+      const text = event.message.content.trim();
+      if (text) return text;
+    }
+  }
+  return null;
+}
+
+function extractLastAssistantMessage(events: ClaudeCodeEvent[]): string {
+  let lastText = '';
+  for (const event of events) {
+    if (event.type !== 'assistant') continue;
+    if (!event.message?.content || !Array.isArray(event.message.content)) continue;
+    for (const block of event.message.content) {
+      if (block.type === 'text' && block.text) {
+        lastText = block.text;
+      }
+    }
+  }
+  return lastText;
+}
+
+function extractToolObservations(events: ClaudeCodeEvent[]): ToolObservation[] {
+  const observations: ToolObservation[] = [];
+  const pendingTools = new Map<string, { name: string; input: unknown }>();
+
+  for (const event of events) {
+    // Assistant messages contain tool_use blocks
+    if (event.type === 'assistant' && Array.isArray(event.message?.content)) {
+      for (const block of event.message!.content as ContentBlock[]) {
+        if (block.type === 'tool_use' && block.id && block.name) {
+          pendingTools.set(block.id, { name: block.name, input: block.input });
+        }
+      }
+    }
+
+    // User messages with toolUseResult contain tool results
+    if (event.type === 'user' && event.toolUseResult) {
+      const content = event.message?.content;
+      if (!Array.isArray(content)) continue;
+      for (const block of content as ContentBlock[]) {
+        if (block.type === 'tool_result' && block.tool_use_id) {
+          const pending = pendingTools.get(block.tool_use_id);
+          if (pending) {
+            observations.push({
+              toolName: pending.name,
+              toolInput: pending.input,
+              toolResponse: typeof block.content === 'string'
+                ? block.content
+                : event.toolUseResult
+            });
+            pendingTools.delete(block.tool_use_id);
+          }
+        }
+      }
+    }
+  }
+
+  return observations;
+}
+
+// ---------------------------------------------------------------------------
+// Main backfill
+// ---------------------------------------------------------------------------
+
+export async function runBackfill(options: BackfillOptions = {}): Promise<BackfillStats> {
+  const stats: BackfillStats = {
+    filesFound: 0,
+    filesProcessed: 0,
+    filesSkipped: 0,
+    sessionsCreated: 0,
+    observationsSent: 0,
+    errors: 0
+  };
+
+  const defaultPath = join(homedir(), '.claude', 'projects', '**', '*.jsonl').replaceAll('\\', '/');
+  const globPattern = (options.path ?? defaultPath).replaceAll('\\', '/');
+  const dryRun = options.dryRun ?? false;
+  const limit = options.limit ?? Infinity;
+  const delayMs = options.delayMs ?? 500;
+  const force = options.force ?? false;
+
+  // Discover JSONL files
+  const files = globSync(globPattern, { nodir: true, absolute: true })
+    .filter(f => f.endsWith('.jsonl'));
+  stats.filesFound = files.length;
+
+  if (files.length === 0) {
+    console.log('No JSONL files found matching pattern:', globPattern);
+    return stats;
+  }
+
+  console.log(`Found ${files.length} JSONL file(s)`);
+
+  // Load state for resume support
+  const state = loadBackfillState();
+
+  // Filter already-processed files unless --force
+  const toProcess = force
+    ? files
+    : files.filter(f => !state.processedFiles[f]);
+  stats.filesSkipped = files.length - toProcess.length;
+
+  if (toProcess.length === 0) {
+    console.log('All files already processed. Use --force to re-process.');
+    return stats;
+  }
+
+  const batch = toProcess.slice(0, limit);
+  console.log(`Processing ${batch.length} of ${toProcess.length} unprocessed file(s)${dryRun ? ' (dry run)' : ''}\n`);
+
+  if (!dryRun) {
+    const workerReady = await ensureWorkerRunning();
+    if (!workerReady) {
+      console.error('Worker is not running. Start it with: npx claude-mem start');
+      return stats;
+    }
+  }
+
+  for (const filePath of batch) {
+    const sessionId = extractSessionId(filePath);
+    if (!sessionId) {
+      logger.debug('SYSTEM', 'Backfill: skipping non-session file', { filePath });
+      stats.filesSkipped++;
+      continue;
+    }
+
+    try {
+      const events = parseJsonlFile(filePath);
+      if (events.length === 0) {
+        stats.filesSkipped++;
+        continue;
+      }
+
+      const cwd = extractCwd(events);
+      const prompt = extractFirstUserPrompt(events);
+      const observations = extractToolObservations(events);
+      const lastAssistant = extractLastAssistantMessage(events);
+
+      if (dryRun) {
+        const truncatedPrompt = prompt
+          ? prompt.length > 60 ? prompt.slice(0, 60) + '...' : prompt
+          : '(no prompt)';
+        console.log(`  ${basename(filePath)}: ${observations.length} tool calls, prompt: "${truncatedPrompt}"`);
+        stats.filesProcessed++;
+        stats.observationsSent += observations.length;
+        if (prompt) stats.sessionsCreated++;
+        continue;
+      }
+
+      // 1. Initialize session with first user prompt
+      if (prompt) {
+        await sessionInitHandler.execute({
+          sessionId,
+          cwd,
+          prompt,
+          platform: 'claude-code'
+        });
+        stats.sessionsCreated++;
+      }
+
+      // 2. Submit tool observations
+      for (const obs of observations) {
+        await observationHandler.execute({
+          sessionId,
+          cwd,
+          toolName: obs.toolName,
+          toolInput: obs.toolInput,
+          toolResponse: obs.toolResponse,
+          platform: 'claude-code'
+        });
+        stats.observationsSent++;
+      }
+
+      // 3. Queue summary from last assistant message
+      if (lastAssistant) {
+        try {
+          await workerHttpRequest('/api/sessions/summarize', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              contentSessionId: sessionId,
+              last_assistant_message: lastAssistant,
+              platformSource: 'claude'
+            })
+          });
+        } catch {
+          // Summary is best-effort
+        }
+      }
+
+      // 4. Complete session
+      await sessionCompleteHandler.execute({
+        sessionId,
+        cwd,
+        platform: 'claude-code'
+      });
+
+      stats.filesProcessed++;
+      state.processedFiles[filePath] = {
+        processedAt: new Date().toISOString(),
+        observations: observations.length
+      };
+      saveBackfillState(state);
+
+      console.log(`  ✓ ${basename(filePath)}: ${observations.length} observations`);
+
+      // Rate-limit between sessions to avoid overwhelming the worker AI queue
+      if (delayMs > 0 && batch.indexOf(filePath) < batch.length - 1) {
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+      }
+    } catch (error) {
+      stats.errors++;
+      console.error(`  ✗ ${basename(filePath)}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  state.lastRun = new Date().toISOString();
+  saveBackfillState(state);
+
+  return stats;
+}

--- a/src/services/transcripts/cli.ts
+++ b/src/services/transcripts/cli.ts
@@ -7,6 +7,10 @@ function getArgValue(args: string[], name: string): string | null {
   return args[index + 1] ?? null;
 }
 
+function hasFlag(args: string[], name: string): boolean {
+  return args.includes(name);
+}
+
 export async function runTranscriptCommand(subcommand: string | undefined, args: string[]): Promise<number> {
   switch (subcommand) {
     case 'init': {
@@ -42,6 +46,28 @@ export async function runTranscriptCommand(subcommand: string | undefined, args:
       process.on('SIGTERM', shutdown);
       return await new Promise(() => undefined);
     }
+    case 'backfill': {
+      const { runBackfill } = await import('./backfill.js');
+
+      const options = {
+        path: getArgValue(args, '--path') ?? undefined,
+        dryRun: hasFlag(args, '--dry-run'),
+        limit: getArgValue(args, '--limit') ? parseInt(getArgValue(args, '--limit')!, 10) : undefined,
+        delayMs: getArgValue(args, '--delay') ? parseInt(getArgValue(args, '--delay')!, 10) : undefined,
+        force: hasFlag(args, '--force')
+      };
+
+      const stats = await runBackfill(options);
+
+      console.log('\n--- Backfill Summary ---');
+      console.log(`  Files found:    ${stats.filesFound}`);
+      console.log(`  Processed:      ${stats.filesProcessed}`);
+      console.log(`  Skipped:        ${stats.filesSkipped}`);
+      console.log(`  Sessions:       ${stats.sessionsCreated}`);
+      console.log(`  Observations:   ${stats.observationsSent}`);
+      console.log(`  Errors:         ${stats.errors}`);
+      return stats.errors > 0 ? 1 : 0;
+    }
     case 'validate': {
       const configPath = getArgValue(args, '--config') ?? DEFAULT_CONFIG_PATH;
       try {
@@ -59,7 +85,20 @@ export async function runTranscriptCommand(subcommand: string | undefined, args:
       return 0;
     }
     default:
-      console.log('Usage: claude-mem transcript <init|watch|validate> [--config <path>]');
+      console.log('Usage: claude-mem transcript <init|watch|backfill|validate>');
+      console.log('');
+      console.log('Commands:');
+      console.log('  init       Create sample transcript-watch.json config');
+      console.log('  watch      Start live transcript watcher');
+      console.log('  backfill   Import historical Claude Code sessions');
+      console.log('  validate   Validate transcript-watch.json config');
+      console.log('');
+      console.log('Backfill options:');
+      console.log('  --path <glob>   JSONL file pattern (default: ~/.claude/projects/**/*.jsonl)');
+      console.log('  --dry-run       Preview without submitting');
+      console.log('  --limit <n>     Max files to process');
+      console.log('  --delay <ms>    Delay between sessions in ms (default: 500)');
+      console.log('  --force         Re-process already-processed files');
       return 1;
   }
 }

--- a/src/services/transcripts/cli.ts
+++ b/src/services/transcripts/cli.ts
@@ -1,16 +1,19 @@
 import { DEFAULT_CONFIG_PATH, DEFAULT_STATE_PATH, expandHomePath, loadTranscriptWatchConfig, writeSampleConfig } from './config.js';
 import { TranscriptWatcher } from './watcher.js';
 
+/** Get the value following a named argument flag (e.g. `--path /foo` returns `/foo`). */
 function getArgValue(args: string[], name: string): string | null {
   const index = args.indexOf(name);
   if (index === -1) return null;
   return args[index + 1] ?? null;
 }
 
+/** Check whether a boolean flag (e.g. `--dry-run`) is present in the argument list. */
 function hasFlag(args: string[], name: string): boolean {
   return args.includes(name);
 }
 
+/** Dispatch a transcript CLI subcommand (init, watch, backfill, validate) and return its exit code. */
 export async function runTranscriptCommand(subcommand: string | undefined, args: string[]): Promise<number> {
   switch (subcommand) {
     case 'init': {

--- a/src/services/transcripts/config.ts
+++ b/src/services/transcripts/config.ts
@@ -162,6 +162,7 @@ export const SAMPLE_CONFIG: TranscriptWatchConfig = {
   stateFile: DEFAULT_STATE_PATH
 };
 
+/** Expand a leading `~` in a file path to the user's home directory. */
 export function expandHomePath(inputPath: string): string {
   if (!inputPath) return inputPath;
   if (inputPath.startsWith('~')) {
@@ -170,6 +171,7 @@ export function expandHomePath(inputPath: string): string {
   return inputPath;
 }
 
+/** Load and validate a transcript watch configuration from a JSON file. */
 export function loadTranscriptWatchConfig(path = DEFAULT_CONFIG_PATH): TranscriptWatchConfig {
   const resolvedPath = expandHomePath(path);
   if (!existsSync(resolvedPath)) {
@@ -186,6 +188,7 @@ export function loadTranscriptWatchConfig(path = DEFAULT_CONFIG_PATH): Transcrip
   return parsed;
 }
 
+/** Write the default sample transcript watch configuration to disk. */
 export function writeSampleConfig(path = DEFAULT_CONFIG_PATH): void {
   const resolvedPath = expandHomePath(path);
   const dir = dirname(resolvedPath);

--- a/src/services/transcripts/config.ts
+++ b/src/services/transcripts/config.ts
@@ -6,6 +6,56 @@ import type { TranscriptSchema, TranscriptWatchConfig } from './types.js';
 export const DEFAULT_CONFIG_PATH = join(homedir(), '.claude-mem', 'transcript-watch.json');
 export const DEFAULT_STATE_PATH = join(homedir(), '.claude-mem', 'transcript-watch-state.json');
 
+const CLAUDE_CODE_SAMPLE_SCHEMA: TranscriptSchema = {
+  name: 'claude-code',
+  version: '0.1',
+  description: 'Schema for Claude Code session JSONL files under ~/.claude/projects/.',
+  sessionIdPath: 'sessionId',
+  cwdPath: 'cwd',
+  events: [
+    {
+      name: 'session-context',
+      match: { path: 'sessionId', exists: true },
+      action: 'session_context',
+      fields: {
+        sessionId: 'sessionId',
+        cwd: 'cwd'
+      }
+    },
+    {
+      name: 'user-message',
+      match: { path: 'type', equals: 'user' },
+      action: 'session_init',
+      fields: {
+        sessionId: 'sessionId',
+        prompt: 'message.content'
+      }
+    },
+    {
+      name: 'assistant-message',
+      match: { path: 'type', equals: 'assistant' },
+      action: 'assistant_message',
+      fields: {
+        message: 'message.content'
+      }
+    },
+    {
+      name: 'tool-result',
+      match: { path: 'toolUseResult', exists: true },
+      action: 'tool_result',
+      fields: {
+        toolId: 'sourceToolAssistantUUID',
+        toolResponse: 'toolUseResult'
+      }
+    },
+    {
+      name: 'session-end',
+      match: { path: 'type', equals: 'last-prompt' },
+      action: 'session_end'
+    }
+  ]
+};
+
 const CODEX_SAMPLE_SCHEMA: TranscriptSchema = {
   name: 'codex',
   version: '0.3',
@@ -87,9 +137,16 @@ const CODEX_SAMPLE_SCHEMA: TranscriptSchema = {
 export const SAMPLE_CONFIG: TranscriptWatchConfig = {
   version: 1,
   schemas: {
+    'claude-code': CLAUDE_CODE_SAMPLE_SCHEMA,
     codex: CODEX_SAMPLE_SCHEMA
   },
   watches: [
+    {
+      name: 'claude-code',
+      path: '~/.claude/projects/**/*.jsonl',
+      schema: 'claude-code',
+      startAtEnd: true
+    },
     {
       name: 'codex',
       path: '~/.codex/sessions/**/*.jsonl',

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -1171,6 +1171,15 @@ async function main() {
       break;
     }
 
+    case 'transcript': {
+      const { runTranscriptCommand } = await import('./transcripts/cli.js');
+      const subcommand = process.argv[3];
+      const transcriptArgs = process.argv.slice(3);
+      const transcriptResult = await runTranscriptCommand(subcommand, transcriptArgs);
+      process.exit(transcriptResult);
+      break;
+    }
+
     case 'generate': {
       const dryRun = process.argv.includes('--dry-run');
       const { generateClaudeMd } = await import('../cli/claude-md-commands.js');

--- a/transcript-watch.example.json
+++ b/transcript-watch.example.json
@@ -1,6 +1,55 @@
 {
   "version": 1,
   "schemas": {
+    "claude-code": {
+      "name": "claude-code",
+      "version": "0.1",
+      "description": "Schema for Claude Code session JSONL files under ~/.claude/projects/.",
+      "sessionIdPath": "sessionId",
+      "cwdPath": "cwd",
+      "events": [
+        {
+          "name": "session-context",
+          "match": { "path": "sessionId", "exists": true },
+          "action": "session_context",
+          "fields": {
+            "sessionId": "sessionId",
+            "cwd": "cwd"
+          }
+        },
+        {
+          "name": "user-message",
+          "match": { "path": "type", "equals": "user" },
+          "action": "session_init",
+          "fields": {
+            "sessionId": "sessionId",
+            "prompt": "message.content"
+          }
+        },
+        {
+          "name": "assistant-message",
+          "match": { "path": "type", "equals": "assistant" },
+          "action": "assistant_message",
+          "fields": {
+            "message": "message.content"
+          }
+        },
+        {
+          "name": "tool-result",
+          "match": { "path": "toolUseResult", "exists": true },
+          "action": "tool_result",
+          "fields": {
+            "toolId": "sourceToolAssistantUUID",
+            "toolResponse": "toolUseResult"
+          }
+        },
+        {
+          "name": "session-end",
+          "match": { "path": "type", "equals": "last-prompt" },
+          "action": "session_end"
+        }
+      ]
+    },
     "codex": {
       "name": "codex",
       "version": "0.2",
@@ -78,6 +127,12 @@
     }
   },
   "watches": [
+    {
+      "name": "claude-code",
+      "path": "~/.claude/projects/**/*.jsonl",
+      "schema": "claude-code",
+      "startAtEnd": true
+    },
     {
       "name": "codex",
       "path": "~/.codex/sessions/**/*.jsonl",


### PR DESCRIPTION
## Summary

- Adds `npx claude-mem transcript backfill` CLI command to import historical Claude Code JSONL session files into claude-mem's memory database
- Uses a dedicated parser for Claude Code's nested content format (tool_use inside assistant content arrays, tool_result inside user content arrays) and submits through the existing handler pipeline
- Adds a Claude Code transcript schema to the watcher config for live session watching alongside the existing Codex schema

## Motivation

Claude-mem captures sessions in real-time via hooks, but there's no way to backfill historical sessions from before claude-mem was installed. Users with hundreds of existing Claude Code sessions lose all that context. The [export/import docs](https://docs.claude-mem.ai/usage/export-import) reference scripts that aren't shipped in the npm package, and those are for transferring between installations — not for initial population from raw JSONL files.

## Usage

```bash
# Preview what would be processed
npx claude-mem transcript backfill --dry-run

# Process 10 sessions
npx claude-mem transcript backfill --limit 10

# Process all historical sessions
npx claude-mem transcript backfill

# Re-process already-processed files
npx claude-mem transcript backfill --force

# Custom JSONL path
npx claude-mem transcript backfill --path "~/custom/path/**/*.jsonl"
```

## Implementation

**New file:** `src/services/transcripts/backfill.ts`
- Finds `~/.claude/projects/**/*.jsonl` files via glob
- Extracts session ID from UUID filename
- Parses JSONL lines to identify user prompts, tool_use/tool_result pairs, and assistant messages
- Submits through existing `sessionInitHandler` → `observationHandler` → summarize API → `sessionCompleteHandler`
- Resume support via `~/.claude-mem/backfill-state.json`
- Windows-compatible (glob paths normalized to forward slashes)

**Modified files:**
- `src/services/transcripts/cli.ts` — Added `backfill` subcommand with `--dry-run`, `--limit`, `--delay`, `--force`, `--path` flags
- `src/services/transcripts/config.ts` — Added Claude Code transcript schema to `SAMPLE_CONFIG`
- `src/services/worker-service.ts` — Added `transcript` case to CLI entry point
- `src/npx-cli/index.ts` — Route `transcript backfill` through npx CLI
- `src/npx-cli/commands/runtime.ts` — Added `runTranscriptBackfillCommand`
- `transcript-watch.example.json` — Added Claude Code schema example

## Test plan

- [x] TypeScript compiles (no new errors in modified files)
- [x] esbuild bundles successfully
- [x] `--dry-run` correctly discovers 144 JSONL files and extracts prompts + tool counts
- [x] Live backfill of 2 sessions: 24 observations submitted, verified in database via `/api/stats`
- [x] Non-UUID files (subagent compact files) correctly skipped
- [x] Resume support: re-running skips already-processed files
- [x] Help text displays correctly for `transcript` and `--help`
- [ ] Test on macOS/Linux (developed on Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)