### PR TITLE
fix(install): wire server-beta runtime into installer + UX cleanup

### DIFF
--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -432,7 +432,7 @@ async function installClaudeCode(): Promise<boolean> {
     child.stderr?.on('data', (chunk: Buffer) => { captured += chunk.toString(); });
 
     child.on('error', (error: Error) => {
-      spinner?.stop('Claude Code install failed', 1);
+      spinner?.stop('Claude Code install failed');
       if (captured) process.stderr.write(captured);
       log.error(`Claude Code install failed: ${error.message}`);
       log.info('You can install it manually later: https://claude.ai/install.sh');
@@ -441,7 +441,7 @@ async function installClaudeCode(): Promise<boolean> {
 
     child.on('exit', (code) => {
       if (code !== 0) {
-        spinner?.stop('Claude Code install failed', 1);
+        spinner?.stop('Claude Code install failed');
         if (captured) process.stderr.write(captured);
         log.error(`Claude Code install failed (exit ${code ?? 'unknown'})`);
         log.info('You can install it manually later: https://claude.ai/install.sh');
@@ -536,6 +536,9 @@ function copyPluginToMarketplace(): void {
     'LICENSE',
     'README.md',
     'CHANGELOG.md',
+    'docker',
+    'docker-compose.yml',
+    'docker-compose.override.yml.example',
   ];
 
   for (const entry of allowedTopLevelEntries) {
@@ -643,9 +646,11 @@ function resolveClaudeAuthMethod(): 'subscription' | 'api-key' | 'gateway' {
   return 'subscription';
 }
 
-async function promptRuntime(): Promise<RuntimeId> {
+async function promptRuntime(options: InstallOptions): Promise<RuntimeId> {
+  if (options.runtime) {
+    return options.runtime;
+  }
   if (!isInteractive) {
-    mergeSettings({ CLAUDE_MEM_RUNTIME: 'worker' });
     return 'worker';
   }
 
@@ -653,7 +658,7 @@ async function promptRuntime(): Promise<RuntimeId> {
     message: 'Which runtime should claude-mem start after install?',
     options: [
       { value: 'worker', label: 'Worker', hint: 'stable compatibility path' },
-      { value: 'server-beta', label: 'Server (beta)', hint: 'REST V1, API keys, team-ready storage' },
+      { value: 'server-beta', label: 'Server (beta)', hint: 'REST V1, API keys, team-ready storage (requires Docker)' },
     ],
     initialValue: 'worker',
   });
@@ -663,46 +668,26 @@ async function promptRuntime(): Promise<RuntimeId> {
     process.exit(0);
   }
 
-  mergeSettings({
-    CLAUDE_MEM_RUNTIME: selected,
-  });
-
-  if (selected === 'server-beta') {
-    await maybeBootstrapServerBetaApiKey();
-  }
   return selected;
 }
 
-async function maybeBootstrapServerBetaApiKey(): Promise<void> {
-  // Only attempt if Postgres is configured. Without DATABASE_URL we cannot
-  // reach the api_keys table — the operator must configure the server first
-  // and rerun `claude-mem server keys rotate`.
-  if (!process.env.CLAUDE_MEM_SERVER_DATABASE_URL) {
-    log.warn(
-      'Skipping local hook API key bootstrap: CLAUDE_MEM_SERVER_DATABASE_URL is not set. '
-        + 'Run `npx claude-mem server keys rotate` after configuring Postgres to provision a key.',
-    );
-    return;
-  }
-  try {
-    const { bootstrapServerBetaApiKey, persistServerBetaSettings } = await import(
-      '../../services/hooks/server-beta-bootstrap.js'
-    );
-    const result = await bootstrapServerBetaApiKey();
-    persistServerBetaSettings(USER_SETTINGS_PATH, {
-      apiKey: result.rawKey,
-      projectId: result.projectId,
-    });
-    log.info(
-      `Provisioned local hook API key (project=${result.projectId.slice(0, 8)}…). `
-        + 'Settings saved with mode 0600.',
-    );
-  } catch (error: unknown) {
-    log.warn(
-      `Failed to bootstrap server-beta API key: ${error instanceof Error ? error.message : String(error)}. `
-        + 'Hooks will fall back to the worker until you run `npx claude-mem server keys rotate`.',
-    );
-  }
+function commitRuntimeSetting(runtime: RuntimeId): void {
+  mergeSettings({ CLAUDE_MEM_RUNTIME: runtime });
+}
+
+async function setupServerBeta(args: {
+  marketplaceDir: string;
+  dryRun: boolean;
+  optInIdes?: string[];
+  logger: typeof log;
+}): Promise<import('../../services/install/server-beta-setup.js').SetupResult> {
+  const { setupServerBeta: impl } = await import('../../services/install/server-beta-setup.js');
+  return impl({
+    marketplaceDir: args.marketplaceDir,
+    dryRun: args.dryRun,
+    optInIdes: args.optInIdes,
+    logger: args.logger,
+  });
 }
 
 async function promptProvider(options: InstallOptions): Promise<ProviderId> {
@@ -1019,6 +1004,9 @@ export interface InstallOptions {
   provider?: 'claude' | 'gemini' | 'openrouter';
   model?: string;
   noAutoStart?: boolean;
+  runtime?: 'worker' | 'server-beta';
+  dryRun?: boolean;
+  optInIdes?: string[];
 }
 
 export async function runInstallCommand(options: InstallOptions = {}): Promise<void> {
@@ -1088,7 +1076,7 @@ export async function runInstallCommand(options: InstallOptions = {}): Promise<v
     selectedIDEs = ['claude-code'];
   }
 
-  const selectedRuntime = await promptRuntime();
+  const selectedRuntime = await promptRuntime(options);
   const selectedProvider = await promptProvider(options);
   if (selectedProvider === 'claude') {
     await promptClaudeModel(options);
@@ -1120,7 +1108,7 @@ export async function runInstallCommand(options: InstallOptions = {}): Promise<v
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
         if (shutdownSpinner) {
-          shutdownSpinner.stop(`Pre-overwrite worker shutdown failed: ${message}`, 1);
+          shutdownSpinner.stop(`Pre-overwrite worker shutdown failed: ${message}`);
         } else {
           console.warn('[install] Pre-overwrite worker shutdown failed:', message);
         }
@@ -1203,6 +1191,42 @@ export async function runInstallCommand(options: InstallOptions = {}): Promise<v
     await runTasks(tasks);
   }
 
+  let serverBetaSetupOk = false;
+  if (selectedRuntime === 'server-beta') {
+
+    if (isInteractive) {
+      p.log.info('Setting up server-beta runtime (Docker + Postgres + Valkey + worker)…');
+    } else {
+      console.log('Setting up server-beta runtime (Docker + Postgres + Valkey + worker)…');
+    }
+    const setupResult = await setupServerBeta({
+      marketplaceDir,
+      dryRun: options.dryRun === true,
+      optInIdes: options.optInIdes,
+      logger: log,
+    });
+    serverBetaSetupOk = setupResult.ok;
+    if (!serverBetaSetupOk) {
+      const failed = setupResult.steps.find(s => s.status === 'failed');
+      log.error(`Server-beta setup failed at step '${failed?.step ?? 'unknown'}': ${failed?.message ?? '(no detail)'}`);
+      log.warn('CLAUDE_MEM_RUNTIME was NOT committed. Re-run `npx claude-mem install --runtime server-beta` after fixing the issue, or fall back to `--runtime worker`.');
+      if (isInteractive) {
+        p.outro(pc.red('claude-mem install --runtime server-beta failed.'));
+      }
+      process.exit(1);
+    }
+    commitRuntimeSetting('server-beta');
+    if (setupResult.apiKey && setupResult.projectId) {
+      log.success(`Server-beta runtime active. Project ID: ${setupResult.projectId.slice(0, 8)}…`);
+    } else if (setupResult.dryRun) {
+      log.info('[dry-run] setupServerBeta completed all preview steps.');
+    } else {
+      log.info('Server-beta runtime active (reused existing API key).');
+    }
+  } else {
+    commitRuntimeSetting('worker');
+  }
+
   const failedIDEs = await setupIDEs(selectedIDEs);
 
   // Disable Claude Code's built-in auto-memory (CLAUDE_CODE_DISABLE_AUTO_MEMORY=1)
@@ -1235,6 +1259,10 @@ export async function runInstallCommand(options: InstallOptions = {}): Promise<v
     {
       title: selectedRuntime === 'server-beta' ? 'Starting server beta daemon' : 'Starting worker daemon',
       task: async (message) => {
+        if (selectedRuntime === 'server-beta') {
+          workerStartResult = 'ready';
+          return `Server beta managed by docker compose ${pc.green('OK')}`;
+        }
         if (autoStartSkipped) {
           return isInteractive
             ? `Skipped (--no-auto-start)`
@@ -1244,15 +1272,15 @@ export async function runInstallCommand(options: InstallOptions = {}): Promise<v
         const marketplaceScriptPath = join(marketplaceDirectory(), 'plugin', 'scripts', 'worker-service.cjs');
         const cacheScriptPath = join(pluginCacheDirectory(version), 'scripts', 'worker-service.cjs');
         const scriptPath = existsSync(marketplaceScriptPath) ? marketplaceScriptPath : cacheScriptPath;
-        message(`Spawning ${selectedRuntime === 'server-beta' ? 'server beta' : 'worker'} on port ${port}...`);
+        message(`Spawning worker on port ${port}...`);
         workerStartResult = await ensureWorkerStarted(port, scriptPath);
         switch (workerStartResult) {
           case 'ready':
-            return `${selectedRuntime === 'server-beta' ? 'Server beta' : 'Worker'} ready at http://localhost:${port} ${pc.green('OK')}`;
+            return `Worker ready at http://localhost:${port} ${pc.green('OK')}`;
           case 'warming':
-            return `${selectedRuntime === 'server-beta' ? 'Server beta' : 'Worker'} starting on port ${port} — finishing in background ${pc.yellow('⏳')}`;
+            return `Worker starting on port ${port} — finishing in background ${pc.yellow('⏳')}`;
           case 'dead':
-            return `${selectedRuntime === 'server-beta' ? 'Server beta' : 'Worker'} did not start — try \`${selectedRuntime === 'server-beta' ? 'npx claude-mem server start' : 'npx claude-mem start'}\` manually ${pc.yellow('!')}`;
+            return `Worker did not start — try \`npx claude-mem start\` manually ${pc.yellow('!')}`;
         }
       },
     },
@@ -1262,7 +1290,13 @@ export async function runInstallCommand(options: InstallOptions = {}): Promise<v
   const summaryLines = [
     `Version:     ${pc.cyan(version)}`,
     `Plugin dir:  ${pc.cyan(marketplaceDir)}`,
-    `IDEs:        ${pc.cyan(selectedIDEs.join(', '))}`,
+    // BUG B fix — the summary previously showed only `selectedIDEs` (the
+    // interactive/default selection), so `--opt-in-ide a,b,c` installs
+    // listed just `claude-code` even though four IDEs got the MCP entry.
+    // Merge the opt-in list so the summary reflects what was actually wired.
+    `IDEs:        ${pc.cyan(
+      Array.from(new Set([...selectedIDEs, ...(options.optInIdes ?? [])])).join(', '),
+    )}`,
   ];
   if (autoMemoryStatus === 'disabled') {
     summaryLines.push(`Auto-memory: ${pc.cyan('disabled')} (CLAUDE_CODE_DISABLE_AUTO_MEMORY=1)`);
@@ -1282,7 +1316,12 @@ export async function runInstallCommand(options: InstallOptions = {}): Promise<v
     summaryLines.forEach(l => console.log(`  ${l}`));
   }
 
-  const workerPort = getSetting('CLAUDE_MEM_WORKER_PORT');
+  // BUG C fix — use the port that matches the active runtime. Worker runs
+  // on the UID-derived CLAUDE_MEM_WORKER_PORT (e.g. 37703); server-beta runs
+  // on the fixed Docker-published 37877. Picking the worker port for a
+  // server-beta install pointed users at a dead URL.
+  const rawWorkerPort = getSetting('CLAUDE_MEM_WORKER_PORT');
+  const workerPort = selectedRuntime === 'server-beta' ? '37877' : rawWorkerPort;
 
   let actualPort: number | string = workerPort;
   let workerReady = false;
@@ -1322,12 +1361,18 @@ export async function runInstallCommand(options: InstallOptions = {}): Promise<v
   const workerAlive = finalWorkerState !== 'dead' || workerReady;
   const runtimeLabel = selectedRuntime === 'server-beta' ? 'Server beta' : 'Worker';
   const runtimeStartCommand = selectedRuntime === 'server-beta' ? 'npx claude-mem server start' : 'npx claude-mem start';
-  const workerHeadline = autoStartSkipped
+  // BUG D fix — server-beta installs run the Docker stack as part of
+  // setupServerBeta() before we reach this code; calling that 'autostart
+  // skipped' is wrong because the stack IS running. Override the headline
+  // when the stack came up healthy.
+  const serverBetaRunning = selectedRuntime === 'server-beta' && serverBetaSetupOk;
+  const effectiveAutoStartSkipped = autoStartSkipped && !serverBetaRunning;
+  const workerHeadline = effectiveAutoStartSkipped
     ? `${pc.yellow('!')} ${runtimeLabel} autostart skipped — start it manually with ${pc.bold(runtimeStartCommand)}`
-    : workerReady || finalWorkerState === 'ready'
+    : serverBetaRunning || workerReady || finalWorkerState === 'ready'
       ? `${pc.green('✓')} ${runtimeLabel} running at ${pc.underline(`http://localhost:${actualPort}`)}`
       : `${pc.yellow('⏳')} ${runtimeLabel} starting at ${pc.underline(`http://localhost:${actualPort}`)} — give it ~30s, then refresh`;
-  const nextSteps = autoStartSkipped
+  const nextSteps = effectiveAutoStartSkipped
     ? [
         workerHeadline,
         ``,

--- a/src/services/install/claude-host-bridge.ts
+++ b/src/services/install/claude-host-bridge.ts
@@ -175,6 +175,65 @@ export function ensureClaudeHostBridge(): HostBridgeResult {
   }
 }
 
+// Tear down the host-bridge so uninstall doesn't leave a running service
+// pointing at a stale token. Idempotent — safe to call when nothing is
+// installed. Returns ok:true even when nothing was removed so the caller's
+// rollback flow doesn't fail on first-time uninstalls.
+export function stopClaudeHostBridge(): { ok: boolean; message: string; removedFiles: string[] } {
+  const removedFiles: string[] = [];
+  const home = homedir();
+
+  try {
+    if (process.platform === 'darwin') {
+      const plistPath = join(home, 'Library', 'LaunchAgents', `${LAUNCHD_LABEL}.plist`);
+      if (existsSync(plistPath)) {
+        spawnSync('launchctl', ['unload', plistPath], { stdio: 'ignore' });
+        try {
+          // unlinkSync via require avoided — use writeFileSync to /dev/null is
+          // not portable; just rely on fs.unlinkSync via dynamic require if
+          // unavailable as a top-level import here.
+          require('fs').unlinkSync(plistPath);
+          removedFiles.push(plistPath);
+        } catch { /* already gone */ }
+      }
+    } else if (process.platform === 'linux') {
+      const unitDir = join(home, '.config', 'systemd', 'user');
+      const unitPath = join(unitDir, SYSTEMD_UNIT_NAME);
+      if (existsSync(unitPath)) {
+        spawnSync('systemctl', ['--user', 'stop', SYSTEMD_UNIT_NAME], { stdio: 'ignore' });
+        spawnSync('systemctl', ['--user', 'disable', SYSTEMD_UNIT_NAME], { stdio: 'ignore' });
+        try {
+          require('fs').unlinkSync(unitPath);
+          removedFiles.push(unitPath);
+        } catch { /* already gone */ }
+        spawnSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'ignore' });
+      }
+    }
+    // Token + port files live in paths.dataDir(); remove them too so a
+    // future install starts from a clean state.
+    const tokenPath = join(paths.dataDir(), 'host-bridge-token');
+    const portPath = join(paths.dataDir(), 'host-bridge-port');
+    for (const f of [tokenPath, portPath]) {
+      if (existsSync(f)) {
+        try { require('fs').unlinkSync(f); removedFiles.push(f); } catch { /* */ }
+      }
+    }
+    return {
+      ok: true,
+      message: removedFiles.length
+        ? `host-bridge stopped; removed ${removedFiles.length} file(s)`
+        : 'host-bridge was not installed',
+      removedFiles,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      message: err instanceof Error ? err.message : String(err),
+      removedFiles,
+    };
+  }
+}
+
 function claudeCliReachable(): boolean {
   return resolveClaudeCliPath() !== null;
 }

--- a/src/services/install/claude-host-bridge.ts
+++ b/src/services/install/claude-host-bridge.ts
@@ -30,7 +30,7 @@
 //     CLAUDE_MEM_CLAUDE_BRIDGE_TOKEN and signs every request. Prevents other
 //     processes on the host from accidentally using the bridge.
 
-import { execSync, spawnSync } from 'child_process';
+import { spawnSync } from 'child_process';
 import {
   chmodSync,
   existsSync,
@@ -375,18 +375,35 @@ function waitForBridge(port: number, timeoutMs: number): { ok: boolean; message:
   const deadline = Date.now() + timeoutMs;
   let lastError = 'timeout';
   while (Date.now() < deadline) {
-    try {
-      const result = execSync(`curl -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:${port}/healthz`, {
-        encoding: 'utf-8',
-        timeout: 1500,
-        stdio: ['ignore', 'pipe', 'pipe'],
-      }).trim();
-      if (result === '200') {
-        return { ok: true, message: 'healthz returned 200' };
-      }
+    // Probe /healthz via a worker thread that uses Node's built-in http
+    // module. Avoids depending on `curl`, which is absent by default on
+    // Debian/Ubuntu minimal, Alpine, and many WSL images — those installs
+    // previously failed silently here even when the bridge process started
+    // successfully.
+    const probeScript = `
+      const http = require('http');
+      const req = http.get('http://127.0.0.1:${port}/healthz', { timeout: 1500 }, (res) => {
+        const code = res.statusCode || 0;
+        res.resume();
+        process.stdout.write(String(code));
+        process.exit(0);
+      });
+      req.on('timeout', () => { req.destroy(); process.stdout.write('timeout'); process.exit(0); });
+      req.on('error', (err) => { process.stdout.write('error:' + err.message); process.exit(0); });
+    `;
+    const probe = spawnSync(process.execPath, ['-e', probeScript], {
+      encoding: 'utf-8',
+      timeout: 2000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const result = (probe.stdout ?? '').trim();
+    if (result === '200') {
+      return { ok: true, message: 'healthz returned 200' };
+    }
+    if (result.startsWith('error:') || result === '' || result === 'timeout') {
+      lastError = result || 'timeout';
+    } else {
       lastError = `healthz returned ${result}`;
-    } catch (err) {
-      lastError = err instanceof Error ? err.message : String(err);
     }
     // Poll loop without `await`: install code runs synchronously.
     spawnSync(process.execPath, ['-e', 'setTimeout(()=>process.exit(0),200)'], {

--- a/src/services/install/claude-host-bridge.ts
+++ b/src/services/install/claude-host-bridge.ts
@@ -1,0 +1,455 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// / Phase 2 — Claude host-bridge launcher.
+//
+// On macOS the user's Claude Code OAuth credentials may live ONLY in the
+// Keychain — `~/.claude/.credentials.json` doesn't exist. Bind-mounting the
+// Keychain into a Docker container is not possible, so the worker container
+// would have to bake in a snapshot. Snapshots go stale when the user switches
+// accounts or when Claude CLI refreshes the OAuth token.
+//
+// The host-bridge solves this cleanly: a tiny localhost HTTP proxy on the
+// host shells out to the locally-installed `claude` CLI for every generation
+// request. The Docker container POSTs prompts at
+// http://host.docker.internal:<port>/v1/generate. The host's `claude` CLI
+// handles auth (via Keychain or .credentials.json — same as a normal
+// interactive session), so:
+//   - account switches propagate INSTANTLY (next request uses the new account)
+//   - token refresh is automatic (CLI handles it)
+//   - the user's installed CLAUDE_MEM_CLAUDE_MODEL (4.5/4.6/4.7) is what gets
+//     used, NOT a frozen-at-install model
+//
+// Lifecycle:
+//   - The bridge is a tiny Node script at ~/.claude-mem/claude-host-bridge.cjs
+//     (~150 LOC).
+//   - On macOS we install a launchd plist that keeps it running across
+//     reboots and restarts it if it crashes.
+//   - On Linux/WSL we install a systemd user unit with the same semantics.
+//   - The port is allocated dynamically (ephemeral, written to .env).
+//   - Authentication: shared secret in the .env; the container reads it from
+//     CLAUDE_MEM_CLAUDE_BRIDGE_TOKEN and signs every request. Prevents other
+//     processes on the host from accidentally using the bridge.
+
+import { execSync, spawnSync } from 'child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import { randomBytes } from 'crypto';
+import { paths } from '../../shared/paths.js';
+import { logger } from '../../utils/logger.js';
+
+export interface HostBridgeResult {
+  ok: boolean;
+  bridgeUrl: string;
+  bridgeToken: string;
+  message: string;
+}
+
+const BRIDGE_SCRIPT_BASENAME = 'claude-host-bridge.cjs';
+const LAUNCHD_LABEL = 'ai.claude-mem.host-bridge';
+const SYSTEMD_UNIT_NAME = 'claude-mem-host-bridge.service';
+
+/**
+ * Idempotent: returns the existing bridge URL when the service is already
+ * running, otherwise writes the script + service definition and starts it.
+ */
+export function ensureClaudeHostBridge(): HostBridgeResult {
+  try {
+    // 1. Verify `claude` CLI is on PATH — bridge can't function without it.
+    if (!claudeCliReachable()) {
+      return {
+        ok: false,
+        bridgeUrl: '',
+        bridgeToken: '',
+        message:
+          '`claude` CLI not found on PATH — install @anthropic-ai/claude-code globally before enabling subscription auth',
+      };
+    }
+
+    // 2. Prepare data dir + script + token.
+    const dataDir = paths.dataDir();
+    if (!existsSync(dataDir)) {
+      mkdirSync(dataDir, { recursive: true, mode: 0o700 });
+    }
+    const scriptPath = join(dataDir, BRIDGE_SCRIPT_BASENAME);
+    const tokenPath = join(dataDir, 'host-bridge-token');
+
+    writeFileSync(scriptPath, BRIDGE_SCRIPT_SOURCE, {
+      encoding: 'utf-8',
+      mode: 0o755,
+    });
+
+    let bridgeToken: string;
+    if (existsSync(tokenPath)) {
+      bridgeToken = readFileSync(tokenPath, 'utf-8').trim();
+    } else {
+      bridgeToken = randomBytes(32).toString('hex');
+      writeFileSync(tokenPath, bridgeToken, {
+        encoding: 'utf-8',
+        mode: 0o600,
+      });
+    }
+    try {
+      chmodSync(tokenPath, 0o600);
+    } catch {
+      /* non-POSIX */
+    }
+
+    // 3. Allocate a port (ephemeral; first install picks 37990 by default,
+    //    later installs reuse the same port).
+    const portPath = join(dataDir, 'host-bridge-port');
+    let port: number;
+    if (existsSync(portPath)) {
+      const parsed = Number.parseInt(readFileSync(portPath, 'utf-8').trim(), 10);
+      port = Number.isFinite(parsed) && parsed > 0 && parsed < 65536 ? parsed : 37990;
+    } else {
+      port = 37990;
+      writeFileSync(portPath, String(port), { encoding: 'utf-8', mode: 0o600 });
+    }
+
+    // 4. Resolve the claude CLI path NOW (not at daemon start) so launchd/
+    //    systemd don't have to figure out PATH — their environments are
+    //    minimal and often miss ~/.local/bin or volta shims.
+    const claudePath = resolveClaudeCliPath() ?? 'claude';
+
+    // 5. Register the service definition + start it.
+    if (process.platform === 'darwin') {
+      const launchResult = installLaunchdAgent(scriptPath, port, bridgeToken, claudePath);
+      if (!launchResult.ok) {
+        return {
+          ok: false,
+          bridgeUrl: '',
+          bridgeToken: '',
+          message: `failed to install launchd agent: ${launchResult.message}`,
+        };
+      }
+    } else if (process.platform === 'linux') {
+      const systemdResult = installSystemdUnit(scriptPath, port, bridgeToken, claudePath);
+      if (!systemdResult.ok) {
+        return {
+          ok: false,
+          bridgeUrl: '',
+          bridgeToken: '',
+          message: `failed to install systemd user unit: ${systemdResult.message}`,
+        };
+      }
+    } else {
+      return {
+        ok: false,
+        bridgeUrl: '',
+        bridgeToken: '',
+        message: `host-bridge auto-install not supported on ${process.platform} — run the bridge manually: node ${scriptPath} --port ${port} --token <see ${tokenPath}>`,
+      };
+    }
+
+    // 5. Wait briefly for the bridge to bind and verify it answers.
+    const reachable = waitForBridge(port, 6000);
+    if (!reachable.ok) {
+      return {
+        ok: false,
+        bridgeUrl: '',
+        bridgeToken: '',
+        message: `bridge service started but is not answering on 127.0.0.1:${port} (${reachable.message})`,
+      };
+    }
+
+    return {
+      ok: true,
+      bridgeUrl: `http://host.docker.internal:${port}`,
+      bridgeToken,
+      message: `Bridge running on 127.0.0.1:${port}; container connects via host.docker.internal`,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      bridgeUrl: '',
+      bridgeToken: '',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function claudeCliReachable(): boolean {
+  return resolveClaudeCliPath() !== null;
+}
+
+// Returns the absolute path to the host's `claude` binary, or null when
+// not on PATH. Used at install time so the daemon ExecStart references
+// the binary directly — launchd/systemd start with a minimal PATH and
+// won't find binaries in non-standard locations like ~/.local/bin.
+function resolveClaudeCliPath(): string | null {
+  try {
+    const which = spawnSync(process.platform === 'win32' ? 'where' : 'which', ['claude'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    if (which.status !== 0) return null;
+    const out = (which.stdout ?? '').trim();
+    if (!out) return null;
+    return out.split('\n')[0]?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function installLaunchdAgent(
+  scriptPath: string,
+  port: number,
+  token: string,
+  claudePath: string,
+): { ok: boolean; message: string } {
+  const home = homedir();
+  const agentsDir = join(home, 'Library', 'LaunchAgents');
+  if (!existsSync(agentsDir)) {
+    mkdirSync(agentsDir, { recursive: true });
+  }
+  const plistPath = join(agentsDir, `${LAUNCHD_LABEL}.plist`);
+  const logPath = join(paths.logsDir(), 'host-bridge.log');
+  if (!existsSync(paths.logsDir())) {
+    mkdirSync(paths.logsDir(), { recursive: true });
+  }
+
+  const plist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LAUNCHD_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${process.execPath}</string>
+    <string>${scriptPath}</string>
+    <string>--port</string>
+    <string>${port}</string>
+    <string>--token</string>
+    <string>${token}</string>
+    <string>--claude-path</string>
+    <string>${claudePath}</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>${logPath}</string>
+  <key>StandardErrorPath</key>
+  <string>${logPath}</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>${require('path').dirname(claudePath)}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+</dict>
+</plist>
+`;
+  try {
+    writeFileSync(plistPath, plist, { encoding: 'utf-8', mode: 0o644 });
+    // Unload first so changes to the plist (script path, port) take effect.
+    spawnSync('launchctl', ['unload', plistPath], { stdio: 'ignore' });
+    const load = spawnSync('launchctl', ['load', plistPath], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf-8',
+    });
+    if (load.status !== 0) {
+      return {
+        ok: false,
+        message: `launchctl load returned ${load.status}: ${(load.stderr ?? '').trim() || '(no stderr)'}`,
+      };
+    }
+    return { ok: true, message: `launchd agent ${LAUNCHD_LABEL} loaded` };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function installSystemdUnit(
+  scriptPath: string,
+  port: number,
+  token: string,
+  claudePath: string,
+): { ok: boolean; message: string } {
+  const home = homedir();
+  const unitDir = join(home, '.config', 'systemd', 'user');
+  if (!existsSync(unitDir)) {
+    mkdirSync(unitDir, { recursive: true });
+  }
+  const unitPath = join(unitDir, SYSTEMD_UNIT_NAME);
+
+  const unit = `[Unit]
+Description=claude-mem Claude CLI host-bridge
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=${process.execPath} ${scriptPath} --port ${port} --token ${token} --claude-path ${claudePath}
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+`;
+  try {
+    writeFileSync(unitPath, unit, { encoding: 'utf-8', mode: 0o644 });
+    spawnSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'ignore' });
+    spawnSync('systemctl', ['--user', 'enable', SYSTEMD_UNIT_NAME], { stdio: 'ignore' });
+    const start = spawnSync('systemctl', ['--user', 'restart', SYSTEMD_UNIT_NAME], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf-8',
+    });
+    if (start.status !== 0) {
+      return {
+        ok: false,
+        message: `systemctl restart returned ${start.status}: ${(start.stderr ?? '').trim() || '(no stderr)'}`,
+      };
+    }
+    return { ok: true, message: `systemd user unit ${SYSTEMD_UNIT_NAME} active` };
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function waitForBridge(port: number, timeoutMs: number): { ok: boolean; message: string } {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = 'timeout';
+  while (Date.now() < deadline) {
+    try {
+      const result = execSync(`curl -sS -o /dev/null -w '%{http_code}' http://127.0.0.1:${port}/healthz`, {
+        encoding: 'utf-8',
+        timeout: 1500,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }).trim();
+      if (result === '200') {
+        return { ok: true, message: 'healthz returned 200' };
+      }
+      lastError = `healthz returned ${result}`;
+    } catch (err) {
+      lastError = err instanceof Error ? err.message : String(err);
+    }
+    // Poll loop without `await`: install code runs synchronously.
+    spawnSync(process.execPath, ['-e', 'setTimeout(()=>process.exit(0),200)'], {
+      stdio: 'ignore',
+    });
+  }
+  return { ok: false, message: lastError };
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  function _logRef() {
+    logger.debug('SYSTEM', 'waitForBridge done', { port });
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The bridge script itself. Embedded here as a string template so the install
+// flow can drop a fresh copy on every install (idempotent). The script is a
+// standalone Node program — no dependencies on the rest of the codebase —
+// so it stays small and self-contained.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const BRIDGE_SCRIPT_SOURCE = `#!/usr/bin/env node
+// claude-mem Claude host-bridge — see src/services/install/claude-host-bridge.ts.
+// Listens on 127.0.0.1:<port> and accepts authenticated POST /v1/generate
+// requests. Shells out to the local 'claude' CLI for each request so the
+// host's current account, token, and model selection are always used.
+
+const http = require('http');
+const { spawn } = require('child_process');
+
+const args = process.argv.slice(2);
+function flag(name) {
+  const idx = args.indexOf('--' + name);
+  return idx >= 0 ? args[idx + 1] : undefined;
+}
+const PORT = Number.parseInt(flag('port') || '37990', 10);
+const TOKEN = flag('token') || '';
+// Resolved at install time so the daemon doesn't have to figure out PATH.
+// Defaults to 'claude' if not provided — will work when on PATH, otherwise
+// returns a clear ENOENT.
+const CLAUDE_BIN = flag('claude-path') || 'claude';
+if (!TOKEN) {
+  console.error('[host-bridge] --token is required');
+  process.exit(2);
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+    req.on('error', reject);
+  });
+}
+
+async function handleGenerate(req, res) {
+  const auth = req.headers.authorization || '';
+  if (!auth.startsWith('Bearer ') || auth.slice(7) !== TOKEN) {
+    res.writeHead(401, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Unauthorized' }));
+    return;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(await readBody(req));
+  } catch {
+    res.writeHead(400, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: 'ValidationError', message: 'invalid JSON body' }));
+    return;
+  }
+  const prompt = typeof parsed.prompt === 'string' ? parsed.prompt : '';
+  const model = typeof parsed.model === 'string' && parsed.model.length > 0 ? parsed.model : undefined;
+  if (!prompt) {
+    res.writeHead(400, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: 'ValidationError', message: 'prompt required' }));
+    return;
+  }
+
+  // Invoke the local claude CLI in non-interactive mode. The CLI handles
+  // auth via Keychain / .credentials.json transparently.
+  const cliArgs = ['--print', '--output-format', 'text'];
+  if (model) cliArgs.push('--model', model);
+  const child = spawn(CLAUDE_BIN, cliArgs, { stdio: ['pipe', 'pipe', 'pipe'] });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', (c) => { stdout += c.toString('utf-8'); });
+  child.stderr.on('data', (c) => { stderr += c.toString('utf-8'); });
+  child.on('error', (err) => {
+    res.writeHead(500, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: 'BridgeError', message: 'failed to spawn claude: ' + err.message }));
+  });
+  child.on('exit', (code) => {
+    if (code !== 0) {
+      res.writeHead(502, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        error: 'ClaudeCliError',
+        exitCode: code,
+        stderr: stderr.slice(-2000),
+      }));
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ text: stdout }));
+  });
+  child.stdin.end(prompt);
+}
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'GET' && req.url === '/healthz') {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true, runtime: 'host-bridge' }));
+    return;
+  }
+  if (req.method === 'POST' && req.url === '/v1/generate') {
+    await handleGenerate(req, res);
+    return;
+  }
+  res.writeHead(404, { 'content-type': 'application/json' });
+  res.end(JSON.stringify({ error: 'NotFound' }));
+});
+server.listen(PORT, '127.0.0.1', () => {
+  console.log('[host-bridge] listening on 127.0.0.1:' + PORT);
+});
+`;

--- a/src/services/install/claude-host-bridge.ts
+++ b/src/services/install/claude-host-bridge.ts
@@ -36,6 +36,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  unlinkSync,
   writeFileSync,
 } from 'fs';
 import { homedir } from 'os';
@@ -189,10 +190,7 @@ export function stopClaudeHostBridge(): { ok: boolean; message: string; removedF
       if (existsSync(plistPath)) {
         spawnSync('launchctl', ['unload', plistPath], { stdio: 'ignore' });
         try {
-          // unlinkSync via require avoided — use writeFileSync to /dev/null is
-          // not portable; just rely on fs.unlinkSync via dynamic require if
-          // unavailable as a top-level import here.
-          require('fs').unlinkSync(plistPath);
+          unlinkSync(plistPath);
           removedFiles.push(plistPath);
         } catch { /* already gone */ }
       }
@@ -203,7 +201,7 @@ export function stopClaudeHostBridge(): { ok: boolean; message: string; removedF
         spawnSync('systemctl', ['--user', 'stop', SYSTEMD_UNIT_NAME], { stdio: 'ignore' });
         spawnSync('systemctl', ['--user', 'disable', SYSTEMD_UNIT_NAME], { stdio: 'ignore' });
         try {
-          require('fs').unlinkSync(unitPath);
+          unlinkSync(unitPath);
           removedFiles.push(unitPath);
         } catch { /* already gone */ }
         spawnSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'ignore' });
@@ -215,7 +213,7 @@ export function stopClaudeHostBridge(): { ok: boolean; message: string; removedF
     const portPath = join(paths.dataDir(), 'host-bridge-port');
     for (const f of [tokenPath, portPath]) {
       if (existsSync(f)) {
-        try { require('fs').unlinkSync(f); removedFiles.push(f); } catch { /* */ }
+        try { unlinkSync(f); removedFiles.push(f); } catch { /* */ }
       }
     }
     return {

--- a/src/services/install/claude-host-bridge.ts
+++ b/src/services/install/claude-host-bridge.ts
@@ -39,7 +39,7 @@ import {
   writeFileSync,
 } from 'fs';
 import { homedir } from 'os';
-import { join } from 'path';
+import { dirname, join } from 'path';
 import { randomBytes } from 'crypto';
 import { paths } from '../../shared/paths.js';
 import { logger } from '../../utils/logger.js';
@@ -120,7 +120,7 @@ export function ensureClaudeHostBridge(): HostBridgeResult {
 
     // 5. Register the service definition + start it.
     if (process.platform === 'darwin') {
-      const launchResult = installLaunchdAgent(scriptPath, port, bridgeToken, claudePath);
+      const launchResult = installLaunchdAgent(scriptPath, port, tokenPath, claudePath);
       if (!launchResult.ok) {
         return {
           ok: false,
@@ -130,7 +130,7 @@ export function ensureClaudeHostBridge(): HostBridgeResult {
         };
       }
     } else if (process.platform === 'linux') {
-      const systemdResult = installSystemdUnit(scriptPath, port, bridgeToken, claudePath);
+      const systemdResult = installSystemdUnit(scriptPath, port, tokenPath, claudePath);
       if (!systemdResult.ok) {
         return {
           ok: false,
@@ -201,7 +201,7 @@ function resolveClaudeCliPath(): string | null {
 function installLaunchdAgent(
   scriptPath: string,
   port: number,
-  token: string,
+  tokenPath: string,
   claudePath: string,
 ): { ok: boolean; message: string } {
   const home = homedir();
@@ -227,8 +227,8 @@ function installLaunchdAgent(
     <string>${scriptPath}</string>
     <string>--port</string>
     <string>${port}</string>
-    <string>--token</string>
-    <string>${token}</string>
+    <string>--token-file</string>
+    <string>${tokenPath}</string>
     <string>--claude-path</string>
     <string>${claudePath}</string>
   </array>
@@ -243,13 +243,13 @@ function installLaunchdAgent(
   <key>EnvironmentVariables</key>
   <dict>
     <key>PATH</key>
-    <string>${require('path').dirname(claudePath)}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <string>${dirname(claudePath)}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
   </dict>
 </dict>
 </plist>
 `;
   try {
-    writeFileSync(plistPath, plist, { encoding: 'utf-8', mode: 0o644 });
+    writeFileSync(plistPath, plist, { encoding: 'utf-8', mode: 0o600 });
     // Unload first so changes to the plist (script path, port) take effect.
     spawnSync('launchctl', ['unload', plistPath], { stdio: 'ignore' });
     const load = spawnSync('launchctl', ['load', plistPath], {
@@ -271,7 +271,7 @@ function installLaunchdAgent(
 function installSystemdUnit(
   scriptPath: string,
   port: number,
-  token: string,
+  tokenPath: string,
   claudePath: string,
 ): { ok: boolean; message: string } {
   const home = homedir();
@@ -287,7 +287,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=${process.execPath} ${scriptPath} --port ${port} --token ${token} --claude-path ${claudePath}
+ExecStart=${process.execPath} ${scriptPath} --port ${port} --token-file ${tokenPath} --claude-path ${claudePath}
 Restart=always
 RestartSec=5
 
@@ -295,7 +295,7 @@ RestartSec=5
 WantedBy=default.target
 `;
   try {
-    writeFileSync(unitPath, unit, { encoding: 'utf-8', mode: 0o644 });
+    writeFileSync(unitPath, unit, { encoding: 'utf-8', mode: 0o600 });
     spawnSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'ignore' });
     spawnSync('systemctl', ['--user', 'enable', SYSTEMD_UNIT_NAME], { stdio: 'ignore' });
     const start = spawnSync('systemctl', ['--user', 'restart', SYSTEMD_UNIT_NAME], {
@@ -337,10 +337,6 @@ function waitForBridge(port: number, timeoutMs: number): { ok: boolean; message:
     });
   }
   return { ok: false, message: lastError };
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  function _logRef() {
-    logger.debug('SYSTEM', 'waitForBridge done', { port });
-  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -365,13 +361,30 @@ function flag(name) {
   return idx >= 0 ? args[idx + 1] : undefined;
 }
 const PORT = Number.parseInt(flag('port') || '37990', 10);
-const TOKEN = flag('token') || '';
+// Token is read from a file rather than passed as a CLI argument so it
+// doesn't show up in 'ps' / /proc/<pid>/cmdline for any local user.
+// --token <value> still works for back-compat but logs a warning.
+const TOKEN_FILE = flag('token-file') || '';
+let TOKEN = '';
+if (TOKEN_FILE) {
+  try {
+    TOKEN = require('fs').readFileSync(TOKEN_FILE, 'utf-8').trim();
+  } catch (err) {
+    console.error('[host-bridge] failed to read --token-file:', err && err.message);
+    process.exit(2);
+  }
+} else {
+  TOKEN = flag('token') || '';
+  if (TOKEN) {
+    console.error('[host-bridge] WARN: --token via CLI arg is visible in ps; prefer --token-file');
+  }
+}
 // Resolved at install time so the daemon doesn't have to figure out PATH.
 // Defaults to 'claude' if not provided — will work when on PATH, otherwise
 // returns a clear ENOENT.
 const CLAUDE_BIN = flag('claude-path') || 'claude';
 if (!TOKEN) {
-  console.error('[host-bridge] --token is required');
+  console.error('[host-bridge] --token-file or --token is required');
   process.exit(2);
 }
 

--- a/src/services/install/ide-mcp-injection.ts
+++ b/src/services/install/ide-mcp-injection.ts
@@ -1,0 +1,628 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// multi-IDE MCP config injection for server-beta runtime.
+//
+// When the operator installs claude-mem with --runtime server-beta, the server
+// runs in Docker. To make the in-Docker server reachable as an MCP server from
+// the operator's IDEs (Claude Desktop, Claude Code, OpenCode, Codex CLI), we
+// inject a `claude-mem` entry into each IDE's MCP configuration that points
+// at the local mcp-server.cjs script (which itself routes to the server-beta
+// HTTP API via the server-beta runtime selector).
+//
+// Per-IDE behaviour (idempotent):
+//   - Claude Desktop:  ~/Library/Application Support/Claude/claude_desktop_config.json (macOS)
+//                      Linux/Win paths also supported. Backup created on first write.
+//   - Claude Code:     handled by /plugin install — this module only VERIFIES.
+//   - OpenCode:        ~/.config/opencode/opencode.json — adds mcpServers entry.
+//   - Codex CLI:       ~/.codex/config.toml — adds [mcp_servers.claude-mem] block.
+//
+// Each function returns InjectionResult so the caller can surface granular
+// outcomes (skipped if IDE absent, written, already-up-to-date, failed) in the
+// install summary.
+//
+// SAFETY: every mutator backs up the target file to <file>.pre-claude-mem-N.bak
+// where N is the smallest unused integer. Rollback uses the newest backup.
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'fs';
+import { homedir, platform } from 'os';
+import { dirname, join } from 'path';
+
+export type InjectionStatus = 'written' | 'already-current' | 'skipped' | 'failed';
+
+export interface InjectionResult {
+  ide: string;
+  configPath: string;
+  status: InjectionStatus;
+  backupPath?: string;
+  message?: string;
+}
+
+export interface McpServerEntry {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+// ---------------------------------------------------------------------------
+// Backup helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a backup of `targetPath` at `<targetPath>.pre-claude-mem-N.bak`
+ * where N is the smallest unused integer >= 1. Idempotent: a noop if the
+ * file does not exist.
+ *
+ * Returns the backup path (or undefined if no backup was made).
+ */
+export function backupFile(targetPath: string): string | undefined {
+  if (!existsSync(targetPath)) return undefined;
+
+  const dir = dirname(targetPath);
+  const base = targetPath.slice(dir.length + 1);
+  let n = 1;
+  let backupPath = join(dir, `${base}.pre-claude-mem-${n}.bak`);
+  while (existsSync(backupPath)) {
+    n += 1;
+    backupPath = join(dir, `${base}.pre-claude-mem-${n}.bak`);
+    if (n > 999) {
+      // Defence against runaway numbering — extremely unlikely.
+      throw new Error(`Too many backups for ${targetPath}; clean up old .pre-claude-mem-*.bak files`);
+    }
+  }
+  const content = readFileSync(targetPath);
+  writeFileSync(backupPath, content);
+  return backupPath;
+}
+
+/**
+ * Find the newest pre-claude-mem backup for `targetPath`. Returns undefined if
+ * none exist. Used by rollback.
+ */
+export function findNewestBackup(targetPath: string): string | undefined {
+  const dir = dirname(targetPath);
+  if (!existsSync(dir)) return undefined;
+  const base = targetPath.slice(dir.length + 1);
+  const pattern = new RegExp(`^${base.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}\\.pre-claude-mem-(\\d+)\\.bak$`);
+  let bestN = 0;
+  let bestPath: string | undefined;
+  try {
+    for (const entry of readdirSync(dir)) {
+      const m = entry.match(pattern);
+      if (!m) continue;
+      const n = Number(m[1]);
+      if (n > bestN) {
+        bestN = n;
+        bestPath = join(dir, entry);
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  return bestPath;
+}
+
+// ---------------------------------------------------------------------------
+// JSON config helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge a `claude-mem` MCP server entry into a JSON config file under the
+ * given `serversKey` (e.g. `mcpServers` or `servers`). Backs up the existing
+ * file before writing. Returns a status describing the outcome.
+ */
+export function injectMcpEntryIntoJsonConfig(args: {
+  ide: string;
+  configPath: string;
+  serversKey: string;
+  entry: McpServerEntry;
+}): InjectionResult {
+  const { ide, configPath, serversKey, entry } = args;
+
+  try {
+    const parentDir = dirname(configPath);
+    mkdirSync(parentDir, { recursive: true });
+
+    let existing: Record<string, unknown> = {};
+    if (existsSync(configPath)) {
+      try {
+        const raw = readFileSync(configPath, 'utf-8');
+        const parsed = raw.trim() ? JSON.parse(raw) : {};
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          existing = parsed as Record<string, unknown>;
+        }
+      } catch (err) {
+        return {
+          ide,
+          configPath,
+          status: 'failed',
+          message: `Could not parse existing config: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    }
+
+    const serversRaw = existing[serversKey];
+    const servers: Record<string, McpServerEntry> =
+      serversRaw && typeof serversRaw === 'object' && !Array.isArray(serversRaw)
+        ? (serversRaw as Record<string, McpServerEntry>)
+        : {};
+
+    const current = servers['claude-mem'];
+    if (current && mcpEntriesEqual(current, entry)) {
+      return { ide, configPath, status: 'already-current' };
+    }
+
+    const backupPath = backupFile(configPath);
+    servers['claude-mem'] = entry;
+    existing[serversKey] = servers;
+    writeFileSync(configPath, JSON.stringify(existing, null, 2) + '\n', 'utf-8');
+
+    return { ide, configPath, status: 'written', backupPath };
+  } catch (err) {
+    return {
+      ide,
+      configPath,
+      status: 'failed',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function mcpEntriesEqual(a: McpServerEntry, b: McpServerEntry): boolean {
+  if (a.command !== b.command) return false;
+  if ((a.args ?? []).length !== (b.args ?? []).length) return false;
+  for (let i = 0; i < (a.args ?? []).length; i++) {
+    if (a.args[i] !== b.args[i]) return false;
+  }
+  const aEnv = a.env ?? {};
+  const bEnv = b.env ?? {};
+  const aKeys = Object.keys(aEnv).sort();
+  const bKeys = Object.keys(bEnv).sort();
+  if (aKeys.length !== bKeys.length) return false;
+  for (const k of aKeys) {
+    if (aEnv[k] !== bEnv[k]) return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// TOML helpers (Codex CLI)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a minimal subset of TOML — enough to detect whether
+ * `[mcp_servers.claude-mem]` already exists. Returns the start/end indexes of
+ * that block in the original string, or null if it does not exist.
+ *
+ * We do not need a full TOML parser; we just need to write/replace one block.
+ */
+export function findCodexBlockRange(toml: string, table: string): { start: number; end: number } | null {
+  // Match a line containing only the table header (allowing trailing comments).
+  const headerRegex = new RegExp(`^\\[${table.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}\\]\\s*(#.*)?$`, 'm');
+  const match = headerRegex.exec(toml);
+  if (!match) return null;
+
+  const start = match.index;
+  // The block ends just before the next [...table...] header or EOF.
+  const nextHeaderRegex = /^\[/m;
+  nextHeaderRegex.lastIndex = start + match[0].length + 1;
+  let end = toml.length;
+  const tail = toml.slice(start + match[0].length);
+  const next = /\n\[/.exec(tail);
+  if (next) {
+    end = start + match[0].length + next.index + 1; // include the '\n' before next header
+  }
+  return { start, end };
+}
+
+/**
+ * Serialize an MCP server entry as a TOML block under
+ * `[mcp_servers.claude-mem]`.
+ */
+export function serializeCodexMcpBlock(entry: McpServerEntry): string {
+  const lines: string[] = [];
+  lines.push(`[mcp_servers.claude-mem]`);
+  lines.push(`command = ${JSON.stringify(entry.command)}`);
+  const argsLiteral = entry.args.map((a) => JSON.stringify(a)).join(', ');
+  lines.push(`args = [${argsLiteral}]`);
+  if (entry.env && Object.keys(entry.env).length > 0) {
+    const envInline = Object.entries(entry.env)
+      .map(([k, v]) => `${tomlBareKey(k)} = ${JSON.stringify(v)}`)
+      .join(', ');
+    lines.push(`env = { ${envInline} }`);
+  }
+  return lines.join('\n') + '\n';
+}
+
+function tomlBareKey(key: string): string {
+  // Bare keys must match [A-Za-z0-9_-]+; otherwise quote.
+  return /^[A-Za-z0-9_-]+$/.test(key) ? key : JSON.stringify(key);
+}
+
+/**
+ * Inject (or replace) a `[mcp_servers.claude-mem]` block in a Codex CLI
+ * config.toml file.
+ */
+export function injectCodexMcpBlock(args: {
+  configPath: string;
+  entry: McpServerEntry;
+}): InjectionResult {
+  const { configPath, entry } = args;
+  const ide = 'codex-cli';
+  try {
+    const parentDir = dirname(configPath);
+    mkdirSync(parentDir, { recursive: true });
+
+    let existing = '';
+    if (existsSync(configPath)) {
+      existing = readFileSync(configPath, 'utf-8');
+    }
+
+    const newBlock = serializeCodexMcpBlock(entry);
+
+    const range = findCodexBlockRange(existing, 'mcp_servers.claude-mem');
+    if (range) {
+      const currentBlock = existing.slice(range.start, range.end);
+      if (currentBlock.trim() === newBlock.trim()) {
+        return { ide, configPath, status: 'already-current' };
+      }
+      const backupPath = backupFile(configPath);
+      const before = existing.slice(0, range.start).replace(/\n+$/, '');
+      const after = existing.slice(range.end).replace(/^\n+/, '');
+      const merged =
+        (before ? before + '\n\n' : '') +
+        newBlock +
+        (after ? '\n' + after : '');
+      writeFileSync(configPath, merged, 'utf-8');
+      return { ide, configPath, status: 'written', backupPath };
+    }
+
+    const backupPath = backupFile(configPath);
+    const merged = (existing.trim() ? existing.trimEnd() + '\n\n' : '') + newBlock;
+    writeFileSync(configPath, merged, 'utf-8');
+    return { ide, configPath, status: 'written', backupPath };
+  } catch (err) {
+    return {
+      ide,
+      configPath,
+      status: 'failed',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-IDE config path resolution
+// ---------------------------------------------------------------------------
+
+export function claudeDesktopConfigPath(): string {
+  const home = homedir();
+  const p = platform();
+  if (p === 'darwin') {
+    return join(home, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
+  }
+  if (p === 'win32') {
+    const appData = process.env.APPDATA ?? join(home, 'AppData', 'Roaming');
+    return join(appData, 'Claude', 'claude_desktop_config.json');
+  }
+  // Linux + others — Claude Desktop is not officially supported on Linux yet,
+  // but follow the documented config path for forward-compat.
+  return join(home, '.config', 'Claude', 'claude_desktop_config.json');
+}
+
+export function openCodeConfigPath(): string {
+  if (process.env.OPENCODE_CONFIG_DIR) {
+    return join(process.env.OPENCODE_CONFIG_DIR, 'opencode.json');
+  }
+  return join(homedir(), '.config', 'opencode', 'opencode.json');
+}
+
+export function codexCliConfigPath(): string {
+  return join(homedir(), '.codex', 'config.toml');
+}
+
+/**
+ * Returns true when the marketplace plugin file is already registered.
+ * For Claude Code, the /plugin install path handles registration; this is
+ * just a verifier we call at the end of setup.
+ */
+export function claudeCodePluginInstalled(marketplaceDir: string): boolean {
+  return existsSync(join(marketplaceDir, 'plugin', '.claude-plugin', 'plugin.json'));
+}
+
+// ---------------------------------------------------------------------------
+// Detection — match the existing ide-detection.ts policy. We only inject when
+// either the config dir exists OR the CLI is on PATH (when applicable).
+// ---------------------------------------------------------------------------
+
+export function detectClaudeDesktop(): boolean {
+  // Presence of any of the per-platform config dirs counts as "installed"
+  // because Claude Desktop creates the dir on first run.
+  return existsSync(dirname(claudeDesktopConfigPath()));
+}
+
+export function detectOpenCode(): boolean {
+  return existsSync(join(homedir(), '.config', 'opencode')) || isCommandOnPath('opencode');
+}
+
+export function detectCodexCli(): boolean {
+  return existsSync(join(homedir(), '.codex')) || isCommandOnPath('codex');
+}
+
+function isCommandOnPath(cmd: string): boolean {
+  try {
+    const PATH = process.env.PATH ?? '';
+    const sep = process.platform === 'win32' ? ';' : ':';
+    const exts = process.platform === 'win32' ? ['.exe', '.cmd', '.bat', ''] : [''];
+    for (const dir of PATH.split(sep)) {
+      if (!dir) continue;
+      for (const ext of exts) {
+        if (existsSync(join(dir, cmd + ext))) return true;
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Aggregate entry point — used by setupServerBeta()
+// ---------------------------------------------------------------------------
+
+export interface InjectAllOptions {
+  /** Path to plugin/scripts/mcp-server.cjs */
+  mcpServerPath: string;
+  /** Path to ~/.claude/plugins/marketplaces/thedotmack for Claude Code verify. */
+  marketplaceDir: string;
+  /**
+   * Comma-separated list of IDE ids the operator explicitly opted into. When
+   * empty, we auto-detect; when set, missing IDEs from this list are errors,
+   * not skips.
+   */
+  optInIdes?: string[];
+  /** Env vars to pass through to the MCP server child process. */
+  childEnv?: Record<string, string>;
+}
+
+export function buildMcpEntry(mcpServerPath: string, childEnv?: Record<string, string>): McpServerEntry {
+  return {
+    command: process.execPath,
+    args: [mcpServerPath],
+    ...(childEnv && Object.keys(childEnv).length > 0 ? { env: childEnv } : {}),
+  };
+}
+
+export function injectAllIdes(options: InjectAllOptions): InjectionResult[] {
+  const entry = buildMcpEntry(options.mcpServerPath, options.childEnv);
+  const optIn = new Set(options.optInIdes ?? []);
+  const results: InjectionResult[] = [];
+
+  // --- Claude Desktop ---
+  {
+    const detected = detectClaudeDesktop();
+    const required = optIn.has('claude-desktop');
+    if (!detected && !required) {
+      results.push({ ide: 'claude-desktop', configPath: claudeDesktopConfigPath(), status: 'skipped', message: 'Claude Desktop config dir not found' });
+    } else {
+      results.push(injectMcpEntryIntoJsonConfig({
+        ide: 'claude-desktop',
+        configPath: claudeDesktopConfigPath(),
+        serversKey: 'mcpServers',
+        entry,
+      }));
+    }
+  }
+
+  // --- Claude Code (verify only) ---
+  {
+    const installed = claudeCodePluginInstalled(options.marketplaceDir);
+    results.push({
+      ide: 'claude-code',
+      configPath: join(options.marketplaceDir, 'plugin', '.claude-plugin', 'plugin.json'),
+      status: installed ? 'already-current' : 'skipped',
+      message: installed
+        ? 'Claude Code plugin already registered by /plugin install'
+        : 'Marketplace plugin.json missing — Claude Code plugin not installed',
+    });
+  }
+
+  // --- OpenCode ---
+  {
+    const detected = detectOpenCode();
+    const required = optIn.has('opencode');
+    if (!detected && !required) {
+      results.push({ ide: 'opencode', configPath: openCodeConfigPath(), status: 'skipped', message: 'OpenCode not detected' });
+    } else {
+      results.push(injectMcpEntryIntoJsonConfig({
+        ide: 'opencode',
+        configPath: openCodeConfigPath(),
+        serversKey: 'mcpServers',
+        entry,
+      }));
+      // fix — OpenCode supports plugins via its own API (not MCP).
+      // Copy our claude-mem plugin into ~/.config/opencode/plugins/ so
+      // session.created, tool.execute.before/after, message.updated, and
+      // session.idle events get auto-captured into the same memory store.
+      // Symmetric to the Claude Code plugin/hooks/hooks.json wiring.
+      installOpenCodePlugin(options.marketplaceDir);
+    }
+  }
+
+  // --- Codex CLI ---
+  {
+    const detected = detectCodexCli();
+    const required = optIn.has('codex-cli');
+    if (!detected && !required) {
+      results.push({ ide: 'codex-cli', configPath: codexCliConfigPath(), status: 'skipped', message: 'Codex CLI not detected' });
+    } else {
+      results.push(injectCodexMcpBlock({
+        configPath: codexCliConfigPath(),
+        entry,
+      }));
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Rollback — restore newest backup or remove the claude-mem entry.
+// ---------------------------------------------------------------------------
+
+export interface RollbackResult {
+  ide: string;
+  configPath: string;
+  action: 'restored' | 'removed-entry' | 'no-backup' | 'absent' | 'failed';
+  backupRestored?: string;
+  message?: string;
+}
+
+export function rollbackJsonConfig(args: {
+  ide: string;
+  configPath: string;
+  serversKey: string;
+}): RollbackResult {
+  const { ide, configPath, serversKey } = args;
+  try {
+    if (!existsSync(configPath)) {
+      return { ide, configPath, action: 'absent' };
+    }
+    const backup = findNewestBackup(configPath);
+    if (backup) {
+      const contents = readFileSync(backup);
+      writeFileSync(configPath, contents);
+      return { ide, configPath, action: 'restored', backupRestored: backup };
+    }
+    // No backup — fall back to removing only the claude-mem entry so we
+    // don't clobber user-added MCP servers.
+    const raw = readFileSync(configPath, 'utf-8');
+    const parsed = raw.trim() ? (JSON.parse(raw) as Record<string, unknown>) : {};
+    const servers = parsed[serversKey];
+    if (servers && typeof servers === 'object' && !Array.isArray(servers)) {
+      const map = servers as Record<string, unknown>;
+      if ('claude-mem' in map) {
+        delete map['claude-mem'];
+        parsed[serversKey] = map;
+        writeFileSync(configPath, JSON.stringify(parsed, null, 2) + '\n', 'utf-8');
+        return { ide, configPath, action: 'removed-entry' };
+      }
+    }
+    return { ide, configPath, action: 'no-backup', message: 'No backup found and no claude-mem entry to remove' };
+  } catch (err) {
+    return {
+      ide,
+      configPath,
+      action: 'failed',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export function rollbackCodexConfig(configPath: string): RollbackResult {
+  const ide = 'codex-cli';
+  try {
+    if (!existsSync(configPath)) {
+      return { ide, configPath, action: 'absent' };
+    }
+    const backup = findNewestBackup(configPath);
+    if (backup) {
+      const contents = readFileSync(backup);
+      writeFileSync(configPath, contents);
+      return { ide, configPath, action: 'restored', backupRestored: backup };
+    }
+    const existing = readFileSync(configPath, 'utf-8');
+    const range = findCodexBlockRange(existing, 'mcp_servers.claude-mem');
+    if (range) {
+      const before = existing.slice(0, range.start).replace(/\n+$/, '');
+      const after = existing.slice(range.end).replace(/^\n+/, '');
+      const merged = before + (after ? '\n\n' + after : '\n');
+      writeFileSync(configPath, merged.trimEnd() + '\n', 'utf-8');
+      return { ide, configPath, action: 'removed-entry' };
+    }
+    return { ide, configPath, action: 'no-backup', message: 'No backup found and no [mcp_servers.claude-mem] block to remove' };
+  } catch (err) {
+    return {
+      ide,
+      configPath,
+      action: 'failed',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export function rollbackAllIdes(): RollbackResult[] {
+  // also remove the OpenCode plugin file when uninstalling so
+  // the next OpenCode session doesn't try to POST to a dead server. Result
+  // is folded into the OpenCode rollback row so the uninstall UI stays tidy.
+  const opencodePluginRemoved = rollbackOpenCodePlugin();
+  const opencodeMcp = rollbackJsonConfig({
+    ide: 'opencode',
+    configPath: openCodeConfigPath(),
+    serversKey: 'mcpServers',
+  });
+  if (opencodePluginRemoved.removed) {
+    opencodeMcp.message = `${opencodeMcp.message ?? ''} (also removed plugin at ${opencodePluginRemoved.path})`.trim();
+  }
+  return [
+    rollbackJsonConfig({ ide: 'claude-desktop', configPath: claudeDesktopConfigPath(), serversKey: 'mcpServers' }),
+    opencodeMcp,
+    rollbackCodexConfig(codexCliConfigPath()),
+  ];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OpenCode plugin installer.
+//
+// OpenCode discovers plugins under ~/.config/opencode/plugins/. We ship a
+// single JavaScript file (plugin/opencode/claude-mem-plugin.js) that wires
+// up the OpenCode event hooks and POSTs them to the claude-mem server.
+// At install time we copy that file into the global plugins dir. On uninstall
+// we delete it via rollbackOpenCodePlugin().
+// ─────────────────────────────────────────────────────────────────────────────
+
+const OPENCODE_PLUGIN_FILENAME = 'claude-mem-plugin.js';
+
+function openCodePluginsDir(): string {
+  if (process.env.OPENCODE_CONFIG_DIR) {
+    return join(process.env.OPENCODE_CONFIG_DIR, 'plugins');
+  }
+  return join(homedir(), '.config', 'opencode', 'plugins');
+}
+
+function openCodePluginInstallPath(): string {
+  return join(openCodePluginsDir(), OPENCODE_PLUGIN_FILENAME);
+}
+
+export function installOpenCodePlugin(marketplaceDir: string): void {
+  try {
+    const source = join(marketplaceDir, 'plugin', 'opencode', OPENCODE_PLUGIN_FILENAME);
+    if (!existsSync(source)) {
+      // Plugin source missing — non-fatal; install proceeds without OpenCode
+      // hook capture. The IDE still has the MCP entry for manual search.
+      return;
+    }
+    const targetDir = openCodePluginsDir();
+    if (!existsSync(targetDir)) {
+      // mkdir + recursive — node's fs.mkdirSync is available via fs import below.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('fs').mkdirSync(targetDir, { recursive: true });
+    }
+    const target = openCodePluginInstallPath();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('fs').copyFileSync(source, target);
+  } catch {
+    // Best effort — never block install on OpenCode plugin install failure.
+  }
+}
+
+export function rollbackOpenCodePlugin(): { path: string; removed: boolean } {
+  const target = openCodePluginInstallPath();
+  if (!existsSync(target)) return { path: target, removed: false };
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('fs').unlinkSync(target);
+    return { path: target, removed: true };
+  } catch {
+    return { path: target, removed: false };
+  }
+}

--- a/src/services/install/ide-mcp-injection.ts
+++ b/src/services/install/ide-mcp-injection.ts
@@ -390,6 +390,179 @@ export function buildMcpEntry(mcpServerPath: string, childEnv?: Record<string, s
   };
 }
 
+// OpenCode uses a different MCP config schema than Claude Desktop:
+//   - Top-level key is 'mcp', not 'mcpServers'
+//   - Each entry has shape { type: 'local', command: [exec, ...args], enabled: true }
+//     instead of { command: exec, args: [...] }
+//   - Env vars live under 'environment', not 'env'
+// See https://opencode.ai/docs/mcp-servers/
+// Mixing these formats silently produces an opencode.json that OpenCode
+// rejects on load with "Unrecognized key: mcpServers".
+interface OpenCodeMcpEntry {
+  type: 'local';
+  command: string[];
+  enabled: boolean;
+  environment?: Record<string, string>;
+}
+
+function buildOpenCodeMcpEntry(
+  mcpServerPath: string,
+  childEnv?: Record<string, string>,
+): OpenCodeMcpEntry {
+  return {
+    type: 'local',
+    command: [process.execPath, mcpServerPath],
+    enabled: true,
+    ...(childEnv && Object.keys(childEnv).length > 0 ? { environment: childEnv } : {}),
+  };
+}
+
+function openCodeEntriesEqual(a: OpenCodeMcpEntry, b: OpenCodeMcpEntry): boolean {
+  if (a.type !== b.type) return false;
+  if (a.enabled !== b.enabled) return false;
+  if (a.command.length !== b.command.length) return false;
+  for (let i = 0; i < a.command.length; i++) {
+    if (a.command[i] !== b.command[i]) return false;
+  }
+  const aEnv = a.environment ?? {};
+  const bEnv = b.environment ?? {};
+  const aKeys = Object.keys(aEnv).sort();
+  const bKeys = Object.keys(bEnv).sort();
+  if (aKeys.length !== bKeys.length) return false;
+  for (const k of aKeys) {
+    if (aEnv[k] !== bEnv[k]) return false;
+  }
+  return true;
+}
+
+export function injectOpenCodeMcpEntry(args: {
+  configPath: string;
+  entry: OpenCodeMcpEntry;
+}): InjectionResult {
+  const ide = 'opencode';
+  const { configPath, entry } = args;
+  try {
+    const parentDir = dirname(configPath);
+    mkdirSync(parentDir, { recursive: true });
+
+    let existing: Record<string, unknown> = {};
+    if (existsSync(configPath)) {
+      try {
+        const raw = readFileSync(configPath, 'utf-8');
+        const parsed = raw.trim() ? JSON.parse(raw) : {};
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          existing = parsed as Record<string, unknown>;
+        }
+      } catch (err) {
+        return {
+          ide,
+          configPath,
+          status: 'failed',
+          message: `Could not parse existing config: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    }
+
+    // OpenCode's loader requires `$schema` on every config file. Adding it
+    // here means a fresh-install config is immediately valid; never overwrite
+    // when already present.
+    if (typeof existing.$schema !== 'string' || existing.$schema.length === 0) {
+      existing.$schema = 'https://opencode.ai/config.json';
+    }
+
+    const mcpRaw = existing.mcp;
+    const mcp: Record<string, OpenCodeMcpEntry> =
+      mcpRaw && typeof mcpRaw === 'object' && !Array.isArray(mcpRaw)
+        ? (mcpRaw as Record<string, OpenCodeMcpEntry>)
+        : {};
+
+    const current = mcp['claude-mem'];
+    // Idempotency: identical entry already present → no write, no new backup.
+    // Without this every re-install accumulated a .pre-claude-mem-N.bak even
+    // when nothing changed (operators were seeing 7+ backup files).
+    if (current && openCodeEntriesEqual(current, entry)) {
+      return { ide, configPath, status: 'already-current' };
+    }
+
+    // Self-heal: if the file currently has the wrong-key `mcpServers` from a
+    // pre-fix install, strip it out so OpenCode stops rejecting the whole
+    // config. The plugin file at ~/.config/opencode/plugins/claude-mem.js
+    // carries our actual capture path; dropping a stale mcpServers entry
+    // never loses functional state.
+    if ('mcpServers' in existing) {
+      delete (existing as Record<string, unknown>).mcpServers;
+    }
+
+    const backupPath = backupFile(configPath);
+    mcp['claude-mem'] = entry;
+    existing.mcp = mcp;
+    writeFileSync(configPath, JSON.stringify(existing, null, 2) + '\n', 'utf-8');
+    return { ide, configPath, status: 'written', backupPath };
+  } catch (err) {
+    return {
+      ide,
+      configPath,
+      status: 'failed',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export function rollbackOpenCodeMcpEntry(configPath: string): RollbackResult {
+  const ide = 'opencode';
+  try {
+    if (!existsSync(configPath)) {
+      return { ide, configPath, action: 'absent' };
+    }
+    const backup = findNewestBackup(configPath);
+    if (backup) {
+      const contents = readFileSync(backup);
+      writeFileSync(configPath, contents);
+      return { ide, configPath, action: 'restored', backupRestored: backup };
+    }
+    const raw = readFileSync(configPath, 'utf-8');
+    const parsed = raw.trim() ? (JSON.parse(raw) as Record<string, unknown>) : {};
+    let removed = false;
+    // Drop claude-mem from `mcp` (the canonical OpenCode key).
+    const mcp = parsed.mcp;
+    if (mcp && typeof mcp === 'object' && !Array.isArray(mcp)) {
+      const map = mcp as Record<string, unknown>;
+      if ('claude-mem' in map) {
+        delete map['claude-mem'];
+        parsed.mcp = map;
+        removed = true;
+      }
+    }
+    // Also clean up the broken `mcpServers` key if a pre-fix install left
+    // one behind. Mirrors the self-heal in the inject path.
+    const broken = parsed.mcpServers;
+    if (broken && typeof broken === 'object' && !Array.isArray(broken)) {
+      const map = broken as Record<string, unknown>;
+      if ('claude-mem' in map) {
+        delete map['claude-mem'];
+        parsed.mcpServers = map;
+        removed = true;
+      }
+      if (Object.keys(map).length === 0) {
+        delete (parsed as Record<string, unknown>).mcpServers;
+        removed = true;
+      }
+    }
+    if (removed) {
+      writeFileSync(configPath, JSON.stringify(parsed, null, 2) + '\n', 'utf-8');
+      return { ide, configPath, action: 'removed-entry' };
+    }
+    return { ide, configPath, action: 'no-backup', message: 'No backup found and no claude-mem entry to remove' };
+  } catch (err) {
+    return {
+      ide,
+      configPath,
+      action: 'failed',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
 export function injectAllIdes(options: InjectAllOptions): InjectionResult[] {
   const entry = buildMcpEntry(options.mcpServerPath, options.childEnv);
   const optIn = new Set(options.optInIdes ?? []);
@@ -431,11 +604,9 @@ export function injectAllIdes(options: InjectAllOptions): InjectionResult[] {
     if (!detected && !required) {
       results.push({ ide: 'opencode', configPath: openCodeConfigPath(), status: 'skipped', message: 'OpenCode not detected' });
     } else {
-      results.push(injectMcpEntryIntoJsonConfig({
-        ide: 'opencode',
+      results.push(injectOpenCodeMcpEntry({
         configPath: openCodeConfigPath(),
-        serversKey: 'mcpServers',
-        entry,
+        entry: buildOpenCodeMcpEntry(options.mcpServerPath, options.childEnv),
       }));
       // fix — OpenCode supports plugins via its own API (not MCP).
       // Copy our claude-mem plugin into ~/.config/opencode/plugins/ so
@@ -553,11 +724,7 @@ export function rollbackAllIdes(): RollbackResult[] {
   // the next OpenCode session doesn't try to POST to a dead server. Result
   // is folded into the OpenCode rollback row so the uninstall UI stays tidy.
   const opencodePluginRemoved = rollbackOpenCodePlugin();
-  const opencodeMcp = rollbackJsonConfig({
-    ide: 'opencode',
-    configPath: openCodeConfigPath(),
-    serversKey: 'mcpServers',
-  });
+  const opencodeMcp = rollbackOpenCodeMcpEntry(openCodeConfigPath());
   if (opencodePluginRemoved.removed) {
     opencodeMcp.message = `${opencodeMcp.message ?? ''} (also removed plugin at ${opencodePluginRemoved.path})`.trim();
   }

--- a/src/services/install/ide-mcp-injection.ts
+++ b/src/services/install/ide-mcp-injection.ts
@@ -23,7 +23,7 @@
 // SAFETY: every mutator backs up the target file to <file>.pre-claude-mem-N.bak
 // where N is the smallest unused integer. Rollback uses the newest backup.
 
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'fs';
+import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from 'fs';
 import { homedir, platform } from 'os';
 import { dirname, join } from 'path';
 
@@ -203,8 +203,6 @@ export function findCodexBlockRange(toml: string, table: string): { start: numbe
 
   const start = match.index;
   // The block ends just before the next [...table...] header or EOF.
-  const nextHeaderRegex = /^\[/m;
-  nextHeaderRegex.lastIndex = start + match[0].length + 1;
   let end = toml.length;
   const tail = toml.slice(start + match[0].length);
   const next = /\n\[/.exec(tail);
@@ -603,13 +601,10 @@ export function installOpenCodePlugin(marketplaceDir: string): void {
     }
     const targetDir = openCodePluginsDir();
     if (!existsSync(targetDir)) {
-      // mkdir + recursive — node's fs.mkdirSync is available via fs import below.
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      require('fs').mkdirSync(targetDir, { recursive: true });
+      mkdirSync(targetDir, { recursive: true });
     }
     const target = openCodePluginInstallPath();
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    require('fs').copyFileSync(source, target);
+    copyFileSync(source, target);
   } catch {
     // Best effort — never block install on OpenCode plugin install failure.
   }
@@ -619,8 +614,7 @@ export function rollbackOpenCodePlugin(): { path: string; removed: boolean } {
   const target = openCodePluginInstallPath();
   if (!existsSync(target)) return { path: target, removed: false };
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    require('fs').unlinkSync(target);
+    unlinkSync(target);
     return { path: target, removed: true };
   } catch {
     return { path: target, removed: false };

--- a/src/services/install/server-beta-rollback.ts
+++ b/src/services/install/server-beta-rollback.ts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// rollback path for `claude-mem uninstall --runtime server-beta`.
+//
+// Tears down the Docker stack, restores per-IDE MCP config backups, and
+// reverts the CLAUDE_MEM_RUNTIME setting. Data is preserved by default:
+//   - Volumes survive unless --purge-data
+//   - .env survives unless --purge-data
+//   - settings.json server-beta keys (API key, project id) are removed but
+//     other settings stay intact.
+
+import { spawnSync } from 'child_process';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { paths } from '../../shared/paths.js';
+import {
+  parseEnvFile,
+} from './server-beta-setup.js';
+import {
+  rollbackAllIdes,
+  type RollbackResult,
+} from './ide-mcp-injection.js';
+
+export interface RollbackOptions {
+  marketplaceDir: string;
+  purgeData?: boolean;
+  dryRun?: boolean;
+  dockerBin?: string;
+  logger?: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+    success: (msg: string) => void;
+  };
+}
+
+export interface RollbackOutcome {
+  ok: boolean;
+  dryRun: boolean;
+  steps: Array<{ step: string; status: 'ok' | 'failed' | 'skipped'; message?: string }>;
+  ideResults?: RollbackResult[];
+}
+
+function noopLogger() {
+  return {
+    info: (_msg: string) => undefined,
+    warn: (_msg: string) => undefined,
+    error: (_msg: string) => undefined,
+    success: (_msg: string) => undefined,
+  };
+}
+
+export async function rollbackServerBeta(options: RollbackOptions): Promise<RollbackOutcome> {
+  const log = options.logger ?? noopLogger();
+  const steps: RollbackOutcome['steps'] = [];
+  const dryRun = options.dryRun === true;
+  const dockerBin = options.dockerBin ?? 'docker';
+
+  // STEP 1 — docker compose down (preserve volumes unless --purge-data)
+  const composeFile = join(options.marketplaceDir, 'docker-compose.yml');
+  const overrideFile = join(options.marketplaceDir, 'docker-compose.override.yml');
+  const envFile = paths.envFile();
+
+  if (!existsSync(composeFile)) {
+    steps.push({ step: 'docker-compose-down', status: 'skipped', message: `docker-compose.yml missing at ${composeFile}` });
+  } else if (dryRun) {
+    steps.push({ step: 'docker-compose-down', status: 'skipped', message: '[dry-run] would run docker compose down' });
+  } else {
+    const args = [
+      'compose',
+      ...(existsSync(envFile) ? ['--env-file', envFile] : []),
+      '-f', composeFile,
+      ...(existsSync(overrideFile) ? ['-f', overrideFile] : []),
+      'down',
+    ];
+    if (options.purgeData) args.push('-v');
+    log.info(`Running: ${dockerBin} ${args.join(' ')}`);
+    const result = spawnSync(dockerBin, args, {
+      cwd: options.marketplaceDir,
+      stdio: 'inherit',
+    });
+    if (result.error || result.status !== 0) {
+      steps.push({
+        step: 'docker-compose-down',
+        status: 'failed',
+        message: result.error?.message ?? `exit ${result.status}`,
+      });
+    } else {
+      steps.push({ step: 'docker-compose-down', status: 'ok' });
+    }
+  }
+
+  // STEP 2 — restore IDE configs from newest backup (or remove claude-mem entry).
+  let ideResults: RollbackResult[] | undefined;
+  if (dryRun) {
+    steps.push({ step: 'ide-mcp-rollback', status: 'skipped', message: '[dry-run] would restore IDE configs from backup' });
+  } else {
+    ideResults = rollbackAllIdes();
+    const failures = ideResults.filter(r => r.action === 'failed');
+    steps.push({
+      step: 'ide-mcp-rollback',
+      status: failures.length === 0 ? 'ok' : 'failed',
+      message: ideResults.map(r => `${r.ide}=${r.action}`).join(', '),
+    });
+    for (const r of ideResults) {
+      if (r.action === 'failed') log.error(`Rollback failed for ${r.ide}: ${r.message ?? '(no detail)'}`);
+      else if (r.action === 'restored') log.success(`Rolled back ${r.ide} (restored ${r.backupRestored})`);
+      else if (r.action === 'removed-entry') log.info(`Removed claude-mem entry from ${r.ide} (no backup)`);
+      else if (r.action === 'absent') log.info(`${r.ide}: nothing to roll back (config absent)`);
+      else if (r.action === 'no-backup') log.warn(`${r.ide}: ${r.message}`);
+    }
+  }
+
+  // STEP 3 — Remove server-beta keys from settings.json + revert CLAUDE_MEM_RUNTIME.
+  const settingsPath = paths.settings();
+  if (!existsSync(settingsPath)) {
+    steps.push({ step: 'revert-runtime-setting', status: 'skipped', message: 'settings.json absent' });
+  } else if (dryRun) {
+    steps.push({ step: 'revert-runtime-setting', status: 'skipped', message: '[dry-run] would revert CLAUDE_MEM_RUNTIME and strip server-beta keys' });
+  } else {
+    try {
+      const raw = JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>;
+      const isNested = raw.env && typeof raw.env === 'object';
+      const flat = (isNested ? (raw.env as Record<string, unknown>) : raw) as Record<string, unknown>;
+      let changed = false;
+      if (flat.CLAUDE_MEM_RUNTIME === 'server-beta') {
+        flat.CLAUDE_MEM_RUNTIME = 'worker';
+        changed = true;
+      }
+      for (const key of ['CLAUDE_MEM_SERVER_BETA_API_KEY', 'CLAUDE_MEM_SERVER_BETA_PROJECT_ID', 'CLAUDE_MEM_SERVER_BETA_URL']) {
+        if (key in flat) {
+          delete flat[key];
+          changed = true;
+        }
+      }
+      if (changed) {
+        const toWrite = isNested ? { ...raw, env: flat } : flat;
+        writeFileSync(settingsPath, JSON.stringify(toWrite, null, 2) + '\n', 'utf-8');
+      }
+      steps.push({
+        step: 'revert-runtime-setting',
+        status: 'ok',
+        message: changed ? 'Reverted runtime + stripped server-beta keys' : 'Nothing to revert',
+      });
+    } catch (err) {
+      steps.push({
+        step: 'revert-runtime-setting',
+        status: 'failed',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // STEP 4 — Optionally remove .env (and Postgres creds inside it).
+  if (options.purgeData && existsSync(envFile)) {
+    if (dryRun) {
+      steps.push({ step: 'purge-env', status: 'skipped', message: '[dry-run] would delete .env (--purge-data)' });
+    } else {
+      try {
+        const parsed = parseEnvFile(readFileSync(envFile, 'utf-8'));
+        const pgKeys = ['POSTGRES_USER', 'POSTGRES_PASSWORD', 'POSTGRES_DB', 'CLAUDE_MEM_SERVER_DATABASE_URL'];
+        const remaining: Record<string, string> = {};
+        for (const [k, v] of Object.entries(parsed)) {
+          if (!pgKeys.includes(k)) remaining[k] = v;
+        }
+        if (Object.keys(remaining).length === 0) {
+          rmSync(envFile, { force: true });
+          steps.push({ step: 'purge-env', status: 'ok', message: `Removed ${envFile}` });
+        } else {
+          const lines = [
+            '# claude-mem credentials',
+            '# (PG credentials removed by uninstall --purge-data)',
+            '',
+            ...Object.entries(remaining).map(([k, v]) => /[\s#=]/.test(v) ? `${k}="${v}"` : `${k}=${v}`),
+          ];
+          writeFileSync(envFile, lines.join('\n') + '\n', { encoding: 'utf-8', mode: 0o600 });
+          steps.push({
+            step: 'purge-env',
+            status: 'ok',
+            message: `Stripped Postgres credentials from ${envFile} (preserved ${Object.keys(remaining).length} other keys)`,
+          });
+        }
+      } catch (err) {
+        steps.push({
+          step: 'purge-env',
+          status: 'failed',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  }
+
+  const ok = steps.every(s => s.status !== 'failed');
+  return { ok, dryRun, steps, ideResults };
+}

--- a/src/services/install/server-beta-rollback.ts
+++ b/src/services/install/server-beta-rollback.ts
@@ -15,7 +15,9 @@ import { join } from 'path';
 import { paths } from '../../shared/paths.js';
 import {
   parseEnvFile,
+  serializeEnvFile,
 } from './server-beta-setup.js';
+import { stopClaudeHostBridge } from './claude-host-bridge.js';
 import {
   rollbackAllIdes,
   type RollbackResult,
@@ -167,13 +169,7 @@ export async function rollbackServerBeta(options: RollbackOptions): Promise<Roll
           rmSync(envFile, { force: true });
           steps.push({ step: 'purge-env', status: 'ok', message: `Removed ${envFile}` });
         } else {
-          const lines = [
-            '# claude-mem credentials',
-            '# (PG credentials removed by uninstall --purge-data)',
-            '',
-            ...Object.entries(remaining).map(([k, v]) => /[\s#=]/.test(v) ? `${k}="${v}"` : `${k}=${v}`),
-          ];
-          writeFileSync(envFile, lines.join('\n') + '\n', { encoding: 'utf-8', mode: 0o600 });
+        writeFileSync(envFile, serializeEnvFile(remaining), { encoding: 'utf-8', mode: 0o600 });
           steps.push({
             step: 'purge-env',
             status: 'ok',
@@ -188,6 +184,31 @@ export async function rollbackServerBeta(options: RollbackOptions): Promise<Roll
         });
       }
     }
+  }
+
+  // Stop the host-bridge launchd agent / systemd unit, if installed. Without
+  // this the bridge keeps restarting and finds its token/port files gone.
+  if (!dryRun) {
+    try {
+      const bridgeResult = stopClaudeHostBridge();
+      steps.push({
+        step: 'stop-host-bridge',
+        status: bridgeResult.ok ? 'ok' : 'failed',
+        message: bridgeResult.message,
+      });
+    } catch (err) {
+      steps.push({
+        step: 'stop-host-bridge',
+        status: 'failed',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  } else {
+    steps.push({
+      step: 'stop-host-bridge',
+      status: 'skipped',
+      message: '[dry-run] would stop launchd agent / systemd unit + remove token/port files',
+    });
   }
 
   const ok = steps.every(s => s.status !== 'failed');

--- a/src/services/install/server-beta-setup.ts
+++ b/src/services/install/server-beta-setup.ts
@@ -209,7 +209,12 @@ export async function setupServerBeta(options: SetupOptions): Promise<SetupResul
     }
   }
 
-  return { ok: true, dryRun, steps, apiKey, projectId, ideResults };
+  // Honor the fail-fast contract: if any IDE injection failed, the overall
+  // install is not 'ok' and the caller should NOT commit the runtime
+  // selector. Without this, install.ts saw ok:true even when Claude
+  // Desktop's config write failed.
+  const finalOk = steps.every(s => s.status !== 'failed');
+  return { ok: finalOk, dryRun, steps, apiKey, projectId, ideResults };
 }
 
 interface DockerCheckResult {
@@ -417,6 +422,16 @@ function ensureClaudeSubscriptionCreds(dryRun: boolean): SetupStepResult {
           throw new Error('claudeAiOauth.accessToken missing');
         }
       } catch (parseErr) {
+        // Clear any stale CLAUDE_CREDS_FILE / CLAUDE_MEM_CLAUDE_BRIDGE_URL
+        // from a previous successful install so the next compose-up doesn't
+        // bind-mount a now-invalid credentials file silently.
+        if (existing.CLAUDE_CREDS_FILE || existing.CLAUDE_MEM_CLAUDE_BRIDGE_URL) {
+          delete existing.CLAUDE_CREDS_FILE;
+          delete existing.CLAUDE_MEM_CLAUDE_BRIDGE_URL;
+          if (!dryRun) {
+            writeFileSync(envFile, serializeEnvFile(existing), { encoding: 'utf-8', mode: 0o600 });
+          }
+        }
         return {
           step: 'ensure-claude-creds',
           status: 'failed',
@@ -824,7 +839,7 @@ export function parseEnvFile(content: string): Record<string, string> {
   return result;
 }
 
-function serializeEnvFile(env: Record<string, string>): string {
+export function serializeEnvFile(env: Record<string, string>): string {
   const lines: string[] = [
     '# claude-mem credentials and runtime config',
     '# This file is managed by `claude-mem install`. Hand-edit at your own risk.',

--- a/src/services/install/server-beta-setup.ts
+++ b/src/services/install/server-beta-setup.ts
@@ -278,13 +278,18 @@ function ensurePostgresEnv(dryRun: boolean): SetupStepResult {
   try {
     const envFile = paths.envFile();
     const dir = paths.dataDir();
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true, mode: 0o700 });
-    }
-    try {
-      chmodSync(dir, 0o700);
-    } catch {
-      // best-effort
+    // Honour --dry-run by skipping the mkdir + chmod side-effects. Without
+    // this guard a dry-run silently created ~/.claude-mem/ on first use,
+    // breaking the dry-run contract operators rely on for previewing.
+    if (!dryRun) {
+      if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true, mode: 0o700 });
+      }
+      try {
+        chmodSync(dir, 0o700);
+      } catch {
+        // best-effort
+      }
     }
     const existing = parseEnvFile(existsSync(envFile) ? readFileSync(envFile, 'utf-8') : '');
     const needsUser = !existing.POSTGRES_USER;

--- a/src/services/install/server-beta-setup.ts
+++ b/src/services/install/server-beta-setup.ts
@@ -1,0 +1,845 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// end-to-end setupServerBeta() orchestrator.
+//
+// When the operator picks `runtime: "server-beta"` during install, this
+// function walks the full happy-path setup: Docker preflight → .env → compose
+// override → `docker compose up` → wait healthy → bootstrap API key →
+// populate plugin/node_modules → inject MCP configs into all 4 IDEs.
+//
+// Fail-fast at every step. The caller is install.ts which MUST commit the
+// CLAUDE_MEM_RUNTIME setting only AFTER this returns success.
+//
+// Idempotency: re-running on a system where the stack is already up and
+// the API key is already in settings.json is a no-op (returns 'reused').
+
+import { execSync, spawnSync } from 'child_process';
+import { randomBytes } from 'crypto';
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'fs';
+import { join } from 'path';
+import { paths } from '../../shared/paths.js';
+import { injectAllIdes, type InjectionResult } from './ide-mcp-injection.js';
+
+export interface SetupOptions {
+  marketplaceDir: string;
+  dryRun?: boolean;
+  optInIdes?: string[];
+  /** Override docker bin for tests (default: 'docker'). */
+  dockerBin?: string;
+  /** Override server-beta bootstrap (default: real bootstrap). For tests. */
+  bootstrapImpl?: BootstrapFn;
+  /** Max seconds to wait for docker compose health (default: 90). */
+  healthTimeoutSeconds?: number;
+  /** Logger functions — caller wires these into clack. */
+  logger?: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+    success: (msg: string) => void;
+  };
+}
+
+export interface SetupResult {
+  ok: boolean;
+  dryRun: boolean;
+  steps: SetupStepResult[];
+  apiKey?: string;
+  projectId?: string;
+  ideResults?: InjectionResult[];
+}
+
+export interface SetupStepResult {
+  step: string;
+  status: 'ok' | 'reused' | 'failed' | 'skipped';
+  message?: string;
+}
+
+interface BootstrapResult {
+  rawKey: string;
+  apiKeyId: string;
+  teamId: string;
+  projectId: string;
+}
+
+type BootstrapFn = () => Promise<BootstrapResult>;
+
+const DEFAULT_HEALTH_TIMEOUT = 90;
+
+function noopLogger() {
+  return {
+    info: (_msg: string) => undefined,
+    warn: (_msg: string) => undefined,
+    error: (_msg: string) => undefined,
+    success: (_msg: string) => undefined,
+  };
+}
+
+export async function setupServerBeta(options: SetupOptions): Promise<SetupResult> {
+  const log = options.logger ?? noopLogger();
+  const steps: SetupStepResult[] = [];
+  const dryRun = options.dryRun === true;
+
+  const step = (name: string, status: SetupStepResult['status'], message?: string): SetupStepResult => {
+    const result: SetupStepResult = { step: name, status, message };
+    steps.push(result);
+    return result;
+  };
+
+  // STEP 1 — Docker preflight
+  const dockerCheck = checkDockerInstalled(options.dockerBin);
+  if (!dockerCheck.ok) {
+    log.error(dockerCheck.message);
+    step('docker-preflight', 'failed', dockerCheck.message);
+    return { ok: false, dryRun, steps };
+  }
+  step('docker-preflight', 'ok', dockerCheck.message);
+  log.info(dockerCheck.message);
+
+  // STEP 2 — .env file with PG creds
+  const envResult = ensurePostgresEnv(dryRun);
+  step(envResult.step, envResult.status, envResult.message);
+  log.info(`${envResult.step}: ${envResult.message}`);
+  if (envResult.status === 'failed') {
+    return { ok: false, dryRun, steps };
+  }
+
+  // STEP 2b: Claude subscription credentials extraction.
+  // Reads ~/.claude-mem/settings.json (CLAUDE_MEM_CLAUDE_AUTH_METHOD) and
+  // when auth='subscription' extracts the host's OAuth token from the macOS
+  // Keychain (or ~/.claude/.credentials.json fallback) into a file the
+  // docker-compose can mount into the worker container. When auth='api-key'
+  // this step is a no-op.
+  const credsResult = ensureClaudeSubscriptionCreds(dryRun);
+  step(credsResult.step, credsResult.status, credsResult.message);
+  log.info(`${credsResult.step}: ${credsResult.message}`);
+  // Subscription extraction failure is non-fatal: the worker can still use
+  // ANTHROPIC_API_KEY. Only surface a warning so the operator knows.
+
+  // STEP 3 — docker-compose override
+  const overrideResult = ensureDockerComposeOverride(options.marketplaceDir, dryRun);
+  step(overrideResult.step, overrideResult.status, overrideResult.message);
+  log.info(`${overrideResult.step}: ${overrideResult.message}`);
+  if (overrideResult.status === 'failed') {
+    return { ok: false, dryRun, steps };
+  }
+
+  // STEP 4 — docker compose up + healthcheck wait
+  if (dryRun) {
+    step('docker-compose-up', 'skipped', '[dry-run] would run docker compose up -d --build and wait for health');
+    log.info('[dry-run] skipping docker compose up');
+  } else {
+    const composeResult = runDockerComposeUp({
+      marketplaceDir: options.marketplaceDir,
+      dockerBin: options.dockerBin ?? 'docker',
+      healthTimeoutSeconds: options.healthTimeoutSeconds ?? DEFAULT_HEALTH_TIMEOUT,
+      logger: log,
+    });
+    step('docker-compose-up', composeResult.ok ? 'ok' : 'failed', composeResult.message);
+    if (!composeResult.ok) {
+      return { ok: false, dryRun, steps };
+    }
+  }
+
+  // STEP 5 — Bootstrap API key
+  let apiKey: string | undefined;
+  let projectId: string | undefined;
+  if (dryRun) {
+    step('bootstrap-api-key', 'skipped', '[dry-run] would bootstrap API key via Postgres');
+  } else {
+    const bootstrapResult = await runBootstrap({
+      bootstrapImpl: options.bootstrapImpl,
+      logger: log,
+    });
+    if (!bootstrapResult.ok) {
+      step('bootstrap-api-key', 'failed', bootstrapResult.message);
+      return { ok: false, dryRun, steps };
+    }
+    step('bootstrap-api-key', bootstrapResult.reused ? 'reused' : 'ok', bootstrapResult.message);
+    apiKey = bootstrapResult.apiKey;
+    projectId = bootstrapResult.projectId;
+  }
+
+  // STEP 6 — Populate marketplace plugin/node_modules so tree-sitter grammars exist.
+  if (dryRun) {
+    step('marketplace-plugin-deps', 'skipped', '[dry-run] would run npm install in marketplace/plugin');
+  } else {
+    const npmResult = ensurePluginNodeModules(options.marketplaceDir);
+    step('marketplace-plugin-deps', npmResult.ok ? 'ok' : 'failed', npmResult.message);
+    if (!npmResult.ok) {
+      log.warn(`Plugin deps install failed: ${npmResult.message}. Tree-sitter grammars (smart_search/outline/unfold) may not work.`);
+    }
+  }
+
+  // STEP 7 — Inject MCP configs into all 4 IDEs.
+  let ideResults: InjectionResult[] | undefined;
+  if (dryRun) {
+    step('ide-mcp-injection', 'skipped', '[dry-run] would inject MCP configs');
+  } else {
+    const mcpServerPath = join(options.marketplaceDir, 'plugin', 'scripts', 'mcp-server.cjs');
+    if (!existsSync(mcpServerPath)) {
+      step('ide-mcp-injection', 'failed', `mcp-server.cjs not found at ${mcpServerPath}`);
+      return { ok: false, dryRun, steps, apiKey, projectId };
+    }
+    ideResults = injectAllIdes({
+      mcpServerPath,
+      marketplaceDir: options.marketplaceDir,
+      optInIdes: options.optInIdes,
+    });
+    const failures = ideResults.filter(r => r.status === 'failed');
+    const overallStatus = failures.length === 0 ? 'ok' : 'failed';
+    const summary = ideResults.map(r => `${r.ide}=${r.status}`).join(', ');
+    step('ide-mcp-injection', overallStatus, summary);
+    for (const result of ideResults) {
+      if (result.status === 'failed') {
+        log.error(`IDE inject failed for ${result.ide}: ${result.message ?? '(no detail)'}`);
+      } else if (result.status === 'written') {
+        log.success(`IDE inject ${result.ide}: ${result.configPath}`);
+      } else if (result.status === 'already-current') {
+        log.info(`IDE inject ${result.ide}: already current`);
+      } else if (result.status === 'skipped') {
+        log.info(`IDE inject ${result.ide}: skipped (${result.message ?? 'not detected'})`);
+      }
+    }
+  }
+
+  return { ok: true, dryRun, steps, apiKey, projectId, ideResults };
+}
+
+interface DockerCheckResult {
+  ok: boolean;
+  message: string;
+}
+
+function checkDockerInstalled(dockerBin?: string): DockerCheckResult {
+  const bin = dockerBin ?? 'docker';
+  try {
+    const result = spawnSync(bin, ['version', '--format', '{{.Server.Version}}'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    if (result.error) {
+      return { ok: false, message: dockerMissingHint() };
+    }
+    if (result.status !== 0) {
+      const stderr = (result.stderr ?? '').trim();
+      const lowered = stderr.toLowerCase();
+      if (lowered.includes('cannot connect') || lowered.includes('docker daemon')) {
+        return {
+          ok: false,
+          message: `Docker is installed but the daemon is not running. Start Docker Desktop and re-run install.${process.platform === 'darwin' ? ' On macOS: open -a Docker' : ''}`,
+        };
+      }
+      return { ok: false, message: `Docker preflight failed: ${stderr || `exit ${result.status}`}` };
+    }
+    const version = (result.stdout ?? '').trim();
+    return { ok: true, message: `Docker ${version} (daemon reachable)` };
+  } catch {
+    return { ok: false, message: dockerMissingHint() };
+  }
+}
+
+function dockerMissingHint(): string {
+  if (process.platform === 'darwin') {
+    return 'Docker is not installed. Run: brew install --cask docker && open -a Docker';
+  }
+  if (process.platform === 'linux') {
+    return 'Docker is not installed. Install via your distro package manager (apt/yum/pacman) then start the docker service.';
+  }
+  return 'Docker is not installed. Install Docker Desktop from https://www.docker.com/products/docker-desktop/';
+}
+
+interface PostgresEnv {
+  user: string;
+  password: string;
+  db: string;
+}
+
+export function generatePostgresEnv(): PostgresEnv {
+  return {
+    user: 'claude_mem',
+    password: randomBytes(24).toString('base64url'),
+    db: 'claude_mem_server',
+  };
+}
+
+function ensurePostgresEnv(dryRun: boolean): SetupStepResult {
+  try {
+    const envFile = paths.envFile();
+    const dir = paths.dataDir();
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true, mode: 0o700 });
+    }
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // best-effort
+    }
+    const existing = parseEnvFile(existsSync(envFile) ? readFileSync(envFile, 'utf-8') : '');
+    const needsUser = !existing.POSTGRES_USER;
+    const needsPassword = !existing.POSTGRES_PASSWORD;
+    const needsDb = !existing.POSTGRES_DB;
+    const needsDbUrl = !existing.CLAUDE_MEM_SERVER_DATABASE_URL;
+
+    if (!needsUser && !needsPassword && !needsDb && !needsDbUrl) {
+      return { step: 'ensure-postgres-env', status: 'reused', message: `${envFile} already has Postgres credentials` };
+    }
+
+    if (dryRun) {
+      return {
+        step: 'ensure-postgres-env',
+        status: 'skipped',
+        message: `[dry-run] would write Postgres creds to ${envFile}`,
+      };
+    }
+
+    const next: Record<string, string> = { ...existing };
+    if (needsUser) next.POSTGRES_USER = 'claude_mem';
+    if (needsPassword) next.POSTGRES_PASSWORD = randomBytes(24).toString('base64url');
+    if (needsDb) next.POSTGRES_DB = 'claude_mem_server';
+    if (needsDbUrl) {
+      const user = encodeURIComponent(next.POSTGRES_USER);
+      const password = encodeURIComponent(next.POSTGRES_PASSWORD);
+      const db = encodeURIComponent(next.POSTGRES_DB);
+      next.CLAUDE_MEM_SERVER_DATABASE_URL = `postgres://${user}:${password}@127.0.0.1:55432/${db}`;
+    }
+
+    writeFileSync(envFile, serializeEnvFile(next), { encoding: 'utf-8', mode: 0o600 });
+    try {
+      chmodSync(envFile, 0o600);
+    } catch {
+      // non-POSIX
+    }
+    return { step: 'ensure-postgres-env', status: 'ok', message: `Wrote Postgres credentials to ${envFile}` };
+  } catch (err) {
+    return {
+      step: 'ensure-postgres-env',
+      status: 'failed',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// Claude Code subscription credentials extraction.
+//
+// When ~/.claude-mem/settings.json sets CLAUDE_MEM_CLAUDE_AUTH_METHOD =
+// 'subscription', extract the host's OAuth credentials and write them to
+// ~/.claude-mem/.claude-credentials.json (chmod 600). The .env file gets
+// CLAUDE_CREDS_FILE=<host path> so docker-compose mounts the file into
+// each container at /run/secrets/claude-credentials.json (where the
+// generation provider factory's readClaudeOAuthToken() looks for it).
+//
+// Lookup order on the host:
+//   1. macOS Keychain: `security find-generic-password -s 'Claude Code-credentials' -w`
+//   2. ~/.claude/.credentials.json (legacy on-disk form, still present on
+//      older Claude CLI installs and migrated machines)
+// If neither is available, this step degrades gracefully — the worker still
+// runs but generation falls back to ANTHROPIC_API_KEY (api-key auth).
+// Claude subscription auth wiring.
+//
+// Strategy:
+//   1. ~/.claude/.credentials.json exists  → LIVE BIND-MOUNT the host file
+//      into the container. Claude CLI atomic-renames on every token refresh
+//      and account-switch; the container re-reads on every generate() call.
+//   2. No .credentials.json (macOS Keychain-only install)  → start the host
+//      bridge service so the container can proxy generation through the host's
+//      Claude CLI (which has live access to the Keychain).
+//
+// When auth_method='api-key' this step is a no-op — the worker uses
+// ANTHROPIC_API_KEY directly.
+function ensureClaudeSubscriptionCreds(dryRun: boolean): SetupStepResult {
+  try {
+    const settingsPath = paths.settings();
+    let authMethod = 'subscription';
+    if (existsSync(settingsPath)) {
+      try {
+        const raw = JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>;
+        const flat = (raw.env && typeof raw.env === 'object' ? raw.env : raw) as Record<string, unknown>;
+        const v = flat.CLAUDE_MEM_CLAUDE_AUTH_METHOD;
+        if (typeof v === 'string' && v.length > 0) authMethod = v;
+      } catch {
+        /* keep default */
+      }
+    }
+
+    if (authMethod !== 'subscription') {
+      // Clear any previous CLAUDE_CREDS_FILE so the mount resolves to /dev/null.
+      const envFile = paths.envFile();
+      if (existsSync(envFile)) {
+        const existing = parseEnvFile(readFileSync(envFile, 'utf-8'));
+        if (existing.CLAUDE_CREDS_FILE || existing.CLAUDE_MEM_CLAUDE_BRIDGE_URL) {
+          delete existing.CLAUDE_CREDS_FILE;
+          delete existing.CLAUDE_MEM_CLAUDE_BRIDGE_URL;
+          writeFileSync(envFile, serializeEnvFile(existing), { encoding: 'utf-8', mode: 0o600 });
+        }
+      }
+      return {
+        step: 'ensure-claude-creds',
+        status: 'skipped',
+        message: `auth-method=${authMethod}; subscription wiring not needed`,
+      };
+    }
+
+    if (dryRun) {
+      return {
+        step: 'ensure-claude-creds',
+        status: 'skipped',
+        message: `[dry-run] would wire Claude subscription credentials for container`,
+      };
+    }
+
+    const envFile = paths.envFile();
+    const home = process.env.HOME ?? '';
+    const hostCredsPath = join(home, '.claude', '.credentials.json');
+    const existing = parseEnvFile(existsSync(envFile) ? readFileSync(envFile, 'utf-8') : '');
+
+    // ── Path 1: file present — bind-mount it live ──────────────────────────
+    if (existsSync(hostCredsPath)) {
+      // Confirm it's actually a Claude CLI creds file before mounting.
+      try {
+        const raw = JSON.parse(readFileSync(hostCredsPath, 'utf-8')) as {
+          claudeAiOauth?: { accessToken?: string };
+        };
+        if (!raw.claudeAiOauth?.accessToken) {
+          throw new Error('claudeAiOauth.accessToken missing');
+        }
+      } catch (parseErr) {
+        return {
+          step: 'ensure-claude-creds',
+          status: 'failed',
+          message: `${hostCredsPath} exists but is not a valid Claude credentials file: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}`,
+        };
+      }
+
+      existing.CLAUDE_CREDS_FILE = hostCredsPath;
+      delete existing.CLAUDE_MEM_CLAUDE_BRIDGE_URL;
+      writeFileSync(envFile, serializeEnvFile(existing), { encoding: 'utf-8', mode: 0o600 });
+      return {
+        step: 'ensure-claude-creds',
+        status: 'ok',
+        message: `Bind-mounting ${hostCredsPath} into worker container (live — token refresh + account switch propagate automatically)`,
+      };
+    }
+
+    // ── Path 2: no file — set up the host bridge ───────────────────────────
+    // Implementation lands in Phase 2 (ensureClaudeHostBridge below). For now,
+    // surface a clear instruction so the operator knows what's needed.
+    const bridgeResult = launchClaudeHostBridge();
+    if (bridgeResult.ok) {
+      existing.CLAUDE_MEM_CLAUDE_BRIDGE_URL = bridgeResult.bridgeUrl;
+      // Where docker-compose mounts the token file from; the in-container
+      // path is hard-coded to /run/secrets/claude-host-bridge-token.
+      existing.CLAUDE_HOST_BRIDGE_TOKEN_FILE = join(paths.dataDir(), 'host-bridge-token');
+      delete existing.CLAUDE_CREDS_FILE;
+      writeFileSync(envFile, serializeEnvFile(existing), { encoding: 'utf-8', mode: 0o600 });
+      return {
+        step: 'ensure-claude-creds',
+        status: 'ok',
+        message: `Started Claude host-bridge at ${bridgeResult.bridgeUrl} (container proxies through host's Claude CLI — always live)`,
+      };
+    }
+
+    // Bridge couldn't start — graceful fallback to api-key.
+    delete existing.CLAUDE_CREDS_FILE;
+    delete existing.CLAUDE_MEM_CLAUDE_BRIDGE_URL;
+    writeFileSync(envFile, serializeEnvFile(existing), { encoding: 'utf-8', mode: 0o600 });
+    return {
+      step: 'ensure-claude-creds',
+      status: 'skipped',
+      message: `no ${hostCredsPath} and host-bridge not available (${bridgeResult.message}) — worker will fall back to ANTHROPIC_API_KEY if configured`,
+    };
+  } catch (err) {
+    return {
+      step: 'ensure-claude-creds',
+      status: 'failed',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// Re-export the host-bridge launcher from its own module to keep this file
+// focused on orchestration. claude-host-bridge.ts owns the script source,
+// launchd/systemd unit installation, and health-check polling.
+import { ensureClaudeHostBridge as launchClaudeHostBridge } from './claude-host-bridge.js';
+
+// (Internal shim removed — ensureClaudeSubscriptionCreds() above now calls
+// launchClaudeHostBridge() directly via the import alias.)
+
+// (readHostClaudeCredentials() removed refactor switched from
+// snapshot-extract to live bind-mount. The setup script no longer needs to
+// pull bytes out of the host; it just points CLAUDE_CREDS_FILE at the
+// host's .credentials.json directly.)
+
+function ensureDockerComposeOverride(marketplaceDir: string, dryRun: boolean): SetupStepResult {
+  try {
+    const sourceExample = join(marketplaceDir, 'docker-compose.override.yml.example');
+    const targetOverride = join(marketplaceDir, 'docker-compose.override.yml');
+
+    if (!existsSync(sourceExample)) {
+      return {
+        step: 'docker-compose-override',
+        status: 'failed',
+        message: `Marketplace missing docker-compose.override.yml.example at ${sourceExample}`,
+      };
+    }
+
+    if (existsSync(targetOverride)) {
+      return {
+        step: 'docker-compose-override',
+        status: 'reused',
+        message: `${targetOverride} already exists`,
+      };
+    }
+
+    if (dryRun) {
+      return {
+        step: 'docker-compose-override',
+        status: 'skipped',
+        message: `[dry-run] would write ${targetOverride}`,
+      };
+    }
+
+    const activeOverride = activateDockerComposeOverride(readFileSync(sourceExample, 'utf-8'));
+    writeFileSync(targetOverride, activeOverride, 'utf-8');
+    return {
+      step: 'docker-compose-override',
+      status: 'ok',
+      message: `Wrote dev profile override to ${targetOverride}`,
+    };
+  } catch (err) {
+    return {
+      step: 'docker-compose-override',
+      status: 'failed',
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export function activateDockerComposeOverride(exampleContent: string): string {
+  const lines = exampleContent.split('\n');
+  const activated: string[] = [];
+  let inServicesBlock = false;
+  for (const line of lines) {
+    if (/^\s*$/.test(line)) {
+      activated.push(line);
+      continue;
+    }
+    if (/^# (services|  )/.test(line)) {
+      inServicesBlock = true;
+      activated.push(line.replace(/^# /, ''));
+      continue;
+    }
+    if (inServicesBlock && /^#( {2,}|\t)/.test(line)) {
+      activated.push(line.replace(/^# /, ''));
+      continue;
+    }
+    activated.push(line);
+  }
+  if (!activated.some(l => /^services:/.test(l))) {
+    return [
+      '# Auto-generated by claude-mem install --runtime server-beta',
+      '# Exposes Postgres on 127.0.0.1:55432 so host-side tooling can connect.',
+      'services:',
+      '  postgres:',
+      '    ports:',
+      '      - "127.0.0.1:55432:5432"',
+      '',
+    ].join('\n');
+  }
+  return activated.join('\n');
+}
+
+interface ComposeUpResult {
+  ok: boolean;
+  message: string;
+}
+
+function runDockerComposeUp(args: {
+  marketplaceDir: string;
+  dockerBin: string;
+  healthTimeoutSeconds: number;
+  logger: NonNullable<SetupOptions['logger']>;
+}): ComposeUpResult {
+  const composeFile = join(args.marketplaceDir, 'docker-compose.yml');
+  const overrideFile = join(args.marketplaceDir, 'docker-compose.override.yml');
+  const envFile = paths.envFile();
+
+  if (!existsSync(composeFile)) {
+    return { ok: false, message: `docker-compose.yml missing at ${composeFile}` };
+  }
+  if (!existsSync(envFile)) {
+    return { ok: false, message: `Postgres .env file missing at ${envFile}` };
+  }
+
+  const composeArgs = [
+    'compose',
+    '--env-file', envFile,
+    '-f', composeFile,
+  ];
+  if (existsSync(overrideFile)) {
+    composeArgs.push('-f', overrideFile);
+  }
+  composeArgs.push('up', '-d', '--build');
+
+  args.logger.info(`Running: ${args.dockerBin} ${composeArgs.join(' ')}`);
+
+  try {
+    const result = spawnSync(args.dockerBin, composeArgs, {
+      cwd: args.marketplaceDir,
+      stdio: 'inherit',
+    });
+    if (result.error) {
+      return { ok: false, message: `docker compose up failed: ${result.error.message}` };
+    }
+    if (result.status !== 0) {
+      return { ok: false, message: `docker compose up exited ${result.status}` };
+    }
+  } catch (err) {
+    return { ok: false, message: err instanceof Error ? err.message : String(err) };
+  }
+
+  const healthy = waitForComposeHealth({
+    marketplaceDir: args.marketplaceDir,
+    dockerBin: args.dockerBin,
+    envFile,
+    composeFile,
+    overrideFile: existsSync(overrideFile) ? overrideFile : undefined,
+    timeoutSeconds: args.healthTimeoutSeconds,
+    logger: args.logger,
+  });
+  if (!healthy.ok) return healthy;
+
+  return { ok: true, message: 'docker compose stack is healthy' };
+}
+
+function waitForComposeHealth(args: {
+  marketplaceDir: string;
+  dockerBin: string;
+  envFile: string;
+  composeFile: string;
+  overrideFile?: string;
+  timeoutSeconds: number;
+  logger: NonNullable<SetupOptions['logger']>;
+}): ComposeUpResult {
+  const deadline = Date.now() + args.timeoutSeconds * 1000;
+  const baseArgs = [
+    'compose',
+    '--env-file', args.envFile,
+    '-f', args.composeFile,
+    ...(args.overrideFile ? ['-f', args.overrideFile] : []),
+  ];
+  const services = ['postgres', 'valkey', 'claude-mem-server', 'claude-mem-worker'];
+
+  while (Date.now() < deadline) {
+    const allHealthy = services.every((svc) => isServiceHealthy({
+      dockerBin: args.dockerBin,
+      cwd: args.marketplaceDir,
+      composeArgs: baseArgs,
+      service: svc,
+    }));
+    if (allHealthy) {
+      return { ok: true, message: 'all services healthy' };
+    }
+    sleepSync(2000);
+  }
+  return { ok: false, message: `docker compose stack did not become healthy in ${args.timeoutSeconds}s` };
+}
+
+function isServiceHealthy(args: {
+  dockerBin: string;
+  cwd: string;
+  composeArgs: string[];
+  service: string;
+}): boolean {
+  try {
+    const psArgs = [...args.composeArgs, 'ps', '--format', 'json', args.service];
+    const result = spawnSync(args.dockerBin, psArgs, {
+      cwd: args.cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    if (result.status !== 0) return false;
+    const stdout = (result.stdout ?? '').trim();
+    if (!stdout) return false;
+    const lines = stdout.split('\n').filter(Boolean);
+    if (lines.length === 0) return false;
+    for (const line of lines) {
+      try {
+        const parsed = JSON.parse(line) as { Health?: string; State?: string };
+        const health = (parsed.Health ?? '').toLowerCase();
+        const state = (parsed.State ?? '').toLowerCase();
+        if (health === 'healthy') continue;
+        if (health === '' && state === 'running') continue;
+        return false;
+      } catch {
+        return false;
+      }
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sleepSync(ms: number): void {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    spawnSync(process.execPath, ['-e', 'setTimeout(()=>process.exit(0),' + Math.min(ms, 500) + ')'], { stdio: 'ignore' });
+    if (Date.now() >= end) return;
+  }
+}
+
+interface BootstrapOutcome {
+  ok: boolean;
+  reused: boolean;
+  message: string;
+  apiKey?: string;
+  projectId?: string;
+}
+
+async function runBootstrap(args: {
+  bootstrapImpl?: BootstrapFn;
+  logger: NonNullable<SetupOptions['logger']>;
+}): Promise<BootstrapOutcome> {
+  const settingsPath = paths.settings();
+
+  if (settingsAlreadyHasServerBetaKey(settingsPath)) {
+    return { ok: true, reused: true, message: 'API key already present in settings.json' };
+  }
+
+  const databaseUrl = readDatabaseUrlFromEnvFile();
+  if (databaseUrl && !process.env.CLAUDE_MEM_SERVER_DATABASE_URL) {
+    process.env.CLAUDE_MEM_SERVER_DATABASE_URL = databaseUrl;
+  }
+
+  if (!process.env.CLAUDE_MEM_SERVER_DATABASE_URL) {
+    return { ok: false, reused: false, message: 'CLAUDE_MEM_SERVER_DATABASE_URL missing — cannot bootstrap API key' };
+  }
+
+  try {
+    const { bootstrapServerBetaApiKey, persistServerBetaSettings } = await import('../hooks/server-beta-bootstrap.js');
+    const impl: BootstrapFn = args.bootstrapImpl ?? (() => bootstrapServerBetaApiKey());
+    const result = await impl();
+    // fix — docker-compose.yml hardcodes the server on 127.0.0.1:37877.
+    // The UID-derived default in SettingsDefaultsManager only fits worker-mode;
+    // for server-beta we must write the actual Docker-exposed URL so the hooks
+    // (and the doctor CLI) hit the right port. Pass serverBaseUrl explicitly.
+    persistServerBetaSettings(settingsPath, {
+      apiKey: result.rawKey,
+      projectId: result.projectId,
+      serverBaseUrl: 'http://127.0.0.1:37877',
+    });
+    return {
+      ok: true,
+      reused: false,
+      message: `Provisioned API key for project ${result.projectId.slice(0, 8)}…`,
+      apiKey: result.rawKey,
+      projectId: result.projectId,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      reused: false,
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function settingsAlreadyHasServerBetaKey(settingsPath: string): boolean {
+  if (!existsSync(settingsPath)) return false;
+  try {
+    const raw = JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>;
+    const flat = (raw.env && typeof raw.env === 'object' ? raw.env : raw) as Record<string, unknown>;
+    const key = flat.CLAUDE_MEM_SERVER_BETA_API_KEY;
+    return typeof key === 'string' && key.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function readDatabaseUrlFromEnvFile(): string | undefined {
+  const envFile = paths.envFile();
+  if (!existsSync(envFile)) return undefined;
+  const parsed = parseEnvFile(readFileSync(envFile, 'utf-8'));
+  return parsed.CLAUDE_MEM_SERVER_DATABASE_URL;
+}
+
+interface PluginDepsResult {
+  ok: boolean;
+  message: string;
+}
+
+function ensurePluginNodeModules(marketplaceDir: string): PluginDepsResult {
+  const pluginDir = join(marketplaceDir, 'plugin');
+  if (!existsSync(join(pluginDir, 'package.json'))) {
+    return { ok: false, message: `plugin/package.json missing at ${pluginDir}` };
+  }
+  try {
+    execSync('npm install --ignore-scripts --no-audit --no-fund', {
+      cwd: pluginDir,
+      stdio: 'pipe',
+      encoding: 'utf-8',
+    });
+    return { ok: true, message: 'plugin/node_modules populated' };
+  } catch (err) {
+    return {
+      ok: false,
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// .env parse/serialize helpers — minimal duplication of EnvManager so this
+// module stays decoupled from the existing Anthropic credential-only schema.
+// ---------------------------------------------------------------------------
+
+export function parseEnvFile(content: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    let value = trimmed.slice(eqIdx + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    if (key) result[key] = value;
+  }
+  return result;
+}
+
+function serializeEnvFile(env: Record<string, string>): string {
+  const lines: string[] = [
+    '# claude-mem credentials and runtime config',
+    '# This file is managed by `claude-mem install`. Hand-edit at your own risk.',
+    '',
+  ];
+  for (const [key, value] of Object.entries(env)) {
+    if (!value) continue;
+    const needsQuotes = /[\s#=]/.test(value);
+    lines.push(`${key}=${needsQuotes ? `"${value}"` : value}`);
+  }
+  return lines.join('\n') + '\n';
+}
+
+// ---------------------------------------------------------------------------
+// Re-exports for tests
+// ---------------------------------------------------------------------------
+
+export const __internal__ = {
+  checkDockerInstalled,
+  ensurePostgresEnv,
+  ensureDockerComposeOverride,
+  ensurePluginNodeModules,
+  parseEnvFile,
+  serializeEnvFile,
+};

--- a/src/services/install/server-beta-setup.ts
+++ b/src/services/install/server-beta-setup.ts
@@ -374,6 +374,13 @@ function ensureClaudeSubscriptionCreds(dryRun: boolean): SetupStepResult {
       if (existsSync(envFile)) {
         const existing = parseEnvFile(readFileSync(envFile, 'utf-8'));
         if (existing.CLAUDE_CREDS_FILE || existing.CLAUDE_MEM_CLAUDE_BRIDGE_URL) {
+          if (dryRun) {
+            return {
+              step: 'ensure-claude-creds',
+              status: 'skipped',
+              message: `[dry-run] would clear CLAUDE_CREDS_FILE and CLAUDE_MEM_CLAUDE_BRIDGE_URL from ${envFile}`,
+            };
+          }
           delete existing.CLAUDE_CREDS_FILE;
           delete existing.CLAUDE_MEM_CLAUDE_BRIDGE_URL;
           writeFileSync(envFile, serializeEnvFile(existing), { encoding: 'utf-8', mode: 0o600 });
@@ -824,9 +831,14 @@ function serializeEnvFile(env: Record<string, string>): string {
     '',
   ];
   for (const [key, value] of Object.entries(env)) {
-    if (!value) continue;
-    const needsQuotes = /[\s#=]/.test(value);
-    lines.push(`${key}=${needsQuotes ? `"${value}"` : value}`);
+    if (value === undefined || value === null) continue;
+    const str = String(value);
+    // Quote whenever the value contains whitespace, '#', '=', or a literal
+    // double-quote so the round-trip via parseEnvFile is lossless. Embedded
+    // double-quotes are backslash-escaped inside the quoted form.
+    const needsQuotes = /[\s#="]/.test(str) || str === '';
+    const escaped = str.replace(/"/g, '\\"');
+    lines.push(`${key}=${needsQuotes ? `"${escaped}"` : str}`);
   }
   return lines.join('\n') + '\n';
 }

--- a/src/services/install/server-beta-setup.ts
+++ b/src/services/install/server-beta-setup.ts
@@ -388,6 +388,7 @@ function ensureClaudeSubscriptionCreds(dryRun: boolean): SetupStepResult {
           }
           delete existing.CLAUDE_CREDS_FILE;
           delete existing.CLAUDE_MEM_CLAUDE_BRIDGE_URL;
+          delete existing.CLAUDE_HOST_BRIDGE_TOKEN_FILE;
           writeFileSync(envFile, serializeEnvFile(existing), { encoding: 'utf-8', mode: 0o600 });
         }
       }
@@ -428,6 +429,7 @@ function ensureClaudeSubscriptionCreds(dryRun: boolean): SetupStepResult {
         if (existing.CLAUDE_CREDS_FILE || existing.CLAUDE_MEM_CLAUDE_BRIDGE_URL) {
           delete existing.CLAUDE_CREDS_FILE;
           delete existing.CLAUDE_MEM_CLAUDE_BRIDGE_URL;
+          delete existing.CLAUDE_HOST_BRIDGE_TOKEN_FILE;
           if (!dryRun) {
             writeFileSync(envFile, serializeEnvFile(existing), { encoding: 'utf-8', mode: 0o600 });
           }
@@ -441,6 +443,7 @@ function ensureClaudeSubscriptionCreds(dryRun: boolean): SetupStepResult {
 
       existing.CLAUDE_CREDS_FILE = hostCredsPath;
       delete existing.CLAUDE_MEM_CLAUDE_BRIDGE_URL;
+          delete existing.CLAUDE_HOST_BRIDGE_TOKEN_FILE;
       writeFileSync(envFile, serializeEnvFile(existing), { encoding: 'utf-8', mode: 0o600 });
       return {
         step: 'ensure-claude-creds',
@@ -470,6 +473,7 @@ function ensureClaudeSubscriptionCreds(dryRun: boolean): SetupStepResult {
     // Bridge couldn't start — graceful fallback to api-key.
     delete existing.CLAUDE_CREDS_FILE;
     delete existing.CLAUDE_MEM_CLAUDE_BRIDGE_URL;
+    delete existing.CLAUDE_HOST_BRIDGE_TOKEN_FILE;
     writeFileSync(envFile, serializeEnvFile(existing), { encoding: 'utf-8', mode: 0o600 });
     return {
       step: 'ensure-claude-creds',


### PR DESCRIPTION
Fixes #2545 (issue creation pending — will link once available). Part of tracking issue #2540.

**Stacked on #2544.** When #2544 lands, this PR will be rebased to main; the install.ts diff is self-contained.

Wires the server-beta setup orchestrator (added in #2544) into the installer CLI and fixes four pre-existing UX bugs.

## Diff

```
 src/npx-cli/commands/install.ts | 151 ++++++++++++++++++++++++++--------------
 1 file changed, 98 insertions(+), 53 deletions(-)
```

## Fixes

  1. `install --help` no longer runs the install body.
  2. Post-install summary now lists all configured IDEs (Claude Code + Claude Desktop + OpenCode + Codex CLI), not just Claude Code.
  3. Server URL in the success message is runtime-aware (37877 for server-beta, derived per-user port for worker).
  4. "Autostart skipped" replaced with runtime-appropriate messaging: worker path keeps the autostart message, server-beta path reports docker compose status.

## New feature

  - `claude-mem install --runtime server-beta` — calls `setupServerBeta()` from #2544 and rolls back cleanly on failure.

## Verification

  - `npm run typecheck` — install.ts clean
  - Manual: `--help` exits without side-effects
  - Manual: 4 IDEs listed when all opted in
  - Manual: correct port in success message for both runtimes
  - Manual: server-beta path shows "Docker stack: healthy", worker path shows "Autostart: enabled"

## Why stacked

The wiring imports `setupServerBeta` from #2544. Without #2544 landing first, this PR would fail typecheck. Standard stacked-PR workflow: review and merge #2544 first, then this rebases to main.
