### PR TITLE
fix: rename bun-runner.js to .mjs to fix ESM SyntaxError on macOS (fixes #1662) [v2]

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -24,12 +24,12 @@
           },
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" start",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.mjs\" \"$_R/scripts/worker-service.cjs\" start",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code context",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.mjs\" \"$_R/scripts/worker-service.cjs\" hook claude-code context",
             "timeout": 60
           }
         ]
@@ -40,7 +40,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code session-init",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.mjs\" \"$_R/scripts/worker-service.cjs\" hook claude-code session-init",
             "timeout": 60
           }
         ]
@@ -52,7 +52,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code observation",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.mjs\" \"$_R/scripts/worker-service.cjs\" hook claude-code observation",
             "timeout": 120
           }
         ]
@@ -63,7 +63,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code summarize",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.mjs\" \"$_R/scripts/worker-service.cjs\" hook claude-code summarize",
             "timeout": 120
           }
         ]

--- a/plugin/scripts/bun-runner.mjs
+++ b/plugin/scripts/bun-runner.mjs
@@ -22,7 +22,7 @@ const IS_WINDOWS = process.platform === 'win32';
 // Self-resolve plugin root when CLAUDE_PLUGIN_ROOT is not set by Claude Code.
 // Upstream bug: anthropics/claude-code#24529 — Stop hooks (and on Linux, all hooks)
 // don't receive CLAUDE_PLUGIN_ROOT, causing script paths to resolve to /scripts/...
-// which doesn't exist. This fallback derives the plugin root from bun-runner.js's
+// which doesn't exist. This fallback derives the plugin root from bun-runner.mjs's
 // own filesystem location (this file lives in <plugin-root>/scripts/).
 const __bun_runner_dirname = dirname(fileURLToPath(import.meta.url));
 const RESOLVED_PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || resolve(__bun_runner_dirname, '..');
@@ -97,7 +97,7 @@ if (isPluginDisabledInClaudeSettings()) {
   process.exit(0);
 }
 
