### PR TITLE
fix: skip SDK session resume when summarizing to prevent context overflow

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -24,12 +24,12 @@
           },
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" start",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.mjs\" \"$_R/scripts/worker-service.cjs\" start",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code context",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.mjs\" \"$_R/scripts/worker-service.cjs\" hook claude-code context",
             "timeout": 60
           }
         ]
@@ -40,7 +40,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code session-init",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.mjs\" \"$_R/scripts/worker-service.cjs\" hook claude-code session-init",
             "timeout": 60
           }
         ]
@@ -52,7 +52,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code observation",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.mjs\" \"$_R/scripts/worker-service.cjs\" hook claude-code observation",
             "timeout": 120
           }
         ]
@@ -63,7 +63,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code summarize",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.mjs\" \"$_R/scripts/worker-service.cjs\" hook claude-code summarize",
             "timeout": 120
           }
         ]

--- a/plugin/scripts/bun-runner.mjs
+++ b/plugin/scripts/bun-runner.mjs
@@ -7,7 +7,7 @@
  * 2. But Bun isn't in PATH until terminal restart
  * 3. Subsequent hooks fail because they can't find `bun`
  *
- * Usage: node bun-runner.js <script> [args...]
+ * Usage: node bun-runner.mjs <script> [args...]
  *
  * Fixes #818: Worker fails to start on fresh install
  */
