### PR TITLE
feat(crush): IDE adapter, hooks installer, SQLite transcript watcher

### DIFF
--- a/src/cli/adapters/crush.ts
+++ b/src/cli/adapters/crush.ts
@@ -1,0 +1,71 @@
+import type { PlatformAdapter, HookResult } from '../types.js';
+import { AdapterRejectedInput, isValidCwd } from './errors.js';
+
+const FILE_EDIT_TOOLS = new Set(['write', 'edit', 'multiedit']);
+
+export const crushAdapter: PlatformAdapter = {
+  normalizeInput(raw) {
+    const r = (raw ?? {}) as any;
+
+    const cwd =
+      r.cwd ??
+      process.env.CRUSH_CWD ??
+      process.env.CRUSH_PROJECT_DIR ??
+      process.cwd();
+
+    if (!isValidCwd(cwd)) {
+      throw new AdapterRejectedInput('invalid_cwd');
+    }
+
+    const sessionId =
+      r.session_id ??
+      r.sessionId ??
+      process.env.CRUSH_SESSION_ID;
+
+    const toolName =
+      r.tool_name ??
+      r.toolName ??
+      process.env.CRUSH_TOOL_NAME;
+
+    const toolInput = r.tool_input ?? r.toolInput;
+
+    const metadata: Record<string, unknown> = {};
+    if (r.event) metadata.hook_event_name = r.event;
+    if (process.env.CRUSH_PROJECT_DIR) metadata.project_dir = process.env.CRUSH_PROJECT_DIR;
+
+    const lowered = typeof toolName === 'string' ? toolName.toLowerCase() : '';
+    const filePath =
+      (toolInput && typeof toolInput === 'object'
+        ? (toolInput as any).file_path ?? (toolInput as any).filePath ?? (toolInput as any).path
+        : undefined) ?? process.env.CRUSH_TOOL_INPUT_FILE_PATH;
+
+    const edits = FILE_EDIT_TOOLS.has(lowered)
+      ? (toolInput && typeof toolInput === 'object'
+          ? (toolInput as any).edits ?? [toolInput]
+          : undefined)
+      : undefined;
+
+    return {
+      sessionId,
+      cwd,
+      toolName,
+      toolInput,
+      toolResponse: r.tool_response ?? r.toolResponse,
+      filePath,
+      edits,
+      metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+    };
+  },
+
+  formatOutput(result) {
+    const r = result ?? ({} as HookResult);
+    const output: Record<string, unknown> = { version: 1 };
+
+    const injected = r.hookSpecificOutput?.additionalContext;
+    if (typeof injected === 'string' && injected.trim().length > 0) {
+      output.context = injected;
+    }
+
+    return output;
+  },
+};

--- a/src/cli/adapters/index.ts
+++ b/src/cli/adapters/index.ts
@@ -1,5 +1,6 @@
 import type { PlatformAdapter } from '../types.js';
 import { claudeCodeAdapter } from './claude-code.js';
+import { crushAdapter } from './crush.js';
 import { cursorAdapter } from './cursor.js';
 import { geminiCliAdapter } from './gemini-cli.js';
 import { rawAdapter } from './raw.js';
