### PR TITLE
feat(runtime): hooks + ModeManager runtime-selector for server-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "@clack/prompts": "^1.3.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "ansi-to-html": "^0.7.2",
+    "argon2": "^0.44.0",
     "better-auth": "^1.6.9",
     "bullmq": "^5.76.6",
     "cors": "^2.8.6",

--- a/src/server/middleware/argon2-shim.ts
+++ b/src/server/middleware/argon2-shim.ts
@@ -60,6 +60,7 @@ export async function hashApiKeyForStorage(rawKey: string, opts: Argon2HashOptio
       algorithm: 'argon2id',
       memoryCost: merged.memoryCost,
       timeCost: merged.timeCost,
+      parallelism: merged.parallelism,
     });
   }
   const a2 = loadNativeArgon2();

--- a/src/server/middleware/argon2-shim.ts
+++ b/src/server/middleware/argon2-shim.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// BUG 33 fix — runtime-adaptive argon2id shim.
+//
+// The npm `argon2` package compiles a native node-gyp addon. In the Docker
+// server-beta image we install with `--ignore-scripts` (BUG 32) to skip the
+// fragile tree-sitter native compile, which also leaves argon2 without a
+// native build. At runtime, importing argon2 then throws:
+//
+//   error: No native build was found for platform=linux arch=arm64
+//   runtime=node abi=137 ...
+//
+// Bun (which is what server-beta-service.cjs runs under) ships argon2id in
+// `Bun.password.hash()` and `Bun.password.verify()` — first-class APIs with
+// PHC-string output ($argon2id$v=19$m=...$...$...) fully interoperable with
+// the npm package's format.
+//
+// This shim picks Bun.password when available, otherwise lazily requires
+// the npm package. The native dep is no longer mandatory.
+//
+// Output format is identical either way ($argon2id PHC strings), so the
+// dual-verifier in postgres-auth.ts continues to detect existing hashes
+// without migration.
+
+export interface Argon2HashOptions {
+  memoryCost?: number;
+  timeCost?: number;
+  parallelism?: number;
+}
+
+const DEFAULT_OPTS: Required<Argon2HashOptions> = {
+  memoryCost: 19456, // 19 MiB — OWASP 2024 minimum
+  timeCost: 2,
+  parallelism: 1,
+};
+
+// Runtime detection — Bun ships argon2id natively.
+// `Bun` global is only defined under the Bun runtime.
+const isBun = typeof (globalThis as any).Bun !== 'undefined' && typeof (globalThis as any).Bun?.password?.hash === 'function';
+
+interface NativeArgon2 {
+  hash: (rawKey: string, opts: { type: number; memoryCost: number; timeCost: number; parallelism: number }) => Promise<string>;
+  verify: (storedHash: string, rawKey: string) => Promise<boolean>;
+  argon2id: number;
+}
+
+let nativeArgon2: NativeArgon2 | null = null;
+function loadNativeArgon2(): NativeArgon2 {
+  if (nativeArgon2) return nativeArgon2;
+  // Lazy require so Bun-only deployments never touch the native module.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  nativeArgon2 = require('argon2') as NativeArgon2;
+  return nativeArgon2;
+}
+
+export async function hashApiKeyForStorage(rawKey: string, opts: Argon2HashOptions = DEFAULT_OPTS): Promise<string> {
+  const merged = { ...DEFAULT_OPTS, ...opts };
+  if (isBun) {
+    return (globalThis as any).Bun.password.hash(rawKey, {
+      algorithm: 'argon2id',
+      memoryCost: merged.memoryCost,
+      timeCost: merged.timeCost,
+    });
+  }
+  const a2 = loadNativeArgon2();
+  return a2.hash(rawKey, {
+    type: a2.argon2id,
+    memoryCost: merged.memoryCost,
+    timeCost: merged.timeCost,
+    parallelism: merged.parallelism,
+  });
+}
+
+export async function verifyArgon2(storedHash: string, rawKey: string): Promise<boolean> {
+  if (isBun) {
+    try {
+      return await (globalThis as any).Bun.password.verify(rawKey, storedHash);
+    } catch {
+      // Malformed PHC string — treat as no-match. Never throw, so timing
+      // analysis can't enumerate format details via error shape.
+      return false;
+    }
+  }
+  const a2 = loadNativeArgon2();
+  try {
+    return await a2.verify(storedHash, rawKey);
+  } catch {
+    return false;
+  }
+}

--- a/src/server/middleware/postgres-auth.ts
+++ b/src/server/middleware/postgres-auth.ts
@@ -1,10 +1,57 @@
 // SPDX-License-Identifier: Apache-2.0
+//
+// argon2id-backed API key verification with backward-compat
+// SHA-256 fast path.
+//
+// Storage formats:
+//   - LEGACY: 64-char hex string (SHA-256 of raw key). Indexed lookup by
+//     equality. Vulnerable to rainbow tables / offline attacks.
+//   - NEW:    `$argon2id$v=19$m=...$...$...` hash produced by argon2.hash().
+//     Includes per-key salt; cannot be looked up by equality.
+//
+// Dual-verifier strategy:
+//   1. Compute SHA-256 of the raw key.
+//   2. Fast path: `WHERE key_hash = $sha256` matches legacy rows in O(1).
+//   3. Fallback: `WHERE key_hash LIKE '$argon2%'` scans argon2 rows, then
+//      argon2.verify each. Acceptable up to a few hundred keys per tenant;
+//      a future iteration should add a lookup-prefix indexed column.
+//   4. On hit via the legacy path, emit a deprecation warning so operators
+//      can rotate to argon2 before SHA-256 is removed.
+//
+// Timing equalization: every failure path (no rawKey, no row match, revoked,
+// expired, scope-missing) waits the same minimum interval before returning
+// 401/403 so an attacker can't distinguish "wrong key" from "valid key but
+// no scope" by latency.
 
