### PR TITLE
fix(chroma): drop cmd.exe wrap on Windows uvx spawn (2426)

### DIFF
--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -105,18 +105,22 @@ export class ChromaMcpManager {
     const spawnEnvironment = this.getSpawnEnv();
     getSupervisor().assertCanSpawn('chroma mcp');
 
-    const isWindows = process.platform === 'win32';
-    const uvxSpawnCommand = isWindows ? (process.env.ComSpec || 'cmd.exe') : 'uvx';
-    const uvxSpawnArgs = isWindows ? ['/c', 'uvx', ...commandArgs] : commandArgs;
-
+    // Spawn uvx directly on every platform (issue 2426). The previous Windows
+    // branch wrapped this as `cmd.exe /c uvx ...`, which made cmd.exe reassemble
+    // the argv array into a single command line and re-parse the dep-override
+    // version specifiers (`onnxruntime>=1.20`, `protobuf<7`) as I/O redirection
+    // — so `chroma-mcp` never started and every tool call closed in ~30 ms with
+    // `MCP error -32000: Connection closed`. Node's child_process.spawn (via
+    // cross-spawn) resolves `uvx` → `uvx.exe` on PATH on Windows the same way
+    // it does on POSIX, so no shell wrap is needed.
     logger.info('CHROMA_MCP', 'Connecting to chroma-mcp via MCP stdio', {
-      command: uvxSpawnCommand,
-      args: uvxSpawnArgs.join(' ')
+      command: 'uvx',
+      args: commandArgs.join(' ')
     });
 
     this.transport = new StdioClientTransport({
-      command: uvxSpawnCommand,
-      args: uvxSpawnArgs,
+      command: 'uvx',
+      args: commandArgs,
       env: spawnEnvironment,
       cwd: os.homedir(),
       stderr: 'pipe'

--- a/tests/services/sync/chroma-mcp-manager-windows-spawn.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-windows-spawn.test.ts
@@ -112,6 +112,7 @@ mock.module('child_process', () => {
 });
 
 const ORIGINAL_PLATFORM = process.platform;
+const ORIGINAL_COM_SPEC = process.env.ComSpec;
 Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
 process.env.ComSpec = 'C:\\Windows\\System32\\cmd.exe';
 
@@ -125,6 +126,11 @@ describe('ChromaMcpManager Windows spawn (2426)', () => {
 
   afterAll(() => {
     Object.defineProperty(process, 'platform', { value: ORIGINAL_PLATFORM, configurable: true });
+    if (ORIGINAL_COM_SPEC === undefined) {
+      delete process.env.ComSpec;
+    } else {
+      process.env.ComSpec = ORIGINAL_COM_SPEC;
+    }
   });
 
   it('spawns uvx directly on Windows (no cmd.exe /c wrapper)', async () => {

--- a/tests/services/sync/chroma-mcp-manager-windows-spawn.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-windows-spawn.test.ts
@@ -1,0 +1,149 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+// Regression coverage for issue 2426.
+//
+// Symptom on Windows: every chroma-mcp tool call closed in ~30 ms with
+// `MCP error -32000: Connection closed`. Root cause: the Windows code path
+// wrapped the spawn as `cmd.exe /c uvx ...`, and cmd.exe re-parses the argv
+// array back into a single command line. The dep-override `--with` arguments
+// (`onnxruntime>=1.20`, `protobuf<7`) then parse as I/O redirection
+// (`>=1.20` becomes "redirect stdout to file =1.20", `<7` becomes
+// "redirect stdin from file 7"), so the Python subprocess never starts.
+//
+// Fix: drop the Windows-only cmd.exe wrap. Node's spawn (via cross-spawn)
+// resolves `uvx` → `uvx.exe` on PATH on Windows the same way every other
+// platform does, and argv stays an array so no I/O redirection re-parse fires.
+
+let lastSpawn: { command: string; args: string[] } | null = null;
+
+interface FakeChildProcess {
+  pid: number;
+  once: () => FakeChildProcess;
+  on: () => FakeChildProcess;
+}
+
+class FakeTransport {
+  static nextPid = 200_000;
+  onclose: (() => void) | null = null;
+  _process: FakeChildProcess;
+
+  constructor(opts: { command: string; args: string[] }) {
+    lastSpawn = { command: opts.command, args: opts.args };
+    const pid = FakeTransport.nextPid++;
+    const self: FakeChildProcess = {
+      pid,
+      once: function (this: FakeChildProcess) { return this; },
+      on: function (this: FakeChildProcess) { return this; },
+    };
+    this._process = self;
+  }
+
+  async close(): Promise<void> {}
+}
+
+mock.module('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: FakeTransport,
+}));
+
+class FakeClient {
+  async connect(): Promise<void> {}
+  async callTool(): Promise<unknown> {
+    return { content: [{ type: 'text', text: '{}' }] };
+  }
+  async close(): Promise<void> {}
+}
+
+mock.module('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: FakeClient,
+}));
+
+mock.module('../../../src/shared/SettingsDefaultsManager.js', () => ({
+  SettingsDefaultsManager: {
+    get: () => '',
+    getInt: () => 0,
+    loadFromFile: () => ({}),
+  },
+}));
+
+mock.module('../../../src/shared/paths.js', () => ({
+  USER_SETTINGS_PATH: '/tmp/fake-settings.json',
+  paths: {
+    chroma: () => 'C:\\Users\\test\\.claude-mem\\chroma',
+    combinedCerts: () => '/tmp/fake-combined-certs.pem',
+  },
+}));
+
+mock.module('../../../src/utils/logger.js', () => ({
+  logger: {
+    info: () => {},
+    debug: () => {},
+    warn: () => {},
+    error: () => {},
+    failure: () => {},
+  },
+}));
+
+mock.module('../../../src/supervisor/index.ts', () => ({
+  getSupervisor: () => ({
+    assertCanSpawn: () => {},
+    registerProcess: () => {},
+    unregisterProcess: () => {},
+  }),
+}));
+
+mock.module('../../../src/supervisor/env-sanitizer.js', () => ({
+  sanitizeEnv: (env: NodeJS.ProcessEnv) => env,
+}));
+
+mock.module('child_process', () => {
+  const original = require('node:child_process');
+  return {
+    ...original,
+    execFile: (
+      _cmd: string,
+      _args: string[],
+      _opts: unknown,
+      cb: (err: Error | null, stdout: { stdout: string; stderr: string }) => void
+    ) => {
+      cb(null, { stdout: '', stderr: '' } as { stdout: string; stderr: string });
+    },
+    execSync: () => '',
+  };
+});
+
+const ORIGINAL_PLATFORM = process.platform;
+Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+process.env.ComSpec = 'C:\\Windows\\System32\\cmd.exe';
+
+const { ChromaMcpManager } = await import('../../../src/services/sync/ChromaMcpManager.js');
+
+describe('ChromaMcpManager Windows spawn (2426)', () => {
+  beforeEach(async () => {
+    await ChromaMcpManager.reset();
+    lastSpawn = null;
+  });
+
+  afterAll(() => {
+    Object.defineProperty(process, 'platform', { value: ORIGINAL_PLATFORM, configurable: true });
+  });
+
+  it('spawns uvx directly on Windows (no cmd.exe /c wrapper)', async () => {
+    const mgr = ChromaMcpManager.getInstance();
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+
+    expect(lastSpawn).not.toBeNull();
+    expect(lastSpawn!.command).toBe('uvx');
+    expect(lastSpawn!.args[0]).not.toBe('/c');
+    expect(lastSpawn!.args).not.toContain('/c');
+  });
+
+  it('passes dep-override version specifiers as argv elements (not as cmd.exe redirection)', async () => {
+    const mgr = ChromaMcpManager.getInstance();
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+
+    expect(lastSpawn).not.toBeNull();
+    expect(lastSpawn!.args).toContain('--with');
+    expect(lastSpawn!.args).toContain('onnxruntime>=1.20');
+    expect(lastSpawn!.args).toContain('protobuf<7');
+  });
+});


### PR DESCRIPTION
## Summary

Fix 2426 — Windows chroma-mcp stdio failure on every uvx-based install.

- Drop the Windows-specific `cmd.exe /c uvx ...` wrap in `ChromaMcpManager.connectInternal()` and spawn `uvx` directly on all platforms. Node's `child_process.spawn` (via cross-spawn) resolves `uvx` -> `uvx.exe` on PATH on Windows the same way it does on POSIX, so the shell wrap is not needed.
- Restores semantic search on Windows when `uv` is installed via WinGet **or** the official PowerShell installer.
- Adds a regression test that fails on the unfixed code and passes after — pins the spawn command to `uvx` and asserts the dep-override `--with` version specifiers reach uvx as argv elements (not as `cmd.exe` I/O redirection).

## Root cause

`ChromaMcpManager` built the spawn arguments as an array and then wrapped them on Windows:

```ts
const isWindows = process.platform === 'win32';
const uvxSpawnCommand = isWindows ? (process.env.ComSpec || 'cmd.exe') : 'uvx';
const uvxSpawnArgs = isWindows ? ['/c', 'uvx', ...commandArgs] : commandArgs;
```

`cmd.exe /c` reassembles the argv array back into a single command line. When the dep-override flags from `CHROMA_MCP_DEP_OVERRIDES` land in that command line they parse as I/O redirection:

- `onnxruntime>=1.20` -> "redirect stdout to file `=1.20`"
- `protobuf<7` -> "redirect stdin from file `7`"

The Python subprocess never starts, so every `chroma-mcp` tool call closes in ~30 ms with `MCP error -32000: Connection closed`. This is not WinGet-specific — it fires on any uv install on Windows.

Reproducible in isolation without the plugin:

```
cmd /c "uvx --python 3.13 --with onnxruntime>=1.20 chroma-mcp --help"
```

returns immediately with no uvx output. Quoting the version specifier (`"onnxruntime>=1.20"`) avoids the redirection re-parse and makes uvx run normally — but argv-based spawn already gives us that guarantee without the quoting dance.

## Fix

```diff
-    const isWindows = process.platform === 'win32';
-    const uvxSpawnCommand = isWindows ? (process.env.ComSpec || 'cmd.exe') : 'uvx';
-    const uvxSpawnArgs = isWindows ? ['/c', 'uvx', ...commandArgs] : commandArgs;
-
-    logger.info('CHROMA_MCP', 'Connecting to chroma-mcp via MCP stdio', {
-      command: uvxSpawnCommand,
-      args: uvxSpawnArgs.join(' ')
-    });
-
-    this.transport = new StdioClientTransport({
-      command: uvxSpawnCommand,
-      args: uvxSpawnArgs,
+    // Spawn uvx directly on every platform (issue 2426). The previous Windows
+    // branch wrapped this as `cmd.exe /c uvx ...`, which made cmd.exe reassemble
+    // the argv array into a single command line and re-parse the dep-override
+    // version specifiers (`onnxruntime>=1.20`, `protobuf<7`) as I/O redirection
+    // — so chroma-mcp never started and every tool call closed in ~30 ms.
+    logger.info('CHROMA_MCP', 'Connecting to chroma-mcp via MCP stdio', {
+      command: 'uvx',
+      args: commandArgs.join(' ')
+    });
+
+    this.transport = new StdioClientTransport({
+      command: 'uvx',
+      args: commandArgs,
       env: spawnEnvironment,
       cwd: os.homedir(),
       stderr: 'pipe'
     });
```

No other call sites need updating — all the descendant-tracking comments (`uvx -> uv -> python -> chroma-mcp`) remain accurate because the direct child on Windows is now `uvx`, matching POSIX behaviour.

## TDD verification

- **RED check** (test on `main` without prod fix): the new test `spawns uvx directly on Windows (no cmd.exe /c wrapper)` fails with:

  ```
  expect(received).toBe(expected)
  Expected: "uvx"
  Received: "C:\Windows\System32\cmd.exe"
  ```

- **GREEN check** (with prod fix): 2/2 new tests pass.

## Verification

- `bun test tests/services/sync/chroma-mcp-manager-*.test.ts` -> 12/12 pass (10 existing + 2 new).
- `bun test tests/integration/chroma-vector-sync.test.ts` -> 19/19 pass.
- Wider sweep `bun test tests/services/` -> 163 pass, 5 pre-existing failures unrelated to this patch (`sqlite/schema-repair`, `ensureWorkerStarted validation guards` — confirmed to fail identically on `upstream/main` without the patch).
- No regressions introduced.

## Files changed

| File | Change |
|------|--------|
| `src/services/sync/ChromaMcpManager.ts` | Drop the Windows-only `cmd.exe /c` wrap; spawn `uvx` directly on all platforms. |
| `tests/services/sync/chroma-mcp-manager-windows-spawn.test.ts` | New regression test (RED-then-GREEN against issue 2426). |

The built `plugin/scripts/worker-service.cjs` bundle is intentionally not rebuilt in this diff — the Windows CI job (`.github/workflows/windows.yml`) runs `npm run build` on every PR, and the release `chore: bump version` commits regenerate it. Source-only patches match the recent merged-PR convention.
