### PR TITLE
fix(db): fix migration rebuild loop, CASCADE rewrites, dedup, WAL growth, pending purge

### DIFF
--- a/src/services/sqlite/Database.ts
+++ b/src/services/sqlite/Database.ts
@@ -10,6 +10,8 @@ import { MigrationRunner } from './migrations/runner.js';
 // SQLite configuration constants
 const SQLITE_MMAP_SIZE_BYTES = 256 * 1024 * 1024; // 256MB
 const SQLITE_CACHE_SIZE_PAGES = 10_000;
+const SQLITE_JOURNAL_SIZE_LIMIT_BYTES = 64 * 1024 * 1024; // 64MB - prevents unbounded WAL growth
+const WAL_CHECKPOINT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
 export interface Migration {
   version: number;
@@ -144,6 +146,7 @@ function repairMalformedSchemaWithReopen(dbPath: string, db: Database): Database
  */
 export class ClaudeMemDatabase {
   public db: Database;
+  private walCheckpointInterval: ReturnType<typeof setInterval> | null = null;
 
   constructor(dbPath: string = DB_PATH) {
     // Ensure data directory exists (skip for in-memory databases)
@@ -166,16 +169,31 @@ export class ClaudeMemDatabase {
     this.db.run('PRAGMA temp_store = memory');
     this.db.run(`PRAGMA mmap_size = ${SQLITE_MMAP_SIZE_BYTES}`);
     this.db.run(`PRAGMA cache_size = ${SQLITE_CACHE_SIZE_PAGES}`);
+    this.db.run(`PRAGMA journal_size_limit = ${SQLITE_JOURNAL_SIZE_LIMIT_BYTES}`);
 
     // Run all migrations
     const migrationRunner = new MigrationRunner(this.db);
     migrationRunner.runAllMigrations();
+
+    // Schedule periodic WAL checkpoints to prevent unbounded WAL growth
+    this.walCheckpointInterval = setInterval(() => {
+      try {
+        this.db.run('PRAGMA wal_checkpoint(TRUNCATE)');
+        logger.debug('DB', 'WAL checkpoint (TRUNCATE) completed');
+      } catch (error) {
+        logger.warn('DB', 'WAL checkpoint failed (non-fatal)', {}, error as Error);
+      }
+    }, WAL_CHECKPOINT_INTERVAL_MS);
   }
 
   /**
-   * Close the database connection
+   * Close the database connection and stop background tasks
    */
   close(): void {
+    if (this.walCheckpointInterval) {
+      clearInterval(this.walCheckpointInterval);
+      this.walCheckpointInterval = null;
+    }
     this.db.close();
   }
 }

--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -116,7 +116,7 @@ export class SessionStore {
         type TEXT NOT NULL,
         created_at TEXT NOT NULL,
         created_at_epoch INTEGER NOT NULL,
-        FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE CASCADE
+        FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE RESTRICT
       );
 
       CREATE INDEX IF NOT EXISTS idx_observations_sdk_session ON observations(memory_session_id);
@@ -138,7 +138,7 @@ export class SessionStore {
         notes TEXT,
         created_at TEXT NOT NULL,
         created_at_epoch INTEGER NOT NULL,
-        FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE CASCADE
+        FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE RESTRICT
       );
 
       CREATE INDEX IF NOT EXISTS idx_session_summaries_sdk_session ON session_summaries(memory_session_id);
@@ -716,7 +716,7 @@ export class SessionStore {
           discovery_tokens INTEGER DEFAULT 0,
           created_at TEXT NOT NULL,
           created_at_epoch INTEGER NOT NULL,
-          FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE CASCADE
+          FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE RESTRICT
         )
       `);
 
@@ -787,7 +787,7 @@ export class SessionStore {
           discovery_tokens INTEGER DEFAULT 0,
           created_at TEXT NOT NULL,
           created_at_epoch INTEGER NOT NULL,
-          FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE CASCADE
+          FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE RESTRICT
         )
       `);
 
@@ -1017,6 +1017,29 @@ export class SessionStore {
     }
 
     if (session.memory_session_id !== memorySessionId) {
+      // If the old memory_session_id has child rows (observations/summaries),
+      // don't update in-place — ON UPDATE RESTRICT would reject it, and we
+      // shouldn't rewrite historical attribution anyway. Only update when
+      // transitioning from NULL or when there are no children.
+      if (session.memory_session_id !== null) {
+        const childCount = this.db.prepare(`
+          SELECT
+            (SELECT COUNT(*) FROM observations WHERE memory_session_id = ?) +
+            (SELECT COUNT(*) FROM session_summaries WHERE memory_session_id = ?)
+          AS total
+        `).get(session.memory_session_id, session.memory_session_id) as { total: number };
+
+        if (childCount.total > 0) {
+          logger.warn('DB', 'Skipping memory_session_id update: old ID has child rows (historical attribution preserved)', {
+            sessionDbId,
+            oldId: session.memory_session_id,
+            newId: memorySessionId,
+            childCount: childCount.total
+          });
+          return;
+        }
+      }
+
       this.db.prepare(`
         UPDATE sdk_sessions SET memory_session_id = ? WHERE id = ?
       `).run(memorySessionId, sessionDbId);

--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -1006,8 +1006,10 @@ export class SessionStore {
    *
    * @param sessionDbId - The database ID of the session
    * @param memorySessionId - The memory session ID to ensure is registered
+   * @returns true if the memory_session_id was updated (or already matched),
+   *          false if the update was skipped because the old ID has child rows.
    */
-  ensureMemorySessionIdRegistered(sessionDbId: number, memorySessionId: string): void {
+  ensureMemorySessionIdRegistered(sessionDbId: number, memorySessionId: string): boolean {
     const session = this.db.prepare(`
       SELECT id, memory_session_id FROM sdk_sessions WHERE id = ?
     `).get(sessionDbId) as { id: number; memory_session_id: string | null } | undefined;
@@ -1016,40 +1018,43 @@ export class SessionStore {
       throw new Error(`Session ${sessionDbId} not found in sdk_sessions`);
     }
 
-    if (session.memory_session_id !== memorySessionId) {
-      // If the old memory_session_id has child rows (observations/summaries),
-      // don't update in-place — ON UPDATE RESTRICT would reject it, and we
-      // shouldn't rewrite historical attribution anyway. Only update when
-      // transitioning from NULL or when there are no children.
-      if (session.memory_session_id !== null) {
-        const childCount = this.db.prepare(`
-          SELECT
-            (SELECT COUNT(*) FROM observations WHERE memory_session_id = ?) +
-            (SELECT COUNT(*) FROM session_summaries WHERE memory_session_id = ?)
-          AS total
-        `).get(session.memory_session_id, session.memory_session_id) as { total: number };
-
-        if (childCount.total > 0) {
-          logger.warn('DB', 'Skipping memory_session_id update: old ID has child rows (historical attribution preserved)', {
-            sessionDbId,
-            oldId: session.memory_session_id,
-            newId: memorySessionId,
-            childCount: childCount.total
-          });
-          return;
-        }
-      }
-
-      this.db.prepare(`
-        UPDATE sdk_sessions SET memory_session_id = ? WHERE id = ?
-      `).run(memorySessionId, sessionDbId);
-
-      logger.info('DB', 'Registered memory_session_id before storage (FK fix)', {
-        sessionDbId,
-        oldId: session.memory_session_id,
-        newId: memorySessionId
-      });
+    if (session.memory_session_id === memorySessionId) {
+      return true; // Already matches
     }
+
+    // If the old memory_session_id has child rows (observations/summaries),
+    // don't update in-place — ON UPDATE RESTRICT would reject it, and we
+    // shouldn't rewrite historical attribution anyway. Only update when
+    // transitioning from NULL or when there are no children.
+    if (session.memory_session_id !== null) {
+      const childCount = this.db.prepare(`
+        SELECT
+          (SELECT COUNT(*) FROM observations WHERE memory_session_id = ?) +
+          (SELECT COUNT(*) FROM session_summaries WHERE memory_session_id = ?)
+        AS total
+      `).get(session.memory_session_id, session.memory_session_id) as { total: number };
+
+      if (childCount.total > 0) {
+        logger.warn('DB', 'Skipping memory_session_id update: old ID has child rows (historical attribution preserved)', {
+          sessionDbId,
+          oldId: session.memory_session_id,
+          newId: memorySessionId,
+          childCount: childCount.total
+        });
+        return false;
+      }
+    }
+
+    this.db.prepare(`
+      UPDATE sdk_sessions SET memory_session_id = ? WHERE id = ?
+    `).run(memorySessionId, sessionDbId);
+
+    logger.info('DB', 'Registered memory_session_id before storage (FK fix)', {
+      sessionDbId,
+      oldId: session.memory_session_id,
+      newId: memorySessionId
+    });
+    return true;
   }
 
   /**

--- a/src/services/sqlite/migrations/runner.ts
+++ b/src/services/sqlite/migrations/runner.ts
@@ -971,13 +971,47 @@ export class MigrationRunner {
 
     logger.debug('DB', 'Replacing ON UPDATE CASCADE with ON UPDATE RESTRICT on FK constraints');
 
-    // Get current column lists to ensure we copy all columns including any added by later migrations
-    const obsColumns = (this.db.query('PRAGMA table_info(observations)').all() as TableColumnInfo[])
+    // Check if the FK actually uses CASCADE before rebuilding.
+    // Fresh databases created with the new initializeSchema() already have RESTRICT,
+    // so the expensive table rebuild is unnecessary.
+    const obsFkInfo = this.db.query('PRAGMA foreign_key_list(observations)').all() as any[];
+    const obsHasCascadeOnUpdate = obsFkInfo.some((fk: any) => fk.on_update === 'CASCADE');
+    const sumFkInfo = this.db.query('PRAGMA foreign_key_list(session_summaries)').all() as any[];
+    const sumHasCascadeOnUpdate = sumFkInfo.some((fk: any) => fk.on_update === 'CASCADE');
+
+    if (!obsHasCascadeOnUpdate && !sumHasCascadeOnUpdate) {
+      // Already using RESTRICT (or no FK at all), skip rebuild
+      logger.debug('DB', 'FK constraints already use RESTRICT, skipping table rebuild');
+      this.db.prepare('INSERT OR IGNORE INTO schema_versions (version, applied_at) VALUES (?, ?)').run(26, new Date().toISOString());
+      return;
+    }
+
+    // Get current column lists to ensure we copy all columns including any added by later migrations.
+    // Filter to only columns that exist in the new schema to prevent INSERT failures when
+    // the source table has columns not defined in the target (e.g. from a future migration).
+    const obsSourceColumns = (this.db.query('PRAGMA table_info(observations)').all() as TableColumnInfo[])
       .map(c => c.name)
       .filter(n => n !== undefined);
-    const sumColumns = (this.db.query('PRAGMA table_info(session_summaries)').all() as TableColumnInfo[])
+    const sumSourceColumns = (this.db.query('PRAGMA table_info(session_summaries)').all() as TableColumnInfo[])
       .map(c => c.name)
       .filter(n => n !== undefined);
+
+    // Canonical column sets for the new tables
+    const obsNewSchemaColumns = new Set([
+      'id', 'memory_session_id', 'project', 'text', 'type', 'title', 'subtitle',
+      'facts', 'narrative', 'concepts', 'files_read', 'files_modified',
+      'prompt_number', 'discovery_tokens', 'content_hash',
+      'created_at', 'created_at_epoch', 'merged_into_project'
+    ]);
+    const sumNewSchemaColumns = new Set([
+      'id', 'memory_session_id', 'project', 'request', 'investigated', 'learned',
+      'completed', 'next_steps', 'files_read', 'files_edited', 'notes',
+      'prompt_number', 'discovery_tokens',
+      'created_at', 'created_at_epoch', 'merged_into_project'
+    ]);
+
+    const obsColumns = obsSourceColumns.filter(c => obsNewSchemaColumns.has(c));
+    const sumColumns = sumSourceColumns.filter(c => sumNewSchemaColumns.has(c));
 
     this.db.run('PRAGMA foreign_keys = OFF');
     this.db.run('BEGIN TRANSACTION');

--- a/src/services/sqlite/migrations/runner.ts
+++ b/src/services/sqlite/migrations/runner.ts
@@ -38,6 +38,7 @@ export class MigrationRunner {
     this.createObservationFeedbackTable();
     this.addSessionPlatformSourceColumn();
     this.ensureMergedIntoProjectColumns();
+    this.replaceOnUpdateCascadeWithRestrict();
   }
 
   /**
@@ -88,7 +89,7 @@ export class MigrationRunner {
         type TEXT NOT NULL,
         created_at TEXT NOT NULL,
         created_at_epoch INTEGER NOT NULL,
-        FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE CASCADE
+        FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE RESTRICT
       );
 
       CREATE INDEX IF NOT EXISTS idx_observations_sdk_session ON observations(memory_session_id);
@@ -110,7 +111,7 @@ export class MigrationRunner {
         notes TEXT,
         created_at TEXT NOT NULL,
         created_at_epoch INTEGER NOT NULL,
-        FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE CASCADE
+        FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE RESTRICT
       );
 
       CREATE INDEX IF NOT EXISTS idx_session_summaries_sdk_session ON session_summaries(memory_session_id);
@@ -639,11 +640,12 @@ export class MigrationRunner {
   }
 
   /**
-   * Add ON UPDATE CASCADE to FK constraints on observations and session_summaries (migration 21)
+   * Set ON UPDATE RESTRICT on FK constraints for observations and session_summaries (migration 21)
    *
-   * Both tables have FK(memory_session_id) -> sdk_sessions(memory_session_id) with ON DELETE CASCADE
-   * but missing ON UPDATE CASCADE. This causes FK constraint violations when code updates
-   * sdk_sessions.memory_session_id while child rows still reference the old value.
+   * Both tables have FK(memory_session_id) -> sdk_sessions(memory_session_id) with ON DELETE CASCADE.
+   * ON UPDATE RESTRICT prevents cascading session ID changes into historical child rows.
+   * When a session's memory_session_id needs to change, new rows should be inserted rather
+   * than updating the parent and cascading into all historical observations/summaries.
    *
    * SQLite doesn't support ALTER TABLE for FK changes, so we recreate both tables.
    */
@@ -687,7 +689,7 @@ export class MigrationRunner {
           discovery_tokens INTEGER DEFAULT 0,
           created_at TEXT NOT NULL,
           created_at_epoch INTEGER NOT NULL,
-          FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE CASCADE
+          FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE RESTRICT
         )
       `);
 
@@ -756,7 +758,7 @@ export class MigrationRunner {
           discovery_tokens INTEGER DEFAULT 0,
           created_at TEXT NOT NULL,
           created_at_epoch INTEGER NOT NULL,
-          FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE CASCADE
+          FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE RESTRICT
         )
       `);
 
@@ -951,5 +953,176 @@ export class MigrationRunner {
     this.db.run(
       'CREATE INDEX IF NOT EXISTS idx_summaries_merged_into ON session_summaries(merged_into_project)'
     );
+  }
+
+  /**
+   * Replace ON UPDATE CASCADE with ON UPDATE RESTRICT on FK constraints (migration 26)
+   *
+   * Migration 21 added ON UPDATE CASCADE, which causes historical observations and summaries
+   * to have their memory_session_id rewritten when a session's ID is updated (e.g. stale resume).
+   * ON UPDATE RESTRICT prevents this: historical child rows keep their original attribution.
+   *
+   * For existing databases that already ran migration 21 with CASCADE, this migration
+   * rebuilds both tables with RESTRICT instead.
+   */
+  private replaceOnUpdateCascadeWithRestrict(): void {
+    const applied = this.db.prepare('SELECT version FROM schema_versions WHERE version = ?').get(26) as SchemaVersion | undefined;
+    if (applied) return;
+
+    logger.debug('DB', 'Replacing ON UPDATE CASCADE with ON UPDATE RESTRICT on FK constraints');
+
+    // Get current column lists to ensure we copy all columns including any added by later migrations
+    const obsColumns = (this.db.query('PRAGMA table_info(observations)').all() as TableColumnInfo[])
+      .map(c => c.name)
+      .filter(n => n !== undefined);
+    const sumColumns = (this.db.query('PRAGMA table_info(session_summaries)').all() as TableColumnInfo[])
+      .map(c => c.name)
+      .filter(n => n !== undefined);
+
+    this.db.run('PRAGMA foreign_keys = OFF');
+    this.db.run('BEGIN TRANSACTION');
+
+    try {
+      // ===================================
+      // 1. Recreate observations table with ON UPDATE RESTRICT
+      // ===================================
+      this.db.run('DROP TRIGGER IF EXISTS observations_ai');
+      this.db.run('DROP TRIGGER IF EXISTS observations_ad');
+      this.db.run('DROP TRIGGER IF EXISTS observations_au');
+      this.db.run('DROP TABLE IF EXISTS observations_new');
+
+      this.db.run(`
+        CREATE TABLE observations_new (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          memory_session_id TEXT NOT NULL,
+          project TEXT NOT NULL,
+          text TEXT,
+          type TEXT NOT NULL,
+          title TEXT,
+          subtitle TEXT,
+          facts TEXT,
+          narrative TEXT,
+          concepts TEXT,
+          files_read TEXT,
+          files_modified TEXT,
+          prompt_number INTEGER,
+          discovery_tokens INTEGER DEFAULT 0,
+          content_hash TEXT,
+          created_at TEXT NOT NULL,
+          created_at_epoch INTEGER NOT NULL,
+          merged_into_project TEXT,
+          FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE RESTRICT
+        )
+      `);
+
+      const obsColumnList = obsColumns.join(', ');
+      this.db.run(`INSERT INTO observations_new (${obsColumnList}) SELECT ${obsColumnList} FROM observations`);
+      this.db.run('DROP TABLE observations');
+      this.db.run('ALTER TABLE observations_new RENAME TO observations');
+
+      this.db.run(`
+        CREATE INDEX idx_observations_sdk_session ON observations(memory_session_id);
+        CREATE INDEX idx_observations_project ON observations(project);
+        CREATE INDEX idx_observations_type ON observations(type);
+        CREATE INDEX idx_observations_created ON observations(created_at_epoch DESC);
+        CREATE INDEX IF NOT EXISTS idx_observations_content_hash ON observations(content_hash, created_at_epoch);
+        CREATE INDEX IF NOT EXISTS idx_observations_merged_into ON observations(merged_into_project);
+      `);
+
+      // Recreate FTS triggers if FTS table exists
+      const hasFTS = (this.db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='observations_fts'").all() as { name: string }[]).length > 0;
+      if (hasFTS) {
+        this.db.run(`
+          CREATE TRIGGER IF NOT EXISTS observations_ai AFTER INSERT ON observations BEGIN
+            INSERT INTO observations_fts(rowid, title, subtitle, narrative, text, facts, concepts)
+            VALUES (new.id, new.title, new.subtitle, new.narrative, new.text, new.facts, new.concepts);
+          END;
+          CREATE TRIGGER IF NOT EXISTS observations_ad AFTER DELETE ON observations BEGIN
+            INSERT INTO observations_fts(observations_fts, rowid, title, subtitle, narrative, text, facts, concepts)
+            VALUES('delete', old.id, old.title, old.subtitle, old.narrative, old.text, old.facts, old.concepts);
+          END;
+          CREATE TRIGGER IF NOT EXISTS observations_au AFTER UPDATE ON observations BEGIN
+            INSERT INTO observations_fts(observations_fts, rowid, title, subtitle, narrative, text, facts, concepts)
+            VALUES('delete', old.id, old.title, old.subtitle, old.narrative, old.text, old.facts, old.concepts);
+            INSERT INTO observations_fts(rowid, title, subtitle, narrative, text, facts, concepts)
+            VALUES (new.id, new.title, new.subtitle, new.narrative, new.text, new.facts, new.concepts);
+          END;
+        `);
+      }
+
+      // ===================================
+      // 2. Recreate session_summaries table with ON UPDATE RESTRICT
+      // ===================================
+      this.db.run('DROP TRIGGER IF EXISTS session_summaries_ai');
+      this.db.run('DROP TRIGGER IF EXISTS session_summaries_ad');
+      this.db.run('DROP TRIGGER IF EXISTS session_summaries_au');
+      this.db.run('DROP TABLE IF EXISTS session_summaries_new');
+
+      this.db.run(`
+        CREATE TABLE session_summaries_new (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          memory_session_id TEXT NOT NULL,
+          project TEXT NOT NULL,
+          request TEXT,
+          investigated TEXT,
+          learned TEXT,
+          completed TEXT,
+          next_steps TEXT,
+          files_read TEXT,
+          files_edited TEXT,
+          notes TEXT,
+          prompt_number INTEGER,
+          discovery_tokens INTEGER DEFAULT 0,
+          created_at TEXT NOT NULL,
+          created_at_epoch INTEGER NOT NULL,
+          merged_into_project TEXT,
+          FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE RESTRICT
+        )
+      `);
+
+      const sumColumnList = sumColumns.join(', ');
+      this.db.run(`INSERT INTO session_summaries_new (${sumColumnList}) SELECT ${sumColumnList} FROM session_summaries`);
+
+      this.db.run('DROP TABLE session_summaries');
+      this.db.run('ALTER TABLE session_summaries_new RENAME TO session_summaries');
+
+      this.db.run(`
+        CREATE INDEX idx_session_summaries_sdk_session ON session_summaries(memory_session_id);
+        CREATE INDEX idx_session_summaries_project ON session_summaries(project);
+        CREATE INDEX idx_session_summaries_created ON session_summaries(created_at_epoch DESC);
+        CREATE INDEX IF NOT EXISTS idx_summaries_merged_into ON session_summaries(merged_into_project);
+      `);
+
+      // Recreate session_summaries FTS triggers if FTS table exists
+      const hasSummariesFTS = (this.db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='session_summaries_fts'").all() as { name: string }[]).length > 0;
+      if (hasSummariesFTS) {
+        this.db.run(`
+          CREATE TRIGGER IF NOT EXISTS session_summaries_ai AFTER INSERT ON session_summaries BEGIN
+            INSERT INTO session_summaries_fts(rowid, request, investigated, learned, completed, next_steps, notes)
+            VALUES (new.id, new.request, new.investigated, new.learned, new.completed, new.next_steps, new.notes);
+          END;
+          CREATE TRIGGER IF NOT EXISTS session_summaries_ad AFTER DELETE ON session_summaries BEGIN
+            INSERT INTO session_summaries_fts(session_summaries_fts, rowid, request, investigated, learned, completed, next_steps, notes)
+            VALUES('delete', old.id, old.request, old.investigated, old.learned, old.completed, old.next_steps, old.notes);
+          END;
+          CREATE TRIGGER IF NOT EXISTS session_summaries_au AFTER UPDATE ON session_summaries BEGIN
+            INSERT INTO session_summaries_fts(session_summaries_fts, rowid, request, investigated, learned, completed, next_steps, notes)
+            VALUES('delete', old.id, old.request, old.investigated, old.learned, old.completed, old.next_steps, old.notes);
+            INSERT INTO session_summaries_fts(rowid, request, investigated, learned, completed, next_steps, notes)
+            VALUES (new.id, new.request, new.investigated, new.learned, new.completed, new.next_steps, new.notes);
+          END;
+        `);
+      }
+
+      this.db.prepare('INSERT OR IGNORE INTO schema_versions (version, applied_at) VALUES (?, ?)').run(26, new Date().toISOString());
+      this.db.run('COMMIT');
+      this.db.run('PRAGMA foreign_keys = ON');
+
+      logger.debug('DB', 'Successfully replaced ON UPDATE CASCADE with ON UPDATE RESTRICT on FK constraints');
+    } catch (error) {
+      this.db.run('ROLLBACK');
+      this.db.run('PRAGMA foreign_keys = ON');
+      throw error;
+    }
   }
 }

--- a/src/services/sqlite/observations/store.ts
+++ b/src/services/sqlite/observations/store.ts
@@ -13,8 +13,23 @@ import type { ObservationInput, StoreObservationResult } from './types.js';
 const DEDUP_WINDOW_MS = 30_000;
 
 /**
+ * Normalize content for dedup hashing: trim, collapse whitespace, lowercase.
+ * Ensures near-identical observations with minor whitespace/case differences
+ * produce the same hash and are properly deduped.
+ */
+function normalizeForDedup(value: string | null): string {
+  if (!value) return '';
+  return value
+    .trim()
+    .replace(/\s+/g, ' ')
+    .toLowerCase();
+}
+
+/**
  * Compute a short content hash for deduplication.
  * Uses (memory_session_id, title, narrative) as the semantic identity of an observation.
+ * Content is normalized (trimmed, whitespace-collapsed, lowercased) before hashing
+ * to prevent near-identical observations from bypassing dedup.
  */
 export function computeObservationContentHash(
   memorySessionId: string,
@@ -22,7 +37,11 @@ export function computeObservationContentHash(
   narrative: string | null
 ): string {
   return createHash('sha256')
-    .update([memorySessionId || '', title || '', narrative || ''].join('\x00'))
+    .update([
+      memorySessionId || '',
+      normalizeForDedup(title),
+      normalizeForDedup(narrative)
+    ].join('\x00'))
     .digest('hex')
     .slice(0, 16);
 }

--- a/src/services/sqlite/sessions/create.ts
+++ b/src/services/sqlite/sessions/create.ts
@@ -26,7 +26,8 @@ function resolveCreateSessionArgs(
  * - Result: Same database ID returned for all prompts in conversation
  *
  * Pure get-or-create: never modifies memory_session_id.
- * Multi-terminal isolation is handled by ON UPDATE CASCADE at the schema level.
+ * Multi-terminal isolation is handled by ON UPDATE RESTRICT at the schema level
+ * (prevents cascading rewrites of historical child rows).
  */
 export function createSDKSession(
   db: Database,

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -174,6 +174,7 @@ export class WorkerService {
 
   // Failed pending messages purge interval (Issue #1957)
   private failedMessagesPurgeInterval: ReturnType<typeof setInterval> | null = null;
+  private failedMessagesPurgeInFlight = false;
 
   // AI interaction tracking for health endpoint
   private lastAiInteraction: {
@@ -542,16 +543,20 @@ export class WorkerService {
       }, 2 * 60 * 1000);
 
       // Purge failed pending messages every 30 minutes (Issue #1957)
+      const { PendingMessageStore: PurgeMessageStore } = await import('./sqlite/PendingMessageStore.js');
+      const purgeStore = new PurgeMessageStore(this.dbManager.getSessionStore().db, 3);
       this.failedMessagesPurgeInterval = setInterval(async () => {
+        if (this.failedMessagesPurgeInFlight || this.isShuttingDown) return;
+        this.failedMessagesPurgeInFlight = true;
         try {
-          const { PendingMessageStore } = await import('./sqlite/PendingMessageStore.js');
-          const purgeStore = new PendingMessageStore(this.dbManager.getSessionStore().db, 3);
           const purged = purgeStore.clearFailed();
           if (purged > 0) {
             logger.info('SYSTEM', `Purged ${purged} failed pending messages`);
           }
         } catch (e) {
           logger.error('SYSTEM', 'Failed message purge error', { error: e instanceof Error ? e.message : String(e) });
+        } finally {
+          this.failedMessagesPurgeInFlight = false;
         }
       }, 30 * 60 * 1000);
 

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -172,6 +172,9 @@ export class WorkerService {
   // Stale session reaper interval (Issue #1168)
   private staleSessionReaperInterval: ReturnType<typeof setInterval> | null = null;
 
+  // Failed pending messages purge interval (Issue #1957)
+  private failedMessagesPurgeInterval: ReturnType<typeof setInterval> | null = null;
+
   // AI interaction tracking for health endpoint
   private lastAiInteraction: {
     timestamp: number;
@@ -537,6 +540,20 @@ export class WorkerService {
           logger.error('SYSTEM', 'Stale session reaper error', { error: e instanceof Error ? e.message : String(e) });
         }
       }, 2 * 60 * 1000);
+
+      // Purge failed pending messages every 30 minutes (Issue #1957)
+      this.failedMessagesPurgeInterval = setInterval(async () => {
+        try {
+          const { PendingMessageStore } = await import('./sqlite/PendingMessageStore.js');
+          const purgeStore = new PendingMessageStore(this.dbManager.getSessionStore().db, 3);
+          const purged = purgeStore.clearFailed();
+          if (purged > 0) {
+            logger.info('SYSTEM', `Purged ${purged} failed pending messages`);
+          }
+        } catch (e) {
+          logger.error('SYSTEM', 'Failed message purge error', { error: e instanceof Error ? e.message : String(e) });
+        }
+      }, 30 * 60 * 1000);
 
       // Auto-recover orphaned queues (fire-and-forget with error logging)
       this.processPendingQueues(50).then(result => {
@@ -1005,6 +1022,12 @@ export class WorkerService {
     if (this.staleSessionReaperInterval) {
       clearInterval(this.staleSessionReaperInterval);
       this.staleSessionReaperInterval = null;
+    }
+
+    // Stop failed messages purge (Issue #1957)
+    if (this.failedMessagesPurgeInterval) {
+      clearInterval(this.failedMessagesPurgeInterval);
+      this.failedMessagesPurgeInterval = null;
     }
 
     await performGracefulShutdown({

--- a/src/services/worker/agents/ResponseProcessor.ts
+++ b/src/services/worker/agents/ResponseProcessor.ts
@@ -99,7 +99,22 @@ export async function processAgentResponse(
   // in case the DB was somehow not updated (race condition, crash, etc.).
   // In multi-terminal scenarios, createSDKSession() now resets memory_session_id to NULL
   // for each new generator, ensuring clean isolation.
-  sessionStore.ensureMemorySessionIdRegistered(session.sessionDbId, session.memorySessionId);
+  const memorySessionIdRegistered = sessionStore.ensureMemorySessionIdRegistered(session.sessionDbId, session.memorySessionId);
+  if (!memorySessionIdRegistered) {
+    // The DB still holds the old memory_session_id because child rows exist.
+    // Use the DB's current value so FK constraints are satisfied.
+    const currentSession = sessionStore.getSessionById(session.sessionDbId);
+    if (currentSession?.memory_session_id) {
+      logger.warn('DB', 'Using existing memory_session_id from DB for storage (child-row guard)', {
+        sessionDbId: session.sessionDbId,
+        requested: session.memorySessionId,
+        using: currentSession.memory_session_id
+      });
+      session.memorySessionId = currentSession.memory_session_id;
+    } else {
+      throw new Error(`Cannot store observations: memory_session_id update was skipped and no existing ID found for session ${session.sessionDbId}`);
+    }
+  }
 
   // Log pre-storage with session ID chain for verification
   logger.info('DB', `STORING | sessionDbId=${session.sessionDbId} | memorySessionId=${session.memorySessionId} | obsCount=${observations.length} | hasSummary=${!!summaryForStore}`, {


### PR DESCRIPTION
## Summary
- **Fix #1953**: Migration 7's unique-constraint check already filters out PK index (`idx.origin !== 'pk'`), confirmed in both `runner.ts` and `SessionStore.ts` — no code change needed (already fixed).
- **Fix #1952**: Replace `ON UPDATE CASCADE` with `ON UPDATE RESTRICT` on session FK constraints in initial schema, migration 21, and new migration 26 (rebuilds existing tables). Update `ensureMemorySessionIdRegistered()` to skip in-place updates when the old `memory_session_id` has child rows, preserving historical attribution.
- **Fix #1955**: Normalize observation content before hashing — trim whitespace, collapse multiple spaces/newlines, lowercase — so near-identical observations are properly deduped.
- **Fix #1956**: Add `PRAGMA journal_size_limit = 67108864` (64MB) and periodic WAL checkpoint (`TRUNCATE`) every 5 minutes via `setInterval` in `ClaudeMemDatabase`, with cleanup on `close()`.
- **Fix #1957**: Schedule periodic `clearFailed()` every 30 minutes in worker-service background initialization to purge stale failed pending messages, with cleanup on shutdown.

## Test plan
- [ ] Verify migration 7 no longer rebuilds table on every startup
- [ ] Verify session ID updates don't cascade to historical observations
- [ ] Verify near-identical observations are properly deduped
- [ ] Verify WAL file doesn't grow unbounded
- [ ] Verify failed pending messages are periodically cleaned up

Closes #1953, closes #1952, closes #1955, closes #1956, closes #1957

🤖 Generated with [Claude Code](https://claude.com/claude-code)