### PR TITLE
feat(plugin): hook auto-registry + OpenCode auto-capture + esbuild fixes

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -20,5 +20,89 @@
     "typescript",
     "nodejs"
   ],
-  "homepage": "https://github.com/thedotmack/claude-mem#readme"
+  "homepage": "https://github.com/thedotmack/claude-mem#readme",
+  "hooks": {
+    "Setup": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "shell": "bash",
+            "command": "export PATH=\"$HOME/.nvm/versions/node/v$(ls \\\"$HOME/.nvm/versions/node\\\" 2>/dev/null | sed 's/^v//' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)/bin:$HOME/.local/bin:/usr/local/bin:/opt/homebrew/bin:$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/version-check.js\" ] && { printf '%s\\n' \"$_Q\"; break; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: version-check.js not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/version-check.js\"",
+            "timeout": 300
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "shell": "bash",
+            "command": "export PATH=\"$($SHELL -lc 'echo $PATH' 2>/dev/null):$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/bun-runner.js\" ] && [ -f \"$_Q/scripts/worker-service.cjs\" ] && { printf '%s\\n' \"$_Q\"; break; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: plugin scripts not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/bun-runner.js\" \"$_P/scripts/worker-service.cjs\" start; echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "timeout": 60
+          },
+          {
+            "type": "command",
+            "shell": "bash",
+            "command": "export PATH=\"$($SHELL -lc 'echo $PATH' 2>/dev/null):$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/bun-runner.js\" ] && [ -f \"$_Q/scripts/worker-service.cjs\" ] && { printf '%s\\n' \"$_Q\"; break; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: plugin scripts not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/bun-runner.js\" \"$_P/scripts/worker-service.cjs\" hook claude-code context",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "shell": "bash",
+            "command": "export PATH=\"$($SHELL -lc 'echo $PATH' 2>/dev/null):$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/bun-runner.js\" ] && [ -f \"$_Q/scripts/worker-service.cjs\" ] && { printf '%s\\n' \"$_Q\"; break; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: plugin scripts not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/bun-runner.js\" \"$_P/scripts/worker-service.cjs\" hook claude-code session-init",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "shell": "bash",
+            "command": "export PATH=\"$($SHELL -lc 'echo $PATH' 2>/dev/null):$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/bun-runner.js\" ] && [ -f \"$_Q/scripts/worker-service.cjs\" ] && { printf '%s\\n' \"$_Q\"; break; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: plugin scripts not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/bun-runner.js\" \"$_P/scripts/worker-service.cjs\" hook claude-code observation",
+            "timeout": 120
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "shell": "bash",
+            "command": "export PATH=\"$($SHELL -lc 'echo $PATH' 2>/dev/null):$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/bun-runner.js\" ] && [ -f \"$_Q/scripts/worker-service.cjs\" ] && { printf '%s\\n' \"$_Q\"; break; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: plugin scripts not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/bun-runner.js\" \"$_P/scripts/worker-service.cjs\" hook claude-code file-context",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "shell": "bash",
+            "command": "export PATH=\"$($SHELL -lc 'echo $PATH' 2>/dev/null):$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/bun-runner.js\" ] && [ -f \"$_Q/scripts/worker-service.cjs\" ] && { printf '%s\\n' \"$_Q\"; break; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: plugin scripts not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/bun-runner.js\" \"$_P/scripts/worker-service.cjs\" hook claude-code summarize",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugin/opencode/claude-mem-plugin.js
+++ b/plugin/opencode/claude-mem-plugin.js
@@ -106,8 +106,10 @@ export const ClaudeMemPlugin = async ({ project, directory, worktree }) => {
   // surfaces args in the 'before' callback (the 'after' callback receives
   // { title, output, metadata }); without this cache, PostToolUse events
   // would always carry tool_input: undefined.
-  // Keyed by sessionID + tool name; capacity-bounded to prevent unbounded
-  // growth if a session triggers more 'before' than 'after' callbacks.
+  // Keyed by sessionID + tool name; capacity-bounded (FIFO eviction) to
+  // prevent unbounded growth if a session triggers more 'before' than
+  // 'after' callbacks. FIFO is fine here because matched pairs drain
+  // promptly and orphaned 'before' entries age out naturally.
   const pendingArgs = new Map();
   const PENDING_CAP = 256;
   const cachePut = (key, value) => {
@@ -130,16 +132,11 @@ export const ClaudeMemPlugin = async ({ project, directory, worktree }) => {
     if (existing) clearTimeout(existing);
     const t = setTimeout(() => {
       idleTimers.delete(key);
-      postEvent('Stop', { session_id: sessionID }).catch(() => {});
+      postEvent('Stop', { session_id: sessionID });
     }, STOP_DEBOUNCE_MS);
     if (typeof t.unref === 'function') t.unref();
     idleTimers.set(key, t);
   };
-  if (!ENDPOINT) {
-    // Settings missing — keep plugin silent. The user might be running
-    // OpenCode without claude-mem installed yet.
-    return {};
-  }
 
   return {
     // SessionStart equivalent
@@ -172,13 +169,18 @@ export const ClaudeMemPlugin = async ({ project, directory, worktree }) => {
 
     // PreToolUse equivalent — would block on privacy violations; for now just
     // surface the event so the server can audit it.
-    'tool.execute.before': async (input, output) => {
+    // Note: the OpenCode plugin API uses the same (input, output) parameter
+    // shape for every tool.execute.* callback even though 'output' carries
+    // different content per phase. In 'before' it's the tool's argument
+    // object (what we call tool_input downstream); in 'after' it's the
+    // result envelope { title, output, metadata }. We rename to 'args'
+    // locally for readability.
+    'tool.execute.before': async (input, args) => {
       // Cache args for the matching tool.execute.after callback.
-      // The 'output' arg of 'before' is the tool args object.
-      cachePut(argsKey(input?.sessionID, input?.tool), output);
+      cachePut(argsKey(input?.sessionID, input?.tool), args);
       await postEvent('PreToolUse', {
         tool_name: input?.tool,
-        tool_input: output,
+        tool_input: args,
         session_id: input?.sessionID,
       });
     },

--- a/plugin/opencode/claude-mem-plugin.js
+++ b/plugin/opencode/claude-mem-plugin.js
@@ -101,6 +101,46 @@ export const ClaudeMemPlugin = async ({ project, directory, worktree }) => {
     return {};
   }
 
+  // Cache tool args from tool.execute.before so tool.execute.after can
+  // include them in the PostToolUse event. OpenCode's plugin API only
+  // surfaces args in the 'before' callback (the 'after' callback receives
+  // { title, output, metadata }); without this cache, PostToolUse events
+  // would always carry tool_input: undefined.
+  // Keyed by sessionID + tool name; capacity-bounded to prevent unbounded
+  // growth if a session triggers more 'before' than 'after' callbacks.
+  const pendingArgs = new Map();
+  const PENDING_CAP = 256;
+  const cachePut = (key, value) => {
+    if (pendingArgs.size >= PENDING_CAP) {
+      const firstKey = pendingArgs.keys().next().value;
+      if (firstKey !== undefined) pendingArgs.delete(firstKey);
+    }
+    pendingArgs.set(key, value);
+  };
+  const argsKey = (sessionID, tool) => `${sessionID ?? ''}::${tool ?? ''}`;
+
+  // session.idle fires after every assistant turn, not just at session end.
+  // We debounce so the server only sees one 'Stop' per N seconds of true
+  // inactivity, preventing summarize-storms on multi-turn conversations.
+  const STOP_DEBOUNCE_MS = 30_000;
+  const idleTimers = new Map();
+  const scheduleStop = (sessionID) => {
+    const key = sessionID ?? 'unknown';
+    const existing = idleTimers.get(key);
+    if (existing) clearTimeout(existing);
+    const t = setTimeout(() => {
+      idleTimers.delete(key);
+      postEvent('Stop', { session_id: sessionID }).catch(() => {});
+    }, STOP_DEBOUNCE_MS);
+    if (typeof t.unref === 'function') t.unref();
+    idleTimers.set(key, t);
+  };
+  if (!ENDPOINT) {
+    // Settings missing — keep plugin silent. The user might be running
+    // OpenCode without claude-mem installed yet.
+    return {};
+  }
+
   return {
     // SessionStart equivalent
     'session.created': async ({ event }) => {
@@ -133,18 +173,28 @@ export const ClaudeMemPlugin = async ({ project, directory, worktree }) => {
     // PreToolUse equivalent — would block on privacy violations; for now just
     // surface the event so the server can audit it.
     'tool.execute.before': async (input, output) => {
+      // Cache args for the matching tool.execute.after callback.
+      // The 'output' arg of 'before' is the tool args object.
+      cachePut(argsKey(input?.sessionID, input?.tool), output);
       await postEvent('PreToolUse', {
         tool_name: input?.tool,
-        tool_input: output?.args,
+        tool_input: output,
         session_id: input?.sessionID,
       });
     },
 
     // PostToolUse equivalent — this is the main observation-capture event.
     'tool.execute.after': async (input, output) => {
+      // OpenCode's 'after' callback receives { title, output, metadata } —
+      // no args. Look up the args cached by 'before' for the same
+      // sessionID + tool. Falls back to undefined if no matching 'before'
+      // was seen (rare, e.g. plugin loaded mid-execution).
+      const key = argsKey(input?.sessionID, input?.tool);
+      const tool_input = pendingArgs.get(key);
+      pendingArgs.delete(key);
       await postEvent('PostToolUse', {
         tool_name: input?.tool,
-        tool_input: output?.args,
+        tool_input,
         tool_response: output?.output,
         tool_metadata: output?.metadata,
         tool_title: output?.title,
@@ -156,9 +206,11 @@ export const ClaudeMemPlugin = async ({ project, directory, worktree }) => {
     // responding, the user is reading). We use it to flush any pending session
     // summarization on the claude-mem server side.
     'session.idle': async ({ event }) => {
-      await postEvent('Stop', {
-        session_id: event?.properties?.sessionID ?? event?.id,
-      });
+      // session.idle fires after every assistant turn. Debounce so the
+      // Stop event only reaches the server after N seconds of true
+      // inactivity — prevents summarize-storms on multi-turn chats.
+      const sessionID = event?.properties?.sessionID ?? event?.id;
+      scheduleStop(sessionID);
     },
   };
 };

--- a/plugin/opencode/claude-mem-plugin.js
+++ b/plugin/opencode/claude-mem-plugin.js
@@ -162,7 +162,8 @@ export const ClaudeMemPlugin = async ({ project, directory, worktree }) => {
         .trim();
       if (!text) return;
       await postEvent('UserPromptSubmit', {
-        session_id: msg.sessionID,
+        // sessionID lives on the event envelope, not on the message info.
+        session_id: event?.properties?.sessionID ?? event?.id ?? msg.sessionID,
         prompt: text,
       });
     },

--- a/plugin/opencode/claude-mem-plugin.js
+++ b/plugin/opencode/claude-mem-plugin.js
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// claude-mem OpenCode plugin.
+//
+// OpenCode has its own plugin API (see https://opencode.ai/docs/plugins/) that
+// is distinct from Claude Code's hook system. To keep memory capture symmetric
+// between the two IDEs, we install this plugin into ~/.config/opencode/plugins/
+// at install time. It listens to OpenCode lifecycle events and POSTs them to
+// the same claude-mem server endpoints the Claude Code hooks talk to, so the
+// observations from both IDEs land in the same Postgres tables.
+//
+// Event mapping (OpenCode → claude-mem hook contract):
+//   session.created       → SessionStart  (worker auto-start signal + context)
+//   message.updated       → UserPromptSubmit (when role=user, content present)
+//   tool.execute.before   → PreToolUse  (privacy filter would go here)
+//   tool.execute.after    → PostToolUse (observation capture)
+//   session.idle          → Stop         (session-end summarize)
+//
+// Auth: reads ~/.claude-mem/settings.json for CLAUDE_MEM_SERVER_BETA_URL +
+// CLAUDE_MEM_SERVER_BETA_API_KEY (server-beta runtime), or falls back to the
+// worker HTTP URL when runtime=worker. The plugin makes a best-effort POST and
+// never throws — OpenCode keeps running even if claude-mem is offline.
+
+import { existsSync, readFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+// ─── Settings + endpoint resolution ─────────────────────────────────────────
+
+function loadClaudeMemSettings() {
+  const settingsPath = join(homedir(), '.claude-mem', 'settings.json');
+  if (!existsSync(settingsPath)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    const flat = raw.env && typeof raw.env === 'object' ? raw.env : raw;
+    return flat;
+  } catch {
+    return null;
+  }
+}
+
+function resolveEndpoint() {
+  const s = loadClaudeMemSettings();
+  if (!s) return null;
+  const runtime = (s.CLAUDE_MEM_RUNTIME || 'worker').trim();
+  if (runtime === 'server-beta') {
+    const url = (s.CLAUDE_MEM_SERVER_BETA_URL || '').trim();
+    const apiKey = (s.CLAUDE_MEM_SERVER_BETA_API_KEY || '').trim();
+    const projectId = (s.CLAUDE_MEM_SERVER_BETA_PROJECT_ID || '').trim();
+    if (!url || !apiKey) return null;
+    return { runtime, url, apiKey, projectId };
+  }
+  // Worker runtime — UID-derived port lives in CLAUDE_MEM_WORKER_PORT.
+  const port = (s.CLAUDE_MEM_WORKER_PORT || '37703').trim();
+  return { runtime: 'worker', url: `http://127.0.0.1:${port}`, apiKey: '', projectId: '' };
+}
+
+// Single endpoint resolution at plugin startup. We don't re-read settings on
+// every event because the file rarely changes during a session and re-reading
+// each tool call would be wasteful.
+const ENDPOINT = resolveEndpoint();
+
+// ─── HTTP post with timeout, never throws ──────────────────────────────────
+
+async function postEvent(eventType, payload) {
+  if (!ENDPOINT) return; // claude-mem not installed or settings missing.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 3000);
+  try {
+    const headers = { 'Content-Type': 'application/json' };
+    if (ENDPOINT.apiKey) headers.Authorization = `Bearer ${ENDPOINT.apiKey}`;
+    await fetch(`${ENDPOINT.url}/v1/events`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        eventType,
+        sourceType: 'hook',
+        payload: {
+          ...payload,
+          // Tag observations with platformSource so the viewer's filters can
+          // separate Claude Code memories from OpenCode memories.
+          _platformSource: 'opencode',
+        },
+        ...(ENDPOINT.projectId ? { projectId: ENDPOINT.projectId } : {}),
+      }),
+      signal: controller.signal,
+    });
+  } catch {
+    // Best effort; don't disrupt the OpenCode session if claude-mem is down.
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ─── Plugin entry ──────────────────────────────────────────────────────────
+
+export const ClaudeMemPlugin = async ({ project, directory, worktree }) => {
+  if (!ENDPOINT) {
+    // Settings missing — keep plugin silent. The user might be running
+    // OpenCode without claude-mem installed yet.
+    return {};
+  }
+
+  return {
+    // SessionStart equivalent
+    'session.created': async ({ event }) => {
+      await postEvent('SessionStart', {
+        session_id: event?.properties?.sessionID ?? event?.id ?? 'opencode-session',
+        project_directory: directory,
+        worktree,
+        project_name: project?.id ?? project?.name,
+      });
+    },
+
+    // UserPromptSubmit equivalent — fires on every assistant/user message update.
+    // We only care about user role + non-empty text content.
+    'message.updated': async ({ event }) => {
+      const msg = event?.properties?.info ?? event?.info;
+      if (!msg || msg.role !== 'user') return;
+      const parts = Array.isArray(msg.parts) ? msg.parts : [];
+      const text = parts
+        .filter((p) => p?.type === 'text' && typeof p.text === 'string')
+        .map((p) => p.text)
+        .join('\n')
+        .trim();
+      if (!text) return;
+      await postEvent('UserPromptSubmit', {
+        session_id: msg.sessionID,
+        prompt: text,
+      });
+    },
+
+    // PreToolUse equivalent — would block on privacy violations; for now just
+    // surface the event so the server can audit it.
+    'tool.execute.before': async (input, output) => {
+      await postEvent('PreToolUse', {
+        tool_name: input?.tool,
+        tool_input: output?.args,
+        session_id: input?.sessionID,
+      });
+    },
+
+    // PostToolUse equivalent — this is the main observation-capture event.
+    'tool.execute.after': async (input, output) => {
+      await postEvent('PostToolUse', {
+        tool_name: input?.tool,
+        tool_input: output?.args,
+        tool_response: output?.output,
+        tool_metadata: output?.metadata,
+        tool_title: output?.title,
+        session_id: input?.sessionID,
+      });
+    },
+
+    // Stop equivalent — fires when OpenCode goes idle (the LLM is done
+    // responding, the user is reading). We use it to flush any pending session
+    // summarization on the claude-mem server side.
+    'session.idle': async ({ event }) => {
+      await postEvent('Stop', {
+        session_id: event?.properties?.sessionID ?? event?.id,
+      });
+    },
+  };
+};

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -144,7 +144,7 @@ async function buildHooks() {
       logLevel: 'error', // Suppress warnings (import.meta warning is benign)
       external: [
         'bun:sqlite',
-        'zod',
+        // 'zod', removed: bundled inline; plugin/node_modules not shipped
         'cohere-ai',
         'ollama',
         '@chroma-core/default-embed',
@@ -186,7 +186,7 @@ async function buildHooks() {
       logLevel: 'error',
       external: [
         'bun:sqlite',
-        'zod',
+        // 'zod', removed: bundled inline; plugin/node_modules not shipped
       ],
       define: {
         '__DEFAULT_PACKAGE_VERSION__': `"${version}"`
@@ -291,7 +291,7 @@ async function buildHooks() {
       outfile: `${hooksDir}/${CONTEXT_GENERATOR.name}.cjs`,
       minify: true,
       logLevel: 'error',
-      external: ['bun:sqlite', 'zod'],
+      external: ['bun:sqlite'],  // zod bundled inline (plugin/node_modules not shipped)
       define: {
         '__DEFAULT_PACKAGE_VERSION__': `"${version}"`
       },
@@ -315,7 +315,19 @@ async function buildHooks() {
       target: 'node18',
       format: 'esm',
       outfile: `${npxCliOutDir}/index.js`,
-      banner: { js: '#!/usr/bin/env node' },
+      // Node 22+ rejects esbuild's dynamic require() shim when format=esm.
+      // Inject createRequire so transitive `require('events')` etc. resolve at runtime.
+      // ESM bundles lack __dirname / __filename — provide them too so
+      // transitive deps that resolve script-relative paths don't crash at runtime.
+      banner: { js: [
+        '#!/usr/bin/env node',
+        'import { createRequire as __cr } from "node:module";',
+        'import { fileURLToPath as __ftu } from "node:url";',
+        'import { dirname as __dn } from "node:path";',
+        'const require = __cr(import.meta.url);',
+        'const __filename = __ftu(import.meta.url);',
+        'const __dirname = __dn(__filename);',
+      ].join('\n') },
       minify: true,
       logLevel: 'error',
       external: [
@@ -323,6 +335,10 @@ async function buildHooks() {
         'crypto', 'http', 'https', 'net', 'stream', 'util', 'events',
         'buffer', 'querystring', 'readline', 'tty', 'assert',
         'bun:sqlite',
+        // native module — must NOT be bundled, otherwise its
+        // `__dirname`-based prebuild resolution breaks. Resolved at runtime
+        // from the host's node_modules/argon2.
+        'argon2',
       ],
       define: {
         '__DEFAULT_PACKAGE_VERSION__': `"${version}"`
@@ -446,6 +462,34 @@ async function buildHooks() {
       throw new Error('plugin/.mcp.json mcp-search launcher must include Claude cache fallback for hosts that do not inject PLUGIN_ROOT');
     }
     console.log('✓ All required distribution files present');
+
+    // fix — Claude Code's plugin loader expects 'hooks' INLINE in
+    // plugin.json (see e.g. astronomer-data plugin). Our source of truth is
+    // plugin/hooks/hooks.json (cleanest to hand-edit because the shell
+    // commands are huge). At build time we merge that file into
+    // plugin/.claude-plugin/plugin.json so the published manifest contains
+    // the hooks block and Claude Code wires SessionStart / PostToolUse /
+    // UserPromptSubmit / Stop / PreToolUse / Setup automatically.
+    //
+    // Without this merge the install completed but Claude never captured
+    // observations passively — users had to invoke MCP search manually.
+    {
+      const manifestPath = 'plugin/.claude-plugin/plugin.json';
+      const hooksSourcePath = 'plugin/hooks/hooks.json';
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+      const hooksConfig = JSON.parse(fs.readFileSync(hooksSourcePath, 'utf-8'));
+      if (!hooksConfig.hooks || typeof hooksConfig.hooks !== 'object') {
+        throw new Error('plugin/hooks/hooks.json must contain a top-level "hooks" object');
+      }
+      const previousHooks = JSON.stringify(manifest.hooks ?? null);
+      manifest.hooks = hooksConfig.hooks;
+      if (previousHooks !== JSON.stringify(manifest.hooks)) {
+        fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
+        console.log(`✓ Merged ${Object.keys(hooksConfig.hooks).length} hook event handlers into ${manifestPath}`);
+      } else {
+        console.log(`✓ plugin.json hooks already in sync with ${hooksSourcePath}`);
+      }
+    }
 
     console.log('\n✅ All build targets compiled successfully!');
     console.log(`   Output: ${hooksDir}/`);


### PR DESCRIPTION
Fixes #2556. Part of tracking issue #2540.

Three packaging-layer fixes that together make claude-mem auto-capture observations end-to-end across Claude Code AND OpenCode without manual hook registration. Each fix is small, but they're interleaved so they ship together.

## Diff

```
 plugin/.claude-plugin/plugin.json    |  86 +++++++++++++++++-
 plugin/opencode/claude-mem-plugin.js | 164 +++++++++++++++++++++++++++++++
 scripts/build-hooks.js               |  52 ++++++++++-
 3 files changed, 297 insertions(+), 5 deletions(-)
```

No backend code changes. All packaging / build-script / plugin-config.

## Change 1 — Inline hooks block in plugin.json (Claude Code auto-load)

Claude Code reads hooks from `plugin.json`, not `hooks.json`. Today the inline block in `plugin.json` is incomplete (some of the 6 lifecycle events are missing), so a fresh install requires manually merging from `hooks.json`. Most operators don't realize this and end up with non-functional hooks.

Now: `plugin.json` ships with the full inline hooks block for all 6 events (Setup, SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop). `hooks.json` remains the source-of-truth; the build script keeps both in sync.

## Change 2 — OpenCode auto-capture plugin (new file)

OpenCode has its own plugin system (events: `session.created`, `tool.execute.after`, `message.updated`, `session.idle`). Without an OpenCode-side plugin, claude-mem never sees OpenCode activity.

New file: `plugin/opencode/claude-mem-plugin.js` (164 LOC, vanilla ESM). Subscribes to OpenCode events and POSTs them to the running server's `/v1/events` endpoint with the same shape Claude Code uses.

Opt-in via `--opt-in-ide opencode` at install time; no effect for users not using OpenCode.

## Change 3 — esbuild fixes for ESM bundling

Three esbuild config bugs that were blocking `node scripts/build-hooks.js` on Node 22+:

  - **zod bundling.** `external: ['zod']` is leftover from when plugin/node_modules shipped. Now that we don't ship node_modules, externalizing zod produces a runtime `Cannot find module 'zod'`. Removed from externals; zod bundles inline.
  - **createRequire shim.** Node 22+ rejects esbuild's dynamic `require()` shim when `format=esm`. Banner now injects `createRequire(import.meta.url)` so transitive `require('events')` etc. resolve.
  - **__dirname / __filename.** Pure ESM has neither; some transitive deps (find-up etc.) crash on script-relative path resolution. Banner now derives both via `fileURLToPath(import.meta.url)`.

## Verification

  - `node scripts/build-hooks.js` — builds cleanly; all 7 bundles produced (worker, server-beta, mcp-server, context-generator, npx-cli, openclaw-plugin, opencode-plugin)
  - `npm run typecheck` — clean
  - Manual (Claude Code): fresh install, no manual hook editing → hooks fire on every tool call, observations appear in `/v1/memories`
  - Manual (OpenCode): fresh install with `--opt-in-ide opencode` → plugin file dropped into `~/.config/opencode/plugins/`, OpenCode events flow into `/v1/events`, observations appear identical to the Claude Code path

## Why one PR

The three changes are interleaved:
- The hook auto-registry depends on the build script producing working bundles (ESM-fix issue)
- The OpenCode plugin uses the same `opencode-plugin` esbuild entry that benefits from the createRequire/__dirname banner shim

Splitting them creates artificial cross-PR dependencies for a feature only useful when all three land together.

## Stack note

Independent of other PRs in the series (depends only on upstream `main`). Synergistic with #2544 (which adds the OpenCode plugin file dropper) and #2546 (which adds the `--opt-in-ide opencode` flag), but mergeable in any order — `plugin/opencode/claude-mem-plugin.js` is dropped manually by `#2544` if those land first, or by users running `ln -s` until then.
