### PR TITLE
fix: list_corpora MCP tool — wrap response in CallToolResult shape (fixes #1700)

### DIFF
--- a/src/services/worker/http/routes/CorpusRoutes.ts
+++ b/src/services/worker/http/routes/CorpusRoutes.ts
@@ -72,7 +72,14 @@ export class CorpusRoutes extends BaseRouteHandler {
    */
   private handleListCorpora = this.wrapHandler((_req: Request, res: Response): void => {
     const corpora = this.corpusStore.list();
-    res.json(corpora);
+    // Wrap in MCP CallToolResult shape so the MCP server wrapper (callWorkerAPI)
+    // can forward it without failing tools/call schema validation.
+    // See: #1700 — every other corpus endpoint is a POST that already returns
+    // {content:[...]}, but this GET used to return a bare array, which MCP
+    // rejects with "expected object, received array".
+    res.json({
+      content: [{ type: 'text', text: JSON.stringify(corpora, null, 2) }]
+    });
   });
 
   /**


### PR DESCRIPTION
## Summary

- Fixes #1700 — `list_corpora` MCP tool was completely broken in v12.1.0, failing every call with `MCP error -32602: Invalid tools/call result: expected object, received array`.
- One-file change in `src/services/worker/http/routes/CorpusRoutes.ts`: wrap the `GET /api/corpus` response in the MCP `CallToolResult` shape (`{ content: [{ type: 'text', text: ... }] }`) instead of returning a bare JSON array.

## Root cause (short version)

`GET /api/corpus` returned `corpusStore.list()` directly as JSON, i.e. a bare array. The MCP server wrapper `callWorkerAPI` in `src/servers/mcp-server.ts` forwards the HTTP response as-is — its type comment literally says *"Worker returns { content: [...] } format directly"* — so the array propagated straight to the MCP client, which rejects it against the `CallToolResult` schema.

Every other corpus endpoint (`build_corpus`, `prime_corpus`, `query_corpus`, `rebuild_corpus`, `reprime_corpus`, …) is a `POST` and already returns a `{content:[...]}` wrapped payload, so they were unaffected. `list_corpora` was the only `GET` in the set, and the only broken tool.

## The fix

```ts
private handleListCorpora = this.wrapHandler((_req, res): void => {
  const corpora = this.corpusStore.list();
  res.json({
    content: [{ type: 'text', text: JSON.stringify(corpora, null, 2) }]
  });
});
```

An inline comment documents the invariant so a future refactor doesn't regress it.

## Test plan

- [x] Patched the minified runtime (`plugin/scripts/worker-service.cjs`) on my install with the equivalent change, restarted the worker via `worker-cli.js restart`.
- [x] `curl http://127.0.0.1:37777/api/corpus` → `{"content":[{"type":"text","text":"[]"}]}` (previously: `[]`).
- [x] MCP `list_corpora` call via Claude Code → returns `[]` cleanly, no schema error (previously: `MCP error -32602`).
- [ ] Verified no other caller of `GET /api/corpus` exists that would expect the bare-array shape — grep shows only the MCP server handler, which *wants* the wrapped shape.

## Notes

- No behavior change for any other endpoint.
- No schema/type changes required — the MCP server wrapper's declared return type already matched the wrapped shape; only the worker was lying to it.
- If preferred, the fix could live in `callWorkerAPI` instead (normalize any non-`{content:[...]}` response), but a per-handler fix keeps blast radius minimal and matches how the other corpus endpoints already handle their own wrapping.