### PR TITLE
fix: support ANTHROPIC_AUTH_TOKEN and ANTHROPIC_BASE_URL in ~/.claude-mem/.env

### DIFF
--- a/src/shared/EnvManager.ts
+++ b/src/shared/EnvManager.ts
@@ -33,6 +33,8 @@ const BLOCKED_ENV_VARS = [
 // Credential keys that claude-mem manages
 export const MANAGED_CREDENTIAL_KEYS = [
   'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'ANTHROPIC_BASE_URL',
   'GEMINI_API_KEY',
   'OPENROUTER_API_KEY',
 ];
@@ -40,6 +42,9 @@ export const MANAGED_CREDENTIAL_KEYS = [
 export interface ClaudeMemEnv {
   // Credentials (optional - empty means use CLI billing for Claude)
   ANTHROPIC_API_KEY?: string;
+  // Third-party Anthropic-compatible provider auth (e.g. z.ai, AWS Bedrock)
+  ANTHROPIC_AUTH_TOKEN?: string;
+  ANTHROPIC_BASE_URL?: string;
   GEMINI_API_KEY?: string;
   OPENROUTER_API_KEY?: string;
 }
@@ -115,6 +120,8 @@ export function loadClaudeMemEnv(): ClaudeMemEnv {
     // Only return managed credential keys
     const result: ClaudeMemEnv = {};
     if (parsed.ANTHROPIC_API_KEY) result.ANTHROPIC_API_KEY = parsed.ANTHROPIC_API_KEY;
+    if (parsed.ANTHROPIC_AUTH_TOKEN) result.ANTHROPIC_AUTH_TOKEN = parsed.ANTHROPIC_AUTH_TOKEN;
+    if (parsed.ANTHROPIC_BASE_URL) result.ANTHROPIC_BASE_URL = parsed.ANTHROPIC_BASE_URL;
     if (parsed.GEMINI_API_KEY) result.GEMINI_API_KEY = parsed.GEMINI_API_KEY;
     if (parsed.OPENROUTER_API_KEY) result.OPENROUTER_API_KEY = parsed.OPENROUTER_API_KEY;
 
@@ -149,6 +156,20 @@ export function saveClaudeMemEnv(env: ClaudeMemEnv): void {
         updated.ANTHROPIC_API_KEY = env.ANTHROPIC_API_KEY;
       } else {
         delete updated.ANTHROPIC_API_KEY;
+      }
+    }
+    if (env.ANTHROPIC_AUTH_TOKEN !== undefined) {
+      if (env.ANTHROPIC_AUTH_TOKEN) {
+        updated.ANTHROPIC_AUTH_TOKEN = env.ANTHROPIC_AUTH_TOKEN;
+      } else {
+        delete updated.ANTHROPIC_AUTH_TOKEN;
+      }
+    }
+    if (env.ANTHROPIC_BASE_URL !== undefined) {
+      if (env.ANTHROPIC_BASE_URL) {
+        updated.ANTHROPIC_BASE_URL = env.ANTHROPIC_BASE_URL;
+      } else {
+        delete updated.ANTHROPIC_BASE_URL;
       }
     }
     if (env.GEMINI_API_KEY !== undefined) {
@@ -209,6 +230,15 @@ export function buildIsolatedEnv(includeCredentials: boolean = true): Record<str
     // If not configured, CLI billing will be used (via ANTHROPIC_AUTH_TOKEN passthrough)
     if (credentials.ANTHROPIC_API_KEY) {
       isolatedEnv.ANTHROPIC_API_KEY = credentials.ANTHROPIC_API_KEY;
+    }
+    // Inject third-party Anthropic-compatible provider auth from ~/.claude-mem/.env
+    // These take precedence over any ambient shell values so users can configure
+    // providers like z.ai, AWS Bedrock, etc. without modifying their shell profile.
+    if (credentials.ANTHROPIC_AUTH_TOKEN) {
+      isolatedEnv.ANTHROPIC_AUTH_TOKEN = credentials.ANTHROPIC_AUTH_TOKEN;
+    }
+    if (credentials.ANTHROPIC_BASE_URL) {
+      isolatedEnv.ANTHROPIC_BASE_URL = credentials.ANTHROPIC_BASE_URL;
     }
     // Note: GEMINI_API_KEY and OPENROUTER_API_KEY pass through from process.env,
     // but claude-mem's .env takes precedence if configured


### PR DESCRIPTION
Fixes #1704

## Problem
Third-party Anthropic-compatible providers (z.ai, AWS Bedrock, OpenRouter via direct auth, etc.) use `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_BASE_URL` instead of `ANTHROPIC_API_KEY`. While these variables already pass through to the SDK subprocess when set in the shell environment, users who configure them in `~/.claude-mem/.env` received no forwarding — the SDK subprocess launched without them, resulting in "Not logged in" errors and zero observations.

## Solution
Add `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_BASE_URL` to `EnvManager`'s managed credential set:

- Added to `MANAGED_CREDENTIAL_KEYS` and the `ClaudeMemEnv` interface
- Parsed from `~/.claude-mem/.env` in `loadClaudeMemEnv()`
- Persisted via `saveClaudeMemEnv()`
- Injected into subprocess env in `buildIsolatedEnv()` with precedence over ambient shell values

Variables set in the shell environment already passed through (they're not in `BLOCKED_ENV_VARS`). This change adds `.env` file support to complete the picture.

## Testing
- Set `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_BASE_URL` in `~/.claude-mem/.env`
- Confirm the SDK subprocess receives them (visible in worker debug logs when env vars are present)
- Existing behavior for `ANTHROPIC_API_KEY` and CLI subscription billing is unchanged