### PR TITLE
fix(build): populate plugin/node_modules during build (partial #2407)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "plugin/.codex-plugin",
     "plugin/.mcp.json",
     "plugin/package.json",
+    "plugin/node_modules",
     "plugin/hooks",
     "plugin/modes",
     "plugin/scripts/*.js",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -6,6 +6,9 @@
   "type": "module",
   "dependencies": {
     "zod": "^4.3.6",
+    "shell-quote": "^1.8.3"
+  },
+  "optionalDependencies": {
     "tree-sitter-cli": "^0.26.5",
     "tree-sitter-c": "^0.24.1",
     "tree-sitter-cpp": "^0.23.4",
@@ -30,8 +33,7 @@
     "@tree-sitter-grammars/tree-sitter-toml": "^0.7.0",
     "@tree-sitter-grammars/tree-sitter-yaml": "^0.7.1",
     "@derekstride/tree-sitter-sql": "^0.3.11",
-    "@tree-sitter-grammars/tree-sitter-markdown": "^0.3.2",
-    "shell-quote": "^1.8.3"
+    "@tree-sitter-grammars/tree-sitter-markdown": "^0.3.2"
   },
   "overrides": {
     "tree-sitter": "^0.25.0"

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -537,6 +537,57 @@ async function buildHooks() {
       console.log(`✓ opencode plugin built (${(opencodeStats.size / 1024).toFixed(2)} KB)`);
     }
 
+    console.log('\n📦 Installing plugin runtime dependencies into plugin/node_modules...');
+    // Why this exists: with better-auth externalized from the worker bundle
+    // (PR #2596 / issue #2584) and the existing zod + tree-sitter externals,
+    // the worker now relies on `plugin/node_modules` being populated at
+    // runtime. Marketplace installs already get this via `sync-marketplace.cjs`
+    // running `bun install` post-rsync, but:
+    //   1. Dev workflow (`bun plugin/scripts/worker-service.cjs start`) was
+    //      broken — repo-local plugin/ had no node_modules until you synced.
+    //   2. The npm tarball (`npm install -g claude-mem` → `npx claude-mem
+    //      install`) ships plugin/package.json but no plugin/node_modules
+    //      (issue #2407), so the worker fails with `Cannot find module 'zod/v3'`.
+    //
+    // Running install here fixes (1) outright and is a prerequisite for the
+    // npm tarball fix (which bundles plugin/node_modules into the published
+    // tarball — coming in a follow-up PR). We use `npm install` not `bun
+    // install` so this works on CI / publishers that may not have bun.
+    //
+    // We intentionally DO NOT pass --ignore-scripts: tree-sitter grammar
+    // packages rely on prebuild-install (a postinstall script) to download
+    // prebuilt .node bindings for the current arch. With --ignore-scripts
+    // the bindings never arrive and the MCP server fails to load any
+    // grammar. prebuild-install handles cross-platform via prebuilt
+    // binaries; only on niche archs (linux arm64 without prebuilt) does it
+    // fall back to node-gyp compilation. If the install fails entirely
+    // (e.g. node-gyp prerequisites missing on a publisher's machine), we
+    // log a warning but don't abort the build — the maintainer can resolve
+    // it before publishing.
+    try {
+      const { spawn: spawnInstall } = await import('child_process');
+      const installResult = spawnInstall('npm', ['install', '--omit=dev', '--no-audit', '--no-fund'], {
+        cwd: 'plugin',
+        stdio: 'inherit',
+      });
+      await new Promise((resolve) => {
+        installResult.on('exit', (code) => {
+          if (code === 0) {
+            console.log('✓ plugin/node_modules populated');
+          } else {
+            console.warn(`⚠️  npm install in plugin/ exited with code ${code}. The build artifact is still valid, but you'll need to run \`cd plugin && npm install\` manually before the worker can resolve external dependencies (zod, better-auth, tree-sitter grammars).`);
+          }
+          resolve();
+        });
+        installResult.on('error', (err) => {
+          console.warn(`⚠️  Could not invoke npm in plugin/: ${err.message}. The build artifact is still valid, but you'll need to run \`cd plugin && npm install\` manually.`);
+          resolve();
+        });
+      });
+    } catch (installError) {
+      console.warn(`⚠️  plugin/ install raised: ${installError.message}. Continuing — artifacts are still valid.`);
+    }
+
     console.log('\n📋 Copying onboarding explainer to plugin tree...');
     const onboardingExplainerSrc = 'src/services/worker/onboarding-explainer.md';
     const onboardingExplainerDst = 'plugin/skills/how-it-works/onboarding-explainer.md';

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -578,16 +578,19 @@ async function buildHooks() {
         shell: process.platform === 'win32',
       });
       await new Promise((resolve) => {
+        let errorHandled = false;
+        installResult.on('error', (err) => {
+          errorHandled = true;
+          console.warn(`⚠️  Could not invoke npm in plugin/: ${err.message}. The build artifact is still valid, but you'll need to run \`cd plugin && npm install\` manually.`);
+          resolve();
+        });
         installResult.on('exit', (code) => {
+          if (errorHandled) { resolve(); return; }
           if (code === 0) {
             console.log('✓ plugin/node_modules populated');
           } else {
             console.warn(`⚠️  npm install in plugin/ exited with code ${code}. The build artifact is still valid, but you'll need to run \`cd plugin && npm install\` manually before the worker can resolve external dependencies (zod, better-auth, tree-sitter grammars).`);
           }
-          resolve();
-        });
-        installResult.on('error', (err) => {
-          console.warn(`⚠️  Could not invoke npm in plugin/: ${err.message}. The build artifact is still valid, but you'll need to run \`cd plugin && npm install\` manually.`);
           resolve();
         });
       });

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -565,10 +565,17 @@ async function buildHooks() {
     // log a warning but don't abort the build — the maintainer can resolve
     // it before publishing.
     try {
-      const { spawn: spawnInstall } = await import('child_process');
+      const { spawn: spawnInstall } = await import('node:child_process');
+      // shell: true on Windows is critical — npm there is a .cmd batch file,
+      // not a bare executable, so spawn('npm', ...) without shell hits ENOENT
+      // and the fail-soft handler below would silently leave Windows builds
+      // with an empty plugin/node_modules.
+      // cwd anchored to __dirname (not process.cwd()) so the step works even
+      // if the script is invoked from outside the repo root.
       const installResult = spawnInstall('npm', ['install', '--omit=dev', '--no-audit', '--no-fund'], {
-        cwd: 'plugin',
+        cwd: path.join(__dirname, '..', 'plugin'),
         stdio: 'inherit',
+        shell: process.platform === 'win32',
       });
       await new Promise((resolve) => {
         installResult.on('exit', (code) => {

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -205,8 +205,20 @@ async function buildHooks() {
       private: true,
       description: 'Runtime dependencies for claude-mem bundled hooks',
       type: 'module',
+      // Hook-critical, pure-JS deps that MUST install for the worker to boot.
+      // Kept here (not in optionalDependencies) so a failure fails the build.
       dependencies: {
         'zod': '^4.3.6',
+        'shell-quote': '^1.8.3',
+      },
+      // Tree-sitter grammars need native node-gyp / prebuild-install builds. As
+      // hard dependencies, a single grammar build failure (e.g. a Node version
+      // with no prebuilt binding) aborts the ENTIRE `npm install`, taking zod
+      // down with it and crashing every hook (#2407 / #2379). As optional deps
+      // the failure is tolerated: zod still installs, hooks still boot, and only
+      // code-graph parsing degrades. The resolve gate at the end of this build
+      // is the hard guard that zod actually landed.
+      optionalDependencies: {
         'tree-sitter-cli': '^0.26.5',
         'tree-sitter-c': '^0.24.1',
         'tree-sitter-cpp': '^0.23.4',
@@ -232,7 +244,6 @@ async function buildHooks() {
         '@tree-sitter-grammars/tree-sitter-yaml': '^0.7.1',
         '@derekstride/tree-sitter-sql': '^0.3.11',
         '@tree-sitter-grammars/tree-sitter-markdown': '^0.3.2',
-        'shell-quote': '^1.8.3',
       },
       overrides: {
         'tree-sitter': '^0.25.0'
@@ -658,6 +669,25 @@ async function buildHooks() {
     console.log('✓ All required distribution files present');
 
     await verifyShellTemplateCanonical();
+
+    // Hard gate: prove the worker's externalized runtime deps actually resolve
+    // from plugin/node_modules. The install step above is fail-soft (grammars
+    // are optionalDependencies), so this is the real guard against shipping a
+    // build that crashes every hook with `Cannot find module 'zod'`
+    // (#2407 / #2379).
+    console.log('\n📋 Verifying plugin runtime deps resolve...');
+    {
+      const { createRequire } = await import('node:module');
+      const pluginRequire = createRequire(path.join(__dirname, '..', 'plugin', 'package.json'));
+      for (const dep of ['zod', 'shell-quote']) {
+        try {
+          pluginRequire.resolve(dep);
+        } catch {
+          throw new Error(`Plugin runtime dep '${dep}' does not resolve from plugin/node_modules — the bundled worker would crash at runtime. Run \`cd plugin && npm install\` and rebuild.`);
+        }
+      }
+    }
+    console.log('✓ Plugin runtime deps resolve (zod, shell-quote)');
 
     console.log('\n✅ All build targets compiled successfully!');
     console.log(`   Output: ${hooksDir}/`);

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -678,12 +678,23 @@ async function buildHooks() {
     console.log('\n📋 Verifying plugin runtime deps resolve...');
     {
       const { createRequire } = await import('node:module');
+      const pluginNodeModules = path.join(__dirname, '..', 'plugin', 'node_modules');
       const pluginRequire = createRequire(path.join(__dirname, '..', 'plugin', 'package.json'));
       for (const dep of ['zod', 'shell-quote']) {
+        let resolved;
         try {
-          pluginRequire.resolve(dep);
+          resolved = pluginRequire.resolve(dep);
         } catch {
-          throw new Error(`Plugin runtime dep '${dep}' does not resolve from plugin/node_modules — the bundled worker would crash at runtime. Run \`cd plugin && npm install\` and rebuild.`);
+          throw new Error(`Plugin runtime dep '${dep}' does not resolve at all — the bundled worker would crash at runtime. Run \`cd plugin && npm install\` and rebuild.`);
+        }
+        // require.resolve walks UP to the repo-root node_modules, where zod and
+        // shell-quote also exist as build-time deps — so a successful resolve does
+        // NOT prove plugin/node_modules is populated. Assert the resolved path is
+        // actually inside plugin/node_modules, which is what ships in the npm
+        // tarball (root package.json `files`) and what every hook resolves from
+        // at runtime.
+        if (!resolved.startsWith(pluginNodeModules + path.sep)) {
+          throw new Error(`Plugin runtime dep '${dep}' resolved from ${resolved}, OUTSIDE plugin/node_modules — plugin/node_modules is not populated, so the npm tarball / fresh marketplace install would crash every hook with \`Cannot find module '${dep}'\`. Run \`cd plugin && npm install\` and rebuild.`);
         }
       }
     }

--- a/tests/infrastructure/plugin-distribution.test.ts
+++ b/tests/infrastructure/plugin-distribution.test.ts
@@ -184,6 +184,14 @@ describe('Plugin Distribution - package.json Files Field', () => {
     expect(packageJson.files).toContain('plugin/skills');
     expect(packageJson.files).toContain('plugin/scripts/*.cjs');
   });
+
+  it('ships plugin/node_modules in the npm tarball so hooks resolve zod at runtime (#2407)', () => {
+    const packageJson = JSON.parse(readFileSync(path.join(projectRoot, 'package.json'), 'utf-8'));
+    // npm strips a *top-level* node_modules from the tarball but keeps a nested
+    // one that is explicitly named in `files`, so this carries the worker's
+    // externalized runtime deps (zod, shell-quote) into `npm install -g`.
+    expect(packageJson.files).toContain('plugin/node_modules');
+  });
 });
 
 describe('Plugin Distribution - Build Script Verification', () => {

--- a/tests/infrastructure/plugin-distribution.test.ts
+++ b/tests/infrastructure/plugin-distribution.test.ts
@@ -197,6 +197,31 @@ describe('Plugin Distribution - Build Script Verification', () => {
   });
 });
 
+describe('Plugin Distribution - Runtime Dependency Isolation (#2407 / #2379)', () => {
+  const pluginPkg = () => readJson('plugin/package.json');
+
+  it('keeps zod and shell-quote as hard dependencies', () => {
+    const deps = pluginPkg().dependencies ?? {};
+    expect(deps['zod']).toBeDefined();
+    expect(deps['shell-quote']).toBeDefined();
+  });
+
+  it('moves native tree-sitter grammars to optionalDependencies so a grammar build failure cannot abort the whole install', () => {
+    const pkg = pluginPkg();
+    const deps = pkg.dependencies ?? {};
+    const optional = pkg.optionalDependencies ?? {};
+    expect(Object.keys(deps).some((k) => k.includes('tree-sitter'))).toBe(false);
+    expect(Object.keys(optional).some((k) => k.includes('tree-sitter'))).toBe(true);
+  });
+
+  it('gates the build on plugin runtime deps resolving from plugin/node_modules', () => {
+    const content = readFileSync(path.join(projectRoot, 'scripts/build-hooks.js'), 'utf-8');
+    expect(content).toContain('optionalDependencies');
+    expect(content).toContain('Verifying plugin runtime deps resolve');
+    expect(content).toContain('createRequire');
+  });
+});
+
 describe('Plugin Distribution - Setup Hook (#1547)', () => {
   it('should not reference removed setup.sh in Setup hook', () => {
     const hooksPath = path.join(projectRoot, 'plugin/hooks/hooks.json');


### PR DESCRIPTION
## Summary

Makes the bundled worker's externalized runtime deps (`zod`, `shell-quote`) actually resolve at runtime on every install path, fixing the recurring `Cannot find module 'zod/v3'` failure (#2407 / #2379).

## What it does

1. **Build-time install** — `build-hooks.js` runs `npm install --omit=dev` in `plugin/` so `plugin/node_modules` is populated (Windows-safe `shell`, `__dirname`-anchored cwd, `node:` protocol).
2. **Grammars → `optionalDependencies`** — tree-sitter grammars need native node-gyp / prebuild builds; as hard deps a single grammar failure (e.g. Node 26 with no prebuilt binding) aborts the whole `npm install` and takes `zod` down with it. As optional deps the failure is tolerated — only code-graph parsing degrades.
3. **Resolve gate** — after install, asserts `zod` + `shell-quote` resolve *from inside* `plugin/node_modules`, not the repo-root fallback that `require.resolve` would otherwise walk up to (the root has them as build-time deps, which would mask an empty `plugin/node_modules`). Fails the build loudly otherwise.
4. **Ships in the npm tarball** — root `package.json` `files` lists `plugin/node_modules`. npm strips only a *top-level* node_modules; a nested one named explicitly in `files` is kept — verified via `npm pack --dry-run` (2037 `plugin/node_modules/` entries incl. zod + shell-quote).

Together these cover all three #2407 paths: dev workflow, marketplace sync, and `npm install -g`.

## Native binaries in the tarball

The tarball includes the tree-sitter `.node` bindings, which are arch-specific. This is acceptable by design: grammars are `optionalDependencies`, so on a mismatched arch they simply fail to load and only code-graph parsing degrades — the hook-critical deps (`zod`, `shell-quote`) are pure JS and portable. Worst case is degraded code-graph, never a crashed hook.

## Why not inline zod (re: #2610)

Inlining zod into the worker bundle crashes it at startup (`new Class2(...)` → undefined): the worker pulls in multiple layers of zod v4 (classic / core / mini) with internal circular deps that esbuild can't satisfy when inlined into one CJS bundle. Verified — not minify-related. `external zod` + a populated `plugin/node_modules` is the path that actually boots, which is what this PR guarantees.

## Test plan

- [x] `bun test tests/infrastructure/plugin-distribution.test.ts` — grammars-optional, resolve gate, and files-entry assertions pass
- [x] `npm run build` exit 0; `bun plugin/scripts/worker-service.cjs start` → `{"status":"ready"}`
- [x] `npm pack --dry-run` — 2037 `plugin/node_modules/` entries ship in the tarball
