### PR TITLE
fix(windows): escape single quotes in WQL orphan reaper filter

### DIFF
--- a/src/services/infrastructure/ProcessManager.ts
+++ b/src/services/infrastructure/ProcessManager.ts
@@ -376,8 +376,10 @@ export async function cleanupOrphanedProcesses(): Promise<void> {
     if (isWindows) {
       // Windows: Use WQL -Filter for server-side filtering (no $_ pipeline syntax).
       // Avoids Git Bash $_ interpretation (#1062) and PowerShell syntax errors (#1024).
+      // Inner single quotes must be doubled ('') to escape them within PowerShell
+      // single-quoted strings — otherwise '%pattern%' breaks the filter parsing (#1832).
       const wqlPatternConditions = ORPHAN_PROCESS_PATTERNS
-        .map(p => `CommandLine LIKE '%${p}%'`)
+        .map(p => `CommandLine LIKE ''%${p}%''`)
         .join(' OR ');
 
       const cmd = `powershell -NoProfile -NonInteractive -Command "Get-CimInstance Win32_Process -Filter '(${wqlPatternConditions}) AND ProcessId != ${currentPid}' | Select-Object ProcessId, CreationDate | ConvertTo-Json"`;
@@ -526,8 +528,10 @@ export async function aggressiveStartupCleanup(): Promise<void> {
     if (isWindows) {
       // Use WQL -Filter for server-side filtering (no $_ pipeline syntax).
       // Avoids Git Bash $_ interpretation (#1062) and PowerShell syntax errors (#1024).
+      // Inner single quotes must be doubled ('') to escape them within PowerShell
+      // single-quoted strings — otherwise '%pattern%' breaks the filter parsing (#1832).
       const wqlPatternConditions = allPatterns
-        .map(p => `CommandLine LIKE '%${p}%'`)
+        .map(p => `CommandLine LIKE ''%${p}%''`)
         .join(' OR ');
 
       const cmd = `powershell -NoProfile -NonInteractive -Command "Get-CimInstance Win32_Process -Filter '(${wqlPatternConditions}) AND ProcessId != ${currentPid}' | Select-Object ProcessId, CommandLine, CreationDate | ConvertTo-Json"`;


### PR DESCRIPTION
## Summary

- Fix PowerShell quoting bug in `cleanupOrphanedProcesses()` and `aggressiveStartupCleanup()` that causes the WQL filter to **always fail** on Windows
- The orphan reaper has never successfully run on any Windows machine since it was introduced

## Problem

The WQL filter wraps LIKE patterns in single quotes inside a PowerShell single-quoted string:

```powershell
# Generated command (broken):
Get-CimInstance Win32_Process -Filter '(CommandLine LIKE '%worker-service.cjs%' OR ...)'
#                                      ↑ string ends here    ↑ positional argument (error!)
```

PowerShell interprets the inner `'` as the end of the string, then treats `%worker-service.cjs%` as a positional argument:

```
Get-CimInstance : Cannot find positional parameter that accepts argument
  '%worker-service.cjs% OR CommandLine LIKE %chroma-mcp%...'
```

This error occurs on **every startup** but is caught and logged as a non-blocking error, so it goes unnoticed. The result: orphaned `bun`, `chroma-mcp`, and `mcp-server` processes are **never cleaned up** on Windows.

## Fix

Double the inner single quotes (`''`), which is standard PowerShell escaping for literal single quotes inside single-quoted strings:

```typescript
// Before:
.map(p => `CommandLine LIKE '%${p}%'`)

// After:
.map(p => `CommandLine LIKE ''%${p}%''`)
```

Both `cleanupOrphanedProcesses()` (L380) and `aggressiveStartupCleanup()` (L530) are fixed.

## Test result

Before (every startup since feature was introduced):
```
[ERROR] Failed to enumerate orphaned processes during aggressive cleanup
```

After patch (tested on Windows 11 Build 26200, claude-mem 12.1.0):
```
[INFO] Aggressive startup cleanup: killing orphaned processes {platform=Windows, count=8}
[INFO] Aggressive startup cleanup complete {count=8}
```

8 orphaned processes detected and killed on first startup.

## Impact

This is the root cause or contributing factor for multiple open issues on Windows:

| Issue | Title | How this fix helps |
|-------|-------|-------------------|
| #1832 | Windows cold-start 2m21s stall | Orphan cleanup now works, reducing port conflicts |
| #1841 | chroma-mcp not killed on exit | Orphans now cleaned on next startup |
| #1361 | chroma-mcp leak + 15GB bandwidth | 184 orphans would now be detected and killed |
| #1726 | worker-service SIGKILL (OOM) | Accumulated orphans consuming RAM now cleaned |
| #1077 | 146 orphans causing OOM | Same root cause — reaper was silently broken |

## Test plan

- [x] Verified locally on Windows 11 (bundled file patch)
- [x] Confirmed orphan reaper now finds and kills orphaned processes
- [x] Confirmed worker starts and remains stable after patch
- [ ] Run existing test suite (`bun test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)