### PR TITLE
fix(worker): emit fail-loud warning visibly and continue gracefully

### DIFF
--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -1,9 +1,9 @@
 import path from "path";
-import { readFileSync, existsSync, writeFileSync, renameSync, mkdirSync } from "fs";
+import { readFileSync, existsSync, writeFileSync, renameSync, mkdirSync, writeSync } from "fs";
 import { execSync } from "child_process";
 import { spawnHidden } from "./spawn.js";
 import { logger } from "../utils/logger.js";
-import { HOOK_TIMEOUTS, HOOK_EXIT_CODES, getTimeout } from "./hook-constants.js";
+import { HOOK_TIMEOUTS, getTimeout } from "./hook-constants.js";
 import { SettingsDefaultsManager } from "./SettingsDefaultsManager.js";
 import { MARKETPLACE_ROOT, DATA_DIR } from "./paths.js";
 import { loadFromFileOnce } from "./hook-settings.js";
@@ -408,10 +408,16 @@ function recordWorkerUnreachable(): number {
 
   const threshold = getFailLoudThreshold();
   if (next.consecutiveFailures >= threshold) {
-    process.stderr.write(
-      `claude-mem worker unreachable for ${next.consecutiveFailures} consecutive hooks.\n`
-    );
-    process.exit(HOOK_EXIT_CODES.BLOCKING_ERROR);
+    // writeSync(2, ...) goes straight to fd 2, bypassing hookCommand's
+    // process.stderr.write override that would otherwise swallow the warning.
+    // Do not process.exit — honors the exit-0 philosophy spelled out in CLAUDE.md
+    // ("Worker/hook errors exit with code 0 to prevent Windows Terminal tab
+    // accumulation") so hooks continue gracefully instead of blocking tool calls.
+    try {
+      writeSync(2, `claude-mem worker unreachable for ${next.consecutiveFailures} consecutive hooks.\n`);
+    } catch {
+      // stderr unwritable — nothing actionable
+    }
   }
   return next.consecutiveFailures;
 }


### PR DESCRIPTION
Two interacting bugs in `recordWorkerUnreachable`'s threshold-crossing branch produce the user-facing failure *"blocking error: No stderr output"* on the client with no signal of what went wrong:

1. The warning is written via `process.stderr.write`, but `hookCommand` (`src/cli/hook-command.ts:75-76`) replaces `process.stderr.write` with a no-op for the lifetime of every hook. The user-visible message is unconditionally swallowed.
2. `process.exit(HOOK_EXIT_CODES.BLOCKING_ERROR)` violates the exit-0 philosophy spelled out in `CLAUDE.md` (*"Worker/hook errors exit with code 0 to prevent Windows Terminal tab accumulation"*), causing every tool call past the threshold to block.

Switch the warning to `fs.writeSync(2, ...)` so it survives the stderr override, and drop the `process.exit` so the caller's `continue: true` fallback propagates and the hook exits 0 like every other worker/hook error path.

## Hit in practice

When a worker is briefly unreachable (restart, crash, network) on a setup where hooks talk to it over HTTP, every subsequent hook past `CLAUDE_MEM_HOOK_FAIL_LOUD_THRESHOLD` (default 3) blocks tool calls with no diagnostic. The user sees Claude Code surface a generic *"blocking error"* but with empty stderr, so neither the user nor Claude itself can tell what's wrong. After this change, hooks emit a visible *"claude-mem worker unreachable for N consecutive hooks"* warning on stderr and continue normally.

## Net behavior change

Only when `consecutiveFailures >= threshold`:

| | before | after |
|---|---|---|
| exit code | `2` (BLOCKING_ERROR) | `0` (SUCCESS) |
| stderr | silent (swallowed) | visible warning |
| tool call | blocked | continues |

## Relationship to #2474

#2474 (circuit breaker) rewrites this code path entirely and happens to remove the `process.exit(2)` as a side effect of the bigger refactor — but its replacement `process.stderr.write(...)` calls run inside the same hook-execution context, so they hit the same stderr silencer. I've left an inline comment on #2474 with the same `writeSync` pattern; the fixes compose in either merge order.