### PR TITLE
feat(worker): periodic sweep for orphaned pending_messages

### DIFF
--- a/src/services/infrastructure/StalePendingSweep.ts
+++ b/src/services/infrastructure/StalePendingSweep.ts
@@ -1,0 +1,75 @@
+import type { Database } from 'bun:sqlite';
+import { logger } from '../../utils/logger.js';
+
+/** Sessions idle this long with no queue progress are considered orphaned. */
+const DEFAULT_THRESHOLD_MS = 6 * 60 * 60 * 1000;
+
+export interface StalePendingSweepResult {
+  staleSessions: number;
+  deletedMessages: number;
+  failedSessions: number;
+}
+
+export interface StalePendingSweepOptions {
+  thresholdMs?: number;
+  now?: number;
+}
+
+/**
+ * Clear pending_messages left behind by sessions that never got an SDK
+ * processor (e.g. sessions that fire INIT_COMPLETE then die). Such rows sit
+ * on status='pending' forever and inflate the WebUI "unprocessed" counter.
+ *
+ * A session is swept when its NEWEST pending_message predates the threshold
+ * AND it is not in `activeSessionIds`. Its pending_messages are deleted and an
+ * 'active' session is marked 'failed'.
+ */
+export function sweepStalePendingMessages(
+  db: Database,
+  activeSessionIds: Iterable<number>,
+  options: StalePendingSweepOptions = {},
+): StalePendingSweepResult {
+  const thresholdMs = options.thresholdMs ?? DEFAULT_THRESHOLD_MS;
+  const now = options.now ?? Date.now();
+  const cutoff = now - thresholdMs;
+  const active = activeSessionIds instanceof Set
+    ? activeSessionIds
+    : new Set<number>(activeSessionIds);
+
+  const result: StalePendingSweepResult = { staleSessions: 0, deletedMessages: 0, failedSessions: 0 };
+
+  const candidates = db.prepare(
+    `SELECT session_db_id AS sid, COUNT(*) AS n
+       FROM pending_messages
+      GROUP BY session_db_id
+     HAVING MAX(created_at_epoch) < ?`
+  ).all(cutoff) as { sid: number; n: number }[];
+
+  const stale = candidates.filter(c => !active.has(c.sid));
+  if (stale.length === 0) return result;
+
+  const deletePending = db.prepare('DELETE FROM pending_messages WHERE session_db_id = ?');
+  const failSession = db.prepare(
+    `UPDATE sdk_sessions
+        SET status = 'failed', completed_at = ?, completed_at_epoch = ?
+      WHERE id = ? AND status = 'active'`
+  );
+  const nowIso = new Date(now).toISOString();
+
+  db.run('BEGIN IMMEDIATE');
+  try {
+    for (const c of stale) {
+      deletePending.run(c.sid);
+      result.deletedMessages += c.n;
+      if (failSession.run(nowIso, now, c.sid).changes > 0) result.failedSessions += 1;
+      result.staleSessions += 1;
+    }
+    db.run('COMMIT');
+  } catch (err: unknown) {
+    try { db.run('ROLLBACK'); } catch { /* already rolled back */ }
+    throw err;
+  }
+
+  logger.info('SYSTEM', 'Stale pending_messages sweep complete', { ...result });
+  return result;
+}

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -38,6 +38,7 @@ import {
   touchPidFile
 } from './infrastructure/ProcessManager.js';
 import { runOneTimeV12_4_3Cleanup } from './infrastructure/CleanupV12_4_3.js';
