### PR TITLE
fix: skip SDK session resume when summarizing to prevent context overflow [v2]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,7 +217,7 @@ The standard exploration cycle (Glob → Grep → Read) forces agents to consume
 ## Bug Fixes
 
 - **Fix PostToolUse hook crashes and 5-second latency (#1220)**: Added missing `break` statements to all 7 switch cases in `worker-service.ts` preventing fall-through execution, added `.catch()` on `main()` to handle unhandled promise rejections, and removed redundant `start` commands from hook groups that triggered the 5-second `collectStdin()` timeout
-- **Fix CLAUDE_PLUGIN_ROOT fallback for Stop hooks (#1215)**: Added POSIX shell-level `CLAUDE_PLUGIN_ROOT` fallback in `hooks.json` for environments where the variable isn't injected, added script-level self-resolution via `import.meta.url` in `bun-runner.js`, and regression test added in `plugin-distribution.test.ts`
+- **Fix CLAUDE_PLUGIN_ROOT fallback for Stop hooks (#1215)**: Added POSIX shell-level `CLAUDE_PLUGIN_ROOT` fallback in `hooks.json` for environments where the variable isn't injected, added script-level self-resolution via `import.meta.url` in `bun-runner.mjs`, and regression test added in `plugin-distribution.test.ts`
 
 ## Maintenance
 
@@ -228,7 +228,7 @@ The standard exploration cycle (Glob → Grep → Read) forces agents to consume
 ## Bug Fixes
 
 - **Fix PostToolUse hook crashes and 5-second latency (#1220)**: Added missing `break` statements to all 7 switch cases in `worker-service.ts` preventing fall-through execution, added `.catch()` on `main()` to handle unhandled promise rejections, and removed redundant `start` commands from hook groups that triggered the 5-second `collectStdin()` timeout
-- **Fix CLAUDE_PLUGIN_ROOT fallback for Stop hooks (#1215)**: Added POSIX shell-level `CLAUDE_PLUGIN_ROOT` fallback in `hooks.json` for environments where the variable isn't injected, added script-level self-resolution via `import.meta.url` in `bun-runner.js`, and regression test added in `plugin-distribution.test.ts`
+- **Fix CLAUDE_PLUGIN_ROOT fallback for Stop hooks (#1215)**: Added POSIX shell-level `CLAUDE_PLUGIN_ROOT` fallback in `hooks.json` for environments where the variable isn't injected, added script-level self-resolution via `import.meta.url` in `bun-runner.mjs`, and regression test added in `plugin-distribution.test.ts`
 - **Sync plugin.json version**: Fixed `plugin.json` being stuck at 10.4.0 while other version files were at 10.4.1
 
 ## [v10.4.1] - 2026-02-24
@@ -807,7 +807,7 @@ Hooks no longer block Claude Code when the worker is unavailable or slow:
 
 ### Windows Stability
 
-- **Path spaces fix** — bun-runner.js no longer fails for Windows usernames with spaces (PR #972 by @farikh)
+- **Path spaces fix** — bun-runner.mjs no longer fails for Windows usernames with spaces (PR #972 by @farikh)
 - **Spawn guard** — 2-minute cooldown prevents repeated worker popup windows on startup failure
 
 ### Process & Zombie Management
@@ -877,7 +877,7 @@ Thank you to the 35+ contributors whose PRs were reviewed in this release:
 
 On fresh installations, hooks would fail because Bun wasn't in PATH until terminal restart. The `smart-install.js` script installs Bun to `~/.bun/bin/bun`, but the current shell session doesn't have it in PATH.
 
-**Fix:** Introduced `bun-runner.js` — a Node.js wrapper that searches common Bun installation locations across all platforms:
+**Fix:** Introduced `bun-runner.mjs` — a Node.js wrapper that searches common Bun installation locations across all platforms:
 - PATH (via `which`/`where`)
 - `~/.bun/bin/bun` (default install location)
 - `/usr/local/bin/bun`
@@ -885,10 +885,10 @@ On fresh installations, hooks would fail because Bun wasn't in PATH until termin
 - `/home/linuxbrew/.linuxbrew/bin/bun` (Linuxbrew)
 - Windows: `%LOCALAPPDATA%\bun` or fallback paths
 
-All 9 hook definitions updated to use `node bun-runner.js` instead of direct `bun` calls.
+All 9 hook definitions updated to use `node bun-runner.mjs` instead of direct `bun` calls.
 
 **Files changed:**
-- `plugin/scripts/bun-runner.js` — New 88-line Bun discovery script
+- `plugin/scripts/bun-runner.mjs` — New 88-line Bun discovery script
 - `plugin/hooks/hooks.json` — All hook commands now route through bun-runner
 
 Fixes #818 | PR #827 by @bigphoot

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -24,12 +24,12 @@
           },
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" start",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.mjs\" \"$_R/scripts/worker-service.cjs\" start",
             "timeout": 60
           },
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code context",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.mjs\" \"$_R/scripts/worker-service.cjs\" hook claude-code context",
             "timeout": 60
           }
         ]
@@ -40,7 +40,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code session-init",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.mjs\" \"$_R/scripts/worker-service.cjs\" hook claude-code session-init",
             "timeout": 60
           }
         ]
@@ -52,7 +52,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code observation",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.mjs\" \"$_R/scripts/worker-service.cjs\" hook claude-code observation",
             "timeout": 120
           }
         ]