@@ -8,6 +9,7 @@ import { windsurfAdapter } from './windsurf.js';
 export function getPlatformAdapter(platform: string): PlatformAdapter {
   switch (platform) {
     case 'claude-code': return claudeCodeAdapter;
+    case 'crush': return crushAdapter;
     case 'cursor': return cursorAdapter;
     case 'gemini':
     case 'gemini-cli': return geminiCliAdapter;
@@ -17,4 +19,4 @@ export function getPlatformAdapter(platform: string): PlatformAdapter {
   }
 }
 
-export { claudeCodeAdapter, cursorAdapter, geminiCliAdapter, rawAdapter, windsurfAdapter };
+export { claudeCodeAdapter, crushAdapter, cursorAdapter, geminiCliAdapter, rawAdapter, windsurfAdapter };

--- a/src/npx-cli/commands/ide-detection.ts
+++ b/src/npx-cli/commands/ide-detection.ts
@@ -116,7 +116,7 @@ export function detectInstalledIDEs(): IDEInfo[] {
       label: 'Crush',
       detected: isCommandInPath('crush'),
       supported: true,
-      hint: 'MCP-based integration',
+      hint: 'MCP + PreToolUse hooks',
     },
     {
       id: 'roo-code',

--- a/src/services/integrations/CrushHooksInstaller.ts
+++ b/src/services/integrations/CrushHooksInstaller.ts
@@ -1,0 +1,345 @@
+import path from 'path';
+import { homedir } from 'os';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { logger } from '../../utils/logger.js';
+import { findBunPath, findWorkerServicePath } from './CursorHooksInstaller.js';
+import {
+  DEFAULT_CONFIG_PATH as TRANSCRIPT_CONFIG_PATH,
+  DEFAULT_STATE_PATH as TRANSCRIPT_STATE_PATH,
+  SAMPLE_CONFIG as TRANSCRIPT_SAMPLE_CONFIG,
+} from '../transcripts/config.js';
+import type { TranscriptWatchConfig, WatchTarget } from '../transcripts/types.js';
+
+const CRUSH_CONFIG_DIR = path.join(homedir(), '.config', 'crush');
+const CRUSH_CONFIG_PATH = path.join(CRUSH_CONFIG_DIR, 'crush.json');
+
+const CLAUDE_MEM_HOOK_MARKER = 'claude-mem-hook';
+
+interface CrushHookEntry {
+  matcher?: string;
+  command: string;
+  timeout?: number;
+}
+
+interface CrushHooksConfig {
+  hooks?: {
+    PreToolUse?: CrushHookEntry[];
+    [event: string]: CrushHookEntry[] | undefined;
+  };
+  [key: string]: unknown;
+}
+
+const FILE_EDIT_MATCHER = '^(write|edit|multiedit)$';
+const OBSERVATION_MATCHER = '^(?!write$|edit$|multiedit$).*';
+
+function buildFileEditCommand(bunPath: string, workerServicePath: string): string {
+  return `"${bunPath}" "${workerServicePath}" hook crush file-edit # ${CLAUDE_MEM_HOOK_MARKER}`;
+}
+
+function buildObservationCommand(bunPath: string, workerServicePath: string): string {
+  return `"${bunPath}" "${workerServicePath}" hook crush observation # ${CLAUDE_MEM_HOOK_MARKER}`;
+}
+
+function readCrushConfig(): CrushHooksConfig {
+  if (!existsSync(CRUSH_CONFIG_PATH)) return {};
+  try {
+    return JSON.parse(readFileSync(CRUSH_CONFIG_PATH, 'utf-8'));
+  } catch (error) {
+    const normalized = error instanceof Error ? error : new Error(String(error));
+    logger.error(
+      'CRUSH',
+      'Corrupt crush.json, refusing to overwrite',
+      { path: CRUSH_CONFIG_PATH },
+      normalized,
+    );
+    throw new Error(
+      `Corrupt crush.json at ${CRUSH_CONFIG_PATH}, refusing to overwrite. Fix the file and rerun.`,
+    );
+  }
+}
+
+function stripClaudeMemEntries(entries: CrushHookEntry[] | undefined): CrushHookEntry[] {
+  if (!Array.isArray(entries)) return [];
+  return entries.filter((entry) => !(entry?.command ?? '').includes(CLAUDE_MEM_HOOK_MARKER));
+}
+
+function mergeCrushHooks(bunPath: string, workerServicePath: string): void {
+  mkdirSync(CRUSH_CONFIG_DIR, { recursive: true });
+
+  const config = readCrushConfig();
+  if (!config.hooks || typeof config.hooks !== 'object') {
+    config.hooks = {};
+  }
+
+  const existing = stripClaudeMemEntries(config.hooks.PreToolUse);
+
+  const fileEditEntry: CrushHookEntry = {
+    matcher: FILE_EDIT_MATCHER,
+    command: buildFileEditCommand(bunPath, workerServicePath),
+    timeout: 15,
+  };
+
+  const observationEntry: CrushHookEntry = {
+    matcher: OBSERVATION_MATCHER,
+    command: buildObservationCommand(bunPath, workerServicePath),
+    timeout: 15,
+  };
+
+  config.hooks.PreToolUse = [...existing, fileEditEntry, observationEntry];
+
+  writeFileSync(CRUSH_CONFIG_PATH, JSON.stringify(config, null, 2) + '\n');
+}
+
+export async function installCrushHooks(): Promise<number> {
+  console.log('\nInstalling Claude-Mem Crush hooks (user level)...\n');
+
+  const workerServicePath = findWorkerServicePath();
+  if (!workerServicePath) {
+    console.error('Could not find worker-service.cjs');
+    console.error('   Expected at: ~/.claude/plugins/marketplaces/thedotmack/plugin/scripts/worker-service.cjs');
+    return 1;
+  }
+
+  const bunPath = findBunPath();
+  if (!bunPath) {
+    console.error('Could not find Bun runtime');
+    console.error('   Install Bun: curl -fsSL https://bun.sh/install | bash');
+    return 1;
+  }
+
+  console.log(`  Using Bun runtime: ${bunPath}`);
+  console.log(`  Worker service:   ${workerServicePath}`);
+
+  try {
+    mergeCrushHooks(bunPath, workerServicePath);
+    console.log(`  Wrote PreToolUse hooks to: ${CRUSH_CONFIG_PATH}`);
+    console.log(`
+Installation complete!
+
+Events registered (PreToolUse only — the only lifecycle hook Crush supports):
+  - write|edit|multiedit  → file-edit observation
+  - (all other tools)     → generic observation
+
+Next steps:
+  1. Ensure the claude-mem worker is running: npx claude-mem start
+  2. Restart Crush (or start a new session) to pick up the hooks
+  3. Tool observations will stream to the worker at localhost:<worker-port>
+`);
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`\nInstallation failed: ${message}`);
+    return 1;
+  }
+}
+
+export function uninstallCrushHooks(): number {
+  console.log('\nUninstalling Claude-Mem Crush hooks...\n');
+
+  if (!existsSync(CRUSH_CONFIG_PATH)) {
+    console.log(`  No crush.json found at ${CRUSH_CONFIG_PATH}`);
+    return 0;
+  }
+
+  try {
+    const config = readCrushConfig();
+    if (!config.hooks || typeof config.hooks !== 'object') {
+      console.log(`  No hooks section present — nothing to do`);
+      return 0;
+    }
+
+    const remaining = stripClaudeMemEntries(config.hooks.PreToolUse);
+    if (remaining.length === 0) {
+      delete config.hooks.PreToolUse;
+    } else {
+      config.hooks.PreToolUse = remaining;
+    }
+
+    if (config.hooks && Object.keys(config.hooks).length === 0) {
+      delete config.hooks;
+    }
+
+    writeFileSync(CRUSH_CONFIG_PATH, JSON.stringify(config, null, 2) + '\n');
+    console.log(`  Removed claude-mem entries from ${CRUSH_CONFIG_PATH}`);
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`\nUninstallation failed: ${message}`);
+    return 1;
+  }
+}
+
+export function checkCrushHooksStatus(): number {
+  console.log('\nClaude-Mem Crush Hooks Status\n');
+
+  if (!existsSync(CRUSH_CONFIG_PATH)) {
+    console.log('User-level: Not installed');
+    console.log(`\nNo hooks installed. Run: npx claude-mem install (and pick Crush)\n`);
+    return 0;
+  }
+
+  let config: CrushHooksConfig;
+  try {
+    config = readCrushConfig();
+  } catch {
+    console.log(`Unable to parse ${CRUSH_CONFIG_PATH}`);
+    return 1;
+  }
+
+  const entries = config.hooks?.PreToolUse ?? [];
+  const claudeMemEntries = entries.filter((entry) =>
+    (entry?.command ?? '').includes(CLAUDE_MEM_HOOK_MARKER),
+  );
+
+  if (claudeMemEntries.length === 0) {
+    console.log('User-level: Not installed');
+  } else {
+    console.log('User-level: Installed');
+    console.log(`   Config:  ${CRUSH_CONFIG_PATH}`);
+    console.log(`   Events:  ${claudeMemEntries.length} PreToolUse entries registered`);
+    for (const entry of claudeMemEntries) {
+      console.log(`     - matcher=${entry.matcher ?? '*'}`);
+    }
+  }
+
+  console.log('');
+  return 0;
+}
+
+const CRUSH_TRANSCRIPT_WATCH_NAME = 'crush';
+const CLAUDE_MEM_DATA_DIR = path.join(homedir(), '.claude-mem');
+
+function loadExistingTranscriptWatchConfig(): TranscriptWatchConfig {
+  if (!existsSync(TRANSCRIPT_CONFIG_PATH)) {
+    return {
+      version: 1,
+      schemas: {},
+      watches: [],
+      stateFile: TRANSCRIPT_STATE_PATH,
+    };
+  }
+
+  try {
+    const raw = readFileSync(TRANSCRIPT_CONFIG_PATH, 'utf-8');
+    const parsed = JSON.parse(raw) as TranscriptWatchConfig;
+    if (!parsed.version) parsed.version = 1;
+    if (!parsed.watches) parsed.watches = [];
+    if (!parsed.schemas) parsed.schemas = {};
+    if (!parsed.stateFile) parsed.stateFile = TRANSCRIPT_STATE_PATH;
+    return parsed;
+  } catch (error) {
+    const normalized = error instanceof Error ? error : new Error(String(error));
+    logger.error(
+      'CRUSH',
+      'Corrupt transcript-watch.json, creating backup',
+      { path: TRANSCRIPT_CONFIG_PATH },
+      normalized,
+    );
+    const backupPath = `${TRANSCRIPT_CONFIG_PATH}.backup.${Date.now()}`;
+    writeFileSync(backupPath, readFileSync(TRANSCRIPT_CONFIG_PATH));
+    console.warn(`  Backed up corrupt transcript-watch.json to ${backupPath}`);
+    return {
+      version: 1,
+      schemas: {},
+      watches: [],
+      stateFile: TRANSCRIPT_STATE_PATH,
+    };
+  }
+}
+
+function mergeCrushTranscriptConfig(existing: TranscriptWatchConfig): TranscriptWatchConfig {
+  const merged: TranscriptWatchConfig = {
+    ...existing,
+    schemas: { ...(existing.schemas ?? {}) },
+    watches: Array.isArray(existing.watches) ? [...existing.watches] : [],
+  };
+
+  const crushSchema = TRANSCRIPT_SAMPLE_CONFIG.schemas?.[CRUSH_TRANSCRIPT_WATCH_NAME];
+  if (crushSchema) {
+    merged.schemas![CRUSH_TRANSCRIPT_WATCH_NAME] = crushSchema;
+  }
+
+  const sampleWatch = TRANSCRIPT_SAMPLE_CONFIG.watches.find(
+    (w: WatchTarget) => w.name === CRUSH_TRANSCRIPT_WATCH_NAME,
+  );
+
+  if (sampleWatch) {
+    const existingIdx = merged.watches.findIndex(
+      (w: WatchTarget) => w.name === CRUSH_TRANSCRIPT_WATCH_NAME,
+    );
+    if (existingIdx !== -1) {
+      merged.watches[existingIdx] = sampleWatch;
+    } else {
+      merged.watches.push(sampleWatch);
+    }
+  }
+
+  return merged;
+}
+
+function writeTranscriptWatchConfig(config: TranscriptWatchConfig): void {
+  mkdirSync(CLAUDE_MEM_DATA_DIR, { recursive: true });
+  writeFileSync(TRANSCRIPT_CONFIG_PATH, JSON.stringify(config, null, 2) + '\n');
+}
+
+export function installCrushTranscript(): number {
+  console.log('\nInstalling Claude-Mem Crush transcript watcher...\n');
+
+  try {
+    const existing = loadExistingTranscriptWatchConfig();
+    const merged = mergeCrushTranscriptConfig(existing);
+    writeTranscriptWatchConfig(merged);
+    console.log(`  Updated ${TRANSCRIPT_CONFIG_PATH}`);
+    console.log(`  Registry: crush-projects (~/.local/share/crush/projects.json)`);
+    console.log(`  Schema:   crush (messages.parts via json_each)`);
+    console.log(`
+Transcript watcher installed.
+
+What it captures (beyond PreToolUse hooks):
+  - User prompts        -> session_init + context injection
+  - Assistant replies   -> last-message tracking + summary queueing
+  - Tool results        -> full observations with tool output
+  - Turn completions    -> session_end (queues summary, refreshes context)
+
+The worker polls each project's .crush/crush.db every 2s and
+replays new rows from the messages table through the normal
+claude-mem event pipeline.
+
+Next steps:
+  1. Restart the worker: npx claude-mem restart
+  2. Continue using Crush normally -- capture is automatic.
+`);
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`\nInstallation failed: ${message}`);
+    return 1;
+  }
+}
+
+export function uninstallCrushTranscript(): number {
+  console.log('\nUninstalling Claude-Mem Crush transcript watcher...\n');
+
+  if (!existsSync(TRANSCRIPT_CONFIG_PATH)) {
+    console.log('  No transcript-watch.json found -- nothing to remove.');
+    return 0;
+  }
+
+  try {
+    const config = loadExistingTranscriptWatchConfig();
+    config.watches = config.watches.filter(
+      (w: WatchTarget) => w.name !== CRUSH_TRANSCRIPT_WATCH_NAME,
+    );
+    if (config.schemas) {
+      delete config.schemas[CRUSH_TRANSCRIPT_WATCH_NAME];
+    }
+    writeTranscriptWatchConfig(config);
+    console.log(`  Removed crush watch from ${TRANSCRIPT_CONFIG_PATH}`);
+    console.log('\nRestart the worker to apply: npx claude-mem restart\n');
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`\nUninstallation failed: ${message}`);
+    return 1;
+  }
+}

