### PR TITLE
fix(file-context): preserve targeted reads + invalidate on mtime (#1719)

### DIFF
--- a/src/cli/handlers/file-context.ts
+++ b/src/cli/handlers/file-context.ts
@@ -106,7 +106,11 @@ function deduplicateObservations(
   return scored.slice(0, displayLimit).map(s => s.obs);
 }
 
-function formatFileTimeline(observations: ObservationRow[], filePath: string): string {
+function formatFileTimeline(
+  observations: ObservationRow[],
+  filePath: string,
+  truncated: boolean
+): string {
   // Escape filePath for safe interpolation into recovery hints (quotes, backslashes, newlines)
   const safePath = filePath.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
   // Group observations by day
@@ -136,9 +140,13 @@ function formatFileTimeline(observations: ObservationRow[], filePath: string): s
   }).toLowerCase().replace(' ', '');
   const currentTimezone = now.toLocaleTimeString('en-US', { timeZoneName: 'short' }).split(' ').pop();
 
+  const headerLine = truncated
+    ? `This file has prior observations. Only line 1 was read to save tokens.`
+    : `This file has prior observations. The requested section was read normally.`;
+
   const lines: string[] = [
     `Current: ${currentDate} ${currentTime} ${currentTimezone}`,
-    `This file has prior observations. Only line 1 was read to save tokens.`,
+    headerLine,
     `- **Already know enough?** The timeline below may be all you need (semantic priming).`,
     `- **Need details?** get_observations([IDs]) — ~300 tokens each.`,
     `- **Need full file?** Read again with offset/limit for the section you need.`,
@@ -170,16 +178,28 @@ export const fileContextHandler: EventHandler = {
       return { continue: true, suppressOutput: true };
     }
 
-    // Skip gate for files below the token-economics threshold — timeline (~370 tokens)
-    // costs more than reading small files directly.
+    // Honor user-supplied offset/limit so Claude can re-read specific sections
+    // after the initial truncated read. Without this, the hook strips offset/limit
+    // and the Claude Code harness's read-dedup cache returns "File unchanged"
+    // because every rewritten input collapses to the same {file_path, limit:1}.
+    // See issue #1719.
+    const userOffset = typeof toolInput?.offset === 'number' ? (toolInput.offset as number) : undefined;
+    const userLimit = typeof toolInput?.limit === 'number' ? (toolInput.limit as number) : undefined;
+    const isTargetedRead = userOffset !== undefined || userLimit !== undefined;
+
+    // Stat the file once: we need both size (gate) and mtime (cache invalidation).
+    let fileMtimeMs = 0;
     try {
       const statPath = path.isAbsolute(filePath)
         ? filePath
         : path.resolve(input.cwd || process.cwd(), filePath);
       const stat = statSync(statPath);
+      // Skip gate for files below the token-economics threshold — timeline (~370 tokens)
+      // costs more than reading small files directly.
       if (stat.size < FILE_READ_GATE_MIN_BYTES) {
         return { continue: true, suppressOutput: true };
       }
+      fileMtimeMs = stat.mtimeMs;
     } catch (err: any) {
       if (err.code === 'ENOENT') return { continue: true, suppressOutput: true };
       // Other errors (symlink, permission denied) — fall through and let gate proceed
@@ -227,25 +247,49 @@ export const fileContextHandler: EventHandler = {
         return { continue: true, suppressOutput: true };
       }
 
+      // mtime invalidation: if the file has been modified since the most recent
+      // observation, the cached timeline is stale. Pass the read through unchanged
+      // so Claude (or its parent agent after a subagent edit) sees fresh content.
+      // Observation epochs are in milliseconds, matching stat.mtimeMs.
+      if (fileMtimeMs > 0) {
+        const newestObservationMs = Math.max(...data.observations.map(o => o.created_at_epoch));
+        if (fileMtimeMs > newestObservationMs) {
+          logger.debug('HOOK', 'File modified since last observation, skipping truncation', {
+            filePath: relativePath,
+            fileMtimeMs,
+            newestObservationMs,
+          });
+          return { continue: true, suppressOutput: true };
+        }
+      }
+
       // Deduplicate: one per session, ranked by specificity to this file
       const dedupedObservations = deduplicateObservations(data.observations, relativePath, DISPLAY_LIMIT);
       if (dedupedObservations.length === 0) {
         return { continue: true, suppressOutput: true };
       }
 
-      // Allow the read with limit: 1 line — just enough for Edit's "file must be read"
-      // check to pass, while keeping token cost near zero. The observation timeline
-      // gives Claude full context about prior work on this file.
-      const timeline = formatFileTimeline(dedupedObservations, filePath);
+      // For an unconstrained read, truncate to 1 line — enough to satisfy Edit's
+      // "file must be read" precondition while keeping token cost near zero. For a
+      // targeted read (offset/limit supplied), preserve Claude's request so it can
+      // actually fetch the section it asked for. The observation timeline accompanies
+      // both as additional context.
+      const truncated = !isTargetedRead;
+      const timeline = formatFileTimeline(dedupedObservations, filePath, truncated);
+      const updatedInput: Record<string, unknown> = { file_path: filePath };
+      if (isTargetedRead) {
+        if (userOffset !== undefined) updatedInput.offset = userOffset;
+        if (userLimit !== undefined) updatedInput.limit = userLimit;
+      } else {
+        updatedInput.limit = 1;
+      }
+
       return {
         hookSpecificOutput: {
           hookEventName: 'PreToolUse',
           additionalContext: timeline,
           permissionDecision: 'allow',
-          updatedInput: {
-            file_path: filePath,
-            limit: 1,
-          },
+          updatedInput,
         },
       };
     } catch (error) {

--- a/src/cli/handlers/file-context.ts
+++ b/src/cli/handlers/file-context.ts
@@ -178,16 +178,15 @@ export const fileContextHandler: EventHandler = {
       return { continue: true, suppressOutput: true };
     }
 
-    // Honor user-supplied offset/limit so Claude can re-read specific sections
-    // after the initial truncated read. Without this, the hook strips offset/limit
-    // and the Claude Code harness's read-dedup cache returns "File unchanged"
-    // because every rewritten input collapses to the same {file_path, limit:1}.
-    // See issue #1719.
-    const userOffset = typeof toolInput?.offset === 'number' ? (toolInput.offset as number) : undefined;
-    const userLimit = typeof toolInput?.limit === 'number' ? (toolInput.limit as number) : undefined;
+    // Preserve user-supplied offset/limit to avoid read-dedup collisions (fixes #1719)
+    const userOffset = typeof toolInput?.offset === 'number' && Number.isFinite(toolInput.offset) && toolInput.offset >= 0
+      ? Math.floor(toolInput.offset) : undefined;
+    const userLimit = typeof toolInput?.limit === 'number' && Number.isFinite(toolInput.limit) && toolInput.limit > 0
+      ? Math.floor(toolInput.limit) : undefined;
     const isTargetedRead = userOffset !== undefined || userLimit !== undefined;
 
-    // Stat the file once: we need both size (gate) and mtime (cache invalidation).
+    // Stat the file once: size (gate) + mtime (cache invalidation).
+    // 0 = stat failed non-fatally (e.g. EPERM) — skip mtime check, fall through to truncation.
     let fileMtimeMs = 0;
     try {
       const statPath = path.isAbsolute(filePath)
@@ -247,13 +246,11 @@ export const fileContextHandler: EventHandler = {
         return { continue: true, suppressOutput: true };
       }
 
-      // mtime invalidation: if the file has been modified since the most recent
-      // observation, the cached timeline is stale. Pass the read through unchanged
-      // so Claude (or its parent agent after a subagent edit) sees fresh content.
-      // Observation epochs are in milliseconds, matching stat.mtimeMs.
+      // mtime invalidation: bypass truncation when the file is newer than the latest observation.
+      // Uses >= to handle same-millisecond edits (cost: one extra full read vs risk of stuck truncation).
       if (fileMtimeMs > 0) {
         const newestObservationMs = Math.max(...data.observations.map(o => o.created_at_epoch));
-        if (fileMtimeMs > newestObservationMs) {
+        if (fileMtimeMs >= newestObservationMs) {
           logger.debug('HOOK', 'File modified since last observation, skipping truncation', {
             filePath: relativePath,
             fileMtimeMs,
@@ -269,11 +266,7 @@ export const fileContextHandler: EventHandler = {
         return { continue: true, suppressOutput: true };
       }
 
-      // For an unconstrained read, truncate to 1 line — enough to satisfy Edit's
-      // "file must be read" precondition while keeping token cost near zero. For a
-      // targeted read (offset/limit supplied), preserve Claude's request so it can
-      // actually fetch the section it asked for. The observation timeline accompanies
-      // both as additional context.
+      // Unconstrained → truncate to 1 line; targeted → preserve offset/limit.
       const truncated = !isTargetedRead;
       const timeline = formatFileTimeline(dedupedObservations, filePath, truncated);
       const updatedInput: Record<string, unknown> = { file_path: filePath };

--- a/tests/hooks/file-context.test.ts
+++ b/tests/hooks/file-context.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for File Context Handler — Cache Validation Fix (#1719)
+ *
+ * Validates the two-part fix for the PreToolUse:Read hook getting stuck:
+ *
+ * 1. **Targeted re-reads pass through**: when Claude supplies offset/limit,
+ *    the hook preserves them instead of stripping to {limit:1}, so the Claude
+ *    Code harness's read-dedup cache doesn't trigger "File unchanged".
+ *
+ * 2. **mtime invalidation**: if the file has been modified since the most
+ *    recent observation timestamp (e.g., a subagent edited it), the hook
+ *    bypasses truncation entirely so the parent agent sees fresh content.
+ *
+ * 3. **Existing behavior preserved**: an unconstrained Read still gets
+ *    rewritten to {limit:1} alongside the observation timeline.
+ */
+import { describe, it, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test';
+import { mkdtempSync, writeFileSync, utimesSync, rmSync } from 'fs';
+import { tmpdir, homedir } from 'os';
+import { join } from 'path';
+
+// Mock modules that cause import chain issues — MUST be before handler imports
+mock.module('../../src/shared/SettingsDefaultsManager.js', () => ({
+  SettingsDefaultsManager: {
+    get: (key: string) => {
+      if (key === 'CLAUDE_MEM_DATA_DIR') return join(homedir(), '.claude-mem');
+      return '';
+    },
+    getInt: () => 0,
+    loadFromFile: () => ({ CLAUDE_MEM_EXCLUDED_PROJECTS: [] }),
+  },
+}));
+
+mock.module('../../src/shared/worker-utils.js', () => ({
+  ensureWorkerRunning: () => Promise.resolve(true),
+  getWorkerPort: () => 37777,
+  workerHttpRequest: (apiPath: string, options?: any) => {
+    const url = `http://127.0.0.1:37777${apiPath}`;
+    return globalThis.fetch(url, {
+      method: options?.method ?? 'GET',
+      headers: options?.headers,
+      body: options?.body,
+    });
+  },
+}));
+
+mock.module('../../src/utils/project-name.js', () => ({
+  getProjectName: () => 'test-project',
+  getProjectContext: () => ({ allProjects: ['test-project'] }),
+}));
+
+mock.module('../../src/utils/project-filter.js', () => ({
+  isProjectExcluded: () => false,
+}));
+
+// Import after mocks
+import { fileContextHandler } from '../../src/cli/handlers/file-context.js';
+import { logger } from '../../src/utils/logger.js';
+
+const PADDING = 'x'.repeat(2_000); // ensures file > FILE_READ_GATE_MIN_BYTES (1500)
+
+let tmpDir: string;
+let testFile: string;
+let loggerSpies: ReturnType<typeof spyOn>[] = [];
+let fetchSpy: ReturnType<typeof spyOn> | null = null;
+
+function makeObservationsResponse(observations: Array<{ id: number; created_at_epoch: number; type?: string; title?: string }>) {
+  return new Response(
+    JSON.stringify({
+      observations: observations.map(o => ({
+        id: o.id,
+        memory_session_id: `session-${o.id}`,
+        title: o.title ?? `Observation ${o.id}`,
+        type: o.type ?? 'discovery',
+        created_at_epoch: o.created_at_epoch,
+        files_read: JSON.stringify([]),
+        files_modified: JSON.stringify(['test.md']),
+      })),
+      count: observations.length,
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'file-context-test-'));
+  testFile = join(tmpDir, 'test.md');
+  writeFileSync(testFile, PADDING);
+
+  loggerSpies = [
+    spyOn(logger, 'info').mockImplementation(() => {}),
+    spyOn(logger, 'debug').mockImplementation(() => {}),
+    spyOn(logger, 'warn').mockImplementation(() => {}),
+    spyOn(logger, 'error').mockImplementation(() => {}),
+  ];
+});
+
+afterEach(() => {
+  loggerSpies.forEach(s => s.mockRestore());
+  if (fetchSpy) {
+    fetchSpy.mockRestore();
+    fetchSpy = null;
+  }
+  try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+});
+
+describe('fileContextHandler — cache validation fix (#1719)', () => {
+  it('truncates to limit:1 for an unconstrained Read (existing behavior)', async () => {
+    // File mtime is "now" (just written). Make observations newer to avoid mtime bypass.
+    const future = Date.now() + 60_000;
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      makeObservationsResponse([{ id: 1, created_at_epoch: future }])
+    );
+
+    const result = await fileContextHandler.execute({
+      sessionId: 'sess',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile },
+    });
+
+    expect(result.hookSpecificOutput).toBeDefined();
+    expect(result.hookSpecificOutput!.updatedInput).toEqual({
+      file_path: testFile,
+      limit: 1,
+    });
+  });
+
+  it('preserves user-supplied offset/limit on a targeted Read (#1719 fix)', async () => {
+    const future = Date.now() + 60_000;
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      makeObservationsResponse([{ id: 1, created_at_epoch: future }])
+    );
+
+    const result = await fileContextHandler.execute({
+      sessionId: 'sess',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile, offset: 289, limit: 140 },
+    });
+
+    expect(result.hookSpecificOutput).toBeDefined();
+    expect(result.hookSpecificOutput!.updatedInput).toEqual({
+      file_path: testFile,
+      offset: 289,
+      limit: 140,
+    });
+  });
+
+  it('preserves user-supplied limit only', async () => {
+    const future = Date.now() + 60_000;
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      makeObservationsResponse([{ id: 1, created_at_epoch: future }])
+    );
+
+    const result = await fileContextHandler.execute({
+      sessionId: 'sess',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile, limit: 50 },
+    });
+
+    expect(result.hookSpecificOutput!.updatedInput).toEqual({
+      file_path: testFile,
+      limit: 50,
+    });
+    // offset must NOT be present
+    expect((result.hookSpecificOutput!.updatedInput as any).offset).toBeUndefined();
+  });
+
+  it('bypasses truncation when file mtime is newer than newest observation (#1719 fix)', async () => {
+    // Backdate observations 1 hour into the past so the just-written file is newer.
+    const stale = Date.now() - 3_600_000;
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      makeObservationsResponse([
+        { id: 1, created_at_epoch: stale },
+        { id: 2, created_at_epoch: stale - 1000 },
+      ])
+    );
+
+    const result = await fileContextHandler.execute({
+      sessionId: 'sess',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile },
+    });
+
+    // Pass-through: no hookSpecificOutput, no updatedInput rewrite
+    expect(result.continue).toBe(true);
+    expect(result.hookSpecificOutput).toBeUndefined();
+  });
+
+  it('still truncates when file mtime is older than newest observation', async () => {
+    // Backdate the file by 1 hour, observations stamped "now"
+    const past = (Date.now() - 3_600_000) / 1000;
+    utimesSync(testFile, past, past);
+
+    const now = Date.now();
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      makeObservationsResponse([{ id: 1, created_at_epoch: now }])
+    );
+
+    const result = await fileContextHandler.execute({
+      sessionId: 'sess',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile },
+    });
+
+    expect(result.hookSpecificOutput).toBeDefined();
+    expect(result.hookSpecificOutput!.updatedInput).toEqual({
+      file_path: testFile,
+      limit: 1,
+    });
+  });
+
+  it('targeted-read header line reflects that the section was read normally', async () => {
+    const future = Date.now() + 60_000;
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      makeObservationsResponse([{ id: 1, created_at_epoch: future }])
+    );
+
+    const result = await fileContextHandler.execute({
+      sessionId: 'sess',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile, offset: 10, limit: 20 },
+    });
+
+    const ctx = result.hookSpecificOutput!.additionalContext;
+    expect(ctx).toContain('The requested section was read normally');
+    expect(ctx).not.toContain('Only line 1 was read');
+  });
+});