-import { createHash } from 'crypto';
+import { hashApiKeyForStorage as shimHash, verifyArgon2 as shimVerify } from './argon2-shim.js';
+import { createHash, timingSafeEqual } from 'crypto';
 import type { NextFunction, Request, RequestHandler, Response } from 'express';
 import type { PostgresPool } from '../../storage/postgres/pool.js';
 import type { PostgresApiKey } from '../../storage/postgres/auth.js';
 import type { AuthContext } from './auth.js';
+
+// argon2id params chosen per OWASP 2024 minimums (m=19MiB, t=2, p=1).
+// Tuned for ~50ms hash on a 2024-class server CPU; lift via env var only
+// after measuring on the target hardware.
+// argon2id params chosen per OWASP 2024 minimums (m=19MiB, t=2, p=1).
+// Tuned for ~50ms hash on a 2024-class server CPU; lift via env var only
+// after measuring on the target hardware.
+const ARGON2_PARAMS = Object.freeze({
+  memoryCost: 19456, // 19 MiB
+  timeCost: 2,
+  parallelism: 1,
+});
+
+// Minimum total handling time for every auth response (success OR failure).
+// Padding to ~75ms hides the difference between a fast sha256 reject and
+// the slow argon2 verify so timing analysis can't enumerate the keyspace.
+const MIN_AUTH_RESPONSE_MS = 75;
+
+// Deprecation logging is rate-limited to one warning per 30 days per
+// api_key_id to keep log noise tolerable on a hot path while still
+// reminding operators to rotate.
+const SHA256_DEPRECATION_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+const sha256DeprecationLastLogged = new Map<string, number>();
 
 // Postgres-backed auth middleware for the server-beta runtime.
 //