-// Get args: node bun-runner.js <script> [args...]
+// Get args: node bun-runner.mjs <script> [args...]
 const args = process.argv.slice(2);
 
 if (args.length === 0) {

--- a/plugin/scripts/bun-runner.mjs
+++ b/plugin/scripts/bun-runner.mjs
@@ -7,7 +7,7 @@
  * 2. But Bun isn't in PATH until terminal restart
  * 3. Subsequent hooks fail because they can't find `bun`
  *
- * Usage: node bun-runner.js <script> [args...]
+ * Usage: node bun-runner.mjs <script> [args...]
  *
  * Fixes #818: Worker fails to start on fresh install
  */
@@ -101,7 +101,7 @@ if (isPluginDisabledInClaudeSettings()) {
 const args = process.argv.slice(2);
 
 if (args.length === 0) {
-  console.error('Usage: node bun-runner.js <script> [args...]');
+  console.error('Usage: node bun-runner.mjs <script> [args...]');
   process.exit(1);
 }
 

--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -14,7 +14,7 @@
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import path from 'path';
 import os from 'os';
 import fs from 'fs';
@@ -391,8 +391,9 @@ export class ChromaMcpManager {
       let certifiPath: string | undefined;
       try {
         const resolvedUvx = getUvxPath() ?? 'uvx';
-        certifiPath = execSync(
-          `${resolvedUvx} --with certifi python -c "import certifi; print(certifi.where())"`,
+        certifiPath = execFileSync(
+          resolvedUvx,
+          ['--with', 'certifi', 'python', '-c', 'import certifi; print(certifi.where())'],
           { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 }
         ).trim();
       } catch {

--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -390,8 +390,9 @@ export class ChromaMcpManager {
     try {
       let certifiPath: string | undefined;
       try {
+        const resolvedUvx = getUvxPath() ?? 'uvx';
         certifiPath = execSync(
-          'uvx --with certifi python -c "import certifi; print(certifi.where())"',
+          `${resolvedUvx} --with certifi python -c "import certifi; print(certifi.where())"`,
           { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 }
         ).trim();
       } catch {

--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -23,6 +23,7 @@ import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js
 import { USER_SETTINGS_PATH } from '../../shared/paths.js';
 import { sanitizeEnv } from '../../supervisor/env-sanitizer.js';
 import { getSupervisor } from '../../supervisor/index.js';
+import { getUvxPath } from '../../utils/uvx-path.js';
 
 const CHROMA_MCP_CLIENT_NAME = 'claude-mem-chroma';
 const CHROMA_MCP_CLIENT_VERSION = '1.0.0';
@@ -112,7 +113,12 @@ export class ChromaMcpManager {
     // This also fixes Git Bash compatibility (#1062) since cmd.exe handles
     // Windows-native command resolution regardless of the calling shell.
     const isWindows = process.platform === 'win32';
-    const uvxSpawnCommand = isWindows ? (process.env.ComSpec || 'cmd.exe') : 'uvx';
+    // On non-Windows, resolve uvx absolute path so the worker can find it when
+    // started from non-interactive contexts (launchd, cron, nohup) where
+    // ~/.local/bin is not in PATH. Falls back to 'uvx' if not found (allows
+    // a clear error message rather than silent failure).
+    const resolvedUvxPath = !isWindows ? (getUvxPath() ?? 'uvx') : 'uvx';
+    const uvxSpawnCommand = isWindows ? (process.env.ComSpec || 'cmd.exe') : resolvedUvxPath;
     const uvxSpawnArgs = isWindows ? ['/c', 'uvx', ...commandArgs] : commandArgs;
 
     logger.info('CHROMA_MCP', 'Connecting to chroma-mcp via MCP stdio', {

--- a/src/utils/uvx-path.ts
+++ b/src/utils/uvx-path.ts
@@ -1,0 +1,69 @@
+/**
+ * Uvx Path Utility
+ *
+ * Resolves the uvx executable path for environments where uvx is not in PATH
+ * (e.g., launchd, cron, nohup contexts where ~/.local/bin is not included).
+ */
+
+import { spawnSync } from 'child_process';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { logger } from './logger.js';
+
+/**
+ * Get the uvx executable path.
+ * Tries PATH first, then checks common installation locations.
+ * Returns absolute path if found, null otherwise.
+ */
+export function getUvxPath(): string | null {
+  // Try PATH first
+  try {
+    const result = spawnSync('uvx', ['--version'], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      shell: false
+    });
+    if (result.status === 0) {
+      return 'uvx'; // Available in PATH
+    }
+  } catch (e) {
+    logger.debug('SYSTEM', 'uvx not found in PATH, checking common installation locations', {
+      error: e instanceof Error ? e.message : String(e)
+    });
+  }
+
+  // Check common installation paths
+  const uvxPaths = [
+    join(homedir(), '.local', 'bin', 'uvx'),   // Default uv/uvx install on Linux/macOS
+    join(homedir(), '.cargo', 'bin', 'uvx'),    // Cargo-based install
+    '/opt/homebrew/bin/uvx',                    // Homebrew on Apple Silicon
+    '/usr/local/bin/uvx',                       // Homebrew on Intel / manual install
+    '/usr/bin/uvx',
+  ];
+
+  for (const uvxPath of uvxPaths) {
+    if (existsSync(uvxPath)) {
+      logger.debug('SYSTEM', 'Found uvx at known location', { path: uvxPath });
+      return uvxPath;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Get the uvx executable path or throw an error.
+ * Use this when uvx is required for operation.
+ */
+export function getUvxPathOrThrow(): string {
+  const uvxPath = getUvxPath();
+  if (!uvxPath) {
+    throw new Error(
+      'uvx is required but not found in PATH or common locations.\n' +
+      'Install it with: curl -LsSf https://astral.sh/uv/install.sh | sh\n' +
+      'Then ensure ~/.local/bin is in your PATH.'
+    );
+  }
+  return uvxPath;
+}


### PR DESCRIPTION
Supersedes #1672 (from octo-patch/claude-mem — no longer writable).

Identical changes + CodeRabbit fix applied:
- Renames `bun-runner.js` → `bun-runner.mjs` to fix ESM SyntaxError on macOS
- `getCombinedCertPath()` now resolves `uvx` via `getUvxPath() ?? 'uvx'` instead of hardcoded string (fixes non-interactive context failures)

Closes #1662