### PR TITLE
fix(deps): upgrade glob ^11.0.3 → ^13.0.0 (fixes #1717)

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "ansi-to-html": "^0.7.2",
     "dompurify": "^3.3.1",
     "express": "^4.18.2",
-    "glob": "^11.0.3",
+    "glob": "^13.0.0",
     "handlebars": "^4.7.8",
     "picocolors": "^1.1.1",
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary

Upgrades `glob` from the deprecated `^11.0.3` to the current stable `^13.0.0`, resolving #1717.

- The npm maintainer deprecated all glob releases below v13, citing widely-publicised security vulnerabilities (including ReDoS risks).
- Users on security-hardened environments (`socket-dev`, strict audit configs) receive blocking warnings or failures on install.

## Compatibility verification

Searched all call sites with `globSync` in the codebase:

| File | Usage |
|---|---|
| `src/services/transcripts/watcher.ts` | `globSync(pattern, { nodir: true, absolute: true })` |
| `scripts/analyze-transformations-smart.js` | `globSync(path.join(dir, '*.jsonl'))` |

The `globSync` function and both `nodir` / `absolute` options have **identical signatures** in glob@13. No call-site changes are needed.

The only breaking change between v11→v13 was removal of the Minipass streaming API (the `Glob` class `.stream()` methods) in v12 — which this codebase does not use.

## Test plan

- [ ] `npm install` completes without glob deprecation warning
- [ ] `npm audit` reports no glob-related vulnerabilities
- [ ] Transcript watcher resolves files correctly (`globSync` paths)
- [ ] Existing tests pass: `bun test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)