### PR TITLE
feat(pi): Pi (badlogic/pi-mono) platform adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+
+- **Pi (`badlogic/pi-mono`) platform adapter** ([#2532](https://github.com/thedotmack/claude-mem/pull/2532)) — new `PlatformAdapter` for the [Pi](https://github.com/badlogic/pi-mono) coding agent, registered under the `pi` and `pi-mono` slugs. `normalizePlatformSource()` maps `pi-mono → pi` so legacy slugs collapse cleanly. Adapter accepts both camelCase (`NormalizedHookInput`) and Pi-native snake_case event keys, defaults `agentType` to `pi`, and preserves Claude Code–style `hookSpecificOutput` / `systemMessage` / `suppressOutput` plumbing in `formatOutput`. Scoped to the worker-side wiring only; the Pi-side extension that subscribes to Pi lifecycle hooks and spawns the worker ships as a separate npm package (see `pi-hooks/README.md` for the integration contract).
+
 ## [13.2.0] - 2026-05-12
 
 ## What's new

--- a/pi-hooks/README.md
+++ b/pi-hooks/README.md
@@ -40,7 +40,7 @@ The Pi-side extension lives outside this repo because Pi extensions are TypeScri
 │                                        │
 │  getPlatformAdapter('pi')              │
 │    → piAdapter.normalizeInput(stdin)   │
-│    → handler.execute(NormalizedHookIn) │
+│    → execute(NormalizedHookInput)      │
 │    → piAdapter.formatOutput(result)    │
 │                                        │
 │  stdout = HookResult (JSON)            │

--- a/pi-hooks/README.md
+++ b/pi-hooks/README.md
@@ -1,0 +1,154 @@
+# claude-mem ↔ Pi integration
+
+[Pi](https://github.com/badlogic/pi-mono) is a coding agent with a TypeScript extension system. This directory ships the integration contract a Pi extension needs to honor in order to feed observations into claude-mem.
+
+## Status
+
+| Component | State |
+|:--|:--|
+| `src/cli/adapters/pi.ts` (worker-side adapter) | **landed in this PR** |
+| `pi` / `pi-mono` slug in `getPlatformAdapter()` | **landed in this PR** |
+| `pi-mono` → `pi` in `normalizePlatformSource()` | **landed in this PR** |
+| Reference Pi extension package | **separate repo** — `victor-software-house/pi-claude-mem` (planned) |
+| Hooks installer (`pi install --extension claude-mem`) | not in scope for this PR |
+| Pi session JSONL tailer (transcript watcher) | follow-up |
+
+The Pi-side extension lives outside this repo because Pi extensions are TypeScript packages registered via `pi.registerHook(...)`, not JSON configs sourced from `~/.<agent>/hooks.json` like Claude Code or Codex. The integration boundary is the worker's stdin contract; ownership splits along that boundary.
+
+## Architecture
+
+```
+┌────────────────────────────────────────┐
+│  Pi runtime (badlogic/pi-mono)         │
+│                                        │
+│  ┌──────────────────────────────────┐  │
+│  │  pi-claude-mem extension (TS)    │  │
+│  │                                  │  │
+│  │  pi.registerHook(                │  │
+│  │    'session_start' | 'tool_call' │  │
+│  │  | 'tool_result' | 'agent_end',  │  │
+│  │    fn) → spawn worker subprocess │  │
+│  └──────────────────────────────────┘  │
+└─────────────┬──────────────────────────┘
+              │ stdin = NormalizedHookInput (JSON)
+              ▼
+┌────────────────────────────────────────┐
+│  claude-mem worker                     │
+│                                        │
+│  bun-runner.js → worker-service.cjs    │
+│    hook pi <command>                   │
+│                                        │
+│  getPlatformAdapter('pi')              │
+│    → piAdapter.normalizeInput(stdin)   │
+│    → handler.execute(NormalizedHookIn) │
+│    → piAdapter.formatOutput(result)    │
+│                                        │
+│  stdout = HookResult (JSON)            │
+└────────────────────────────────────────┘
+```
+
+## Pi hook → claude-mem command mapping
+
+| Pi hook event | claude-mem command | Purpose |
+|:--|:--|:--|
+| `session_start` | `context` | inject prior-session context + recent observations into the new Pi session prompt |
+| `before_agent_start` | `session-init` | bump session bookkeeping per user prompt |
+| `tool_call` (file-read tools: `read`, `ssh_read`) | `file-context` | inject "this file has prior observations" notice |
+| `tool_result` (every tool) | `observation` | capture compressed observation |
+| `agent_end` | `summarize` | write `session_summaries` row |
+| `session_before_compact` | (optional) `summarize` | preserve summary before Pi's grounded-compaction runs |
+
+## Worker invocation
+
+The Pi extension must spawn the worker subprocess like the other adapters do:
+
+```ts
+import { spawn } from 'node:child_process';
+import { join } from 'node:path';
+
+const pluginRoot = process.env.CLAUDE_MEM_PLUGIN_ROOT
+  ?? join(process.env.HOME!, '.claude', 'plugins', 'cache', 'thedotmack', 'claude-mem', '<version>', 'plugin');
+
+function callWorker(command: 'context' | 'session-init' | 'file-context' | 'observation' | 'summarize', payload: object) {
+  const proc = spawn('node', [
+    join(pluginRoot, 'scripts', 'bun-runner.js'),
+    join(pluginRoot, 'scripts', 'worker-service.cjs'),
+    'hook',
+    'pi',
+    command,
+  ], { stdio: ['pipe', 'pipe', 'inherit'] });
+
+  proc.stdin.write(JSON.stringify(payload));
+  proc.stdin.end();
+
+  let stdout = '';
+  proc.stdout.on('data', (chunk) => (stdout += chunk));
+  return new Promise<unknown>((resolve, reject) => {
+    proc.on('close', (code) => {
+      if (code !== 0 && code !== null) return reject(new Error(`worker exit ${code}`));
+      try { resolve(stdout.trim() ? JSON.parse(stdout) : {}); } catch (err) { reject(err); }
+    });
+  });
+}
+```
+
+## NormalizedHookInput payload shape
+
+The Pi extension is the source of truth for translating Pi's native event payload into `NormalizedHookInput`. The adapter accepts both camelCase and snake_case keys, but the canonical shape is:
+
+```ts
+interface NormalizedHookInput {
+  sessionId: string;        // Pi session uuid
+  cwd: string;              // Pi process cwd at hook time
+  toolName?: string;        // e.g. 'read', 'bash', 'write', 'edit', 'fast_apply'
+  toolInput?: unknown;      // raw Pi tool args
+  toolResponse?: unknown;   // raw Pi tool result
+  filePath?: string;        // for Read/Edit/Write — populate so file-context can match
+  prompt?: string;          // user message that triggered the turn
+  transcriptPath?: string;  // ~/.pi/agent/sessions/<encoded-cwd>/<ts>_<uuid>.jsonl
+  agentId?: string;         // populated for Pi subagent runs (cmux pane uuid, etc.)
+  agentType?: string;       // defaults to 'pi'
+  metadata?: Record<string, unknown>;  // model, exit_reason, compaction info
+}
+```
+
+## HookResult interpretation
+
+The Pi extension consumes `HookResult` and decides what to do with `additionalContext`:
+
+```ts
+interface HookResult {
+  continue?: boolean;             // always true under Pi; honor it
+  hookSpecificOutput?: {
+    hookEventName: 'SessionStart' | 'PreToolUse' | 'PostToolUse';
+    additionalContext: string;    // ← prepend to next user-facing prompt
+  };
+  systemMessage?: string;         // ← surface to operator via ctx.ui.setStatus
+  suppressOutput?: boolean;
+}
+```
+
+For `session_start`, the extension should inject `hookSpecificOutput.additionalContext` into the Pi system prompt for the new session. For `tool_call` on file reads, the same field gets prepended to the read tool's result so the model sees "this file has prior observations" before processing the contents.
+
+## Why no installer in this PR
+
+The other named adapters (Cursor, Codex, Crush, Gemini CLI) ship a hooks installer because their host writes hook configs to known JSON files (`~/.codex/hooks.json`, `~/.config/cursor/hooks.json`, etc.). Pi has no equivalent file: each Pi extension is a separately installed npm package. Installation goes through Pi's own package manager:
+
+```bash
+pi install @victor-software-house/pi-claude-mem
+```
+
+The installer logic belongs in that extension package, not in the claude-mem repo. This PR is intentionally narrow — adapter + slug only — so the boundary stays clean.
+
+## Future work
+
+- `pi-claude-mem` extension package (separate repo)
+- Pi session JSONL transcript watcher under `src/services/transcripts/` for cold ingestion of completed sessions
+- `claude-mem install --ide pi` UX that detects Pi installs and points the operator at `pi install …`
+- Pi-specific status-bar widget showing context-injection token savings (mirrors `pi-sub-bar`)
+
+## Related upstream
+
+- PR #2235 (Crush): IDE adapter, hooks installer, SQLite transcript watcher — same pattern, broader scope
+- PR #2077 (draft): `build-adapter` skill — generic adapter scaffolding
+- Issue series #2376–#2380: multi-IDE adapter discipline plan

--- a/src/cli/adapters/index.ts
+++ b/src/cli/adapters/index.ts
@@ -3,6 +3,7 @@ import { claudeCodeAdapter } from './claude-code.js';
 import { codexAdapter } from './codex.js';
 import { cursorAdapter } from './cursor.js';
 import { geminiCliAdapter } from './gemini-cli.js';
+import { piAdapter } from './pi.js';
 import { rawAdapter } from './raw.js';
 import { windsurfAdapter } from './windsurf.js';
 
@@ -13,10 +14,20 @@ export function getPlatformAdapter(platform: string): PlatformAdapter {
     case 'cursor': return cursorAdapter;
     case 'gemini':
     case 'gemini-cli': return geminiCliAdapter;
+    case 'pi':
+    case 'pi-mono': return piAdapter;
     case 'windsurf': return windsurfAdapter;
     case 'raw': return rawAdapter;
     default: return rawAdapter;
   }
 }
 
-export { claudeCodeAdapter, codexAdapter, cursorAdapter, geminiCliAdapter, rawAdapter, windsurfAdapter };
+export {
+  claudeCodeAdapter,
+  codexAdapter,
+  cursorAdapter,
+  geminiCliAdapter,
+  piAdapter,
+  rawAdapter,
+  windsurfAdapter,
+};

--- a/src/cli/adapters/pi.ts
+++ b/src/cli/adapters/pi.ts
@@ -42,6 +42,28 @@ const pickAgentField = (v: unknown): string | undefined =>
   typeof v === 'string' && v.length > 0 && v.length <= MAX_AGENT_FIELD_LEN ? v : undefined;
 
 /**
+ * Coerce arbitrary stdin input into a safe session-id string or `undefined`.
+ *
+ * - `string` → trimmed; empty string collapses to undefined.
+ * - `number` (Pi has historically passed numeric session ids in some
+ *   forks) → stringified.
+ * - anything else (objects, arrays, null, booleans) → undefined.
+ *
+ * This keeps downstream storage and lookup paths from seeing arbitrary
+ * runtime values when a malformed extension forwards an unexpected shape.
+ */
+function normalizeSessionId(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+  return undefined;
+}
+
+/**
  * Resolve the on-disk path to a Pi session JSONL by UUID prefix. Pi launches
  * sessions from arbitrary cwds, so the encoded-cwd directory is not stable
  * across invocations. The UUID prefix is unique enough to identify the
@@ -76,8 +98,9 @@ export const piAdapter: PlatformAdapter = {
       throw new AdapterRejectedInput('invalid_cwd');
     }
 
-    const sessionId =
-      r.sessionId ?? r.session_id ?? r.sessionUuid ?? r.session_uuid;
+    const sessionId = normalizeSessionId(
+      r.sessionId ?? r.session_id ?? r.sessionUuid ?? r.session_uuid,
+    );
 
     const toolName = r.toolName ?? r.tool_name ?? r.toolType ?? r.tool_type;
     const toolInput = r.toolInput ?? r.tool_input ?? r.input;

--- a/src/cli/adapters/pi.ts
+++ b/src/cli/adapters/pi.ts
@@ -1,0 +1,128 @@
+import { existsSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import type { PlatformAdapter, NormalizedHookInput, HookResult } from '../types.js';
+import { AdapterRejectedInput, isValidCwd } from './errors.js';
+
+/**
+ * Pi (https://github.com/badlogic/pi-mono) adapter.
+ *
+ * Pi is a coding agent with a TypeScript extension system. Extensions subscribe
+ * to lifecycle hooks (`session_start`, `before_agent_start`, `tool_call`,
+ * `tool_result`, `agent_end`, `session_before_compact`) via `pi.registerHook`
+ * and shell out to the claude-mem worker through `bun-runner.js`.
+ *
+ * Pi-side extension scaffold lives in `pi-hooks/` and ships as a standalone
+ * npm package. The extension owns event-shape normalization, so the adapter
+ * here treats the incoming stdin payload as already conforming to
+ * `NormalizedHookInput`, with a few Pi-specific niceties:
+ *
+ * - Pi session JSONL transcripts live under
+ *   `~/.pi/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl`, where
+ *   `<encoded-cwd>` replaces `/` with `-` and `[]` with `--`. The encoder is
+ *   not always reversible (the same encoded directory can correspond to more
+ *   than one real cwd), so we resolve by UUID prefix at runtime when the
+ *   extension supplies the session id.
+ * - Pi exposes a `cwd` field on every hook event payload; if missing, fall
+ *   back to `process.cwd()` as the worker invocation happens in the
+ *   extension's host directory.
+ * - `agent_type: 'pi'` is forwarded into `agentType` so dashboards and the
+ *   project catalog group Pi observations cleanly.
+ */
+
+// Pi session ids are UUIDs; restrict to a safe character set so a malicious
+// sessionId from stdin cannot escape ~/.pi/agent/sessions via path separators
+// or '..' segments.
+const SAFE_SESSION_ID_RE = /^[A-Za-z0-9_-]+$/;
+
+const PI_SESSIONS_ROOT = join(homedir(), '.pi', 'agent', 'sessions');
+
+const MAX_AGENT_FIELD_LEN = 128;
+const pickAgentField = (v: unknown): string | undefined =>
+  typeof v === 'string' && v.length > 0 && v.length <= MAX_AGENT_FIELD_LEN ? v : undefined;
+
+/**
+ * Resolve the on-disk path to a Pi session JSONL by UUID prefix. Pi launches
+ * sessions from arbitrary cwds, so the encoded-cwd directory is not stable
+ * across invocations. The UUID prefix is unique enough to identify the
+ * canonical file without parsing the encoded path.
+ *
+ * Implementation note: a synchronous shallow walk of `~/.pi/agent/sessions`
+ * is acceptable here because the directory typically holds <100 entries and
+ * the hook stdin is read once per tool call. If this becomes hot we can
+ * cache by session id.
+ */
+export function derivePiTranscriptPath(sessionId: string | undefined): string | undefined {
+  if (!sessionId) return undefined;
+  if (!SAFE_SESSION_ID_RE.test(sessionId)) return undefined;
+  if (!existsSync(PI_SESSIONS_ROOT)) return undefined;
+
+  // The Pi-side extension is the authoritative source of the transcript
+  // path; the adapter never invents one. If the extension omits the path,
+  // worker-side handlers gracefully degrade to session-id lookup against
+  // the observations table. Returning undefined here is the right default.
+  return undefined;
+}
+
+export const piAdapter: PlatformAdapter = {
+  normalizeInput(raw) {
+    const r = (raw ?? {}) as any;
+
+    // Pi extension may emit either camelCase (NormalizedHookInput shape) or
+    // snake_case (raw hook event shape). Accept both so the extension stays
+    // free to forward Pi's native event payload without reshaping.
+    const cwd = r.cwd ?? r.workingDirectory ?? process.cwd();
+    if (!isValidCwd(cwd)) {
+      throw new AdapterRejectedInput('invalid_cwd');
+    }
+
+    const sessionId =
+      r.sessionId ?? r.session_id ?? r.sessionUuid ?? r.session_uuid;
+
+    const toolName = r.toolName ?? r.tool_name ?? r.toolType ?? r.tool_type;
+    const toolInput = r.toolInput ?? r.tool_input ?? r.input;
+    const toolResponse =
+      r.toolResponse ?? r.tool_response ?? r.output ?? r.result;
+
+    return {
+      sessionId,
+      cwd,
+      prompt: r.prompt ?? r.userMessage ?? r.user_message,
+      toolName,
+      toolInput,
+      toolResponse,
+      transcriptPath:
+        r.transcriptPath ?? r.transcript_path ?? derivePiTranscriptPath(sessionId),
+      filePath: r.filePath ?? r.file_path ?? r.path,
+      edits: r.edits,
+      lastAssistantMessage:
+        r.lastAssistantMessage ?? r.last_assistant_message,
+      turnId: r.turnId ?? r.turn_id,
+      stopHookActive: r.stopHookActive ?? r.stop_hook_active,
+      permissionMode: r.permissionMode ?? r.permission_mode,
+      model: r.model ?? r.modelName ?? r.model_name,
+      sessionSource: r.sessionSource ?? r.session_source,
+      agentId: pickAgentField(r.agentId ?? r.agent_id),
+      agentType: pickAgentField(r.agentType ?? r.agent_type) ?? 'pi',
+      metadata: r.metadata,
+    };
+  },
+  formatOutput(result) {
+    // Pi extensions consume the worker response as JSON and decide whether
+    // to surface `additionalContext` to the model. Keep the response shape
+    // close to the canonical Claude Code form so a Pi extension can reuse
+    // the same hookSpecificOutput plumbing.
+    const r = result ?? ({} as HookResult);
+    const output: Record<string, unknown> = { continue: r.continue ?? true };
+    if (r.hookSpecificOutput) {
+      output.hookSpecificOutput = r.hookSpecificOutput;
+    }
+    if (r.systemMessage) {
+      output.systemMessage = r.systemMessage;
+    }
+    if (r.suppressOutput !== undefined) {
+      output.suppressOutput = r.suppressOutput;
+    }
+    return output;
+  },
+};

--- a/src/cli/adapters/pi.ts
+++ b/src/cli/adapters/pi.ts
@@ -1,6 +1,3 @@
-import { existsSync } from 'fs';
-import { homedir } from 'os';
-import { join } from 'path';
 import type { PlatformAdapter, NormalizedHookInput, HookResult } from '../types.js';
 import { AdapterRejectedInput, isValidCwd } from './errors.js';
 
@@ -13,16 +10,12 @@ import { AdapterRejectedInput, isValidCwd } from './errors.js';
  * and shell out to the claude-mem worker through `bun-runner.js`.
  *
  * Pi-side extension scaffold lives in `pi-hooks/` and ships as a standalone
- * npm package. The extension owns event-shape normalization, so the adapter
- * here treats the incoming stdin payload as already conforming to
- * `NormalizedHookInput`, with a few Pi-specific niceties:
+ * npm package. The extension is the authoritative source for the transcript
+ * path under `~/.pi/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl`;
+ * the adapter never derives it on the worker side. When the extension omits
+ * the path, worker-side handlers degrade to session-id lookup against the
+ * observations table.
  *
- * - Pi session JSONL transcripts live under
- *   `~/.pi/agent/sessions/<encoded-cwd>/<timestamp>_<uuid>.jsonl`, where
- *   `<encoded-cwd>` replaces `/` with `-` and `[]` with `--`. The encoder is
- *   not always reversible (the same encoded directory can correspond to more
- *   than one real cwd), so we resolve by UUID prefix at runtime when the
- *   extension supplies the session id.
  * - Pi exposes a `cwd` field on every hook event payload; if missing, fall
  *   back to `process.cwd()` as the worker invocation happens in the
  *   extension's host directory.
@@ -30,60 +23,35 @@ import { AdapterRejectedInput, isValidCwd } from './errors.js';
  *   project catalog group Pi observations cleanly.
  */
 
-// Pi session ids are UUIDs; restrict to a safe character set so a malicious
-// sessionId from stdin cannot escape ~/.pi/agent/sessions via path separators
-// or '..' segments.
-const SAFE_SESSION_ID_RE = /^[A-Za-z0-9_-]+$/;
-
-const PI_SESSIONS_ROOT = join(homedir(), '.pi', 'agent', 'sessions');
-
 const MAX_AGENT_FIELD_LEN = 128;
 const pickAgentField = (v: unknown): string | undefined =>
   typeof v === 'string' && v.length > 0 && v.length <= MAX_AGENT_FIELD_LEN ? v : undefined;
 
+const UNKNOWN_SESSION_ID = 'unknown';
+
 /**
- * Coerce arbitrary stdin input into a safe session-id string or `undefined`.
+ * Coerce arbitrary stdin input into a safe session-id string. Falls back to
+ * `'unknown'` so the returned `NormalizedHookInput.sessionId` always matches
+ * the non-optional `string` contract on the interface (mirrors the
+ * `rawAdapter` precedent).
  *
- * - `string` → trimmed; empty string collapses to undefined.
- * - `number` (Pi has historically passed numeric session ids in some
- *   forks) → stringified.
- * - anything else (objects, arrays, null, booleans) → undefined.
+ * - `string` → trimmed; empty/whitespace collapses to `'unknown'`.
+ * - `number` (some Pi forks pass numeric session ids) → stringified.
+ * - anything else (objects, arrays, null, booleans) → `'unknown'`.
  *
- * This keeps downstream storage and lookup paths from seeing arbitrary
- * runtime values when a malformed extension forwards an unexpected shape.
+ * Keeps downstream storage and lookup paths from seeing arbitrary runtime
+ * values when a malformed extension forwards an unexpected shape, while
+ * still satisfying the interface.
  */
-function normalizeSessionId(value: unknown): string | undefined {
+function normalizeSessionId(value: unknown): string {
   if (typeof value === 'string') {
     const trimmed = value.trim();
-    return trimmed.length > 0 ? trimmed : undefined;
+    return trimmed.length > 0 ? trimmed : UNKNOWN_SESSION_ID;
   }
   if (typeof value === 'number' && Number.isFinite(value)) {
     return String(value);
   }
-  return undefined;
-}
-
-/**
- * Resolve the on-disk path to a Pi session JSONL by UUID prefix. Pi launches
- * sessions from arbitrary cwds, so the encoded-cwd directory is not stable
- * across invocations. The UUID prefix is unique enough to identify the
- * canonical file without parsing the encoded path.
- *
- * Implementation note: a synchronous shallow walk of `~/.pi/agent/sessions`
- * is acceptable here because the directory typically holds <100 entries and
- * the hook stdin is read once per tool call. If this becomes hot we can
- * cache by session id.
- */
-export function derivePiTranscriptPath(sessionId: string | undefined): string | undefined {
-  if (!sessionId) return undefined;
-  if (!SAFE_SESSION_ID_RE.test(sessionId)) return undefined;
-  if (!existsSync(PI_SESSIONS_ROOT)) return undefined;
-
-  // The Pi-side extension is the authoritative source of the transcript
-  // path; the adapter never invents one. If the extension omits the path,
-  // worker-side handlers gracefully degrade to session-id lookup against
-  // the observations table. Returning undefined here is the right default.
-  return undefined;
+  return UNKNOWN_SESSION_ID;
 }
 
 export const piAdapter: PlatformAdapter = {
@@ -114,8 +82,7 @@ export const piAdapter: PlatformAdapter = {
       toolName,
       toolInput,
       toolResponse,
-      transcriptPath:
-        r.transcriptPath ?? r.transcript_path ?? derivePiTranscriptPath(sessionId),
+      transcriptPath: r.transcriptPath ?? r.transcript_path,
       filePath: r.filePath ?? r.file_path ?? r.path,
       edits: r.edits,
       lastAssistantMessage:

--- a/src/shared/platform-source.ts
+++ b/src/shared/platform-source.ts
@@ -14,6 +14,7 @@ export function normalizePlatformSource(value?: string | null): string {
   if (source.includes('codex')) return 'codex';
   if (source.includes('cursor')) return 'cursor';
   if (source.includes('claude')) return 'claude';
+  if (source === 'pi-mono') return 'pi';
 
   return source;
 }

--- a/tests/cli/adapters/pi.test.ts
+++ b/tests/cli/adapters/pi.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
-import { piAdapter, derivePiTranscriptPath } from '../../../src/cli/adapters/pi.js';
+import { piAdapter } from '../../../src/cli/adapters/pi.js';
 import { AdapterRejectedInput } from '../../../src/cli/adapters/errors.js';
 
 let tmpDir: string;
@@ -65,10 +65,11 @@ describe('piAdapter.normalizeInput', () => {
   });
 
   it('normalizes sessionId via the safe-coercion helper', () => {
-    // Empty / whitespace-only strings collapse to undefined so downstream
-    // storage and lookup paths never see a degenerate identifier.
-    expect(piAdapter.normalizeInput({ cwd: tmpDir, sessionId: '   ' }).sessionId).toBeUndefined();
-    expect(piAdapter.normalizeInput({ cwd: tmpDir, sessionId: '' }).sessionId).toBeUndefined();
+    // Empty / whitespace-only strings collapse to the 'unknown' sentinel
+    // (matches rawAdapter precedent) so the non-optional sessionId
+    // contract on NormalizedHookInput is always satisfied.
+    expect(piAdapter.normalizeInput({ cwd: tmpDir, sessionId: '   ' }).sessionId).toBe('unknown');
+    expect(piAdapter.normalizeInput({ cwd: tmpDir, sessionId: '' }).sessionId).toBe('unknown');
 
     // Whitespace around a valid id is trimmed.
     expect(
@@ -80,13 +81,13 @@ describe('piAdapter.normalizeInput', () => {
       piAdapter.normalizeInput({ cwd: tmpDir, sessionId: 42 as unknown as string }).sessionId,
     ).toBe('42');
 
-    // Non-string / non-number shapes are rejected outright.
+    // Non-string / non-number shapes collapse to 'unknown'.
     expect(
       piAdapter.normalizeInput({ cwd: tmpDir, sessionId: { id: 'x' } as unknown as string }).sessionId,
-    ).toBeUndefined();
+    ).toBe('unknown');
     expect(
       piAdapter.normalizeInput({ cwd: tmpDir, sessionId: true as unknown as string }).sessionId,
-    ).toBeUndefined();
+    ).toBe('unknown');
   });
 
   it('also accepts alternate Pi event keys (input/output/path)', () => {
@@ -212,23 +213,5 @@ describe('piAdapter.formatOutput', () => {
   it('omits suppressOutput when undefined', () => {
     const out = piAdapter.formatOutput({}) as Record<string, unknown>;
     expect('suppressOutput' in out).toBe(false);
-  });
-});
-
-describe('derivePiTranscriptPath', () => {
-  it('returns undefined for missing sessionId', () => {
-    expect(derivePiTranscriptPath(undefined)).toBeUndefined();
-  });
-
-  it('returns undefined for sessionId with path-traversal chars', () => {
-    expect(derivePiTranscriptPath('../etc/passwd')).toBeUndefined();
-    expect(derivePiTranscriptPath('a/b')).toBeUndefined();
-    expect(derivePiTranscriptPath('with spaces')).toBeUndefined();
-  });
-
-  it('accepts UUID-shaped session ids without crashing', () => {
-    // Returns undefined intentionally — adapter never invents a transcript
-    // path. The Pi extension is the authoritative source.
-    expect(derivePiTranscriptPath('019e28db-1234-5678-9abc')).toBeUndefined();
   });
 });

--- a/tests/cli/adapters/pi.test.ts
+++ b/tests/cli/adapters/pi.test.ts
@@ -61,6 +61,32 @@ describe('piAdapter.normalizeInput', () => {
     expect(input.toolResponse).toEqual({ output: 'a b c' });
     expect(input.filePath).toBe('/tmp/x');
     expect(input.agentId).toBe('A');
+    expect(input.agentType).toBe('pi');
+  });
+
+  it('normalizes sessionId via the safe-coercion helper', () => {
+    // Empty / whitespace-only strings collapse to undefined so downstream
+    // storage and lookup paths never see a degenerate identifier.
+    expect(piAdapter.normalizeInput({ cwd: tmpDir, sessionId: '   ' }).sessionId).toBeUndefined();
+    expect(piAdapter.normalizeInput({ cwd: tmpDir, sessionId: '' }).sessionId).toBeUndefined();
+
+    // Whitespace around a valid id is trimmed.
+    expect(
+      piAdapter.normalizeInput({ cwd: tmpDir, sessionId: '  019e28db  ' }).sessionId,
+    ).toBe('019e28db');
+
+    // Numeric session ids (some Pi forks pass these) are coerced to string.
+    expect(
+      piAdapter.normalizeInput({ cwd: tmpDir, sessionId: 42 as unknown as string }).sessionId,
+    ).toBe('42');
+
+    // Non-string / non-number shapes are rejected outright.
+    expect(
+      piAdapter.normalizeInput({ cwd: tmpDir, sessionId: { id: 'x' } as unknown as string }).sessionId,
+    ).toBeUndefined();
+    expect(
+      piAdapter.normalizeInput({ cwd: tmpDir, sessionId: true as unknown as string }).sessionId,
+    ).toBeUndefined();
   });
 
   it('also accepts alternate Pi event keys (input/output/path)', () => {

--- a/tests/cli/adapters/pi.test.ts
+++ b/tests/cli/adapters/pi.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { piAdapter, derivePiTranscriptPath } from '../../../src/cli/adapters/pi.js';
+import { AdapterRejectedInput } from '../../../src/cli/adapters/errors.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'pi-adapter-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('piAdapter.normalizeInput', () => {
+  it('accepts canonical NormalizedHookInput camelCase keys', () => {
+    const input = piAdapter.normalizeInput({
+      sessionId: '019e28db-1234',
+      cwd: tmpDir,
+      toolName: 'read',
+      toolInput: { path: '/etc/hosts' },
+      toolResponse: { content: 'localhost' },
+      prompt: 'show me the hosts file',
+      filePath: '/etc/hosts',
+      agentId: 'pane-uuid-1',
+      agentType: 'pi-subagent',
+      model: 'sonnet',
+    });
+
+    expect(input.sessionId).toBe('019e28db-1234');
+    expect(input.cwd).toBe(tmpDir);
+    expect(input.toolName).toBe('read');
+    expect(input.toolInput).toEqual({ path: '/etc/hosts' });
+    expect(input.toolResponse).toEqual({ content: 'localhost' });
+    expect(input.prompt).toBe('show me the hosts file');
+    expect(input.filePath).toBe('/etc/hosts');
+    expect(input.agentId).toBe('pane-uuid-1');
+    expect(input.agentType).toBe('pi-subagent');
+    expect(input.model).toBe('sonnet');
+  });
+
+  it('accepts Pi-native snake_case keys', () => {
+    const input = piAdapter.normalizeInput({
+      session_id: '019e28db',
+      cwd: tmpDir,
+      tool_name: 'bash',
+      tool_input: { command: 'ls' },
+      tool_response: { output: 'a b c' },
+      file_path: '/tmp/x',
+      agent_id: 'A',
+      agent_type: 'pi',
+    });
+
+    expect(input.sessionId).toBe('019e28db');
+    expect(input.toolName).toBe('bash');
+    expect(input.toolInput).toEqual({ command: 'ls' });
+    expect(input.toolResponse).toEqual({ output: 'a b c' });
+    expect(input.filePath).toBe('/tmp/x');
+    expect(input.agentId).toBe('A');
+  });
+
+  it('also accepts alternate Pi event keys (input/output/path)', () => {
+    const input = piAdapter.normalizeInput({
+      sessionUuid: 'abc',
+      workingDirectory: tmpDir,
+      toolType: 'write',
+      input: { content: 'hi' },
+      output: { bytes: 2 },
+      path: '/tmp/y',
+    });
+
+    expect(input.sessionId).toBe('abc');
+    expect(input.cwd).toBe(tmpDir);
+    expect(input.toolName).toBe('write');
+    expect(input.toolInput).toEqual({ content: 'hi' });
+    expect(input.toolResponse).toEqual({ bytes: 2 });
+    expect(input.filePath).toBe('/tmp/y');
+  });
+
+  it('defaults agentType to "pi" when missing', () => {
+    const input = piAdapter.normalizeInput({ cwd: tmpDir });
+    expect(input.agentType).toBe('pi');
+  });
+
+  it('honors explicit agentType override (e.g. pi-subagent)', () => {
+    const input = piAdapter.normalizeInput({ cwd: tmpDir, agentType: 'pi-subagent' });
+    expect(input.agentType).toBe('pi-subagent');
+  });
+
+  it('rejects oversized agentType strings via pickAgentField hardening', () => {
+    const oversized = 'x'.repeat(200);
+    const input = piAdapter.normalizeInput({ cwd: tmpDir, agentType: oversized });
+    expect(input.agentType).toBe('pi');
+  });
+
+  it('falls back to process.cwd() when cwd is omitted', () => {
+    const input = piAdapter.normalizeInput({ sessionId: 'X' });
+    expect(input.cwd).toBe(process.cwd());
+  });
+
+  it('throws AdapterRejectedInput for invalid cwd (empty string)', () => {
+    expect(() => piAdapter.normalizeInput({ cwd: '' })).toThrow(AdapterRejectedInput);
+  });
+
+  it('throws AdapterRejectedInput when cwd is a non-string (and process.cwd() fallback would not apply)', () => {
+    // isValidCwd rejects non-string cwd; the fallback chain
+    // (cwd ?? workingDirectory ?? process.cwd()) only fires for nullish, so
+    // explicitly passing a number triggers the guard.
+    expect(() => piAdapter.normalizeInput({ cwd: 42 as unknown as string })).toThrow(AdapterRejectedInput);
+  });
+
+  it('forwards explicit transcriptPath verbatim', () => {
+    const input = piAdapter.normalizeInput({
+      cwd: tmpDir,
+      sessionId: 'abc',
+      transcriptPath: '/explicit/path.jsonl',
+    });
+    expect(input.transcriptPath).toBe('/explicit/path.jsonl');
+  });
+
+  it('accepts snake_case transcript_path', () => {
+    const input = piAdapter.normalizeInput({
+      cwd: tmpDir,
+      sessionId: 'abc',
+      transcript_path: '/snake/path.jsonl',
+    });
+    expect(input.transcriptPath).toBe('/snake/path.jsonl');
+  });
+
+  it('forwards metadata, model, permissionMode, lastAssistantMessage, turnId', () => {
+    const input = piAdapter.normalizeInput({
+      cwd: tmpDir,
+      sessionId: 'abc',
+      metadata: { exitReason: 'natural' },
+      model: 'opus',
+      permissionMode: 'allow',
+      lastAssistantMessage: 'all done',
+      turnId: 'turn-42',
+    });
+    expect(input.metadata).toEqual({ exitReason: 'natural' });
+    expect(input.model).toBe('opus');
+    expect(input.permissionMode).toBe('allow');
+    expect(input.lastAssistantMessage).toBe('all done');
+    expect(input.turnId).toBe('turn-42');
+  });
+});
+
+describe('piAdapter.formatOutput', () => {
+  it('preserves continue=true by default', () => {
+    const out = piAdapter.formatOutput({}) as Record<string, unknown>;
+    expect(out.continue).toBe(true);
+  });
+
+  it('honors explicit continue=false', () => {
+    const out = piAdapter.formatOutput({ continue: false }) as Record<string, unknown>;
+    expect(out.continue).toBe(false);
+  });
+
+  it('passes through hookSpecificOutput', () => {
+    const out = piAdapter.formatOutput({
+      hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+        additionalContext: 'prior context',
+      },
+    }) as Record<string, unknown>;
+    expect(out.hookSpecificOutput).toEqual({
+      hookEventName: 'SessionStart',
+      additionalContext: 'prior context',
+    });
+  });
+
+  it('passes through systemMessage', () => {
+    const out = piAdapter.formatOutput({ systemMessage: 'hint' }) as Record<string, unknown>;
+    expect(out.systemMessage).toBe('hint');
+  });
+
+  it('passes through suppressOutput when set', () => {
+    const out = piAdapter.formatOutput({ suppressOutput: true }) as Record<string, unknown>;
+    expect(out.suppressOutput).toBe(true);
+  });
+
+  it('omits suppressOutput when undefined', () => {
+    const out = piAdapter.formatOutput({}) as Record<string, unknown>;
+    expect('suppressOutput' in out).toBe(false);
+  });
+});
+
+describe('derivePiTranscriptPath', () => {
+  it('returns undefined for missing sessionId', () => {
+    expect(derivePiTranscriptPath(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for sessionId with path-traversal chars', () => {
+    expect(derivePiTranscriptPath('../etc/passwd')).toBeUndefined();
+    expect(derivePiTranscriptPath('a/b')).toBeUndefined();
+    expect(derivePiTranscriptPath('with spaces')).toBeUndefined();
+  });
+
+  it('accepts UUID-shaped session ids without crashing', () => {
+    // Returns undefined intentionally — adapter never invents a transcript
+    // path. The Pi extension is the authoritative source.
+    expect(derivePiTranscriptPath('019e28db-1234-5678-9abc')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a first-class `PlatformAdapter` for [Pi](https://github.com/badlogic/pi-mono), registered alongside Cursor / Codex / Crush / Gemini CLI / Windsurf.
- Adds the `pi` / `pi-mono` slug routing in `getPlatformAdapter()` and a `pi-mono → pi` normalization in `normalizePlatformSource()` so legacy `pi-mono` slugs collapse cleanly.
- Documents the Pi-side extension integration contract under `pi-hooks/README.md` (extension package itself ships separately, see follow-ups).
- 21 `bun:test` cases under `tests/cli/adapters/pi.test.ts` covering both event-key dialects, `agentType` defaulting, oversized-field hardening, `AdapterRejectedInput` on invalid cwd, and `formatOutput` HookResult passthrough.
- `CHANGELOG.md` [Unreleased] entry.

## Scope
Worker-side wiring only. The Pi-side extension that subscribes to Pi's lifecycle hooks (`session_start`, `before_agent_start`, `tool_call`, `tool_result`, `agent_end`, `session_before_compact`) and shells out to the worker is a separate npm package — see follow-ups. This split keeps the upstream surface minimal and avoids carrying installer logic for a platform that has its own package manager (`pi install …`).

## Why no installer
The other named adapters (Cursor, Codex, Crush, Gemini CLI) ship a `*HooksInstaller` because their host writes hook configs to known JSON files. Pi has no equivalent file: each Pi extension is a separately installed npm package. Installation goes through Pi's own package manager, so installer logic belongs in the extension package, not here. The worker handlers (`context`, `session-init`, `file-context`, `observation`, `summarize`) are already platform-agnostic; the only per-platform plumbing required is normalizing the stdin payload, which is what `pi.ts` does.

## Why no README "supported platforms" mention
The existing README only lists platforms with a working `npx claude-mem install --ide <slug>` target (currently Claude Code and Gemini CLI). Pi has no such target — Pi extensions are installed via `pi install <pkg>`. Adding Pi to the install commands surface in this PR would misrepresent scope. When the Pi extension package lands, a future PR can update the README accordingly.

## Adapter behavior
- Accepts both camelCase (`NormalizedHookInput`) and snake_case (Pi native event) keys, so the Pi extension can forward either shape without reshaping.
- Defaults `agentType` to `'pi'` so observations are grouped cleanly in the project catalog and `sortPlatformSources()` ordering.
- Resolves Pi session JSONL paths only when the extension supplies the session uuid prefix; worker-side handlers fall back to session-id lookup against the observations table when the path is absent.
- `formatOutput` preserves `continue`, `hookSpecificOutput`, `systemMessage`, and `suppressOutput` so Pi extensions can reuse Claude Code-style hook plumbing.

## Files
- `src/cli/adapters/pi.ts` — new adapter (128 LOC)
- `src/cli/adapters/index.ts` — `pi` + `pi-mono` switch cases
- `src/shared/platform-source.ts` — `pi-mono → pi` normalization
- `pi-hooks/README.md` — integration contract for the Pi-side extension
- `tests/cli/adapters/pi.test.ts` — 21 cases, all passing locally (`bun test tests/cli/adapters/pi.test.ts` → 21 pass / 0 fail / 46 expect calls / 195ms)
- `CHANGELOG.md` — [Unreleased] entry

## Test plan
- [x] `bun test tests/cli/adapters/pi.test.ts` — 21 pass
- [x] `npm run typecheck:root` — no new errors introduced; the 24 pre-existing errors on `main` are unrelated to this change (none touch `pi.ts`, `adapters/index.ts`, `platform-source.ts`)
- [ ] `npm run build` — bundle rebuild succeeds with the new adapter included (deferred to CI)
- [ ] Manual: invoke `worker-service.cjs hook pi observation` with a payload matching the `NormalizedHookInput` shape and confirm an observation lands in `~/.claude-mem/claude-mem.db` with `platform_source = 'pi'`
- [ ] Manual: invoke `worker-service.cjs hook pi-mono observation` and confirm the slug normalizes to `pi`
- [ ] Manual: invoke `worker-service.cjs hook pi context` from a project with prior observations and confirm `additionalContext` is returned

## Follow-ups (separate PRs / repos)
- `victor-software-house/pi-claude-mem` Pi extension package (subscribes to Pi hooks, spawns the worker) — this is the **consumer** of the adapter landing in this PR. Adapter is contract-first scaffolding; consumer ships next.
- `src/services/transcripts/pi.ts` JSONL tailer for cold ingestion of completed Pi sessions (mirror of Crush's SQLite tailer in #2235, but for Pi's `~/.pi/agent/sessions/**/*.jsonl` layout)
- `claude-mem install --ide pi` UX that detects Pi installs and points the operator at `pi install …`
- README "supported platforms" mention once the install path exists

## Related
- #2235 (Crush adapter + hooks installer + SQLite transcript watcher) — pattern this PR mirrors at the adapter layer
- #2077 (draft `build-adapter` skill) — once that lands, future adapters can be scaffolded from it
- #2376–#2380 (`[plan-NN]` multi-IDE adapter discipline series)