### PR TITLE
fix(mcp): launch mcp-search via node so Windows can spawn it

### DIFF
--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -2,10 +2,10 @@
   "mcpServers": {
     "mcp-search": {
       "type": "stdio",
-      "command": "sh",
+      "command": "node",
       "args": [
-        "-c",
-        "_C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; printf '%s\\n' \"$PWD/plugin\" \"$PWD\"; ls -dt \"$HOME/.codex/plugins/cache/claude-mem-local/claude-mem\"/[0-9]*/ \"$HOME/.codex/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/mcp-server.cjs\" ] && { printf '%s\\n' \"$_Q\"; break; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: mcp server not found\" >&2; exit 1; }; exec node \"$_P/scripts/mcp-server.cjs\""
+        "-e",
+        "(()=>{const fs=require(\"fs\"),p=require(\"path\"),os=require(\"os\");const h=os.homedir(),c=process.env.CLAUDE_CONFIG_DIR||p.join(h,\".claude\"),e=process.env.CLAUDE_PLUGIN_ROOT||process.env.PLUGIN_ROOT;const L=d=>{try{return fs.readdirSync(d).filter(n=>/^[0-9]/.test(n)).map(n=>p.join(d,n)).filter(x=>{try{return fs.statSync(x).isDirectory()}catch{return false}}).sort((a,b)=>fs.statSync(b).mtimeMs-fs.statSync(a).mtimeMs)}catch{return[]}};const C=[e,p.join(process.cwd(),\"plugin\"),process.cwd(),...L(p.join(h,\".codex/plugins/cache/claude-mem-local/claude-mem\")),...L(p.join(h,\".codex/plugins/cache/thedotmack/claude-mem\")),...L(p.join(c,\"plugins/cache/thedotmack/claude-mem\")),p.join(c,\"plugins/marketplaces/thedotmack/plugin\")].filter(Boolean);for(const x of C){const b=fs.existsSync(p.join(x,\"plugin\",\"scripts\"))?p.join(x,\"plugin\"):x;const f=p.join(b,\"scripts\",\"mcp-server.cjs\");if(fs.existsSync(f)){require(f);return;}}console.error(\"claude-mem: mcp server not found\");process.exit(1);})();"
       ]
     }
   }

--- a/tests/infrastructure/plugin-distribution.test.ts
+++ b/tests/infrastructure/plugin-distribution.test.ts
@@ -126,19 +126,21 @@ describe('Plugin Distribution - hooks.json Integrity', () => {
 });
 
 describe('Plugin Distribution - Startup Root Resolution', () => {
-  it('MCP startup commands should have config-dir based non-empty fallbacks', () => {
+  // The MCP server is spawned by Claude Code WITHOUT a shell, so `command` must
+  // resolve against PATH directly. `sh` is not on PATH on Windows (Git Bash is
+  // not guaranteed to be there), so the bundled launcher uses `node` — which is
+  // always present as the runtime — and performs root resolution in JS.
+  it('MCP startup command resolves the plugin root in node (cross-platform)', () => {
     for (const relativePath of ['plugin/.mcp.json']) {
       const command = mcpStartupCommandFrom(relativePath);
 
-      expect(command).toContain('${CLAUDE_CONFIG_DIR:-$HOME/.claude}');
-      expect(command).toContain('_E="${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}"');
-      expect(command).toContain('while IFS= read -r _R');
-      expect(command).toContain('$_C/plugins/marketplaces/thedotmack/plugin');
-      expect(command).toContain('$_C/plugins/cache/thedotmack/claude-mem');
-      expect(command).toContain('[ -f "$_Q/scripts/mcp-server.cjs" ]');
-      expect(command).not.toContain('"/scripts/mcp-server.cjs"');
-      expect(command.indexOf('$_C/plugins/cache/thedotmack/claude-mem')).toBeLessThan(
-        command.indexOf('$_C/plugins/marketplaces/thedotmack/plugin')
+      expect(command).toContain('process.env.CLAUDE_CONFIG_DIR');
+      expect(command).toContain('process.env.CLAUDE_PLUGIN_ROOT||process.env.PLUGIN_ROOT');
+      expect(command).toContain('plugins/marketplaces/thedotmack/plugin');
+      expect(command).toContain('plugins/cache/thedotmack/claude-mem');
+      expect(command).toContain('mcp-server.cjs');
+      expect(command.indexOf('plugins/cache/thedotmack/claude-mem')).toBeLessThan(
+        command.indexOf('plugins/marketplaces/thedotmack/plugin')
       );
     }
   });


### PR DESCRIPTION
## Problem

On Windows the `mcp-search` MCP server fails to start. Claude Code spawns MCP servers **without a shell**, so the `.mcp.json` `command` is resolved directly against PATH. `sh` is not on PATH on Windows (Git Bash is not guaranteed to be present), so `command: "sh"` fails with ENOENT and the server never starts (`MCP error -32000: Connection closed`).

`.mcp.json` has no per-OS configuration, no `shell` field, and no environment-variable expansion — so a single `command` must work on every OS. The only binary guaranteed to be present on all platforms is `node` (it is the runtime the MCP server itself runs under).

## Change

Switches **only** the bundled `plugin/.mcp.json` launcher to `command: "node"`, which performs the same plugin-root resolution in JS and then `require()`s the resolved `mcp-server.cjs`.

**Intentionally minimal scope:** the hooks are left untouched. They run via `"shell": "bash"`, which Claude Code provides itself, so the existing `sh`/bash hook launchers keep working on Windows. Only the shell-less MCP spawn needed a node bootstrap. This does **not** revert the maintainer's `sh` approach — it only fixes the one case where `sh` cannot be spawned at all.

## Tests

The MCP startup assertions now validate the node launcher; the hook-command assertions are unchanged (still `sh`). Distribution test suite passing (24 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)