### PR TITLE
Fix resumed session reactivation

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -1703,8 +1703,8 @@ export class SessionStore {
     const storedUserPrompt = normalizeStoredPromptText(userPrompt);
 
     const existing = this.db.prepare(`
-      SELECT id, platform_source FROM sdk_sessions WHERE content_session_id = ?
-    `).get(contentSessionId) as { id: number; platform_source: string | null } | undefined;
+      SELECT id, platform_source, status FROM sdk_sessions WHERE content_session_id = ?
+    `).get(contentSessionId) as { id: number; platform_source: string | null; status: string } | undefined;
 
     if (existing) {
       if (project) {
@@ -1736,6 +1736,22 @@ export class SessionStore {
             `Platform source conflict for session ${contentSessionId}: existing=${storedPlatformSource}, received=${resolved.platformSource}`
           );
         }
+      }
+      if (existing.status === 'completed') {
+        const reactivateNow = new Date();
+        this.db.prepare(`
+          UPDATE sdk_sessions
+          SET status = 'active',
+              completed_at = NULL,
+              completed_at_epoch = NULL,
+              started_at = ?,
+              started_at_epoch = ?
+          WHERE id = ?
+        `).run(reactivateNow.toISOString(), reactivateNow.getTime(), existing.id);
+        logger.debug('DB', 'Reactivated completed SDK session for resumed content session', {
+          sessionId: existing.id,
+          contentSessionId
+        });
       }
       return existing.id;
     }

--- a/src/services/sqlite/sessions/create.ts
+++ b/src/services/sqlite/sessions/create.ts
@@ -29,8 +29,8 @@ export function createSDKSession(
   const storedUserPrompt = normalizeStoredPromptText(userPrompt);
 
   const existing = db.prepare(`
-    SELECT id, platform_source FROM sdk_sessions WHERE content_session_id = ?
-  `).get(contentSessionId) as { id: number; platform_source: string | null } | undefined;
+    SELECT id, platform_source, status FROM sdk_sessions WHERE content_session_id = ?
+  `).get(contentSessionId) as { id: number; platform_source: string | null; status: string } | undefined;
 
   if (existing) {
     if (project) {
@@ -63,6 +63,23 @@ export function createSDKSession(
         );
       }
     }
+    if (existing.status === 'completed') {
+      const reactivateNow = new Date();
+      db.prepare(`
+        UPDATE sdk_sessions
+        SET status = 'active',
+            completed_at = NULL,
+            completed_at_epoch = NULL,
+            started_at = ?,
+            started_at_epoch = ?
+        WHERE id = ?
+      `).run(reactivateNow.toISOString(), reactivateNow.getTime(), existing.id);
+      logger.debug('DB', 'Reactivated completed SDK session for resumed content session', {
+        sessionId: existing.id,
+        contentSessionId
+      });
+    }
+
     logger.debug('DB', 'Reused existing SDK session row', {
       contentSessionId,
       sessionDbId: existing.id,

--- a/tests/session_store.test.ts
+++ b/tests/session_store.test.ts
@@ -111,6 +111,37 @@ describe('SessionStore', () => {
     expect(ids).not.toContain(olderDuplicateId);
   });
 
+  it('should reactivate completed sessions when they receive new work', () => {
+    const sdkId = store.createSDKSession('resumed-content-session', 'test-project', 'initial prompt');
+    store.markSessionCompleted(sdkId);
+    store.db.prepare(`
+      UPDATE sdk_sessions
+      SET started_at = '2026-05-16T00:00:00.000Z',
+          started_at_epoch = 1778889600000
+      WHERE id = ?
+    `).run(sdkId);
+
+    const resumedId = store.createSDKSession('resumed-content-session', 'test-project', 'next prompt');
+    const session = store.db.prepare(`
+      SELECT status, started_at, started_at_epoch, completed_at, completed_at_epoch
+      FROM sdk_sessions
+      WHERE id = ?
+    `).get(sdkId) as {
+      status: string;
+      started_at: string;
+      started_at_epoch: number;
+      completed_at: string | null;
+      completed_at_epoch: number | null;
+    };
+
+    expect(resumedId).toBe(sdkId);
+    expect(session?.status).toBe('active');
+    expect(session?.started_at).not.toBe('2026-05-16T00:00:00.000Z');
+    expect(session?.started_at_epoch).toBeGreaterThan(1778889600000);
+    expect(session?.completed_at).toBeNull();
+    expect(session?.completed_at_epoch).toBeNull();
+  });
+
   it('should store observation with timestamp override', () => {
     const claudeId = 'claude-sess-obs';
     const memoryId = 'memory-sess-obs';

--- a/tests/sqlite/sessions.test.ts
+++ b/tests/sqlite/sessions.test.ts
@@ -59,6 +59,39 @@ describe('Sessions Module', () => {
       expect(session?.user_prompt.length).toBe(MAX_STORED_PROMPT_CHARS);
       expect(session?.user_prompt.endsWith('…')).toBe(true);
     });
+
+    it('should reactivate completed sessions when the same content_session_id resumes', () => {
+      const sessionId = createSDKSession(db, 'resumed-session', 'project', 'prompt');
+      db.prepare(`
+        UPDATE sdk_sessions
+        SET status = 'completed',
+            started_at = '2026-05-16T00:00:00.000Z',
+            started_at_epoch = 1778889600000,
+            completed_at = '2026-05-17T00:00:00.000Z',
+            completed_at_epoch = 1778976000000
+        WHERE id = ?
+      `).run(sessionId);
+
+      const resumedId = createSDKSession(db, 'resumed-session', 'project', 'next prompt');
+      const session = db.prepare(`
+        SELECT status, started_at, started_at_epoch, completed_at, completed_at_epoch
+        FROM sdk_sessions
+        WHERE id = ?
+      `).get(sessionId) as {
+        status: string;
+        started_at: string;
+        started_at_epoch: number;
+        completed_at: string | null;
+        completed_at_epoch: number | null;
+      };
+
+      expect(resumedId).toBe(sessionId);
+      expect(session?.status).toBe('active');
+      expect(session?.started_at).not.toBe('2026-05-16T00:00:00.000Z');
+      expect(session?.started_at_epoch).toBeGreaterThan(1778889600000);
+      expect(session?.completed_at).toBeNull();
+      expect(session?.completed_at_epoch).toBeNull();
+    });
   });
 
   describe('getSessionById', () => {


### PR DESCRIPTION
## Summary

Reactivates completed SDK sessions when the same `content_session_id` receives new work after being resumed.

Changes include:

- Reads the existing session status when reusing a session by `content_session_id`.
- Changes completed resumed sessions back to `active`.
- Clears `completed_at` and `completed_at_epoch` when a completed session is reactivated.
- Adds regression coverage in both `SessionStore` and the standalone session creation helper.

## Motivation

A resumed content session can reuse the same SDK session row. If that row remains marked as `completed`, later processing can treat an active resumed session as finished. Reactivating the row keeps session state consistent with new incoming work.

## Validation

This PR is opened as a draft so repository CI can validate it against current upstream. Local review was performed before publishing.