--- a/tests/hooks/file-context.test.ts
+++ b/tests/hooks/file-context.test.ts
@@ -1,19 +1,4 @@
-/**
- * Tests for File Context Handler — Cache Validation Fix (#1719)
- *
- * Validates the two-part fix for the PreToolUse:Read hook getting stuck:
- *
- * 1. **Targeted re-reads pass through**: when Claude supplies offset/limit,
- *    the hook preserves them instead of stripping to {limit:1}, so the Claude
- *    Code harness's read-dedup cache doesn't trigger "File unchanged".
- *
- * 2. **mtime invalidation**: if the file has been modified since the most
- *    recent observation timestamp (e.g., a subagent edited it), the hook
- *    bypasses truncation entirely so the parent agent sees fresh content.
- *
- * 3. **Existing behavior preserved**: an unconstrained Read still gets
- *    rewritten to {limit:1} alongside the observation timeline.
- */
+// Tests for file-context cache validation fix (#1719)
 import { describe, it, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test';
 import { mkdtempSync, writeFileSync, utimesSync, rmSync } from 'fs';
 import { tmpdir, homedir } from 'os';
@@ -145,6 +130,26 @@ describe('fileContextHandler — cache validation fix (#1719)', () => {
       offset: 289,
       limit: 140,
     });
+  });
+
+  it('preserves user-supplied offset only', async () => {
+    const future = Date.now() + 60_000;
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      makeObservationsResponse([{ id: 1, created_at_epoch: future }])
+    );
+
+    const result = await fileContextHandler.execute({
+      sessionId: 'sess',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile, offset: 100 },
+    });
+
+    expect(result.hookSpecificOutput!.updatedInput).toEqual({
+      file_path: testFile,
+      offset: 100,
+    });
+    expect((result.hookSpecificOutput!.updatedInput as any).limit).toBeUndefined();
   });
 
   it('preserves user-supplied limit only', async () => {


### PR DESCRIPTION
## Summary

Fixes #1719. The `PreToolUse:Read` hook in `file-context.ts` unconditionally rewrote the Read tool input to `{file_path, limit:1}`, which interacted with two failure modes that made files unreadable for the rest of a conversation:

1. **Subagent edits a file** → the parent agent's next Read still gets truncated because the cached observation snapshot predates the change.
2. **Claude requests a different section with `offset`/`limit`** → the hook strips them, so the Claude Code harness's read-dedup cache returns `"File unchanged since last read"` against the prior 1-line read. This contradicts the hook's own recovery hint: *"Read again with offset/limit for the section you need."*

I observed scenario (2) in a real session: a 1116-line architecture doc became permanently unreadable after the first hook-truncated read. Claude tried four targeted re-reads (`offset:12 limit:65`, `offset:289 limit:140`, etc.), and every attempt was rewritten to `{limit:1}` and then short-circuited with `"File unchanged"`. The eventual workaround was to abandon `Read` entirely and shell out to `Bash(sed -n '...')` — bypassing all hooks and observation tracking.

## Fix

Two complementary changes to `src/cli/handlers/file-context.ts`:

### 1. mtime invalidation (issue reporter's proposed fix)
We already `statSync` the file for the size gate. Now we also capture `mtimeMs` and compare it to the newest observation's `created_at_epoch`. If the file is newer, the cached timeline is stale → pass the read through unchanged so fresh content reaches Claude.

### 2. Targeted-read pass-through
When `toolInput` already specifies `offset` and/or `limit`, preserve them in `updatedInput` instead of collapsing to `{limit:1}`. The harness's dedup cache then sees a distinct input and lets the read proceed normally.

The unconstrained-read path (no offset, no limit) is **unchanged**: still truncated to 1 line plus the observation timeline, so token economics are preserved for the common case. The header line in the timeline is now conditional — it only claims *"Only line 1 was read"* when that's actually true.

## Test plan

Six new tests in `tests/hooks/file-context.test.ts` covering all branches:

- [x] Unconstrained Read still truncates to `{limit:1}` (existing behavior)
- [x] Targeted Read with `offset` + `limit` preserves both
- [x] Targeted Read with `limit` only preserves it without injecting `offset`
- [x] File mtime newer than newest observation → pass-through (no rewrite)
- [x] File mtime older than newest observation → still truncated
- [x] Header line in `additionalContext` reflects whether the read was truncated

All tests use real temp files (no `fs` mocking) and a mocked observations endpoint. Local results:

```
$ bun test tests/hooks/file-context.test.ts
 6 pass
 0 fail
 12 expect() calls

$ bun test tests/hooks/ tests/hook-constants.test.ts tests/hook-lifecycle.test.ts tests/hook-command.test.ts
 96 pass
 0 fail
 154 expect() calls
```

`npm run build` succeeds; no bundled artifacts committed (per the project's external-contributor convention — maintainer rebuilds).

## Notes

- The `formatFileTimeline` signature gained a `truncated: boolean` parameter. Only one caller, internal to this file.
- No new dependencies, no API changes outside this handler.
- Both fixes are independently useful and address different scenarios — keeping them in one PR because they share the file-context handler and the same observation-fetch path.