### PR TITLE
Prevent observer file edits from self-recording

### DIFF
--- a/src/cli/handlers/file-edit.ts
+++ b/src/cli/handlers/file-edit.ts
@@ -4,6 +4,7 @@ import { executeWithWorkerFallback, isWorkerFallback } from '../../shared/worker
 import { logger } from '../../utils/logger.js';
 import { HOOK_EXIT_CODES } from '../../shared/hook-constants.js';
 import { normalizePlatformSource } from '../../shared/platform-source.js';
+import { shouldTrackProject } from '../../shared/should-track-project.js';
 
 export const fileEditHandler: EventHandler = {
   async execute(input: NormalizedHookInput): Promise<HookResult> {
@@ -20,6 +21,11 @@ export const fileEditHandler: EventHandler = {
 
     if (!cwd) {
       throw new Error(`Missing cwd in FileEdit hook input for session ${sessionId}, file ${filePath}`);
+    }
+
+    if (!shouldTrackProject(cwd)) {
+      logger.debug('HOOK', 'Project excluded from tracking, skipping file edit observation', { cwd, filePath });
+      return { continue: true, suppressOutput: true, exitCode: HOOK_EXIT_CODES.SUCCESS };
     }
 
     const result = await executeWithWorkerFallback<{ status?: string }>(

--- a/tests/cli/handlers/file-edit-observer-session-skip.test.ts
+++ b/tests/cli/handlers/file-edit-observer-session-skip.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const dataDir = join(tmpdir(), 'claude-mem-file-edit-observer-test');
+const workerCallLog: Array<{ path: string; method: string; body: unknown }> = [];
+
+mock.module('../../../src/shared/SettingsDefaultsManager.js', () => ({
+  SettingsDefaultsManager: {
+    get: (key: string) => {
+      if (key === 'CLAUDE_MEM_DATA_DIR') return dataDir;
+      return '';
+    },
+    getInt: () => 0,
+    loadFromFile: () => ({ CLAUDE_MEM_EXCLUDED_PROJECTS: '' }),
+  },
+}));
+
+mock.module('../../../src/shared/hook-settings.js', () => ({
+  loadFromFileOnce: () => ({ CLAUDE_MEM_EXCLUDED_PROJECTS: '' }),
+}));
+
+mock.module('../../../src/shared/worker-utils.js', () => ({
+  executeWithWorkerFallback: (apiPath: string, method: string, body: unknown) => {
+    workerCallLog.push({ path: apiPath, method, body });
+    throw new Error(`worker must not be called for internal observer sessions: ${apiPath}`);
+  },
+  isWorkerFallback: () => false,
+}));
+
+import { OBSERVER_SESSIONS_DIR } from '../../../src/shared/paths.js';
+import { logger } from '../../../src/utils/logger.js';
+
+let loggerSpies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(() => {
+  workerCallLog.length = 0;
+  loggerSpies = [
+    spyOn(logger, 'debug').mockImplementation(() => {}),
+    spyOn(logger, 'dataIn').mockImplementation(() => {}),
+  ];
+});
+
+afterEach(() => {
+  loggerSpies.forEach(spy => spy.mockRestore());
+});
+
+describe('fileEditHandler internal observer sessions', () => {
+  it('skips file edit observations before calling the worker', async () => {
+    const { fileEditHandler } = await import('../../../src/cli/handlers/file-edit.js');
+
+    const result = await fileEditHandler.execute({
+      sessionId: 'observer-session-file-edit',
+      cwd: OBSERVER_SESSIONS_DIR,
+      platform: 'claude-code',
+      filePath: join(OBSERVER_SESSIONS_DIR, 'transcript.jsonl'),
+      edits: [{ oldText: 'before', newText: 'after' }],
+    });
+
+    expect(result.continue).toBe(true);
+    expect(result.suppressOutput).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(workerCallLog).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add the existing project tracking guard to the `file-edit` hook before it records `write_file` observations.
- Cover observer-session file edits with a regression test that fails if the hook reaches the worker.

## Why

Observer sessions are already excluded by `shouldTrackProject()`, and most hook handlers call that helper before touching the worker. The `file-edit` handler was the remaining path that could still record file edits from the internal observer session directory.

## Validation

- `bun test tests/cli/handlers/file-edit-observer-session-skip.test.ts`
- `npm run build`
- `git diff --check upstream/main..HEAD`
