### PR TITLE
fix: validate watch.context.path before writing AGENTS.md (#1204)

### DIFF
--- a/src/services/transcripts/processor.ts
+++ b/src/services/transcripts/processor.ts
@@ -5,7 +5,8 @@ import { sessionCompleteHandler } from '../../cli/handlers/session-complete.js';
 import { ensureWorkerRunning, workerHttpRequest } from '../../shared/worker-utils.js';
 import { logger } from '../../utils/logger.js';
 import { getProjectContext, getProjectName } from '../../utils/project-name.js';
-import { writeAgentsMd } from '../../utils/agents-md-utils.js';
+import { writeAgentsMd, isSafeContextPath } from '../../utils/agents-md-utils.js';
+import { resolve } from 'path';
 import { resolveFieldSpec, resolveFields, matchesRule } from './field-utils.js';
 import { expandHomePath } from './config.js';
 import type { TranscriptSchema, WatchTarget, SchemaEvent } from './types.js';
@@ -361,7 +362,15 @@ export class TranscriptEventProcessor {
       const content = (await response.text()).trim();
       if (!content) return;
 
-      const agentsPath = expandHomePath(watch.context.path ?? `${cwd}/AGENTS.md`);
+      const expandedPath = expandHomePath(watch.context.path ?? `${cwd}/AGENTS.md`);
+      const agentsPath = resolve(cwd, expandedPath);
+      if (!isSafeContextPath(agentsPath, cwd)) {
+        logger.warn('TRANSCRIPT', 'Refusing unsafe context.path — outside project root and ~/.claude-mem', {
+          agentsPath,
+          watch: watch.name
+        });
+        return;
+      }
       writeAgentsMd(agentsPath, content);
       logger.debug('TRANSCRIPT', 'Updated AGENTS.md context', { agentsPath, watch: watch.name });
     } catch (error) {

--- a/src/utils/agents-md-utils.ts
+++ b/src/utils/agents-md-utils.ts
@@ -1,7 +1,20 @@
 import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync } from 'fs';
-import { dirname, resolve } from 'path';
+import { dirname, resolve, sep } from 'path';
+import { homedir } from 'os';
 import { replaceTaggedContent } from './claude-md-utils.js';
 import { logger } from './logger.js';
+
+/**
+ * Returns true if resolvedPath is safely within projectRoot or ~/.claude-mem/.
+ * Prevents path traversal attacks via watch.context.path in settings.
+ */
+export function isSafeContextPath(resolvedPath: string, projectRoot: string): boolean {
+  const withSep = (p: string) => (p.endsWith(sep) ? p : p + sep);
+  const projectPrefix = withSep(resolve(projectRoot));
+  const dataPrefix = withSep(resolve(homedir(), '.claude-mem'));
+  const normalizedPath = withSep(resolvedPath);
+  return normalizedPath.startsWith(projectPrefix) || normalizedPath.startsWith(dataPrefix);
+}
 
 /**
  * Write AGENTS.md with claude-mem context, preserving user content outside tags.

--- a/src/utils/agents-md-utils.ts
+++ b/src/utils/agents-md-utils.ts
@@ -1,19 +1,31 @@
-import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync, realpathSync } from 'fs';
 import { dirname, resolve, sep } from 'path';
 import { homedir } from 'os';
 import { replaceTaggedContent } from './claude-md-utils.js';
 import { logger } from './logger.js';
 
 /**
+ * Canonicalize a path using realpathSync to resolve symlinks.
+ * Falls back to the input path if it doesn't exist yet (realpathSync requires the path to exist).
+ */
+function canonicalize(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+
+/**
  * Returns true if resolvedPath is safely within projectRoot or ~/.claude-mem/.
- * Prevents path traversal attacks via watch.context.path in settings.
+ * Prevents path traversal attacks (including symlink escapes) via watch.context.path in settings.
  */
 export function isSafeContextPath(resolvedPath: string, projectRoot: string): boolean {
   const withSep = (p: string) => (p.endsWith(sep) ? p : p + sep);
-  const projectPrefix = withSep(resolve(projectRoot));
-  const dataPrefix = withSep(resolve(homedir(), '.claude-mem'));
-  const normalizedPath = withSep(resolvedPath);
-  return normalizedPath.startsWith(projectPrefix) || normalizedPath.startsWith(dataPrefix);
+  const canonicalPath = withSep(canonicalize(resolve(resolvedPath)));
+  const projectPrefix = withSep(canonicalize(resolve(projectRoot)));
+  const dataPrefix = withSep(canonicalize(resolve(homedir(), '.claude-mem')));
+  return canonicalPath.startsWith(projectPrefix) || canonicalPath.startsWith(dataPrefix);
 }
 
 /**

--- a/tests/utils/agents-md-utils.test.ts
+++ b/tests/utils/agents-md-utils.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for isSafeContextPath — guards against path traversal via watch.context.path.
+ * Fixes #1204: watch.context.path can write AGENTS.md content to arbitrary file paths.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { homedir } from 'os';
+import { resolve } from 'path';
+import { isSafeContextPath } from '../../src/utils/agents-md-utils.js';
+
+const HOME = homedir();
+const PROJECT = resolve(HOME, 'projects', 'my-app');
+const DATA_DIR = resolve(HOME, '.claude-mem');
+
+describe('isSafeContextPath', () => {
+  describe('allowed paths', () => {
+    it('allows AGENTS.md directly in project root', () => {
+      expect(isSafeContextPath(resolve(PROJECT, 'AGENTS.md'), PROJECT)).toBe(true);
+    });
+
+    it('allows a nested path within the project', () => {
+      expect(isSafeContextPath(resolve(PROJECT, 'docs', 'AGENTS.md'), PROJECT)).toBe(true);
+    });
+
+    it('allows path within ~/.claude-mem/', () => {
+      expect(isSafeContextPath(resolve(DATA_DIR, 'context.md'), PROJECT)).toBe(true);
+    });
+
+    it('allows nested path within ~/.claude-mem/', () => {
+      expect(isSafeContextPath(resolve(DATA_DIR, 'projects', 'my-app', 'AGENTS.md'), PROJECT)).toBe(true);
+    });
+  });
+
+  describe('path traversal attacks — must be rejected', () => {
+    it('rejects ../../.bashrc relative traversal', () => {
+      // ../../.bashrc from PROJECT resolves to HOME/.bashrc
+      const traversal = resolve(PROJECT, '../../.bashrc');
+      expect(isSafeContextPath(traversal, PROJECT)).toBe(false);
+    });
+
+    it('rejects ~/.ssh/authorized_keys', () => {
+      expect(isSafeContextPath(resolve(HOME, '.ssh', 'authorized_keys'), PROJECT)).toBe(false);
+    });
+
+    it('rejects /etc/passwd', () => {
+      expect(isSafeContextPath('/etc/passwd', PROJECT)).toBe(false);
+    });
+
+    it('rejects /tmp/evil.sh', () => {
+      expect(isSafeContextPath('/tmp/evil.sh', PROJECT)).toBe(false);
+    });
+
+    it('rejects a sibling directory that shares the project prefix', () => {
+      // e.g. projectRoot = /home/user/projects/my-app
+      // attack path = /home/user/projects/my-app-evil/AGENTS.md
+      const sibling = resolve(HOME, 'projects', 'my-app-evil', 'AGENTS.md');
+      expect(isSafeContextPath(sibling, PROJECT)).toBe(false);
+    });
+
+    it('rejects the home directory itself', () => {
+      expect(isSafeContextPath(HOME, PROJECT)).toBe(false);
+    });
+
+    it('rejects ~/.gitconfig', () => {
+      expect(isSafeContextPath(resolve(HOME, '.gitconfig'), PROJECT)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1204

- Resolves `watch.context.path` relative to the session `cwd` and validates it stays within the project root or `~/.claude-mem/` before calling `writeAgentsMd`
- Adds `isSafeContextPath(resolvedPath, projectRoot)` utility in `agents-md-utils.ts` (sep-normalized prefix check, cross-platform)
- Rejects paths like `../../.bashrc`, `~/.ssh/authorized_keys`, `/etc/passwd` with a `logger.warn` and early return

## Verification

- [x] Baseline tests: 1200 pass, 34 pre-existing failures
- [x] Post-fix tests: 1211 pass, 34 failures (no regressions)
- [x] New tests: 11 added in `tests/utils/agents-md-utils.test.ts`, all pass — cover allowed paths (project root, `~/.claude-mem/`) and attack vectors (traversal, sibling-prefix bypass, absolute paths to `/etc`, `~/.ssh`)
- [x] Review agent: issue alignment verified (Gate 1–4 all PASS)

## Files changed

| File | Change |
|------|--------|
| `src/utils/agents-md-utils.ts` | Add `isSafeContextPath` export |
| `src/services/transcripts/processor.ts` | Use `isSafeContextPath` guard in `updateContext` |
| `tests/utils/agents-md-utils.test.ts` | New test file (11 tests) |

Generated by Ora Studio
Vibe coded by ousamabenyounes