### PR TITLE
feat: Pass mode prompts as system prompt for improved instruction adherence

### DIFF
--- a/src/sdk/prompts.ts
+++ b/src/sdk/prompts.ts
@@ -24,15 +24,23 @@ export interface SDKSession {
 }
 
 /**
- * Build initial prompt to initialize the SDK agent
+ * Build system prompt from mode configuration.
+ * This contains all the system-level instructions that should be passed as
+ * the SDK's systemPrompt option rather than buried in user messages.
+ *
+ * Following Anthropic's context engineering best practices:
+ * - Minimal: Only system-level directives
+ * - Structured: Clear section delineation
+ * - Instruction priority: Format requirements in system prompt
+ *
+ * The system prompt includes:
+ * - Identity and role definition
+ * - Output format instructions
+ * - XML schema with placeholders
+ * - Examples and footer guidance
  */
-export function buildInitPrompt(project: string, sessionId: string, userPrompt: string, mode: ModeConfig): string {
+export function buildSystemPrompt(mode: ModeConfig): string {
   return `${mode.prompts.system_identity}
-
-<observed_from_primary_session>
-  <user_request>${userPrompt}</user_request>
-  <requested_at>${new Date().toISOString().split('T')[0]}</requested_at>
-</observed_from_primary_session>
 
 ${mode.prompts.observer_role}
 
@@ -41,6 +49,85 @@ ${mode.prompts.spatial_awareness}
 ${mode.prompts.recording_focus}
 
 ${mode.prompts.skip_guidance}
+
+${mode.prompts.output_format_header}
+
+\`\`\`xml
+<observation>
+  <type>[ ${mode.observation_types.map(t => t.id).join(' | ')} ]</type>
+  <!--
+    ${mode.prompts.type_guidance}
+  -->
+  <title>${mode.prompts.xml_title_placeholder}</title>
+  <subtitle>${mode.prompts.xml_subtitle_placeholder}</subtitle>
+  <facts>
+    <fact>${mode.prompts.xml_fact_placeholder}</fact>
+    <fact>${mode.prompts.xml_fact_placeholder}</fact>
+    <fact>${mode.prompts.xml_fact_placeholder}</fact>
+  </facts>
+  <!--
+    ${mode.prompts.field_guidance}
+  -->
+  <narrative>${mode.prompts.xml_narrative_placeholder}</narrative>
+  <concepts>
+    <concept>${mode.prompts.xml_concept_placeholder}</concept>
+    <concept>${mode.prompts.xml_concept_placeholder}</concept>
+  </concepts>
+  <!--
+    ${mode.prompts.concept_guidance}
+  -->
+  <files_read>
+    <file>${mode.prompts.xml_file_placeholder}</file>
+    <file>${mode.prompts.xml_file_placeholder}</file>
+  </files_read>
+  <files_modified>
+    <file>${mode.prompts.xml_file_placeholder}</file>
+    <file>${mode.prompts.xml_file_placeholder}</file>
+  </files_modified>
+</observation>
+\`\`\`
+${mode.prompts.format_examples}
+
+${mode.prompts.footer}`;
+}
+
+/**
+ * Build initial prompt to initialize the SDK agent.
+ *
+ * @param project - Project name
+ * @param sessionId - Content session ID
+ * @param userPrompt - User's original prompt
+ * @param mode - Active mode configuration
+ * @param includeSystemPrompts - When true (default), include system prompts in user message.
+ *   When false (using buildSystemPrompt separately), exclude them to avoid duplication.
+ */
+export function buildInitPrompt(
+  project: string,
+  sessionId: string,
+  userPrompt: string,
+  mode: ModeConfig,
+  includeSystemPrompts: boolean = true
+): string {
+  // System prompts are included in user message unless explicitly excluded
+  // When using buildSystemPrompt() separately, set includeSystemPrompts=false
+  const systemSection = includeSystemPrompts
+    ? `${mode.prompts.system_identity}
+
+${mode.prompts.observer_role}
+
+${mode.prompts.spatial_awareness}
+
+${mode.prompts.recording_focus}
+
+${mode.prompts.skip_guidance}
+
+`
+    : '';
+
+  return `${systemSection}<observed_from_primary_session>
+  <user_request>${userPrompt}</user_request>
+  <requested_at>${new Date().toISOString().split('T')[0]}</requested_at>
+</observed_from_primary_session>
 
 ${mode.prompts.output_format_header}
 
@@ -160,6 +247,13 @@ ${mode.prompts.summary_footer}`;
 /**
  * Build prompt for continuation of existing session
  *
+ * @param userPrompt - User's original prompt
+ * @param promptNumber - Current prompt number in the session
+ * @param contentSessionId - Content session ID for tracking
+ * @param mode - Active mode configuration
+ * @param includeSystemPrompts - When true (default), include system prompts in user message.
+ *   When false (using buildSystemPrompt separately), exclude them to avoid duplication.
+ *
  * CRITICAL: Why contentSessionId Parameter is Required
  * ====================================================
  * This function receives contentSessionId from SDKAgent.ts, which comes from:
@@ -178,15 +272,15 @@ ${mode.prompts.summary_footer}`;
  * Called when: promptNumber > 1 (see SDKAgent.ts line 150)
  * First prompt: Uses buildInitPrompt instead (promptNumber === 1)
  */
-export function buildContinuationPrompt(userPrompt: string, promptNumber: number, contentSessionId: string, mode: ModeConfig): string {
-  return `${mode.prompts.continuation_greeting}
-
-<observed_from_primary_session>
-  <user_request>${userPrompt}</user_request>
-  <requested_at>${new Date().toISOString().split('T')[0]}</requested_at>
-</observed_from_primary_session>
-
-${mode.prompts.system_identity}
+export function buildContinuationPrompt(
+  userPrompt: string,
+  promptNumber: number,
+  contentSessionId: string,
+  mode: ModeConfig,
+  includeSystemPrompts: boolean = true
+): string {
+  const systemSection = includeSystemPrompts
+    ? `${mode.prompts.system_identity}
 
 ${mode.prompts.observer_role}
 
@@ -195,6 +289,16 @@ ${mode.prompts.spatial_awareness}
 ${mode.prompts.recording_focus}
 
 ${mode.prompts.skip_guidance}
+
+`
+    : '';
+
+  return `${mode.prompts.continuation_greeting}
+
+${systemSection}<observed_from_primary_session>
+  <user_request>${userPrompt}</user_request>
+  <requested_at>${new Date().toISOString().split('T')[0]}</requested_at>
+</observed_from_primary_session>
 
 ${mode.prompts.continuation_instruction}
 
@@ -239,4 +343,4 @@ ${mode.prompts.format_examples}
 ${mode.prompts.footer}
 
 ${mode.prompts.header_memory_continued}`;
-} 
+}

--- a/src/services/worker/GeminiAgent.ts
+++ b/src/services/worker/GeminiAgent.ts
@@ -15,7 +15,7 @@ import { homedir } from 'os';
 import { DatabaseManager } from './DatabaseManager.js';
 import { SessionManager } from './SessionManager.js';
 import { logger } from '../../utils/logger.js';
-import { buildInitPrompt, buildObservationPrompt, buildSummaryPrompt, buildContinuationPrompt } from '../../sdk/prompts.js';
+import { buildSystemPrompt, buildInitPrompt, buildObservationPrompt, buildSummaryPrompt, buildContinuationPrompt } from '../../sdk/prompts.js';
 import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js';
 import { getCredential } from '../../shared/EnvManager.js';
 import { USER_SETTINGS_PATH } from '../../shared/paths.js';
@@ -154,14 +154,20 @@ export class GeminiAgent {
       // Load active mode
       const mode = ModeManager.getInstance().getActiveMode();
 
+      // Build system prompt for improved instruction adherence
+      // Following Anthropic's best practices: system-level instructions in system prompt,
+      // task-specific content in user messages. This reduces XML tag misclassification.
+      const systemPrompt = buildSystemPrompt(mode);
+
       // Build initial prompt
+      // Use includeSystemPrompts=false since system prompts are passed separately
       const initPrompt = session.lastPromptNumber === 1
-        ? buildInitPrompt(session.project, session.contentSessionId, session.userPrompt, mode)
-        : buildContinuationPrompt(session.userPrompt, session.lastPromptNumber, session.contentSessionId, mode);
+        ? buildInitPrompt(session.project, session.contentSessionId, session.userPrompt, mode, false)
+        : buildContinuationPrompt(session.userPrompt, session.lastPromptNumber, session.contentSessionId, mode, false);
 
       // Add to conversation history and query Gemini with full context
       session.conversationHistory.push({ role: 'user', content: initPrompt });
-      const initResponse = await this.queryGeminiMultiTurn(session.conversationHistory, apiKey, model, rateLimitingEnabled);
+      const initResponse = await this.queryGeminiMultiTurn(session.conversationHistory, apiKey, model, rateLimitingEnabled, systemPrompt);
 
       if (initResponse.content) {
         // Add response to conversation history
@@ -233,7 +239,7 @@ export class GeminiAgent {
 
           // Add to conversation history and query Gemini with full context
           session.conversationHistory.push({ role: 'user', content: obsPrompt });
-          const obsResponse = await this.queryGeminiMultiTurn(session.conversationHistory, apiKey, model, rateLimitingEnabled);
+          const obsResponse = await this.queryGeminiMultiTurn(session.conversationHistory, apiKey, model, rateLimitingEnabled, systemPrompt);
 
           let tokensUsed = 0;
           if (obsResponse.content) {
@@ -284,7 +290,7 @@ export class GeminiAgent {
 
           // Add to conversation history and query Gemini with full context
           session.conversationHistory.push({ role: 'user', content: summaryPrompt });
-          const summaryResponse = await this.queryGeminiMultiTurn(session.conversationHistory, apiKey, model, rateLimitingEnabled);
+          const summaryResponse = await this.queryGeminiMultiTurn(session.conversationHistory, apiKey, model, rateLimitingEnabled, systemPrompt);
 
           let tokensUsed = 0;
           if (summaryResponse.content) {
@@ -419,7 +425,8 @@ export class GeminiAgent {
     history: ConversationMessage[],
     apiKey: string,
     model: GeminiModel,
-    rateLimitingEnabled: boolean
+    rateLimitingEnabled: boolean,
+    systemInstruction?: string
   ): Promise<{ content: string; tokensUsed?: number }> {
     const truncatedHistory = this.truncateHistory(history);
     const contents = this.conversationToGeminiContents(truncatedHistory);
@@ -428,7 +435,9 @@ export class GeminiAgent {
     logger.debug('SDK', `Querying Gemini multi-turn (${model})`, {
       turns: truncatedHistory.length,
       totalTurns: history.length,
-      totalChars
+      totalChars,
+      hasSystemInstruction: !!systemInstruction,
+      systemInstructionLength: systemInstruction?.length ?? 0
     });
 
     const url = `${GEMINI_API_URL}/${model}:generateContent?key=${apiKey}`;
@@ -436,18 +445,29 @@ export class GeminiAgent {
     // Enforce RPM rate limit for free tier (skipped if rate limiting disabled)
     await enforceRateLimitForModel(model, rateLimitingEnabled);
 
+    // Build request body with optional system instruction
+    // System instruction improves format adherence (reduces XML tag misclassification)
+    const requestBody: Record<string, unknown> = {
+      contents,
+      generationConfig: {
+        temperature: 0.3,  // Lower temperature for structured extraction
+        maxOutputTokens: 4096,
+      },
+    };
+
+    // Add system instruction if provided (improves instruction adherence)
+    if (systemInstruction) {
+      requestBody.systemInstruction = {
+        parts: [{ text: systemInstruction }]
+      };
+    }
+
     const response = await fetch(url, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
-        contents,
-        generationConfig: {
-          temperature: 0.3,  // Lower temperature for structured extraction
-          maxOutputTokens: 4096,
-        },
-      }),
+      body: JSON.stringify(requestBody),
     });
 
     if (!response.ok) {

--- a/src/services/worker/OpenRouterAgent.ts
+++ b/src/services/worker/OpenRouterAgent.ts
@@ -11,7 +11,7 @@
  * - Support dynamic model selection across providers
  */
 
-import { buildContinuationPrompt, buildInitPrompt, buildObservationPrompt, buildSummaryPrompt } from '../../sdk/prompts.js';
+import { buildSystemPrompt, buildContinuationPrompt, buildInitPrompt, buildObservationPrompt, buildSummaryPrompt } from '../../sdk/prompts.js';
 import { getCredential } from '../../shared/EnvManager.js';
 import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js';
 import { USER_SETTINGS_PATH } from '../../shared/paths.js';
@@ -103,14 +103,20 @@ export class OpenRouterAgent {
       // Load active mode
       const mode = ModeManager.getInstance().getActiveMode();
 
+      // Build system prompt for improved instruction adherence
+      // Following Anthropic's best practices: system-level instructions in system prompt,
+      // task-specific content in user messages. This reduces XML tag misclassification.
+      const systemPrompt = buildSystemPrompt(mode);
+
       // Build initial prompt
+      // Use includeSystemPrompts=false since system prompts are passed separately
       const initPrompt = session.lastPromptNumber === 1
-        ? buildInitPrompt(session.project, session.contentSessionId, session.userPrompt, mode)
-        : buildContinuationPrompt(session.userPrompt, session.lastPromptNumber, session.contentSessionId, mode);
+        ? buildInitPrompt(session.project, session.contentSessionId, session.userPrompt, mode, false)
+        : buildContinuationPrompt(session.userPrompt, session.lastPromptNumber, session.contentSessionId, mode, false);
 
       // Add to conversation history and query OpenRouter with full context
       session.conversationHistory.push({ role: 'user', content: initPrompt });
-      const initResponse = await this.queryOpenRouterMultiTurn(session.conversationHistory, apiKey, model, siteUrl, appName);
+      const initResponse = await this.queryOpenRouterMultiTurn(session.conversationHistory, apiKey, model, siteUrl, appName, systemPrompt);
 
       if (initResponse.content) {
         // Add response to conversation history
@@ -181,7 +187,7 @@ export class OpenRouterAgent {
 
           // Add to conversation history and query OpenRouter with full context
           session.conversationHistory.push({ role: 'user', content: obsPrompt });
-          const obsResponse = await this.queryOpenRouterMultiTurn(session.conversationHistory, apiKey, model, siteUrl, appName);
+          const obsResponse = await this.queryOpenRouterMultiTurn(session.conversationHistory, apiKey, model, siteUrl, appName, systemPrompt);
 
           let tokensUsed = 0;
           if (obsResponse.content) {
@@ -224,7 +230,7 @@ export class OpenRouterAgent {
 
           // Add to conversation history and query OpenRouter with full context
           session.conversationHistory.push({ role: 'user', content: summaryPrompt });
-          const summaryResponse = await this.queryOpenRouterMultiTurn(session.conversationHistory, apiKey, model, siteUrl, appName);
+          const summaryResponse = await this.queryOpenRouterMultiTurn(session.conversationHistory, apiKey, model, siteUrl, appName, systemPrompt);
 
           let tokensUsed = 0;
           if (summaryResponse.content) {
@@ -339,12 +345,26 @@ export class OpenRouterAgent {
 
   /**
    * Convert shared ConversationMessage array to OpenAI-compatible message format
+   * Optionally prepends a system message for improved instruction adherence
    */
-  private conversationToOpenAIMessages(history: ConversationMessage[]): OpenAIMessage[] {
-    return history.map(msg => ({
+  private conversationToOpenAIMessages(history: ConversationMessage[], systemPrompt?: string): OpenAIMessage[] {
+    const messages: OpenAIMessage[] = [];
+
+    // Prepend system message if provided (improves format instruction adherence)
+    if (systemPrompt) {
+      messages.push({
+        role: 'system',
+        content: systemPrompt
+      });
+    }
+
+    // Add conversation history
+    messages.push(...history.map(msg => ({
       role: msg.role === 'assistant' ? 'assistant' : 'user',
       content: msg.content
-    }));
+    })));
+
+    return messages;
   }
 
   /**
@@ -356,17 +376,20 @@ export class OpenRouterAgent {
     apiKey: string,
     model: string,
     siteUrl?: string,
-    appName?: string
+    appName?: string,
+    systemPrompt?: string
   ): Promise<{ content: string; tokensUsed?: number }> {
     // Truncate history to prevent runaway costs
     const truncatedHistory = this.truncateHistory(history);
-    const messages = this.conversationToOpenAIMessages(truncatedHistory);
+    const messages = this.conversationToOpenAIMessages(truncatedHistory, systemPrompt);
     const totalChars = truncatedHistory.reduce((sum, m) => sum + m.content.length, 0);
     const estimatedTokens = this.estimateTokens(truncatedHistory.map(m => m.content).join(''));
 
     logger.debug('SDK', `Querying OpenRouter multi-turn (${model})`, {
       turns: truncatedHistory.length,
       totalChars,
+      hasSystemPrompt: !!systemPrompt,
+      systemPromptLength: systemPrompt?.length ?? 0,
       estimatedTokens
     });
 

--- a/src/services/worker/SDKAgent.ts
+++ b/src/services/worker/SDKAgent.ts
@@ -14,7 +14,7 @@ import path from 'path';
 import { DatabaseManager } from './DatabaseManager.js';
 import { SessionManager } from './SessionManager.js';
 import { logger } from '../../utils/logger.js';
-import { buildInitPrompt, buildObservationPrompt, buildSummaryPrompt, buildContinuationPrompt } from '../../sdk/prompts.js';
+import { buildSystemPrompt, buildInitPrompt, buildObservationPrompt, buildSummaryPrompt, buildContinuationPrompt } from '../../sdk/prompts.js';
 import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js';
 import { USER_SETTINGS_PATH, OBSERVER_SESSIONS_DIR, ensureDir } from '../../shared/paths.js';
 import { buildIsolatedEnv, getAuthMethodDescription } from '../../shared/EnvManager.js';
@@ -67,8 +67,16 @@ export class SDKAgent {
       'TodoWrite'       // No todo management
     ];
 
+    // Load active mode and build system prompt
+    // This follows Anthropic's best practices: system-level instructions in system prompt,
+    // task-specific content in user messages. This improves instruction adherence and
+    // reduces the 70%+ XML tag misclassification rate.
+    const mode = ModeManager.getInstance().getActiveMode();
+    const systemPrompt = buildSystemPrompt(mode);
+
     // Create message generator (event-driven)
-    const messageGenerator = this.createMessageGenerator(session, cwdTracker);
+    // Pass systemPrompt so it can exclude system prompts from user messages
+    const messageGenerator = this.createMessageGenerator(session, cwdTracker, systemPrompt);
 
     // CRITICAL: Only resume if:
     // 1. memorySessionId exists (was captured from a previous SDK response)
@@ -129,10 +137,17 @@ export class SDKAgent {
     // Use dedicated cwd to isolate observer sessions from user's `claude --resume` list
     ensureDir(OBSERVER_SESSIONS_DIR);
     // CRITICAL: Pass isolated env to prevent Issue #733 (API key pollution from project .env files)
+    // Run Agent SDK query loop with system prompt for improved instruction adherence
+    // Following Anthropic's best practices: system-level instructions in system prompt,
+    // task-specific content in user messages. This improves format adherence and
+    // reduces XML tag misclassification (was 70%+).
     const queryResult = query({
       prompt: messageGenerator,
       options: {
         model: modelId,
+        // System prompt: mode-level instructions for better adherence
+        // User messages only contain task-specific content (observations, summaries)
+        systemPrompt,
         // Isolate observer sessions - they'll appear under project "observer-sessions"
         // instead of polluting user's actual project resume lists
         cwd: OBSERVER_SESSIONS_DIR,
@@ -333,24 +348,28 @@ export class SDKAgent {
    */
   private async *createMessageGenerator(
     session: ActiveSession,
-    cwdTracker: { lastCwd: string | undefined }
+    cwdTracker: { lastCwd: string | undefined },
+    systemPrompt: string
   ): AsyncIterableIterator<SDKUserMessage> {
-    // Load active mode
+    // Load active mode for format guidance in user messages
+    // Note: System prompts (identity, role, etc.) are passed separately via systemPrompt parameter
     const mode = ModeManager.getInstance().getActiveMode();
 
     // Build initial prompt
+    // Use includeSystemPrompts=false since system prompts are passed separately via systemPrompt
     const isInitPrompt = session.lastPromptNumber === 1;
     logger.info('SDK', 'Creating message generator', {
       sessionDbId: session.sessionDbId,
       contentSessionId: session.contentSessionId,
       lastPromptNumber: session.lastPromptNumber,
       isInitPrompt,
-      promptType: isInitPrompt ? 'INIT' : 'CONTINUATION'
+      promptType: isInitPrompt ? 'INIT' : 'CONTINUATION',
+      systemPromptLength: systemPrompt.length
     });
 
     const initPrompt = isInitPrompt
-      ? buildInitPrompt(session.project, session.contentSessionId, session.userPrompt, mode)
-      : buildContinuationPrompt(session.userPrompt, session.lastPromptNumber, session.contentSessionId, mode);
+      ? buildInitPrompt(session.project, session.contentSessionId, session.userPrompt, mode, false)
+      : buildContinuationPrompt(session.userPrompt, session.lastPromptNumber, session.contentSessionId, mode, false);
 
     // Add to shared conversation history for provider interop
     session.conversationHistory.push({ role: 'user', content: initPrompt });


### PR DESCRIPTION
## Problem

Mode prompts (`output_format_header`, `summary_footer`, etc.) were being injected into user messages rather than passed as system prompts to the LLM.

This caused 70%+ XML tag misclassification because system-level instructions have weaker adherence when buried in user content.

### Current Architecture (Before)
```
[System: default identity]
[User: MODE PROMPTS + task data]
[User: observation tags]
```

### Expected Architecture (After)
```
[System: Mode prompts + output format requirements + role definition]
[User: Task-specific content only]
```

## Solution

Following Anthropic's context engineering best practices:

1. **Add `buildSystemPrompt()` function** in `src/sdk/prompts.ts`:
   - Extracts system-level prompts (identity, role, format instructions) from mode config
   - These are the directives that should have highest attention weight

2. **SDK Agent** (`SDKAgent.ts`):
   - Pass `systemPrompt` to the SDK `query()` options
   - User messages only contain task-specific content

3. **Gemini Agent** (`GeminiAgent.ts`):
   - Add `systemInstruction` field to API request body

4. **OpenRouter Agent** (`OpenRouterAgent.ts`):
   - Prepend system message to messages array

5. **Modified prompt builders**:
   - `buildInitPrompt()` and `buildContinuationPrompt()` now accept `includeSystemPrompts` parameter
   - When `false`, excludes system prompts from user messages (avoiding duplication)

## Impact

- Improved format instruction adherence (system prompts have higher attention weight)
- Reduced XML tag misclassification
- Better separation of concerns: system-level directives vs. task content

## Files Changed

| File | Change |
|------|--------|
| `src/sdk/prompts.ts` | Add `buildSystemPrompt()`, modify prompt builders |
| `src/services/worker/SDKAgent.ts` | Pass `systemPrompt` to `query()` options |
| `src/services/worker/GeminiAgent.ts` | Add `systemInstruction` to API calls |
| `src/services/worker/OpenRouterAgent.ts` | Prepend system message to API calls |

## Testing

The change maintains backward compatibility:
- If no system prompt is provided, behavior is identical to before
- The `includeSystemPrompts` parameter defaults to `true` for existing callers
