### PR TITLE
fix: add cache path and PATH export to PreToolUse hook (#1660)

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -64,7 +64,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code file-context",
+            "command": "export PATH=\"$HOME/.nvm/versions/node/v$(ls \\\"$HOME/.nvm/versions/node\\\" 2>/dev/null | sed 's/^v//' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)/bin:$HOME/.local/bin:/usr/local/bin:/opt/homebrew/bin:$PATH\"; _R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=$(ls -dt $HOME/.claude/plugins/cache/thedotmack/claude-mem/[0-9]*/ 2>/dev/null | head -1); _R=\"${_R%/}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code file-context",
             "timeout": 2000
           }
         ]

--- a/tests/infrastructure/plugin-distribution.test.ts
+++ b/tests/infrastructure/plugin-distribution.test.ts
@@ -116,6 +116,24 @@ describe('Plugin Distribution - hooks.json Integrity', () => {
       }
     }
   });
+
+  it('should include export PATH in all node-invoking hook commands (#1660)', () => {
+    // Ensures node can be found on nvm/homebrew installations regardless of shell PATH.
+    // PreToolUse was introduced without this export, causing hook failures when
+    // CLAUDE_PLUGIN_ROOT is not injected and the user installs Node via nvm.
+    const hooksPath = path.join(projectRoot, 'plugin/hooks/hooks.json');
+    const parsed = JSON.parse(readFileSync(hooksPath, 'utf-8'));
+
+    for (const [eventName, matchers] of Object.entries(parsed.hooks)) {
+      for (const matcher of matchers as any[]) {
+        for (const hook of matcher.hooks) {
+          if (hook.type === 'command' && hook.command.includes('node ')) {
+            expect(hook.command).toContain('export PATH=');
+          }
+        }
+      }
+    }
+  });
 });
 
 describe('Plugin Distribution - package.json Files Field', () => {


### PR DESCRIPTION
## Summary

Fixes #1660

The `PreToolUse:Read` hook was introduced (in feat: file-read-timeline-inject) **after** the cache-path fix (#1533) had already been applied to all other hooks. As a result, it used the old fallback pattern — jumping straight to the `marketplaces` path without checking the versioned cache directory first, and without exporting `PATH` for nvm/homebrew installations.

**Impact:** When `CLAUDE_PLUGIN_ROOT` is not injected by the plugin runtime (common on fresh installs or after clearing settings.json) AND the user installs Node via nvm or homebrew, the `PreToolUse:Read` hook resolves to a non-existent path and fails. Depending on exit code, this can block the Read tool and prevent `PostToolUse` observations from being recorded — which is exactly the symptom reported in #1660.

**Fix:** Apply the same two-part pattern already used by every other node-invoking hook:
1. `export PATH=…` — makes node discoverable in nvm/homebrew environments
2. Cache path lookup (`$HOME/.claude/plugins/cache/thedotmack/claude-mem/[0-9]*/`) before falling back to the marketplace path

## Verification

- [x] Baseline tests: 1200 pass, 34 fail (pre-existing)
- [x] Post-fix tests: 1202 pass, 33 fail — 1 fewer failure, 2 new passes, **zero regressions**
- [x] Fixed test: `should try cache path before marketplaces fallback in all hook commands (#1533)`
- [x] New test added: `should include export PATH in all node-invoking hook commands (#1660)` — catches this class of omission for any future hook

## Files changed

| File | Change |
|------|--------|
| `plugin/hooks/hooks.json` | Add `export PATH=…` and cache-path lookup to `PreToolUse:Read` hook command |
| `tests/infrastructure/plugin-distribution.test.ts` | New regression test verifying PATH export on all node-invoking hooks |

Generated by Ora Studio
Vibe coded by Ousama Ben Younes