### PR TITLE
fix(supervisor): preserve proxy env for worker daemon

### DIFF
--- a/src/supervisor/env-sanitizer.ts
+++ b/src/supervisor/env-sanitizer.ts
@@ -20,6 +20,7 @@ export const ENV_PROXY_VARS = new Set([
 ]);
 
 export const ENV_PRESERVE = new Set([
+  ...ENV_PROXY_VARS,
   'CLAUDE_CODE_OAUTH_TOKEN',
   'CLAUDE_CODE_GIT_BASH_PATH',
   'CLAUDE_CODE_USE_BEDROCK',
@@ -42,7 +43,6 @@ export function sanitizeEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.Proces
     if (value === undefined) continue;
     if (ENV_PRESERVE.has(key)) { sanitized[key] = value; continue; }
     if (ENV_EXACT_MATCHES.has(key)) continue;
-    if (ENV_PROXY_VARS.has(key)) continue;
     if (ENV_PREFIXES.some(prefix => key.startsWith(prefix))) continue;
     sanitized[key] = value;
   }

--- a/tests/supervisor/env-sanitizer.test.ts
+++ b/tests/supervisor/env-sanitizer.test.ts
@@ -130,31 +130,31 @@ describe('sanitizeEnv', () => {
     expect(result.HOME).toBe('/home/user');
   });
 
-  it('strips proxy env vars (uppercase and lowercase) so the worker subprocess is not routed through the user proxy', () => {
+  it('preserves proxy env vars (uppercase and lowercase) so the worker subprocess can use the configured proxy', () => {
     const result = sanitizeEnv({
-      HTTP_PROXY: 'http://bad-proxy:1234',
-      HTTPS_PROXY: 'http://bad-proxy:1234',
-      ALL_PROXY: 'socks5://bad-proxy:1080',
+      HTTP_PROXY: 'http://proxy.internal:1234',
+      HTTPS_PROXY: 'http://proxy.internal:1234',
+      ALL_PROXY: 'socks5://proxy.internal:1080',
       NO_PROXY: 'localhost,127.0.0.1',
-      http_proxy: 'http://bad-proxy:1234',
-      https_proxy: 'http://bad-proxy:1234',
-      all_proxy: 'socks5://bad-proxy:1080',
+      http_proxy: 'http://proxy.internal:1234',
+      https_proxy: 'http://proxy.internal:1234',
+      all_proxy: 'socks5://proxy.internal:1080',
       no_proxy: 'localhost,127.0.0.1',
-      npm_config_proxy: 'http://bad-proxy:1234',
-      npm_config_https_proxy: 'http://bad-proxy:1234',
+      npm_config_proxy: 'http://proxy.internal:1234',
+      npm_config_https_proxy: 'http://proxy.internal:1234',
       PATH: '/usr/bin'
     });
 
-    expect(result.HTTP_PROXY).toBeUndefined();
-    expect(result.HTTPS_PROXY).toBeUndefined();
-    expect(result.ALL_PROXY).toBeUndefined();
-    expect(result.NO_PROXY).toBeUndefined();
-    expect(result.http_proxy).toBeUndefined();
-    expect(result.https_proxy).toBeUndefined();
-    expect(result.all_proxy).toBeUndefined();
-    expect(result.no_proxy).toBeUndefined();
-    expect(result.npm_config_proxy).toBeUndefined();
-    expect(result.npm_config_https_proxy).toBeUndefined();
+    expect(result.HTTP_PROXY).toBe('http://proxy.internal:1234');
+    expect(result.HTTPS_PROXY).toBe('http://proxy.internal:1234');
+    expect(result.ALL_PROXY).toBe('socks5://proxy.internal:1080');
+    expect(result.NO_PROXY).toBe('localhost,127.0.0.1');
+    expect(result.http_proxy).toBe('http://proxy.internal:1234');
+    expect(result.https_proxy).toBe('http://proxy.internal:1234');
+    expect(result.all_proxy).toBe('socks5://proxy.internal:1080');
+    expect(result.no_proxy).toBe('localhost,127.0.0.1');
+    expect(result.npm_config_proxy).toBe('http://proxy.internal:1234');
+    expect(result.npm_config_https_proxy).toBe('http://proxy.internal:1234');
     expect(result.PATH).toBe('/usr/bin');
   });
 


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Preserve proxy-related environment variables when spawning the worker daemon.
- Keep the existing proxy env var list, but include it in `ENV_PRESERVE` so `sanitizeEnv()` forwards those values instead of stripping them.
- Update the env sanitizer regression test to assert uppercase/lowercase proxy vars and npm proxy config are preserved.

## Test Plan
- `bun test tests/supervisor/env-sanitizer.test.ts`

## Risk / Notes
- Scope is limited to the supervisor environment sanitizer.
- No proxy values or credentials are hard-coded; tests use placeholder proxy hosts only.

Fixes #2464
