### PR TITLE
fix(windows): kill zombie port owner before spawning new worker

### DIFF
--- a/src/services/infrastructure/HealthMonitor.ts
+++ b/src/services/infrastructure/HealthMonitor.ts
@@ -11,6 +11,7 @@
 
 import path from 'path';
 import net from 'net';
+import { execSync } from 'child_process';
 import { readFileSync } from 'fs';
 import { logger } from '../../utils/logger.js';
 import { MARKETPLACE_ROOT } from '../../shared/paths.js';
@@ -46,16 +47,19 @@ async function httpRequestToWorker(
  */
 export async function isPortInUse(port: number): Promise<boolean> {
   if (process.platform === 'win32') {
-    // APPROVED OVERRIDE: Windows keeps HTTP health check because socket bind
-    // semantics differ (SO_REUSEADDR defaults, firewall prompts). The TOCTOU
-    // race remains on Windows but is an accepted limitation — the atomic
-    // socket approach would cause false positives or UAC popups.
+    // First: try HTTP health check (fast path — worker is alive and responding)
     try {
       const response = await fetch(`http://127.0.0.1:${port}/api/health`);
-      return response.ok;
+      if (response.ok) return true;
     } catch {
-      return false;
+      // Worker not responding — but port might still be occupied
     }
+
+    // Second: check OS-level TCP state via PowerShell.
+    // This catches zombie ports: the worker process crashed but Windows TCP
+    // stack still holds the port in LISTEN/TIME_WAIT/CLOSE_WAIT state.
+    // Without this check, spawn() succeeds but the new worker fails to bind.
+    return isPortOccupiedWindows(port);
   }
 
   // Unix: atomic socket bind check — no TOCTOU race
@@ -73,6 +77,51 @@ export async function isPortInUse(port: number): Promise<boolean> {
     });
     server.listen(port, '127.0.0.1');
   });
