### PR TITLE
fix: default search/timeline to current project when project param omitted

### DIFF
--- a/src/services/worker/SearchManager.ts
+++ b/src/services/worker/SearchManager.ts
@@ -24,6 +24,7 @@ import type { ObservationSearchResult, SessionSummarySearchResult, UserPromptSea
 import { logger } from '../../utils/logger.js';
 import { formatDate, formatTime, formatDateTime, extractFirstFile, groupByDate, estimateTokens } from '../../shared/timeline-formatting.js';
 import { ModeManager } from '../domain/ModeManager.js';
+import { getCurrentProjectName } from '../../shared/paths.js';
 
 import {
   SearchOrchestrator,
@@ -126,6 +127,10 @@ export class SearchManager {
   async search(args: any): Promise<any> {
     // Normalize URL-friendly params to internal format
     const normalized = this.normalizeParams(args);
+    // Default project to current git/project context if not specified
+    if (!normalized.project) {
+      normalized.project = getCurrentProjectName();
+    }
     const { query, type, obs_type, concepts, files, format, ...options } = normalized;
     let observations: ObservationSearchResult[] = [];
     let sessions: SessionSummarySearchResult[] = [];
@@ -396,6 +401,7 @@ export class SearchManager {
    */
   async timeline(args: any): Promise<any> {
     const { anchor, query, depth_before = 10, depth_after = 10, project } = args;
+    const resolvedProject = project || getCurrentProjectName();
     const cwd = process.cwd();
 
     // Validate: must provide either anchor or query, not both
@@ -464,7 +470,7 @@ export class SearchManager {
       anchorId = topResult.id;
       anchorEpoch = topResult.created_at_epoch;
       logger.debug('SEARCH', 'Query mode: Using observation as timeline anchor', { observationId: topResult.id });
-      timelineData = this.sessionStore.getTimelineAroundObservation(topResult.id, topResult.created_at_epoch, depth_before, depth_after, project);
+      timelineData = this.sessionStore.getTimelineAroundObservation(topResult.id, topResult.created_at_epoch, depth_before, depth_after, resolvedProject);
     }
     // MODE 2: Anchor-based timeline
     else if (typeof anchor === 'number') {
@@ -481,7 +487,7 @@ export class SearchManager {
       }
       anchorId = anchor;
       anchorEpoch = obs.created_at_epoch;
-      timelineData = this.sessionStore.getTimelineAroundObservation(anchor, anchorEpoch, depth_before, depth_after, project);
+      timelineData = this.sessionStore.getTimelineAroundObservation(anchor, anchorEpoch, depth_before, depth_after, resolvedProject);
     } else if (typeof anchor === 'string') {
       // Session ID or ISO timestamp
       if (anchor.startsWith('S') || anchor.startsWith('#S')) {
@@ -499,7 +505,7 @@ export class SearchManager {
         }
         anchorEpoch = sessions[0].created_at_epoch;
         anchorId = `S${sessionNum}`;
-        timelineData = this.sessionStore.getTimelineAroundTimestamp(anchorEpoch, depth_before, depth_after, project);
+        timelineData = this.sessionStore.getTimelineAroundTimestamp(anchorEpoch, depth_before, depth_after, resolvedProject);
       } else {
         // ISO timestamp
         const date = new Date(anchor);
@@ -514,7 +520,7 @@ export class SearchManager {
         }
         anchorEpoch = date.getTime();
         anchorId = anchor;
-        timelineData = this.sessionStore.getTimelineAroundTimestamp(anchorEpoch, depth_before, depth_after, project);
+        timelineData = this.sessionStore.getTimelineAroundTimestamp(anchorEpoch, depth_before, depth_after, resolvedProject);
       }
     } else {
       return {
@@ -1317,7 +1323,7 @@ export class SearchManager {
    * Tool handler: get_recent_context
    */
   async getRecentContext(args: any): Promise<any> {
-    const project = args.project || basename(process.cwd());
+    const project = args.project || getCurrentProjectName();
     const limit = args.limit || 3;
 
     const sessions = this.sessionStore.getRecentSessionsWithStatus(project, limit);
@@ -1444,7 +1450,7 @@ export class SearchManager {
    */
   async getContextTimeline(args: any): Promise<any> {
     const { anchor, depth_before = 10, depth_after = 10, project } = args;
-    const cwd = process.cwd();
+    const resolvedProject = project || getCurrentProjectName();
     let anchorEpoch: number;
     let anchorId: string | number = anchor;
 
@@ -1463,7 +1469,7 @@ export class SearchManager {
         };
       }
       anchorEpoch = obs.created_at_epoch;
-      timelineData = this.sessionStore.getTimelineAroundObservation(anchor, anchorEpoch, depth_before, depth_after, project);
+      timelineData = this.sessionStore.getTimelineAroundObservation(anchor, anchorEpoch, depth_before, depth_after, resolvedProject);
     } else if (typeof anchor === 'string') {
       // Session ID or ISO timestamp
       if (anchor.startsWith('S') || anchor.startsWith('#S')) {
@@ -1481,7 +1487,7 @@ export class SearchManager {
         }
         anchorEpoch = sessions[0].created_at_epoch;
         anchorId = `S${sessionNum}`;
-        timelineData = this.sessionStore.getTimelineAroundTimestamp(anchorEpoch, depth_before, depth_after, project);
+        timelineData = this.sessionStore.getTimelineAroundTimestamp(anchorEpoch, depth_before, depth_after, resolvedProject);
       } else {
         // ISO timestamp
         const date = new Date(anchor);
@@ -1495,7 +1501,7 @@ export class SearchManager {
           };
         }
         anchorEpoch = date.getTime(); // Keep as milliseconds
-        timelineData = this.sessionStore.getTimelineAroundTimestamp(anchorEpoch, depth_before, depth_after, project);
+        timelineData = this.sessionStore.getTimelineAroundTimestamp(anchorEpoch, depth_before, depth_after, resolvedProject);
       }
     } else {
       return {
@@ -1656,7 +1662,7 @@ export class SearchManager {
    */
   async getTimelineByQuery(args: any): Promise<any> {
     const { query, mode = 'auto', depth_before = 10, depth_after = 10, limit = 5, project } = args;
-    const cwd = process.cwd();
+    const resolvedProject = project || getCurrentProjectName();
 
     // Step 1: Search for observations
     let results: ObservationSearchResult[] = [];
@@ -1738,7 +1744,7 @@ export class SearchManager {
         topResult.created_at_epoch,
         depth_before,
         depth_after,
-        project
+        resolvedProject
       );
 
       // Combine, sort, and filter timeline items


### PR DESCRIPTION
## Problem

`search()` and `timeline()` return results from ALL projects when `project` is not specified, causing cross-project memory pollution. Observations use a global auto-increment ID across all projects, so without an explicit project filter the results are mixed.

## Fix

Default `project` to `getCurrentProjectName()` (git root context, matches status line / working directory) when not explicitly provided. Storage of observations already uses the correct project context — only read/search operations were affected.

Affected methods: `search()`, `timeline()`, `getRecentContext()`, `getContextTimeline()`, `getTimelineByQuery()`.

## Diff

\`\`\`diff
--- a/src/services/worker/SearchManager.ts
+++ b/src/services/worker/SearchManager.ts
@@ -24,6 +24,7 @@ import type { ObservationSearchResult, ... } from '../sqlite/types.js';
 import { logger } from '../../utils/logger.js';
 import { formatDate, ... } from '../../shared/timeline-formatting.js';
 import { ModeManager } from '../domain/ModeManager.js';
+import { getCurrentProjectName } from '../../shared/paths.js';
 
@@ -127,6 +128,10 @@ export class SearchManager {
   async search(args: any): Promise<any> {
     const normalized = this.normalizeParams(args);
+    if (!normalized.project) {
+      normalized.project = getCurrentProjectName();
+    }
     const { query, type, ... } = normalized;

- timeline(): add `const resolvedProject = project || getCurrentProjectName()`
- getRecentContext(): `basename(process.cwd())` → `getCurrentProjectName()`
- getContextTimeline(), getTimelineByQuery(): same `resolvedProject` pattern
\`\`\`