### PR TITLE
fix: reject URI schemes in isValidPathForClaudeMd to prevent phantom directories

### DIFF
--- a/src/utils/claude-md-utils.ts
+++ b/src/utils/claude-md-utils.ts
@@ -66,8 +66,20 @@ function isValidPathForClaudeMd(filePath: string, projectRoot?: string): boolean
   // Reject tilde paths (Node.js doesn't expand ~)
   if (filePath.startsWith('~')) return false;
 
-  // Reject URLs
+  // Reject URLs — http/https explicit (kept for readability)
   if (filePath.startsWith('http://') || filePath.startsWith('https://')) return false;
+
+  // Reject ANY URL scheme (gs://, s3://, file://, git://, ftp://, ssh://, ...).
+  // Root-cause fix for phantom directories like `gs:/bucket-name/...` which
+  // appeared when Bash commands referencing cloud-storage URLs leaked into
+  // filePaths via PostToolUse hooks. Using path.dirname('gs://foo/bar')
+  // yields 'gs:/foo' which Node then happily mkdir's.
+  if (filePath.includes('://')) return false;
+
+  // Reject paths starting with a URI scheme prefix (e.g., `file:`, `mailto:`,
+  // `javascript:`). Regex: RFC-3986-ish scheme — letter followed by
+  // [letters/digits/+/./-] then `:`.
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(filePath)) return false;
 
   // Reject paths with spaces (likely command text or PR references)
   if (filePath.includes(' ')) return false;

--- a/tests/utils/claude-md-utils.test.ts
+++ b/tests/utils/claude-md-utils.test.ts
@@ -594,6 +594,94 @@ describe('path validation in updateFolderClaudeMdFiles', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  // Regression: phantom CLAUDE.md directories created from URL schemes
+  // leaking into filePaths (e.g. Bash commands referencing `gs://bucket/obj`).
+  // Before the fix, `path.dirname('gs://foo/bar')` yielded `gs:/foo` which
+  // Node.js happily mkdir'd at the repo root.
+  it('should reject gs:// cloud storage URLs', async () => {
+    const fetchMock = mock(() => Promise.resolve({ ok: true } as Response));
+    global.fetch = fetchMock;
+
+    await updateFolderClaudeMdFiles(
+      ['gs://galaxy-hq-dev-harness/sessions/2026-04-11/foo/bar.jsonl'],
+      'test-project',
+      37777,
+      tempDir
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('should reject s3:// cloud storage URLs', async () => {
+    const fetchMock = mock(() => Promise.resolve({ ok: true } as Response));
+    global.fetch = fetchMock;
+
+    await updateFolderClaudeMdFiles(
+      ['s3://my-bucket/key/object.txt'],
+      'test-project',
+      37777,
+      tempDir
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('should reject file:// URLs', async () => {
+    const fetchMock = mock(() => Promise.resolve({ ok: true } as Response));
+    global.fetch = fetchMock;
+
+    await updateFolderClaudeMdFiles(
+      ['file:///etc/passwd'],
+      'test-project',
+      37777,
+      tempDir
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('should reject git:// URLs', async () => {
+    const fetchMock = mock(() => Promise.resolve({ ok: true } as Response));
+    global.fetch = fetchMock;
+
+    await updateFolderClaudeMdFiles(
+      ['git://github.com/foo/bar.git'],
+      'test-project',
+      37777,
+      tempDir
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('should reject mailto: URI scheme', async () => {
+    const fetchMock = mock(() => Promise.resolve({ ok: true } as Response));
+    global.fetch = fetchMock;
+
+    await updateFolderClaudeMdFiles(
+      ['mailto:user@example.com'],
+      'test-project',
+      37777,
+      tempDir
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('should reject javascript: URI scheme', async () => {
+    const fetchMock = mock(() => Promise.resolve({ ok: true } as Response));
+    global.fetch = fetchMock;
+
+    await updateFolderClaudeMdFiles(
+      ['javascript:alert(1)'],
+      'test-project',
+      37777,
+      tempDir
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('should reject paths with spaces', async () => {
     const fetchMock = mock(() => Promise.resolve({ ok: true } as Response));
     global.fetch = fetchMock;


### PR DESCRIPTION
## Summary

Rejects URI schemes (gs://, s3://, file://, git://, mailto:, javascript:, …) in `isValidPathForClaudeMd` so that `path.dirname()` on cloud-storage / protocol URLs can no longer leak through the path validator and cause phantom `gs:/`, `s3:/`, etc. directories to be created at the project root.

Surgical change — 14 lines added to `isValidPathForClaudeMd`, no behaviour change for existing non-URI paths. Optional-projectRoot path is untouched (the existing `should accept absolute paths when no projectRoot is provided` test still passes).

## Problem

`path.dirname('gs://galaxy-hq-dev-harness/sessions/2026-04-11/abc/obj.jsonl')` returns `'gs:/galaxy-hq-dev-harness/sessions/2026-04-11/abc'`, which:

- does not start with `http://` / `https://`
- does not contain a space or `#`
- resolves to an absolute path the projectRoot boundary check cannot constrain (because it looks like a root-anchored path)

So the validator accepts it, `writeClaudeMdToFolder` is called with `gs:/…`, and Node.js happily `mkdir`s a directory literally named `gs:` at the repo root. In a real Galaxy project this produced six phantom directories including deeply nested ones like `frontend/astro-insight/src/frontend/astro-insight/`, each with its own auto-generated `CLAUDE.md`.

Reproduction is trivial: run any Bash command referencing a cloud-storage URL (`gsutil cp /tmp/x gs://bucket/y`, `aws s3 cp … s3://…`, or even `git clone git://…`) in a project with claude-mem installed, then look at `git status`.

## Fix

Two cheap guards added to the existing validator:

```ts
// Reject ANY URL scheme (gs://, s3://, file://, git://, ftp://, ssh://, ...).
if (filePath.includes('://')) return false;

// Reject paths starting with a URI scheme prefix (e.g., `file:`, `mailto:`).
if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(filePath)) return false;
```

Placed right after the existing `http://` / `https://` short-circuit so the common case remains O(1).

## Tests

6 new regression tests added to `tests/utils/claude-md-utils.test.ts` under the existing `'path validation in updateFolderClaudeMdFiles'` describe block:

- `should reject gs:// cloud storage URLs`
- `should reject s3:// cloud storage URLs`
- `should reject file:// URLs`
- `should reject git:// URLs`
- `should reject mailto: URI scheme`
- `should reject javascript: URI scheme`

All follow the existing test pattern (mock fetch, call `updateFolderClaudeMdFiles`, assert `fetchMock` not called). All previously-passing tests remain green — the `should accept absolute paths when no projectRoot is provided` contract is intentionally untouched.

## Scope

This PR is intentionally narrow and defensive. A separate follow-up issue will be filed to discuss the broader architectural question of whether folder-level `CLAUDE.md` auto-writes should be opt-in or gated by git-tracked status, which is out of scope for this fix.

## Checklist

- [x] Minimal surgical change (14 LOC in src + 88 LOC in tests)
- [x] No breaking behavior for existing tests
- [x] Regression coverage for 6 URI scheme families
- [x] Root cause explained with concrete reproduction