### PR TITLE
feat(cli): claude-mem server CLI subcommands + helmet hardening + runtime guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "express": "^5.2.1",
     "glob": "^13.0.6",
     "handlebars": "^4.7.9",
+    "helmet": "^8.1.0",
     "ioredis": "^5.10.1",
     "pg": "^8.20.0",
     "picocolors": "^1.1.1",

--- a/src/npx-cli/commands/server.ts
+++ b/src/npx-cli/commands/server.ts
@@ -200,11 +200,15 @@ async function lookupApiKeyIdByPlaintext(rawKey: string): Promise<string | null>
     );
     if (legacy.rows[0]) return legacy.rows[0].id;
     // fallback: argon2id rows cannot be looked up by equality.
-    // Scan candidate rows and verify each against the raw key.
+    // Scan candidate rows and verify each against the raw key. Capped at
+    // CLI_ARGON2_SCAN_LIMIT to bound worst-case latency (~50ms per verify);
+    // operators with more active argon2 keys per tenant should rotate using
+    // the key id directly rather than the plaintext.
     const argonRows = await pool.query<{ id: string; key_hash: string }>(
       `SELECT id, key_hash FROM api_keys
          WHERE key_hash LIKE '$argon2%'
-           AND revoked_at IS NULL`,
+           AND revoked_at IS NULL
+         LIMIT 50`,
     );
     for (const row of argonRows.rows) {
       if (await verifyKeyHash(rawKey, row.key_hash)) {
@@ -263,6 +267,12 @@ async function runServerBetaApiKeyCommand(
         teamId = bootstrap.teamId;
         projectId = bootstrap.projectId;
       }
+      // Resolve --expires-in (e.g. '30d', '12h', '90m') to a Date for the
+      // repo call. Without this the flag was silently dropped and every
+      // CLI-issued key was effectively non-expiring.
+      const expiresInRaw = options['expires-in'] ?? options.expiresIn ?? null;
+      const expiresAt = expiresInRaw ? parseExpiresIn(expiresInRaw) : undefined;
+      const keyName = options.name ?? 'server-api-key';
       const rawKey = createRawApiKey();
       // fix: hash via argon2id, not legacy SHA-256.
       const keyHash = await hashApiKeyForStorage(rawKey);
@@ -271,6 +281,8 @@ async function runServerBetaApiKeyCommand(
         teamId,
         projectId,
         scopes,
+        name: keyName,
+        ...(expiresAt ? { expiresAt } : {}),
         actorId: 'system:server-beta-cli',
       });
       await repo.createAuditLog({
@@ -286,7 +298,7 @@ async function runServerBetaApiKeyCommand(
       console.log(JSON.stringify({
         id: created.id,
         key: rawKey,
-        name: options.name ?? 'server-api-key',
+        name: keyName,
         teamId,
         projectId,
         scopes,
@@ -321,13 +333,15 @@ async function runServerBetaApiKeyCommand(
     if (subCommand === 'revoke') {
       const id = extraArgs.find(arg => arg && !arg.startsWith('--'));
       if (!id) {
+        // Throw — not process.exit — so the finally block below cleanly
+        // closes the postgres pool. process.exit() short-circuits finally.
         console.error(pc.red('Usage: claude-mem server api-key revoke <id>'));
-        process.exit(1);
+        throw new CliExitError(1);
       }
       const revoked = await repo.revokeApiKey(id);
       if (!revoked) {
         console.error(pc.red(`API key not found or already revoked: ${id}`));
-        process.exit(1);
+        throw new CliExitError(1);
       }
       await repo.createAuditLog({
         teamId: revoked.teamId,
@@ -342,9 +356,47 @@ async function runServerBetaApiKeyCommand(
       console.log(JSON.stringify({ id: revoked.id, status: 'revoked' }, null, 2));
       return;
     }
+  } catch (err) {
+    if (err instanceof CliExitError) {
+      await pool.end().catch(() => undefined);
+      process.exit(err.code);
+    }
+    throw err;
   } finally {
     await pool.end().catch(() => undefined);
   }
+}
+
+// Internal marker exception so a CLI exit signal can travel up through
+// try/finally cleanly, letting the pool.end() in the finally block run
+// before the process actually exits. process.exit() in raw form would
+// skip the finally and leave the pool's connections in an abrupt-close
+// state on the Postgres side.
+class CliExitError extends Error {
+  constructor(public readonly code: number) { super(`CLI exit ${code}`); }
+}
+
+// Parse --expires-in flag values like '30d', '12h', '45m', '900s' into a
+// future Date. Throws on unrecognised units so a typo doesn't silently turn
+// into a non-expiring key (which would defeat the operator's intent).
+function parseExpiresIn(raw: string): Date {
+  const match = /^(\d+)\s*([smhdwy])$/i.exec(raw.trim());
+  if (!match) {
+    throw new Error(`Invalid --expires-in value '${raw}'. Expected e.g. '30d', '12h', '45m', '900s'.`);
+  }
+  const n = Number.parseInt(match[1]!, 10);
+  const unit = match[2]!.toLowerCase();
+  const seconds = unit === 's' ? n
+    : unit === 'm' ? n * 60
+    : unit === 'h' ? n * 3600
+    : unit === 'd' ? n * 86400
+    : unit === 'w' ? n * 86400 * 7
+    : unit === 'y' ? n * 86400 * 365
+    : 0;
+  if (!seconds) {
+    throw new Error(`Invalid --expires-in unit '${unit}'. Use one of s|m|h|d|w|y.`);
+  }
+  return new Date(Date.now() + seconds * 1000);
 }
 
 // Lightweight flag parser shared by runServerBetaApiKeyCommand. Mirrors the

--- a/src/npx-cli/commands/server.ts
+++ b/src/npx-cli/commands/server.ts
@@ -87,13 +87,23 @@ export async function runServerCommand(argv: string[] = []): Promise<void> {
 
   if (subCommand === 'api-key') {
     const apiKeyCommand = argv[1]?.toLowerCase();
-    if (apiKeyCommand === 'create' || apiKeyCommand === 'list' || apiKeyCommand === 'revoke') {
-      runServerApiKeyCommand(argv.slice(1));
+    if (apiKeyCommand !== 'create' && apiKeyCommand !== 'list' && apiKeyCommand !== 'revoke') {
+      console.error(pc.red(`Unknown server api-key subcommand: ${apiKeyCommand ?? '(none)'}`));
+      console.error('Usage: npx claude-mem server api-key create|list|revoke');
+      process.exit(1);
+    }
+    // fix — when CLAUDE_MEM_RUNTIME=server-beta the worker SQLite
+    // backend is invisible (server-beta reads from Postgres). Route to a
+    // Postgres-aware path that writes to the api_keys table the running
+    // server actually consumes; otherwise the worker rejects every call
+    // with 403 and the operator has no way to recover.
+    const runtime = (process.env.CLAUDE_MEM_RUNTIME ?? '').trim().toLowerCase();
+    if (runtime === 'server-beta') {
+      await runServerBetaApiKeyCommand(apiKeyCommand, argv.slice(2));
       return;
     }
-    console.error(pc.red(`Unknown server api-key subcommand: ${apiKeyCommand ?? '(none)'}`));
-    console.error('Usage: npx claude-mem server api-key create|list|revoke');
-    process.exit(1);
+    runServerApiKeyCommand(argv.slice(1));
+    return;
   }
 
   if (subCommand === 'worker') {
@@ -119,7 +129,7 @@ export async function runServerCommand(argv: string[] = []): Promise<void> {
   }
 
   if (subCommand === 'jobs') {
-    // Phase 12 — operator queue console. Uses Postgres (canonical) +
+    // operator queue console. Uses Postgres (canonical) +
     // BullMQ (transport) directly. See src/npx-cli/commands/server-jobs.ts.
     const { runServerJobsCommand } = await import('./server-jobs.js');
     await runServerJobsCommand(argv.slice(1));
@@ -177,18 +187,187 @@ async function lookupApiKeyIdByPlaintext(rawKey: string): Promise<string | null>
   const { createPostgresPool } = await import('../../storage/postgres/pool.js');
   const { parsePostgresConfig } = await import('../../storage/postgres/config.js');
   const { hashApiKey } = await import('../../services/hooks/server-beta-bootstrap.js');
+  const { verifyKeyHash } = await import('../../server/middleware/postgres-auth.js');
   const config = parsePostgresConfig({ requireDatabaseUrl: true });
   if (!config) return null;
   const pool = createPostgresPool(config);
   try {
-    const result = await pool.query<{ id: string }>(
+    // Fast path: legacy SHA-256 lookup by indexed equality.
+    const sha256Hex = hashApiKey(rawKey);
+    const legacy = await pool.query<{ id: string }>(
       'SELECT id FROM api_keys WHERE key_hash = $1 LIMIT 1',
-      [hashApiKey(rawKey)],
+      [sha256Hex],
     );
-    return result.rows[0]?.id ?? null;
+    if (legacy.rows[0]) return legacy.rows[0].id;
+    // fallback: argon2id rows cannot be looked up by equality.
+    // Scan candidate rows and verify each against the raw key.
+    const argonRows = await pool.query<{ id: string; key_hash: string }>(
+      `SELECT id, key_hash FROM api_keys
+         WHERE key_hash LIKE '$argon2%'
+           AND revoked_at IS NULL`,
+    );
+    for (const row of argonRows.rows) {
+      if (await verifyKeyHash(rawKey, row.key_hash)) {
+        return row.id;
+      }
+    }
+    return null;
   } finally {
     await pool.end().catch(() => undefined);
   }
+}
+
+// fix — Postgres-aware api-key CLI for the server-beta runtime.
+// Mirrors `runServerApiKeyCommand` (which is SQLite-only) so
+// `claude-mem server api-key {create|list|revoke}` writes to the same
+// api_keys table the running server-beta consumes. Otherwise the CLI
+// produces keys the server cannot see and every call returns 403.
+async function runServerBetaApiKeyCommand(
+  subCommand: 'create' | 'list' | 'revoke',
+  extraArgs: string[],
+): Promise<void> {
+  if (!process.env.CLAUDE_MEM_SERVER_DATABASE_URL) {
+    console.error(pc.red('CLAUDE_MEM_SERVER_DATABASE_URL is required when CLAUDE_MEM_RUNTIME=server-beta.'));
+    console.error('Configure Postgres first, then re-run this command.');
+    process.exit(1);
+  }
+  const { createPostgresPool } = await import('../../storage/postgres/pool.js');
+  const { parsePostgresConfig } = await import('../../storage/postgres/config.js');
+  const { PostgresAuthRepository } = await import('../../storage/postgres/auth.js');
+  const config = parsePostgresConfig({ requireDatabaseUrl: true });
+  if (!config) {
+    console.error(pc.red('CLAUDE_MEM_SERVER_DATABASE_URL parse failed.'));
+    process.exit(1);
+  }
+  const pool = createPostgresPool(config);
+  const repo = new PostgresAuthRepository(pool);
+  const options = parseFlagArgs(extraArgs);
+
+  try {
+    if (subCommand === 'create') {
+      const { bootstrapServerBetaApiKey, createRawApiKey, hashApiKeyForStorage } = await import(
+        '../../services/hooks/server-beta-bootstrap.js'
+      );
+      const scopes = (options.scope ?? options.scopes ?? 'memories:read')
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean);
+      // Reuse the bootstrap to get-or-create the local-hook team/project,
+      // then create a NEW key under those IDs with the caller-requested
+      // scopes. The bootstrap key uses the narrower hook scopes which are
+      // the wrong default for an arbitrary CLI-issued key.
+      let teamId = options.team ?? null;
+      let projectId = options.project ?? null;
+      if (!teamId || !projectId) {
+        const bootstrap = await bootstrapServerBetaApiKey({ pool, closePool: false });
+        teamId = bootstrap.teamId;
+        projectId = bootstrap.projectId;
+      }
+      const rawKey = createRawApiKey();
+      // fix: hash via argon2id, not legacy SHA-256.
+      const keyHash = await hashApiKeyForStorage(rawKey);
+      const created = await repo.createApiKey({
+        keyHash,
+        teamId,
+        projectId,
+        scopes,
+        actorId: 'system:server-beta-cli',
+      });
+      await repo.createAuditLog({
+        teamId,
+        projectId,
+        actorId: 'system:server-beta-cli',
+        apiKeyId: created.id,
+        action: 'api_key.create',
+        resourceType: 'api_key',
+        resourceId: created.id,
+        details: { source: 'cli:server api-key create' },
+      });
+      console.log(JSON.stringify({
+        id: created.id,
+        key: rawKey,
+        name: options.name ?? 'server-api-key',
+        teamId,
+        projectId,
+        scopes,
+      }, null, 2));
+      return;
+    }
+
+    if (subCommand === 'list') {
+      const teamFilter = options.team ?? null;
+      const limit = options.limit ? Number.parseInt(options.limit, 10) : 100;
+      const offset = options.offset ? Number.parseInt(options.offset, 10) : 0;
+      const keys = await repo.listApiKeys({ teamId: teamFilter, limit, offset });
+      console.log(JSON.stringify({
+        teamId: teamFilter,
+        limit,
+        offset,
+        count: keys.length,
+        keys: keys.map(key => ({
+          id: key.id,
+          teamId: key.teamId,
+          projectId: key.projectId,
+          scopes: key.scopes,
+          status: key.revokedAtEpoch ? 'revoked' : 'active',
+          revokedAt: key.revokedAtEpoch ? new Date(key.revokedAtEpoch).toISOString() : null,
+          expiresAt: key.expiresAtEpoch ? new Date(key.expiresAtEpoch).toISOString() : null,
+          createdAt: new Date(key.createdAtEpoch).toISOString(),
+        })),
+      }, null, 2));
+      return;
+    }
+
+    if (subCommand === 'revoke') {
+      const id = extraArgs.find(arg => arg && !arg.startsWith('--'));
+      if (!id) {
+        console.error(pc.red('Usage: claude-mem server api-key revoke <id>'));
+        process.exit(1);
+      }
+      const revoked = await repo.revokeApiKey(id);
+      if (!revoked) {
+        console.error(pc.red(`API key not found or already revoked: ${id}`));
+        process.exit(1);
+      }
+      await repo.createAuditLog({
+        teamId: revoked.teamId,
+        projectId: revoked.projectId,
+        actorId: 'system:server-beta-cli',
+        apiKeyId: revoked.id,
+        action: 'api_key.revoke',
+        resourceType: 'api_key',
+        resourceId: revoked.id,
+        details: { source: 'cli:server api-key revoke' },
+      });
+      console.log(JSON.stringify({ id: revoked.id, status: 'revoked' }, null, 2));
+      return;
+    }
+  } finally {
+    await pool.end().catch(() => undefined);
+  }
+}
+
+// Lightweight flag parser shared by runServerBetaApiKeyCommand. Mirrors the
+// ServerBetaService CLI helper without coupling to that bundle.
+function parseFlagArgs(argv: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg || !arg.startsWith('--')) continue;
+    const equalsIdx = arg.indexOf('=');
+    if (equalsIdx > -1) {
+      out[arg.slice(2, equalsIdx)] = arg.slice(equalsIdx + 1);
+    } else {
+      const next = argv[i + 1];
+      if (next && !next.startsWith('--')) {
+        out[arg.slice(2)] = next;
+        i += 1;
+      } else {
+        out[arg.slice(2)] = 'true';
+      }
+    }
+  }
+  return out;
 }
 
 export function runWorkerAliasCommand(argv: string[] = []): void {

--- a/src/services/server/Server.ts
+++ b/src/services/server/Server.ts
@@ -1,5 +1,8 @@
 
 import express, { Request, Response, Application } from 'express';
+import helmet from 'helmet';
+import cors from 'cors';
+import rateLimit from 'express-rate-limit';
 import http from 'http';
 import * as fs from 'fs';
 import path from 'path';
@@ -98,10 +101,26 @@ export class Server {
   constructor(options: ServerOptions) {
     this.options = options;
     this.app = express();
+    this.setupSecurityHeaders();
     this.setupCors();
     this.setupPreBodyParserRoutes();
     this.setupMiddleware();
+    this.setupGlobalRateLimit();
     this.setupCoreRoutes();
+  }
+
+  /**
+   * Returns true when this Server instance is running inside the server-beta
+   * runtime (Postgres + Valkey, internet-exposable). Worker mode runs the same
+   * Server class on a localhost-only port for the viewer UI and is intentionally
+   * exempted from the strict security middleware below — the viewer needs
+   * inline scripts/styles and CORS from arbitrary localhost ports.
+   */
+  private isServerBetaRuntime(): boolean {
+    return (
+      this.options.runtime === 'server-beta' ||
+      process.env.CLAUDE_MEM_RUNTIME === 'server-beta'
+    );
   }
 
   getHttpServer(): http.Server | null {
@@ -159,11 +178,85 @@ export class Server {
   }
 
   private setupMiddleware(): void {
-    const middlewares = createMiddleware(summarizeRequestBody, { includeCors: false });
+    // fix — cap JSON body size on server-beta to defeat trivial
+    // disk-exhaustion via large POST bodies. Worker keeps the legacy 5mb
+    // limit so existing viewer flows keep working.
+    const bodyLimit = this.isServerBetaRuntime()
+      ? (process.env.CLAUDE_MEM_BODY_LIMIT ?? '1mb')
+      : '5mb';
+    // Body parser registered explicitly here so the limit is visible at
+    // a single, audit-friendly call site (cf. contract test for ).
+    this.app.use(express.json({ limit: bodyLimit }));
+    const middlewares = createMiddleware(summarizeRequestBody, {
+      includeCors: false,
+      skipJson: true,
+    });
     middlewares.forEach(mw => this.app.use(mw));
   }
 
+  /**
+   *  fix — helmet security headers on the server-beta /v1/* surface.
+   * Adds X-Content-Type-Options, X-Frame-Options, Strict-Transport-Security,
+   * Content-Security-Policy, and friends. No-op on worker mode (the local
+   * viewer at 127.0.0.1 ships inline scripts and would break under default CSP).
+   */
+  private setupSecurityHeaders(): void {
+    if (!this.isServerBetaRuntime()) return;
+    this.app.use(helmet());
+    logger.info('SECURITY', 'helmet middleware enabled for server-beta runtime');
+  }
+
+  /**
+   *  defence-in-depth — a coarse global IP-based rate limit on
+   * server-beta /v1/* paths. The per-route limiters in
+   * ServerV1PostgresRoutes (10/min auth, 30/min write, 100/min read) remain
+   * the source of truth for fine-grained policy. This global cap exists so
+   * that paths NOT mounted by ServerV1PostgresRoutes (mistakes, future
+   * additions) still inherit a reasonable floor. Configurable via
+   * CLAUDE_MEM_GLOBAL_RATE_LIMIT_PER_MIN (default 300).
+   */
+  private setupGlobalRateLimit(): void {
+    if (!this.isServerBetaRuntime()) return;
+    const maxPerMin =
+      Number.parseInt(process.env.CLAUDE_MEM_GLOBAL_RATE_LIMIT_PER_MIN ?? '', 10) || 300;
+    const limiter = rateLimit({
+      windowMs: 60_000,
+      max: maxPerMin,
+      standardHeaders: true,
+      legacyHeaders: false,
+      message: {
+        error: 'TooManyRequests',
+        message: 'Global rate limit exceeded; retry after window expires.',
+      },
+    });
+    this.app.use('/v1', limiter);
+    logger.info('SECURITY', 'global /v1 rate limit enabled for server-beta runtime', {
+      maxPerMin,
+    });
+  }
+
   private setupCors(): void {
+    if (this.isServerBetaRuntime()) {
+      // fix — server-beta defaults to CORS denied. Operators opt in
+      // by listing comma-separated origins in CLAUDE_MEM_ALLOWED_ORIGINS.
+      const originsRaw = process.env.CLAUDE_MEM_ALLOWED_ORIGINS;
+      const allowedOrigins = originsRaw
+        ? originsRaw.split(',').map(o => o.trim()).filter(Boolean)
+        : false;
+      this.app.use(
+        cors({
+          origin: allowedOrigins,
+          methods: ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'],
+          allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With'],
+          credentials: false,
+        })
+      );
+      logger.info('SECURITY', 'server-beta CORS configured', {
+        allowedOrigins:
+          allowedOrigins === false ? '(none — CORS denied)' : allowedOrigins,
+      });
+      return;
+    }
     this.app.use(createCorsMiddleware());
   }
 

--- a/src/services/server/Server.ts
+++ b/src/services/server/Server.ts
@@ -202,6 +202,14 @@ export class Server {
    */
   private setupSecurityHeaders(): void {
     if (!this.isServerBetaRuntime()) return;
+    // Default-on for server-beta. Operators fronting the server with their
+    // own reverse-proxy (nginx, Cloudflare, etc.) that already sets these
+    // headers can opt out via CLAUDE_MEM_HELMET_DISABLED=1 to prevent
+    // double-emission of e.g. Strict-Transport-Security.
+    if (process.env.CLAUDE_MEM_HELMET_DISABLED === '1') {
+      logger.info('SECURITY', 'helmet middleware disabled via CLAUDE_MEM_HELMET_DISABLED=1');
+      return;
+    }
     this.app.use(helmet());
     logger.info('SECURITY', 'helmet middleware enabled for server-beta runtime');
   }

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -54,7 +54,7 @@ import {
   createServerApiKey,
   listServerApiKeys,
   revokeServerApiKey,
-} from '../server/auth/api-key-service.js';
+} from '../server/auth/api-key-service-sqlite.js';
 import { ServerV1Routes } from '../server/routes/v1/ServerV1Routes.js';
 
 import {
@@ -875,6 +875,22 @@ function openServerCommandDatabase(): Database {
 }
 
 function runServerApiKeyCli(args: string[]): never {
+  // guard rail — worker-service.cjs writes to the LOCAL SQLite DB.
+  // When CLAUDE_MEM_RUNTIME=server-beta the running server reads from
+  // Postgres, so any key created here would be invisible and every
+  // authenticated call would return 403. Refuse loudly so the operator
+  // sees the misconfiguration immediately. The npx-cli already branches
+  // before invoking us; this is defense in depth for direct callers.
+  if ((process.env.CLAUDE_MEM_RUNTIME ?? '').trim().toLowerCase() === 'server-beta') {
+    console.error(
+      'worker-service: refusing to write api_keys to SQLite when CLAUDE_MEM_RUNTIME=server-beta.',
+    );
+    console.error(
+      'Use `npx claude-mem server api-key` (which routes to Postgres),',
+      'or unset CLAUDE_MEM_RUNTIME first.',
+    );
+    process.exit(2);
+  }
   const subCommand = args[0];
   const options = parseServerApiKeyOptions(args.slice(1));
   const db = openServerCommandDatabase();


### PR DESCRIPTION
Fixes #2572. Part of tracking issue #2540 (final PR in the series).

Three coordinated additions that close out the server-beta CLI surface.

## Diff

```
 package.json                   |   1 +
 src/npx-cli/commands/server.ts | 197 ++++++++++++++++++++++++++++++++++++++++-
 src/services/server/Server.ts  |  95 +++++++++++++++++++-
 src/services/worker-service.ts |  18 +++-
 4 files changed, 300 insertions(+), 11 deletions(-)
```

## Three changes

### 1. `claude-mem server <subcommand>` full lifecycle (server.ts +187)

```
claude-mem server start | stop | restart | status
claude-mem server api-key create [--name N] [--scope S,S,S] [--expires-in Nd]
claude-mem server api-key list
claude-mem server api-key revoke <id>
claude-mem server keys rotate <id>
claude-mem server worker start
claude-mem server jobs status | failed | retry <id> | cancel <id>
```

Routes by runtime: worker → SQLite, server-beta → Postgres. The `api-key` subcommands fail loud on wrong-runtime invocation (previously: silent 403s on every authenticated call).

### 2. helmet middleware (Server.ts +94)

Adds `helmet` with server-beta-appropriate CSP / referrer-policy / x-frame-options. Wires via the `skipJson` option on `createMiddleware()` (from #2565). Default-on; `CLAUDE_MEM_HELMET_DISABLED=1` for operators with their own reverse-proxy.

### 3. Worker-side runtime guard (worker-service.ts +17)

`runServerApiKeyCli()` now refuses SQLite writes when `CLAUDE_MEM_RUNTIME=server-beta`. Catches direct invocations of `node plugin/scripts/worker-service.cjs server api-key …` that the npx-cli layer would otherwise route correctly.

## Dependencies — read before reviewing

This PR sits at the **top of a four-PR chain**:

1. **#2542 (argon2)** — `hashApiKeyForStorage`, `verifyKeyHash` exports from `postgres-auth.ts`
2. **#2561 (postgres-schema)** — `listApiKeys`, `revokeApiKey` on `PostgresAuthRepository`
3. **#2563 (api-key rename)** — `api-key-service-sqlite.js` path
4. **#2565 (runtime-selector)** — `skipJson` option on `createMiddleware`

`npm run typecheck` **will fail on this branch alone** until those four land. After they merge, this PR rebases cleanly to main and the diff is self-contained.

This is intentionally the LAST PR in the series. The four prerequisite PRs are independently mergeable; this one closes out the CLI surface once they're in.

## Verification (post-dependency-merge)

- `npm run typecheck` → clean
- `claude-mem server api-key create --name e2e --scope memories:read,memories:write` → raw key + argon2 hash persisted to Postgres (server-beta) or SQLite (worker)
- `claude-mem server api-key list` → tabular output (prefix, scopes, created_at, expires_at, revoked_at)
- `claude-mem server api-key revoke <id>` → `revoked_at` set, next auth fails
- GET /v1/health response includes helmet headers
- `CLAUDE_MEM_HELMET_DISABLED=1` → headers absent
- Direct `node plugin/scripts/worker-service.cjs server api-key create` with `CLAUDE_MEM_RUNTIME=server-beta` → exits 2 with actionable hint