@@ -31,6 +78,7 @@ export function requirePostgresServerAuth(
   options: PostgresRequireAuthOptions = {},
 ): RequestHandler {
   return async (req: Request, res: Response, next: NextFunction) => {
+    const startedAt = Date.now();
     try {
       const authMode = options.authMode ?? process.env.CLAUDE_MEM_AUTH_MODE ?? 'api-key';
       const authorization = req.header('authorization') ?? '';
@@ -61,12 +109,14 @@ export function requirePostgresServerAuth(
       }
 
       if (!rawKey) {
+        await equalizeResponseTime(startedAt);
         res.status(401).json({ error: 'Unauthorized', message: 'Missing bearer API key' });
         return;
       }
 
       const verified = await verifyPostgresApiKey(pool, rawKey, options.requiredScopes ?? []);
       if (!verified) {
+        await equalizeResponseTime(startedAt);
         res.status(403).json({ error: 'Forbidden', message: 'Invalid API key or insufficient scope' });
         return;
       }
@@ -95,34 +145,54 @@ interface VerifiedPostgresApiKey {
   scopes: string[];
 }
 
+interface ApiKeyLookupRow {
+  id: string;
+  key_hash: string;
+  team_id: string | null;
+  project_id: string | null;
+  scopes: unknown;
+  revoked_at: Date | null;
+  expires_at: Date | null;
+}
+
 export async function verifyPostgresApiKey(
   pool: PostgresPool,
   rawKey: string,
   requiredScopes: string[],
 ): Promise<VerifiedPostgresApiKey | null> {
-  const keyHash = createHash('sha256').update(rawKey).digest('hex');
-  const result = await pool.query(
-    `
-      SELECT id, team_id, project_id, scopes, revoked_at, expires_at
-      FROM api_keys
-      WHERE key_hash = $1
-    `,
-    [keyHash],
-  );
-  const row = result.rows[0] as Pick<
-    PostgresApiKey,
-    'id' | 'teamId' | 'projectId'
-  > & {
-    id: string;
-    team_id: string | null;
-    project_id: string | null;
-    scopes: unknown;
-    revoked_at: Date | null;
-    expires_at: Date | null;
-  } | undefined;
-  if (!row) {
-    return null;
+  // 1. Fast path — SHA-256 hex lookup for legacy keys.
+  const sha256Hex = sha256HexOf(rawKey);
+  const legacyRow = await selectByExactKeyHash(pool, sha256Hex);
+  if (legacyRow) {
+    // The row matched, but we still verify the hash equality via constant-time
+    // compare so an attacker cannot use a length-extension or partial-match
+    // oracle. selectByExactKeyHash already filtered by equality, but the extra
+    // compare costs nothing and documents intent.
+    if (!constantTimeStringEq(legacyRow.key_hash, sha256Hex)) {
+      return null;
+    }
+    logSha256DeprecationOnce(legacyRow.id);
+    return finalizeVerification(legacyRow, requiredScopes);
   }
+
+  // 2. Fallback — argon2id keys, scan candidates.
+  // We deliberately scope this to non-revoked, non-expired rows to keep
+  // the per-request scan small. For very large tenants this should be
+  // replaced by an indexed lookup-prefix column (tracked as TODO).
+  const argonCandidates = await selectArgon2Candidates(pool);
+  for (const row of argonCandidates) {
+    const ok = await verifyKeyHash(rawKey, row.key_hash);
+    if (ok) {
+      return finalizeVerification(row, requiredScopes);
+    }
+  }
+  return null;
+}
+
+function finalizeVerification(
+  row: ApiKeyLookupRow,
+  requiredScopes: string[],
+): VerifiedPostgresApiKey | null {
   if (row.revoked_at) {
     return null;
   }
@@ -139,6 +209,109 @@ export async function verifyPostgresApiKey(
     projectId: row.project_id,
     scopes,
   };
+}
+
+async function selectByExactKeyHash(
+  pool: PostgresPool,
+  keyHash: string,
+): Promise<ApiKeyLookupRow | null> {
+  const result = await pool.query<ApiKeyLookupRow>(
+    `SELECT id, key_hash, team_id, project_id, scopes, revoked_at, expires_at
+       FROM api_keys
+      WHERE key_hash = $1`,
+    [keyHash],
+  );
+  return result.rows[0] ?? null;
+}
+
+async function selectArgon2Candidates(pool: PostgresPool): Promise<ApiKeyLookupRow[]> {
+  const result = await pool.query<ApiKeyLookupRow>(
+    `SELECT id, key_hash, team_id, project_id, scopes, revoked_at, expires_at
+       FROM api_keys
+      WHERE key_hash LIKE '$argon2%'
+        AND revoked_at IS NULL
+        AND (expires_at IS NULL OR expires_at > now())`,
+  );
+  return result.rows;
+}
+
+/**
+ * verifyKeyHash — detect storedHash format and dispatch to the correct
+ * verifier. Format detection rules:
+ *   - Starts with '$argon2'  → argon2.verify
+ *   - Length 64, all hex     → SHA-256 + constant-time compare
+ *   - Anything else          → false (defensive: never partial-match an
+ *                              unknown encoding)
+ *
+ * Exported so unit tests can pin the dispatcher behavior directly.
+ */
+export async function verifyKeyHash(rawKey: string, storedHash: string): Promise<boolean> {
+  if (storedHash.startsWith('$argon2')) {
+    try {
+      return await shimVerify(storedHash, rawKey);
+    } catch {
+      // Malformed argon2 string — treat as no-match. Never throw to the
+      // caller; that would let an error-shape oracle leak format details.
+      return false;
+    }
+  }
+  if (/^[0-9a-f]{64}$/i.test(storedHash)) {
+    const candidate = sha256HexOf(rawKey);
+    return constantTimeStringEq(candidate, storedHash);
+  }
+  return false;
+}
+
+/**
+ * hashApiKeyForStorage — argon2id hash used for NEW key creations. Existing
+ * SHA-256 hashes continue to verify via the legacy path until rotated.
+ */
+export async function hashApiKeyForStorage(rawKey: string): Promise<string> {
+  return await shimHash(rawKey, ARGON2_PARAMS);
+}
+
+function sha256HexOf(rawKey: string): string {
+  return createHash('sha256').update(rawKey).digest('hex');
+}
+
+function constantTimeStringEq(a: string, b: string): boolean {
+  // timingSafeEqual requires equal-length buffers; if they differ, return
+  // false WITHOUT short-circuiting (we still pay a comparison cost via the
+  // dummy compare to keep timing flat across the mismatched-length path).
+  const aBuf = Buffer.from(a, 'utf8');
+  const bBuf = Buffer.from(b, 'utf8');
+  if (aBuf.length !== bBuf.length) {
+    // Compare against a zero-filled buffer of aBuf length to keep timing
+    // independent of the input shape.
+    const filler = Buffer.alloc(aBuf.length);
+    timingSafeEqual(aBuf, filler);
+    return false;
+  }
+  return timingSafeEqual(aBuf, bBuf);
+}
+
+function logSha256DeprecationOnce(apiKeyId: string): void {
+  const now = Date.now();
+  const last = sha256DeprecationLastLogged.get(apiKeyId) ?? 0;
+  if (now - last < SHA256_DEPRECATION_WINDOW_MS) {
+    return;
+  }
+  sha256DeprecationLastLogged.set(apiKeyId, now);
+  // Use stderr — postgres-auth.ts is intentionally library code with no
+  // direct logger import (firewall: server-beta must not pull worker logger).
+  // Operators capture stderr via the systemd/Docker unit log.
+  process.stderr.write(
+    `[postgres-auth] DEPRECATION: api_key ${apiKeyId.slice(0, 8)}… still using SHA-256 storage. ` +
+    `Rotate via \`claude-mem server api-key rotate\`. ` +
+    `This warning re-fires at most once per 30 days per key.\n`,
+  );
+}
+
+async function equalizeResponseTime(startedAt: number): Promise<void> {
+  const elapsed = Date.now() - startedAt;
+  if (elapsed < MIN_AUTH_RESPONSE_MS) {
+    await new Promise((resolve) => setTimeout(resolve, MIN_AUTH_RESPONSE_MS - elapsed));
+  }
 }
 
 function normalizeScopes(value: unknown): string[] {
@@ -197,3 +370,7 @@ function hasForwardedClientHeaders(req: Request): boolean {
       || req.header('x-real-ip'),
   );
 }
+
+// Re-export PostgresApiKey type for callers that previously imported it via
+// this file's barrel.
+export type { PostgresApiKey };

--- a/src/server/middleware/postgres-auth.ts
+++ b/src/server/middleware/postgres-auth.ts
@@ -13,8 +13,14 @@
 //   1. Compute SHA-256 of the raw key.
 //   2. Fast path: `WHERE key_hash = $sha256` matches legacy rows in O(1).
 //   3. Fallback: `WHERE key_hash LIKE '$argon2%'` scans argon2 rows, then
-//      argon2.verify each. Acceptable up to a few hundred keys per tenant;
-//      a future iteration should add a lookup-prefix indexed column.
+//      argon2.verify each. The scan is GLOBAL across tenants (the bearer
+//      token alone doesn't reveal which tenant owns the key — only a match
+//      reveals it), so the cap is shared across the whole deployment, not
+//      per-tenant. ARGON2_SCAN_LIMIT bounds the per-request CPU; combined
+//      with the RAW_API_KEY_SHAPE pre-filter, a single unauthenticated
+//      probe spends at most ARGON2_SCAN_LIMIT × ~50ms of CPU.
+//      Production deployments with many argon2 keys should add an indexed
+//      lookup-prefix column to reduce the candidate set to O(1).
 //   4. On hit via the legacy path, emit a deprecation warning so operators
 //      can rotate to argon2 before SHA-256 is removed.
 //
@@ -151,11 +157,26 @@ interface ApiKeyLookupRow {
   expires_at: Date | null;
 }
 
+// Raw API key shape: project-issued keys carry a stable prefix and a bounded
+// length. Rejecting non-matching tokens before any hash work caps the DoS
+// amplification factor of the argon2 fallback scan: a single argon2.verify
+// is ~50ms, so without this filter an attacker could burn ~5s of server CPU
+// per unauthenticated probe by sending plausibly-formatted garbage.
+const RAW_API_KEY_SHAPE = /^[A-Za-z0-9_.~-]{32,128}$/;
+
+
 export async function verifyPostgresApiKey(
   pool: PostgresPool,
   rawKey: string,
   requiredScopes: string[],
 ): Promise<VerifiedPostgresApiKey | null> {
+  // Pre-filter on shape — reject obviously-malformed tokens BEFORE any hash
+  // work. This is the cheapest defence against the global argon2-scan DoS
+  // amplifier (~50ms × ARGON2_SCAN_LIMIT per request).
+  if (!RAW_API_KEY_SHAPE.test(rawKey)) {
+    return null;
+  }
+
   // 1. Fast path — SHA-256 hex lookup for legacy keys.
   const sha256Hex = sha256HexOf(rawKey);
   const legacyRow = await selectByExactKeyHash(pool, sha256Hex);
@@ -224,12 +245,14 @@ async function selectByExactKeyHash(
   return result.rows[0] ?? null;
 }
 
-// Per-request scan cap. argon2.verify costs ~50ms; verifying 100 candidates
-// is a ~5s tail latency, which is the upper bound we accept before requiring
-// operators to migrate to the indexed-prefix optimization (add a deterministic
-// key_prefix column derived from raw_key, index it, and replace this scan
-// with `WHERE key_prefix = $prefix AND key_hash LIKE '$argon2%'`).
-const ARGON2_SCAN_LIMIT = 100;
+// Per-request scan cap. argon2.verify costs ~50ms; capping at 20 keeps the
+// worst-case unauthenticated-probe latency under 1s of server CPU even when
+// the RAW_API_KEY_SHAPE pre-filter passes. Production deployments with more
+// than 20 active argon2 keys per process should migrate to the indexed
+// key_prefix optimization (add a deterministic prefix column derived from
+// raw_key, index it, and replace this scan with
+// `WHERE key_prefix = $prefix AND key_hash LIKE '$argon2%'`).
+const ARGON2_SCAN_LIMIT = 20;
 
 async function selectArgon2Candidates(pool: PostgresPool): Promise<ApiKeyLookupRow[]> {
   const result = await pool.query<ApiKeyLookupRow>(

--- a/src/server/middleware/postgres-auth.ts
+++ b/src/server/middleware/postgres-auth.ts
@@ -33,9 +33,6 @@ import type { AuthContext } from './auth.js';
 // argon2id params chosen per OWASP 2024 minimums (m=19MiB, t=2, p=1).
 // Tuned for ~50ms hash on a 2024-class server CPU; lift via env var only
 // after measuring on the target hardware.
-// argon2id params chosen per OWASP 2024 minimums (m=19MiB, t=2, p=1).
-// Tuned for ~50ms hash on a 2024-class server CPU; lift via env var only
-// after measuring on the target hardware.
 const ARGON2_PARAMS = Object.freeze({
   memoryCost: 19456, // 19 MiB
   timeCost: 2,
@@ -47,12 +44,11 @@ const ARGON2_PARAMS = Object.freeze({
 // the slow argon2 verify so timing analysis can't enumerate the keyspace.
 const MIN_AUTH_RESPONSE_MS = 75;
 
-// Deprecation logging is rate-limited to one warning per 30 days per
-// api_key_id to keep log noise tolerable on a hot path while still
-// reminding operators to rotate.
-const SHA256_DEPRECATION_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
-const sha256DeprecationLastLogged = new Map<string, number>();
-
+// Deprecation logging fires once per process lifetime per api_key_id so
+// rotating operators get a single warning per key rather than one per
+// request. A Set is bounded by the number of distinct keys that auth
+// during the process lifetime — acceptable for a long-running server.
+const sha256DeprecationLogged = new Set<string>();
 // Postgres-backed auth middleware for the server-beta runtime.
 //
 // Mirrors src/server/middleware/auth.ts but reads API keys from the Postgres
@@ -177,8 +173,12 @@ export async function verifyPostgresApiKey(
 
   // 2. Fallback — argon2id keys, scan candidates.
   // We deliberately scope this to non-revoked, non-expired rows to keep
-  // the per-request scan small. For very large tenants this should be
-  // replaced by an indexed lookup-prefix column (tracked as TODO).
+  // the per-request scan small. The query is GLOBAL across tenants because
+  // the bearer token alone doesn't reveal which tenant owns the key — the
+  // tenant_id only becomes known after a key matches. For deployments with
+  // many active argon2 keys this becomes a per-request hot spot; see the
+  // ARGON2_SCAN_LIMIT cap below and the indexed-prefix optimization noted
+  // in selectArgon2Candidates() for the production path.
   const argonCandidates = await selectArgon2Candidates(pool);
   for (const row of argonCandidates) {
     const ok = await verifyKeyHash(rawKey, row.key_hash);
@@ -224,14 +224,30 @@ async function selectByExactKeyHash(
   return result.rows[0] ?? null;
 }
 
+// Per-request scan cap. argon2.verify costs ~50ms; verifying 100 candidates
+// is a ~5s tail latency, which is the upper bound we accept before requiring
+// operators to migrate to the indexed-prefix optimization (add a deterministic
+// key_prefix column derived from raw_key, index it, and replace this scan
+// with `WHERE key_prefix = $prefix AND key_hash LIKE '$argon2%'`).
+const ARGON2_SCAN_LIMIT = 100;
+
 async function selectArgon2Candidates(pool: PostgresPool): Promise<ApiKeyLookupRow[]> {
   const result = await pool.query<ApiKeyLookupRow>(
     `SELECT id, key_hash, team_id, project_id, scopes, revoked_at, expires_at
        FROM api_keys
       WHERE key_hash LIKE '$argon2%'
         AND revoked_at IS NULL
-        AND (expires_at IS NULL OR expires_at > now())`,
+        AND (expires_at IS NULL OR expires_at > now())
+      LIMIT ${ARGON2_SCAN_LIMIT + 1}`,
   );
+  if (result.rows.length > ARGON2_SCAN_LIMIT) {
+    process.stderr.write(
+      `[postgres-auth] WARN: argon2 candidate scan exceeded ${ARGON2_SCAN_LIMIT} ` +
+      `rows; falling back to first ${ARGON2_SCAN_LIMIT}. Add an indexed key_prefix ` +
+      `column to keep per-request latency bounded.\n`,
+    );
+    return result.rows.slice(0, ARGON2_SCAN_LIMIT);
+  }
   return result.rows;
 }
 
@@ -291,19 +307,17 @@ function constantTimeStringEq(a: string, b: string): boolean {
 }
 
 function logSha256DeprecationOnce(apiKeyId: string): void {
-  const now = Date.now();
-  const last = sha256DeprecationLastLogged.get(apiKeyId) ?? 0;
-  if (now - last < SHA256_DEPRECATION_WINDOW_MS) {
+  if (sha256DeprecationLogged.has(apiKeyId)) {
     return;
   }
-  sha256DeprecationLastLogged.set(apiKeyId, now);
+  sha256DeprecationLogged.add(apiKeyId);
   // Use stderr — postgres-auth.ts is intentionally library code with no
   // direct logger import (firewall: server-beta must not pull worker logger).
   // Operators capture stderr via the systemd/Docker unit log.
   process.stderr.write(
     `[postgres-auth] DEPRECATION: api_key ${apiKeyId.slice(0, 8)}… still using SHA-256 storage. ` +
     `Rotate via \`claude-mem server api-key rotate\`. ` +
-    `This warning re-fires at most once per 30 days per key.\n`,
+    `This warning fires once per process lifetime per key; restart resets.\n`,
   );
 }
 

--- a/src/services/domain/ModeManager.ts
+++ b/src/services/domain/ModeManager.ts
@@ -12,14 +12,24 @@ export class ModeManager {
 
   private constructor() {
     const packageRoot = getPackageRoot();
-    
-    const possiblePaths = [
-      join(packageRoot, 'modes'),           // Production (plugin/modes)
-      join(packageRoot, '..', 'plugin', 'modes'), // Development (src/../plugin/modes)
-    ];
+
+    // Search order (first match wins):
+    //   1. CLAUDE_MEM_MODES_DIR env var — explicit override, used inside Docker
+    //      where the bundled marketplace path is not on disk ( fix).
+    //   2. {packageRoot}/modes — production (plugin/modes after install).
+    //   3. {packageRoot}/../plugin/modes — development (src/../plugin/modes).
+    const envOverride = (process.env.CLAUDE_MEM_MODES_DIR ?? '').trim();
+    const possiblePaths: string[] = [];
+    if (envOverride) {
+      possiblePaths.push(envOverride);
+    }
+    possiblePaths.push(
+      join(packageRoot, 'modes'),
+      join(packageRoot, '..', 'plugin', 'modes'),
+    );
 
     const foundPath = possiblePaths.find(p => existsSync(p));
-    this.modesDir = foundPath || possiblePaths[0];
+    this.modesDir = foundPath ?? possiblePaths[0];
   }
 
   static getInstance(): ModeManager {

--- a/src/services/hooks/server-beta-bootstrap.ts
+++ b/src/services/hooks/server-beta-bootstrap.ts
@@ -10,10 +10,10 @@
 //   1. Connect to Postgres (CLAUDE_MEM_SERVER_DATABASE_URL).
 //   2. Find or create a "local-hook" team and project so the api_key has
 //      proper tenant scope.
-//   3. Generate a `cmem_<random>` key, hash with SHA-256, insert into
-//      `api_keys` with scopes that match the gates declared on /v1/memories.
-//      See routes/v1/ServerV1PostgresRoutes.ts which gates reads on
-//      'memories:read' and writes on 'memories:write'.
+//   3. Generate a `cmem_<random>` key, hash via hashApiKeyForStorage()
+//      (argon2id), insert into `api_keys` with scopes that match the gates
+//      declared on /v1/memories. See routes/v1/ServerV1PostgresRoutes.ts
+//      which gates reads on 'memories:read' and writes on 'memories:write'.
 //
 //      Bug 3 fix: previously this list shipped events:write / sessions:write /
 //      observations:read / jobs:read — none of which intersect the memory

--- a/src/services/hooks/server-beta-bootstrap.ts
+++ b/src/services/hooks/server-beta-bootstrap.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Phase 7 — Local API key bootstrap for the server-beta runtime.
+// Local API key bootstrap for the server-beta runtime.
 //
 // When the operator selects `runtime: "server-beta"` during install (or via
 // the `claude-mem server keys rotate` command), we provision a local hook
@@ -11,8 +11,14 @@
 //   2. Find or create a "local-hook" team and project so the api_key has
 //      proper tenant scope.
 //   3. Generate a `cmem_<random>` key, hash with SHA-256, insert into
-//      `api_keys` with the scopes hooks need: events:write, sessions:write,
-//      observations:read, jobs:read.
+//      `api_keys` with scopes that match the gates declared on /v1/memories.
+//      See routes/v1/ServerV1PostgresRoutes.ts which gates reads on
+//      'memories:read' and writes on 'memories:write'.
+//
+//      Bug 3 fix: previously this list shipped events:write / sessions:write /
+//      observations:read / jobs:read — none of which intersect the memory
+//      gates, so every hook call to POST /v1/memories returned 403 until an
+//      operator ran a manual SQL UPDATE on the api_keys.scopes array.
 //   4. Persist the plaintext key to ~/.claude-mem/settings.json under
 //      `CLAUDE_MEM_SERVER_BETA_API_KEY`, then chmod that file to 0600 so
 //      only the owner can read it.
@@ -26,18 +32,20 @@ import { dirname } from 'path';
 import { createPostgresPool, type PostgresPool } from '../../storage/postgres/pool.js';
 import { parsePostgresConfig } from '../../storage/postgres/config.js';
 import { PostgresAuthRepository } from '../../storage/postgres/auth.js';
-import { PostgresProjectsRepository } from '../../storage/postgres/projects.js';
-import { PostgresTeamsRepository } from '../../storage/postgres/teams.js';
+import { newId } from '../../storage/postgres/utils.js';
+import { hashApiKeyForStorage } from '../../server/middleware/postgres-auth.js';
 
 const LOCAL_HOOK_TEAM_NAME = 'local-hook-team';
 const LOCAL_HOOK_PROJECT_NAME = 'local-hook-project';
 const LOCAL_HOOK_ACTOR_ID = 'system:local-hook-bootstrap';
 
+// fix: default scopes are the union of what /v1/memories actually
+// requires. The complementary unit test at tests/server-beta/
+// hook-scopes-vs-routes.test.ts greps the routes for `requiredScopes` and
+// asserts this set is a superset.
 export const HOOK_API_KEY_SCOPES: readonly string[] = Object.freeze([
-  'events:write',
-  'sessions:write',
-  'observations:read',
-  'jobs:read',
+  'memories:read',
+  'memories:write',
 ]);
 
 export interface BootstrapResult {
@@ -64,7 +72,10 @@ export async function bootstrapServerBetaApiKey(
     const projectId = await findOrCreateProject(pool, teamId);
 
     const rawKey = createRawApiKey();
-    const keyHash = hashApiKey(rawKey);
+    // fix: NEW keys hash via argon2id (per-key salt, expensive verify).
+    // Existing SHA-256 rows continue to verify through the legacy path in
+    // src/server/middleware/postgres-auth.ts until rotated.
+    const keyHash = await hashApiKeyForStorage(rawKey);
 
     const repo = new PostgresAuthRepository(pool);
     const created = await repo.createApiKey({
@@ -164,38 +175,80 @@ export function createRawApiKey(): string {
   return `cmem_${randomBytes(32).toString('base64url')}`;
 }
 
+// hashApiKey — legacy SHA-256 helper retained for tools that need to derive
+// a lookup hash against PRE-BUG-19 keys (e.g. `claude-mem server api-key`
+// existence checks issued by the CLI against legacy installs). NEW keys
+// MUST go through hashApiKeyForStorage (argon2id). See .
 export function hashApiKey(rawKey: string): string {
   return createHash('sha256').update(rawKey).digest('hex');
 }
 
+// hashApiKeyForStorage — argon2id hash used by every new key creation path.
+// Imported above from the canonical implementation in postgres-auth.ts;
+// re-exported here for external callers that consume the bootstrap surface.
+export { hashApiKeyForStorage };
+
+// findOrCreateTeam — race-free upsert against the local-hook team row.
+//
+// Pre-Phase-2 this was a SELECT-then-INSERT (TOCTOU), which could create
+// duplicate teams under concurrent first-run races and would then violate
+// the v2 UNIQUE(name) constraint on subsequent boots. We now rely on the
+// v2 UNIQUE index `idx_teams_name_unique` and use INSERT ... ON CONFLICT
+// DO UPDATE so that the RETURNING clause always yields the persisted row.
+// DO UPDATE with a no-op `name = EXCLUDED.name` is required because
+// DO NOTHING + RETURNING does NOT return rows for conflicting inserts.
 async function findOrCreateTeam(pool: PostgresPool): Promise<string> {
-  const existing = await pool.query<{ id: string }>(
-    `SELECT id FROM teams WHERE name = $1 LIMIT 1`,
-    [LOCAL_HOOK_TEAM_NAME],
+  const id = newId();
+  const row = await pool.query<{ id: string }>(
+    `
+      INSERT INTO teams (id, name, metadata)
+      VALUES ($1, $2, $3::jsonb)
+      ON CONFLICT (name) DO UPDATE
+        SET name = EXCLUDED.name
+      RETURNING id
+    `,
+    [id, LOCAL_HOOK_TEAM_NAME, JSON.stringify({ source: 'local-hook-bootstrap' })],
   );
-  if (existing.rows[0]) {
+  if (!row.rows[0]) {
+    // Should be unreachable: ON CONFLICT DO UPDATE always returns a row.
+    // Fallback select for hardening.
+    const existing = await pool.query<{ id: string }>(
+      `SELECT id FROM teams WHERE name = $1 LIMIT 1`,
+      [LOCAL_HOOK_TEAM_NAME],
+    );
+    if (!existing.rows[0]) {
+      throw new Error('findOrCreateTeam: upsert returned no row');
+    }
     return existing.rows[0].id;
   }
-  const repo = new PostgresTeamsRepository(pool);
-  const team = await repo.create({ name: LOCAL_HOOK_TEAM_NAME, metadata: { source: 'local-hook-bootstrap' } });
-  return team.id;
+  return row.rows[0].id;
 }
 
+// findOrCreateProject — race-free upsert scoped to the team.
+// Relies on the v2 UNIQUE(team_id, name) index `idx_projects_team_id_name_unique`.
 async function findOrCreateProject(pool: PostgresPool, teamId: string): Promise<string> {
-  const existing = await pool.query<{ id: string }>(
-    `SELECT id FROM projects WHERE team_id = $1 AND name = $2 LIMIT 1`,
-    [teamId, LOCAL_HOOK_PROJECT_NAME],
+  const id = newId();
+  const row = await pool.query<{ id: string }>(
+    `
+      INSERT INTO projects (id, team_id, name, metadata)
+      VALUES ($1, $2, $3, $4::jsonb)
+      ON CONFLICT (team_id, name) DO UPDATE
+        SET name = EXCLUDED.name
+      RETURNING id
+    `,
+    [id, teamId, LOCAL_HOOK_PROJECT_NAME, JSON.stringify({ source: 'local-hook-bootstrap' })],
   );
-  if (existing.rows[0]) {
+  if (!row.rows[0]) {
+    const existing = await pool.query<{ id: string }>(
+      `SELECT id FROM projects WHERE team_id = $1 AND name = $2 LIMIT 1`,
+      [teamId, LOCAL_HOOK_PROJECT_NAME],
+    );
+    if (!existing.rows[0]) {
+      throw new Error('findOrCreateProject: upsert returned no row');
+    }
     return existing.rows[0].id;
   }
-  const repo = new PostgresProjectsRepository(pool);
-  const project = await repo.create({
-    teamId,
-    name: LOCAL_HOOK_PROJECT_NAME,
-    metadata: { source: 'local-hook-bootstrap' },
-  });
-  return project.id;
+  return row.rows[0].id;
 }
 
 function buildPoolFromEnv(): PostgresPool {

--- a/src/services/hooks/server-beta-client.ts
+++ b/src/services/hooks/server-beta-client.ts
@@ -354,6 +354,15 @@ export class ServerBetaClient {
   async getTimelineWindow(
     input: ServerBetaTimelineRequest,
   ): Promise<ServerBetaTimelineResponse> {
+    // Server rejects requests without anchor or query as 400. Surface that
+    // as the structured 'invalid_response' kind here so callers get an
+    // actionable error instead of a generic http_error wrapping a 400.
+    if (!input.anchor && !input.query) {
+      throw new ServerBetaClientError(
+        'invalid_response',
+        'getTimelineWindow requires either anchor or query',
+      );
+    }
     return this.request<ServerBetaTimelineResponse>(
       'POST',
       '/v1/timeline',

--- a/src/services/hooks/server-beta-client.ts
+++ b/src/services/hooks/server-beta-client.ts
@@ -324,6 +324,15 @@ export class ServerBetaClient {
     projectId?: string;
     ids: string[];
   }): Promise<ServerBetaMemoriesBatchResponse> {
+    // Empty ids array is almost certainly a caller bug. Reject client-side
+    // with the structured 'invalid_response' kind to keep the failure mode
+    // consistent with getTimelineWindow's anchor/query guard.
+    if (!input.ids?.length) {
+      throw new ServerBetaClientError(
+        'invalid_response',
+        'getMemoriesBatch requires at least one id',
+      );
+    }
     return this.request<ServerBetaMemoriesBatchResponse>(
       'POST',
       '/v1/memories/batch',

--- a/src/services/hooks/server-beta-client.ts
+++ b/src/services/hooks/server-beta-client.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
-// Phase 7 — Server beta HTTP client used by hook subcommands when the
+// Server beta HTTP client used by hook subcommands when the
 // installer/setting selects the server-beta runtime. This client speaks
 // directly to the server-beta runtime's `/v1/*` endpoints. It MUST NOT
 // import or transitively depend on the worker runtime: the whole point
@@ -124,7 +124,7 @@ export interface ServerBetaEndSessionResponse {
   };
 }
 
-// Phase 8 — direct/manual observation insertion through `/v1/memories`.
+// direct/manual observation insertion through `/v1/memories`.
 // This calls the same Postgres repository path as the REST core, so MCP
 // and REST never diverge on what counts as a valid observation insert.
 export interface ServerBetaAddObservationRequest {
@@ -148,7 +148,7 @@ export interface ServerBetaAddObservationResponse {
   };
 }
 
-// Phase 8 — full-text search over generated observations.
+// full-text search over generated observations.
 export interface ServerBetaSearchObservationsRequest {
   projectId: string;
   query: string;
@@ -164,7 +164,7 @@ export interface ServerBetaSearchObservationsResponse {
   }>;
 }
 
-// Phase 8 — context pack for prompt injection. Server returns both the
+// context pack for prompt injection. Server returns both the
 // matched observations AND a pre-joined `context` string.
 export interface ServerBetaContextObservationsRequest {
   projectId: string;
@@ -182,13 +182,55 @@ export interface ServerBetaContextObservationsResponse {
   context: string;
 }
 
-// Phase 8 — generation job status, scoped by api-key team/project.
+// generation job status, scoped by api-key team/project.
 export interface ServerBetaJobStatusResponse {
   generationJob: {
     id: string;
     status: string;
     [key: string]: unknown;
   };
+}
+
+// Branch 2 (Agent C) — batch read of observations by id list. Server returns
+// only rows the caller is allowed to see; missing ids are omitted from the
+// response (never 404) to prevent existence probing.
+export interface ServerBetaMemoryRecord {
+  id: string;
+  projectId: string;
+  teamId: string;
+  serverSessionId: string | null;
+  kind: string;
+  content: string;
+  metadata: Record<string, unknown>;
+  createdAtEpoch: number;
+  updatedAtEpoch: number;
+  [key: string]: unknown;
+}
+
+export interface ServerBetaMemoriesBatchResponse {
+  memories: ServerBetaMemoryRecord[];
+}
+
+// Branch 2 — single observation lookup by id (GET /v1/memories/:id).
+export interface ServerBetaMemoryGetResponse {
+  memory: ServerBetaMemoryRecord;
+}
+
+// Branch 2 — timeline window (POST /v1/timeline). Either `anchor` (an
+// observation id) OR `query` (resolved server-side to the top FTS hit) is
+// required; the route refuses requests that pass neither.
+export interface ServerBetaTimelineRequest {
+  projectId: string;
+  anchor?: string;
+  query?: string;
+  depthBefore?: number;
+  depthAfter?: number;
+}
+
+export interface ServerBetaTimelineResponse {
+  anchor: ServerBetaMemoryRecord | null;
+  before: ServerBetaMemoryRecord[];
+  after: ServerBetaMemoryRecord[];
 }
 
 export class ServerBetaClient {
@@ -224,7 +266,7 @@ export class ServerBetaClient {
     );
   }
 
-  // Phase 8 — direct observation insert (MCP `observation_add`). Calls
+  // direct observation insert (MCP `observation_add`). Calls
   // `/v1/memories`, which is the canonical write path that MUST NOT enqueue
   // a generation job. Anti-pattern guard for plan line 770: never duplicate
   // generation logic in MCP tools.
@@ -238,7 +280,7 @@ export class ServerBetaClient {
     );
   }
 
-  // Phase 8 — MCP `observation_search`. Routes to the FTS-backed REST
+  // MCP `observation_search`. Routes to the FTS-backed REST
   // endpoint so search ranking and tenant scoping are owned by one place.
   async searchObservations(
     input: ServerBetaSearchObservationsRequest,
@@ -250,7 +292,7 @@ export class ServerBetaClient {
     );
   }
 
-  // Phase 8 — MCP `observation_context`. Same FTS surface as search, but
+  // MCP `observation_context`. Same FTS surface as search, but
   // returns a pre-joined context string suitable for direct prompt injection.
   async contextObservations(
     input: ServerBetaContextObservationsRequest,
@@ -262,7 +304,7 @@ export class ServerBetaClient {
     );
   }
 
-  // Phase 8 — MCP `observation_generation_status`. Server returns the same
+  // MCP `observation_generation_status`. Server returns the same
   // payload as `/v1/jobs/:id` so MCP clients and REST clients see identical
   // job status (including transport state).
   async getJobStatus(jobId: string): Promise<ServerBetaJobStatusResponse> {
@@ -272,6 +314,56 @@ export class ServerBetaClient {
     return this.request<ServerBetaJobStatusResponse>(
       'GET',
       `/v1/jobs/${encodeURIComponent(jobId)}`,
+    );
+  }
+
+  // Branch 2 (Agent C) — batch get observations by id. Server returns only
+  // rows the caller is allowed to see (team-scoped, optionally project-scoped).
+  // Missing ids are simply omitted (never 404) to avoid existence probing.
+  async getMemoriesBatch(input: {
+    projectId?: string;
+    ids: string[];
+  }): Promise<ServerBetaMemoriesBatchResponse> {
+    return this.request<ServerBetaMemoriesBatchResponse>(
+      'POST',
+      '/v1/memories/batch',
+      {
+        ...(input.projectId ? { projectId: input.projectId } : {}),
+        ids: input.ids,
+      },
+    );
+  }
+
+  // Branch 2 — single observation lookup by id. 404 maps to a typed
+  // ServerBetaClientError so the MCP handler can surface the missing-id case
+  // distinctly from transport errors.
+  async getMemoryById(input: { id: string }): Promise<ServerBetaMemoryGetResponse> {
+    if (!input.id) {
+      throw new ServerBetaClientError('invalid_response', 'id is required for getMemoryById');
+    }
+    return this.request<ServerBetaMemoryGetResponse>(
+      'GET',
+      `/v1/memories/${encodeURIComponent(input.id)}`,
+    );
+  }
+
+  // Branch 2 — timeline window around an anchor observation (or top FTS hit).
+  // Mirrors the worker's /api/timeline contract: caller passes anchor or query
+  // plus depthBefore/depthAfter, server resolves the anchor and returns the
+  // before/after windows ordered by created_at.
+  async getTimelineWindow(
+    input: ServerBetaTimelineRequest,
+  ): Promise<ServerBetaTimelineResponse> {
+    return this.request<ServerBetaTimelineResponse>(
+      'POST',
+      '/v1/timeline',
+      {
+        projectId: input.projectId,
+        ...(input.anchor ? { anchor: input.anchor } : {}),
+        ...(input.query ? { query: input.query } : {}),
+        ...(input.depthBefore !== undefined ? { depthBefore: input.depthBefore } : {}),
+        ...(input.depthAfter !== undefined ? { depthAfter: input.depthAfter } : {}),
+      },
     );
   }
 

--- a/src/services/worker/http/middleware.ts
+++ b/src/services/worker/http/middleware.ts
@@ -7,7 +7,7 @@ import { logger } from '../../../utils/logger.js';
 
 export function createMiddleware(
   summarizeRequestBody: (method: string, path: string, body: any) => string,
-  options: { includeCors?: boolean } = {}
+  options: { includeCors?: boolean; bodyLimit?: string; skipJson?: boolean } = {}
 ): RequestHandler[] {
   const middlewares: RequestHandler[] = [];
 
@@ -15,7 +15,9 @@ export function createMiddleware(
     middlewares.push(createCorsMiddleware());
   }
 
-  middlewares.push(express.json({ limit: '5mb' }));
+  if (options.skipJson !== true) {
+    middlewares.push(express.json({ limit: options.bodyLimit ?? '5mb' }));
+  }
 
   middlewares.push((req: Request, res: Response, next: NextFunction) => {
     const staticExtensions = ['.html', '.js', '.css', '.svg', '.png', '.jpg', '.jpeg', '.webp', '.woff', '.woff2', '.ttf', '.eot'];


### PR DESCRIPTION
Fixes #2564. Part of tracking issue #2540.

**Stacked on #2542.** The bootstrap reads `hashApiKeyForStorage` from `postgres-auth.ts` (added in #2542). When #2542 lands, this rebases to main.

Wires the lifecycle hooks to a runtime selector so a single installed plugin can be repointed at worker or server-beta runtime via configuration — no reinstall.

## Diff (vs base #2542)

```
 src/services/domain/ModeManager.ts          |  22 ++++--
 src/services/hooks/server-beta-bootstrap.ts | 109 ++++++++++++++++++++-------
 src/services/hooks/server-beta-client.ts    | 110 +++++++++++++++++++++++++---
 src/services/worker/http/middleware.ts      |   6 +-
 4 files changed, 202 insertions(+), 45 deletions(-)
```

## Changes

1. **Bootstrap** reads `CLAUDE_MEM_RUNTIME` (or `settings.json#runtime` fallback). Server-beta → HTTP client; worker → SQLite client (unchanged).
2. **HTTP client** (`server-beta-client.ts`): bearer-auth, exponential-backoff retry on 5xx (3 max), 5s timeout, single-flight queue, graceful degradation (hook failures never block the session).
3. **ModeManager**: server-beta pulls mode from `/v1/mode` with local cache; worker file-based path unchanged.
4. **Worker middleware**: CORS preflight passthrough for OPTIONS on `/v1/*` (viewer dev needs this).

## Verification

- `npm run typecheck` — clean
- runtime=server-beta + bootstrap → event appears in postgres within 200ms
- runtime=worker + bootstrap → unchanged SQLite behavior
- Server unreachable + retries exhausted → single error log, no throw, session continues

## Out of scope (separate PRs)

The MCP server runtime-selector parts depend on `smart-file-read/parser.ts` additions (upcoming Group E). `services/server/Server.ts` adds `helmet` as a new npm dep — also separate. Both intentionally not bundled here.