+}
+
+/**
+ * Windows-specific: check if a port is occupied at the OS level using
+ * Get-NetTCPConnection. This catches zombie ports where the process
+ * crashed but TCP state lingers (TIME_WAIT, CLOSE_WAIT, or orphaned LISTEN).
+ *
+ * Returns true if the port has any active TCP connection (regardless of state).
+ */
+function isPortOccupiedWindows(port: number): boolean {
+  try {
+    const output = execSync(
+      `powershell -NoProfile -NonInteractive -Command "(Get-NetTCPConnection -LocalPort ${port} -ErrorAction SilentlyContinue | Measure-Object).Count"`,
+      { encoding: 'utf-8', timeout: 5000, windowsHide: true }
+    ).trim();
+    return parseInt(output, 10) > 0;
+  } catch {
+    // If PowerShell fails, assume port is free
+    return false;
+  }
+}
+
+/**
+ * Windows-specific: find the PID of the process holding a port in LISTEN state.
+ * Returns the PID, or null if no process found or if the port is only in TIME_WAIT.
+ *
+ * Only returns PIDs in Listen state — TIME_WAIT connections have no owning process
+ * that can be killed (they are handled by the OS TCP stack).
+ */
+export function getPortOwnerPidWindows(port: number): number | null {
+  if (process.platform !== 'win32') return null;
+
+  try {
+    const output = execSync(
+      `powershell -NoProfile -NonInteractive -Command "Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess"`,
+      { encoding: 'utf-8', timeout: 5000, windowsHide: true }
+    ).trim();
+
+    if (!output) return null;
+
+    const pid = parseInt(output.split('\n')[0].trim(), 10);
+    return (Number.isInteger(pid) && pid > 0) ? pid : null;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/src/services/worker-spawner.ts
+++ b/src/services/worker-spawner.ts
@@ -24,6 +24,7 @@ import { HOOK_TIMEOUTS } from '../shared/hook-constants.js';
 import { SettingsDefaultsManager } from '../shared/SettingsDefaultsManager.js';
 import {
   cleanStalePidFile,
+  forceKillProcess,
   getPlatformTimeout,
   removePidFile,
   spawnDaemon,
@@ -33,6 +34,7 @@ import {
   isPortInUse,
   waitForHealth,
   waitForReadiness,
+  getPortOwnerPidWindows,
 } from './infrastructure/HealthMonitor.js';
 
 // Windows: avoid repeated spawn popups when startup fails (issue #921)
@@ -167,8 +169,43 @@ export async function ensureWorkerStarted(
       logger.info('SYSTEM', 'Worker is now healthy');
       return true;
     }
-    logger.error('SYSTEM', 'Port in use but worker not responding to health checks');
-    return false;
+
+    // Windows: port is occupied but nobody responds to health checks.
+    // This happens when a worker process crashed but the OS still holds the port
+    // (zombie port). Try to find and kill the owning process so a new worker can bind.
+    if (process.platform === 'win32') {
+      const zombiePid = getPortOwnerPidWindows(port);
+      if (zombiePid !== null && zombiePid !== process.pid) {
+        logger.warn('SYSTEM', 'Port occupied by unresponsive process, killing zombie', { port, zombiePid });
+        try {
+          await forceKillProcess(zombiePid);
+          // Wait briefly for port to be released after kill
+          const { waitForPortFree } = await import('./infrastructure/HealthMonitor.js');
+          const portFreed = await waitForPortFree(port, 5000);
+          if (portFreed) {
+            logger.info('SYSTEM', 'Zombie process killed, port freed — proceeding to spawn');
+            // Fall through to spawn logic below instead of returning false
+          } else {
+            logger.error('SYSTEM', 'Killed zombie process but port still occupied (TIME_WAIT). Will retry after cooldown.');
+            return false;
+          }
+        } catch (error) {
+          logger.error('SYSTEM', 'Failed to kill zombie port owner', { zombiePid }, error as Error);
+          return false;
+        }
+      } else if (zombiePid === null) {
+        // Port is in TIME_WAIT with no owning process — OS will release it eventually.
+        // On Windows, TIME_WAIT typically lasts ~2 minutes.
+        logger.warn('SYSTEM', 'Port in TIME_WAIT state (no owning process). Will retry after cooldown.');
+        return false;
+      } else {
+        logger.error('SYSTEM', 'Port in use but worker not responding to health checks');
+        return false;
+      }
+    } else {
+      logger.error('SYSTEM', 'Port in use but worker not responding to health checks');
+      return false;
+    }
   }
 
   // Windows: skip spawn if a recent attempt already failed (issue #921)


### PR DESCRIPTION
## Summary

Fixes #1720 — Worker fails to restart on Windows when a crashed worker leaves the port occupied (zombie port).

- **HealthMonitor.ts**: Add OS-level port check via `Get-NetTCPConnection` as fallback when HTTP health check fails on Windows. Also adds `getPortOwnerPidWindows()` to identify the PID holding a port in LISTEN state.
- **worker-spawner.ts**: When port is occupied but unresponsive, kill the zombie process owner and wait for port release before spawning a new worker. Distinguishes TIME_WAIT (no owner, OS will release) from zombie LISTEN (stale process, safe to kill).

## Problem

On Windows, when the worker process crashes, the OS TCP stack retains the port in LISTEN or TIME_WAIT state. The existing `isPortInUse()` only checks HTTP health (returns false for dead processes), so the spawner thinks the port is free, attempts spawn, and the new worker fails to bind. The 2-minute Windows cooldown then blocks all retries.

```
[ERROR] ✗ Worker failed to start Failed to start server. Is port 37777 in use?
[WARN ] Worker unavailable on Windows — skipping spawn (recent attempt failed within cooldown)
```

## Solution

```
Before: HTTP check fails → port "free" → spawn → bind fails → 2min cooldown → repeat
After:  HTTP check fails → OS port check → zombie detected → kill zombie → spawn → success
```

Three cases handled:
1. **Zombie LISTEN** (crashed worker, PID still exists) → kill it, wait for port free, spawn
2. **TIME_WAIT** (no owning PID, OS will release in ~2min) → log, return false, retry after cooldown
3. **Port truly free** → proceed to spawn as before

## Test plan

- [x] Tested on Windows 11 with concurrent Claude Code sessions
- [x] Verified `Get-NetTCPConnection` correctly detects zombie ports
- [x] Verified zombie process is killed and port freed before new spawn
- [x] Verified TIME_WAIT state is correctly identified (no false kills)
- [ ] Unix behavior unchanged (no code path changes for non-Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)