### PR TITLE
Normalize path separators in isWithin() to prevent tracking loop

### DIFF
--- a/src/shared/should-track-project.ts
+++ b/src/shared/should-track-project.ts
@@ -1,12 +1,14 @@
 
-import { relative, isAbsolute } from 'path';
+import { relative, isAbsolute, normalize } from 'path';
 import { isProjectExcluded } from '../utils/project-filter.js';
 import { loadFromFileOnce } from './hook-settings.js';
 import { OBSERVER_SESSIONS_DIR, OBSERVER_SESSIONS_PROJECT } from './paths.js';
 
 function isWithin(child: string, parent: string): boolean {
-  if (child === parent) return true;
-  const rel = relative(parent, child);
+  const normChild = normalize(child);
+  const normParent = normalize(parent);
+  if (normChild === normParent) return true;
+  const rel = relative(normParent, normChild);
   return rel.length > 0 && !rel.startsWith('..') && !isAbsolute(rel);
 }
 

--- a/tests/shared/should-track-project.test.ts
+++ b/tests/shared/should-track-project.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { OBSERVER_SESSIONS_DIR } from '../../src/shared/paths.js';
+import { normalize } from 'path';
+
+// Mock loadFromFileOnce to avoid real file I/O and settings-dependent results
+mock.module('../../src/shared/hook-settings.js', () => ({
+  loadFromFileOnce: () => ({ CLAUDE_MEM_EXCLUDED_PROJECTS: '' }),
+}));
+
+// Import after mock so the module picks up the mocked dependency
+const { shouldTrackProject } = await import('../../src/shared/should-track-project.js');
+
+describe('shouldTrackProject — path normalization', () => {
+  let savedInternal: string | undefined;
+
+  beforeEach(() => {
+    savedInternal = process.env.CLAUDE_MEM_INTERNAL;
+    delete process.env.CLAUDE_MEM_INTERNAL;
+  });
+
+  afterEach(() => {
+    if (savedInternal !== undefined) {
+      process.env.CLAUDE_MEM_INTERNAL = savedInternal;
+    } else {
+      delete process.env.CLAUDE_MEM_INTERNAL;
+    }
+  });
+
+  it('returns false when cwd matches OBSERVER_SESSIONS_DIR with forward slashes', () => {
+    // Hooks may pass forward-slash paths on Windows; normalize() handles this
+    const forwardSlash = OBSERVER_SESSIONS_DIR.replace(/\\/g, '/');
+    expect(shouldTrackProject(forwardSlash)).toBe(false);
+  });
+
+  it('returns false when cwd is a subdirectory of OBSERVER_SESSIONS_DIR (mixed separators)', () => {
+    const forwardSlash = OBSERVER_SESSIONS_DIR.replace(/\\/g, '/');
+    expect(shouldTrackProject(forwardSlash + '/some-session')).toBe(false);
+  });
+
+  it('returns false when cwd matches OBSERVER_SESSIONS_DIR exactly (native separators)', () => {
+    expect(shouldTrackProject(OBSERVER_SESSIONS_DIR)).toBe(false);
+  });
+
+  it('returns true for an unrelated project path', () => {
+    const unrelated = normalize('/tmp/my-project');
+    expect(shouldTrackProject(unrelated)).toBe(true);
+  });
+
+  it('returns false when CLAUDE_MEM_INTERNAL is set', () => {
+    process.env.CLAUDE_MEM_INTERNAL = '1';
+    expect(shouldTrackProject('/any/path')).toBe(false);
+  });
+});


### PR DESCRIPTION
shouldTrackProject() failed to block observer-sessions from being tracked when OBSERVER_SESSIONS_DIR (generated by path.join) used backslashes while the cwd from Claude Code hooks used forward slashes.

Fix by applying path.normalize() to both child and parent before comparison so separators are canonicalized consistently on all platforms.