+import { sweepStalePendingMessages } from './infrastructure/StalePendingSweep.js';
 import {
   isPortInUse,
   waitForHealth,
@@ -139,6 +140,7 @@ export class WorkerService implements WorkerRef {
 
   private chromaMcpManager: ChromaMcpManager | null = null;
   private transcriptWatcher: TranscriptWatcher | null = null;
+  private stalePendingSweepTimer: ReturnType<typeof setInterval> | null = null;
   private initializationComplete: Promise<void>;
   private resolveInitialization!: () => void;
 
@@ -398,6 +400,8 @@ export class WorkerService implements WorkerRef {
       this.initializationCompleteFlag = true;
       this.resolveInitialization();
       logger.info('SYSTEM', 'Core initialization complete (DB + search ready)');
+
+      this.startStalePendingSweep();
 
       await this.startTranscriptWatcher(settings);
 
@@ -737,7 +741,29 @@ export class WorkerService implements WorkerRef {
     this.sessionManager.removeSessionImmediate(sessionDbId);
   }
 
+  private startStalePendingSweep(): void {
+    const SWEEP_INTERVAL_MS = 30 * 60 * 1000;
+    this.stalePendingSweepTimer = setInterval(() => {
+      try {
+        const result = sweepStalePendingMessages(
+          this.dbManager.getSessionStore().db,
+          this.sessionManager.getActiveSessionIds(),
+        );
+        if (result.staleSessions > 0) {
+          this.broadcastProcessingStatus();
+        }
+      } catch (err: unknown) {
+        logger.error('SYSTEM', 'Stale pending_messages sweep failed', {}, err instanceof Error ? err : new Error(String(err)));
+      }
+    }, SWEEP_INTERVAL_MS);
+    this.stalePendingSweepTimer.unref();
+  }
+
   async shutdown(): Promise<void> {
+    if (this.stalePendingSweepTimer) {
+      clearInterval(this.stalePendingSweepTimer);
+      this.stalePendingSweepTimer = null;
+    }
     if (this.transcriptWatcher) {
       this.transcriptWatcher.stop();
       this.transcriptWatcher = null;

--- a/src/services/worker/SessionManager.ts
+++ b/src/services/worker/SessionManager.ts
@@ -412,6 +412,10 @@ export class SessionManager {
     return this.sessions.size;
   }
 
+  getActiveSessionIds(): number[] {
+    return Array.from(this.sessions.keys());
+  }
+
   async getTotalQueueDepth(): Promise<number> {
     return await this.getQueueEngine().getTotalQueueDepth();
   }

--- a/tests/infrastructure/stale-pending-sweep.test.ts
+++ b/tests/infrastructure/stale-pending-sweep.test.ts
@@ -1,0 +1,126 @@
+
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import type { Database } from 'bun:sqlite';
+import { ClaudeMemDatabase } from '../../src/services/sqlite/Database.js';
+import { sweepStalePendingMessages } from '../../src/services/infrastructure/StalePendingSweep.js';
+import { logger } from '../../src/utils/logger.js';
+
+const HOUR_MS = 60 * 60 * 1000;
+
+let loggerSpies: ReturnType<typeof spyOn>[] = [];
+
+function silenceLogger(): void {
+  loggerSpies = [
+    spyOn(logger, 'info').mockImplementation(() => {}),
+    spyOn(logger, 'debug').mockImplementation(() => {}),
+    spyOn(logger, 'warn').mockImplementation(() => {}),
+    spyOn(logger, 'error').mockImplementation(() => {}),
+  ];
+}
+
+function restoreLogger(): void {
+  loggerSpies.forEach(s => s.mockRestore());
+  loggerSpies = [];
+}
+
+function seedSession(db: Database, suffix: string, status: 'active' | 'completed' | 'failed' = 'active'): number {
+  const now = new Date().toISOString();
+  const epoch = Date.now();
+  const result = db.prepare(
+    `INSERT INTO sdk_sessions (content_session_id, memory_session_id, project, started_at, started_at_epoch, status)
+     VALUES (?, ?, 'test-project', ?, ?, ?)`
+  ).run(`content-${suffix}`, `memory-${suffix}`, now, epoch, status);
+  return Number(result.lastInsertRowid);
+}
+
+function seedPending(db: Database, sessionDbId: number, suffix: string, createdAtEpoch: number, count = 1): void {
+  const insert = db.prepare(
+    `INSERT INTO pending_messages (session_db_id, content_session_id, message_type, status, created_at_epoch)
+     VALUES (?, ?, 'observation', 'pending', ?)`
+  );
+  for (let i = 0; i < count; i++) insert.run(sessionDbId, `content-${suffix}`, createdAtEpoch);
+}
+
+function pendingCount(db: Database, sessionDbId: number): number {
+  return (db.prepare('SELECT COUNT(*) AS n FROM pending_messages WHERE session_db_id = ?')
+    .get(sessionDbId) as { n: number }).n;
+}
+
+function sessionStatus(db: Database, sessionDbId: number): string {
+  return (db.prepare('SELECT status FROM sdk_sessions WHERE id = ?')
+    .get(sessionDbId) as { status: string }).status;
+}
+
+describe('sweepStalePendingMessages', () => {
+  let cmdb: ClaudeMemDatabase;
+  let db: Database;
+  const now = Date.now();
+
+  beforeEach(() => {
+    cmdb = new ClaudeMemDatabase(':memory:');
+    db = cmdb.db;
+    silenceLogger();
+  });
+
+  afterEach(() => {
+    restoreLogger();
+    cmdb.close();
+  });
+
+  it('deletes pending_messages of a stale orphaned session and marks the session failed', () => {
+    const sid = seedSession(db, 'stale');
+    seedPending(db, sid, 'stale', now - 8 * HOUR_MS, 3);
+
+    const result = sweepStalePendingMessages(db, new Set<number>(), { now });
+
+    expect(result.staleSessions).toBe(1);
+    expect(result.deletedMessages).toBe(3);
+    expect(result.failedSessions).toBe(1);
+    expect(pendingCount(db, sid)).toBe(0);
+    expect(sessionStatus(db, sid)).toBe('failed');
+  });
+
+  it('leaves a session with recent pending_messages untouched', () => {
+    const sid = seedSession(db, 'recent');
+    seedPending(db, sid, 'recent', now - 1 * HOUR_MS, 2);
+
+    const result = sweepStalePendingMessages(db, new Set<number>(), { now });
+
+    expect(result.staleSessions).toBe(0);
+    expect(pendingCount(db, sid)).toBe(2);
+    expect(sessionStatus(db, sid)).toBe('active');
+  });
+
+  it('skips a stale session that is still in the active set', () => {
+    const sid = seedSession(db, 'active');
+    seedPending(db, sid, 'active', now - 8 * HOUR_MS, 2);
+
+    const result = sweepStalePendingMessages(db, new Set<number>([sid]), { now });
+
+    expect(result.staleSessions).toBe(0);
+    expect(pendingCount(db, sid)).toBe(2);
+    expect(sessionStatus(db, sid)).toBe('active');
+  });
+
+  it('protects a session whose newest pending_message is recent even if older ones exist', () => {
+    const sid = seedSession(db, 'mixed');
+    seedPending(db, sid, 'mixed', now - 8 * HOUR_MS, 1);
+    seedPending(db, sid, 'mixed', now - 1 * HOUR_MS, 1);
+
+    const result = sweepStalePendingMessages(db, new Set<number>(), { now });
+
+    expect(result.staleSessions).toBe(0);
+    expect(pendingCount(db, sid)).toBe(2);
+  });
+
+  it('does not change a session whose status is not active', () => {
+    const sid = seedSession(db, 'done', 'completed');
+    seedPending(db, sid, 'done', now - 8 * HOUR_MS, 1);
+
+    const result = sweepStalePendingMessages(db, new Set<number>(), { now });
+
+    expect(result.deletedMessages).toBe(1);
+    expect(result.failedSessions).toBe(0);
+    expect(sessionStatus(db, sid)).toBe('completed');
+  });
+});

--- a/tests/services/worker/session-manager-queue.test.ts
+++ b/tests/services/worker/session-manager-queue.test.ts
@@ -95,4 +95,13 @@ describe('SessionManager queue integration', () => {
       }
     }
   });
+
+  test('getActiveSessionIds returns the db ids of all initialized sessions', () => {
+    const a = store.createSDKSession('content-a', 'test-project', 'A');
+    const b = store.createSDKSession('content-b', 'test-project', 'B');
+    manager.initializeSession(a);
+    manager.initializeSession(b);
+
+    expect(manager.getActiveSessionIds().sort()).toEqual([a, b].sort());
+  });
 });


### PR DESCRIPTION
## Problem

Sessions that fire `INIT_COMPLETE` then die never get an SDK processor. Their `summarize`/`observation` rows sit on `status='pending'` forever and inflate the WebUI "unprocessed" counter. Observed 2026-05-15: 5 stale rows from sessions that had been dead for ~20h.

The existing startup sweep only resets `processing → pending`; it never clears rows that were never claimed.

## Change

New `sweepStalePendingMessages()` (`src/services/infrastructure/StalePendingSweep.ts`):

- A session is swept when its **newest** `pending_message` predates a 6h threshold **and** it is not currently active. A mix of old + recent rows keeps the session safe.
- Its `pending_messages` are deleted; an `active` such session is marked `failed`.
- `pending_messages` has no `failed` status (CHECK allows only `pending`/`processing`), so orphaned rows are deleted rather than re-statused — matching the manual remediation precedent.

Wired into the worker as a 30-min `setInterval` in `initializeBackground()`, cleared on `shutdown()`. Active sessions are sourced from the new `SessionManager.getActiveSessionIds()`.

## Tests

- `tests/infrastructure/stale-pending-sweep.test.ts` — 5 cases: stale orphan swept, recent session untouched, active session skipped, mixed old/recent protected, non-active session status preserved.
- `tests/services/worker/session-manager-queue.test.ts` — `getActiveSessionIds()` coverage.

Full suite: 1800 pass / 56 fail — the 56 failures are the pre-existing `main` baseline, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)