### PR TITLE
fix(summarizer): salvage summary from observation tags, support Gemini transcripts, use user_prompt

### DIFF
--- a/src/sdk/parser.ts
+++ b/src/sdk/parser.ts
@@ -139,8 +139,11 @@ export function parseSummary(text: string, sessionId?: number): ParsedSummary | 
     }
 
     // Raw text fallback: no XML tags at all — use full text as narrative (see #1908)
+    // Guard: only salvage raw text when the response truly has no XML-like tags.
+    // Malformed/truncated XML should not be stored as narrative.
     const stripped = text.trim();
-    if (stripped.length > 0) {
+    const hasXmlLikeTags = /<\/?[A-Za-z][^>]*>/.test(stripped);
+    if (stripped.length > 0 && !hasXmlLikeTags) {
       logger.warn('PARSER', 'Summary response contained no XML tags — salvaging raw text as narrative', { sessionId });
       return {
         request: null,

--- a/src/sdk/parser.ts
+++ b/src/sdk/parser.ts
@@ -206,7 +206,8 @@ export function parseSummary(text: string, sessionId?: number): ParsedSummary | 
 /**
  * Salvage a ParsedSummary from <observation> tags when the LLM failed to
  * emit <summary> tags. Extracts title → request, narrative → learned,
- * and facts → investigated/completed fields from the first observation.
+ * and facts → investigated/completed fields from all observations,
+ * joining multiple values with semicolons or double newlines.
  * Returns null only if the observation content is completely empty. (#1908)
  */
 function salvageSummaryFromObservationTags(text: string, sessionId?: number): ParsedSummary | null {

--- a/src/sdk/parser.ts
+++ b/src/sdk/parser.ts
@@ -132,11 +132,26 @@ export function parseSummary(text: string, sessionId?: number): ParsedSummary | 
   const summaryMatch = summaryRegex.exec(text);
 
   if (!summaryMatch) {
-    // Log when the response contains <observation> instead of <summary>
-    // to help diagnose prompt conditioning issues (see #1312)
+    // Salvage fallback: LLM emitted <observation> tags instead of <summary> (see #1908)
     if (/<observation>/.test(text)) {
-      logger.warn('PARSER', 'Summary response contained <observation> tags instead of <summary> — prompt conditioning may need strengthening', { sessionId });
+      logger.warn('PARSER', 'Summary response contained <observation> tags instead of <summary> — attempting salvage', { sessionId });
+      return salvageSummaryFromObservationTags(text, sessionId);
     }
+
+    // Raw text fallback: no XML tags at all — use full text as narrative (see #1908)
+    const stripped = text.trim();
+    if (stripped.length > 0) {
+      logger.warn('PARSER', 'Summary response contained no XML tags — salvaging raw text as narrative', { sessionId });
+      return {
+        request: null,
+        investigated: null,
+        learned: stripped,
+        completed: null,
+        next_steps: null,
+        notes: null
+      };
+    }
+
     return null;
   }
 
@@ -182,6 +197,45 @@ export function parseSummary(text: string, sessionId?: number): ParsedSummary | 
     completed,
     next_steps,
     notes
+  };
+}
+
+/**
+ * Salvage a ParsedSummary from <observation> tags when the LLM failed to
+ * emit <summary> tags. Extracts title → request, narrative → learned,
+ * and facts → investigated/completed fields from the first observation.
+ * Returns null only if the observation content is completely empty. (#1908)
+ */
+function salvageSummaryFromObservationTags(text: string, sessionId?: number): ParsedSummary | null {
+  const observationRegex = /<observation>([\s\S]*?)<\/observation>/g;
+  const titles: string[] = [];
+  const narratives: string[] = [];
+  const allFacts: string[] = [];
+
+  let match;
+  while ((match = observationRegex.exec(text)) !== null) {
+    const obsContent = match[1];
+    const title = extractField(obsContent, 'title');
+    const narrative = extractField(obsContent, 'narrative');
+    const facts = extractArrayElements(obsContent, 'facts', 'fact');
+
+    if (title) titles.push(title);
+    if (narrative) narratives.push(narrative);
+    allFacts.push(...facts);
+  }
+
+  if (titles.length === 0 && narratives.length === 0 && allFacts.length === 0) {
+    logger.warn('PARSER', 'Observation tags present but all content fields empty — salvage failed', { sessionId });
+    return null;
+  }
+
+  return {
+    request: titles.length > 0 ? titles.join('; ') : null,
+    investigated: allFacts.length > 0 ? allFacts.join('; ') : null,
+    learned: narratives.length > 0 ? narratives.join('\n\n') : null,
+    completed: null,
+    next_steps: null,
+    notes: null
   };
 }
 

--- a/src/sdk/prompts.ts
+++ b/src/sdk/prompts.ts
@@ -135,8 +135,15 @@ export function buildSummaryPrompt(session: SDKSession, mode: ModeConfig): strin
   })();
 
   // Include user_prompt for grounding the summary against the original request (#1910)