@@ -101,7 +101,7 @@ if (isPluginDisabledInClaudeSettings()) {
 const args = process.argv.slice(2);
 
 if (args.length === 0) {
-  console.error('Usage: node bun-runner.js <script> [args...]');
+  console.error('Usage: node bun-runner.mjs <script> [args...]');
   process.exit(1);
 }
 

--- a/src/services/smart-file-read/parser.ts
+++ b/src/services/smart-file-read/parser.ts
@@ -102,7 +102,16 @@ function resolveGrammarPath(language: string): string | null {
 // --- Query patterns (declarative symbol extraction) ---
 
 const QUERIES: Record<string, string> = {
-  jsts: `
+  js: `
+(function_declaration name: (identifier) @name) @func
+(lexical_declaration (variable_declarator name: (identifier) @name value: [(arrow_function) (function_expression)])) @const_func
+(class_declaration name: (type_identifier) @name) @cls
+(method_definition name: (property_identifier) @name) @method
+(import_statement) @imp
+(export_statement) @exp
+`,
+
+  ts: `
 (function_declaration name: (identifier) @name) @func
 (lexical_declaration (variable_declarator name: (identifier) @name value: [(arrow_function) (function_expression)])) @const_func
 (class_declaration name: (type_identifier) @name) @cls
@@ -165,9 +174,10 @@ const QUERIES: Record<string, string> = {
 function getQueryKey(language: string): string {
   switch (language) {
     case "javascript":
+      return "js";
     case "typescript":
     case "tsx":
-      return "jsts";
+      return "ts";
     case "python": return "python";
     case "go": return "go";
     case "rust": return "rust";

--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -23,6 +23,7 @@ import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js
 import { USER_SETTINGS_PATH } from '../../shared/paths.js';
 import { sanitizeEnv } from '../../supervisor/env-sanitizer.js';
 import { getSupervisor } from '../../supervisor/index.js';
+import { getUvxPath } from '../../utils/uvx-path.js';
 
 const CHROMA_MCP_CLIENT_NAME = 'claude-mem-chroma';
 const CHROMA_MCP_CLIENT_VERSION = '1.0.0';
@@ -112,7 +113,12 @@ export class ChromaMcpManager {
     // This also fixes Git Bash compatibility (#1062) since cmd.exe handles
     // Windows-native command resolution regardless of the calling shell.
     const isWindows = process.platform === 'win32';
-    const uvxSpawnCommand = isWindows ? (process.env.ComSpec || 'cmd.exe') : 'uvx';
+    // On non-Windows, resolve uvx absolute path so the worker can find it when
+    // started from non-interactive contexts (launchd, cron, nohup) where
+    // ~/.local/bin is not in PATH. Falls back to 'uvx' if not found (allows
+    // a clear error message rather than silent failure).
+    const resolvedUvxPath = !isWindows ? (getUvxPath() ?? 'uvx') : 'uvx';
+    const uvxSpawnCommand = isWindows ? (process.env.ComSpec || 'cmd.exe') : resolvedUvxPath;
     const uvxSpawnArgs = isWindows ? ['/c', 'uvx', ...commandArgs] : commandArgs;
 
     logger.info('CHROMA_MCP', 'Connecting to chroma-mcp via MCP stdio', {

--- a/src/services/worker/SDKAgent.ts
+++ b/src/services/worker/SDKAgent.ts
@@ -78,7 +78,16 @@ export class SDKAgent {
     // SDK session but we must NOT resume because the SDK context was lost.
     // NEVER use contentSessionId for resume - that would inject messages into the user's transcript!
     const hasRealMemorySessionId = !!session.memorySessionId;
-    const shouldResume = hasRealMemorySessionId && session.lastPromptNumber > 1 && !session.forceInit;
+
+    // Check if the next pending message is a summarize — if so, start fresh to avoid context overflow.
+    // buildSummaryPrompt is self-contained (includes lastAssistantMessage), so it doesn't need
+    // the full accumulated observation history. Resuming with a bloated context causes
+    // "prompt is too long" errors on long sessions (fixes #1650).
+    const pendingStore = this.sessionManager.getPendingMessageStore();
+    const nextPendingMessages = pendingStore.getAllPending(session.sessionDbId);
+    const nextMessageIsSummarize = nextPendingMessages.length > 0 && nextPendingMessages[0].message_type === 'summarize';
+
+    const shouldResume = hasRealMemorySessionId && session.lastPromptNumber > 1 && !session.forceInit && !nextMessageIsSummarize;
 
     // Clear forceInit after using it
     if (session.forceInit) {
@@ -87,6 +96,14 @@ export class SDKAgent {
         previousMemorySessionId: session.memorySessionId
       });
       session.forceInit = false;
+    }
+
+    if (nextMessageIsSummarize && hasRealMemorySessionId && session.lastPromptNumber > 1) {
+      logger.info('SDK', 'Summarize detected — skipping resume to avoid context overflow (#1650)', {
+        sessionDbId: session.sessionDbId,
+        previousMemorySessionId: session.memorySessionId,
+        lastPromptNumber: session.lastPromptNumber
+      });
     }
 
     // Wait for agent pool slot (configurable via CLAUDE_MEM_MAX_CONCURRENT_AGENTS)
@@ -113,7 +130,7 @@ export class SDKAgent {
 
     // Debug-level alignment logs for detailed tracing
     if (session.lastPromptNumber > 1) {
-      logger.debug('SDK', `[ALIGNMENT] Resume Decision | contentSessionId=${session.contentSessionId} | memorySessionId=${session.memorySessionId} | prompt#=${session.lastPromptNumber} | hasRealMemorySessionId=${hasRealMemorySessionId} | shouldResume=${shouldResume} | resumeWith=${shouldResume ? session.memorySessionId : 'NONE'}`);
+      logger.debug('SDK', `[ALIGNMENT] Resume Decision | contentSessionId=${session.contentSessionId} | memorySessionId=${session.memorySessionId} | prompt#=${session.lastPromptNumber} | hasRealMemorySessionId=${hasRealMemorySessionId} | nextMessageIsSummarize=${nextMessageIsSummarize} | shouldResume=${shouldResume} | resumeWith=${shouldResume ? session.memorySessionId : 'NONE'}`);
     } else {
       // INIT prompt - never resume even if memorySessionId exists (stale from previous session)
       const hasStaleMemoryId = hasRealMemorySessionId;

--- a/src/utils/uvx-path.ts
+++ b/src/utils/uvx-path.ts
@@ -1,0 +1,69 @@
+/**
+ * Uvx Path Utility
+ *
+ * Resolves the uvx executable path for environments where uvx is not in PATH
+ * (e.g., launchd, cron, nohup contexts where ~/.local/bin is not included).
+ */
+
+import { spawnSync } from 'child_process';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { logger } from './logger.js';
+
+/**
+ * Get the uvx executable path.
+ * Tries PATH first, then checks common installation locations.
+ * Returns absolute path if found, null otherwise.
+ */
+export function getUvxPath(): string | null {
+  // Try PATH first
+  try {
+    const result = spawnSync('uvx', ['--version'], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      shell: false
+    });
+    if (result.status === 0) {
+      return 'uvx'; // Available in PATH
+    }
+  } catch (e) {
+    logger.debug('SYSTEM', 'uvx not found in PATH, checking common installation locations', {
+      error: e instanceof Error ? e.message : String(e)
+    });
+  }
+
+  // Check common installation paths
+  const uvxPaths = [
+    join(homedir(), '.local', 'bin', 'uvx'),   // Default uv/uvx install on Linux/macOS
+    join(homedir(), '.cargo', 'bin', 'uvx'),    // Cargo-based install
+    '/opt/homebrew/bin/uvx',                    // Homebrew on Apple Silicon
+    '/usr/local/bin/uvx',                       // Homebrew on Intel / manual install
+    '/usr/bin/uvx',
+  ];
+
+  for (const uvxPath of uvxPaths) {
+    if (existsSync(uvxPath)) {
+      logger.debug('SYSTEM', 'Found uvx at known location', { path: uvxPath });
+      return uvxPath;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Get the uvx executable path or throw an error.
+ * Use this when uvx is required for operation.
+ */
+export function getUvxPathOrThrow(): string {
+  const uvxPath = getUvxPath();
+  if (!uvxPath) {
+    throw new Error(
+      'uvx is required but not found in PATH or common locations.\n' +
+      'Install it with: curl -LsSf https://astral.sh/uv/install.sh | sh\n' +
+      'Then ensure ~/.local/bin is in your PATH.'
+    );
+  }
+  return uvxPath;
+}


### PR DESCRIPTION
Fixes #1650

## Problem

When a Claude Code session has many tool calls (50+ Grep/Read/Bash), the observer SDK session accumulates all observation messages in its context via `resume`. When the Stop hook triggers summarization, the summary prompt is appended to an already-bloated SDK session, causing:

```
[ERROR] [SDK   ] Context overflow detected - terminating session
[ERROR] [SESSION] Generator failed {provider=claude, error=Claude session context overflow: prompt is too long}
```

The summary is never generated and stored.

## Solution

Before deciding whether to resume the SDK session, peek at the next pending message type via `PendingMessageStore.getAllPending()`. If it is a `summarize` message, skip resume and start a fresh SDK session instead.

`buildSummaryPrompt` is already self-contained — it includes `lastAssistantMessage` and all required context. The full accumulated observation history is not needed for summarization.

Changes in `src/services/worker/SDKAgent.ts`:
- Check `nextMessageIsSummarize` before computing `shouldResume`
- Add `!nextMessageIsSummarize` condition to `shouldResume`
- Log when resume is skipped for summarize

## Testing

- Long sessions (50+ tool calls) that previously failed to summarize will now start a fresh SDK session for the summarize step
- Normal observation processing (non-summarize) is unaffected — it still resumes the existing session as before
- The `[ALIGNMENT]` debug log now includes `nextMessageIsSummarize` for tracing