### PR TITLE
fix: restrict ~/.claude-mem/.env permissions to owner-only (0600)

### DIFF
--- a/src/shared/EnvManager.ts
+++ b/src/shared/EnvManager.ts
@@ -136,6 +136,9 @@ export function saveClaudeMemEnv(env: ClaudeMemEnv): void {
     if (!existsSync(DATA_DIR)) {
       mkdirSync(DATA_DIR, { recursive: true, mode: 0o700 });
     }
+    // Fix permissions on pre-existing directories (mode: is only applied on creation)
+    // Note: On Windows, chmod has no effect — permissions are controlled via ACLs.
+    chmodSync(DATA_DIR, 0o700);
 
     // Load existing to preserve any extra keys
     const existing = existsSync(ENV_FILE_PATH)
@@ -176,7 +179,9 @@ export function saveClaudeMemEnv(env: ClaudeMemEnv): void {
     }
 
     writeFileSync(ENV_FILE_PATH, serializeEnvFile(updated), { encoding: 'utf-8', mode: 0o600 });
-    // Explicitly set permissions in case the file already existed before this fix
+    // Explicitly set permissions in case the file already existed before this fix.
+    // writeFileSync's mode option only applies on file creation (O_CREAT), not on overwrites.
+    // Note: On Windows, chmod has no effect — permissions are controlled via ACLs.
     chmodSync(ENV_FILE_PATH, 0o600);
   } catch (error) {
     logger.error('ENV', 'Failed to save .env file', { path: ENV_FILE_PATH }, error as Error);

--- a/src/shared/EnvManager.ts
+++ b/src/shared/EnvManager.ts
@@ -9,7 +9,7 @@
  * causing memory operations to bill personal API accounts instead of CLI subscription.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from 'fs';
 import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { logger } from '../utils/logger.js';
@@ -132,9 +132,9 @@ export function loadClaudeMemEnv(): ClaudeMemEnv {
  */
 export function saveClaudeMemEnv(env: ClaudeMemEnv): void {
   try {
-    // Ensure directory exists
+    // Ensure directory exists with restricted permissions (owner only)
     if (!existsSync(DATA_DIR)) {
-      mkdirSync(DATA_DIR, { recursive: true });
+      mkdirSync(DATA_DIR, { recursive: true, mode: 0o700 });
     }
 
     // Load existing to preserve any extra keys
@@ -175,7 +175,9 @@ export function saveClaudeMemEnv(env: ClaudeMemEnv): void {
       }
     }
 
-    writeFileSync(ENV_FILE_PATH, serializeEnvFile(updated), 'utf-8');
+    writeFileSync(ENV_FILE_PATH, serializeEnvFile(updated), { encoding: 'utf-8', mode: 0o600 });
+    // Explicitly set permissions in case the file already existed before this fix
+    chmodSync(ENV_FILE_PATH, 0o600);
   } catch (error) {
     logger.error('ENV', 'Failed to save .env file', { path: ENV_FILE_PATH }, error as Error);
     throw error;


### PR DESCRIPTION
## Summary

API keys stored in `~/.claude-mem/.env` were created without explicit file permissions. On systems with a permissive `umask` (e.g. `0022`, which is the default on many Linux distros and macOS), the file would be world-readable — exposing `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, and `OPENROUTER_API_KEY` to any local user.

- Set directory permissions to `0700` on creation via `mkdirSync` `mode` option
- Set file permissions to `0600` via `writeFileSync` `mode` option
- Call `chmodSync(0o600)` after write to fix permissions on **pre-existing** `.env` files (Node's `mode` option only applies on file creation via `O_CREAT`, not on overwrites)
- Call `chmodSync(0o700)` on the directory unconditionally, so pre-existing `~/.claude-mem/` directories from earlier installs are also hardened

**Windows note:** `chmod` has no effect on Windows — file access there is controlled via ACLs. This is documented in code comments but not otherwise addressed by this PR.

**Scope:** `saveClaudeMemEnv()` is the only write path to the `.env` file in this codebase (called exclusively via `setCredential()`), so this change is complete.

## Test plan

- [ ] Fresh install: verify `~/.claude-mem/.env` is created with `-rw-------` (0600)
- [ ] Existing install: trigger a credential save (e.g. via settings), verify permissions are updated on the pre-existing file
- [ ] Verify `~/.claude-mem/` directory shows `drwx------` (0700)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)