### PR TITLE
fix: sync root .mcp.json from plugin config so MCP server registers (#1471)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,3 +1,8 @@
 {
-  "mcpServers": {}
+  "mcpServers": {
+    "mcp-search": {
+      "type": "stdio",
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/mcp-server.cjs"
+    }
+  }
 }

--- a/scripts/sync-plugin-manifests.js
+++ b/scripts/sync-plugin-manifests.js
@@ -74,6 +74,28 @@ function normalizeRepositoryUrl(repository) {
   return '';
 }
 
+/**
+ * Sync plugin/.mcp.json to the repository root .mcp.json.
+ *
+ * Claude Code reads .mcp.json from the marketplace root directory
+ * (~/.claude/plugins/marketplaces/thedotmack/.mcp.json), not from the
+ * plugin/ subdirectory. The root file must mirror plugin/.mcp.json so that
+ * MCP search tools are automatically registered after install/sync.
+ * See: https://github.com/thedotmack/claude-mem/issues/1471
+ */
+function syncRootMcpJson() {
+  const pluginMcpPath = path.join(rootDir, 'plugin', '.mcp.json');
+  const rootMcpPath = path.join(rootDir, '.mcp.json');
+
+  if (!fs.existsSync(pluginMcpPath)) {
+    console.error(`Missing plugin .mcp.json at: ${pluginMcpPath}`);
+    process.exit(1);
+  }
+
+  writeJson(rootMcpPath, readJson(pluginMcpPath));
+  console.log('✓ Synced root .mcp.json from plugin/.mcp.json');
+}
+
 function main() {
   for (const filePath of [packageJsonPath, codexPluginPath, claudePluginPath]) {
     if (!fs.existsSync(filePath)) {
@@ -90,6 +112,8 @@ function main() {
   writeJson(claudePluginPath, syncClaudePlugin(claudePlugin, pkg));
 
   console.log('✓ Synced plugin manifests from package.json');
+
+  syncRootMcpJson();
 }
 
 main();

--- a/src/services/worker/http/routes/SettingsRoutes.ts
+++ b/src/services/worker/http/routes/SettingsRoutes.ts
@@ -410,7 +410,8 @@ export class SettingsRoutes extends BaseRouteHandler {
       // Enable: rename .mcp.json.disabled -> .mcp.json
       renameSync(mcpDisabledPath, mcpPath);
       // Restore root .mcp.json so Claude Code sees the server again
-      if (existsSync(rootMcpPath)) {
+      // Always write (create if deleted) so a previously-removed file is recreated
+      if (existsSync(mcpPath)) {
         writeFileSync(rootMcpPath, readFileSync(mcpPath, 'utf-8'), 'utf-8');
       }
       logger.info('WORKER', 'MCP search server enabled');
@@ -418,9 +419,8 @@ export class SettingsRoutes extends BaseRouteHandler {
       // Disable: rename .mcp.json -> .mcp.json.disabled
       renameSync(mcpPath, mcpDisabledPath);
       // Empty root .mcp.json so Claude Code stops registering the server
-      if (existsSync(rootMcpPath)) {
-        writeFileSync(rootMcpPath, emptyMcpServers, 'utf-8');
-      }
+      // Always write (create if deleted) so a previously-removed file is cleared
+      writeFileSync(rootMcpPath, emptyMcpServers, 'utf-8');
       logger.info('WORKER', 'MCP search server disabled');
     } else {
       logger.debug('WORKER', 'MCP toggle no-op (already in desired state)', { enabled });

--- a/src/services/worker/http/routes/SettingsRoutes.ts
+++ b/src/services/worker/http/routes/SettingsRoutes.ts
@@ -9,7 +9,7 @@ import express, { Request, Response } from 'express';
 import path from 'path';
 import { readFileSync, writeFileSync, existsSync, renameSync, mkdirSync } from 'fs';
 import { homedir } from 'os';
-import { getPackageRoot } from '../../../../shared/paths.js';
+import { getPackageRoot, MARKETPLACE_ROOT } from '../../../../shared/paths.js';
 import { logger } from '../../../../utils/logger.js';
 import { SettingsManager } from '../../SettingsManager.js';
 import { getBranchInfo, switchBranch, pullUpdates } from '../../BranchManager.js';
@@ -393,20 +393,34 @@ export class SettingsRoutes extends BaseRouteHandler {
   }
 
   /**
-   * Toggle MCP search server (rename .mcp.json <-> .mcp.json.disabled)
+   * Toggle MCP search server (rename .mcp.json <-> .mcp.json.disabled).
+   *
+   * Updates both plugin/.mcp.json (internal config) and the marketplace root
+   * .mcp.json (the file Claude Code actually reads for MCP server registration).
+   * See: https://github.com/thedotmack/claude-mem/issues/1471
    */
   private toggleMcp(enabled: boolean): void {
     const packageRoot = getPackageRoot();
     const mcpPath = path.join(packageRoot, 'plugin', '.mcp.json');
     const mcpDisabledPath = path.join(packageRoot, 'plugin', '.mcp.json.disabled');
+    const rootMcpPath = path.join(MARKETPLACE_ROOT, '.mcp.json');
+    const emptyMcpServers = JSON.stringify({ mcpServers: {} }, null, 2) + '\n';
 
     if (enabled && existsSync(mcpDisabledPath)) {
       // Enable: rename .mcp.json.disabled -> .mcp.json
       renameSync(mcpDisabledPath, mcpPath);
+      // Restore root .mcp.json so Claude Code sees the server again
+      if (existsSync(rootMcpPath)) {
+        writeFileSync(rootMcpPath, readFileSync(mcpPath, 'utf-8'), 'utf-8');
+      }
       logger.info('WORKER', 'MCP search server enabled');
     } else if (!enabled && existsSync(mcpPath)) {
       // Disable: rename .mcp.json -> .mcp.json.disabled
       renameSync(mcpPath, mcpDisabledPath);
+      // Empty root .mcp.json so Claude Code stops registering the server
+      if (existsSync(rootMcpPath)) {
+        writeFileSync(rootMcpPath, emptyMcpServers, 'utf-8');
+      }
       logger.info('WORKER', 'MCP search server disabled');
     } else {
       logger.debug('WORKER', 'MCP toggle no-op (already in desired state)', { enabled });

--- a/src/services/worker/http/routes/SettingsRoutes.ts
+++ b/src/services/worker/http/routes/SettingsRoutes.ts
@@ -412,6 +412,7 @@ export class SettingsRoutes extends BaseRouteHandler {
       // Restore root .mcp.json so Claude Code sees the server again
       // Always write (create if deleted) so a previously-removed file is recreated
       if (existsSync(mcpPath)) {
+        mkdirSync(path.dirname(rootMcpPath), { recursive: true });
         writeFileSync(rootMcpPath, readFileSync(mcpPath, 'utf-8'), 'utf-8');
       }
       logger.info('WORKER', 'MCP search server enabled');
@@ -420,6 +421,7 @@ export class SettingsRoutes extends BaseRouteHandler {
       renameSync(mcpPath, mcpDisabledPath);
       // Empty root .mcp.json so Claude Code stops registering the server
       // Always write (create if deleted) so a previously-removed file is cleared
+      mkdirSync(path.dirname(rootMcpPath), { recursive: true });
       writeFileSync(rootMcpPath, emptyMcpServers, 'utf-8');
       logger.info('WORKER', 'MCP search server disabled');
     } else {

--- a/tests/mcp-root-config.test.ts
+++ b/tests/mcp-root-config.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'bun:test';
+import { readFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+// Resolve project root regardless of ESM/CJS context
+const _dir = typeof __dirname !== 'undefined'
+  ? __dirname
+  : dirname(fileURLToPath(import.meta.url));
+
+const PROJECT_ROOT = join(_dir, '..');
+const ROOT_MCP_PATH = join(PROJECT_ROOT, '.mcp.json');
+const PLUGIN_MCP_PATH = join(PROJECT_ROOT, 'plugin', '.mcp.json');
+
+/**
+ * Issue #1471: MCP server not registered because the marketplace root .mcp.json
+ * is empty while the actual config lives in plugin/.mcp.json.
+ *
+ * Claude Code reads .mcp.json from the marketplace root
+ * (~/.claude/plugins/marketplaces/thedotmack/.mcp.json), not from the
+ * plugin/ subdirectory. Both files must be kept in sync so that
+ * MCP search tools are automatically available in every session.
+ */
+describe('MCP root configuration (issue #1471)', () => {
+  it('root .mcp.json exists', () => {
+    expect(existsSync(ROOT_MCP_PATH)).toBe(true);
+  });
+
+  it('root .mcp.json has mcp-search server registered', () => {
+    const content = JSON.parse(readFileSync(ROOT_MCP_PATH, 'utf-8'));
+    expect(content.mcpServers).toBeDefined();
+    expect(content.mcpServers['mcp-search']).toBeDefined();
+  });
+
+  it('mcp-search command references mcp-server.cjs', () => {
+    const content = JSON.parse(readFileSync(ROOT_MCP_PATH, 'utf-8'));
+    const mcpSearch = content.mcpServers['mcp-search'];
+    expect(mcpSearch.command).toContain('mcp-server.cjs');
+  });
+
+  it('root .mcp.json matches plugin/.mcp.json (kept in sync by build)', () => {
+    const rootContent = JSON.parse(readFileSync(ROOT_MCP_PATH, 'utf-8'));
+    const pluginContent = JSON.parse(readFileSync(PLUGIN_MCP_PATH, 'utf-8'));
+    expect(rootContent).toEqual(pluginContent);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1471

- **Root cause**: `~/.claude/plugins/marketplaces/thedotmack/.mcp.json` (the file Ora Studio reads for MCP server registration) was permanently empty `{"mcpServers": {}}`. The actual `mcp-search` server declaration lived only in `plugin/.mcp.json`, a subdirectory Ora Studio does not read for this purpose.
- **Fix**: Populate the root `.mcp.json` with the `mcp-search` entry, add a `syncRootMcpJson()` step to `sync-plugin-manifests.js` so every `npm run build` keeps both files in sync, and update `SettingsRoutes.toggleMcp()` to also write/clear the root file when the user enables or disables MCP via the UI.

## Verification

- [x] Baseline tests: 1200 pass, 34 pre-existing failures
- [x] Post-fix tests: 1204 pass, 34 pre-existing failures — no regressions
- [x] New tests: 4 added in `tests/mcp-root-config.test.ts`, all pass
- [x] `node scripts/sync-plugin-manifests.js` exits cleanly with `✓ Synced root .mcp.json from plugin/.mcp.json`

## Files changed

| File | Change |
|------|--------|
| `.mcp.json` | Populated with `mcp-search` server entry (matches `plugin/.mcp.json`) |
| `scripts/sync-plugin-manifests.js` | Added `syncRootMcpJson()` called from `main()` on every build |
| `src/services/worker/http/routes/SettingsRoutes.ts` | `toggleMcp()` now also writes/clears root `.mcp.json` |
| `tests/mcp-root-config.test.ts` | 4 new tests guarding the root/plugin parity invariant |

Generated by Ora Studio
Vibe coded by Ousama Ben Younes