### PR TITLE
feat: add Claude Code plugin lifecycle hooks

### DIFF
--- a/.claude-plugin/hooks/hooks.json
+++ b/.claude-plugin/hooks/hooks.json
@@ -1,0 +1,65 @@
+{
+  "description": "claude-mem lifecycle hooks — SessionStart worker init + context injection, UserPromptSubmit capture, PostToolUse observation, Stop/SessionEnd session complete",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.mjs",
+            "timeout": 20000
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt.mjs",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use.mjs",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/stop.mjs",
+            "timeout": 10000
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/stop.mjs",
+            "timeout": 10000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude-plugin/hooks/post-tool-use.mjs
+++ b/.claude-plugin/hooks/post-tool-use.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// claude-mem PostToolUse hook
+// Sends tool usage data to the worker as an observation for the current session.
+// Respects CLAUDE_MEM_SKIP_TOOLS to avoid capturing low-signal tool calls.
+
+const PORT = process.env.CLAUDE_MEM_WORKER_PORT || '37777';
+const BASE = `http://127.0.0.1:${PORT}`;
+const CONTINUE = JSON.stringify({ continue: true, suppressOutput: true });
+
+const DEFAULT_SKIP = new Set([
+  'ListMcpResourcesTool', 'SlashCommand', 'Skill', 'TodoWrite',
+  'AskUserQuestion', 'mcp__ccd_session__mark_chapter',
+]);
+
+function buildSkipSet() {
+  const env = process.env.CLAUDE_MEM_SKIP_TOOLS;
+  if (!env) return DEFAULT_SKIP;
+  return new Set(env.split(',').map(s => s.trim()).filter(Boolean));
+}
+
+async function main() {
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  await new Promise(resolve => {
+    process.stdin.on('data', d => { raw += d; });
+    process.stdin.on('end', resolve);
+  });
+
+  let hookData = {};
+  try { hookData = JSON.parse(raw); } catch {}
+
+  const toolName = hookData.tool_name || hookData.toolName || '';
+  const skipTools = buildSkipSet();
+
+  // Skip low-signal tools
+  if (!toolName || skipTools.has(toolName)) {
+    process.stdout.write(CONTINUE + '\n');
+    process.exit(0);
+  }
+
+  const sessionId = hookData.session_id || hookData.sessionId || '';
+  const cwd = hookData.cwd || process.cwd();
+  const toolInput = hookData.tool_input ?? hookData.toolInput ?? {};
+  const toolResponse = hookData.tool_response ?? hookData.toolResponse ?? {};
+
+  // Build a compact observation text
+  let text = `Tool: ${toolName}`;
+  if (toolInput?.file_path) text += ` | file: ${toolInput.file_path}`;
+  else if (toolInput?.command) text += ` | cmd: ${String(toolInput.command).slice(0, 120)}`;
+  else if (toolInput?.pattern) text += ` | pattern: ${toolInput.pattern}`;
+  else if (toolInput?.query) text += ` | query: ${toolInput.query}`;
+
+  try {
+    const ctrl = new AbortController();
+    setTimeout(() => ctrl.abort(), 4000);
+    await fetch(`${BASE}/api/observations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contentSessionId: sessionId,
+        project: cwd,
+        text,
+        type: 'tool-use',
+        toolName,
+        toolInput,
+        toolResponse,
+      }),
+      signal: ctrl.signal,
+    });
+  } catch { /* non-fatal */ }
+
+  process.stdout.write(CONTINUE + '\n');
+  process.exit(0);
+}
+
+main().catch(() => {
+  process.stdout.write(CONTINUE + '\n');
+  process.exit(0);
+});

--- a/.claude-plugin/hooks/session-start.mjs
+++ b/.claude-plugin/hooks/session-start.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// claude-mem SessionStart hook
+// 1. Ensures the worker service is running (starts it via bun if needed)
+// 2. Initialises a session record in the worker
+// 3. Fetches past context and injects it as a system reminder
+
+import { execFile, execFileSync } from 'child_process';
+import { join } from 'path';
+import { homedir } from 'os';
+import { existsSync } from 'fs';
+
+const PORT = process.env.CLAUDE_MEM_WORKER_PORT || '37777';
+const BASE = `http://127.0.0.1:${PORT}`;
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+async function tryFetch(url, opts = {}, timeoutMs = 3000) {
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), timeoutMs);
+    const res = await fetch(url, { signal: ctrl.signal, ...opts });
+    clearTimeout(t);
+    return res;
+  } catch {
+    return null;
+  }
+}
+
+async function workerReady() {
+  const res = await tryFetch(`${BASE}/api/health`, {}, 2000);
+  return res?.ok === true;
+}
+
+function findBun() {
+  const candidates = [
+    join(homedir(), '.bun', 'bin', 'bun.exe'),
+    join(homedir(), '.bun', 'bin', 'bun'),
+  ];
+  for (const b of candidates) {
+    if (existsSync(b)) return b;
+  }
+  try {
+    execFileSync('bun', ['--version'], { stdio: 'ignore', timeout: 2000 });
+    return 'bun';
+  } catch { return null; }
+}
+
+async function startWorker() {
+  const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT ||
+    join(homedir(), '.claude', 'plugins', 'marketplaces', 'thedotmack');
+  const workerCli = join(pluginRoot, 'plugin', 'scripts', 'worker-cli.js');
+
+  if (!existsSync(workerCli)) {
+    process.stderr.write('[claude-mem] worker-cli.js not found at ' + workerCli + '\n');
+    return false;
+  }
+
+  const bun = findBun();
+  if (!bun) {
+    process.stderr.write('[claude-mem] bun not found — cannot start worker\n');
+    return false;
+  }
+
+  return new Promise(resolve => {
+    execFile(bun, [workerCli, 'start'], {
+      timeout: 20000,
+      windowsHide: true,
+      env: { ...process.env, CLAUDE_MEM_WORKER_PORT: PORT },
+    }, async () => {
+      for (let i = 0; i < 20; i++) {
+        await new Promise(r => setTimeout(r, 500));
+        if (await workerReady()) { resolve(true); return; }
+      }
+      resolve(false);
+    });
+  });
+}
+
+// ── main ───────────────────────────────────────────────────────────────────
+
+async function main() {
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  await new Promise(resolve => {
+    process.stdin.on('data', d => { raw += d; });
+    process.stdin.on('end', resolve);
+  });
+
+  let hookData = {};
+  try { hookData = JSON.parse(raw); } catch {}
+
+  const sessionId = hookData.session_id || hookData.sessionId || '';
+  const cwd = hookData.cwd || process.cwd();
+
+  // 1. Ensure worker is running
+  if (!(await workerReady())) {
+    const started = await startWorker();
+    if (!started) {
+      process.stderr.write('[claude-mem] Worker unavailable — skipping context injection\n');
+      process.exit(0);
+    }
+  }
+
+  // 2. Init session
+  await tryFetch(`${BASE}/api/sessions/init`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ contentSessionId: sessionId, project: cwd }),
+  }, 5000);
+
+  // 3. Fetch context to inject
+  const ctxRes = await tryFetch(`${BASE}/api/context/inject`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ contentSessionId: sessionId, project: cwd }),
+  }, 10000);
+
+  if (ctxRes?.ok) {
+    const data = await ctxRes.json().catch(() => null);
+    const context = data?.context || data?.content || data?.output || '';
+    if (context && context.trim()) {
+      process.stdout.write(JSON.stringify({ hookSpecificOutput: context }) + '\n');
+      process.exit(0);
+    }
+  }
+
+  process.stdout.write(JSON.stringify({ continue: true, suppressOutput: true }) + '\n');
+  process.exit(0);
+}
+
+main().catch(e => {
+  process.stderr.write('[claude-mem] SessionStart error: ' + e.message + '\n');
+  process.exit(0);
+});

