### PR TITLE
feat(server-beta): subscription auth via OAuth resolver + host-bridge provider

### DIFF
--- a/src/server/generation/providers/ClaudeHostBridgeProvider.ts
+++ b/src/server/generation/providers/ClaudeHostBridgeProvider.ts
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// ClaudeHostBridgeProvider.
+//
+// Proxies observation generation through the user's locally-installed Claude
+// CLI by POSTing prompts to a small HTTP bridge running on the host. The
+// bridge (~/.claude-mem/claude-host-bridge.cjs, started by launchd on macOS or
+// systemd --user on Linux) shells out to `claude` for each request, so:
+//
+//   - account switches propagate INSTANTLY (next request uses the new account)
+//   - OAuth token refresh is handled by Claude CLI transparently
+//   - the model selected via Claude CLI (4.5/4.6/whatever the user installed)
+//     is what gets used — no need to hardcode CLAUDE_MEM_SERVER_MODEL
+//
+// The container reaches the bridge via host.docker.internal (Docker Desktop)
+// or a host-network alias on Linux. CLAUDE_MEM_CLAUDE_BRIDGE_URL is set by
+// the install script when the bridge is active.
+//
+// Authentication: the bridge requires a Bearer token (random 32-byte hex,
+// stored on host at ~/.claude-mem/host-bridge-token, mounted read-only into
+// the container at /run/secrets/claude-host-bridge-token). Prevents other
+// processes on the host or in the container from accidentally hitting the
+// bridge.
+
+import { logger } from '../../../utils/logger.js';
+import { ServerClassifiedProviderError } from './shared/error-classification.js';
+import { buildServerGenerationPrompt } from './shared/prompt-builder.js';
+import type {
+  ServerGenerationContext,
+  ServerGenerationProvider,
+  ServerGenerationResult,
+} from './shared/types.js';
+
+export interface ClaudeHostBridgeProviderOptions {
+  bridgeUrl: string;
+  bridgeToken: string;
+  model?: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+interface BridgeGenerateResponse {
+  text?: string;
+  error?: string;
+  message?: string;
+  exitCode?: number;
+  stderr?: string;
+}
+
+export class ClaudeHostBridgeProvider implements ServerGenerationProvider {
+  readonly providerLabel = 'claude' as const;
+  private readonly bridgeUrl: string;
+  private readonly bridgeToken: string;
+  private readonly model: string | undefined;
+  private readonly fetchImpl: typeof fetch;
+  private readonly timeoutMs: number;
+
+  constructor(options: ClaudeHostBridgeProviderOptions) {
+    if (!options.bridgeUrl) {
+      throw new ServerClassifiedProviderError('Host-bridge URL missing', {
+        kind: 'auth_invalid',
+        cause: new Error('bridgeUrl is required'),
+      });
+    }
+    if (!options.bridgeToken) {
+      throw new ServerClassifiedProviderError('Host-bridge token missing', {
+        kind: 'auth_invalid',
+        cause: new Error('bridgeToken is required'),
+      });
+    }
+    this.bridgeUrl = options.bridgeUrl.replace(/\/$/, '');
+    this.bridgeToken = options.bridgeToken;
+    this.model = options.model;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.timeoutMs = options.timeoutMs ?? 120_000;
+  }
+
+  async generate(
+    context: ServerGenerationContext,
+    signal?: AbortSignal,
+  ): Promise<ServerGenerationResult> {
+    const { prompt, skippedAll } = buildServerGenerationPrompt(context);
+    if (skippedAll) {
+      return {
+        rawText: '<skip_summary reason="all_events_private" />',
+        providerLabel: this.providerLabel,
+        modelId: this.model ?? '(host-bridge default)',
+      };
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    // Compose a combined signal so external aborts (worker shutdown) and our
+    // internal timeout both terminate the fetch.
+    if (signal) {
+      signal.addEventListener('abort', () => controller.abort(), { once: true });
+    }
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(`${this.bridgeUrl}/v1/generate`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.bridgeToken}`,
+        },
+        body: JSON.stringify({
+          prompt,
+          model: this.model,
+        }),
+        signal: controller.signal,
+      });
+    } catch (networkError) {
+      clearTimeout(timer);
+      const reason = networkError instanceof Error ? networkError.message : String(networkError);
+      logger.warn('SYSTEM', 'host-bridge request failed', { bridgeUrl: this.bridgeUrl, reason });
+      throw new ServerClassifiedProviderError(`host-bridge unreachable: ${reason}`, {
+        kind: 'transient',
+        cause: networkError,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!response.ok) {
+      const bodyText = await response.text().catch(() => '');
+      let parsed: BridgeGenerateResponse | undefined;
+      try {
+        parsed = JSON.parse(bodyText) as BridgeGenerateResponse;
+      } catch {
+        /* keep raw */
+      }
+      const message = parsed?.message ?? parsed?.stderr ?? bodyText.slice(0, 500) ?? `HTTP ${response.status}`;
+      // Map common bridge failure modes onto the provider error taxonomy so
+      // the worker retry policy reacts correctly.
+      if (response.status === 401) {
+        throw new ServerClassifiedProviderError('host-bridge rejected token', {
+          kind: 'auth_invalid',
+          cause: new Error(message),
+        });
+      }
+      if (response.status === 502 && parsed?.error === 'ClaudeCliError') {
+        throw new ServerClassifiedProviderError(`claude CLI failed (exit ${parsed.exitCode ?? '?'}): ${message}`, {
+          kind: 'transient',
+          cause: new Error(message),
+        });
+      }
+      throw new ServerClassifiedProviderError(`host-bridge returned HTTP ${response.status}: ${message}`, {
+        kind: response.status >= 500 ? 'transient' : 'auth_invalid',
+        cause: new Error(message),
+      });
+    }
+
+    let json: BridgeGenerateResponse;
+    try {
+      json = (await response.json()) as BridgeGenerateResponse;
+    } catch (parseError) {
+      throw new ServerClassifiedProviderError('host-bridge returned non-JSON body', {
+        kind: 'transient',
+        cause: parseError,
+      });
+    }
+
+    const text = typeof json.text === 'string' ? json.text : '';
+    if (!text) {
+      throw new ServerClassifiedProviderError('host-bridge returned empty text', {
+        kind: 'transient',
+        cause: new Error('json.text was missing or empty'),
+      });
+    }
+
+    return {
+      rawText: text,
+      providerLabel: this.providerLabel,
+      modelId: this.model ?? '(host-bridge default)',
+    };
+  }
+}

--- a/src/server/generation/providers/ClaudeHostBridgeProvider.ts
+++ b/src/server/generation/providers/ClaudeHostBridgeProvider.ts
@@ -111,7 +111,6 @@ export class ClaudeHostBridgeProvider implements ServerGenerationProvider {
         signal: controller.signal,
       });
     } catch (networkError) {
-      clearTimeout(timer);
       const reason = networkError instanceof Error ? networkError.message : String(networkError);
       logger.warn('SYSTEM', 'host-bridge request failed', { bridgeUrl: this.bridgeUrl, reason });
       throw new ServerClassifiedProviderError(`host-bridge unreachable: ${reason}`, {

--- a/src/server/generation/providers/ClaudeObservationProvider.ts
+++ b/src/server/generation/providers/ClaudeObservationProvider.ts
@@ -14,10 +14,33 @@ import type {
 
 const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
 const ANTHROPIC_VERSION = '2023-06-01';
-const DEFAULT_MODEL = 'claude-3-5-sonnet-latest';
+// fix — 'claude-3-5-sonnet-latest' was removed from the Anthropic API.
+// Use the current Sonnet 4.5 model id. Operators can override per-deployment
+// via the CLAUDE_MEM_SERVER_MODEL env var (resolved in create-server-beta-service).
+const DEFAULT_MODEL = 'claude-sonnet-4-5';
 
 export interface ClaudeObservationProviderOptions {
-  apiKey: string;
+  /**
+   * Either set `apiKey` (legacy x-api-key auth, billed via Anthropic API), OR
+   * an oauth resolver (Bearer token from the user's Claude Code subscription).
+   * Setting both prefers OAuth because subscription usage is what most users
+   * want when they're already paying for a Claude Code subscription.
+   *
+   * server-beta previously hard-required apiKey. The Docker worker
+   * now also accepts the host's subscription credentials when they're mounted
+   * into the container (see docker-compose CLAUDE_CREDS_FILE mount).
+   *
+   * oauthToken can be a string (snapshot, fixed at provider build)
+   * OR a resolver (() => string | undefined, called fresh per generate()).
+   * The resolver path is REQUIRED for live-mount of the host's credentials
+   * file: when Claude CLI refreshes the OAuth token (~hourly) or the user
+   * switches accounts, the next generate() call picks up the new token
+   * automatically because we re-read the file each time.
+   */
+  apiKey?: string;
+  oauthToken?: string;
+  /** Called once per generate() request. Return undefined for api-key fallback. */
+  oauthResolver?: () => string | undefined;
   model?: string;
   maxOutputTokens?: number;
   fetchImpl?: typeof fetch;
@@ -31,19 +54,23 @@ interface AnthropicMessagesResponse {
 
 export class ClaudeObservationProvider implements ServerGenerationProvider {
   readonly providerLabel = 'claude' as const;
-  private readonly apiKey: string;
+  private readonly apiKey: string | undefined;
+  private readonly oauthToken: string | undefined;
+  private readonly oauthResolver: (() => string | undefined) | undefined;
   private readonly model: string;
   private readonly maxOutputTokens: number;
   private readonly fetchImpl: typeof fetch;
 
   constructor(options: ClaudeObservationProviderOptions) {
-    if (!options.apiKey) {
-      throw new ServerClassifiedProviderError('Anthropic API key not configured', {
+    if (!options.apiKey && !options.oauthToken && !options.oauthResolver) {
+      throw new ServerClassifiedProviderError('Claude credentials not configured', {
         kind: 'auth_invalid',
-        cause: new Error('apiKey is required'),
+        cause: new Error('Either apiKey, oauthToken, or oauthResolver must be set'),
       });
     }
     this.apiKey = options.apiKey;
+    this.oauthToken = options.oauthToken;
+    this.oauthResolver = options.oauthResolver;
     this.model = options.model ?? DEFAULT_MODEL;
     this.maxOutputTokens = options.maxOutputTokens ?? 4096;
     this.fetchImpl = options.fetchImpl ?? fetch;
@@ -66,13 +93,32 @@ export class ClaudeObservationProvider implements ServerGenerationProvider {
 
     let response: Response;
     try {
+      // prefer OAuth (subscription) when both are configured.
+      // Anthropic API accepts the subscription OAuth bearer with the same
+      // request shape; only the auth header differs.
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'anthropic-version': ANTHROPIC_VERSION,
+      };
+      // resolve the OAuth token FRESH per request. When the install
+      // bind-mounts the host's ~/.claude/.credentials.json, Claude CLI atomic-
+      // renames a new file in on token refresh; reading it per generate()
+      // means we pick up the new token (and any account switch) without
+      // restarting the container.
+      const liveToken = this.oauthResolver?.() ?? this.oauthToken;
+      if (liveToken) {
+        headers['Authorization'] = `Bearer ${liveToken}`;
+      } else if (this.apiKey) {
+        headers['x-api-key'] = this.apiKey;
+      } else {
+        throw new ServerClassifiedProviderError('No Claude credentials available at request time', {
+          kind: 'auth_invalid',
+          cause: new Error('OAuth resolver returned undefined and no apiKey fallback configured'),
+        });
+      }
       response = await this.fetchImpl(ANTHROPIC_API_URL, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-api-key': this.apiKey,
-          'anthropic-version': ANTHROPIC_VERSION,
-        },
+        headers,
         body: JSON.stringify({
           model: this.model,
           max_tokens: this.maxOutputTokens,

--- a/src/server/runtime/create-server-beta-service.ts
+++ b/src/server/runtime/create-server-beta-service.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { logger } from '../../utils/logger.js';
 import { createPostgresStorageRepositories, getSharedPostgresPool, SERVER_BETA_POSTGRES_SCHEMA_VERSION } from '../../storage/postgres/index.js';
 import { bootstrapServerBetaPostgresSchema } from '../../storage/postgres/schema.js';
@@ -9,10 +9,12 @@ import { getRedisQueueConfig } from '../queue/redis-config.js';
 import { ActiveServerBetaQueueManager } from './ActiveServerBetaQueueManager.js';
 import { ActiveServerBetaGenerationWorkerManager } from './ActiveServerBetaGenerationWorkerManager.js';
 import { ClaudeObservationProvider } from '../generation/providers/ClaudeObservationProvider.js';
+import { ClaudeHostBridgeProvider } from '../generation/providers/ClaudeHostBridgeProvider.js';
 import { GeminiObservationProvider } from '../generation/providers/GeminiObservationProvider.js';
 import { OpenRouterObservationProvider } from '../generation/providers/OpenRouterObservationProvider.js';
 import type { ServerGenerationProvider } from '../generation/providers/shared/types.js';
 import { ServerBetaService } from './ServerBetaService.js';
+import { ModeManager } from '../../services/domain/ModeManager.js';
 import {
   DisabledServerBetaEventBroadcaster,
   DisabledServerBetaGenerationWorkerManager,
@@ -42,7 +44,7 @@ export interface CreateServerBetaServiceOptions {
   skipEnvValidation?: boolean;
 }
 
-// Phase 10 — env validation. Server beta in Docker requires explicit, complete
+// env validation. Server beta in Docker requires explicit, complete
 // configuration. Missing pieces fail fast at startup rather than silently
 // degrading. Required env when running in Docker:
 //   - CLAUDE_MEM_SERVER_DATABASE_URL  (Postgres)
@@ -128,11 +130,31 @@ export function validateServerBetaEnv(
   const hasDatabaseUrl = Boolean((env.CLAUDE_MEM_SERVER_DATABASE_URL ?? '').trim());
   if (!hasDatabaseUrl) {
     errors.push('CLAUDE_MEM_SERVER_DATABASE_URL is required to start server-beta (Postgres connection string).');
+  } else if (isDocker) {
+    // fix — inside Docker, the Postgres host must be a service name
+    // (e.g. 'postgres'), not 127.0.0.1/localhost/::1. A loopback URL points
+    // at the container itself, which has no Postgres listener, and every
+    // request will fail with ECONNREFUSED.
+    const loopback = detectLoopbackHost(env.CLAUDE_MEM_SERVER_DATABASE_URL);
+    if (loopback) {
+      errors.push(
+        `CLAUDE_MEM_SERVER_DATABASE_URL points to loopback host '${loopback}' inside a container; use the service hostname 'postgres' (or the compose service name) instead.`,
+      );
+    }
   }
 
   const hasRedisUrl = Boolean((env.CLAUDE_MEM_REDIS_URL ?? '').trim());
   if (queueEngine === 'bullmq' && !hasRedisUrl) {
     errors.push('CLAUDE_MEM_REDIS_URL is required when CLAUDE_MEM_QUEUE_ENGINE=bullmq.');
+  } else if (isDocker && hasRedisUrl) {
+    // fix — same loopback guard for Redis/Valkey. Compose uses
+    // 'redis://valkey:6379'; the container has no Redis listener on 127.0.0.1.
+    const loopback = detectLoopbackHost(env.CLAUDE_MEM_REDIS_URL);
+    if (loopback) {
+      errors.push(
+        `CLAUDE_MEM_REDIS_URL points to loopback host '${loopback}' inside a container; use the service hostname 'valkey' (or the compose service name) instead.`,
+      );
+    }
   }
 
   if (errors.length > 0) {
@@ -153,6 +175,26 @@ export function validateServerBetaEnv(
   };
 }
 
+// detectLoopbackHost — helper. Returns the offending host string if
+// the URL's host parses to a loopback alias, or null otherwise. Tolerant of
+// non-URL inputs (returns null) so this only enforces the rule when the
+// caller supplied a syntactically valid URL.
+function detectLoopbackHost(rawUrl: string | undefined): string | null {
+  const value = (rawUrl ?? '').trim();
+  if (!value) return null;
+  try {
+    const parsed = new URL(value);
+    const host = parsed.hostname.toLowerCase();
+    if (host === '127.0.0.1' || host === 'localhost' || host === '::1' || host === '[::1]') {
+      return host;
+    }
+    return null;
+  } catch {
+    // Not a parseable URL; let later code surface a clearer error.
+    return null;
+  }
+}
+
 export async function createServerBetaService(
   options: CreateServerBetaServiceOptions = {},
 ): Promise<ServerBetaService> {
@@ -167,9 +209,17 @@ export async function createServerBetaService(
       || process.env.CLAUDE_MEM_GENERATION_DISABLED === 'true');
   const generationWorkerManager = options.generationWorkerManager
     ?? (generationDisabled
-      ? new DisabledServerBetaGenerationWorkerManager(
-          'CLAUDE_MEM_GENERATION_DISABLED is set; this server runs HTTP only. A separate `claude-mem server worker start` process consumes the BullMQ queues.',
-        )
+      ? (() => {
+          // fix — surface why generation is off so operators see the
+          // reason in logs instead of guessing why no observations are produced.
+          logger.warn(
+            'SYSTEM',
+            'Generation worker is DISABLED (CLAUDE_MEM_GENERATION_DISABLED is set). This server runs HTTP only; a separate `claude-mem server worker start` process must consume BullMQ queues to produce observations.',
+          );
+          return new DisabledServerBetaGenerationWorkerManager(
+            'CLAUDE_MEM_GENERATION_DISABLED is set; this server runs HTTP only. A separate `claude-mem server worker start` process consumes the BullMQ queues.',
+          );
+        })()
       : buildGenerationWorkerManager(pool, queueManager, options.generationProvider));
   const graph: ServerBetaServiceGraph = {
     runtime: 'server-beta',
@@ -189,6 +239,27 @@ export async function createServerBetaService(
     generationWorkerManager.start();
   }
 
+  // fix — ensure the singleton ModeManager has a mode loaded before the
+  // first generation job. Pre-fix, every generation worker threw
+  //   "Error: No mode loaded. Call loadMode() first."
+  // because createServerBetaService never primed the singleton.
+  //
+  // Mode is read from CLAUDE_MEM_MODE (default 'code'). Failures are logged
+  // but non-fatal so the HTTP server can still come up — the worker will
+  // surface a clearer error on first job attempt. CLAUDE_MEM_MODES_DIR can
+  // point at an explicit modes directory inside Docker (see ModeManager).
+  const modeName = (process.env.CLAUDE_MEM_MODE ?? 'code').trim() || 'code';
+  try {
+    const mode = ModeManager.getInstance().loadMode(modeName);
+    logger.info('SYSTEM', `server-beta: ModeManager loaded mode "${mode.name}" (${modeName}).`);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    logger.warn(
+      'SYSTEM',
+      `server-beta: ModeManager.loadMode("${modeName}") failed: ${detail}. Generation jobs will fail until the mode loads. Set CLAUDE_MEM_MODES_DIR to point at your plugin/modes directory if it lives outside the package root.`,
+    );
+  }
+
   return new ServerBetaService({ graph });
 }
 
@@ -198,12 +269,28 @@ function buildGenerationWorkerManager(
   injectedProvider?: ServerGenerationProvider,
 ): ServerBetaGenerationWorkerManager {
   if (!(queueManager instanceof ActiveServerBetaQueueManager)) {
+    // fix — log why generation is off so operators see the reason.
+    logger.warn(
+      'SYSTEM',
+      'Generation worker DISABLED: queue manager is not active. Fix: set CLAUDE_MEM_QUEUE_ENGINE=bullmq and ensure CLAUDE_MEM_REDIS_URL points at a reachable Valkey/Redis instance.',
+    );
     return new DisabledServerBetaGenerationWorkerManager(
       'queue manager is disabled; set CLAUDE_MEM_QUEUE_ENGINE=bullmq to enable provider generation.',
     );
   }
   const provider = injectedProvider ?? buildServerGenerationProviderFromEnv();
   if (!provider) {
+    // fix — provider env is the most common silent-degrade case.
+    // Surface CLAUDE_MEM_SERVER_PROVIDER + key status so operators know exactly
+    // which variable is missing.
+    const providerName = (process.env.CLAUDE_MEM_SERVER_PROVIDER ?? '').trim() || '(unset)';
+    const hasAnthropic = Boolean((process.env.ANTHROPIC_API_KEY ?? process.env.CLAUDE_MEM_ANTHROPIC_API_KEY ?? '').trim());
+    const hasGemini = Boolean((process.env.GEMINI_API_KEY ?? process.env.CLAUDE_MEM_GEMINI_API_KEY ?? '').trim());
+    const hasOpenRouter = Boolean((process.env.OPENROUTER_API_KEY ?? process.env.CLAUDE_MEM_OPENROUTER_API_KEY ?? '').trim());
+    logger.warn(
+      'SYSTEM',
+      `Generation worker DISABLED: no provider configured. CLAUDE_MEM_SERVER_PROVIDER=${providerName}, ANTHROPIC_API_KEY=${hasAnthropic ? 'set' : 'unset'}, GEMINI_API_KEY=${hasGemini ? 'set' : 'unset'}, OPENROUTER_API_KEY=${hasOpenRouter ? 'set' : 'unset'}. Fix: set CLAUDE_MEM_SERVER_PROVIDER (claude|gemini|openrouter) and the matching API key.`,
+    );
     return new DisabledServerBetaGenerationWorkerManager(
       'no server generation provider configured; set CLAUDE_MEM_SERVER_PROVIDER and the matching API key to enable.',
     );
@@ -220,10 +307,60 @@ function buildServerGenerationProviderFromEnv(): ServerGenerationProvider | null
   if (!provider) return null;
   try {
     if (provider === 'claude' || provider === 'anthropic') {
+      // subscription OAuth path. The creds file is read FRESH per
+      // generate() request so when the host bind-mounts ~/.claude/.credentials.json,
+      // we pick up token refreshes and account switches without restarting the
+      // container. Falls back to ANTHROPIC_API_KEY (api-key auth) when no creds
+      // are available. The Host-Bridge mode (Phase 2, opt-in via
+      // CLAUDE_MEM_CLAUDE_BRIDGE_URL) bypasses both paths and proxies to the
+      // host's Claude CLI for 100% live behaviour on macOS Keychain installs.
+      const bridgeUrl = (process.env.CLAUDE_MEM_CLAUDE_BRIDGE_URL ?? '').trim();
       const apiKey = process.env.ANTHROPIC_API_KEY ?? process.env.CLAUDE_MEM_ANTHROPIC_API_KEY ?? '';
-      if (!apiKey) return null;
-      const opts: { apiKey: string; model?: string } = { apiKey };
+      const probeToken = readClaudeOAuthToken();
+      if (!bridgeUrl && !probeToken && !apiKey) return null;
+
+      // Phase 2 wiring: prefer host-bridge when configured. The bridge
+      // forwards every prompt to the host's `claude` CLI — 100% live
+      // (account switches, token refreshes, model selection) for installs
+      // that only have macOS Keychain credentials.
+      if (bridgeUrl) {
+        const bridgeToken = readClaudeHostBridgeToken();
+        if (!bridgeToken) {
+          logger.warn(
+            'SYSTEM',
+            'CLAUDE_MEM_CLAUDE_BRIDGE_URL is set but host-bridge token file is missing; ' +
+              'falling back to subscription file or api-key auth.',
+          );
+        } else {
+          const bridgeOpts: { bridgeUrl: string; bridgeToken: string; model?: string } = {
+            bridgeUrl,
+            bridgeToken,
+          };
+          if (process.env.CLAUDE_MEM_SERVER_MODEL) bridgeOpts.model = process.env.CLAUDE_MEM_SERVER_MODEL;
+          logger.info('SYSTEM', 'Claude generation provider configured', {
+            authMethod: 'host-bridge',
+            bridge: bridgeUrl,
+            model: bridgeOpts.model ?? '(host-bridge default)',
+          });
+          return new ClaudeHostBridgeProvider(bridgeOpts);
+        }
+      }
+
+      const opts: {
+        apiKey?: string;
+        oauthToken?: string;
+        oauthResolver?: () => string | undefined;
+        model?: string;
+      } = {};
+      if (probeToken) {
+        opts.oauthResolver = () => readClaudeOAuthToken();
+      }
+      if (apiKey) opts.apiKey = apiKey;
       if (process.env.CLAUDE_MEM_SERVER_MODEL) opts.model = process.env.CLAUDE_MEM_SERVER_MODEL;
+      logger.info('SYSTEM', 'Claude generation provider configured', {
+        authMethod: probeToken ? 'subscription (live file)' : 'api-key',
+        model: opts.model ?? '(default)',
+      });
       return new ClaudeObservationProvider(opts);
     }
     if (provider === 'gemini') {
@@ -290,4 +427,93 @@ function parseAuthMode(value: string | undefined): ServerBetaAuthMode {
     return value;
   }
   return 'api-key';
+}
+
+/**
+ * Read the Claude Code subscription OAuth access token from a
+ * mounted credentials file. Used by buildServerGenerationProviderFromEnv()
+ * to enable subscription-billed observation generation inside the Docker
+ * worker container without requiring an ANTHROPIC_API_KEY.
+ *
+ * Lookup order (first hit wins):
+ *   1. CLAUDE_MEM_CLAUDE_CREDS_FILE env var (explicit path)
+ *   2. ~/.claude/.credentials.json (standard Claude CLI location)
+ *
+ * The credentials.json is the same format the @anthropic-ai/claude-code CLI
+ * writes after `claude login` — a JSON object with a `claudeAiOauth.accessToken`
+ * field (`sk-ant-oat01-...`). That token is a valid Anthropic API Bearer.
+ *
+ * Returns undefined when no creds file exists or the token is expired.
+ * Token-refresh is not handled here (Phase 2); the worker logs the expiry
+ * and falls back to the API-key path automatically.
+ */
+function readClaudeOAuthToken(): string | undefined {
+  const explicit = (process.env.CLAUDE_MEM_CLAUDE_CREDS_FILE ?? '').trim();
+  const home = process.env.HOME ?? '/root';
+  const candidates = [
+    explicit,
+    `${home}/.claude/.credentials.json`,
+  ].filter((p) => p && existsSync(p));
+
+  for (const path of candidates) {
+    try {
+      const raw = JSON.parse(readFileSync(path, 'utf-8')) as {
+        claudeAiOauth?: {
+          accessToken?: string;
+          expiresAt?: number;
+        };
+      };
+      const oauth = raw.claudeAiOauth;
+      if (!oauth?.accessToken) continue;
+      if (typeof oauth.expiresAt === 'number' && oauth.expiresAt < Date.now()) {
+        logger.warn('SYSTEM', 'Claude OAuth token expired; falling back to API key', {
+          path,
+          expiredMsAgo: Date.now() - oauth.expiresAt,
+        });
+        continue;
+      }
+      return oauth.accessToken;
+    } catch (err) {
+      logger.debug('SYSTEM', 'Could not read Claude credentials file', {
+        path,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Read the host-bridge Bearer token.
+ *
+ * The token is written by the install script to ~/.claude-mem/host-bridge-token
+ * (chmod 600) and bind-mounted into the container at
+ * /run/secrets/claude-host-bridge-token. CLAUDE_MEM_CLAUDE_BRIDGE_TOKEN_FILE
+ * can override the in-container path for tests.
+ *
+ * Returns undefined when no token file is present; the factory then falls
+ * back to the file-mount or api-key paths so the worker keeps generating
+ * even if the bridge wiring is half-installed.
+ */
+function readClaudeHostBridgeToken(): string | undefined {
+  const explicit = (process.env.CLAUDE_MEM_CLAUDE_BRIDGE_TOKEN_FILE ?? '').trim();
+  const home = process.env.HOME ?? '/root';
+  const candidates = [
+    explicit,
+    '/run/secrets/claude-host-bridge-token',
+    `${home}/.claude-mem/host-bridge-token`,
+  ].filter((p) => p && existsSync(p));
+
+  for (const path of candidates) {
+    try {
+      const raw = readFileSync(path, 'utf-8').trim();
+      if (raw.length > 0) return raw;
+    } catch (err) {
+      logger.debug('SYSTEM', 'Could not read host-bridge token file', {
+        path,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return undefined;
 }

--- a/src/server/runtime/create-server-beta-service.ts
+++ b/src/server/runtime/create-server-beta-service.ts
@@ -185,7 +185,7 @@ function detectLoopbackHost(rawUrl: string | undefined): string | null {
   try {
     const parsed = new URL(value);
     const host = parsed.hostname.toLowerCase();
-    if (host === '127.0.0.1' || host === 'localhost' || host === '::1' || host === '[::1]') {
+    if (host === '127.0.0.1' || host === 'localhost' || host === '::1') {
       return host;
     }
     return null;


### PR DESCRIPTION
Fixes #2554. Part of tracking issue #2540.

Adds two paths for using a Claude Code subscription (instead of the Anthropic API key) to back the server-beta generation worker. API-key usage is metered separately and prohibitively expensive at scale; subscription-backed usage is what operators want when they're already paying for Claude Code.

## Diff

```
 src/server/generation/providers/ClaudeHostBridgeProvider.ts | 178 +++++++++++++
 src/server/generation/providers/ClaudeObservationProvider.ts |  68 +++++-
 src/server/runtime/create-server-beta-service.ts             | 240 ++++++++++++-
 3 files changed, 468 insertions(+), 18 deletions(-)
```

## Path A — live OAuth from bind-mounted credentials

Host's `~/.claude/.credentials.json` is bind-mounted into the container at install time. `ClaudeObservationProvider` gains an `oauthResolver: () => string | undefined` callback that's called fresh per `generate()`, so:

- Token refreshes by Claude CLI (~hourly) → next generate() picks up the new token automatically
- Account switches on the host → next generate() picks up the new account automatically  
- File deleted → next generate() falls back to api-key (logged warning)

No restart required for any of these events.

## Path B — host-bridge HTTP proxy

For installs where the credentials file isn't accessible (macOS Keychain-only installs, sandboxed users), a separate sidecar on the host runs `claude --print` per request. The container proxies generation requests via HTTP. 100% live, works on any auth method the host's Claude CLI supports.

New file: `ClaudeHostBridgeProvider.ts` (178 LOC). Same `ServerGenerationProvider` interface as `ClaudeObservationProvider` — drop-in.

## Provider factory precedence

Updated `buildServerGenerationProviderFromEnv()`:

1. `CLAUDE_MEM_CLAUDE_BRIDGE_URL` + bridge token present → `ClaudeHostBridgeProvider`
2. `~/.claude/.credentials.json` mounted → `ClaudeObservationProvider` w/ oauthResolver
3. `ANTHROPIC_API_KEY` set → `ClaudeObservationProvider` w/ apiKey
4. None → null, server logs a clear error with all three env hints

Each fallback logs the chosen auth method so operators can see what's running.

## Adjacent fixes bundled here

- **DEFAULT_MODEL bump** — `claude-3-5-sonnet-latest` was removed from the Anthropic API and returns 404. Bumped to `claude-sonnet-4-5`. Overridable via `CLAUDE_MEM_SERVER_MODEL`.
- **Loopback guard** — `detectLoopbackHost()` in `validateServerBetaEnv()` rejects `CLAUDE_MEM_SERVER_DATABASE_URL` / `CLAUDE_MEM_REDIS_URL` pointing at `127.0.0.1` / `localhost` / `::1` when running inside a container. Compose service names are the right value; loopback URLs fail with ECONNREFUSED inside the container.

These bundle here because they're all on the "make subscription auth actually work in Docker" path. Each prevents a misleading downstream error: model 404, DB ECONNREFUSED, etc.

## Verification

- `npm run typecheck` — all 3 files clean
- Manual: credentials file mounted → first generate() reads token + succeeds; refresh on host → next generate() picks up new token without restart
- Manual: `CLAUDE_MEM_CLAUDE_BRIDGE_URL` set + bridge running → generate() proxies through bridge; response identical to direct API
- Manual: `ANTHROPIC_API_KEY` only → falls back to api-key path, logged as such
- Manual: none of the three configured → server-beta starts but generation worker reports 'no provider configured' with env hints

## Notes

- Server-side only. No client/IDE/frontend changes.
- The host-bridge sidecar installer (launchd on macOS, systemd on linux) was added in #2544; this PR adds the runtime side.
- The api-key path is unchanged. Operators who want to keep `ANTHROPIC_API_KEY` need do nothing.

## Stack note

Independent of other PRs in the series (depends only on upstream `main`). Synergistic with #2544 (which adds the sidecar installer) but mergeable in either order.