+  // Escape XML special characters to prevent prompt injection via user_prompt
+  const escapeXml = (value: string) =>
+    value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+
   const userPromptSection = session.user_prompt
-    ? `<original_user_request>${session.user_prompt}</original_user_request>\n\n`
+    ? `<original_user_request>${escapeXml(session.user_prompt)}</original_user_request>\n\n`
     : '';
 
   return `--- MODE SWITCH: PROGRESS SUMMARY ---

--- a/src/sdk/prompts.ts
+++ b/src/sdk/prompts.ts
@@ -134,11 +134,16 @@ export function buildSummaryPrompt(session: SDKSession, mode: ModeConfig): strin
     return '';
   })();
 
-  return `--- MODE SWITCH: PROGRESS SUMMARY ---
-Do NOT output <observation> tags. This is a summary request, not an observation request.
-Your response MUST use <summary> tags ONLY. Any <observation> output will be discarded.
+  // Include user_prompt for grounding the summary against the original request (#1910)
+  const userPromptSection = session.user_prompt
+    ? `<original_user_request>${session.user_prompt}</original_user_request>\n\n`
+    : '';
 
-${mode.prompts.header_summary_checkpoint}
+  return `--- MODE SWITCH: PROGRESS SUMMARY ---
+You MUST use only <summary> tags in your response. Do NOT use <observation> tags.
+Any output not wrapped in <summary> tags will be discarded.
+
+${userPromptSection}${mode.prompts.header_summary_checkpoint}
 ${mode.prompts.summary_instruction}
 
 ${mode.prompts.summary_context_label}

--- a/src/shared/transcript-parser.ts
+++ b/src/shared/transcript-parser.ts
@@ -123,7 +123,6 @@ function extractLastMessageFromJsonl(
   stripSystemReminders: boolean
 ): string {
   const lines = content.split('\n');
-  let foundMatchingRole = false;
 
   for (let i = lines.length - 1; i >= 0; i--) {
     const trimmedLine = lines[i].trim();
@@ -133,14 +132,13 @@ function extractLastMessageFromJsonl(
     try {
       line = JSON.parse(trimmedLine);
     } catch {
-      // Skip unparseable lines
+      // Skip unparseable lines - log for debugging
+      logger.debug('PARSER', `Skipping unparseable JSONL line ${i}`, { lineLength: trimmedLine.length });
       continue;
     }
 
     const mappedRole = mapJsonlTypeToRole(line.type);
     if (mappedRole === role) {
-      foundMatchingRole = true;
-
       // Gemini JSONL: content is a top-level string field
       if (typeof line.content === 'string') {
         let text = line.content;
@@ -177,11 +175,6 @@ function extractLastMessageFromJsonl(
         return text;
       }
     }
-  }
-
-  // If we searched the whole transcript and didn't find any message of this role
-  if (!foundMatchingRole) {
-    return '';
   }
 
   return '';

--- a/src/shared/transcript-parser.ts
+++ b/src/shared/transcript-parser.ts
@@ -92,8 +92,30 @@ function extractLastMessageFromGeminiTranscript(
 }
 
 /**
- * Extract last message from Claude Code JSONL transcript.
- * Each line is an independent JSON object with `type: "assistant"` or `type: "user"`.
+ * Map a JSONL entry's `type` field to the internal role.
+ * Handles Claude Code ("assistant"/"user") and Gemini CLI ("gemini"/"model"/"user")
+ * transcript formats. Returns null for unrecognized types. (#1909)
+ */
+function mapJsonlTypeToRole(type: string): 'user' | 'assistant' | null {
+  switch (type) {
+    case 'user':
+      return 'user';
+    case 'assistant':
+    case 'gemini':
+    case 'model':
+      return 'assistant';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Extract last message from JSONL transcript.
+ * Each line is an independent JSON object.
+ *
+ * Supports two JSONL conventions:
+ * - Claude Code: `type: "assistant"` or `type: "user"`, content in `message.content`
+ * - Gemini CLI JSONL: `type: "gemini"|"model"` or `type: "user"`, content in `content` (string) or `message.content`
  */
 function extractLastMessageFromJsonl(
   content: string,
@@ -104,10 +126,32 @@ function extractLastMessageFromJsonl(
   let foundMatchingRole = false;
 
   for (let i = lines.length - 1; i >= 0; i--) {
-    const line = JSON.parse(lines[i]);
-    if (line.type === role) {
+    const trimmedLine = lines[i].trim();
+    if (!trimmedLine) continue;
+
+    let line: any;
+    try {
+      line = JSON.parse(trimmedLine);
+    } catch {
+      // Skip unparseable lines
+      continue;
+    }
+
+    const mappedRole = mapJsonlTypeToRole(line.type);
+    if (mappedRole === role) {
       foundMatchingRole = true;
 
+      // Gemini JSONL: content is a top-level string field
+      if (typeof line.content === 'string') {
+        let text = line.content;
+        if (stripSystemReminders) {
+          text = text.replace(SYSTEM_REMINDER_REGEX, '');
+          text = text.replace(/\n{3,}/g, '\n\n').trim();
+        }
+        return text;
+      }
+
+      // Claude Code JSONL: content is nested in message.content
       if (line.message?.content) {
         let text = '';
         const msgContent = line.message.content;

--- a/tests/sdk/parse-summary.test.ts
+++ b/tests/sdk/parse-summary.test.ts
@@ -8,8 +8,19 @@ import { describe, it, expect } from 'bun:test';
 import { parseSummary } from '../../src/sdk/parser.js';
 
 describe('parseSummary', () => {
-  it('returns null when no <summary> tag present', () => {
-    expect(parseSummary('<observation><title>foo</title></observation>')).toBeNull();
+  // Intentional behavior change from #1908: parseSummary now salvages data from
+  // <observation> tags when no <summary> tags are present, rather than discarding
+  // the output. Previously this returned null (see #1360), but #1908 determined
+  // that discarding observation-tagged output loses valuable session data.
+  it('salvages summary from <observation> tags when no <summary> tag present (#1908)', () => {
+    const result = parseSummary('<observation><title>foo</title></observation>');
+    expect(result).not.toBeNull();
+    expect(result?.request).toBe('foo');
+    expect(result?.investigated).toBeNull();
+    expect(result?.learned).toBeNull();
+    expect(result?.completed).toBeNull();
+    expect(result?.next_steps).toBeNull();
+    expect(result?.notes).toBeNull();
   });
 
   it('returns null when <summary> has no sub-tags (false positive — fix for #1360)', () => {


### PR DESCRIPTION
## Summary
- Fix #1908: Add salvage fallback in parseSummary() when LLM emits `<observation>` instead of `<summary>` tags
- Fix #1909: Add Gemini transcript format detection and role mapping in transcript-parser
- Fix #1910: Include user_prompt in summary prompt and add explicit tag guardrails

## Test plan
- [ ] Verify parseSummary handles `<observation>` tags by extracting summary data
- [ ] Verify parseSummary handles raw text output (no tags)
- [ ] Verify Gemini JSONL transcripts parse correctly
- [ ] Verify summary prompt includes user_prompt context
- [ ] Verify summary prompt explicitly instructs model to use only `<summary>` tags

Closes #1908, closes #1909, closes #1910

🤖 Generated with [Claude Code](https://claude.com/claude-code)