### PR TITLE
claude/swebench-claude-mem-prompt-solBH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,10 @@ src/ui/viewer.html
 
 # Local contribution analysis (not part of upstream)
 CONTRIB_NOTES.md
+
+# Python bytecode from scripts/swebench/
+__pycache__/
+*.pyc
+
+# SWE-bench runner outputs
+scripts/swebench/out/

--- a/scripts/swebench/README.md
+++ b/scripts/swebench/README.md
@@ -1,0 +1,88 @@
+# SWE-bench Verified runner (Claude Code + claude-mem)
+
+Runs the [SWE-bench Verified](https://www.swebench.com/) benchmark against
+Claude Code with the claude-mem plugin active. Each task is solved by a
+headless `claude --print` invocation whose prompt is prefixed with the custom
+instruction:
+
+```
+use the /make-plan and /do skill to <problem_statement>
+```
+
+The runner only **generates predictions** (`predictions.jsonl` in SWE-bench
+format). Scoring is done by the official SWE-bench harness via the companion
+`evaluate.sh` wrapper.
+
+## Prerequisites
+
+1. **Claude Code CLI** on `PATH` (`claude --version` should work) with a valid
+   login or `ANTHROPIC_API_KEY`.
+2. **claude-mem plugin installed and enabled** in the user's Claude Code
+   config. Confirm the worker is up:
+   ```bash
+   npm --prefix ~/.claude/plugins/marketplaces/thedotmack run worker:status
+   ```
+   The `/make-plan` and `/do` skills ship with the plugin
+   (`plugin/skills/make-plan/SKILL.md`, `plugin/skills/do/SKILL.md`).
+3. **Python 3.10+** with `datasets` installed (for dataset loading):
+   ```bash
+   uv pip install datasets          # or: pip install datasets
+   ```
+4. **Docker** (only needed for `evaluate.sh`, not for generating predictions).
+
+## Generate predictions
+
+```bash
+python scripts/swebench/run.py \
+  --split test \
+  --predictions scripts/swebench/out/predictions.jsonl \
+  --concurrency 4
+```
+
+Useful flags:
+
+| flag | purpose |
+|------|---------|
+| `--instance-id <id>` | run a single task (repeatable) |
+| `--max-tasks N`      | smoke-test the first N tasks |
+| `--concurrency N`    | run N Claude Code sessions in parallel |
+| `--per-task-timeout` | wall-clock cap per task (default 45m) |
+| `--model`            | pass through to `claude --model` |
+| `--permission-mode`  | `bypassPermissions` (default) for unattended runs |
+| `--keep-workdirs`    | retain per-task clones for debugging |
+| `--no-resume`        | overwrite instead of appending |
+
+The script resumes by default: on restart it skips any `instance_id` already
+present in the predictions file.
+
+## Evaluate
+
+```bash
+scripts/swebench/evaluate.sh scripts/swebench/out/predictions.jsonl
+```
+
+This shells out to `python -m swebench.harness.run_evaluation` with
+`--dataset_name princeton-nlp/SWE-bench_Verified`. Results land under
+`./logs/run_evaluation/<run_id>/` and `./evaluation_results/`.
+
+## Prediction format
+
+Each line of `predictions.jsonl` is:
+
+```json
+{"instance_id": "...", "model_name_or_path": "claude-mem", "model_patch": "<unified diff>"}
+```
+
+This is the canonical SWE-bench predictions schema; it can be fed to any
+SWE-bench-compatible evaluator.
+
+## Notes on reproducibility
+
+- `model_name_or_path` defaults to `claude-mem` — override with `--model-name`
+  to tag runs (e.g. `claude-mem-opus-4.6`).
+- claude-mem's session database (`~/.claude-mem/claude-mem.db`) accumulates
+  memory across tasks. If you want clean-room tasks, wipe it between runs; if
+  you want to study memory carry-over, leave it.
+- Each task runs in an isolated `git clone` under `--workroot`
+  (default `$TMPDIR/claude-mem-swebench`). Workdirs are deleted on success
+  unless `--keep-workdirs` is passed.

--- a/scripts/swebench/README.md
+++ b/scripts/swebench/README.md
@@ -13,16 +13,31 @@ The runner only **generates predictions** (`predictions.jsonl` in SWE-bench
 format). Scoring is done by the official SWE-bench harness via the companion
 `evaluate.sh` wrapper.
 
+### Why the slash-prefixed prompt works in `-p` mode
+
+Per [the Claude Code headless docs](https://code.claude.com/docs/en/headless.md),
+slash commands are **not expanded** in `--print` mode. This runner still sends
+the literal `/make-plan` and `/do` tokens because the claude-mem skills
+(`plugin/skills/make-plan/SKILL.md`, `plugin/skills/do/SKILL.md`) are
+description-driven: the model auto-invokes them by matching the prompt against
+their `description` frontmatter, not by expanding a slash command. Naming the
+skills in the prompt is an explicit hint toward that auto-invocation.
+
 ## Prerequisites
 
 1. **Claude Code CLI** on `PATH` (`claude --version` should work) with a valid
-   login or `ANTHROPIC_API_KEY`.
+   login or `ANTHROPIC_API_KEY`. Verified flags used by this runner:
+   `--print`, `--permission-mode bypassPermissions` (camelCase), `--model`.
+   Reference: [cli-reference](https://code.claude.com/docs/en/cli-reference.md),
+   [headless](https://code.claude.com/docs/en/headless.md).
+   > Do **not** add `--bare` — it disables plugin auto-discovery and would
+   > silently deactivate claude-mem's hooks and skills.
 2. **claude-mem plugin installed and enabled** in the user's Claude Code
    config. Confirm the worker is up:
    ```bash
    npm --prefix ~/.claude/plugins/marketplaces/thedotmack run worker:status
    ```
-   The `/make-plan` and `/do` skills ship with the plugin
+   The make-plan and do skills ship with the plugin
    (`plugin/skills/make-plan/SKILL.md`, `plugin/skills/do/SKILL.md`).
 3. **Python 3.10+** with `datasets` installed (for dataset loading):
    ```bash
@@ -62,8 +77,11 @@ scripts/swebench/evaluate.sh scripts/swebench/out/predictions.jsonl
 ```
 
 This shells out to `python -m swebench.harness.run_evaluation` with
-`--dataset_name princeton-nlp/SWE-bench_Verified`. Results land under
-`./logs/run_evaluation/<run_id>/` and `./evaluation_results/`.
+`--dataset_name SWE-bench/SWE-bench_Verified` (the canonical id after the
+[2025 org rename](https://github.com/SWE-bench/SWE-bench#readme); the old
+`princeton-nlp/SWE-bench_Verified` still resolves via HF aliasing but is
+deprecated). Harness flag names use underscores, not hyphens. Results land
+under `./logs/run_evaluation/<run_id>/` and `./evaluation_results/`.
 
 ## Prediction format
 
@@ -73,8 +91,11 @@ Each line of `predictions.jsonl` is:
 {"instance_id": "...", "model_name_or_path": "claude-mem", "model_patch": "<unified diff>"}
 ```
 
-This is the canonical SWE-bench predictions schema; it can be fed to any
-SWE-bench-compatible evaluator.
+These three keys are the full schema the harness reads — see
+[`swebench/harness/constants/__init__.py:66-68`](https://github.com/SWE-bench/SWE-bench/blob/main/swebench/harness/constants/__init__.py#L66-L68).
+Extra keys are ignored. `model_patch` is written verbatim to a patch file and
+fed to `git apply` inside the per-instance Docker container, so it must be a
+plain unified diff (no `--binary` hunks).
 
 ## Notes on reproducibility
 

--- a/scripts/swebench/evaluate.sh
+++ b/scripts/swebench/evaluate.sh
@@ -29,8 +29,11 @@ if ! python -c "import swebench" >/dev/null 2>&1; then
   python -m pip install --upgrade swebench >&2
 fi
 
+# Harness CLI uses underscored flag names.
+# Source: https://github.com/SWE-bench/SWE-bench/blob/main/swebench/harness/run_evaluation.py#L587-L670
 exec python -m swebench.harness.run_evaluation \
-  --dataset_name princeton-nlp/SWE-bench_Verified \
+  --dataset_name SWE-bench/SWE-bench_Verified \
+  --split test \
   --predictions_path "$PREDICTIONS" \
   --run_id "$RUN_ID" \
   --max_workers "${SWEBENCH_MAX_WORKERS:-4}"

--- a/scripts/swebench/evaluate.sh
+++ b/scripts/swebench/evaluate.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Score a predictions.jsonl produced by ``scripts/swebench/run.py`` using the
+# official SWE-bench evaluation harness. Requires Docker.
+#
+# Usage:
+#   scripts/swebench/evaluate.sh [PREDICTIONS_PATH] [RUN_ID]
+#
+# Defaults:
+#   PREDICTIONS_PATH = scripts/swebench/out/predictions.jsonl
+#   RUN_ID           = claude-mem-$(date +%Y%m%d-%H%M%S)
+set -euo pipefail
+
+PREDICTIONS="${1:-scripts/swebench/out/predictions.jsonl}"
+RUN_ID="${2:-claude-mem-$(date +%Y%m%d-%H%M%S)}"
+
+if [[ ! -f "$PREDICTIONS" ]]; then
+  echo "error: predictions file not found: $PREDICTIONS" >&2
+  exit 2
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "error: docker is required by the SWE-bench evaluation harness" >&2
+  exit 2
+fi
+
+# Install the harness on demand — pinning is the caller's choice.
+if ! python -c "import swebench" >/dev/null 2>&1; then
+  echo "Installing swebench harness ..." >&2
+  python -m pip install --upgrade swebench >&2
+fi
+
+exec python -m swebench.harness.run_evaluation \
+  --dataset_name princeton-nlp/SWE-bench_Verified \
+  --predictions_path "$PREDICTIONS" \
+  --run_id "$RUN_ID" \
+  --max_workers "${SWEBENCH_MAX_WORKERS:-4}"

--- a/scripts/swebench/run.py
+++ b/scripts/swebench/run.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""SWE-bench Verified runner for Claude Code with claude-mem installed.
+
+For each task instance this script:
+  1. Clones the target repo at ``base_commit`` into an isolated workdir.
+  2. Invokes the ``claude`` CLI in headless (``--print``) mode, feeding a
+     prompt prefixed with the custom instructions:
+         "use the /make-plan and /do skill to " + <problem_statement>
+     claude-mem must already be installed as a plugin so its hooks and
+     skills are active during the run.
+  3. Captures the resulting ``git diff`` against ``base_commit`` as the
+     ``model_patch`` and appends a prediction row to ``predictions.jsonl``
+     in SWE-bench's standard prediction format.
+
+The file this produces is the input to the standard SWE-bench evaluation
+harness (see ``scripts/swebench/evaluate.sh``). This runner does NOT score
+results; it only generates predictions.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator
+
+CUSTOM_PROMPT_PREFIX = "use the /make-plan and /do skill to "
+DEFAULT_MODEL_NAME = "claude-mem"
+DEFAULT_SPLIT = "test"
+DEFAULT_DATASET = "princeton-nlp/SWE-bench_Verified"
+
+
+@dataclass
+class Instance:
+    instance_id: str
+    repo: str
+    base_commit: str
+    problem_statement: str
+
+
+def load_instances(dataset: str, split: str) -> list[Instance]:
+    """Load SWE-bench instances via the HuggingFace ``datasets`` library."""
+    try:
+        from datasets import load_dataset  # type: ignore
+    except ImportError as exc:  # pragma: no cover - env bootstrap hint
+        raise SystemExit(
+            "Missing dependency 'datasets'. Install with: "
+            "uv pip install datasets  (or pip install datasets)"
+        ) from exc
+
+    ds = load_dataset(dataset, split=split)
+    out: list[Instance] = []
+    for row in ds:
+        out.append(
+            Instance(
+                instance_id=row["instance_id"],
+                repo=row["repo"],
+                base_commit=row["base_commit"],
+                problem_statement=row["problem_statement"],
+            )
+        )
+    return out
+
+
+def filter_instances(
+    instances: Iterable[Instance],
+    ids: list[str] | None,
+    max_tasks: int | None,
+) -> list[Instance]:
+    filtered = list(instances)
+    if ids:
+        id_set = set(ids)
+        filtered = [i for i in filtered if i.instance_id in id_set]
+    if max_tasks is not None:
+        filtered = filtered[:max_tasks]
+    return filtered
+
+
+def already_predicted(predictions_path: Path) -> set[str]:
+    if not predictions_path.exists():
+        return set()
+    done: set[str] = set()
+    with predictions_path.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            inst = row.get("instance_id")
+            if isinstance(inst, str):
+                done.add(inst)
+    return done
+
+
+def run(cmd: list[str], *, cwd: Path | None = None, timeout: int | None = None,
+        env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        env={**os.environ, **(env or {})},
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def prepare_repo(instance: Instance, workdir: Path) -> Path:
+    """Clone ``instance.repo`` at ``base_commit`` into ``workdir``."""
+    repo_dir = workdir / "repo"
+    if repo_dir.exists():
+        shutil.rmtree(repo_dir)
+    clone_url = f"https://github.com/{instance.repo}.git"
+    res = run(["git", "clone", "--quiet", clone_url, str(repo_dir)])
+    if res.returncode != 0:
+        raise RuntimeError(f"git clone failed for {instance.repo}: {res.stderr}")
+    res = run(
+        ["git", "checkout", "--quiet", instance.base_commit],
+        cwd=repo_dir,
+    )
+    if res.returncode != 0:
+        raise RuntimeError(
+            f"git checkout {instance.base_commit} failed for "
+            f"{instance.instance_id}: {res.stderr}"
+        )
+    return repo_dir
+
+
+def invoke_claude(
+    claude_bin: str,
+    repo_dir: Path,
+    prompt: str,
+    *,
+    timeout: int,
+    model: str | None,
+    permission_mode: str,
+) -> subprocess.CompletedProcess[str]:
+    """Run Claude Code headlessly inside ``repo_dir``."""
+    cmd = [
+        claude_bin,
+        "--print",
+        "--permission-mode", permission_mode,
+        "--output-format", "stream-json",
+        "--verbose",
+    ]
+    if model:
+        cmd += ["--model", model]
+    cmd.append(prompt)
+    return run(cmd, cwd=repo_dir, timeout=timeout)
+
+
+def capture_diff(repo_dir: Path, base_commit: str) -> str:
+    """Return a unified diff against ``base_commit`` for all tracked and
+    untracked text changes."""
+    # Stage everything (including untracked) so ``git diff --cached`` captures
+    # new files; a temporary index keeps the worktree untouched.
+    run(["git", "add", "-A"], cwd=repo_dir)
+    res = run(
+        ["git", "diff", "--cached", "--binary", base_commit],
+        cwd=repo_dir,
+    )
+    if res.returncode != 0:
+        # Fall back to worktree diff if cached diff fails (detached edge cases).
+        res = run(["git", "diff", "--binary", base_commit], cwd=repo_dir)
+    return res.stdout
+
+
+def process_instance(
+    instance: Instance,
+    *,
+    predictions_path: Path,
+    workroot: Path,
+    claude_bin: str,
+    model_name: str,
+    model: str | None,
+    per_task_timeout: int,
+    permission_mode: str,
+    keep_workdirs: bool,
+    lock: "ThreadLock",
+) -> tuple[str, bool, str]:
+    workdir = workroot / instance.instance_id
+    workdir.mkdir(parents=True, exist_ok=True)
+    try:
+        repo_dir = prepare_repo(instance, workdir)
+        prompt = CUSTOM_PROMPT_PREFIX + instance.problem_statement
+        proc = invoke_claude(
+            claude_bin,
+            repo_dir,
+            prompt,
+            timeout=per_task_timeout,
+            model=model,
+            permission_mode=permission_mode,
+        )
+        patch = capture_diff(repo_dir, instance.base_commit)
+        row = {
+            "instance_id": instance.instance_id,
+            "model_name_or_path": model_name,
+            "model_patch": patch,
+        }
+        with lock:
+            with predictions_path.open("a") as fh:
+                fh.write(json.dumps(row) + "\n")
+        ok = proc.returncode == 0 and bool(patch.strip())
+        detail = (
+            f"rc={proc.returncode} patch_bytes={len(patch)} "
+            f"stderr_tail={proc.stderr[-200:]!r}" if proc.stderr else
+            f"rc={proc.returncode} patch_bytes={len(patch)}"
+        )
+        return instance.instance_id, ok, detail
+    except subprocess.TimeoutExpired:
+        return instance.instance_id, False, f"timeout after {per_task_timeout}s"
+    except Exception as exc:  # noqa: BLE001 - surface any failure as row-level
+        return instance.instance_id, False, f"error: {exc}"
+    finally:
+        if not keep_workdirs:
+            shutil.rmtree(workdir, ignore_errors=True)
+
+
+def iter_with_progress(it: Iterable, total: int) -> Iterator:
+    start = time.time()
+    for i, x in enumerate(it, 1):
+        yield x
+        elapsed = time.time() - start
+        rate = i / elapsed if elapsed else 0
+        eta = (total - i) / rate if rate else 0
+        print(
+            f"[{i}/{total}] elapsed={elapsed:.0f}s eta={eta:.0f}s",
+            file=sys.stderr,
+            flush=True,
+        )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--dataset", default=DEFAULT_DATASET,
+                    help=f"HF dataset id (default: {DEFAULT_DATASET})")
+    ap.add_argument("--split", default=DEFAULT_SPLIT,
+                    help=f"Dataset split (default: {DEFAULT_SPLIT})")
+    ap.add_argument("--predictions", type=Path,
+                    default=Path("scripts/swebench/out/predictions.jsonl"),
+                    help="Output JSONL path (appended to; --resume-aware)")
+    ap.add_argument("--workroot", type=Path,
+                    default=Path(tempfile.gettempdir()) / "claude-mem-swebench",
+                    help="Root directory for per-task clones")
+    ap.add_argument("--claude-bin", default=os.environ.get("CLAUDE_BIN", "claude"),
+                    help="Path to the Claude Code CLI (default: 'claude')")
+    ap.add_argument("--model", default=os.environ.get("CLAUDE_MODEL"),
+                    help="Model id passed to claude --model (optional)")
+    ap.add_argument("--model-name", default=DEFAULT_MODEL_NAME,
+                    help=f"model_name_or_path written to predictions "
+                         f"(default: {DEFAULT_MODEL_NAME})")
+    ap.add_argument("--permission-mode", default="bypassPermissions",
+                    choices=["bypassPermissions", "acceptEdits", "default"],
+                    help="Claude Code permission mode for unattended runs")
+    ap.add_argument("--per-task-timeout", type=int, default=45 * 60,
+                    help="Per-task wall-clock timeout in seconds (default 45m)")
+    ap.add_argument("--concurrency", type=int, default=1,
+                    help="Number of tasks to run in parallel (default 1)")
+    ap.add_argument("--max-tasks", type=int, default=None,
+                    help="Stop after N instances (for smoke tests)")
+    ap.add_argument("--instance-id", action="append", default=None,
+                    help="Run only this instance id (repeatable)")
+    ap.add_argument("--no-resume", action="store_true",
+                    help="Do not skip instances already present in predictions")
+    ap.add_argument("--keep-workdirs", action="store_true",
+                    help="Keep per-task clones on disk (debugging)")
+    args = ap.parse_args()
+
+    if shutil.which(args.claude_bin) is None and not Path(args.claude_bin).exists():
+        print(f"error: claude CLI not found at {args.claude_bin!r}. "
+              "Install Claude Code or pass --claude-bin.", file=sys.stderr)
+        return 2
+
+    args.predictions.parent.mkdir(parents=True, exist_ok=True)
+    args.workroot.mkdir(parents=True, exist_ok=True)
+
+    print(f"Loading dataset {args.dataset} split={args.split} ...", file=sys.stderr)
+    instances = load_instances(args.dataset, args.split)
+    instances = filter_instances(instances, args.instance_id, args.max_tasks)
+    if not args.no_resume:
+        done = already_predicted(args.predictions)
+        if done:
+            print(f"Resuming: skipping {len(done)} already-predicted instances",
+                  file=sys.stderr)
+            instances = [i for i in instances if i.instance_id not in done]
+
+    total = len(instances)
+    print(f"Running {total} instance(s) with concurrency={args.concurrency}",
+          file=sys.stderr)
+    if total == 0:
+        return 0
+
+    import threading
+    lock = threading.Lock()
+
+    if args.concurrency <= 1:
+        for inst in iter_with_progress(instances, total):
+            inst_id, ok, detail = process_instance(
+                inst,
+                predictions_path=args.predictions,
+                workroot=args.workroot,
+                claude_bin=args.claude_bin,
+                model_name=args.model_name,
+                model=args.model,
+                per_task_timeout=args.per_task_timeout,
+                permission_mode=args.permission_mode,
+                keep_workdirs=args.keep_workdirs,
+                lock=lock,
+            )
+            print(f"  {inst_id}: {'ok' if ok else 'FAIL'} — {detail}",
+                  file=sys.stderr, flush=True)
+    else:
+        with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+            futures = {
+                pool.submit(
+                    process_instance,
+                    inst,
+                    predictions_path=args.predictions,
+                    workroot=args.workroot,
+                    claude_bin=args.claude_bin,
+                    model_name=args.model_name,
+                    model=args.model,
+                    per_task_timeout=args.per_task_timeout,
+                    permission_mode=args.permission_mode,
+                    keep_workdirs=args.keep_workdirs,
+                    lock=lock,
+                ): inst
+                for inst in instances
+            }
+            done_count = 0
+            for fut in as_completed(futures):
+                done_count += 1
+                inst_id, ok, detail = fut.result()
+                print(f"[{done_count}/{total}] {inst_id}: "
+                      f"{'ok' if ok else 'FAIL'} — {detail}",
+                      file=sys.stderr, flush=True)
+
+    print(f"\nWrote predictions to {args.predictions}", file=sys.stderr)
+    return 0
+
+
+# Typing shim so the dataclass hint above is happy at import time.
+class ThreadLock:  # pragma: no cover - typing only
+    def __enter__(self): ...
+    def __exit__(self, *a): ...
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/swebench/run.py
+++ b/scripts/swebench/run.py
@@ -34,7 +34,11 @@ from typing import Iterable, Iterator
 CUSTOM_PROMPT_PREFIX = "use the /make-plan and /do skill to "
 DEFAULT_MODEL_NAME = "claude-mem"
 DEFAULT_SPLIT = "test"
-DEFAULT_DATASET = "princeton-nlp/SWE-bench_Verified"
+# Canonical HF id after the 2025 org rename (the harness default now points at
+# the SWE-bench/ namespace; princeton-nlp/ still resolves via HF alias but is
+# deprecated).
+# Source: https://github.com/SWE-bench/SWE-bench/blob/main/swebench/harness/run_evaluation.py#L590
+DEFAULT_DATASET = "SWE-bench/SWE-bench_Verified"
 
 
 @dataclass
@@ -145,13 +149,32 @@ def invoke_claude(
     model: str | None,
     permission_mode: str,
 ) -> subprocess.CompletedProcess[str]:
-    """Run Claude Code headlessly inside ``repo_dir``."""
+    """Run Claude Code headlessly inside ``repo_dir``.
+
+    Flags verified against
+    https://code.claude.com/docs/en/cli-reference.md and
+    https://code.claude.com/docs/en/headless.md:
+      * ``--print`` (alias ``-p``) is one-shot/non-interactive mode with the
+        prompt as a positional arg.
+      * ``--permission-mode`` accepts ``bypassPermissions`` (camelCase),
+        ``acceptEdits``, ``plan``, ``auto``, ``dontAsk``, ``default``.
+      * ``--model`` takes a full id (``claude-sonnet-4-6``) or an alias
+        (``sonnet``, ``opus``).
+      * Working directory is set by invoking from ``repo_dir`` (``--add-dir``
+        is for *additional* dirs, not the primary cwd).
+      * ``--bare`` is deliberately NOT passed: it would disable plugin auto-
+        discovery and therefore silently deactivate claude-mem's hooks and
+        skills, which is the whole point of this runner.
+    The prompt deliberately contains the literal ``/make-plan`` and ``/do``
+    tokens: in ``-p`` mode slash commands are not expanded, but skill
+    descriptions still match against the prompt, so naming the skills steers
+    the model toward them the same way description-driven auto-invocation
+    works for any skill.
+    """
     cmd = [
         claude_bin,
         "--print",
         "--permission-mode", permission_mode,
-        "--output-format", "stream-json",
-        "--verbose",
     ]
     if model:
         cmd += ["--model", model]
@@ -161,17 +184,23 @@ def invoke_claude(
 
 def capture_diff(repo_dir: Path, base_commit: str) -> str:
     """Return a unified diff against ``base_commit`` for all tracked and
-    untracked text changes."""
+    untracked text changes.
+
+    ``--binary`` is intentionally omitted: the SWE-bench evaluator applies
+    ``model_patch`` with plain ``git apply`` / ``patch`` and does not handle
+    binary hunks reliably.
+    Source: https://github.com/SWE-bench/SWE-bench/blob/main/swebench/harness/run_evaluation.py#L155-L200
+    """
     # Stage everything (including untracked) so ``git diff --cached`` captures
-    # new files; a temporary index keeps the worktree untouched.
+    # new files.
     run(["git", "add", "-A"], cwd=repo_dir)
     res = run(
-        ["git", "diff", "--cached", "--binary", base_commit],
+        ["git", "diff", "--cached", base_commit],
         cwd=repo_dir,
     )
     if res.returncode != 0:
         # Fall back to worktree diff if cached diff fails (detached edge cases).
-        res = run(["git", "diff", "--binary", base_commit], cwd=repo_dir)
+        res = run(["git", "diff", base_commit], cwd=repo_dir)
     return res.stdout
 
 


### PR DESCRIPTION
Provides a headless harness that invokes `claude --print` per task with a
prompt prefixed by "use the /make-plan and /do skill to ", captures the
resulting git diff as a prediction, and hands off to the official
swebench.harness.run_evaluation for scoring.

https://claude.ai/code/session_011box7y4pYunkodz3tCbQmj