### PR TITLE
fix: migration 7 unique-constraint check incorrectly matches primary-key index

### DIFF
--- a/src/services/sqlite/migrations/runner.ts
+++ b/src/services/sqlite/migrations/runner.ts
@@ -189,7 +189,13 @@ export class MigrationRunner {
   private removeSessionSummariesUniqueConstraint(): void {
     // Check actual constraint state — don't rely on version tracking alone (issue #979)
     const summariesIndexes = this.db.query('PRAGMA index_list(session_summaries)').all() as IndexInfo[];
-    const hasUniqueConstraint = summariesIndexes.some(idx => idx.unique === 1);
+    // Only count non-primary-key unique indexes.
+    // PRAGMA index_list returns the PK index with unique=1 and origin='pk', so
+    // checking unique===1 alone always returns true, causing the table to be
+    // unnecessarily re-created on every startup after migration 7 already ran.
+    const hasUniqueConstraint = summariesIndexes.some(
+      idx => idx.unique === 1 && idx.origin !== 'pk'
+    );
 
     if (!hasUniqueConstraint) {
       // Already migrated (no constraint exists)


### PR DESCRIPTION
## Problem

`removeSessionSummariesUniqueConstraint()` (migration 7) checks whether the UNIQUE constraint still exists on `session_summaries` with:

```ts
const hasUniqueConstraint = summariesIndexes.some(idx => idx.unique === 1);
```

SQLite's `PRAGMA index_list` returns every index on the table, including the implicit index backing the `id INTEGER PRIMARY KEY AUTOINCREMENT` column. That PK index has `unique = 1` and `origin = 'pk'`, so `hasUniqueConstraint` is **always `true`**.

Consequence: the early-return branch (`if (!hasUniqueConstraint) return`) never fires, and the full DROP + CREATE + INSERT + RENAME DDL block executes on **every worker startup** after migration 7 should already be complete.

## Fix

Filter by `origin` to exclude primary-key indexes:

```ts
// Before
const hasUniqueConstraint = summariesIndexes.some(idx => idx.unique === 1);

// After
const hasUniqueConstraint = summariesIndexes.some(
  idx => idx.unique === 1 && idx.origin !== 'pk'
);
```

With this change, once the `UNIQUE` constraint index (origin `'u'`) has been removed, the check correctly returns `false` and the migration short-circuits without re-creating the table.

## Testing

Manual verification: after the fix, a database that has already undergone migration 7 will skip the table-recreation path on subsequent startups.

Closes #1749

---
Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>