### PR TITLE
fix: stop hook no longer spins 110s when worker lacks /api/sessions/status

### DIFF
--- a/src/cli/handlers/summarize.ts
+++ b/src/cli/handlers/summarize.ts
@@ -101,6 +101,11 @@ export const summarizeHandler: EventHandler = {
             });
             break;
           }
+        } else if (statusResponse.status === 404) {
+          // Worker does not support /api/sessions/status (version < 12.1.0).
+          // Treat queue as empty so we don't spin for 110s.
+          logger.warn('HOOK', 'Worker does not support /api/sessions/status (old version) — skipping poll');
+          break;
         }
       } catch {
         // Worker may be busy — keep polling


### PR DESCRIPTION
## Summary

- When a worker older than v12.1.0 is running (e.g. 10.5.2), it does not expose the `/api/sessions/status` endpoint introduced in 12.1.0.
- The Stop hook's polling loop only breaks when `statusResponse.ok && queueLength === 0`.  A 404 response is not `ok`, so the loop silently runs until `MAX_WAIT_FOR_SUMMARY_MS` (110 s) elapses, stalling every session close.

**Fix:** detect a 404 specifically and `break` immediately with a warning log, treating it as "endpoint not supported by this worker version."

## Files Changed

- `src/cli/handlers/summarize.ts` — added `else if (statusResponse.status === 404)` branch inside the polling loop

## Reproduction

1. Install claude-mem 12.1.0 plugin while keeping a worker binary at 10.5.2 running.
2. End any Claude Code session.
3. Observe Stop hook taking ~110 s to exit instead of returning promptly.