### PR TITLE
docs: add CLAUDE_MEM_MODE documentation for language and modes (fix #…

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,9 +324,12 @@ Example:
 }
 ```
 
-Modes are defined in:-
+Modes are defined in:
+
+```text
 plugin/modes/
 
+```
 #### Available modes
 
 | Mode       | Description             |
@@ -334,7 +337,6 @@ plugin/modes/
 | `code`     | Default English mode    |
 | `code--zh` | Simplified Chinese mode |
 | `code--ja` | Japanese mode           |
-
 Note: code--zh (Simplified Chinese) is already built-in.
 No additional installation or plugin update is required.
 

--- a/README.md
+++ b/README.md
@@ -308,9 +308,6 @@ This option controls both:
 - The workflow behavior (e.g. code, chill, investigation)
 - The language used in generated observations
 
-#### How to configure
-
-Edit your settings file:
 
 #### How to Configure
 
@@ -320,9 +317,7 @@ Modes are defined in:
 
 ```text
 plugin/modes/
-
 ```
-
 
 #### Available modes
 
@@ -332,12 +327,10 @@ plugin/modes/
 | `code--zh` | Simplified Chinese mode |
 | `code--ja` | Japanese mode           |
 
-
-Note: code--zh (Simplified Chinese) is already built-in.
-No additional installation or plugin update is required.
-
-After changing mode
-Restart Claude Code to apply changes.
+> Note: `code--zh` (Simplified Chinese) is already built-in.  
+> No additional installation or plugin update is required.
+>After changing mode
+>Restart Claude Code to apply changes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ Modes are defined in:
 plugin/modes/
 
 ```
+
+
 #### Available modes
 
 | Mode       | Description             |
@@ -337,6 +339,8 @@ plugin/modes/
 | `code`     | Default English mode    |
 | `code--zh` | Simplified Chinese mode |
 | `code--ja` | Japanese mode           |
+
+
 Note: code--zh (Simplified Chinese) is already built-in.
 No additional installation or plugin update is required.
 

--- a/README.md
+++ b/README.md
@@ -300,6 +300,43 @@ Settings are managed in `~/.claude-mem/settings.json` (auto-created with default
 
 See the **[Configuration Guide](https://docs.claude-mem.ai/configuration)** for all available settings and examples.
 
+### Mode & Language Configuration
+
+Claude-Mem supports multiple workflow modes and languages via the `CLAUDE_MEM_MODE` setting.
+
+This option controls both:
+- The workflow behavior (e.g. code, chill, investigation)
+- The language used in generated observations
+
+#### How to configure
+
+Edit your settings file:
+
+```text
+~/.claude-mem/settings.json
+
+Example:
+{
+  "CLAUDE_MEM_MODE": "code--zh"
+}
+
+Available modes
+Modes are defined in:
+plugin/modes/
+
+Common examples:
+
+Mode	Description
+code	Default English coding mode
+code--zh	Simplified Chinese mode
+code--ja	Japanese mode
+
+Note: code--zh (Simplified Chinese) is already built-in.
+No additional installation or plugin update is required.
+
+After changing mode
+Restart Claude Code to apply changes.
+
 ---
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -324,10 +324,8 @@ Example:
 }
 ```
 
-Modes are defined in:
+Modes are defined in:-
 plugin/modes/
-
-Common examples:
 
 #### Available modes
 

--- a/README.md
+++ b/README.md
@@ -314,22 +314,28 @@ Edit your settings file:
 
 ```text
 ~/.claude-mem/settings.json
+```
 
 Example:
+
+```json
 {
   "CLAUDE_MEM_MODE": "code--zh"
 }
+```
 
-Available modes
 Modes are defined in:
 plugin/modes/
 
 Common examples:
 
-Mode	Description
-code	Default English coding mode
-code--zh	Simplified Chinese mode
-code--ja	Japanese mode
+#### Available modes
+
+| Mode       | Description             |
+|------------|-------------------------|
+| `code`     | Default English mode    |
+| `code--zh` | Simplified Chinese mode |
+| `code--ja` | Japanese mode           |
 
 Note: code--zh (Simplified Chinese) is already built-in.
 No additional installation or plugin update is required.

--- a/README.md
+++ b/README.md
@@ -308,30 +308,37 @@ This option controls both:
 - The workflow behavior (e.g. code, chill, investigation)
 - The language used in generated observations
 
-
 #### How to Configure
 
 Edit your settings file at `~/.claude-mem/settings.json`:
 
-Modes are defined in:
-
-```text
-plugin/modes/
+```json
+{
+  "CLAUDE_MEM_MODE": "code--zh"
+}
 ```
 
-#### Available modes
+Modes are defined in `plugin/modes/`. To see all available modes locally:
 
-| Mode       | Description             |
+```bash
+ls ~/.claude/plugins/marketplaces/thedotmack/plugin/modes/
+```
+
+#### Available Modes
+
+| Mode | Description |
 |------------|-------------------------|
-| `code`     | Default English mode    |
+| `code` | Default English mode |
 | `code--zh` | Simplified Chinese mode |
-| `code--ja` | Japanese mode           |
+| `code--ja` | Japanese mode |
 
-> Note: `code--zh` (Simplified Chinese) is already built-in.  
-> No additional installation or plugin update is required.
->After changing mode
->Restart Claude Code to apply changes.
+Language-specific modes follow the pattern `code--[lang]` where `[lang]` is the ISO 639-1 language code (e.g., `zh` for Chinese, `ja` for Japanese, `es` for Spanish).
 
+> Note: `code--zh` (Simplified Chinese) is already built-in — no additional installation or plugin update is required.
+
+#### After Changing Mode
+
+Restart Claude Code to apply the new mode configuration.
 ---
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -312,17 +312,9 @@ This option controls both:
 
 Edit your settings file:
 
-```text
-~/.claude-mem/settings.json
-```
+#### How to Configure
 
-Example:
-
-```json
-{
-  "CLAUDE_MEM_MODE": "code--zh"
-}
-```
+Edit your settings file at `~/.claude-mem/settings.json`:
 
 Modes are defined in:
 


### PR DESCRIPTION
Fixes #1767

Adds missing documentation for CLAUDE_MEM_MODE, including:

- How to enable multilingual modes (e.g. code--zh)
- Explanation of mode system
- Configuration example

This improves discoverability of built-in language support.