### PR TITLE
fix: use Zod schemas in OpenCode plugin to fix _zod.def crash

### DIFF
--- a/src/integrations/opencode-plugin/index.ts
+++ b/src/integrations/opencode-plugin/index.ts
@@ -13,6 +13,8 @@
  * - claude_mem_search: Search memory database from within OpenCode
  */
 
+import { z } from "zod";
+
 // ============================================================================
 // Minimal type declarations for OpenCode Plugin SDK
 // These match the runtime API provided by @opencode-ai/plugin
@@ -330,10 +332,7 @@ export const ClaudeMemPlugin = async (ctx: OpenCodePluginContext) => {
         description:
           "Search claude-mem memory database for past observations, sessions, and context",
         args: {
-          query: {
-            type: "string",
-            description: "Search query for memory observations",
-          },
+          query: z.string().describe("Search query for memory observations"),
         },
         async execute(
           args: Record<string, unknown>,


### PR DESCRIPTION
## Summary
- Replace plain JSON Schema `{type: "string"}` args with `z.string().describe()` in the OpenCode plugin
- OpenCode 1.14.x walks `arg._zod.def` at registration — crashes on plain objects lacking `_zod` metadata
- Zod v4.3.6 already installed; build verified with 472 `_zod` references in bundle

Closes #2226, #2225, #2154

## Test plan
- [x] Build succeeds (`npm run build-and-sync`)
- [x] Bundle at `dist/opencode-plugin/index.js` contains `_zod` references
- [ ] Test with OpenCode 1.14.x — plugin registers without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)