### PR TITLE
fix(marketplace): drop unsupported metadata.homepage field

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,8 +4,7 @@
     "name": "Alex Newman"
   },
   "metadata": {
-    "description": "Plugins by Alex Newman (thedotmack)",
-    "homepage": "https://github.com/thedotmack/claude-mem"
+    "description": "Plugins by Alex Newman (thedotmack)"
   },
   "plugins": [
     {


### PR DESCRIPTION
## Summary
`claude plugin validate --strict` emits a warning because `metadata.homepage` is not part of the marketplace manifest schema. Claude Code silently drops the field at load time, so removing it clears the warning without changing any user-visible behaviour.

## Changes
- `.claude-plugin/marketplace.json`: remove `metadata.homepage`

## Test plan
- [ ] `claude plugin validate --strict ~/.claude/plugins/marketplaces/thedotmack` reports no warnings
- [ ] Marketplace still loads with description intact

Closes #2587