### PR TITLE
fix(adapters/codex): strip suppressOutput from Codex hook output (2486)

### DIFF
--- a/src/cli/adapters/codex.ts
+++ b/src/cli/adapters/codex.ts
@@ -46,7 +46,10 @@ function cloneToolInput(toolInput: unknown): unknown {
 function buildBaseOutput(result: HookResult): Record<string, unknown> {
   const output: Record<string, unknown> = {};
   if (result.continue !== undefined) output.continue = result.continue;
-  if (result.suppressOutput !== undefined) output.suppressOutput = result.suppressOutput;
+  // Codex CLI rejects `suppressOutput` in hook stdout (see thedotmack/claude-mem 2486).
+  // Shared HookResults from hook handlers (observation, summarize, …) set
+  // `suppressOutput: true`, but it is a Claude-Code-only field. Stripping it
+  // unconditionally keeps the Codex adapter contract narrow.
   if (result.systemMessage) output.systemMessage = result.systemMessage;
   if (result.decision === 'block') output.decision = 'block';
   if (result.reason) output.reason = result.reason;

--- a/tests/hook-lifecycle.test.ts
+++ b/tests/hook-lifecycle.test.ts
@@ -207,7 +207,35 @@ describe('Codex CLI Compatibility (#744)', () => {
         },
       }) as any;
 
-      expect(output).toEqual({ continue: true, suppressOutput: true });
+      expect(output).toEqual({ continue: true });
+    });
+
+    it('strips suppressOutput from Codex output (Codex CLI rejects it)', async () => {
+      const { codexAdapter } = await import('../src/cli/adapters/codex.js');
+
+      const stopOutput = codexAdapter.formatOutput({
+        continue: true,
+        suppressOutput: true,
+      }) as Record<string, unknown>;
+      expect(stopOutput).not.toHaveProperty('suppressOutput');
+      expect(stopOutput).toEqual({ continue: true });
+
+      const postToolOutput = codexAdapter.formatOutput({
+        continue: true,
+        suppressOutput: true,
+        hookSpecificOutput: {
+          hookEventName: 'PostToolUse',
+          additionalContext: 'ctx',
+        },
+      }) as Record<string, unknown>;
+      expect(postToolOutput).not.toHaveProperty('suppressOutput');
+      expect(postToolOutput).toEqual({
+        continue: true,
+        hookSpecificOutput: {
+          hookEventName: 'PostToolUse',
+          additionalContext: 'ctx',
+        },
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Fix 2486 — Codex CLI rejects `suppressOutput` in hook stdout with
`PostToolUse hook returned unsupported suppressOutput`, so every tool
call under `claude-mem` v13.2.0 surfaces the error.

Hook handlers (`observation`, `summarize`, `session-init`,
`file-context`, ...) build a shared `HookResult` with
`suppressOutput: true` — a Claude-Code-only field. The Codex adapter's
`buildBaseOutput()` forwarded it verbatim to stdout, where the Codex
CLI then refuses the hook.

## Fix

`src/cli/adapters/codex.ts` no longer copies `result.suppressOutput`
into the Codex output object. The field is stripped unconditionally;
the Claude Code adapter is unchanged and still uses it.

After the patch, the repro from the issue body emits the expected
shape:

```
$ bun -e "import {codexAdapter} from './src/cli/adapters/codex.ts';
        console.log(JSON.stringify(codexAdapter.formatOutput(
          { continue: true, suppressOutput: true })));"
{"continue":true}
```

## Verification

- Baseline (before patch): 49/49 pass in `tests/hook-lifecycle.test.ts`
- Post-patch: 50/50 pass (one new focused test, plus one updated Stop
  test that previously asserted the buggy shape)
- Codex-adjacent: 11/11 pass in
  `tests/cli/adapters/codex-file-context.test.ts` +
  `tests/codex-transcript-watcher-windows.test.ts`

## TDD verification

- RED (without `src/cli/adapters/codex.ts` change): new
  `'strips suppressOutput from Codex output'` test fails at
  `expect(stopOutput).not.toHaveProperty('suppressOutput')`
- GREEN (with patch): same test passes

## Files changed

| File | Change |
|------|--------|
| `src/cli/adapters/codex.ts` | Remove `suppressOutput` from `buildBaseOutput()` + comment WHY |
| `tests/hook-lifecycle.test.ts` | Update Stop expectation; add focused test |

Generated by Ora Studio
Vibe coded by ousamabenyounes
