### PR TITLE
Add Codex ingestion provider and Windows Chroma launch fix

### DIFF
--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -105,9 +105,10 @@ export class ChromaMcpManager {
     const spawnEnvironment = this.getSpawnEnv();
     getSupervisor().assertCanSpawn('chroma mcp');
 
-    const isWindows = process.platform === 'win32';
-    const uvxSpawnCommand = isWindows ? (process.env.ComSpec || 'cmd.exe') : 'uvx';
-    const uvxSpawnArgs = isWindows ? ['/c', 'uvx', ...commandArgs] : commandArgs;
+    const uvxSpawnCommand = process.platform === 'win32'
+      ? ChromaMcpManager.resolveWindowsExecutable('uvx.exe')
+      : 'uvx';
+    const uvxSpawnArgs = commandArgs;
 
     logger.info('CHROMA_MCP', 'Connecting to chroma-mcp via MCP stdio', {
       command: uvxSpawnCommand,
@@ -183,6 +184,15 @@ export class ChromaMcpManager {
         });
       }
     };
+  }
+
+  private static resolveWindowsExecutable(command: string): string {
+    const pathEntries = (process.env.PATH || '').split(path.delimiter).filter(Boolean);
+    for (const entry of pathEntries) {
+      const candidate = path.join(entry, command);
+      if (fs.existsSync(candidate)) return candidate;
+    }
+    return command;
   }
 
   private buildCommandArgs(): string[] {

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -72,6 +72,7 @@ import { ClaudeProvider, classifyClaudeError } from './worker/ClaudeProvider.js'
 import type { WorkerRef } from './worker/agents/types.js';
 import { GeminiProvider, classifyGeminiError, isGeminiSelected, isGeminiAvailable } from './worker/GeminiProvider.js';
 import { OpenRouterProvider, classifyOpenRouterError, isOpenRouterSelected, isOpenRouterAvailable } from './worker/OpenRouterProvider.js';
+import { CodexProvider, classifyCodexError, isCodexSelected, isCodexAvailable } from './worker/CodexProvider.js';
 import { ClassifiedProviderError, isClassified, type ProviderErrorClass } from './worker/provider-errors.js';
 import { PaginationHelper } from './worker/PaginationHelper.js';
 import { SettingsManager } from './worker/SettingsManager.js';
@@ -129,6 +130,7 @@ export class WorkerService implements WorkerRef {
   private sdkAgent: ClaudeProvider;
   private geminiAgent: GeminiProvider;
   private openRouterAgent: OpenRouterProvider;
+  private codexAgent: CodexProvider;
   private paginationHelper: PaginationHelper;
   private settingsManager: SettingsManager;
   private sessionEventBroadcaster: SessionEventBroadcaster;
@@ -160,6 +162,7 @@ export class WorkerService implements WorkerRef {
     this.sdkAgent = new ClaudeProvider(this.dbManager, this.sessionManager);
     this.geminiAgent = new GeminiProvider(this.dbManager, this.sessionManager);
     this.openRouterAgent = new OpenRouterProvider(this.dbManager, this.sessionManager);
+    this.codexAgent = new CodexProvider(this.dbManager, this.sessionManager);
 
     this.paginationHelper = new PaginationHelper(this.dbManager);
     this.settingsManager = new SettingsManager(this.dbManager);
@@ -192,7 +195,8 @@ export class WorkerService implements WorkerRef {
       workerPath: __filename,
       getAiStatus: () => {
         let provider = 'claude';
-        if (isOpenRouterSelected() && isOpenRouterAvailable()) provider = 'openrouter';
+        if (isCodexSelected() && isCodexAvailable()) provider = 'codex';
+        else if (isOpenRouterSelected() && isOpenRouterAvailable()) provider = 'openrouter';
         else if (isGeminiSelected() && isGeminiAvailable()) provider = 'gemini';
         return {
           provider,
@@ -260,7 +264,7 @@ export class WorkerService implements WorkerRef {
     });
 
     this.server.registerRoutes(new ViewerRoutes(this.sseBroadcaster, this.dbManager, this.sessionManager));
-    const sessionRoutes = new SessionRoutes(this.sessionManager, this.dbManager, this.sdkAgent, this.geminiAgent, this.openRouterAgent, this.sessionEventBroadcaster, this, this.completionHandler);
+    const sessionRoutes = new SessionRoutes(this.sessionManager, this.dbManager, this.sdkAgent, this.geminiAgent, this.openRouterAgent, this.codexAgent, this.sessionEventBroadcaster, this, this.completionHandler);
     this.server.registerRoutes(sessionRoutes);
     attachIngestGeneratorStarter((sessionDbId, source) =>
       sessionRoutes.ensureGeneratorRunning(sessionDbId, source),
@@ -516,7 +520,13 @@ export class WorkerService implements WorkerRef {
     });
   }
 
-  private getActiveAgent(): ClaudeProvider | GeminiProvider | OpenRouterProvider {
+  private getActiveAgent(): ClaudeProvider | GeminiProvider | OpenRouterProvider | CodexProvider {
+    if (isCodexSelected()) {
+      if (!isCodexAvailable()) {
+        throw new Error('Codex provider selected but codex executable is unavailable. Set CLAUDE_MEM_CODEX_PATH in settings.json.');
+      }
+      return this.codexAgent;
+    }
     if (isOpenRouterSelected() && isOpenRouterAvailable()) {
       return this.openRouterAgent;
     }
@@ -537,7 +547,7 @@ export class WorkerService implements WorkerRef {
    */
   private reclassifyAtDispatch(
     error: unknown,
-    agent: ClaudeProvider | GeminiProvider | OpenRouterProvider
+    agent: ClaudeProvider | GeminiProvider | OpenRouterProvider | CodexProvider
   ): ClassifiedProviderError | null {
     try {
       if (agent instanceof ClaudeProvider) {
@@ -549,6 +559,9 @@ export class WorkerService implements WorkerRef {
       }
       if (agent instanceof OpenRouterProvider) {
         return classifyOpenRouterError({ cause: error });
+      }
+      if (agent instanceof CodexProvider) {
+        return classifyCodexError(error);
       }
     } catch {
       // If the classifier itself throws, fall back to unclassified.

--- a/src/services/worker-types.ts
+++ b/src/services/worker-types.ts
@@ -24,7 +24,7 @@ export interface ActiveSession {
   earliestPendingTimestamp: number | null;  
   claimedMessageIds: number[];
   conversationHistory: ConversationMessage[];  
-  currentProvider: 'claude' | 'gemini' | 'openrouter' | null;  
+  currentProvider: 'claude' | 'gemini' | 'openrouter' | 'codex' | null;  
   consecutiveRestarts: number;  
   restartGuard?: RestartGuard;
   forceInit?: boolean;  

--- a/src/services/worker/CodexProvider.ts
+++ b/src/services/worker/CodexProvider.ts
@@ -1,0 +1,354 @@
+import { spawn } from 'child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import os from 'os';
+import path from 'path';
+import { buildContinuationPrompt, buildInitPrompt, buildObservationPrompt, buildSummaryPrompt } from '../../sdk/prompts.js';
+import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js';
+import { OBSERVER_SESSIONS_DIR, paths } from '../../shared/paths.js';
+import { estimateTokens } from '../../shared/timeline-formatting.js';
+import { logger } from '../../utils/logger.js';
+import { ModeManager } from '../domain/ModeManager.js';
+import type { ModeConfig } from '../domain/types.js';
+import type { ActiveSession, ConversationMessage } from '../worker-types.js';
+import { DatabaseManager } from './DatabaseManager.js';
+import { SessionManager } from './SessionManager.js';
+import { isAbortError, processAgentResponse, type WorkerRef } from './agents/index.js';
+import { ClassifiedProviderError } from './provider-errors.js';
+
+type CodexEffort = 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+
+const DEFAULT_MAX_CONTEXT_MESSAGES = 20;
+const DEFAULT_MAX_ESTIMATED_TOKENS = 100000;
+const VALID_EFFORTS: CodexEffort[] = ['minimal', 'low', 'medium', 'high', 'xhigh'];
+
+export function classifyCodexError(err: unknown): ClassifiedProviderError {
+  const message = err instanceof Error ? err.message : String(err);
+  const lower = message.toLowerCase();
+
+  if (
+    lower.includes('codex executable not found') ||
+    lower.includes('enoent') ||
+    lower.includes('eperm') ||
+    lower.startsWith('spawn ')
+  ) {
+    return new ClassifiedProviderError(message, { kind: 'unrecoverable', cause: err });
+  }
+
+  if (lower.includes('401') || lower.includes('403') || lower.includes('auth') || lower.includes('login')) {
+    return new ClassifiedProviderError(message, { kind: 'auth_invalid', cause: err });
+  }
+
+  if (lower.includes('quota') || lower.includes('insufficient credits')) {
+    return new ClassifiedProviderError(message, { kind: 'quota_exhausted', cause: err });
+  }
+
+  if (lower.includes('429') || lower.includes('rate limit')) {
+    return new ClassifiedProviderError(message, { kind: 'rate_limit', cause: err });
+  }
+
+  if (lower.includes('context window') || lower.includes('prompt is too long')) {
+    return new ClassifiedProviderError(message, { kind: 'unrecoverable', cause: err });
+  }
+
+  return new ClassifiedProviderError(message, { kind: 'transient', cause: err });
+}
+
+export class CodexProvider {
+  constructor(
+    private dbManager: DatabaseManager,
+    private sessionManager: SessionManager,
+  ) {}
+
+  async startSession(session: ActiveSession, worker?: WorkerRef): Promise<void> {
+    const config = this.getCodexConfig();
+
+    if (!session.memorySessionId) {
+      const syntheticMemorySessionId = `codex-${session.contentSessionId}-${Date.now()}`;
+      session.memorySessionId = syntheticMemorySessionId;
+      this.dbManager.getSessionStore().updateMemorySessionId(session.sessionDbId, syntheticMemorySessionId);
+      logger.info('SESSION', `MEMORY_ID_GENERATED | sessionDbId=${session.sessionDbId} | provider=Codex`);
+    }
+
+    const mode = ModeManager.getInstance().getActiveMode();
+    const initPrompt = session.lastPromptNumber === 1
+      ? buildInitPrompt(session.project, session.contentSessionId, session.userPrompt, mode)
+      : buildContinuationPrompt(session.userPrompt, session.lastPromptNumber, session.contentSessionId, mode);
+
+    session.conversationHistory.push({ role: 'user', content: initPrompt });
+
+    try {
+      const initResponse = await this.queryCodexMultiTurn(session.conversationHistory, config, session.abortController.signal);
+      await this.handleProviderResponse(initResponse, session, worker, null, undefined, config.model);
+    } catch (error: unknown) {
+      return this.handleCodexError(error, session);
+    }
+
+    try {
+      await this.processMessageLoop(session, worker, config, mode);
+    } catch (error: unknown) {
+      return this.handleCodexError(error, session);
+    }
+
+    const sessionDuration = Date.now() - session.startTime;
+    logger.success('SDK', 'Codex agent completed', {
+      sessionId: session.sessionDbId,
+      duration: `${(sessionDuration / 1000).toFixed(1)}s`,
+      historyLength: session.conversationHistory.length,
+      model: config.model,
+      effort: config.effort,
+    });
+  }
+
+  private async processMessageLoop(
+    session: ActiveSession,
+    worker: WorkerRef | undefined,
+    config: CodexConfig,
+    mode: ModeConfig,
+  ): Promise<void> {
+    let lastCwd: string | undefined;
+
+    for await (const message of this.sessionManager.getMessageIterator(session.sessionDbId)) {
+      session.pendingAgentId = message.agentId ?? null;
+      session.pendingAgentType = message.agentType ?? null;
+
+      if (message.cwd) {
+        lastCwd = message.cwd;
+      }
+
+      const originalTimestamp = session.earliestPendingTimestamp;
+
+      if (message.type === 'observation') {
+        if (message.prompt_number !== undefined) {
+          session.lastPromptNumber = message.prompt_number;
+        }
+        const obsPrompt = buildObservationPrompt({
+          id: 0,
+          tool_name: message.tool_name!,
+          tool_input: JSON.stringify(message.tool_input),
+          tool_output: JSON.stringify(message.tool_response),
+          created_at_epoch: originalTimestamp ?? Date.now(),
+          cwd: message.cwd,
+        });
+        session.conversationHistory.push({ role: 'user', content: obsPrompt });
+        const obsResponse = await this.queryCodexMultiTurn(session.conversationHistory, config, session.abortController.signal);
+        await this.handleProviderResponse(obsResponse, session, worker, originalTimestamp, lastCwd, config.model);
+      } else if (message.type === 'summarize') {
+        if (!session.memorySessionId) {
+          throw new Error('Cannot process summary: memorySessionId not yet captured. This session may need to be reinitialized.');
+        }
+        const summaryPrompt = buildSummaryPrompt({
+          id: session.sessionDbId,
+          memory_session_id: session.memorySessionId,
+          project: session.project,
+          user_prompt: session.userPrompt,
+          last_assistant_message: message.last_assistant_message || '',
+        }, mode);
+        session.conversationHistory.push({ role: 'user', content: summaryPrompt });
+        const summaryResponse = await this.queryCodexMultiTurn(session.conversationHistory, config, session.abortController.signal);
+        await this.handleProviderResponse(summaryResponse, session, worker, originalTimestamp, lastCwd, config.model);
+      }
+    }
+  }
+
+  private async handleProviderResponse(
+    response: { content: string; tokensUsed?: number },
+    session: ActiveSession,
+    worker: WorkerRef | undefined,
+    originalTimestamp: number | null,
+    lastCwd: string | undefined,
+    model: string,
+  ): Promise<void> {
+    if (!response.content) {
+      logger.warn('SDK', 'Empty Codex response, leaving queue intact', { sessionId: session.sessionDbId });
+      return;
+    }
+
+    session.conversationHistory.push({ role: 'assistant', content: response.content });
+    const tokensUsed = response.tokensUsed || 0;
+    session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
+    session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
+    await processAgentResponse(response.content, session, this.dbManager, this.sessionManager, worker, tokensUsed, originalTimestamp, 'Codex', lastCwd, model);
+  }
+
+  private handleCodexError(error: unknown, session: ActiveSession): never {
+    if (isAbortError(error)) {
+      logger.warn('SDK', 'Codex agent aborted', { sessionId: session.sessionDbId });
+      throw error;
+    }
+    const classified = classifyCodexError(error);
+    logger.failure('SDK', 'Codex agent error', { sessionDbId: session.sessionDbId, kind: classified.kind }, error instanceof Error ? error : new Error(String(error)));
+    throw classified;
+  }
+
+  private truncateHistory(history: ConversationMessage[]): ConversationMessage[] {
+    const settings = SettingsDefaultsManager.loadFromFile(paths.settings());
+    const maxContextMessages = parseInt(settings.CLAUDE_MEM_CODEX_MAX_CONTEXT_MESSAGES, 10) || DEFAULT_MAX_CONTEXT_MESSAGES;
+    const maxEstimatedTokens = parseInt(settings.CLAUDE_MEM_CODEX_MAX_TOKENS, 10) || DEFAULT_MAX_ESTIMATED_TOKENS;
+
+    if (history.length <= maxContextMessages) {
+      const totalTokens = history.reduce((sum, message) => sum + estimateTokens(message.content), 0);
+      if (totalTokens <= maxEstimatedTokens) return history;
+    }
+
+    const truncated: ConversationMessage[] = [];
+    let tokenCount = 0;
+    for (let i = history.length - 1; i >= 0; i--) {
+      const message = history[i];
+      const messageTokens = estimateTokens(message.content);
+      if (truncated.length > 0 && (truncated.length >= maxContextMessages || tokenCount + messageTokens > maxEstimatedTokens)) {
+        logger.warn('SDK', 'Codex context window truncated to prevent runaway costs', {
+          originalMessages: history.length,
+          keptMessages: truncated.length,
+          droppedMessages: i + 1,
+          estimatedTokens: tokenCount,
+          tokenLimit: maxEstimatedTokens,
+        });
+        break;
+      }
+      truncated.unshift(message);
+      tokenCount += messageTokens;
+    }
+    return truncated;
+  }
+
+  private buildCodexPrompt(history: ConversationMessage[]): string {
+    const truncatedHistory = this.truncateHistory(history);
+    return [
+      'You are claude-mem memory extraction provider. Continue this extraction conversation.',
+      'Return only the XML or structured response requested by the latest user message. Do not inspect files, run tools, or ask questions.',
+      '',
+      ...truncatedHistory.map((message, index) => `<${message.role} index="${index + 1}">\n${message.content}\n</${message.role}>`),
+    ].join('\n');
+  }
+
+  private async queryCodexMultiTurn(
+    history: ConversationMessage[],
+    config: CodexConfig,
+    abortSignal: AbortSignal,
+  ): Promise<{ content: string; tokensUsed?: number }> {
+    const prompt = this.buildCodexPrompt(history);
+    const promptTokens = estimateTokens(prompt);
+    logger.debug('SDK', `Querying Codex (${config.model})`, {
+      turns: history.length,
+      promptTokens,
+      effort: config.effort,
+    });
+
+    const outputDir = mkdtempSync(path.join(os.tmpdir(), 'claude-mem-codex-'));
+    const outputFile = path.join(outputDir, 'last-message.txt');
+    const args = [
+      'exec',
+      '--ephemeral',
+      '--ignore-user-config',
+      '--ignore-rules',
+      '--skip-git-repo-check',
+      '--color',
+      'never',
+      '-C',
+      OBSERVER_SESSIONS_DIR,
+      '-m',
+      config.model,
+      '-c',
+      `model_reasoning_effort="${config.effort}"`,
+      '-o',
+      outputFile,
+      '-',
+    ];
+
+    try {
+      const { stdout, stderr, exitCode } = await runCodex(config.executable, args, prompt, abortSignal);
+      if (exitCode !== 0) {
+        throw new Error(`Codex exec failed with exit code ${exitCode}: ${(stderr || stdout).slice(0, 1000)}`);
+      }
+
+      const content = existsSync(outputFile) ? readFileSync(outputFile, 'utf-8').trim() : stdout.trim();
+      return {
+        content,
+        tokensUsed: promptTokens + estimateTokens(content),
+      };
+    } finally {
+      rmSync(outputDir, { recursive: true, force: true });
+    }
+  }
+
+  private getCodexConfig(): CodexConfig {
+    const settings = SettingsDefaultsManager.loadFromFile(paths.settings());
+    const model = settings.CLAUDE_MEM_CODEX_MODEL || 'gpt-5.4-mini';
+    const configuredEffort = (settings.CLAUDE_MEM_CODEX_REASONING_EFFORT || 'medium').toLowerCase();
+    const effort = VALID_EFFORTS.includes(configuredEffort as CodexEffort)
+      ? configuredEffort as CodexEffort
+      : 'medium';
+    return {
+      executable: resolveCodexExecutable(settings.CLAUDE_MEM_CODEX_PATH),
+      model,
+      effort,
+    };
+  }
+}
+
+interface CodexConfig {
+  executable: string;
+  model: string;
+  effort: CodexEffort;
+}
+
+function runCodex(
+  executable: string,
+  args: string[],
+  stdin: string,
+  abortSignal: AbortSignal,
+): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(executable, args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+      env: process.env,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    const onAbort = () => {
+      child.kill();
+      reject(new Error('Codex exec aborted'));
+    };
+
+    abortSignal.addEventListener('abort', onAbort, { once: true });
+    child.stdout?.on('data', chunk => { stdout += chunk.toString(); });
+    child.stderr?.on('data', chunk => { stderr += chunk.toString(); });
+    child.on('error', error => {
+      abortSignal.removeEventListener('abort', onAbort);
+      reject(error);
+    });
+    child.on('close', exitCode => {
+      abortSignal.removeEventListener('abort', onAbort);
+      resolve({ stdout, stderr, exitCode });
+    });
+    child.stdin?.end(stdin);
+  });
+}
+
+export function isCodexSelected(): boolean {
+  const settings = SettingsDefaultsManager.loadFromFile(paths.settings());
+  return settings.CLAUDE_MEM_PROVIDER === 'codex';
+}
+
+export function isCodexAvailable(): boolean {
+  const settings = SettingsDefaultsManager.loadFromFile(paths.settings());
+  const executable = resolveCodexExecutable(settings.CLAUDE_MEM_CODEX_PATH);
+  return executable === 'codex' || existsSync(executable);
+}
+
+function resolveCodexExecutable(configuredPath: string): string {
+  const trimmed = configuredPath?.trim();
+  if (trimmed && trimmed !== 'codex') {
+    return trimmed;
+  }
+
+  const localAppData = process.env.LOCALAPPDATA;
+  if (localAppData) {
+    const bundled = path.join(localAppData, 'OpenAI', 'Codex', 'bin', 'codex.exe');
+    if (existsSync(bundled)) return bundled;
+  }
+
+  return trimmed || 'codex';
+}

--- a/src/services/worker/http/routes/SessionRoutes.ts
+++ b/src/services/worker/http/routes/SessionRoutes.ts
@@ -10,6 +10,7 @@ import { DatabaseManager } from '../../DatabaseManager.js';
 import { ClaudeProvider } from '../../ClaudeProvider.js';
 import { GeminiProvider, isGeminiSelected, isGeminiAvailable } from '../../GeminiProvider.js';
 import { OpenRouterProvider, isOpenRouterSelected, isOpenRouterAvailable } from '../../OpenRouterProvider.js';
+import { CodexProvider, isCodexSelected, isCodexAvailable } from '../../CodexProvider.js';
 import type { WorkerService } from '../../../worker-service.js';
 import { BaseRouteHandler } from '../BaseRouteHandler.js';
 import { SessionEventBroadcaster } from '../../events/SessionEventBroadcaster.js';
@@ -31,6 +32,7 @@ export class SessionRoutes extends BaseRouteHandler {
     private sdkAgent: ClaudeProvider,
     private geminiAgent: GeminiProvider,
     private openRouterAgent: OpenRouterProvider,
+    private codexAgent: CodexProvider,
     private eventBroadcaster: SessionEventBroadcaster,
     private workerService: WorkerService,
     private completionHandler: SessionCompletionHandler,
@@ -38,7 +40,14 @@ export class SessionRoutes extends BaseRouteHandler {
     super();
   }
 
-  private getActiveAgent(): ClaudeProvider | GeminiProvider | OpenRouterProvider {
+  private getActiveAgent(): ClaudeProvider | GeminiProvider | OpenRouterProvider | CodexProvider {
+    if (isCodexSelected()) {
+      if (isCodexAvailable()) {
+        logger.debug('SESSION', 'Using Codex agent');
+        return this.codexAgent;
+      }
+      throw new Error('Codex provider selected but codex executable is unavailable. Set CLAUDE_MEM_CODEX_PATH in settings.json.');
+    }
     if (isOpenRouterSelected()) {
       if (isOpenRouterAvailable()) {
         logger.debug('SESSION', 'Using OpenRouter agent');
@@ -58,7 +67,13 @@ export class SessionRoutes extends BaseRouteHandler {
     return this.sdkAgent;
   }
 
-  private getSelectedProvider(): 'claude' | 'gemini' | 'openrouter' {
+  private getSelectedProvider(): 'claude' | 'gemini' | 'openrouter' | 'codex' {
+    if (isCodexSelected()) {
+      if (isCodexAvailable()) {
+        return 'codex';
+      }
+      throw new Error('Codex provider selected but codex executable is unavailable. Set CLAUDE_MEM_CODEX_PATH in settings.json.');
+    }
     if (isOpenRouterSelected() && isOpenRouterAvailable()) {
       return 'openrouter';
     }
@@ -91,7 +106,7 @@ export class SessionRoutes extends BaseRouteHandler {
 
   private async startGeneratorWithProvider(
     session: ReturnType<typeof this.sessionManager.getSession>,
-    provider: 'claude' | 'gemini' | 'openrouter',
+    provider: 'claude' | 'gemini' | 'openrouter' | 'codex',
     source: string
   ): Promise<void> {
     if (!session) return;
@@ -103,8 +118,12 @@ export class SessionRoutes extends BaseRouteHandler {
       session.abortController = new AbortController();
     }
 
-    const agent = provider === 'openrouter' ? this.openRouterAgent : (provider === 'gemini' ? this.geminiAgent : this.sdkAgent);
-    const agentName = provider === 'openrouter' ? 'OpenRouter' : (provider === 'gemini' ? 'Gemini' : 'Claude SDK');
+    const agent = provider === 'codex'
+      ? this.codexAgent
+      : (provider === 'openrouter' ? this.openRouterAgent : (provider === 'gemini' ? this.geminiAgent : this.sdkAgent));
+    const agentName = provider === 'codex'
+      ? 'Codex'
+      : (provider === 'openrouter' ? 'OpenRouter' : (provider === 'gemini' ? 'Gemini' : 'Claude SDK'));
 
     const pendingStore = this.sessionManager.getPendingMessageStore();
     const actualQueueDepth = await pendingStore.getPendingCount(session.sessionDbId);

--- a/src/services/worker/http/routes/SettingsRoutes.ts
+++ b/src/services/worker/http/routes/SettingsRoutes.ts
@@ -99,6 +99,11 @@ export class SettingsRoutes extends BaseRouteHandler {
       'CLAUDE_MEM_OPENROUTER_APP_NAME',
       'CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES',
       'CLAUDE_MEM_OPENROUTER_MAX_TOKENS',
+      'CLAUDE_MEM_CODEX_PATH',
+      'CLAUDE_MEM_CODEX_MODEL',
+      'CLAUDE_MEM_CODEX_REASONING_EFFORT',
+      'CLAUDE_MEM_CODEX_MAX_CONTEXT_MESSAGES',
+      'CLAUDE_MEM_CODEX_MAX_TOKENS',
       'CLAUDE_MEM_DATA_DIR',
       'CLAUDE_MEM_LOG_LEVEL',
       'CLAUDE_MEM_PYTHON_VERSION',
@@ -189,9 +194,16 @@ export class SettingsRoutes extends BaseRouteHandler {
 
   private validateSettings(settings: any): { valid: boolean; error?: string } {
     if (settings.CLAUDE_MEM_PROVIDER) {
-    const validProviders = ['claude', 'gemini', 'openrouter'];
+    const validProviders = ['claude', 'gemini', 'openrouter', 'codex'];
     if (!validProviders.includes(settings.CLAUDE_MEM_PROVIDER)) {
-      return { valid: false, error: 'CLAUDE_MEM_PROVIDER must be "claude", "gemini", or "openrouter"' };
+      return { valid: false, error: 'CLAUDE_MEM_PROVIDER must be "claude", "gemini", "openrouter", or "codex"' };
+      }
+    }
+
+    if (settings.CLAUDE_MEM_CODEX_REASONING_EFFORT) {
+      const validCodexEfforts = ['minimal', 'low', 'medium', 'high', 'xhigh'];
+      if (!validCodexEfforts.includes(settings.CLAUDE_MEM_CODEX_REASONING_EFFORT)) {
+        return { valid: false, error: 'CLAUDE_MEM_CODEX_REASONING_EFFORT must be one of: minimal, low, medium, high, xhigh' };
       }
     }
 

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -22,6 +22,11 @@ export interface SettingsDefaults {
   CLAUDE_MEM_OPENROUTER_APP_NAME: string;
   CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES: string;
   CLAUDE_MEM_OPENROUTER_MAX_TOKENS: string;
+  CLAUDE_MEM_CODEX_PATH: string;
+  CLAUDE_MEM_CODEX_MODEL: string;
+  CLAUDE_MEM_CODEX_REASONING_EFFORT: string;
+  CLAUDE_MEM_CODEX_MAX_CONTEXT_MESSAGES: string;
+  CLAUDE_MEM_CODEX_MAX_TOKENS: string;
   CLAUDE_MEM_DATA_DIR: string;
   CLAUDE_MEM_LOG_LEVEL: string;
   CLAUDE_MEM_PYTHON_VERSION: string;
@@ -98,6 +103,11 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_OPENROUTER_APP_NAME: 'claude-mem',  // App name for OpenRouter analytics
     CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES: '20',  // Max messages in context window
     CLAUDE_MEM_OPENROUTER_MAX_TOKENS: '100000',  // Max estimated tokens (~100k safety limit)
+    CLAUDE_MEM_CODEX_PATH: '',  // Empty = auto-detect codex executable
+    CLAUDE_MEM_CODEX_MODEL: 'gpt-5.4-mini',
+    CLAUDE_MEM_CODEX_REASONING_EFFORT: 'medium',
+    CLAUDE_MEM_CODEX_MAX_CONTEXT_MESSAGES: '20',
+    CLAUDE_MEM_CODEX_MAX_TOKENS: '100000',
     CLAUDE_MEM_DATA_DIR: join(homedir(), '.claude-mem'),
     CLAUDE_MEM_LOG_LEVEL: 'INFO',
     CLAUDE_MEM_PYTHON_VERSION: '3.13',


### PR DESCRIPTION
## Summary
- add Codex as a first-class ingestion provider with settings/defaults, route dispatch, and worker health reporting
- fail closed when Codex is selected but the Codex executable is unavailable instead of falling back to another provider
- launch chroma-mcp on Windows via direct uvx.exe resolution instead of cmd.exe /c uvx

## Local verification
- npm run build
- /api/health reports provider codex on the local worker
- /api/chroma/status?deep=true returns healthy with semantic round-trip success
- pending queue drains after Codex ingestion

## Notes
This is a draft PR opened from a local durability fix. It intentionally contains source-level changes only; generated marketplace bundle files are not included in this branch.