### PR TITLE
fix: normalize Windows backslash paths in bun-runner.js (#1281)

### DIFF
--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -19,13 +19,26 @@ import { fileURLToPath } from 'url';
 
 const IS_WINDOWS = process.platform === 'win32';
 
+/**
+ * Normalize Windows backslash paths to forward slashes.
+ * On Windows with Git Bash, CLAUDE_PLUGIN_ROOT may contain backslashes
+ * (e.g. C:\Users\...) that get corrupted when the shell interprets escape
+ * sequences like \t (tab) or \b (backspace) in the path. Normalizing to
+ * forward slashes is safe because Node.js accepts both on Windows.
+ * Fixes #1281.
+ */
+function normalizePath(p) {
+  if (!p) return p;
+  return p.replace(/\\/g, '/');
+}
+
 // Self-resolve plugin root when CLAUDE_PLUGIN_ROOT is not set by Claude Code.
 // Upstream bug: anthropics/claude-code#24529 — Stop hooks (and on Linux, all hooks)
 // don't receive CLAUDE_PLUGIN_ROOT, causing script paths to resolve to /scripts/...
 // which doesn't exist. This fallback derives the plugin root from bun-runner.js's
 // own filesystem location (this file lives in <plugin-root>/scripts/).
 const __bun_runner_dirname = dirname(fileURLToPath(import.meta.url));
-const RESOLVED_PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || resolve(__bun_runner_dirname, '..');
+const RESOLVED_PLUGIN_ROOT = normalizePath(process.env.CLAUDE_PLUGIN_ROOT) || resolve(__bun_runner_dirname, '..');
 
 /**
  * Fix script path arguments that were broken by empty CLAUDE_PLUGIN_ROOT.
@@ -113,7 +126,8 @@ if (args.length === 0) {
 }
 
 // Fix broken script paths caused by empty CLAUDE_PLUGIN_ROOT (#1215)
-args[0] = fixBrokenScriptPath(args[0]);
+// Also normalize Windows backslash paths to forward slashes (#1281)
+args[0] = normalizePath(fixBrokenScriptPath(args[0]));
 
 const bunPath = findBun();
 

--- a/tests/bun-runner.test.ts
+++ b/tests/bun-runner.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'bun:test';
+
+/**
+ * Tests for bun-runner.js Windows path normalization (fixes #1281)
+ *
+ * On Windows with Git Bash, CLAUDE_PLUGIN_ROOT expands to a backslash path
+ * (e.g. C:\Users\username\.claude\...) that gets corrupted when the shell
+ * interprets escape sequences like \t (tab in "thedotmack") or \b (backspace
+ * in "basil"). Normalizing backslashes to forward slashes fixes module
+ * resolution without affecting Unix paths.
+ *
+ * bun-runner.js cannot be imported directly (it has top-level await and
+ * process side-effects), so the normalizePath logic is tested here as a
+ * pure function that mirrors the implementation.
+ */
+
+// Mirror of normalizePath() in plugin/scripts/bun-runner.js
+function normalizePath(p: string | undefined | null): string | undefined | null {
+  if (!p) return p;
+  return p.replace(/\\/g, '/');
+}
+
+describe('bun-runner normalizePath (fixes #1281)', () => {
+  it('converts backslashes to forward slashes in a Windows path', () => {
+    const win = 'C:\\Users\\username\\.claude\\plugins\\cache\\thedotmack\\claude-mem\\9.1.1\\scripts\\worker-service.cjs';
+    expect(normalizePath(win)).toBe(
+      'C:/Users/username/.claude/plugins/cache/thedotmack/claude-mem/9.1.1/scripts/worker-service.cjs'
+    );
+  });
+
+  it('leaves Unix paths unchanged', () => {
+    const unix = '/home/user/.claude/plugins/cache/thedotmack/claude-mem/9.1.1/scripts/worker-service.cjs';
+    expect(normalizePath(unix)).toBe(unix);
+  });
+
+  it('handles a path containing \\t (would become tab without normalization)', () => {
+    // \t in "thedotmack" is the problematic sequence from the bug report
+    const withTab = 'C:\\plugins\\cache\\thedotmack\\scripts\\worker.cjs';
+    const result = normalizePath(withTab);
+    expect(result).not.toContain('\\');
+    expect(result).toContain('thedotmack');
+    expect(result).toBe('C:/plugins/cache/thedotmack/scripts/worker.cjs');
+  });
+
+  it('handles a path containing \\b (would become backspace without normalization)', () => {
+    // \b in paths like \basil or \bun would be a backspace character
+    const withBs = 'C:\\Users\\basil\\.claude\\scripts\\bun-runner.js';
+    const result = normalizePath(withBs);
+    expect(result).not.toContain('\\');
+    expect(result).toContain('basil');
+    expect(result).toBe('C:/Users/basil/.claude/scripts/bun-runner.js');
+  });
+
+  it('returns undefined unchanged', () => {
+    expect(normalizePath(undefined)).toBeUndefined();
+  });
+
+  it('returns null unchanged', () => {
+    expect(normalizePath(null)).toBeNull();
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(normalizePath('')).toBe('');
+  });
+
+  it('handles mixed slashes (common in Windows Git Bash)', () => {
+    const mixed = 'C:\\Users\\user/.claude/plugins\\scripts/worker.cjs';
+    expect(normalizePath(mixed)).toBe('C:/Users/user/.claude/plugins/scripts/worker.cjs');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1281

On Windows with Git Bash, `${CLAUDE_PLUGIN_ROOT}` expands to a backslash Windows path (e.g. `C:\Users\username\.claude\...`). When the shell interprets escape sequences in that path, characters like `\t` (in `thedotmack`) become a tab and `\b` (in `\basil`) becomes a backspace, making Node.js unable to resolve `bun-runner.js` or any script it tries to launch.

- Adds a `normalizePath()` helper that converts backslashes to forward slashes (safe on Windows — Node.js accepts both)
- Applies it to `CLAUDE_PLUGIN_ROOT` when building `RESOLVED_PLUGIN_ROOT`
- Applies it to the script path argument (`args[0]`) after `fixBrokenScriptPath()`

## Verification

- [x] Baseline tests: 1200 pass, 34 pre-existing failures
- [x] Post-fix tests: 1208 pass, 34 failures (same pre-existing), 0 regressions
- [x] New tests: 8 added in `tests/bun-runner.test.ts`, all pass
- [x] Issue alignment: diff directly implements Option A from the issue's "Suggested Fix" section

## Files changed

| File | Change |
|------|--------|
| `plugin/scripts/bun-runner.js` | Add `normalizePath()`, apply to `CLAUDE_PLUGIN_ROOT` and script path arg |
| `tests/bun-runner.test.ts` | 8 unit tests covering the normalization logic |

Generated by Ora Studio
Vibe coded by Ousama Ben Younes