### PR TITLE
fix(opencode-plugin): match OpenCode Hooks contract so sessions record (2435)

### DIFF
--- a/src/integrations/opencode-plugin/index.ts
+++ b/src/integrations/opencode-plugin/index.ts
@@ -11,7 +11,7 @@ interface OpenCodePluginContext {
   directory: string;
   worktree: string;
   serverUrl: URL;
-  $: unknown; 
+  $: unknown;
 }
 
 interface ToolExecuteAfterInput {
@@ -27,47 +27,33 @@ interface ToolExecuteAfterOutput {
   metadata: Record<string, unknown>;
 }
 
+interface ChatMessageInput {
+  sessionID: string;
+  agent?: string;
+  model?: { providerID: string; modelID: string };
+  messageID?: string;
+  variant?: string;
+}
+
+interface SessionCompactingInput {
+  sessionID: string;
+}
+
+interface SessionCompactingOutput {
+  context: string[];
+  prompt?: string;
+}
+
 interface ToolDefinition {
   description: string;
   args: Record<string, unknown>;
   execute: (args: Record<string, unknown>, context: unknown) => Promise<string>;
 }
 
-interface SessionCreatedEvent {
+interface OpenCodeEventInput {
   event: {
-    sessionID: string;
-    directory?: string;
-    project?: string;
-  };
-}
-
-interface MessageUpdatedEvent {
-  event: {
-    sessionID: string;
-    role: string;
-    content: string;
-  };
-}
-
-interface SessionCompactedEvent {
-  event: {
-    sessionID: string;
-    summary?: string;
-    messageCount?: number;
-  };
-}
-
-interface FileEditedEvent {
-  event: {
-    sessionID: string;
-    path: string;
-    diff?: string;
-  };
-}
-
-interface SessionDeletedEvent {
-  event: {
-    sessionID: string;
+    type: string;
+    properties: Record<string, unknown>;
   };
 }
 
@@ -83,7 +69,7 @@ function resolveWorkerPort(): string {
 
 const WORKER_BASE_URL = `http://127.0.0.1:${resolveWorkerPort()}`;
 const MAX_TOOL_RESPONSE_LENGTH = 1000;
-
+const MAX_SESSION_MAP_ENTRIES = 1000;
 const JSON_HEADERS: Record<string, string> = { "Content-Type": "application/json" };
 
 function workerPostFireAndForget(
@@ -120,8 +106,7 @@ async function workerGetText(path: string): Promise<string | null> {
 }
 
 const contentSessionIdsByOpenCodeSessionId = new Map<string, string>();
-
-const MAX_SESSION_MAP_ENTRIES = 1000;
+const initializedSessions = new Set<string>();
 
 function getOrCreateContentSessionId(openCodeSessionId: string): string {
   if (!contentSessionIdsByOpenCodeSessionId.has(openCodeSessionId)) {
@@ -129,6 +114,7 @@ function getOrCreateContentSessionId(openCodeSessionId: string): string {
       const oldestKey = contentSessionIdsByOpenCodeSessionId.keys().next().value;
       if (oldestKey !== undefined) {
         contentSessionIdsByOpenCodeSessionId.delete(oldestKey);
+        initializedSessions.delete(oldestKey);
       } else {
         break;
       }
@@ -141,104 +127,108 @@ function getOrCreateContentSessionId(openCodeSessionId: string): string {
   return contentSessionIdsByOpenCodeSessionId.get(openCodeSessionId)!;
 }
 
+function truncate(text: string): string {
+  return text.length > MAX_TOOL_RESPONSE_LENGTH
+    ? text.slice(0, MAX_TOOL_RESPONSE_LENGTH)
+    : text;
+}
+
 export const ClaudeMemPlugin = async (ctx: OpenCodePluginContext) => {
   const projectName = ctx.project?.name || "opencode";
 
   console.log(`[claude-mem] OpenCode plugin loading (project: ${projectName})`);
 
+  function ensureSessionInitialized(openCodeSessionId: string): string {
+    const contentSessionId = getOrCreateContentSessionId(openCodeSessionId);
+    if (!initializedSessions.has(openCodeSessionId)) {
+      initializedSessions.add(openCodeSessionId);
+      workerPostFireAndForget("/api/sessions/init", {
+        contentSessionId,
+        project: projectName,
+        prompt: "",
+      });
+    }
+    return contentSessionId;
+  }
+
   return {
-    hooks: {
-      tool: {
-        execute: {
-          after: (
-            input: ToolExecuteAfterInput,
-            output: ToolExecuteAfterOutput,
-          ) => {
-            const contentSessionId = getOrCreateContentSessionId(input.sessionID);
-
-            let toolResponseText = output.output || "";
-            if (toolResponseText.length > MAX_TOOL_RESPONSE_LENGTH) {
-              toolResponseText = toolResponseText.slice(0, MAX_TOOL_RESPONSE_LENGTH);
-            }
-
-            workerPostFireAndForget("/api/sessions/observations", {
-              contentSessionId,
-              tool_name: input.tool,
-              tool_input: input.args || {},
-              tool_response: toolResponseText,
-              cwd: ctx.directory,
-            });
-          },
-        },
-      },
+    "tool.execute.after": async (
+      input: ToolExecuteAfterInput,
+      output: ToolExecuteAfterOutput,
+    ): Promise<void> => {
+      const contentSessionId = ensureSessionInitialized(input.sessionID);
+      workerPostFireAndForget("/api/sessions/observations", {
+        contentSessionId,
+        tool_name: input.tool,
+        tool_input: input.args || {},
+        tool_response: truncate(output.output || ""),
+        cwd: ctx.directory,
+      });
     },
 
-    event: (eventName: string, payload: unknown) => {
-      switch (eventName) {
-        case "session.created": {
-          const { event } = payload as SessionCreatedEvent;
-          const contentSessionId = getOrCreateContentSessionId(event.sessionID);
+    "chat.message": async (input: ChatMessageInput): Promise<void> => {
+      if (!input?.sessionID) return;
+      ensureSessionInitialized(input.sessionID);
+    },
 
-          workerPostFireAndForget("/api/sessions/init", {
-            contentSessionId,
-            project: projectName,
-            prompt: "",
-          });
+    "experimental.session.compacting": async (
+      input: SessionCompactingInput,
+      _output: SessionCompactingOutput,
+    ): Promise<void> => {
+      if (!input?.sessionID) return;
+      const contentSessionId = ensureSessionInitialized(input.sessionID);
+      workerPostFireAndForget("/api/sessions/summarize", {
+        contentSessionId,
+        last_assistant_message: "",
+      });
+    },
+
+    event: async (eventInput: OpenCodeEventInput): Promise<void> => {
+      const e = eventInput?.event;
+      if (!e || typeof e.type !== "string") return;
+      const props = (e.properties || {}) as Record<string, unknown>;
+
+      switch (e.type) {
+        case "session.created": {
+          const sid = (props.info as { id?: string } | undefined)?.id;
+          if (sid) ensureSessionInitialized(sid);
           break;
         }
 
         case "message.updated": {
-          const { event } = payload as MessageUpdatedEvent;
-
-          if (event.role !== "assistant") break;
-
-          const contentSessionId = getOrCreateContentSessionId(event.sessionID);
-
-          let messageText = event.content || "";
-          if (messageText.length > MAX_TOOL_RESPONSE_LENGTH) {
-            messageText = messageText.slice(0, MAX_TOOL_RESPONSE_LENGTH);
-          }
-
+          const info = props.info as
+            | { role?: string; sessionID?: string; content?: unknown }
+            | undefined;
+          if (!info || info.role !== "assistant" || !info.sessionID) break;
+          const contentSessionId = ensureSessionInitialized(info.sessionID);
+          const text = typeof info.content === "string" ? info.content : "";
           workerPostFireAndForget("/api/sessions/observations", {
             contentSessionId,
             tool_name: "assistant_message",
             tool_input: {},
-            tool_response: messageText,
+            tool_response: truncate(text),
             cwd: ctx.directory,
           });
           break;
         }
 
         case "session.compacted": {
-          const { event } = payload as SessionCompactedEvent;
-          const contentSessionId = getOrCreateContentSessionId(event.sessionID);
-
+          const sid = props.sessionID as string | undefined;
+          if (!sid) break;
+          const contentSessionId = ensureSessionInitialized(sid);
           workerPostFireAndForget("/api/sessions/summarize", {
             contentSessionId,
-            last_assistant_message: event.summary || "",
-          });
-          break;
-        }
-
-        case "file.edited": {
-          const { event } = payload as FileEditedEvent;
-          const contentSessionId = getOrCreateContentSessionId(event.sessionID);
-
-          workerPostFireAndForget("/api/sessions/observations", {
-            contentSessionId,
-            tool_name: "file_edit",
-            tool_input: { path: event.path },
-            tool_response: event.diff
-              ? event.diff.slice(0, MAX_TOOL_RESPONSE_LENGTH)
-              : `File edited: ${event.path}`,
-            cwd: ctx.directory,
+            last_assistant_message: "",
           });
           break;
         }
 
         case "session.deleted": {
-          const { event } = payload as SessionDeletedEvent;
-          contentSessionIdsByOpenCodeSessionId.delete(event.sessionID);
+          const sid = (props.info as { id?: string } | undefined)?.id;
+          if (sid) {
+            contentSessionIdsByOpenCodeSessionId.delete(sid);
+            initializedSessions.delete(sid);
+          }
           break;
         }
       }

--- a/src/integrations/opencode-plugin/index.ts
+++ b/src/integrations/opencode-plugin/index.ts
@@ -161,6 +161,11 @@ export const ClaudeMemPlugin = async (ctx: OpenCodePluginContext) => {
       input: ToolExecuteAfterInput,
       output: ToolExecuteAfterOutput,
     ): Promise<void> => {
+      // Without this guard a sessionless tool call would key the session map
+      // on the literal string "undefined" and collapse every sessionless
+      // observation into one phantom `opencode-undefined-<ts>` session
+      // (claude-mem#2503 P1 follow-up review).
+      if (!input?.sessionID) return;
       const contentSessionId = ensureSessionInitialized(input.sessionID);
       workerPostFireAndForget("/api/sessions/observations", {
         contentSessionId,

--- a/src/integrations/opencode-plugin/index.ts
+++ b/src/integrations/opencode-plugin/index.ts
@@ -105,28 +105,6 @@ async function workerGetText(path: string): Promise<string | null> {
   }
 }
 
-const contentSessionIdsByOpenCodeSessionId = new Map<string, string>();
-const initializedSessions = new Set<string>();
-
-function getOrCreateContentSessionId(openCodeSessionId: string): string {
-  if (!contentSessionIdsByOpenCodeSessionId.has(openCodeSessionId)) {
-    while (contentSessionIdsByOpenCodeSessionId.size >= MAX_SESSION_MAP_ENTRIES) {
-      const oldestKey = contentSessionIdsByOpenCodeSessionId.keys().next().value;
-      if (oldestKey !== undefined) {
-        contentSessionIdsByOpenCodeSessionId.delete(oldestKey);
-        initializedSessions.delete(oldestKey);
-      } else {
-        break;
-      }
-    }
-    contentSessionIdsByOpenCodeSessionId.set(
-      openCodeSessionId,
-      `opencode-${openCodeSessionId}-${Date.now()}`,
-    );
-  }
-  return contentSessionIdsByOpenCodeSessionId.get(openCodeSessionId)!;
-}
-
 function truncate(text: string): string {
   return text.length > MAX_TOOL_RESPONSE_LENGTH
     ? text.slice(0, MAX_TOOL_RESPONSE_LENGTH)
@@ -137,6 +115,33 @@ export const ClaudeMemPlugin = async (ctx: OpenCodePluginContext) => {
   const projectName = ctx.project?.name || "opencode";
 
   console.log(`[claude-mem] OpenCode plugin loading (project: ${projectName})`);
+
+  // Per-plugin-instance state. Keeping these inside the factory closure (rather
+  // than at module scope) gives each `ClaudeMemPlugin(ctx)` call a fresh map/set,
+  // which keeps the idempotency guards (no double `/api/sessions/init`, no double
+  // `/api/sessions/summarize`) provable from unit tests that re-instantiate the
+  // plugin in `beforeEach` instead of having to hand-clear module globals.
+  const contentSessionIdsByOpenCodeSessionId = new Map<string, string>();
+  const initializedSessions = new Set<string>();
+
+  function getOrCreateContentSessionId(openCodeSessionId: string): string {
+    if (!contentSessionIdsByOpenCodeSessionId.has(openCodeSessionId)) {
+      while (contentSessionIdsByOpenCodeSessionId.size >= MAX_SESSION_MAP_ENTRIES) {
+        const oldestKey = contentSessionIdsByOpenCodeSessionId.keys().next().value;
+        if (oldestKey !== undefined) {
+          contentSessionIdsByOpenCodeSessionId.delete(oldestKey);
+          initializedSessions.delete(oldestKey);
+        } else {
+          break;
+        }
+      }
+      contentSessionIdsByOpenCodeSessionId.set(
+        openCodeSessionId,
+        `opencode-${openCodeSessionId}-${Date.now()}`,
+      );
+    }
+    return contentSessionIdsByOpenCodeSessionId.get(openCodeSessionId)!;
+  }
 
   function ensureSessionInitialized(openCodeSessionId: string): string {
     const contentSessionId = getOrCreateContentSessionId(openCodeSessionId);
@@ -176,11 +181,12 @@ export const ClaudeMemPlugin = async (ctx: OpenCodePluginContext) => {
       _output: SessionCompactingOutput,
     ): Promise<void> => {
       if (!input?.sessionID) return;
-      const contentSessionId = ensureSessionInitialized(input.sessionID);
-      workerPostFireAndForget("/api/sessions/summarize", {
-        contentSessionId,
-        last_assistant_message: "",
-      });
+      // Lazy-init only. The summarize POST is intentionally NOT fired here —
+      // OpenCode emits the matching `session.compacted` event after compaction
+      // completes, and that branch (below) owns the single summarize call.
+      // Posting from both signals would double-write the summary row per
+      // compaction cycle (claude-mem#2503 P1 review).
+      ensureSessionInitialized(input.sessionID);
     },
 
     event: async (eventInput: OpenCodeEventInput): Promise<void> => {

--- a/tests/integrations/opencode-plugin.test.ts
+++ b/tests/integrations/opencode-plugin.test.ts
@@ -97,6 +97,26 @@ describe("opencode-plugin — OpenCode Hooks contract", () => {
     expect(obs?.body.cwd).toBe("/tmp/demo");
   });
 
+  it("'tool.execute.after' skips POSTs when sessionID is missing (no phantom 'opencode-undefined-*' session, claude-mem#2503 follow-up)", async () => {
+    const hooks = await loadHooks();
+    const toolAfter = hooks["tool.execute.after"] as (
+      input: unknown,
+      output: unknown,
+    ) => Promise<void>;
+
+    await toolAfter(
+      { tool: "read", sessionID: undefined, callID: "c1", args: { path: "/a" } },
+      { title: "t", output: "OK", metadata: {} },
+    );
+    await toolAfter(
+      { tool: "read", callID: "c2", args: { path: "/b" } },
+      { title: "t", output: "OK", metadata: {} },
+    );
+    await flushFireAndForget();
+
+    expect(captured.length).toBe(0);
+  });
+
   it("'chat.message' triggers session init once per sessionID", async () => {
     const hooks = await loadHooks();
     const chatMessage = hooks["chat.message"] as (input: unknown) => Promise<void>;

--- a/tests/integrations/opencode-plugin.test.ts
+++ b/tests/integrations/opencode-plugin.test.ts
@@ -50,8 +50,14 @@ async function flushFireAndForget(): Promise<void> {
 }
 
 describe("opencode-plugin — OpenCode Hooks contract", () => {
-  beforeEach(() => {
+  // Hoisted so each test gets a fresh plugin instance (fresh closure-scoped
+  // initializedSessions + contentSessionIdsByOpenCodeSessionId maps).
+  // This prevents any session-ID bleed across tests if IDs are ever reused.
+  let hooks: Record<string, unknown>;
+
+  beforeEach(async () => {
     installFetchSpy();
+    hooks = await loadHooks();
   });
 
   afterEach(() => {
@@ -59,8 +65,6 @@ describe("opencode-plugin — OpenCode Hooks contract", () => {
   });
 
   it("exposes hooks as FLAT top-level keys (not nested under a 'hooks' wrapper)", async () => {
-    const hooks = await loadHooks();
-
     expect(typeof hooks["tool.execute.after"]).toBe("function");
     expect(typeof hooks["chat.message"]).toBe("function");
     expect(typeof hooks["experimental.session.compacting"]).toBe("function");
@@ -70,13 +74,11 @@ describe("opencode-plugin — OpenCode Hooks contract", () => {
   });
 
   it("'event' hook uses OpenCode's single-arg contract: (input: { event }) => Promise<void>", async () => {
-    const hooks = await loadHooks();
     const eventFn = hooks.event as (input: unknown) => Promise<void>;
     expect(eventFn.length).toBe(1);
   });
 
   it("'tool.execute.after' POSTs an observation and lazily initializes the session", async () => {
-    const hooks = await loadHooks();
     const toolAfter = hooks["tool.execute.after"] as (
       input: unknown,
       output: unknown,
@@ -98,7 +100,6 @@ describe("opencode-plugin — OpenCode Hooks contract", () => {
   });
 
   it("'tool.execute.after' skips POSTs when sessionID is missing (no phantom 'opencode-undefined-*' session, claude-mem#2503 follow-up)", async () => {
-    const hooks = await loadHooks();
     const toolAfter = hooks["tool.execute.after"] as (
       input: unknown,
       output: unknown,
@@ -118,7 +119,6 @@ describe("opencode-plugin — OpenCode Hooks contract", () => {
   });
 
   it("'chat.message' triggers session init once per sessionID", async () => {
-    const hooks = await loadHooks();
     const chatMessage = hooks["chat.message"] as (input: unknown) => Promise<void>;
 
     await chatMessage({ sessionID: "s-chat" });
@@ -131,7 +131,6 @@ describe("opencode-plugin — OpenCode Hooks contract", () => {
   });
 
   it("'experimental.session.compacting' lazy-inits the session but does NOT POST summarize (owned by session.compacted event)", async () => {
-    const hooks = await loadHooks();
     const compacting = hooks["experimental.session.compacting"] as (
       input: unknown,
       output: unknown,
@@ -148,7 +147,6 @@ describe("opencode-plugin — OpenCode Hooks contract", () => {
   });
 
   it("compacting hook + session.compacted event for the SAME session produces exactly one summarize POST (claude-mem#2503 P1)", async () => {
-    const hooks = await loadHooks();
     const compacting = hooks["experimental.session.compacting"] as (
       input: unknown,
       output: unknown,
@@ -168,7 +166,6 @@ describe("opencode-plugin — OpenCode Hooks contract", () => {
   });
 
   it("event(session.created) initializes the session and uses properties.info.id", async () => {
-    const hooks = await loadHooks();
     const eventFn = hooks.event as (input: unknown) => Promise<void>;
 
     await eventFn({
@@ -181,7 +178,6 @@ describe("opencode-plugin — OpenCode Hooks contract", () => {
   });
 
   it("event(message.updated) records an assistant observation; ignores user messages", async () => {
-    const hooks = await loadHooks();
     const eventFn = hooks.event as (input: unknown) => Promise<void>;
 
     await eventFn({
@@ -211,7 +207,6 @@ describe("opencode-plugin — OpenCode Hooks contract", () => {
   });
 
   it("event(session.compacted) reads properties.sessionID and POSTs summarize", async () => {
-    const hooks = await loadHooks();
     const eventFn = hooks.event as (input: unknown) => Promise<void>;
 
     await eventFn({
@@ -223,7 +218,6 @@ describe("opencode-plugin — OpenCode Hooks contract", () => {
   });
 
   it("event(session.deleted) does not crash on the properties.info.id payload", async () => {
-    const hooks = await loadHooks();
     const eventFn = hooks.event as (input: unknown) => Promise<void>;
 
     await eventFn({
@@ -233,7 +227,6 @@ describe("opencode-plugin — OpenCode Hooks contract", () => {
   });
 
   it("event hook ignores unknown event types without throwing", async () => {
-    const hooks = await loadHooks();
     const eventFn = hooks.event as (input: unknown) => Promise<void>;
 
     await eventFn({ event: { type: "unrelated.event", properties: {} } });
@@ -245,7 +238,6 @@ describe("opencode-plugin — OpenCode Hooks contract", () => {
   });
 
   it("'tool' registry still exposes claude_mem_search", async () => {
-    const hooks = await loadHooks();
     const tool = (hooks.tool as Record<string, { description?: string }>)?.claude_mem_search;
     expect(tool).toBeDefined();
     expect(typeof tool.description).toBe("string");

--- a/tests/integrations/opencode-plugin.test.ts
+++ b/tests/integrations/opencode-plugin.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+
+import { ClaudeMemPlugin } from "../../src/integrations/opencode-plugin/index.ts";
+
+interface CapturedPost {
+  path: string;
+  body: Record<string, unknown>;
+}
+
+const FAKE_CTX = {
+  client: {},
+  project: { name: "demo" },
+  directory: "/tmp/demo",
+  worktree: "/tmp/demo",
+  serverUrl: new URL("http://127.0.0.1:1/"),
+  $: {},
+};
+
+const realFetch = globalThis.fetch;
+let captured: CapturedPost[] = [];
+
+function installFetchSpy(): void {
+  captured = [];
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = (async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1],
+  ): Promise<Response> => {
+    const urlStr = typeof input === "string" ? input : (input as URL).toString();
+    const url = new URL(urlStr);
+    let parsedBody: Record<string, unknown> = {};
+    if (init?.body && typeof init.body === "string") {
+      try {
+        parsedBody = JSON.parse(init.body);
+      } catch {
+        parsedBody = {};
+      }
+    }
+    captured.push({ path: url.pathname, body: parsedBody });
+    return new Response("{}", { status: 200 }) as unknown as Response;
+  }) as typeof fetch;
+}
+
+async function loadHooks(): Promise<Record<string, unknown>> {
+  const hooks = await ClaudeMemPlugin(FAKE_CTX as Parameters<typeof ClaudeMemPlugin>[0]);
+  return hooks as Record<string, unknown>;
+}
+
+async function flushFireAndForget(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+describe("opencode-plugin — OpenCode Hooks contract", () => {
+  beforeEach(() => {
+    installFetchSpy();
+  });
+
+  afterEach(() => {
+    (globalThis as unknown as { fetch: typeof fetch }).fetch = realFetch;
+  });
+
+  it("exposes hooks as FLAT top-level keys (not nested under a 'hooks' wrapper)", async () => {
+    const hooks = await loadHooks();
+
+    expect(typeof hooks["tool.execute.after"]).toBe("function");
+    expect(typeof hooks["chat.message"]).toBe("function");
+    expect(typeof hooks["experimental.session.compacting"]).toBe("function");
+    expect(typeof hooks.event).toBe("function");
+
+    expect((hooks as { hooks?: unknown }).hooks).toBeUndefined();
+  });
+
+  it("'event' hook uses OpenCode's single-arg contract: (input: { event }) => Promise<void>", async () => {
+    const hooks = await loadHooks();
+    const eventFn = hooks.event as (input: unknown) => Promise<void>;
+    expect(eventFn.length).toBe(1);
+  });
+
+  it("'tool.execute.after' POSTs an observation and lazily initializes the session", async () => {
+    const hooks = await loadHooks();
+    const toolAfter = hooks["tool.execute.after"] as (
+      input: unknown,
+      output: unknown,
+    ) => Promise<void>;
+
+    await toolAfter(
+      { tool: "read", sessionID: "s-tool", callID: "c1", args: { path: "/a" } },
+      { title: "t", output: "OK", metadata: {} },
+    );
+    await flushFireAndForget();
+
+    const paths = captured.map((c) => c.path);
+    expect(paths).toContain("/api/sessions/init");
+    expect(paths).toContain("/api/sessions/observations");
+
+    const obs = captured.find((c) => c.path === "/api/sessions/observations");
+    expect(obs?.body.tool_name).toBe("read");
+    expect(obs?.body.cwd).toBe("/tmp/demo");
+  });
+
+  it("'chat.message' triggers session init once per sessionID", async () => {
+    const hooks = await loadHooks();
+    const chatMessage = hooks["chat.message"] as (input: unknown) => Promise<void>;
+
+    await chatMessage({ sessionID: "s-chat" });
+    await chatMessage({ sessionID: "s-chat" });
+    await flushFireAndForget();
+
+    const inits = captured.filter((c) => c.path === "/api/sessions/init");
+    expect(inits.length).toBe(1);
+    expect(inits[0]?.body.project).toBe("demo");
+  });
+
+  it("'experimental.session.compacting' POSTs a summarize request", async () => {
+    const hooks = await loadHooks();
+    const compacting = hooks["experimental.session.compacting"] as (
+      input: unknown,
+      output: unknown,
+    ) => Promise<void>;
+
+    await compacting({ sessionID: "s-comp" }, { context: [] });
+    await flushFireAndForget();
+
+    const summarize = captured.find((c) => c.path === "/api/sessions/summarize");
+    expect(summarize).toBeDefined();
+    expect(typeof summarize?.body.contentSessionId).toBe("string");
+  });
+
+  it("event(session.created) initializes the session and uses properties.info.id", async () => {
+    const hooks = await loadHooks();
+    const eventFn = hooks.event as (input: unknown) => Promise<void>;
+
+    await eventFn({
+      event: { type: "session.created", properties: { info: { id: "s-evt" } } },
+    });
+    await flushFireAndForget();
+
+    const inits = captured.filter((c) => c.path === "/api/sessions/init");
+    expect(inits.length).toBe(1);
+  });
+
+  it("event(message.updated) records an assistant observation; ignores user messages", async () => {
+    const hooks = await loadHooks();
+    const eventFn = hooks.event as (input: unknown) => Promise<void>;
+
+    await eventFn({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: { role: "user", sessionID: "s-msg", content: "hello" },
+        },
+      },
+    });
+    await flushFireAndForget();
+    expect(captured.find((c) => c.path === "/api/sessions/observations")).toBeUndefined();
+
+    await eventFn({
+      event: {
+        type: "message.updated",
+        properties: {
+          info: { role: "assistant", sessionID: "s-msg", content: "hi back" },
+        },
+      },
+    });
+    await flushFireAndForget();
+
+    const obs = captured.find((c) => c.path === "/api/sessions/observations");
+    expect(obs?.body.tool_name).toBe("assistant_message");
+    expect(obs?.body.tool_response).toBe("hi back");
+  });
+
+  it("event(session.compacted) reads properties.sessionID and POSTs summarize", async () => {
+    const hooks = await loadHooks();
+    const eventFn = hooks.event as (input: unknown) => Promise<void>;
+
+    await eventFn({
+      event: { type: "session.compacted", properties: { sessionID: "s-cmp" } },
+    });
+    await flushFireAndForget();
+
+    expect(captured.find((c) => c.path === "/api/sessions/summarize")).toBeDefined();
+  });
+
+  it("event(session.deleted) does not crash on the properties.info.id payload", async () => {
+    const hooks = await loadHooks();
+    const eventFn = hooks.event as (input: unknown) => Promise<void>;
+
+    await eventFn({
+      event: { type: "session.deleted", properties: { info: { id: "s-del" } } },
+    });
+    await flushFireAndForget();
+  });
+
+  it("event hook ignores unknown event types without throwing", async () => {
+    const hooks = await loadHooks();
+    const eventFn = hooks.event as (input: unknown) => Promise<void>;
+
+    await eventFn({ event: { type: "unrelated.event", properties: {} } });
+    await eventFn({ event: { type: "session.idle", properties: { sessionID: "x" } } });
+    await flushFireAndForget();
+
+    expect(captured.find((c) => c.path === "/api/sessions/init")).toBeUndefined();
+    expect(captured.find((c) => c.path === "/api/sessions/observations")).toBeUndefined();
+  });
+
+  it("'tool' registry still exposes claude_mem_search", async () => {
+    const hooks = await loadHooks();
+    const tool = (hooks.tool as Record<string, { description?: string }>)?.claude_mem_search;
+    expect(tool).toBeDefined();
+    expect(typeof tool.description).toBe("string");
+  });
+});

--- a/tests/integrations/opencode-plugin.test.ts
+++ b/tests/integrations/opencode-plugin.test.ts
@@ -110,7 +110,7 @@ describe("opencode-plugin — OpenCode Hooks contract", () => {
     expect(inits[0]?.body.project).toBe("demo");
   });
 
-  it("'experimental.session.compacting' POSTs a summarize request", async () => {
+  it("'experimental.session.compacting' lazy-inits the session but does NOT POST summarize (owned by session.compacted event)", async () => {
     const hooks = await loadHooks();
     const compacting = hooks["experimental.session.compacting"] as (
       input: unknown,
@@ -120,9 +120,31 @@ describe("opencode-plugin — OpenCode Hooks contract", () => {
     await compacting({ sessionID: "s-comp" }, { context: [] });
     await flushFireAndForget();
 
-    const summarize = captured.find((c) => c.path === "/api/sessions/summarize");
-    expect(summarize).toBeDefined();
-    expect(typeof summarize?.body.contentSessionId).toBe("string");
+    // Init MUST fire (defensive lazy init for compact-only sessions).
+    expect(captured.find((c) => c.path === "/api/sessions/init")).toBeDefined();
+    // Summarize MUST NOT fire from this hook — it is owned by the
+    // `session.compacted` event branch to avoid a duplicate POST per cycle.
+    expect(captured.find((c) => c.path === "/api/sessions/summarize")).toBeUndefined();
+  });
+
+  it("compacting hook + session.compacted event for the SAME session produces exactly one summarize POST (claude-mem#2503 P1)", async () => {
+    const hooks = await loadHooks();
+    const compacting = hooks["experimental.session.compacting"] as (
+      input: unknown,
+      output: unknown,
+    ) => Promise<void>;
+    const eventFn = hooks.event as (input: unknown) => Promise<void>;
+
+    // OpenCode fires the hook DURING compaction, then the event AFTER. Replay
+    // that exact sequence and assert the summarize endpoint is hit only once.
+    await compacting({ sessionID: "s-cycle" }, { context: [] });
+    await eventFn({
+      event: { type: "session.compacted", properties: { sessionID: "s-cycle" } },
+    });
+    await flushFireAndForget();
+
+    const summarizes = captured.filter((c) => c.path === "/api/sessions/summarize");
+    expect(summarizes.length).toBe(1);
   });
 
   it("event(session.created) initializes the session and uses properties.info.id", async () => {


### PR DESCRIPTION
## Summary

Fix 2435

The OpenCode integration returned a malformed plugin shape and an
incorrectly-signed `event` hook, so no OpenCode session ever reached the
worker. This change conforms the plugin to OpenCode's actual `Hooks`
contract.

## Root cause

- The plugin returned `{ hooks: { tool: { execute: { after } } }, event, tool }`.
  OpenCode's `Plugin` type is `(input) => Promise<Hooks>`; it dispatches on
  **flat top-level keys** like `"tool.execute.after"`, `"chat.message"`, and
  `"experimental.session.compacting"`. The `hooks.*` wrapper key was never
  read, so `tool.execute.after` never fired.
- The `event` hook was declared as `(eventName, payload) => void`. OpenCode
  invokes it as `(input: { event: Event }) => Promise<void>`. The switch
  compared the wrapping `{ event }` object against the literal strings
  `"session.created"`, `"message.updated"`, etc. — never matched.
- Even with the right signature, the destructuring `const { event } = payload`
  was reading the wrong shape: each SDK Event carries data under
  `event.properties` (e.g. `properties.info.id` for `session.created`,
  `properties.sessionID` for `session.compacted`).

Net effect on `main`: zero entries with `platform_source: "opencode"` in the
database, exactly as reported.

## Fix

- Return `Hooks` directly (no `hooks` wrapper).
- Add flat keys: `"tool.execute.after"`, `"chat.message"`,
  `"experimental.session.compacting"`.
- Correct the `event` hook to `(input: { event: { type, properties } })` and
  destructure each event's actual payload from `properties`.
- Initialize a session lazily on the first observable signal (any of
  `tool.execute.after`, `chat.message`, `session.created`,
  `message.updated`, `session.compacted`). Tracked via a `Set<sessionID>` so
  `/api/sessions/init` only fires once per session.
- Drop `file.edited`: its SDK payload is `{ file: string }` only — no
  `sessionID` to attribute to. Edits land in the database anyway via the
  existing `tool.execute.after` path on the Edit/Write tools.

## Verification

- [x] Baseline tests (pre-fix on `main`): 1797 pass, 53 pre-existing failures.
- [x] Post-fix tests: 1808 pass, same 53 pre-existing failures, zero regressions.
- [x] New tests: 11 added in `tests/integrations/opencode-plugin.test.ts`,
      all green.
- [x] Reproduction confirmed against `main`: zero worker POSTs after firing
      the three real SDK events. Captured under `issue_2435_repro.log`.

## TDD verification

- RED check (new tests against `main`, prod patch stashed): 8/11 fail.
  The remaining 3 (tool registry, ignore-unknown-event, deleted no-crash)
  are no-regression guards for parts of the plugin that were already correct.
- GREEN check (new tests with patch applied): 11/11 pass.

## Files changed

| File | Change |
|------|--------|
| `src/integrations/opencode-plugin/index.ts` | Rewrite — flat Hooks keys, correct `event` signature, lazy session init |
| `tests/integrations/opencode-plugin.test.ts` | New — 11 cases covering each hook + event payload shape |
