### PR TITLE
Prevent duplicate user prompts

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -17,6 +17,7 @@ import type { ObservationSearchResult, SessionSummarySearchResult } from './type
 import { computeObservationContentHash } from './observations/store.js';
 import { parseFileList } from './observations/files.js';
 import { DEFAULT_PLATFORM_SOURCE, normalizePlatformSource, sortPlatformSources } from '../../shared/platform-source.js';
+import { findRecentDuplicateUserPrompt as findRecentDuplicateUserPromptRecord } from './prompts/get.js';
 
 function resolveCreateSessionArgs(
   customTitle?: string,
@@ -1370,6 +1371,14 @@ export class SessionStore {
     `);
 
     return stmt.get(contentSessionId) as LatestPromptResult | undefined;
+  }
+
+  findRecentDuplicateUserPrompt(
+    contentSessionId: string,
+    promptText: string,
+    windowMs: number
+  ): LatestPromptResult | undefined {
+    return findRecentDuplicateUserPromptRecord(this.db, contentSessionId, promptText, windowMs);
   }
 
   getRecentSessionsWithStatus(project: string, limit: number = 3): Array<{

--- a/src/services/sqlite/prompts/get.ts
+++ b/src/services/sqlite/prompts/get.ts
@@ -3,6 +3,7 @@ import type { Database } from 'bun:sqlite';
 import { logger } from '../../../utils/logger.js';
 import type { UserPromptRecord, LatestPromptResult } from '../../../types/database.js';
 import type { RecentUserPromptResult, PromptWithProject, GetPromptsByIdsOptions } from './types.js';
+import { DEFAULT_PLATFORM_SOURCE } from '../../../shared/platform-source.js';
 
 export function getUserPrompt(
   db: Database,
@@ -44,6 +45,31 @@ export function getLatestUserPrompt(
   `);
 
   return stmt.get(contentSessionId) as LatestPromptResult | undefined;
+}
+
+export function findRecentDuplicateUserPrompt(
+  db: Database,
+  contentSessionId: string,
+  promptText: string,
+  windowMs: number
+): LatestPromptResult | undefined {
+  const cutoffEpoch = Date.now() - windowMs;
+  const stmt = db.prepare(`
+    SELECT
+      up.*,
+      s.memory_session_id,
+      s.project,
+      COALESCE(s.platform_source, '${DEFAULT_PLATFORM_SOURCE}') as platform_source
+    FROM user_prompts up
+    JOIN sdk_sessions s ON up.content_session_id = s.content_session_id
+    WHERE up.content_session_id = ?
+      AND up.prompt_text = ?
+      AND up.created_at_epoch >= ?
+    ORDER BY up.created_at_epoch DESC
+    LIMIT 1
+  `);
+
+  return (stmt.get(contentSessionId, promptText, cutoffEpoch) as LatestPromptResult | null) ?? undefined;
 }
 
 export function getAllRecentUserPrompts(

--- a/src/services/worker/PaginationHelper.ts
+++ b/src/services/worker/PaginationHelper.ts
@@ -3,6 +3,7 @@ import type { SQLQueryBindings } from 'bun:sqlite';
 import { DatabaseManager } from './DatabaseManager.js';
 import { logger } from '../../utils/logger.js';
 import { OBSERVER_SESSIONS_PROJECT } from '../../shared/paths.js';
+import { USER_PROMPT_DEDUPE_WINDOW_MS } from '../../shared/user-prompts.js';
 import type { PaginatedResult, Observation, Summary, UserPrompt } from '../worker-types.js';
 
 export class PaginationHelper {
@@ -196,6 +197,24 @@ export class PaginationHelper {
       conditions.push(`COALESCE(s.platform_source, 'claude') = ?`);
       params.push(platformSource);
     }
+
+    conditions.push(`
+      NOT EXISTS (
+        SELECT 1
+        FROM user_prompts duplicate
+        WHERE duplicate.content_session_id = up.content_session_id
+          AND duplicate.prompt_text = up.prompt_text
+          AND (
+            duplicate.created_at_epoch > up.created_at_epoch
+            OR (
+              duplicate.created_at_epoch = up.created_at_epoch
+              AND duplicate.id > up.id
+            )
+          )
+          AND duplicate.created_at_epoch - up.created_at_epoch <= ?
+      )
+    `);
+    params.push(USER_PROMPT_DEDUPE_WINDOW_MS);
 
     if (conditions.length > 0) {
       query += ` WHERE ${conditions.join(' AND ')}`;

--- a/src/services/worker/http/routes/SessionRoutes.ts
+++ b/src/services/worker/http/routes/SessionRoutes.ts
@@ -21,6 +21,7 @@ import { normalizePlatformSource } from '../../../../shared/platform-source.js';
 import { handleGeneratorExit } from '../../session/GeneratorExitHandler.js';
 import { SessionCompletionHandler } from '../../session/SessionCompletionHandler.js';
 import { getUptimeSeconds } from '../../../../shared/uptime.js';
+import { USER_PROMPT_DEDUPE_WINDOW_MS } from '../../../../shared/user-prompts.js';
 
 const MAX_USER_PROMPT_BYTES = 256 * 1024;
 
@@ -401,6 +402,31 @@ export class SessionRoutes extends BaseRouteHandler {
         promptNumber,
         skipped: true,
         reason: 'private'
+      });
+      return;
+    }
+
+    const duplicatePrompt = store.findRecentDuplicateUserPrompt(
+      contentSessionId,
+      cleanedPrompt,
+      USER_PROMPT_DEDUPE_WINDOW_MS
+    );
+
+    if (duplicatePrompt) {
+      const contextInjected = this.sessionManager.getSession(sessionDbId) !== undefined;
+      logger.debug('SESSION', 'Duplicate user prompt skipped', {
+        sessionId: sessionDbId,
+        promptNumber: duplicatePrompt.prompt_number,
+        duplicatePromptId: duplicatePrompt.id,
+        contextInjected
+      });
+
+      res.json({
+        sessionDbId,
+        promptNumber: duplicatePrompt.prompt_number,
+        skipped: true,
+        reason: 'duplicate',
+        contextInjected
       });
       return;
     }

--- a/src/shared/user-prompts.ts
+++ b/src/shared/user-prompts.ts
@@ -1,0 +1,1 @@
+export const USER_PROMPT_DEDUPE_WINDOW_MS = 10_000;

--- a/tests/session_store.test.ts
+++ b/tests/session_store.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { SessionStore } from '../src/services/sqlite/SessionStore.js';
+import { PaginationHelper } from '../src/services/worker/PaginationHelper.js';
 
 describe('SessionStore', () => {
   let store: SessionStore;
@@ -27,6 +28,73 @@ describe('SessionStore', () => {
     store.createSDKSession('claude-session-2', 'test-project', 'initial prompt');
     store.saveUserPrompt('claude-session-2', 1, 'Other prompt');
     expect(store.getPromptNumberFromUserPrompts(claudeId)).toBe(2);
+  });
+
+  it('should find recent duplicate user prompts', () => {
+    const contentSessionId = 'duplicate-session-store';
+    store.createSDKSession(contentSessionId, 'test-project', 'initial prompt');
+    const promptId = store.saveUserPrompt(contentSessionId, 1, 'Repeated prompt');
+
+    const duplicate = store.findRecentDuplicateUserPrompt(contentSessionId, 'Repeated prompt', 10_000);
+
+    expect(duplicate?.id).toBe(promptId);
+    expect(duplicate?.prompt_number).toBe(1);
+    expect(duplicate?.prompt_text).toBe('Repeated prompt');
+  });
+
+  it('should not find duplicate user prompts outside the dedupe window', () => {
+    const contentSessionId = 'old-duplicate-session-store';
+    store.createSDKSession(contentSessionId, 'test-project', 'initial prompt');
+    const promptId = store.saveUserPrompt(contentSessionId, 1, 'Repeated prompt');
+    store.db.prepare('UPDATE user_prompts SET created_at_epoch = ? WHERE id = ?')
+      .run(Date.now() - 20_000, promptId);
+
+    const duplicate = store.findRecentDuplicateUserPrompt(contentSessionId, 'Repeated prompt', 10_000);
+
+    expect(duplicate).toBeUndefined();
+  });
+
+  it('should hide only older duplicate prompts from paginated prompt results', () => {
+    const contentSessionId = 'paginated-duplicate-session-store';
+    store.createSDKSession(contentSessionId, 'test-project', 'initial prompt');
+    const olderDuplicateId = store.saveUserPrompt(contentSessionId, 1, 'Repeated prompt');
+    const newerDuplicateId = store.saveUserPrompt(contentSessionId, 2, 'Repeated prompt');
+    const uniquePromptId = store.saveUserPrompt(contentSessionId, 3, 'Unique prompt');
+
+    const now = Date.now();
+    store.db.prepare('UPDATE user_prompts SET created_at_epoch = ? WHERE id = ?').run(now, olderDuplicateId);
+    store.db.prepare('UPDATE user_prompts SET created_at_epoch = ? WHERE id = ?').run(now + 5000, newerDuplicateId);
+    store.db.prepare('UPDATE user_prompts SET created_at_epoch = ? WHERE id = ?').run(now + 6000, uniquePromptId);
+
+    const helper = new PaginationHelper({
+      getSessionStore: () => store,
+    } as any);
+
+    const ids = helper.getPrompts(0, 10).items.map(prompt => prompt.id);
+
+    expect(ids).toContain(newerDuplicateId);
+    expect(ids).toContain(uniquePromptId);
+    expect(ids).not.toContain(olderDuplicateId);
+  });
+
+  it('should hide older duplicate prompts when timestamps are identical', () => {
+    const contentSessionId = 'same-ms-duplicate-session-store';
+    store.createSDKSession(contentSessionId, 'test-project', 'initial prompt');
+    const olderDuplicateId = store.saveUserPrompt(contentSessionId, 1, 'Repeated prompt');
+    const newerDuplicateId = store.saveUserPrompt(contentSessionId, 2, 'Repeated prompt');
+
+    const sameTimestamp = Date.now();
+    store.db.prepare('UPDATE user_prompts SET created_at_epoch = ? WHERE id IN (?, ?)')
+      .run(sameTimestamp, olderDuplicateId, newerDuplicateId);
+
+    const helper = new PaginationHelper({
+      getSessionStore: () => store,
+    } as any);
+
+    const ids = helper.getPrompts(0, 10).items.map(prompt => prompt.id);
+
+    expect(ids).toContain(newerDuplicateId);
+    expect(ids).not.toContain(olderDuplicateId);
   });
 
   it('should store observation with timestamp override', () => {

--- a/tests/sqlite/prompts.test.ts
+++ b/tests/sqlite/prompts.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { ClaudeMemDatabase } from '../../src/services/sqlite/Database.js';
 import {
   saveUserPrompt,
+  findRecentDuplicateUserPrompt,
   getPromptNumberFromUserPrompts,
 } from '../../src/services/sqlite/Prompts.js';
 import { createSDKSession } from '../../src/services/sqlite/Sessions.js';
@@ -56,6 +57,17 @@ describe('Prompts Module', () => {
       const id2 = saveUserPrompt(db, sessionB, 1, 'Prompt B1');
 
       expect(id1).not.toBe(id2);
+    });
+
+    it('should find a duplicate prompt in the recent dedupe window', () => {
+      const contentSessionId = createSession('duplicate-prompt-session');
+      const id = saveUserPrompt(db, contentSessionId, 1, 'Repeated prompt');
+
+      const duplicate = findRecentDuplicateUserPrompt(db, contentSessionId, 'Repeated prompt', 10_000);
+
+      expect(duplicate?.id).toBe(id);
+      expect(duplicate?.prompt_number).toBe(1);
+      expect(duplicate?.prompt_text).toBe('Repeated prompt');
     });
   });
 


### PR DESCRIPTION
## Summary

Prevents duplicate user prompt rows from appearing in session/prompt APIs.

Changes include:

- Adds query helpers for deduplicated prompt retrieval.
- Applies prompt deduplication in `SessionRoutes` responses.
- Adds pagination support needed for the deduplicated route path.
- Adds regression tests for duplicate prompt suppression in `SessionStore` and prompt query helpers.

## Motivation

Some UI/API views could surface repeated prompt rows for the same underlying user prompt. This makes session history noisy and can confuse downstream display logic.

## Validation

This PR is opened as a draft so repository CI can validate it against current upstream. Local review was performed before publishing.
