### PR TITLE
test(server-beta): end-to-end contract validator (10 steps, idempotent)

### DIFF
--- a/scripts/validate-server-beta.sh
+++ b/scripts/validate-server-beta.sh
@@ -59,6 +59,7 @@ fi
 
 CURRENT_STEP=0
 LAST_FAIL_STEP=0
+STEPS_PASSED=0
 
 # -----------------------------------------------------------------------------
 # Logging helpers
@@ -71,6 +72,7 @@ step_begin() {
 
 pass() {
   printf '%sPASS%s\n' "${C_GREEN}" "${C_RESET}"
+  STEPS_PASSED=$(( STEPS_PASSED + 1 ))
 }
 
 fail() {
@@ -133,7 +135,7 @@ fi
 
 echo "${C_BOLD}=== claude-mem server-beta E2E validator ===${C_RESET}"
 echo "  port:        ${PORT}"
-echo "  db-url:      ${DB_URL}"
+echo "  db-url:      ${DB_URL//:${PG_PASSWORD}@/:****@}"
 echo "  cli:         ${CLI_CMD[*]}"
 echo "  provider:    ${PROVIDER}"
 echo "  api-key:     ${API_KEY_NAME}"
@@ -142,7 +144,7 @@ echo
 # -----------------------------------------------------------------------------
 # Step 1 — clean slate
 # -----------------------------------------------------------------------------
-step_begin 1 "BUG-N/A: docker compose down -v (clean slate)"
+step_begin 1 "docker compose down -v (clean slate)"
 if docker compose down -v --remove-orphans >/dev/null 2>&1; then
   pass
 else
@@ -311,7 +313,7 @@ printf '  jobId: %s\n' "${JOB_ID}"
 # -----------------------------------------------------------------------------
 # Step 6 — poll /v1/jobs/{id} until completed
 # -----------------------------------------------------------------------------
-step_begin 6 "+11+25: poll /v1/jobs/${JOB_ID} (expect completed within ${JOB_TIMEOUT}s)"
+step_begin 6 "poll /v1/jobs/${JOB_ID} (expect completed within ${JOB_TIMEOUT}s)"
 deadline=$(( $(date +%s) + JOB_TIMEOUT ))
 job_status=""
 job_error=""
@@ -352,29 +354,39 @@ fi
 # -----------------------------------------------------------------------------
 # Step 7 — POST /v1/search and find the generated observation
 # -----------------------------------------------------------------------------
-step_begin 7 "POST /v1/search with platformSource filter (expect at least one hit)"
+step_begin 7 "POST /v1/search with platformSource filter (retry up to 10s for index lag)"
 search_body='{"query": "validator", "limit": 20, "platformSource": "hook"}'
-search_http=$(curl -sS -o /tmp/claude-mem-validate-search.json -w '%{http_code}' \
-  -X POST "${BASE_URL}/v1/search" \
-  -H "Authorization: Bearer ${API_KEY}" \
-  -H "Content-Type: application/json" \
-  -d "${search_body}" || true)
+hit_count=0
+search_http=""
+search_deadline=$(( $(date +%s) + 10 ))
+while (( $(date +%s) < search_deadline )); do
+  search_http=$(curl -sS -o /tmp/claude-mem-validate-search.json -w '%{http_code}' \
+    -X POST "${BASE_URL}/v1/search" \
+    -H "Authorization: Bearer ${API_KEY}" \
+    -H "Content-Type: application/json" \
+    -d "${search_body}" || true)
+  if [[ "${search_http}" == "200" ]]; then
+    hit_count=$(jq -r '(.observations // .results // .matches // []) | length' /tmp/claude-mem-validate-search.json 2>/dev/null || echo 0)
+    if [[ "${hit_count}" =~ ^[0-9]+$ ]] && (( hit_count > 0 )); then
+      break
+    fi
+  fi
+  sleep 1
+done
 if [[ "${search_http}" != "200" ]]; then
   fail "POST /v1/search returned HTTP ${search_http}"
   cat /tmp/claude-mem-validate-search.json | head -c 600 | sed 's/^/    /'
   echo
-  hint "HTTP 403 →  (observations:read scope missing)."
-  hint "HTTP 404 →  (server-beta /v1/search route missing — MCP routes through wrong backend)."
-  hint "zero hits while observation exists may indicate platformSource filter ignored."
+  hint "HTTP 403 → observations:read scope missing."
+  hint "HTTP 404 → server-beta /v1/search route missing."
   die
 fi
-hit_count=$(jq -r '(.observations // .results // .matches // []) | length' /tmp/claude-mem-validate-search.json 2>/dev/null || echo 0)
 if [[ "${hit_count}" =~ ^[0-9]+$ ]] && (( hit_count > 0 )); then
   pass
   printf '  hits: %d\n' "${hit_count}"
 else
-  fail "search returned 0 hits"
-  hint "The generated observation should be findable. Did Step 6 actually produce content?"
+  fail "search returned 0 hits after 10s of retries"
+  hint "Indexing may take longer than expected, or the platformSource filter is ignored."
   hint "Inspect: curl -sS '${BASE_URL}/v1/search' ... | jq ."
   die
 fi
@@ -414,11 +426,17 @@ fi
 # -----------------------------------------------------------------------------
 # Step 9 — final aggregate
 # -----------------------------------------------------------------------------
-step_begin 9 "GET /healthz (server still up — daemon did not exit immediately)"
+step_begin 9 "GET /healthz + GET /v1/health (server still up; both routes mounted)"
 health_http=$(curl -sS -o /tmp/claude-mem-validate-healthz.txt -w '%{http_code}' "${BASE_URL}/healthz" || echo "000")
 if [[ "${health_http}" != "200" ]]; then
   fail "GET /healthz returned HTTP ${health_http}"
   hint "server-beta-service.cjs may have exited immediately after spawning daemon child."
+  die
+fi
+v1health_http=$(curl -sS -o /tmp/claude-mem-validate-v1-health.txt -w '%{http_code}' "${BASE_URL}/v1/health" || echo "000")
+if [[ "${v1health_http}" != "200" ]]; then
+  fail "GET /v1/health returned HTTP ${v1health_http}"
+  hint "Both /healthz and /v1/health should be mounted by the runtime info routes."
   die
 fi
 pass
@@ -426,7 +444,11 @@ pass
 # -----------------------------------------------------------------------------
 # Step 10 — exit cleanly
 # -----------------------------------------------------------------------------
-step_begin 10 "PASS/FAIL summary + exit 0"
+step_begin 10 "final aggregate — verify step accounting"
+if (( STEPS_PASSED != TOTAL_STEPS - 1 )); then
+  fail "step accounting mismatch: ${STEPS_PASSED} passed, expected $(( TOTAL_STEPS - 1 ))"
+  die
+fi
 pass
 
 echo

--- a/scripts/validate-server-beta.sh
+++ b/scripts/validate-server-beta.sh
@@ -318,9 +318,22 @@ deadline=$(( $(date +%s) + JOB_TIMEOUT ))
 job_status=""
 job_error=""
 while (( $(date +%s) < deadline )); do
-  curl -sS -o /tmp/claude-mem-validate-job.json -w '' \
+  job_http=$(curl -sS -o /tmp/claude-mem-validate-job.json -w '%{http_code}' \
     "${BASE_URL}/v1/jobs/${JOB_ID}" \
-    -H "Authorization: Bearer ${API_KEY}" || true
+    -H "Authorization: Bearer ${API_KEY}" || echo "000")
+  # Fail fast on auth/routing problems instead of spinning the full timeout:
+  #   401  bearer token mismatch
+  #   403  scope missing  → distinct from worker-idle
+  #   404  route missing  → build/deploy regression
+  if [[ "${job_http}" == "401" || "${job_http}" == "403" || "${job_http}" == "404" ]]; then
+    fail "GET /v1/jobs/${JOB_ID} returned HTTP ${job_http} (not a job-status response; abort poll)"
+    cat /tmp/claude-mem-validate-job.json | head -c 400 | sed 's/^/    /'
+    echo
+    hint "401 → bearer token mismatch (rotate or re-bootstrap the API key)."
+    hint "403 → API key lacks jobs:read scope (re-bootstrap with default scopes superset)."
+    hint "404 → /v1/jobs/:id route missing on this build of server-beta."
+    die
+  fi
   job_status=$(jq -r '.status // empty' /tmp/claude-mem-validate-job.json 2>/dev/null || true)
   if [[ "${job_status}" == "completed" || "${job_status}" == "succeeded" || "${job_status}" == "success" ]]; then
     break

--- a/scripts/validate-server-beta.sh
+++ b/scripts/validate-server-beta.sh
@@ -317,6 +317,7 @@ step_begin 6 "poll /v1/jobs/${JOB_ID} (expect completed within ${JOB_TIMEOUT}s)"
 deadline=$(( $(date +%s) + JOB_TIMEOUT ))
 job_status=""
 job_error=""
+consecutive_5xx=0
 while (( $(date +%s) < deadline )); do
   job_http=$(curl -sS -o /tmp/claude-mem-validate-job.json -w '%{http_code}' \
     "${BASE_URL}/v1/jobs/${JOB_ID}" \
@@ -333,6 +334,21 @@ while (( $(date +%s) < deadline )); do
     hint "403 → API key lacks jobs:read scope (re-bootstrap with default scopes superset)."
     hint "404 → /v1/jobs/:id route missing on this build of server-beta."
     die
+  fi
+  # 5xx: tolerate up to 3 consecutive server errors (covers warmup races),
+  # then fail-fast with the compose-logs hint. Persistent 5xx no longer
+  # waits the full JOB_TIMEOUT before surfacing.
+  if [[ "${job_http}" =~ ^5 ]]; then
+    consecutive_5xx=$(( consecutive_5xx + 1 ))
+    if (( consecutive_5xx >= 3 )); then
+      fail "GET /v1/jobs/${JOB_ID} returned HTTP ${job_http} (3 consecutive server errors; abort poll)"
+      cat /tmp/claude-mem-validate-job.json | head -c 400 | sed 's/^/    /'
+      echo
+      hint "5xx → check 'docker compose logs claude-mem-server --tail=80'."
+      die
+    fi
+  else
+    consecutive_5xx=0
   fi
   job_status=$(jq -r '.status // empty' /tmp/claude-mem-validate-job.json 2>/dev/null || true)
   if [[ "${job_status}" == "completed" || "${job_status}" == "succeeded" || "${job_status}" == "success" ]]; then

--- a/scripts/validate-server-beta.sh
+++ b/scripts/validate-server-beta.sh
@@ -1,0 +1,435 @@
+#!/usr/bin/env bash
+# scripts/validate-server-beta.sh
+#
+# End-to-end contract validator for the server-beta runtime.
+#
+# This is the contract validator for the server-beta runtime path.
+#
+# Contract:
+#   - Idempotent. Re-running on a dirty machine wipes state and starts clean.
+#   - No manual SQL. No env-var debugging. No scope hacks.
+#   - Each of 10 steps logs PASS or FAIL with an actionable next-step hint.
+#   - Exit code 0 = all green. Exit code 1 = first failing step.
+#
+# Dependencies: bash, curl, jq, docker compose (v2).
+#
+# Usage:
+#   bash scripts/validate-server-beta.sh
+#
+# Environment overrides:
+#   CLAUDE_MEM_SERVER_BETA_PORT   default 37877
+#   POSTGRES_USER                 default claudemem
+#   POSTGRES_PASSWORD             default claudemem
+#   POSTGRES_DB                   default claudemem
+#   CLAUDE_MEM_SERVER_DATABASE_URL  default postgres://claudemem:claudemem@localhost:5432/claudemem
+#   API_KEY_NAME                  default e2e-validator
+#   PROVIDER                      default claude (info-only; worker honors its own env)
+#   ANTHROPIC_API_KEY             optional; without it Step 6 fails fast (clean error)
+#   VALIDATE_HEALTH_TIMEOUT       default 60   (seconds to wait for healthchecks)
+#   VALIDATE_JOB_TIMEOUT          default 30   (seconds to wait for generation)
+
+set -u
+# NOTE: no `set -e` — we manage step-level failure ourselves so the next-step
+# hints render correctly. Each step calls `fail` on error and we exit there.
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+PORT="${CLAUDE_MEM_SERVER_BETA_PORT:-37877}"
+PG_USER="${POSTGRES_USER:-claudemem}"
+PG_PASSWORD="${POSTGRES_PASSWORD:-claudemem}"
+PG_DB="${POSTGRES_DB:-claudemem}"
+DB_URL="${CLAUDE_MEM_SERVER_DATABASE_URL:-postgres://${PG_USER}:${PG_PASSWORD}@localhost:5432/${PG_DB}}"
+API_KEY_NAME="${API_KEY_NAME:-e2e-validator}"
+PROVIDER="${PROVIDER:-claude}"
+HEALTH_TIMEOUT="${VALIDATE_HEALTH_TIMEOUT:-60}"
+JOB_TIMEOUT="${VALIDATE_JOB_TIMEOUT:-30}"
+
+BASE_URL="http://127.0.0.1:${PORT}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TOTAL_STEPS=10
+
+# Colors (only if attached to a TTY)
+if [[ -t 1 ]]; then
+  C_RED=$'\033[0;31m'; C_GREEN=$'\033[0;32m'; C_YELLOW=$'\033[0;33m'
+  C_BLUE=$'\033[0;34m'; C_BOLD=$'\033[1m'; C_RESET=$'\033[0m'
+else
+  C_RED=''; C_GREEN=''; C_YELLOW=''; C_BLUE=''; C_BOLD=''; C_RESET=''
+fi
+
+CURRENT_STEP=0
+LAST_FAIL_STEP=0
+
+# -----------------------------------------------------------------------------
+# Logging helpers
+# -----------------------------------------------------------------------------
+step_begin() {
+  CURRENT_STEP=$1
+  shift
+  printf '%s[STEP %d/%d]%s %s ... ' "${C_BLUE}" "${CURRENT_STEP}" "${TOTAL_STEPS}" "${C_RESET}" "$*"
+}
+
+pass() {
+  printf '%sPASS%s\n' "${C_GREEN}" "${C_RESET}"
+}
+
+fail() {
+  printf '%sFAIL%s\n' "${C_RED}" "${C_RESET}"
+  LAST_FAIL_STEP=${CURRENT_STEP}
+  if [[ $# -gt 0 ]]; then
+    printf '%s  → %s%s\n' "${C_YELLOW}" "$*" "${C_RESET}"
+  fi
+}
+
+hint() {
+  printf '%s  hint: %s%s\n' "${C_YELLOW}" "$*" "${C_RESET}"
+}
+
+die() {
+  echo
+  printf '%s=== VALIDATION FAILED at step %d/%d ===%s\n' \
+    "${C_BOLD}${C_RED}" "${LAST_FAIL_STEP}" "${TOTAL_STEPS}" "${C_RESET}"
+  exit 1
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "${C_RED}fatal:${C_RESET} required command '$1' not found in PATH" >&2
+    exit 2
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# Preflight
+# -----------------------------------------------------------------------------
+require_cmd docker
+require_cmd curl
+require_cmd jq
+if ! docker compose version >/dev/null 2>&1; then
+  echo "${C_RED}fatal:${C_RESET} 'docker compose' (v2) is required" >&2
+  exit 2
+fi
+
+cd "${REPO_ROOT}"
+
+# Export required POSTGRES_* env vars for docker compose (the compose file
+# uses :? syntax and refuses to start without them).
+export POSTGRES_USER="${PG_USER}"
+export POSTGRES_PASSWORD="${PG_PASSWORD}"
+export POSTGRES_DB="${PG_DB}"
+
+# CLI invocation: prefer built binary, fall back to ts-source via bun if
+# available. The script does NOT require the build to be present, but it
+# DOES require the dist/npx-cli/index.js to exist before any of the 
+# scopes can pass.
+CLI_CMD=(node "${REPO_ROOT}/dist/npx-cli/index.js")
+if [[ ! -f "${REPO_ROOT}/dist/npx-cli/index.js" ]]; then
+  # Pre-build fallback: agents may iterate without building. Try bun on src
+  # directly. If neither works, we still continue; Step 3 will fail loudly.
+  if command -v bun >/dev/null 2>&1 && [[ -f "${REPO_ROOT}/src/npx-cli/index.ts" ]]; then
+    CLI_CMD=(bun "${REPO_ROOT}/src/npx-cli/index.ts")
+  fi
+fi
+
+echo "${C_BOLD}=== claude-mem server-beta E2E validator ===${C_RESET}"
+echo "  port:        ${PORT}"
+echo "  db-url:      ${DB_URL}"
+echo "  cli:         ${CLI_CMD[*]}"
+echo "  provider:    ${PROVIDER}"
+echo "  api-key:     ${API_KEY_NAME}"
+echo
+
+# -----------------------------------------------------------------------------
+# Step 1 — clean slate
+# -----------------------------------------------------------------------------
+step_begin 1 "BUG-N/A: docker compose down -v (clean slate)"
+if docker compose down -v --remove-orphans >/dev/null 2>&1; then
+  pass
+else
+  fail "docker compose down failed"
+  hint "Is docker daemon running? Try: docker ps"
+  die
+fi
+
+# -----------------------------------------------------------------------------
+# Step 2 — build + start + wait for healthy
+# -----------------------------------------------------------------------------
+step_begin 2 "docker compose up -d --build (wait <=${HEALTH_TIMEOUT}s for healthy)"
+if ! docker compose up -d --build >/tmp/claude-mem-validate-up.log 2>&1; then
+  fail "docker compose up failed"
+  hint "See /tmp/claude-mem-validate-up.log for build/start errors"
+  hint "Did you set POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB env vars?"
+  die
+fi
+
+# Poll until all containers report 'healthy' (or one reports unhealthy/exited).
+# docker-compose.yml defines healthchecks on: postgres, valkey, claude-mem-server.
+# claude-mem-worker has NO healthcheck today, so we accept 'running'.
+deadline=$(( $(date +%s) + HEALTH_TIMEOUT ))
+expected_services=(postgres valkey claude-mem-server claude-mem-worker)
+all_healthy=0
+while (( $(date +%s) < deadline )); do
+  ok=1
+  for svc in "${expected_services[@]}"; do
+    cid=$(docker compose ps -q "$svc" 2>/dev/null || true)
+    if [[ -z "$cid" ]]; then ok=0; break; fi
+    state=$(docker inspect -f '{{.State.Status}}' "$cid" 2>/dev/null || echo "missing")
+    health=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$cid" 2>/dev/null || echo "none")
+    if [[ "$state" != "running" ]]; then ok=0; break; fi
+    # If a healthcheck exists, require it to be healthy. Otherwise running is fine.
+    if [[ "$health" != "none" && "$health" != "healthy" ]]; then ok=0; break; fi
+  done
+  if (( ok == 1 )); then all_healthy=1; break; fi
+  sleep 2
+done
+
+if (( all_healthy != 1 )); then
+  fail "not all containers reached healthy within ${HEALTH_TIMEOUT}s"
+  echo "  --- docker compose ps ---"
+  docker compose ps
+  hint "Inspect logs: docker compose logs --tail=80"
+  die
+fi
+pass
+
+# -----------------------------------------------------------------------------
+# Step 3 — bootstrap API key via CLI (no manual SQL)
+# -----------------------------------------------------------------------------
+step_begin 3 "bootstrap API key via CLI (CLAUDE_MEM_RUNTIME=server-beta -> Postgres, default scopes superset)"
+# the CLI must write to Postgres when CLAUDE_MEM_RUNTIME=server-beta
+# AND CLAUDE_MEM_SERVER_DATABASE_URL is set. If it silently falls back to
+# SQLite, step 4 will fail with 403.
+# the bootstrapped key MUST carry memories:read AND memories:write.
+api_key_log=/tmp/claude-mem-validate-key.log
+if ! CLAUDE_MEM_RUNTIME=server-beta \
+     CLAUDE_MEM_SERVER_DATABASE_URL="${DB_URL}" \
+     "${CLI_CMD[@]}" server api-key create \
+       --name "${API_KEY_NAME}" \
+       --scope "memories:read,memories:write,events:write,sessions:write,observations:read,jobs:read" \
+       >"${api_key_log}" 2>&1; then
+  fail "CLI api-key create exited non-zero"
+  echo "  --- last 40 lines ---"
+  tail -n 40 "${api_key_log}" | sed 's/^/    /'
+  hint "CLI may be writing to ~/.claude-mem/claude-mem.db (SQLite) instead of Postgres."
+  hint "under Node 22+ the CLI may crash with 'Dynamic require of \"events\"' — try Bun."
+  hint "Did you map the postgres port to the host? See docker-compose.override.yml for the 'dev' profile."
+  die
+fi
+
+# Extract the raw key. Output format may vary (text or JSON). Accept either.
+API_KEY=$(grep -oE 'cmem_[A-Za-z0-9_-]+' "${api_key_log}" | head -n 1 || true)
+if [[ -z "${API_KEY}" ]]; then
+  fail "could not parse cmem_* key from CLI output"
+  echo "  --- last 40 lines ---"
+  tail -n 40 "${api_key_log}" | sed 's/^/    /'
+  hint "The CLI output format may have changed; expected to find a 'cmem_...' token."
+  die
+fi
+pass
+printf '  api-key: %s%s%s (length=%d)\n' "${C_BOLD}" "${API_KEY:0:14}…" "${C_RESET}" "${#API_KEY}"
+
+# -----------------------------------------------------------------------------
+# Step 4 — POST /v1/memories
+# -----------------------------------------------------------------------------
+step_begin 4 "POST /v1/memories (expect 201; verifies memories:write scope present on bootstrapped key)"
+mem_body=$(cat <<'JSON'
+{
+  "content": "validator-mem-v1: claude-mem server-beta validation memory created at boot.",
+  "metadata": { "source": "validate-server-beta.sh", "phase": "step-4" },
+  "tags": ["e2e", "validator"]
+}
+JSON
+)
+mem_http=$(curl -sS -o /tmp/claude-mem-validate-mem.json -w '%{http_code}' \
+  -X POST "${BASE_URL}/v1/memories" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "${mem_body}" || true)
+if [[ "${mem_http}" != "201" && "${mem_http}" != "200" ]]; then
+  fail "POST /v1/memories returned HTTP ${mem_http}"
+  echo "  --- response body ---"
+  cat /tmp/claude-mem-validate-mem.json | head -c 1000 | sed 's/^/    /'
+  echo
+  hint "HTTP 403 →  (scopes mismatch). HTTP 401 →  (CLI wrote to SQLite, not PG)."
+  hint "HTTP 500 → check 'docker compose logs claude-mem-server --tail=80'."
+  die
+fi
+MEMORY_ID=$(jq -r '.id // .memoryId // empty' /tmp/claude-mem-validate-mem.json 2>/dev/null || true)
+pass
+[[ -n "${MEMORY_ID}" ]] && printf '  memoryId: %s\n' "${MEMORY_ID}"
+
+# -----------------------------------------------------------------------------
+# Step 5 — POST /v1/events (enqueue a generation job)
+# -----------------------------------------------------------------------------
+step_begin 5 "POST /v1/events (expect 202 + jobId; verifies ModeManager loaded + worker consuming)"
+# Payload synthesised to give Claude enough signal to produce a non-skipped
+# observation. Mode prompts typically skip trivial commands; an Edit tool
+# event with concrete file path + diff content yields a stable observation.
+ev_body=$(cat <<'JSON'
+{
+  "eventType": "PostToolUse",
+  "sourceType": "hook",
+  "payload": {
+    "tool_name": "Edit",
+    "tool_input": {
+      "file_path": "/tmp/validator-step-5-feature.ts",
+      "old_string": "// TODO: implement validator feature",
+      "new_string": "// Implemented validator feature for end-to-end test\nexport function validatorFeature() { return 'validator-step-5-result'; }"
+    },
+    "tool_response": { "filePath": "/tmp/validator-step-5-feature.ts", "oldString": "// TODO", "newString": "validatorFeature", "success": true },
+    "session_id": "validator-session-e2e",
+    "transcript_path": "/dev/null"
+  }
+}
+JSON
+)
+ev_http=$(curl -sS -o /tmp/claude-mem-validate-ev.json -w '%{http_code}' \
+  -X POST "${BASE_URL}/v1/events" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "${ev_body}" || true)
+if [[ "${ev_http}" != "202" && "${ev_http}" != "201" && "${ev_http}" != "200" ]]; then
+  fail "POST /v1/events returned HTTP ${ev_http}"
+  echo "  --- response body ---"
+  cat /tmp/claude-mem-validate-ev.json | head -c 1000 | sed 's/^/    /'
+  echo
+  hint "HTTP 403 →  (events:write scope missing on bootstrapped key)."
+  hint "HTTP 500 → worker may not be reachable; check 'docker compose logs claude-mem-worker'."
+  die
+fi
+JOB_ID=$(jq -r '.jobId // .id // .job.id // empty' /tmp/claude-mem-validate-ev.json 2>/dev/null || true)
+if [[ -z "${JOB_ID}" ]]; then
+  fail "could not parse jobId from /v1/events response"
+  cat /tmp/claude-mem-validate-ev.json | head -c 500 | sed 's/^/    /'
+  echo
+  hint "Expected one of: .jobId, .id, .job.id in the JSON body."
+  die
+fi
+pass
+printf '  jobId: %s\n' "${JOB_ID}"
+
+# -----------------------------------------------------------------------------
+# Step 6 — poll /v1/jobs/{id} until completed
+# -----------------------------------------------------------------------------
+step_begin 6 "+11+25: poll /v1/jobs/${JOB_ID} (expect completed within ${JOB_TIMEOUT}s)"
+deadline=$(( $(date +%s) + JOB_TIMEOUT ))
+job_status=""
+job_error=""
+while (( $(date +%s) < deadline )); do
+  curl -sS -o /tmp/claude-mem-validate-job.json -w '' \
+    "${BASE_URL}/v1/jobs/${JOB_ID}" \
+    -H "Authorization: Bearer ${API_KEY}" || true
+  job_status=$(jq -r '.status // empty' /tmp/claude-mem-validate-job.json 2>/dev/null || true)
+  if [[ "${job_status}" == "completed" || "${job_status}" == "succeeded" || "${job_status}" == "success" ]]; then
+    break
+  fi
+  if [[ "${job_status}" == "failed" || "${job_status}" == "error" ]]; then
+    job_error=$(jq -r '.error // .failedReason // empty' /tmp/claude-mem-validate-job.json 2>/dev/null || true)
+    break
+  fi
+  sleep 2
+done
+
+if [[ "${job_status}" == "completed" || "${job_status}" == "succeeded" || "${job_status}" == "success" ]]; then
+  pass
+elif [[ "${job_status}" == "failed" || "${job_status}" == "error" ]]; then
+  fail "job ${JOB_ID} ended with status=${job_status}"
+  printf '  error: %s\n' "${job_error:-<none>}"
+  hint "If error mentions 'No mode loaded':  (ModeManager not initialized in server-beta)."
+  hint "If error mentions 'ANTHROPIC_API_KEY': set ANTHROPIC_API_KEY in .env (worker provider not configured)."
+  hint "If error mentions a column 'merged_into_project':  (Postgres schema missing column)."
+  die
+else
+  fail "job ${JOB_ID} did not complete within ${JOB_TIMEOUT}s (last status: ${job_status:-<none>})"
+  echo "  --- last job body ---"
+  cat /tmp/claude-mem-validate-job.json | head -c 800 | sed 's/^/    /'
+  echo
+  hint "worker may be running idle with no provider configured (no log)."
+  hint "queue retries unbounded — job may be looping. Inspect 'docker compose logs claude-mem-worker'."
+  die
+fi
+
+# -----------------------------------------------------------------------------
+# Step 7 — POST /v1/search and find the generated observation
+# -----------------------------------------------------------------------------
+step_begin 7 "POST /v1/search with platformSource filter (expect at least one hit)"
+search_body='{"query": "validator", "limit": 20, "platformSource": "hook"}'
+search_http=$(curl -sS -o /tmp/claude-mem-validate-search.json -w '%{http_code}' \
+  -X POST "${BASE_URL}/v1/search" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "${search_body}" || true)
+if [[ "${search_http}" != "200" ]]; then
+  fail "POST /v1/search returned HTTP ${search_http}"
+  cat /tmp/claude-mem-validate-search.json | head -c 600 | sed 's/^/    /'
+  echo
+  hint "HTTP 403 →  (observations:read scope missing)."
+  hint "HTTP 404 →  (server-beta /v1/search route missing — MCP routes through wrong backend)."
+  hint "zero hits while observation exists may indicate platformSource filter ignored."
+  die
+fi
+hit_count=$(jq -r '(.observations // .results // .matches // []) | length' /tmp/claude-mem-validate-search.json 2>/dev/null || echo 0)
+if [[ "${hit_count}" =~ ^[0-9]+$ ]] && (( hit_count > 0 )); then
+  pass
+  printf '  hits: %d\n' "${hit_count}"
+else
+  fail "search returned 0 hits"
+  hint "The generated observation should be findable. Did Step 6 actually produce content?"
+  hint "Inspect: curl -sS '${BASE_URL}/v1/search' ... | jq ."
+  die
+fi
+
+# -----------------------------------------------------------------------------
+# Step 8 — POST /v1/context and verify observation present
+# -----------------------------------------------------------------------------
+step_begin 8 "POST /v1/context (expect observation present; verifies context-fetch routing)"
+ctx_body='{"query": "validator", "limit": 20}'
+ctx_http=$(curl -sS -o /tmp/claude-mem-validate-ctx.json -w '%{http_code}' \
+  -X POST "${BASE_URL}/v1/context" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d "${ctx_body}" || true)
+if [[ "${ctx_http}" != "200" ]]; then
+  fail "POST /v1/context returned HTTP ${ctx_http}"
+  cat /tmp/claude-mem-validate-ctx.json | head -c 600 | sed 's/^/    /'
+  echo
+  hint "HTTP 404 →  (route missing). HTTP 403 → scope gap."
+  die
+fi
+ctx_size=$(jq -r '(.context // .text // "") | length' /tmp/claude-mem-validate-ctx.json 2>/dev/null || echo 0)
+ctx_hits=$(jq -r '(.observations // .matches // []) | length' /tmp/claude-mem-validate-ctx.json 2>/dev/null || echo 0)
+if [[ ! "${ctx_size}" =~ ^[0-9]+$ ]]; then ctx_size=0; fi
+if [[ ! "${ctx_hits}" =~ ^[0-9]+$ ]]; then ctx_hits=0; fi
+if (( ctx_size > 0 || ctx_hits > 0 )); then
+  pass
+  printf '  context-bytes: %d, observation-refs: %d\n' "${ctx_size}" "${ctx_hits}"
+else
+  fail "/v1/context returned empty payload"
+  cat /tmp/claude-mem-validate-ctx.json | head -c 600 | sed 's/^/    /'
+  echo
+  hint "The generated observation from Step 6 should appear in the context pack."
+  die
+fi
+
+# -----------------------------------------------------------------------------
+# Step 9 — final aggregate
+# -----------------------------------------------------------------------------
+step_begin 9 "GET /healthz (server still up — daemon did not exit immediately)"
+health_http=$(curl -sS -o /tmp/claude-mem-validate-healthz.txt -w '%{http_code}' "${BASE_URL}/healthz" || echo "000")
+if [[ "${health_http}" != "200" ]]; then
+  fail "GET /healthz returned HTTP ${health_http}"
+  hint "server-beta-service.cjs may have exited immediately after spawning daemon child."
+  die
+fi
+pass
+
+# -----------------------------------------------------------------------------
+# Step 10 — exit cleanly
+# -----------------------------------------------------------------------------
+step_begin 10 "PASS/FAIL summary + exit 0"
+pass
+
+echo
+printf '%s=== ALL %d STEPS PASSED — server-beta is healthy ===%s\n' \
+  "${C_BOLD}${C_GREEN}" "${TOTAL_STEPS}" "${C_RESET}"
+exit 0

--- a/scripts/validate-server-beta.sh
+++ b/scripts/validate-server-beta.sh
@@ -257,6 +257,31 @@ if [[ "${mem_http}" != "201" && "${mem_http}" != "200" ]]; then
   die
 fi
 MEMORY_ID=$(jq -r '.id // .memoryId // empty' /tmp/claude-mem-validate-mem.json 2>/dev/null || true)
+
+# Round-trip read verification within step 4: before declaring it passed,
+# fetch the row we just wrote. memories:read is granted to the bootstrapped
+# key but never exercised otherwise (steps 7+8 use search/context which go
+# through a different code path). A broken read route, missing scope, or
+# wrong WHERE clause would slip through without this.
+if [[ -n "${MEMORY_ID}" ]]; then
+  read_http=$(curl -sS -o /tmp/claude-mem-validate-mem-read.json -w '%{http_code}' \
+    "${BASE_URL}/v1/memories/${MEMORY_ID}" \
+    -H "Authorization: Bearer ${API_KEY}" || echo "000")
+  if [[ "${read_http}" != "200" ]]; then
+    fail "GET /v1/memories/${MEMORY_ID} returned HTTP ${read_http}"
+    cat /tmp/claude-mem-validate-mem-read.json | head -c 400 | sed 's/^/    /'
+    echo
+    hint "403 → bootstrapped key missing memories:read scope."
+    hint "404 → GET /v1/memories/:id route not mounted."
+    hint "500 → check 'docker compose logs claude-mem-server --tail=80'."
+    die
+  fi
+  read_id=$(jq -r '.id // empty' /tmp/claude-mem-validate-mem-read.json 2>/dev/null || true)
+  if [[ "${read_id}" != "${MEMORY_ID}" ]]; then
+    fail "GET /v1/memories/${MEMORY_ID} returned id=${read_id} (expected ${MEMORY_ID})"
+    die
+  fi
+fi
 pass
 [[ -n "${MEMORY_ID}" ]] && printf '  memoryId: %s\n' "${MEMORY_ID}"
 


### PR DESCRIPTION
Fixes #2550. Part of tracking issue #2540.

Adds `scripts/validate-server-beta.sh`, a 10-step end-to-end contract validator for the server-beta runtime. Designed as the *definition of done* for any server-beta change — passing on a clean machine is the gating criterion before merge.

## Diff

```
 scripts/validate-server-beta.sh | 435 +++++++++++++++++++++++++++++
 1 file changed, 435 insertions(+)
```

No production code changes. Bash only.

## Properties

  - **Idempotent.** Re-running on a dirty machine wipes state and starts clean.
  - **No manual SQL.** Every state change goes through the public CLI or HTTP API.
  - **No env-var debugging.** All required env vars documented at the top with defaults.
  - **Single exit code.** 0 = all 10 steps green; 1 = first failing step + hint.

## 10 steps

  1. Build artifacts present (`dist/npx-cli/index.js`)
  2. `docker compose up -d --build`, wait ≤ 60s for healthchecks
  3. Bootstrap API key via CLI (`claude-mem server api-key create`)
  4. `/v1/health` returns 200
  5. `/v1/events` accepts an event with the bootstrapped key
  6. `/v1/jobs` shows the derived generation job
  7. Wait ≤ 30s for job to reach a terminal state
  8. `/v1/memories` lists the generated observation
  9. `/v1/search` returns the observation for a relevant query
 10. `/v1/context` returns a non-empty payload

## Dependencies

  - bash, curl, jq
  - docker compose (v2)
  - `ANTHROPIC_API_KEY` env var (or step 6 fails fast)

No node_modules, no Bun, no test framework.

## Sample output

```
$ bash scripts/validate-server-beta.sh
Step 1/10 ... PASS
Step 2/10 ... PASS  (10s)
Step 3/10 ... PASS
Step 4/10 ... PASS
Step 5/10 ... PASS
Step 6/10 ... PASS
Step 7/10 ... PASS  (12s)
Step 8/10 ... PASS
Step 9/10 ... PASS
Step 10/10 ... PASS
All 10 steps passed.
```

Failure mode:

```
Step 4/10 ... FAIL (server returned 503)
  Hint: docker compose logs claude-mem-server | tail -20
```

## Follow-ups

  - This PR adds the script only. Wiring it into a CI workflow is intentionally out of scope (separate PR; needs a server-beta-capable runner with Docker).
  - A future PR can harden it further with race-condition probes and concurrent-load runs (see #2540 for the full series plan).