--- a/src/services/integrations/index.ts
+++ b/src/services/integrations/index.ts
@@ -6,4 +6,5 @@ export * from './OpenCodeInstaller.js';
 export * from './WindsurfHooksInstaller.js';
 export * from './OpenClawInstaller.js';
 export * from './CodexCliInstaller.js';
+export * from './CrushHooksInstaller.js';
 export * from './McpIntegrations.js';

--- a/src/services/transcripts/config.ts
+++ b/src/services/transcripts/config.ts
@@ -84,10 +84,87 @@ const CODEX_SAMPLE_SCHEMA: TranscriptSchema = {
   ]
 };
 
+const CRUSH_SAMPLE_SCHEMA: TranscriptSchema = {
+  name: 'crush',
+  version: '0.1',
+  description: 'Schema for Crush CLI session data in per-project SQLite databases under <project>/.crush/crush.db. Each row emitted by the SqliteTailer represents one entry in messages.parts.',
+  events: [
+    {
+      name: 'user-text',
+      match: {
+        all: [
+          { path: 'role', equals: 'user' },
+          { path: 'part.type', equals: 'text' },
+        ],
+      },
+      action: 'session_init',
+      fields: {
+        prompt: 'part.data.text',
+        sessionId: 'session_id',
+      },
+    },
+    {
+      name: 'assistant-text',
+      match: {
+        all: [
+          { path: 'role', equals: 'assistant' },
+          { path: 'part.type', equals: 'text' },
+        ],
+      },
+      action: 'assistant_message',
+      fields: {
+        message: 'part.data.text',
+        sessionId: 'session_id',
+      },
+    },
+    {
+      name: 'tool-call',
+      match: { path: 'part.type', equals: 'tool_call' },
+      action: 'tool_use',
+      fields: {
+        sessionId: 'session_id',
+        toolId: {
+          coalesce: ['part.data.id', 'part.data.tool_call_id', 'part.data.call_id'],
+        },
+        toolName: {
+          coalesce: ['part.data.name', 'part.data.tool_name'],
+        },
+        toolInput: {
+          coalesce: ['part.data.input', 'part.data.arguments', 'part.data.params'],
+        },
+      },
+    },
+    {
+      name: 'tool-result',
+      match: { path: 'part.type', equals: 'tool_result' },
+      action: 'tool_result',
+      fields: {
+        sessionId: 'session_id',
+        toolId: {
+          coalesce: ['part.data.tool_call_id', 'part.data.id', 'part.data.call_id'],
+        },
+        toolName: 'part.data.name',
+        toolResponse: {
+          coalesce: ['part.data.content', 'part.data.output', 'part.data.result'],
+        },
+      },
+    },
+    {
+      name: 'turn-finish',
+      match: { path: 'part.type', equals: 'finish' },
+      action: 'session_end',
+      fields: {
+        sessionId: 'session_id',
+      },
+    },
+  ],
+};
+
 export const SAMPLE_CONFIG: TranscriptWatchConfig = {
   version: 1,
   schemas: {
-    codex: CODEX_SAMPLE_SCHEMA
+    codex: CODEX_SAMPLE_SCHEMA,
+    crush: CRUSH_SAMPLE_SCHEMA,
   },
   watches: [
     {
@@ -99,7 +176,33 @@ export const SAMPLE_CONFIG: TranscriptWatchConfig = {
         mode: 'agents',
         updateOn: ['session_start', 'session_end']
       }
-    }
+    },
+    {
+      name: 'crush',
+      path: '<registry:crush-projects>',
+      source: 'sqlite',
+      schema: 'crush',
+      registry: 'crush-projects',
+      rescanIntervalMs: 30000,
+      sqlite: {
+        sql: [
+          'SELECT',
+          '  m.session_id AS session_id,',
+          '  m.role       AS role,',
+          '  m.created_at AS created_at,',
+          '  m.rowid      AS rowid,',
+          '  p.key        AS part_index,',
+          '  p.value      AS part',
+          'FROM messages m, json_each(m.parts) p',
+          'WHERE m.rowid > :cursor',
+          'ORDER BY m.rowid ASC, p.key ASC',
+          'LIMIT 500',
+        ].join(' '),
+        cursorColumn: 'rowid',
+        jsonColumns: ['part'],
+        pollIntervalMs: 2000,
+      },
+    },
   ],
   stateFile: DEFAULT_STATE_PATH
 };

