### PR TITLE
fix: Windows --print (pipe) mode hangs when plugin hooks block on stdin

### DIFF
--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -154,16 +154,25 @@ function collectStdin() {
       resolve(null);
     });
 
-    // Safety: if no data arrives within 5s, proceed without stdin
+    // Safety: if no data arrives within timeout, proceed without stdin.
+    // On Windows, use a shorter timeout (500ms) because the 5s wait causes
+    // --print (pipe) mode to hang or produce empty output — Claude Code's hook
+    // stdin data arrives in milliseconds when present, and the long timeout
+    // blocks SessionStart hooks for up to 15s total (3 hooks × 5s). Fixes #1482.
+    const stdinTimeoutMs = IS_WINDOWS ? 500 : 5000;
     setTimeout(() => {
       process.stdin.removeAllListeners();
       process.stdin.pause();
       resolve(chunks.length > 0 ? Buffer.concat(chunks) : null);
-    }, 5000);
+    }, stdinTimeoutMs);
   });
 }
 
-const stdinData = await collectStdin();
+// Skip stdin collection for the "start" subcommand — it spawns a daemon and
+// never reads stdin. This avoids a blocking wait on Windows in --print mode
+// where stdin.isTTY is false but no hook data is piped. Fixes #1482.
+const needsStdin = !args.includes('start');
+const stdinData = needsStdin ? await collectStdin() : null;
 
 // Spawn Bun with the provided script and args
 // Use spawn (not spawnSync) to properly handle stdio

--- a/tests/bun-runner.test.ts
+++ b/tests/bun-runner.test.ts
@@ -45,3 +45,17 @@ describe('bun-runner.js findBun: DEP0190 regression guard (#1503)', () => {
     expect(source).toContain("spawnSync('which', ['bun']");
   });
 });
+
+describe('bun-runner.js Windows pipe mode fix (#1482)', () => {
+  it('skips stdin collection for the start subcommand', () => {
+    // The "start" subcommand spawns a daemon and never reads stdin.
+    // Collecting stdin blocks --print mode on Windows for up to 5s per hook.
+    expect(source).toContain("!args.includes('start')");
+  });
+
+  it('uses a shorter stdin timeout on Windows', () => {
+    // The 5s stdin timeout causes --print (pipe) mode to hang on Windows.
+    // Claude Code delivers hook stdin in milliseconds; 500ms is sufficient.
+    expect(source).toContain('IS_WINDOWS ? 500 : 5000');
+  });
+});


### PR DESCRIPTION
Fixes #1482. Fixed pipe mode detection failing on Windows when using claude --print.

I maintain PRISM (https://github.com/jakeefr/prism), a post-session diagnostics tool for Claude Code — CLAUDE.md adherence analysis and session health scoring from the same JSONL files. claude-mem handles session memory, PRISM handles session health — complementary tools.