### PR TITLE
fix: strengthen summary prompt to prevent <observation> tag leakage (#1753)

### DIFF
--- a/src/sdk/prompts.ts
+++ b/src/sdk/prompts.ts
@@ -135,16 +135,24 @@ export function buildSummaryPrompt(session: SDKSession, mode: ModeConfig): strin
   })();
 
   return `--- MODE SWITCH: PROGRESS SUMMARY ---
-Do NOT output <observation> tags. This is a summary request, not an observation request.
-Your response MUST use <summary> tags ONLY. Any <observation> output will be discarded.
+CRITICAL: Output ONLY <summary> tags. Do NOT output <observation> tags.
+Your response MUST be wrapped in <summary>...</summary> XML tags.
 
 ${mode.prompts.header_summary_checkpoint}
 ${mode.prompts.summary_instruction}
+
+USER'S ORIGINAL REQUEST:
+${session.user_prompt}
 
 ${mode.prompts.summary_context_label}
 ${lastAssistantMessage}
 
 ${mode.prompts.summary_format_instruction}
+
+REMINDER: You are in SUMMARY MODE. Output <summary> tags ONLY.
+REMINDER: Do NOT output <observation> tags. Only <summary> tags will be parsed.
+CRITICAL: Your entire response must be wrapped in <summary>...</summary>
+
 <summary>
   <request>${mode.prompts.xml_summary_request_placeholder}</request>
   <investigated>${mode.prompts.xml_summary_investigated_placeholder}</investigated>

--- a/tests/sdk/prompts.test.ts
+++ b/tests/sdk/prompts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 
-import { buildObservationPrompt } from '../../src/sdk/prompts.js';
+import { buildObservationPrompt, buildSummaryPrompt, type SDKSession } from '../../src/sdk/prompts.js';
+import type { ModeConfig } from '../../src/services/domain/types.js';
 
 describe('buildObservationPrompt', () => {
   it('instructs the observer to avoid prose skip responses', () => {
@@ -16,5 +17,91 @@ describe('buildObservationPrompt', () => {
     expect(prompt).toContain('Return either one or more <observation>...</observation> blocks, or an empty response');
     expect(prompt).toContain('Concrete debugging findings from logs, queue state, database rows, session routing, or code-path inspection');
     expect(prompt).toContain('Never reply with prose such as "Skipping", "No substantive tool executions"');
+  });
+});
+
+// Minimal mock ModeConfig for testing buildSummaryPrompt
+const mockMode: ModeConfig = {
+  name: 'test-mode',
+  description: 'Test mode',
+  version: '1.0.0',
+  observation_types: [],
+  observation_concepts: [],
+  prompts: {
+    system_identity: 'You are a test observer.',
+    spatial_awareness: 'Test spatial awareness.',
+    observer_role: 'Test observer role.',
+    recording_focus: 'Test recording focus.',
+    skip_guidance: 'Test skip guidance.',
+    type_guidance: 'Test type guidance.',
+    concept_guidance: 'Test concept guidance.',
+    field_guidance: 'Test field guidance.',
+    output_format_header: 'Test output format header.',
+    format_examples: 'Test format examples.',
+    footer: 'Test footer.',
+    xml_title_placeholder: '[title placeholder]',
+    xml_subtitle_placeholder: '[subtitle placeholder]',
+    xml_fact_placeholder: '[fact placeholder]',
+    xml_narrative_placeholder: '[narrative placeholder]',
+    xml_concept_placeholder: '[concept placeholder]',
+    xml_file_placeholder: '[file placeholder]',
+    xml_summary_request_placeholder: '[request placeholder]',
+    xml_summary_investigated_placeholder: '[investigated placeholder]',
+    xml_summary_learned_placeholder: '[learned placeholder]',
+    xml_summary_completed_placeholder: '[completed placeholder]',
+    xml_summary_next_steps_placeholder: '[next_steps placeholder]',
+    xml_summary_notes_placeholder: '[notes placeholder]',
+    header_memory_start: 'MEMORY PROCESSING START',
+    header_memory_continued: 'MEMORY PROCESSING CONTINUED',
+    header_summary_checkpoint: 'PROGRESS SUMMARY CHECKPOINT',
+    continuation_greeting: 'Hello test agent.',
+    continuation_instruction: 'Continue observing.',
+    summary_instruction: 'Write a progress summary.',
+    summary_context_label: "Claude's Response:",
+    summary_format_instruction: 'Respond in this XML format:',
+    summary_footer: 'End of summary.',
+  },
+};
+
+describe('buildSummaryPrompt', () => {
+  const mockSession: SDKSession = {
+    id: 1,
+    memory_session_id: 'mem-123',
+    project: 'test-project',
+    user_prompt: 'Fix the authentication bug in the login module',
+    last_assistant_message: 'I have analyzed the authentication flow and found the issue.',
+  };
+
+  it('includes user_prompt in the generated prompt', () => {
+    const prompt = buildSummaryPrompt(mockSession, mockMode);
+    expect(prompt).toContain('USER\'S ORIGINAL REQUEST:');
+    expect(prompt).toContain('Fix the authentication bug in the login module');
+  });
+
+  it('includes last_assistant_message in the generated prompt', () => {
+    const prompt = buildSummaryPrompt(mockSession, mockMode);
+    expect(prompt).toContain("Claude's Response:");
+    expect(prompt).toContain('I have analyzed the authentication flow and found the issue.');
+  });
+
+  it('includes MODE SWITCH header', () => {
+    const prompt = buildSummaryPrompt(mockSession, mockMode);
+    expect(prompt).toContain('MODE SWITCH: PROGRESS SUMMARY');
+  });
+
+  it('instructs to NOT output observation tags', () => {
+    const prompt = buildSummaryPrompt(mockSession, mockMode);
+    expect(prompt).toContain('Do NOT output <observation> tags');
+    expect(prompt).toContain('<summary>');
+  });
+
+  it('includes summary XML structure', () => {
+    const prompt = buildSummaryPrompt(mockSession, mockMode);
+    expect(prompt).toContain('<request>');
+    expect(prompt).toContain('<investigated>');
+    expect(prompt).toContain('<learned>');
+    expect(prompt).toContain('<completed>');
+    expect(prompt).toContain('<next_steps>');
+    expect(prompt).toContain('<notes>');
   });
 });


### PR DESCRIPTION
## Summary

Fixes issue #1753 by strengthening the `buildSummaryPrompt()` function with two key improvements:

### Changes

1. **Add user_prompt to Summary context** (Problem B fix)
   - Added `USER'S ORIGINAL REQUEST: ${session.user_prompt}` section to the Summary prompt
   - Previously `user_prompt` was passed but never used

2. **Repeated reinforcement warnings** (Problem A mitigation)
   - Added multiple `CRITICAL` and `REMINDER` warnings throughout the prompt
   - Placed before, during, and after the XML structure
   - Explicitly instructs LLM to output `<summary>` tags ONLY

### No Further Refactoring Planned

Per discussion, this PR uses the **prompt reinforcement approach** rather than the parallel execution方案B originally discussed. No follow-up refactoring for parallel observation/summary processing is planned.

## Test Results

```
bun test tests/sdk/prompts.test.ts
  6 pass - 16 expect() calls
```

## Files Changed

- `src/sdk/prompts.ts` - Strengthened Summary prompt
- `tests/sdk/prompts.test.ts` - Added 5 test cases for buildSummaryPrompt()

## Related

- Issue #1753
- Commit #1345 (previous partial fix)