--- a/.claude-plugin/hooks/stop.mjs
+++ b/.claude-plugin/hooks/stop.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// claude-mem Stop / SessionEnd hook
+// Marks the session as complete and triggers summarization in the worker.
+
+const PORT = process.env.CLAUDE_MEM_WORKER_PORT || '37777';
+const BASE = `http://127.0.0.1:${PORT}`;
+
+async function tryPost(path, body, timeoutMs = 8000) {
+  try {
+    const ctrl = new AbortController();
+    setTimeout(() => ctrl.abort(), timeoutMs);
+    await fetch(`${BASE}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: ctrl.signal,
+    });
+  } catch { /* non-fatal */ }
+}
+
+async function main() {
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  await new Promise(resolve => {
+    process.stdin.on('data', d => { raw += d; });
+    process.stdin.on('end', resolve);
+  });
+
+  let hookData = {};
+  try { hookData = JSON.parse(raw); } catch {}
+
+  const sessionId = hookData.session_id || hookData.sessionId || '';
+  const cwd = hookData.cwd || process.cwd();
+
+  await tryPost('/api/sessions/complete', { contentSessionId: sessionId, project: cwd });
+  await tryPost('/api/sessions/summarize', { contentSessionId: sessionId, project: cwd });
+
+  process.stdout.write(JSON.stringify({ continue: true, suppressOutput: true }) + '\n');
+  process.exit(0);
+}
+
+main().catch(() => { process.exit(0); });

--- a/.claude-plugin/hooks/user-prompt.mjs
+++ b/.claude-plugin/hooks/user-prompt.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// claude-mem UserPromptSubmit hook
+// Sends the user prompt to the worker so it can be stored and associated with
+// the current session for later recall.
+
+const PORT = process.env.CLAUDE_MEM_WORKER_PORT || '37777';
+const BASE = `http://127.0.0.1:${PORT}`;
+const CONTINUE = JSON.stringify({ continue: true, suppressOutput: true });
+
+async function main() {
+  let raw = '';
+  process.stdin.setEncoding('utf8');
+  await new Promise(resolve => {
+    process.stdin.on('data', d => { raw += d; });
+    process.stdin.on('end', resolve);
+  });
+
+  let hookData = {};
+  try { hookData = JSON.parse(raw); } catch {}
+
+  const sessionId = hookData.session_id || hookData.sessionId || '';
+  const prompt = hookData.prompt || hookData.user_prompt || '';
+  const cwd = hookData.cwd || process.cwd();
+
+  if (prompt) {
+    try {
+      const ctrl = new AbortController();
+      setTimeout(() => ctrl.abort(), 4000);
+      await fetch(`${BASE}/api/prompts`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ contentSessionId: sessionId, prompt, project: cwd }),
+        signal: ctrl.signal,
+      });
+    } catch { /* non-fatal */ }
+  }
+
+  process.stdout.write(CONTINUE + '\n');
+  process.exit(0);
+}
+
+main().catch(() => {
+  process.stdout.write(CONTINUE + '\n');
+  process.exit(0);
+});


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/hooks/hooks.json` so claude-mem activates **automatically** when the plugin is enabled in Claude Code — no manual `/mem-search` invocation needed, mirroring the pattern used by `context-mode`
- Five lifecycle hook scripts (Node.js ESM) call the worker HTTP API on port 37777

## What changed

| Hook | File | Behaviour |
|------|------|-----------|
| `SessionStart` | `session-start.mjs` | Ensures worker is running (auto-starts via bun if needed) → `POST /api/sessions/init` → `POST /api/context/inject` → injects past memory as a system reminder |
| `UserPromptSubmit` | `user-prompt.mjs` | `POST /api/prompts` to capture each user message |
| `PostToolUse` | `post-tool-use.mjs` | `POST /api/observations` for significant tool calls; skips tools listed in `CLAUDE_MEM_SKIP_TOOLS` |
| `Stop` | `stop.mjs` | `POST /api/sessions/complete` + `POST /api/sessions/summarize` |
| `SessionEnd` | `stop.mjs` (shared) | Same as Stop, covers both shutdown paths |

## Why

Claude Code plugin hooks (`hooks/hooks.json` inside `.claude-plugin/`) are read automatically for any enabled plugin — the same mechanism `context-mode` uses. Previously claude-mem had no hooks file, so users had to manually invoke `/mem-search` each session. With this change, past context is injected automatically at session start and observations are captured throughout without any user action.

## Notes for reviewer

- All hooks exit 0 on any error — they are non-blocking and will never interrupt Claude Code if the worker is down
- Worker auto-start logic mirrors `worker-cli.js`: finds bun via `~/.bun/bin/bun` or PATH, then waits for `/api/health` readiness
- `CLAUDE_MEM_WORKER_PORT` env var is respected (defaults to `37777`)
- Scripts are plain Node.js ESM with no npm dependencies

## Test plan

- [ ] Enable claude-mem plugin in Claude Code settings
- [ ] Restart Claude Code — worker should start automatically and past context should appear in the first system reminder
- [ ] Run a few tool calls — verify observations appear in the memory viewer at `http://localhost:37777`
- [ ] End the session — verify a summary is generated