### PR TITLE
fix(packaging): bundle plugin/node_modules so marketplace install ships runtime deps (closes #2407)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "plugin/scripts/CLAUDE.md",
     "plugin/skills",
     "plugin/ui",
+    "plugin/node_modules",
     "openclaw"
   ],
   "engines": {

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -4,6 +4,7 @@ import { build } from 'esbuild';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -119,6 +120,10 @@ async function buildHooks() {
     fs.writeFileSync('plugin/package.json', JSON.stringify(pluginPackageJson, null, 2) + '\n');
     console.log('✓ plugin/package.json generated');
 
+    console.log('\n📦 Installing plugin dependencies...');
+    execSync('npm install --production', { cwd: 'plugin', stdio: 'inherit' });
+    console.log('✓ Plugin dependencies installed');
+    
     console.log('\n📋 Building React viewer...');
     const { spawn } = await import('child_process');
     const viewerBuild = spawn('node', ['scripts/build-viewer.js'], { stdio: 'inherit' });


### PR DESCRIPTION
Closes #2407.

## This is not my work — credit

- **@seo-yas** filed #2407 on 2026-05-10 with full reproduction.
- **@ghyghoo8** wrote the actual fix on their fork ([`patch-1`](https://github.com/ghyghoo8/claude-mem/tree/patch-1)) on 2026-05-11. Both commits in this PR are cherry-picked verbatim with their authorship preserved — `git log --format='%an'` shows `ghy` on both. They didn't open the PR themselves because they believed direct PRs were restricted (they're not — the repo has 40+ open community PRs right now).
- **@duluca** added root-cause detail: the cache `bun.lock` predates zod being added to `plugin/package.json`, so `bun install --frozen-lockfile` doesn't recover it. With `plugin/node_modules` bundled, that stops mattering for #2407 — but their lockfile regeneration suggestion is worth a follow-up.
- **@Englader, @troman29, @davertor, @simon-tannai** confirmed across v13.0.0–v13.2.0 on macOS and Windows.

I'm packaging an existing community fix so it can land. Merging credits @ghyghoo8 as commit author.

## Changes (verbatim cherry-pick from `ghyghoo8/claude-mem:patch-1`)

1. `scripts/build-hooks.js` — after generating `plugin/package.json`, run `npm install --production` in `plugin/` so runtime deps (zod, shell-quote, tree-sitter-*) actually exist before publish.
2. `package.json` — add `plugin/node_modules` to the `files` array so the installed deps ship in the marketplace bundle.

Net diff: +6 / -0 across 2 files.

## Why this is worth fast-tracking

When the worker fails to start, claude-mem keeps recording prompts to `sdk_sessions` but never summarizes them — silent data loss. The only signal is a one-line `Stop hook error` in the terminal transcript ([noisy by Claude Code's own admission](https://github.com/anthropics/claude-code/issues/10463)), and the iOS/Android Claude Code apps don't surface local hook errors at all. I lost 19 substantive sessions over 4 weeks of 13.x upgrades before noticing.

Three releases have shipped since #2407 was filed; each one recreates the broken cache state.