### PR TITLE
fix: resolve 24 pre-existing TypeScript errors across 9 files

### DIFF
--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -432,7 +432,7 @@ async function installClaudeCode(): Promise<boolean> {
     child.stderr?.on('data', (chunk: Buffer) => { captured += chunk.toString(); });
 
     child.on('error', (error: Error) => {
-      spinner?.stop('Claude Code install failed', 1);
+      spinner?.stop('Claude Code install failed');
       if (captured) process.stderr.write(captured);
       log.error(`Claude Code install failed: ${error.message}`);
       log.info('You can install it manually later: https://claude.ai/install.sh');
@@ -441,7 +441,7 @@ async function installClaudeCode(): Promise<boolean> {
 
     child.on('exit', (code) => {
       if (code !== 0) {
-        spinner?.stop('Claude Code install failed', 1);
+        spinner?.stop('Claude Code install failed');
         if (captured) process.stderr.write(captured);
         log.error(`Claude Code install failed (exit ${code ?? 'unknown'})`);
         log.info('You can install it manually later: https://claude.ai/install.sh');
@@ -1120,7 +1120,7 @@ export async function runInstallCommand(options: InstallOptions = {}): Promise<v
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
         if (shutdownSpinner) {
-          shutdownSpinner.stop(`Pre-overwrite worker shutdown failed: ${message}`, 1);
+          shutdownSpinner.stop(`Pre-overwrite worker shutdown failed: ${message}`);
         } else {
           console.warn('[install] Pre-overwrite worker shutdown failed:', message);
         }

--- a/src/services/integrations/types.ts
+++ b/src/services/integrations/types.ts
@@ -21,3 +21,5 @@ export interface CursorHooksJson {
     stop?: Array<{ command: string }>;
   };
 }
+
+export type Platform = 'windows' | 'unix';

--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -6,7 +6,6 @@ import {
   IndexInfo,
   TableNameRow,
   SchemaVersion,
-  SdkSessionRecord,
   ObservationRecord,
   SessionSummaryRecord,
   UserPromptRecord,

--- a/src/services/worker/http/BaseRouteHandler.ts
+++ b/src/services/worker/http/BaseRouteHandler.ts
@@ -22,7 +22,10 @@ export abstract class BaseRouteHandler {
   }
 
   protected parseIntParam(req: Request, res: Response, paramName: string): number | null {
-    const value = parseInt(req.params[paramName], 10);
+    // Express 5 types req.params[name] as `string | string[]`; narrow to string.
+    const raw = req.params[paramName];
+    const stringValue = typeof raw === 'string' ? raw : Array.isArray(raw) ? raw[0] ?? '' : '';
+    const value = parseInt(stringValue, 10);
     if (isNaN(value)) {
       this.badRequest(res, `Invalid ${paramName}`);
       return null;

--- a/src/services/worker/http/routes/CorpusRoutes.ts
+++ b/src/services/worker/http/routes/CorpusRoutes.ts
@@ -11,6 +11,15 @@ import type { CorpusFilter } from '../../knowledge/types.js';
 const ALLOWED_CORPUS_TYPES = ['decision', 'bugfix', 'feature', 'refactor', 'discovery', 'change', 'security_alert', 'security_note'] as const;
 const ALLOWED_CORPUS_TYPE_SET = new Set<string>(ALLOWED_CORPUS_TYPES);
 
+// Express 5 types `req.params[name]` as `string | string[]` to cover wildcard
+// routes; our routes use a single :name segment so the runtime value is
+// always a string. Narrow once here instead of casting at every callsite.
+function extractRouteName(value: string | string[] | undefined): string {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return value[0] ?? '';
+  return '';
+}
+
 const stringArrayLike = z.preprocess((value) => {
   if (value === undefined || value === null || value === '') return undefined;
   if (Array.isArray(value)) return value;
@@ -105,7 +114,7 @@ export class CorpusRoutes extends BaseRouteHandler {
   });
 
   private handleGetCorpus = this.wrapHandler((req: Request, res: Response): void => {
-    const { name } = req.params;
+    const name = extractRouteName(req.params.name);
     const corpus = this.corpusStore.read(name);
 
     if (!corpus) {
@@ -122,7 +131,7 @@ export class CorpusRoutes extends BaseRouteHandler {
   });
 
   private handleDeleteCorpus = this.wrapHandler((req: Request, res: Response): void => {
-    const { name } = req.params;
+    const name = extractRouteName(req.params.name);
     const existed = this.corpusStore.delete(name);
 
     if (!existed) {
@@ -138,7 +147,7 @@ export class CorpusRoutes extends BaseRouteHandler {
   });
 
   private handleRebuildCorpus = this.wrapHandler(async (req: Request, res: Response): Promise<void> => {
-    const { name } = req.params;
+    const name = extractRouteName(req.params.name);
     const existingCorpus = this.corpusStore.read(name);
 
     if (!existingCorpus) {
@@ -157,7 +166,7 @@ export class CorpusRoutes extends BaseRouteHandler {
   });
 
   private handlePrimeCorpus = this.wrapHandler(async (req: Request, res: Response): Promise<void> => {
-    const { name } = req.params;
+    const name = extractRouteName(req.params.name);
     const corpus = this.corpusStore.read(name);
 
     if (!corpus) {
@@ -174,7 +183,7 @@ export class CorpusRoutes extends BaseRouteHandler {
   });
 
   private handleQueryCorpus = this.wrapHandler(async (req: Request, res: Response): Promise<void> => {
-    const { name } = req.params;
+    const name = extractRouteName(req.params.name);
     const corpus = this.corpusStore.read(name);
 
     if (!corpus) {
@@ -192,7 +201,7 @@ export class CorpusRoutes extends BaseRouteHandler {
   });
 
   private handleReprimeCorpus = this.wrapHandler(async (req: Request, res: Response): Promise<void> => {
-    const { name } = req.params;
+    const name = extractRouteName(req.params.name);
     const corpus = this.corpusStore.read(name);
 
     if (!corpus) {

--- a/src/shared/find-claude-executable.ts
+++ b/src/shared/find-claude-executable.ts
@@ -12,7 +12,7 @@ import { execSync, execFileSync } from 'child_process';
 import { existsSync } from 'fs';
 import { SettingsDefaultsManager } from './SettingsDefaultsManager.js';
 import { USER_SETTINGS_PATH } from './paths.js';
-import { logger } from '../utils/logger.js';
+import { logger, type Component } from '../utils/logger.js';
 
 /** How long to wait for `claude --version` before giving up (ms). */
 const VERSION_CHECK_TIMEOUT_MS = 3_000;
@@ -69,7 +69,7 @@ function verifyClaudeVersion(candidate: string): string | null {
  * @param logComponent  Logger component tag (e.g. 'SDK', 'WORKER')
  * @throws {Error} when no valid Claude CLI can be found
  */
-export function findClaudeExecutable(logComponent: string = 'SDK'): string {
+export function findClaudeExecutable(logComponent: Component = 'SDK'): string {
   const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
 
   // --- 1. Explicit configured path ----------------------------------------

--- a/src/ui/viewer/components/ScrollToTop.tsx
+++ b/src/ui/viewer/components/ScrollToTop.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
 
 interface ScrollToTopProps {
-  targetRef: React.RefObject<HTMLDivElement>;
+  // React 19: useRef<T>(null) now returns RefObject<T | null>, not RefObject<T>.
+  targetRef: React.RefObject<HTMLDivElement | null>;
 }
 
 export function ScrollToTop({ targetRef }: ScrollToTopProps) {

--- a/src/ui/viewer/hooks/useSSE.ts
+++ b/src/ui/viewer/hooks/useSSE.ts
@@ -12,7 +12,9 @@ export function useSSE() {
   const [isProcessing, setIsProcessing] = useState(false);
   const [queueDepth, setQueueDepth] = useState(0);
   const eventSourceRef = useRef<EventSource | null>(null);
-  const reconnectTimeoutRef = useRef<NodeJS.Timeout>();
+  // React 19: useRef now requires an initial value. NodeJS.Timeout when set,
+  // null when cleared.
+  const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const addProjectIfNew = (project: string) => {
     setProjects(prev => prev.includes(project) ? prev : [...prev, project]);
@@ -41,7 +43,7 @@ export function useSSE() {
         eventSource.close();
 
         reconnectTimeoutRef.current = setTimeout(() => {
-          reconnectTimeoutRef.current = undefined;
+          reconnectTimeoutRef.current = null;
           console.log('[SSE] Attempting to reconnect...');
           connect();
         }, TIMING.SSE_RECONNECT_DELAY_MS);

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -25,6 +25,7 @@ export type Component =
   | 'DEDUP'
   | 'ENV'
   | 'FOLDER_INDEX'
+  | 'GIT'
   | 'HOOK'
   | 'HTTP'
   | 'IMPORT'


### PR DESCRIPTION
Fixes #2538.

A clean checkout of `main` fails `npm run typecheck` with 24 errors. They don't block runtime (transpile-then-typecheck order) but block strict CI and bury real regressions. This PR fixes all 24 with minimal, targeted changes — no behaviour changes, no API changes, no new files.

## Before / after

```
git checkout main && npm run typecheck    # 24 errors
git checkout this-pr && npm run typecheck # 0 errors
```

## Three root causes (see #2538 for the full breakdown)

### 1. Express 5 widens `req.params[name]` to `string | string[]`
`CorpusRoutes.ts` (6), `BaseRouteHandler.ts` (1). Single-segment routes always produce strings at runtime; collapse the union at the callsite. No runtime change.

### 2. Strict `Component` union in `src/utils/logger.ts`
`find-claude-executable.ts` (8), `logger.ts` itself (1). Import `Component` type where it's needed and add `'GIT'` to the union (used by `WorktreeAdoption.ts`).

### 3. React 19 + dep version drift
- React 19 `useRef` types — `ScrollToTop.tsx`, `useSSE.ts`
- Current `@clack/prompts` `spinner().stop()` takes 0-1 args — `install.ts` (3 callsites)
- Missing `SdkSessionRecord` import — `SessionStore.ts` (drop unused import)
- Missing `Platform` export — `types.ts` (add `export type Platform`)

## Diff stats

```
 src/npx-cli/commands/install.ts                 |  6 +++---
 src/services/integrations/types.ts              |  2 ++
 src/services/sqlite/SessionStore.ts             |  1 -
 src/services/worker/http/BaseRouteHandler.ts    |  5 ++++-
 src/services/worker/http/routes/CorpusRoutes.ts | 21 +++++++++++++++------
 src/shared/find-claude-executable.ts            |  4 ++--
 src/ui/viewer/components/ScrollToTop.tsx        |  3 ++-
 src/ui/viewer/hooks/useSSE.ts                   |  6 ++++--
 src/utils/logger.ts                             |  1 +
 9 files changed, 33 insertions(+), 16 deletions(-)
```

## Verification

  - `npm run typecheck` → 0 errors (was 24)
  - No tests added or removed
  - No runtime behaviour change across the 9 files
  - Each fix is local to a single file with one root cause

## Notes for review

This is intended as a warm-up PR — small, surgical, no architecture changes. Once this lands, follow-up PRs can safely add stricter CI (`tsc --noEmit` as a required check) without false negatives.