--- a/src/services/transcripts/field-utils.ts
+++ b/src/services/transcripts/field-utils.ts
@@ -120,6 +120,20 @@ export function matchesRule(
 ): boolean {
   if (!rule) return true;
 
+  if (Array.isArray(rule.all) && rule.all.length > 0) {
+    for (const sub of rule.all) {
+      if (!matchesRule(entry, sub, schema)) return false;
+    }
+    const hasOwnPredicate =
+      rule.path !== undefined ||
+      rule.equals !== undefined ||
+      rule.in !== undefined ||
+      rule.contains !== undefined ||
+      rule.exists !== undefined ||
+      rule.regex !== undefined;
+    if (!hasOwnPredicate) return true;
+  }
+
   const path = rule.path || schema.eventTypePath || 'type';
   const value = path ? getValueByPath(entry, path) : undefined;
 

--- a/src/services/transcripts/field-utils.ts
+++ b/src/services/transcripts/field-utils.ts
@@ -120,6 +120,11 @@ export function matchesRule(
 ): boolean {
   if (!rule) return true;
 
+  // When `all` is present alongside a sibling predicate (equals/in/contains/exists/regex),
+  // semantics are: all.every(subRule) && ownPredicate — the sub-rules AND the sibling predicate
+  // must both match. If there is no sibling predicate, `all` is the sole condition and returns
+  // true once every sub-rule passes. This ANDing is intentional; do not add a sibling predicate
+  // to a rule that uses `all` unless you mean to further narrow the match.
   if (Array.isArray(rule.all) && rule.all.length > 0) {
     for (const sub of rule.all) {
       if (!matchesRule(entry, sub, schema)) return false;

--- a/src/services/transcripts/sqlite-tailer.ts
+++ b/src/services/transcripts/sqlite-tailer.ts
@@ -1,0 +1,168 @@
+import { existsSync, readFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import { Database } from 'bun:sqlite';
+import { logger } from '../../utils/logger.js';
+import type { SqliteQueryConfig, RegistryResolver } from './types.js';
+
+export interface SqliteTargetRef {
+  dbPath: string;
+  /** Optional display name / source annotation (e.g. registry project path). */
+  label?: string;
+}
+
+export function resolveRegistry(registry: RegistryResolver): SqliteTargetRef[] {
+  switch (registry) {
+    case 'crush-projects':
+      return resolveCrushProjects();
+    default:
+      return [];
+  }
+}
+
+function resolveCrushProjects(): SqliteTargetRef[] {
+  const projectsPath = join(homedir(), '.local', 'share', 'crush', 'projects.json');
+  if (!existsSync(projectsPath)) return [];
+
+  try {
+    const raw = readFileSync(projectsPath, 'utf-8');
+    const parsed = JSON.parse(raw) as { projects?: Array<{ path?: string; data_dir?: string }> };
+    const projects = Array.isArray(parsed?.projects) ? parsed.projects : [];
+
+    const refs: SqliteTargetRef[] = [];
+    for (const p of projects) {
+      const dataDir = typeof p?.data_dir === 'string' ? p.data_dir : undefined;
+      if (!dataDir) continue;
+      const dbPath = join(dataDir, 'crush.db');
+      if (!existsSync(dbPath)) continue;
+      refs.push({ dbPath, label: typeof p?.path === 'string' ? p.path : dataDir });
+    }
+    return refs;
+  } catch (error) {
+    logger.warn(
+      'TRANSCRIPT',
+      'Failed to resolve crush-projects registry',
+      { projectsPath },
+      error instanceof Error ? error : undefined,
+    );
+    return [];
+  }
+}
+
+type Timer = ReturnType<typeof setInterval>;
+
+export class SqliteTailer {
+  private db: Database | null = null;
+  private timer: Timer | null = null;
+  private running = false;
+  private pollMs: number;
+  private cursor: number;
+
+  constructor(
+    private readonly dbPath: string,
+    private readonly query: SqliteQueryConfig,
+    initialCursor: number,
+    private readonly onEntry: (entry: Record<string, unknown>) => Promise<void>,
+    private readonly onCursor: (cursor: number) => void,
+  ) {
+    this.cursor = Number.isFinite(initialCursor) ? initialCursor : 0;
+    this.pollMs = query.pollIntervalMs ?? 2000;
+  }
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    try {
+      this.db = new Database(this.dbPath, { readonly: true, create: false });
+    } catch (error) {
+      logger.warn(
+        'TRANSCRIPT',
+        'Failed to open SQLite tailer target',
+        { dbPath: this.dbPath },
+        error instanceof Error ? error : undefined,
+      );
+      this.running = false;
+      return;
+    }
+    this.poll().catch(() => undefined);
+    this.timer = setInterval(() => {
+      this.poll().catch(() => undefined);
+    }, this.pollMs);
+  }
+
+  close(): void {
+    this.running = false;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    try {
+      this.db?.close();
+    } catch {
+      // ignore
+    }
+    this.db = null;
+  }
+
+  poke(): void {
+    this.poll().catch(() => undefined);
+  }
+
+  private async poll(): Promise<void> {
+    if (!this.running || !this.db) return;
+
+    let rows: Array<Record<string, unknown>>;
+    try {
+      rows = this.db
+        .query(this.query.sql)
+        .all({ $cursor: this.cursor }) as Array<Record<string, unknown>>;
+    } catch (error) {
+      logger.debug(
+        'TRANSCRIPT',
+        'SQLite poll failed; will retry',
+        { dbPath: this.dbPath },
+        error instanceof Error ? error : undefined,
+      );
+      return;
+    }
+
+    if (!rows || rows.length === 0) return;
+
+    for (const row of rows) {
+      const parsed = this.parseRow(row);
+      try {
+        await this.onEntry(parsed);
+      } catch (error) {
+        logger.debug(
+          'TRANSCRIPT',
+          'onEntry handler failed for sqlite row',
+          { dbPath: this.dbPath },
+          error instanceof Error ? error : undefined,
+        );
+      }
+
+      const raw = row[this.query.cursorColumn];
+      const cursorNum = typeof raw === 'number' ? raw : Number(raw);
+      if (Number.isFinite(cursorNum) && cursorNum > this.cursor) {
+        this.cursor = cursorNum;
+        this.onCursor(this.cursor);
+      }
+    }
+  }
+
+  private parseRow(row: Record<string, unknown>): Record<string, unknown> {
+    if (!this.query.jsonColumns || this.query.jsonColumns.length === 0) return row;
+    const out: Record<string, unknown> = { ...row };
+    for (const col of this.query.jsonColumns) {
+      const val = out[col];
+      if (typeof val === 'string' && val.trim().length > 0) {
+        try {
+          out[col] = JSON.parse(val);
+        } catch {
+          // keep raw
+        }
+      }
+    }
+    return out;
+  }
+}

--- a/src/services/transcripts/types.ts
+++ b/src/services/transcripts/types.ts
@@ -14,6 +14,7 @@ export interface MatchRule {
   contains?: string;
   exists?: boolean;
   regex?: string;
+  all?: MatchRule[];
 }
 
 export type EventAction =
@@ -51,6 +52,18 @@ export interface WatchContextConfig {
   updateOn?: Array<'session_start' | 'session_end'>;
 }
 
+export type TranscriptSource = 'jsonl' | 'sqlite';
+
+export interface SqliteQueryConfig {
+  sql: string;
+  cursorColumn: string;
+  jsonColumns?: string[];
+  pollIntervalMs?: number;
+  initialCursor?: string | number;
+}
+
+export type RegistryResolver = 'crush-projects';
+
 export interface WatchTarget {
   name: string;
   path: string;
@@ -60,6 +73,9 @@ export interface WatchTarget {
   context?: WatchContextConfig;
   rescanIntervalMs?: number;
   startAtEnd?: boolean;
+  source?: TranscriptSource;
+  sqlite?: SqliteQueryConfig;
+  registry?: RegistryResolver;
 }
 
 export interface TranscriptWatchConfig {

--- a/src/services/transcripts/watcher.ts
+++ b/src/services/transcripts/watcher.ts
@@ -6,6 +6,9 @@ import { expandHomePath } from './config.js';
 import { loadWatchState, saveWatchState, type TranscriptWatchState } from './state.js';
 import type { TranscriptWatchConfig, TranscriptSchema, WatchTarget } from './types.js';
 import { TranscriptEventProcessor } from './processor.js';
+import { SqliteTailer, resolveRegistry, type SqliteTargetRef } from './sqlite-tailer.js';
+
+type Timer = ReturnType<typeof setInterval>;
 
 interface TailState {
   offset: number;
@@ -91,8 +94,10 @@ class FileTailer {
 export class TranscriptWatcher {
   private processor = new TranscriptEventProcessor();
   private tailers = new Map<string, FileTailer>();
+  private sqliteTailers = new Map<string, SqliteTailer>();
   private state: TranscriptWatchState;
   private rootWatchers: Array<ReturnType<typeof fsWatch>> = [];
+  private registryRescanTimers: Timer[] = [];
 
   constructor(private config: TranscriptWatchConfig, private statePath: string) {
     this.state = loadWatchState(statePath);
@@ -109,16 +114,29 @@ export class TranscriptWatcher {
       tailer.close();
     }
     this.tailers.clear();
+    for (const tailer of this.sqliteTailers.values()) {
+      tailer.close();
+    }
+    this.sqliteTailers.clear();
     for (const watcher of this.rootWatchers) {
       watcher.close();
     }
     this.rootWatchers = [];
+    for (const timer of this.registryRescanTimers) {
+      clearInterval(timer);
+    }
+    this.registryRescanTimers = [];
   }
 
   private async setupWatch(watch: WatchTarget): Promise<void> {
     const schema = this.resolveSchema(watch);
     if (!schema) {
       logger.warn('TRANSCRIPT', 'Missing schema for watch', { watch: watch.name });
+      return;
+    }
+
+    if (watch.source === 'sqlite') {
+      await this.setupSqliteWatch(watch, schema);
       return;
     }
 
@@ -159,6 +177,77 @@ export class TranscriptWatcher {
         watchRoot,
       }, error instanceof Error ? error : undefined);
     }
+  }
+
+  private async setupSqliteWatch(
+    watch: WatchTarget,
+    schema: TranscriptSchema,
+  ): Promise<void> {
+    if (!watch.sqlite) {
+      logger.warn('TRANSCRIPT', 'sqlite watch missing sqlite config', { watch: watch.name });
+      return;
+    }
+
+    const addAllTargets = () => {
+      const targets = this.resolveSqliteTargets(watch);
+      for (const target of targets) {
+        this.addSqliteTailer(target, watch, schema);
+      }
+    };
+
+    addAllTargets();
+
+    const rescanMs = watch.rescanIntervalMs ?? 30_000;
+    if (watch.registry) {
+      const timer = setInterval(addAllTargets, rescanMs);
+      if (typeof (timer as any).unref === 'function') (timer as any).unref();
+      this.registryRescanTimers.push(timer);
+    }
+  }
+
+  private resolveSqliteTargets(watch: WatchTarget): SqliteTargetRef[] {
+    if (watch.registry) {
+      return resolveRegistry(watch.registry);
+    }
+    const dbPath = expandHomePath(watch.path);
+    if (!existsSync(dbPath)) return [];
+    return [{ dbPath }];
+  }
+
+  private addSqliteTailer(
+    target: SqliteTargetRef,
+    watch: WatchTarget,
+    schema: TranscriptSchema,
+  ): void {
+    const key = `sqlite::${target.dbPath}`;
+    if (this.sqliteTailers.has(key)) return;
+    if (!watch.sqlite) return;
+
+    const initialCursor = this.state.offsets[key] ?? (
+      typeof watch.sqlite.initialCursor === 'number' ? watch.sqlite.initialCursor : 0
+    );
+
+    const tailer = new SqliteTailer(
+      target.dbPath,
+      watch.sqlite,
+      initialCursor,
+      async (entry) => {
+        const enriched = { ...entry, __sqlite_target: target.label ?? target.dbPath };
+        await this.processor.processEntry(enriched, watch, schema);
+      },
+      (cursor) => {
+        this.state.offsets[key] = cursor;
+        saveWatchState(this.statePath, this.state);
+      },
+    );
+
+    tailer.start();
+    this.sqliteTailers.set(key, tailer);
+    logger.info('TRANSCRIPT', 'Watching sqlite transcript source', {
+      dbPath: target.dbPath,
+      watch: watch.name,
+      schema: schema.name,
+    });
   }
 
   private deepestNonGlobAncestor(inputPath: string): string {


### PR DESCRIPTION
## Summary
- Adds first-class Crush support: new `PlatformAdapter` and `CrushHooksInstaller`, registered alongside Cursor/Codex/Windsurf.
- Adds a SQLite transcript source so the watcher can tail per-project `<project>/.crush/crush.db` databases via `bun:sqlite`, with a registry resolver (`crush-projects`) and periodic rescan.
- Extends transcript schema/types with a compound `all` `MatchRule` and a `CRUSH_SAMPLE_SCHEMA` covering user-text, assistant-text, tool-call, tool-result, and turn-finish.

## Why a separate PR
Split out of #2156 (UX redesign) so Crush integration can land on its own merit without blocking the UX branch. Base is `claude-mem-ux-improvements-with-installer-enhancem`; once #2156 merges, GitHub will retarget this PR to `main` automatically and the diff will collapse to just the Crush commit.

## Test plan
- [ ] `npm run build-and-sync` succeeds (TypeScript + worker dispatcher rebuild)
- [ ] Worker starts cleanly with the new transcript types loaded
- [ ] `claude-mem install --ide crush` runs the new `CrushHooksInstaller` end-to-end and writes a Crush watch entry into the transcript watcher config
- [ ] With Crush installed and a `.crush/crush.db` populated, the watcher tails new `messages.parts` rows and the processor emits `session_init` / `assistant_message` / `tool_use` / `tool_result` / `session_end` actions
- [ ] Registry rescan picks up a freshly-created Crush project without a worker restart
- [ ] Existing JSONL watches (Codex) still work — no regression in `field-utils` from the new `all` rule path

🤖 Generated with [Claude Code](https://claude.com/claude-code)