@@ -63,7 +63,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.js\" \"$_R/scripts/worker-service.cjs\" hook claude-code summarize",
+            "command": "_R=\"${CLAUDE_PLUGIN_ROOT}\"; [ -z \"$_R\" ] && _R=\"$HOME/.claude/plugins/marketplaces/thedotmack/plugin\"; node \"$_R/scripts/bun-runner.mjs\" \"$_R/scripts/worker-service.cjs\" hook claude-code summarize",
             "timeout": 120
           }
         ]

--- a/plugin/scripts/bun-runner.mjs
+++ b/plugin/scripts/bun-runner.mjs
@@ -97,7 +97,7 @@ if (isPluginDisabledInClaudeSettings()) {
   process.exit(0);
 }
 
-// Get args: node bun-runner.js <script> [args...]
+// Get args: node bun-runner.mjs <script> [args...]
 const args = process.argv.slice(2);
 
 if (args.length === 0) {

--- a/plugin/scripts/bun-runner.mjs
+++ b/plugin/scripts/bun-runner.mjs
@@ -7,7 +7,7 @@
  * 2. But Bun isn't in PATH until terminal restart
  * 3. Subsequent hooks fail because they can't find `bun`
  *
- * Usage: node bun-runner.js <script> [args...]
+ * Usage: node bun-runner.mjs <script> [args...]
  *
  * Fixes #818: Worker fails to start on fresh install
  */
@@ -101,7 +101,7 @@ if (isPluginDisabledInClaudeSettings()) {
 const args = process.argv.slice(2);
 
 if (args.length === 0) {
-  console.error('Usage: node bun-runner.js <script> [args...]');
+  console.error('Usage: node bun-runner.mjs <script> [args...]');
   process.exit(1);
 }
 

--- a/src/services/smart-file-read/parser.ts
+++ b/src/services/smart-file-read/parser.ts
@@ -102,7 +102,16 @@ function resolveGrammarPath(language: string): string | null {
 // --- Query patterns (declarative symbol extraction) ---
 
 const QUERIES: Record<string, string> = {
-  jsts: `
+  js: `
+(function_declaration name: (identifier) @name) @func
+(lexical_declaration (variable_declarator name: (identifier) @name value: [(arrow_function) (function_expression)])) @const_func
+(class_declaration name: (type_identifier) @name) @cls
+(method_definition name: (property_identifier) @name) @method
+(import_statement) @imp
+(export_statement) @exp
+`,
+
+  ts: `
 (function_declaration name: (identifier) @name) @func
 (lexical_declaration (variable_declarator name: (identifier) @name value: [(arrow_function) (function_expression)])) @const_func
 (class_declaration name: (type_identifier) @name) @cls
@@ -165,9 +174,10 @@ const QUERIES: Record<string, string> = {
 function getQueryKey(language: string): string {
   switch (language) {
     case "javascript":
+      return "js";
     case "typescript":
     case "tsx":
-      return "jsts";
+      return "ts";
     case "python": return "python";
     case "go": return "go";
     case "rust": return "rust";

--- a/src/services/smart-file-read/parser.ts
+++ b/src/services/smart-file-read/parser.ts
@@ -105,7 +105,7 @@ const QUERIES: Record<string, string> = {
   js: `
 (function_declaration name: (identifier) @name) @func
 (lexical_declaration (variable_declarator name: (identifier) @name value: [(arrow_function) (function_expression)])) @const_func
-(class_declaration name: (type_identifier) @name) @cls
+(class_declaration name: (identifier) @name) @cls
 (method_definition name: (property_identifier) @name) @method
 (import_statement) @imp
 (export_statement) @exp

--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -390,8 +390,9 @@ export class ChromaMcpManager {
     try {
       let certifiPath: string | undefined;
       try {
+        const uvxBin = getUvxPath() ?? 'uvx';
         certifiPath = execSync(
-          'uvx --with certifi python -c "import certifi; print(certifi.where())"',
+          `${uvxBin} --with certifi python -c "import certifi; print(certifi.where())"`,
           { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 }
         ).trim();
       } catch {

--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -23,6 +23,7 @@ import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js
 import { USER_SETTINGS_PATH } from '../../shared/paths.js';
 import { sanitizeEnv } from '../../supervisor/env-sanitizer.js';
 import { getSupervisor } from '../../supervisor/index.js';
+import { getUvxPath } from '../../utils/uvx-path.js';
 
 const CHROMA_MCP_CLIENT_NAME = 'claude-mem-chroma';
 const CHROMA_MCP_CLIENT_VERSION = '1.0.0';
@@ -112,7 +113,12 @@ export class ChromaMcpManager {
     // This also fixes Git Bash compatibility (#1062) since cmd.exe handles
     // Windows-native command resolution regardless of the calling shell.
     const isWindows = process.platform === 'win32';
-    const uvxSpawnCommand = isWindows ? (process.env.ComSpec || 'cmd.exe') : 'uvx';
+    // On non-Windows, resolve uvx absolute path so the worker can find it when
+    // started from non-interactive contexts (launchd, cron, nohup) where
+    // ~/.local/bin is not in PATH. Falls back to 'uvx' if not found (allows
+    // a clear error message rather than silent failure).
+    const resolvedUvxPath = !isWindows ? (getUvxPath() ?? 'uvx') : 'uvx';
+    const uvxSpawnCommand = isWindows ? (process.env.ComSpec || 'cmd.exe') : resolvedUvxPath;
     const uvxSpawnArgs = isWindows ? ['/c', 'uvx', ...commandArgs] : commandArgs;
 
     logger.info('CHROMA_MCP', 'Connecting to chroma-mcp via MCP stdio', {

--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -14,7 +14,7 @@
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import path from 'path';
 import os from 'os';
 import fs from 'fs';
@@ -391,8 +391,9 @@ export class ChromaMcpManager {
       let certifiPath: string | undefined;
       try {
         const uvxBin = getUvxPath() ?? 'uvx';
-        certifiPath = execSync(
-          `${uvxBin} --with certifi python -c "import certifi; print(certifi.where())"`,
+        certifiPath = execFileSync(
+          uvxBin,
+          ['--with', 'certifi', 'python', '-c', 'import certifi; print(certifi.where())'],
           { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 10000 }
         ).trim();
       } catch {

--- a/src/services/worker/SDKAgent.ts
+++ b/src/services/worker/SDKAgent.ts
@@ -106,6 +106,12 @@ export class SDKAgent {
       });
     }
 
+    if (nextMessageIsSummarize && !shouldResume && !session.forceInit) {
+      // Force the init-prompt path so buildContinuationPrompt is never called for
+      // a summarize message that starts a fresh SDK session (fixes #1650).
+      session.lastPromptNumber = 1;
+    }
+
     // Wait for agent pool slot (configurable via CLAUDE_MEM_MAX_CONCURRENT_AGENTS)
     const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
     const maxConcurrent = parseInt(settings.CLAUDE_MEM_MAX_CONCURRENT_AGENTS, 10) || 2;

--- a/src/services/worker/SDKAgent.ts
+++ b/src/services/worker/SDKAgent.ts
@@ -78,7 +78,16 @@ export class SDKAgent {
     // SDK session but we must NOT resume because the SDK context was lost.
     // NEVER use contentSessionId for resume - that would inject messages into the user's transcript!
     const hasRealMemorySessionId = !!session.memorySessionId;
-    const shouldResume = hasRealMemorySessionId && session.lastPromptNumber > 1 && !session.forceInit;
+
+    // Check if the next pending message is a summarize — if so, start fresh to avoid context overflow.
+    // buildSummaryPrompt is self-contained (includes lastAssistantMessage), so it doesn't need
+    // the full accumulated observation history. Resuming with a bloated context causes
+    // "prompt is too long" errors on long sessions (fixes #1650).
+    const pendingStore = this.sessionManager.getPendingMessageStore();
+    const nextPendingMessages = pendingStore.getAllPending(session.sessionDbId);
+    const nextMessageIsSummarize = nextPendingMessages.length > 0 && nextPendingMessages[0].message_type === 'summarize';
+
+    const shouldResume = hasRealMemorySessionId && session.lastPromptNumber > 1 && !session.forceInit && !nextMessageIsSummarize;
 
     // Clear forceInit after using it
     if (session.forceInit) {
@@ -87,6 +96,14 @@ export class SDKAgent {
         previousMemorySessionId: session.memorySessionId
       });
       session.forceInit = false;
+    }
+
+    if (nextMessageIsSummarize && hasRealMemorySessionId && session.lastPromptNumber > 1) {
+      logger.info('SDK', 'Summarize detected — skipping resume to avoid context overflow (#1650)', {
+        sessionDbId: session.sessionDbId,
+        previousMemorySessionId: session.memorySessionId,
+        lastPromptNumber: session.lastPromptNumber
+      });
     }
 
     // Wait for agent pool slot (configurable via CLAUDE_MEM_MAX_CONCURRENT_AGENTS)
@@ -113,7 +130,7 @@ export class SDKAgent {
 
     // Debug-level alignment logs for detailed tracing
     if (session.lastPromptNumber > 1) {
-      logger.debug('SDK', `[ALIGNMENT] Resume Decision | contentSessionId=${session.contentSessionId} | memorySessionId=${session.memorySessionId} | prompt#=${session.lastPromptNumber} | hasRealMemorySessionId=${hasRealMemorySessionId} | shouldResume=${shouldResume} | resumeWith=${shouldResume ? session.memorySessionId : 'NONE'}`);
+      logger.debug('SDK', `[ALIGNMENT] Resume Decision | contentSessionId=${session.contentSessionId} | memorySessionId=${session.memorySessionId} | prompt#=${session.lastPromptNumber} | hasRealMemorySessionId=${hasRealMemorySessionId} | nextMessageIsSummarize=${nextMessageIsSummarize} | shouldResume=${shouldResume} | resumeWith=${shouldResume ? session.memorySessionId : 'NONE'}`);
     } else {
       // INIT prompt - never resume even if memorySessionId exists (stale from previous session)
       const hasStaleMemoryId = hasRealMemorySessionId;

--- a/src/services/worker/SDKAgent.ts
+++ b/src/services/worker/SDKAgent.ts
@@ -79,16 +79,6 @@ export class SDKAgent {
     // NEVER use contentSessionId for resume - that would inject messages into the user's transcript!
     const hasRealMemorySessionId = !!session.memorySessionId;
 
-    // Check if the next pending message is a summarize — if so, start fresh to avoid context overflow.
-    // buildSummaryPrompt is self-contained (includes lastAssistantMessage), so it doesn't need
-    // the full accumulated observation history. Resuming with a bloated context causes
-    // "prompt is too long" errors on long sessions (fixes #1650).
-    const pendingStore = this.sessionManager.getPendingMessageStore();
-    const nextPendingMessages = pendingStore.getAllPending(session.sessionDbId);
-    const nextMessageIsSummarize = nextPendingMessages.length > 0 && nextPendingMessages[0].message_type === 'summarize';
-
-    const shouldResume = hasRealMemorySessionId && session.lastPromptNumber > 1 && !session.forceInit && !nextMessageIsSummarize;
-
     // Clear forceInit after using it
     if (session.forceInit) {
       logger.info('SDK', 'forceInit flag set, starting fresh SDK session', {
@@ -97,6 +87,23 @@ export class SDKAgent {
       });
       session.forceInit = false;
     }
+
+    // Wait for agent pool slot (configurable via CLAUDE_MEM_MAX_CONCURRENT_AGENTS)
+    const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+    const maxConcurrent = parseInt(settings.CLAUDE_MEM_MAX_CONCURRENT_AGENTS, 10) || 2;
+    await waitForSlot(maxConcurrent);
+
+    // Check if the next pending message is a summarize — if so, start fresh to avoid context overflow.
+    // buildSummaryPrompt is self-contained (includes lastAssistantMessage), so it doesn't need
+    // the full accumulated observation history. Resuming with a bloated context causes
+    // "prompt is too long" errors on long sessions (fixes #1650).
+    // NOTE: This check is intentionally done AFTER waitForSlot so we get a fresh snapshot
+    // of the pending queue (a summarize could have been enqueued during the slot wait).
+    const pendingStore = this.sessionManager.getPendingMessageStore();
+    const nextPendingMessages = pendingStore.getAllPending(session.sessionDbId);
+    const nextMessageIsSummarize = nextPendingMessages.length > 0 && nextPendingMessages[0].message_type === 'summarize';
+
+    const shouldResume = hasRealMemorySessionId && session.lastPromptNumber > 1 && !session.forceInit && !nextMessageIsSummarize;
 
     if (nextMessageIsSummarize && hasRealMemorySessionId && session.lastPromptNumber > 1) {
       logger.info('SDK', 'Summarize detected — skipping resume to avoid context overflow (#1650)', {
@@ -111,11 +118,6 @@ export class SDKAgent {
       // a summarize message that starts a fresh SDK session (fixes #1650).
       session.lastPromptNumber = 1;
     }
-
-    // Wait for agent pool slot (configurable via CLAUDE_MEM_MAX_CONCURRENT_AGENTS)
-    const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
-    const maxConcurrent = parseInt(settings.CLAUDE_MEM_MAX_CONCURRENT_AGENTS, 10) || 2;
-    await waitForSlot(maxConcurrent);
 
     // Build isolated environment from ~/.claude-mem/.env
     // This prevents Issue #733: random ANTHROPIC_API_KEY from project .env files

--- a/src/services/worker/SDKAgent.ts
+++ b/src/services/worker/SDKAgent.ts
@@ -79,6 +79,9 @@ export class SDKAgent {
     // NEVER use contentSessionId for resume - that would inject messages into the user's transcript!
     const hasRealMemorySessionId = !!session.memorySessionId;
 
+    // Capture before clearing so downstream shouldResume / summarize checks use the original value.
+    const originalForceInit = session.forceInit;
+
     // Clear forceInit after using it
     if (session.forceInit) {
       logger.info('SDK', 'forceInit flag set, starting fresh SDK session', {
@@ -103,7 +106,7 @@ export class SDKAgent {
     const nextPendingMessages = pendingStore.getAllPending(session.sessionDbId);
     const nextMessageIsSummarize = nextPendingMessages.length > 0 && nextPendingMessages[0].message_type === 'summarize';
 
-    const shouldResume = hasRealMemorySessionId && session.lastPromptNumber > 1 && !session.forceInit && !nextMessageIsSummarize;
+    const shouldResume = hasRealMemorySessionId && session.lastPromptNumber > 1 && !originalForceInit && !nextMessageIsSummarize;
 
     if (nextMessageIsSummarize && hasRealMemorySessionId && session.lastPromptNumber > 1) {
       logger.info('SDK', 'Summarize detected — skipping resume to avoid context overflow (#1650)', {
@@ -113,7 +116,7 @@ export class SDKAgent {
       });
     }
 
-    if (nextMessageIsSummarize && !shouldResume && !session.forceInit) {
+    if (nextMessageIsSummarize && !shouldResume && !originalForceInit) {
       // Force the init-prompt path so buildContinuationPrompt is never called for
       // a summarize message that starts a fresh SDK session (fixes #1650).
       session.lastPromptNumber = 1;

--- a/src/utils/uvx-path.ts
+++ b/src/utils/uvx-path.ts
@@ -59,10 +59,13 @@ export function getUvxPath(): string | null {
 export function getUvxPathOrThrow(): string {
   const uvxPath = getUvxPath();
   if (!uvxPath) {
+    const installInstructions = process.platform === 'win32'
+      ? 'Install it from https://astral.sh/uv or run: winget install astral-sh.uv\n' +
+        'Then ensure the uv installation directory is in your PATH.'
+      : 'Install it with: curl -LsSf https://astral.sh/uv/install.sh | sh\n' +
+        'Then ensure ~/.local/bin is in your PATH.';
     throw new Error(
-      'uvx is required but not found in PATH or common locations.\n' +
-      'Install it with: curl -LsSf https://astral.sh/uv/install.sh | sh\n' +
-      'Then ensure ~/.local/bin is in your PATH.'
+      `uvx is required but not found in PATH or common locations.\n${installInstructions}`
     );
   }
   return uvxPath;

--- a/src/utils/uvx-path.ts
+++ b/src/utils/uvx-path.ts
@@ -1,0 +1,69 @@
+/**
+ * Uvx Path Utility
+ *
+ * Resolves the uvx executable path for environments where uvx is not in PATH
+ * (e.g., launchd, cron, nohup contexts where ~/.local/bin is not included).
+ */
+
+import { spawnSync } from 'child_process';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { logger } from './logger.js';
+
+/**
+ * Get the uvx executable path.
+ * Tries PATH first, then checks common installation locations.
+ * Returns absolute path if found, null otherwise.
+ */
+export function getUvxPath(): string | null {
+  // Try PATH first
+  try {
+    const result = spawnSync('uvx', ['--version'], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      shell: false
+    });
+    if (result.status === 0) {
+      return 'uvx'; // Available in PATH
+    }
+  } catch (e) {
+    logger.debug('SYSTEM', 'uvx not found in PATH, checking common installation locations', {
+      error: e instanceof Error ? e.message : String(e)
+    });
+  }
+
+  // Check common installation paths
+  const uvxPaths = [
+    join(homedir(), '.local', 'bin', 'uvx'),   // Default uv/uvx install on Linux/macOS
+    join(homedir(), '.cargo', 'bin', 'uvx'),    // Cargo-based install
+    '/opt/homebrew/bin/uvx',                    // Homebrew on Apple Silicon
+    '/usr/local/bin/uvx',                       // Homebrew on Intel / manual install
+    '/usr/bin/uvx',
+  ];
+
+  for (const uvxPath of uvxPaths) {
+    if (existsSync(uvxPath)) {
+      logger.debug('SYSTEM', 'Found uvx at known location', { path: uvxPath });
+      return uvxPath;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Get the uvx executable path or throw an error.
+ * Use this when uvx is required for operation.
+ */
+export function getUvxPathOrThrow(): string {
+  const uvxPath = getUvxPath();
+  if (!uvxPath) {
+    throw new Error(
+      'uvx is required but not found in PATH or common locations.\n' +
+      'Install it with: curl -LsSf https://astral.sh/uv/install.sh | sh\n' +
+      'Then ensure ~/.local/bin is in your PATH.'
+    );
+  }
+  return uvxPath;
+}


### PR DESCRIPTION
Supersedes #1703 (from octo-patch/claude-mem — no longer writable).

Changes + CodeRabbit fixes applied:
- Skip SDK session resume when next pending message is summarize
- Fix JS tree-sitter class query: `type_identifier` → `identifier` for correct JS class name capture
- `getCombinedCertPath()` uses `getUvxPath() ?? 'uvx'` for non-interactive context
- Reset `session.lastPromptNumber = 1` when summarize skips resume, so init prompt is used

Closes #1650