### PR TITLE
fix(worker): strip Bedrock/Vertex routing env from worker subprocess

### DIFF
--- a/src/shared/EnvManager.ts
+++ b/src/shared/EnvManager.ts
@@ -34,6 +34,19 @@ const BLOCKED_ENV_VARS = [
   'CLAUDE_CODE_OAUTH_TOKEN', // Issue #2215: prevent stale parent-process token from leaking into
                              // isolated env. The fresh token is read from the keychain at spawn
                              // time by buildIsolatedEnvWithFreshOAuth().
+  // Issue #2620: routing-mode flags + model overrides leak from the host Claude
+  // Code CLI (Bedrock/Vertex/Mantle setups) and reroute the worker's
+  // CLAUDE_MEM_MODEL onto an endpoint that does not accept it, producing
+  // `400 The provided model identifier is invalid` on every compression
+  // indefinitely. The worker uses its own OAuth subscription endpoint, so
+  // these host-side routing hints must be stripped. Same env-leak family as
+  // the CLAUDE_CODE_EFFORT_LEVEL leak fixed in #2357.
+  'CLAUDE_CODE_USE_BEDROCK',
+  'CLAUDE_CODE_USE_VERTEX',
+  'CLAUDE_CODE_USE_MANTLE',
+  'ANTHROPIC_DEFAULT_OPUS_MODEL',
+  'ANTHROPIC_DEFAULT_SONNET_MODEL',
+  'ANTHROPIC_DEFAULT_HAIKU_MODEL',
 ];
 
 export interface ClaudeMemEnv {

--- a/tests/env-isolation.test.ts
+++ b/tests/env-isolation.test.ts
@@ -25,10 +25,26 @@ const TEST_DATA_DIR = fs.mkdtempSync(join(tmpdir(), 'claude-mem-env-isolation-')
 const TEST_ENV_FILE = join(TEST_DATA_DIR, '.env');
 const ORIGINAL_ENV_FILE = process.env.CLAUDE_MEM_ENV_FILE;
 
-const ORIGINAL_BASE_URL = process.env.ANTHROPIC_BASE_URL;
-const ORIGINAL_API_KEY = process.env.ANTHROPIC_API_KEY;
-const ORIGINAL_AUTH_TOKEN = process.env.ANTHROPIC_AUTH_TOKEN;
-const ORIGINAL_OAUTH_TOKEN = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+// Snapshot every env var the suite mutates so afterEach can restore the
+// runner's original environment. A Bedrock/Vertex-configured dev machine may
+// have any of these set going in — the suite must hand them back unchanged.
+const SNAPSHOTTED_VARS = [
+  'ANTHROPIC_BASE_URL',
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'CLAUDE_CODE_OAUTH_TOKEN',
+  // Issue #2620: host-side Bedrock/Vertex/Mantle routing flags + model overrides.
+  'CLAUDE_CODE_USE_BEDROCK',
+  'CLAUDE_CODE_USE_VERTEX',
+  'CLAUDE_CODE_USE_MANTLE',
+  'ANTHROPIC_DEFAULT_OPUS_MODEL',
+  'ANTHROPIC_DEFAULT_SONNET_MODEL',
+  'ANTHROPIC_DEFAULT_HAIKU_MODEL',
+] as const;
+
+const ORIGINAL_ENV: Record<string, string | undefined> = Object.fromEntries(
+  SNAPSHOTTED_VARS.map((name) => [name, process.env[name]]),
+);
 
 function clearEnvFile(): void {
   if (fs.existsSync(TEST_ENV_FILE)) {
@@ -36,33 +52,20 @@ function clearEnvFile(): void {
   }
 }
 
-function clearAnthropicEnv(): void {
-  delete process.env.ANTHROPIC_BASE_URL;
-  delete process.env.ANTHROPIC_API_KEY;
-  delete process.env.ANTHROPIC_AUTH_TOKEN;
-  delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+function clearSnapshottedEnv(): void {
+  for (const name of SNAPSHOTTED_VARS) {
+    delete process.env[name];
+  }
 }
 
 function restoreOriginalEnv(): void {
-  if (ORIGINAL_BASE_URL === undefined) {
-    delete process.env.ANTHROPIC_BASE_URL;
-  } else {
-    process.env.ANTHROPIC_BASE_URL = ORIGINAL_BASE_URL;
-  }
-  if (ORIGINAL_API_KEY === undefined) {
-    delete process.env.ANTHROPIC_API_KEY;
-  } else {
-    process.env.ANTHROPIC_API_KEY = ORIGINAL_API_KEY;
-  }
-  if (ORIGINAL_AUTH_TOKEN === undefined) {
-    delete process.env.ANTHROPIC_AUTH_TOKEN;
-  } else {
-    process.env.ANTHROPIC_AUTH_TOKEN = ORIGINAL_AUTH_TOKEN;
-  }
-  if (ORIGINAL_OAUTH_TOKEN === undefined) {
-    delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
-  } else {
-    process.env.CLAUDE_CODE_OAUTH_TOKEN = ORIGINAL_OAUTH_TOKEN;
+  for (const name of SNAPSHOTTED_VARS) {
+    const original = ORIGINAL_ENV[name];
+    if (original === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = original;
+    }
   }
 }
 
@@ -84,7 +87,7 @@ describe('Issue #2375: ANTHROPIC_BASE_URL env-var isolation', () => {
 
   beforeEach(() => {
     clearEnvFile();
-    clearAnthropicEnv();
+    clearSnapshottedEnv();
   });
 
   afterEach(() => {
@@ -111,6 +114,11 @@ describe('Issue #2375: ANTHROPIC_BASE_URL env-var isolation', () => {
     // worker subprocess, which uses its own OAuth subscription endpoint and
     // would otherwise route CLAUDE_MEM_MODEL against an endpoint that rejects
     // it (`400 The provided model identifier is invalid`).
+    //
+    // Cleanup of the six vars below is handled by afterEach →
+    // restoreOriginalEnv(), which restores any pre-existing values from
+    // ORIGINAL_ENV rather than unconditionally deleting them. Required so
+    // the suite is safe to run on a Bedrock-configured dev machine.
     process.env.CLAUDE_CODE_USE_BEDROCK = '1';
     process.env.CLAUDE_CODE_USE_VERTEX = '1';
     process.env.CLAUDE_CODE_USE_MANTLE = '1';
@@ -118,23 +126,14 @@ describe('Issue #2375: ANTHROPIC_BASE_URL env-var isolation', () => {
     process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'us.anthropic.claude-sonnet-4-6';
     process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = 'us.anthropic.claude-haiku-4-5-20251001-v1:0';
 
-    try {
-      const result = buildIsolatedEnv();
+    const result = buildIsolatedEnv();
 
-      expect(result.CLAUDE_CODE_USE_BEDROCK).toBeUndefined();
-      expect(result.CLAUDE_CODE_USE_VERTEX).toBeUndefined();
-      expect(result.CLAUDE_CODE_USE_MANTLE).toBeUndefined();
-      expect(result.ANTHROPIC_DEFAULT_OPUS_MODEL).toBeUndefined();
-      expect(result.ANTHROPIC_DEFAULT_SONNET_MODEL).toBeUndefined();
-      expect(result.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBeUndefined();
-    } finally {
-      delete process.env.CLAUDE_CODE_USE_BEDROCK;
-      delete process.env.CLAUDE_CODE_USE_VERTEX;
-      delete process.env.CLAUDE_CODE_USE_MANTLE;
-      delete process.env.ANTHROPIC_DEFAULT_OPUS_MODEL;
-      delete process.env.ANTHROPIC_DEFAULT_SONNET_MODEL;
-      delete process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL;
-    }
+    expect(result.CLAUDE_CODE_USE_BEDROCK).toBeUndefined();
+    expect(result.CLAUDE_CODE_USE_VERTEX).toBeUndefined();
+    expect(result.CLAUDE_CODE_USE_MANTLE).toBeUndefined();
+    expect(result.ANTHROPIC_DEFAULT_OPUS_MODEL).toBeUndefined();
+    expect(result.ANTHROPIC_DEFAULT_SONNET_MODEL).toBeUndefined();
+    expect(result.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBeUndefined();
   });
 
   it('~/.claude-mem/.env BASE_URL + AUTH_TOKEN reaches isolatedEnv', () => {

--- a/tests/env-isolation.test.ts
+++ b/tests/env-isolation.test.ts
@@ -104,6 +104,39 @@ describe('Issue #2375: ANTHROPIC_BASE_URL env-var isolation', () => {
     expect(result.ANTHROPIC_BASE_URL).toBeUndefined();
   });
 
+  it('Issue #2620: Bedrock/Vertex routing env is stripped from isolatedEnv', () => {
+    // When the host Claude Code CLI is configured to route via AWS Bedrock,
+    // Google Vertex, or Mantle, it sets CLAUDE_CODE_USE_* + the three
+    // ANTHROPIC_DEFAULT_*_MODEL overrides. These MUST NOT propagate into the
+    // worker subprocess, which uses its own OAuth subscription endpoint and
+    // would otherwise route CLAUDE_MEM_MODEL against an endpoint that rejects
+    // it (`400 The provided model identifier is invalid`).
+    process.env.CLAUDE_CODE_USE_BEDROCK = '1';
+    process.env.CLAUDE_CODE_USE_VERTEX = '1';
+    process.env.CLAUDE_CODE_USE_MANTLE = '1';
+    process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = 'us.anthropic.claude-opus-4-7';
+    process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'us.anthropic.claude-sonnet-4-6';
+    process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = 'us.anthropic.claude-haiku-4-5-20251001-v1:0';
+
+    try {
+      const result = buildIsolatedEnv();
+
+      expect(result.CLAUDE_CODE_USE_BEDROCK).toBeUndefined();
+      expect(result.CLAUDE_CODE_USE_VERTEX).toBeUndefined();
+      expect(result.CLAUDE_CODE_USE_MANTLE).toBeUndefined();
+      expect(result.ANTHROPIC_DEFAULT_OPUS_MODEL).toBeUndefined();
+      expect(result.ANTHROPIC_DEFAULT_SONNET_MODEL).toBeUndefined();
+      expect(result.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBeUndefined();
+    } finally {
+      delete process.env.CLAUDE_CODE_USE_BEDROCK;
+      delete process.env.CLAUDE_CODE_USE_VERTEX;
+      delete process.env.CLAUDE_CODE_USE_MANTLE;
+      delete process.env.ANTHROPIC_DEFAULT_OPUS_MODEL;
+      delete process.env.ANTHROPIC_DEFAULT_SONNET_MODEL;
+      delete process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL;
+    }
+  });
+
   it('~/.claude-mem/.env BASE_URL + AUTH_TOKEN reaches isolatedEnv', () => {
     // User intentionally configured a gateway with a gateway-appropriate
     // auth token. Both must be re-injected into isolatedEnv.


### PR DESCRIPTION
## Summary
Adds the AWS Bedrock / Google Vertex routing env vars to the worker's blocked-env list so the worker subprocess no longer inherits them from the host Claude Code CLI.

Without this, when the host CLI is configured with `CLAUDE_CODE_USE_BEDROCK=1` plus `ANTHROPIC_DEFAULT_{OPUS,SONNET,HAIKU}_MODEL`, the worker resolves its `CLAUDE_MEM_MODEL` against an endpoint that rejects it, and every compression fails with `400 The provided model identifier is invalid` indefinitely (no fallback, no surfaced error).

Same env-leak family as the already-closed #2357 — different variables, same fix shape.

## Changes
- `src/shared/EnvManager.ts`: extend `BLOCKED_ENV_VARS` with `CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_USE_VERTEX`, `CLAUDE_CODE_USE_MANTLE`, `ANTHROPIC_DEFAULT_OPUS_MODEL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`, `ANTHROPIC_DEFAULT_HAIKU_MODEL`. `buildIsolatedEnv()` already filters by this list, so the worker subprocess will no longer inherit any of them from the parent shell or host Claude Code CLI.
- `tests/env-isolation.test.ts`: add a regression test that sets all six vars in `process.env` and asserts each is absent from `buildIsolatedEnv()` output.
- Build artifacts under `plugin/scripts/*.cjs` are not touched — they regenerate from the TS source on release per the existing maintenance flow.

## Test plan
- [x] `bun test tests/env-isolation.test.ts` — 4/4 pass (3 existing #2375 cases + new #2620 case)
- [ ] Confirm worker env no longer contains the listed vars when host CLI has them set
- [ ] Compression succeeds against the default OAuth endpoint while host CLI uses Bedrock
- [ ] Existing env-isolation tests still pass

Closes #2620