### PR TITLE
fix: skip tree-sitter native build on Node 25+ via trustedDependencies

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -35,6 +35,9 @@
   "overrides": {
     "tree-sitter": "^0.25.0"
   },
+  "trustedDependencies": [
+    "tree-sitter-cli"
+  ],
   "engines": {
     "node": ">=18.0.0",
     "bun": ">=1.0.0"

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -101,6 +101,9 @@ async function buildHooks() {
       overrides: {
         'tree-sitter': '^0.25.0'
       },
+      trustedDependencies: [
+        'tree-sitter-cli'
+      ],
       engines: {
         node: '>=18.0.0',
         bun: '>=1.0.0'


### PR DESCRIPTION
## Summary

`bun install` fails during plugin install on Node 25+ with hundreds of C++ compile errors when building the `tree-sitter` native runtime binding. claude-mem doesn't actually use this runtime — it only shells out to the prebuilt `tree-sitter-cli` Rust binary. Adding `trustedDependencies: ["tree-sitter-cli"]` to the generated `plugin/package.json` lets bun run only the CLI's binary download script and skip every other postinstall, including the failing native compile.

## Repro

On macOS arm64 with Node 25.x:
```
$ claude-mem install
...
●  Plugin enabled OK
Fatal error: bun install failed in /Users/<you>/.claude/plugins/cache/thedotmack/claude-mem/12.5.0
...
/usr/local/include/node/v8config.h:13:2: error: "C++20 or later required."
...
error: install script from "tree-sitter" exited with 1
```

## Root cause

- `tree-sitter@0.25.0`'s `binding.gyp` hardcodes `c++17` (`cflags_cc: ["-std=c++17"]`, `CLANG_CXX_LANGUAGE_STANDARD: c++17`).
- Node 25's V8 headers `#error "C++20 or later required."` if compiled against older C++.
- `tree-sitter@0.25.0` ships **no prebuilds at all**, so `node-gyp-build` always falls back to source compile, which fails.
- bun has a default trust list that runs `tree-sitter`'s install script even though the package isn't in the project's `trustedDependencies`.

## Why we don't need that runtime

The bundled `plugin/scripts/mcp-server.cjs` resolves `tree-sitter-cli/package.json`, finds the binary next to it, and `execFileSync`s `tree-sitter query -p <grammar-dir> <query.scm> <source-files>`. The `-p` flag is `--grammar-path` and **implies `--rebuild`** in tree-sitter-cli ≥ 0.25 — the CLI compiles each grammar's `parser.c` (pure C, no C++20 issue) JIT from the package source on first use. The grammar packages' own `.node` Node bindings are never imported either.

`grep -rEn "from ['\"]tree-sitter['\"]|require\(['\"]tree-sitter['\"]\)" src plugin scripts` returns zero matches.

## Fix

Add `trustedDependencies: ["tree-sitter-cli"]` in two places (the source generator + the generated artifact, kept in sync):

- `scripts/build-hooks.js` — the `pluginPackageJson` literal that gets written to `plugin/package.json` on build.
- `plugin/package.json` — same change, mirroring what the generator now produces.

`verifyCriticalModules` in `setup-runtime.ts` only checks directory existence, not native bindings, so this passes the post-install check.

## Test plan

- [x] `bun install` against the new `plugin/package.json` on darwin-arm64 / Node 25.9.0 — 37 packages install in ~30s, **28 postinstalls correctly blocked**.
- [x] `node_modules/tree-sitter-cli/tree-sitter --version` → `tree-sitter 0.26.8`.
- [x] `node_modules/tree-sitter/build/Release/*.node` does not exist (good — runtime native skipped).
- [x] `tree-sitter query -p node_modules/tree-sitter-python <q.scm> <source.py>` parses Python correctly via JIT compile.
- [ ] Repro of the original `claude-mem install` failure no longer occurs (will confirm after merge by running `claude-mem install` against a release with this fix).
- [ ] Older Node versions (20/22) still install cleanly — the change is additive, so should be a no-op there, but worth a CI check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)