### PR TITLE
fix(uninstall): remove CLAUDE_CODE_DISABLE_AUTO_MEMORY from settings.json

### DIFF
--- a/src/npx-cli/commands/uninstall.ts
+++ b/src/npx-cli/commands/uninstall.ts
@@ -81,10 +81,33 @@ function stripLegacyClaudeMemAlias(): void {
   }
 }
 
-function removeFromClaudeSettings(): void {
+export function removeFromClaudeSettings(): void {
   const settings = readJsonSafe<Record<string, any>>(claudeSettingsPath(), {});
+  let dirty = false;
+
   if (settings.enabledPlugins?.['claude-mem@thedotmack'] !== undefined) {
     delete settings.enabledPlugins['claude-mem@thedotmack'];
+    dirty = true;
+  }
+
+  // Symmetric counterpart to disableClaudeAutoMemory() in install.ts. The
+  // installer sets env.CLAUDE_CODE_DISABLE_AUTO_MEMORY = "1" to suppress
+  // Claude Code's built-in auto-memory; on uninstall we restore the host
+  // CLI's default behavior by removing that single key. Any other env
+  // entries the user added themselves (ANTHROPIC_AUTH_TOKEN, AWS_REGION,
+  // etc.) are preserved. If the env block becomes empty as a result, the
+  // block itself is dropped to keep settings.json tidy.
+  if (settings.env && typeof settings.env === 'object' && !Array.isArray(settings.env)) {
+    if (Object.prototype.hasOwnProperty.call(settings.env, 'CLAUDE_CODE_DISABLE_AUTO_MEMORY')) {
+      delete settings.env.CLAUDE_CODE_DISABLE_AUTO_MEMORY;
+      dirty = true;
+      if (Object.keys(settings.env).length === 0) {
+        delete settings.env;
+      }
+    }
+  }
+
+  if (dirty) {
     writeJsonFileAtomic(claudeSettingsPath(), settings);
   }
 }

--- a/src/npx-cli/commands/uninstall.ts
+++ b/src/npx-cli/commands/uninstall.ts
@@ -93,12 +93,21 @@ export function removeFromClaudeSettings(): void {
   // Symmetric counterpart to disableClaudeAutoMemory() in install.ts. The
   // installer sets env.CLAUDE_CODE_DISABLE_AUTO_MEMORY = "1" to suppress
   // Claude Code's built-in auto-memory; on uninstall we restore the host
-  // CLI's default behavior by removing that single key. Any other env
-  // entries the user added themselves (ANTHROPIC_AUTH_TOKEN, AWS_REGION,
-  // etc.) are preserved. If the env block becomes empty as a result, the
-  // block itself is dropped to keep settings.json tidy.
+  // CLI's default behavior by removing that key. The value-equality guard
+  // (=== '1') ensures we only strip the specific token the installer wrote
+  // — if a user had pre-set this key to something else (e.g. '0' to force
+  // auto-memory on), or to '1' themselves before installing claude-mem,
+  // their intent is preserved. The installer's own no-op-when-already-'1'
+  // path means the worst case is leaving behind a value claude-mem would
+  // have written anyway. Any other env entries the user added themselves
+  // (ANTHROPIC_AUTH_TOKEN, AWS_REGION, etc.) are preserved. If the env
+  // block becomes empty as a result, the block itself is dropped to keep
+  // settings.json tidy.
   if (settings.env && typeof settings.env === 'object' && !Array.isArray(settings.env)) {
-    if (Object.prototype.hasOwnProperty.call(settings.env, 'CLAUDE_CODE_DISABLE_AUTO_MEMORY')) {
+    if (
+      Object.prototype.hasOwnProperty.call(settings.env, 'CLAUDE_CODE_DISABLE_AUTO_MEMORY') &&
+      settings.env.CLAUDE_CODE_DISABLE_AUTO_MEMORY === '1'
+    ) {
       delete settings.env.CLAUDE_CODE_DISABLE_AUTO_MEMORY;
       dirty = true;
       if (Object.keys(settings.env).length === 0) {

--- a/tests/uninstall-clear-auto-memory.test.ts
+++ b/tests/uninstall-clear-auto-memory.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { removeFromClaudeSettings } from '../src/npx-cli/commands/uninstall.js';
+
+/**
+ * Tests for the uninstaller's cleanup of ~/.claude/settings.json.
+ *
+ * Closes thedotmack/claude-mem#2579: the installer writes
+ * env.CLAUDE_CODE_DISABLE_AUTO_MEMORY = "1" to suppress Claude Code's
+ * built-in auto-memory while claude-mem is active. The uninstaller must
+ * remove that key symmetrically so the host CLI's auto-memory is restored
+ * to its default state after `claude-mem uninstall`.
+ *
+ * Mirrors the runtime-style tests in install-disable-auto-memory.test.ts —
+ * uses CLAUDE_CONFIG_DIR override to avoid touching the user's settings.
+ */
+
+const uninstallSourcePath = join(
+  __dirname,
+  '..',
+  'src',
+  'npx-cli',
+  'commands',
+  'uninstall.ts',
+);
+const uninstallSource = readFileSync(uninstallSourcePath, 'utf-8');
+
+describe('Uninstall: clear Claude Code auto-memory env var', () => {
+  describe('removeFromClaudeSettings source', () => {
+    it('deletes the CLAUDE_CODE_DISABLE_AUTO_MEMORY env key', () => {
+      const helperBody = uninstallSource.match(
+        /function removeFromClaudeSettings\(\)[\s\S]*?\n\}/,
+      )?.[0];
+      expect(helperBody).toBeDefined();
+      expect(helperBody).toContain('delete settings.env.CLAUDE_CODE_DISABLE_AUTO_MEMORY');
+    });
+
+    it('drops the env block when it becomes empty', () => {
+      const helperBody = uninstallSource.match(
+        /function removeFromClaudeSettings\(\)[\s\S]*?\n\}/,
+      )?.[0];
+      expect(helperBody).toMatch(/Object\.keys\(settings\.env\)\.length === 0[\s\S]{0,80}delete settings\.env/);
+    });
+
+    it('routes the final write through writeJsonFileAtomic', () => {
+      const helperBody = uninstallSource.match(
+        /function removeFromClaudeSettings\(\)[\s\S]*?\n\}/,
+      )?.[0];
+      expect(helperBody).toContain('writeJsonFileAtomic(claudeSettingsPath()');
+    });
+  });
+
+  describe('removeFromClaudeSettings runtime behavior', () => {
+    let tempDir: string;
+    let originalConfigDir: string | undefined;
+    let settingsPath: string;
+
+    beforeEach(() => {
+      tempDir = mkdtempSync(join(tmpdir(), 'claude-mem-uninstall-auto-memory-'));
+      originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+      process.env.CLAUDE_CONFIG_DIR = tempDir;
+      settingsPath = join(tempDir, 'settings.json');
+    });
+
+    afterEach(() => {
+      if (originalConfigDir === undefined) {
+        delete process.env.CLAUDE_CONFIG_DIR;
+      } else {
+        process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+      }
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('removes CLAUDE_CODE_DISABLE_AUTO_MEMORY from the env block', () => {
+      writeFileSync(
+        settingsPath,
+        JSON.stringify({
+          env: { CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1' },
+        }, null, 2),
+      );
+
+      removeFromClaudeSettings();
+
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      expect(settings.env?.CLAUDE_CODE_DISABLE_AUTO_MEMORY).toBeUndefined();
+    });
+
+    it('drops the entire env block when CLAUDE_CODE_DISABLE_AUTO_MEMORY was the only key', () => {
+      writeFileSync(
+        settingsPath,
+        JSON.stringify({
+          theme: 'dark',
+          env: { CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1' },
+        }, null, 2),
+      );
+
+      removeFromClaudeSettings();
+
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      expect(settings.env).toBeUndefined();
+      // Other top-level keys must survive
+      expect(settings.theme).toBe('dark');
+    });
+
+    it('preserves other env vars the user added themselves', () => {
+      writeFileSync(
+        settingsPath,
+        JSON.stringify({
+          env: {
+            CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1',
+            ANTHROPIC_AUTH_TOKEN: 'sk-test',
+            AWS_REGION: 'us-east-1',
+          },
+        }, null, 2),
+      );
+
+      removeFromClaudeSettings();
+
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      expect(settings.env.CLAUDE_CODE_DISABLE_AUTO_MEMORY).toBeUndefined();
+      expect(settings.env.ANTHROPIC_AUTH_TOKEN).toBe('sk-test');
+      expect(settings.env.AWS_REGION).toBe('us-east-1');
+    });
+
+    it('also removes the plugin registration in enabledPlugins (existing behavior)', () => {
+      writeFileSync(
+        settingsPath,
+        JSON.stringify({
+          enabledPlugins: { 'claude-mem@thedotmack': true, 'other-plugin@vendor': true },
+          env: { CLAUDE_CODE_DISABLE_AUTO_MEMORY: '1' },
+        }, null, 2),
+      );
+
+      removeFromClaudeSettings();
+
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      expect(settings.enabledPlugins['claude-mem@thedotmack']).toBeUndefined();
+      expect(settings.enabledPlugins['other-plugin@vendor']).toBe(true);
+      expect(settings.env).toBeUndefined();
+    });
+
+    it('is a no-op when neither the plugin nor the env var are present', () => {
+      writeFileSync(
+        settingsPath,
+        JSON.stringify({ theme: 'dark', env: { AWS_REGION: 'us-east-1' } }, null, 2),
+      );
+      const before = readFileSync(settingsPath, 'utf-8');
+
+      removeFromClaudeSettings();
+
+      // File should be untouched (no write occurred).
+      const after = readFileSync(settingsPath, 'utf-8');
+      expect(after).toBe(before);
+    });
+
+    it('does not crash when settings.json is missing', () => {
+      expect(existsSync(settingsPath)).toBe(false);
+      expect(() => removeFromClaudeSettings()).not.toThrow();
+    });
+
+    it('tolerates a malformed (non-object) env value', () => {
+      writeFileSync(
+        settingsPath,
+        JSON.stringify({ env: 'not-an-object', theme: 'dark' }, null, 2),
+      );
+
+      expect(() => removeFromClaudeSettings()).not.toThrow();
+
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      expect(settings.theme).toBe('dark');
+      // Malformed env value is left alone — we only act on object-shaped envs.
+      expect(settings.env).toBe('not-an-object');
+    });
+  });
+});

--- a/tests/uninstall-clear-auto-memory.test.ts
+++ b/tests/uninstall-clear-auto-memory.test.ts
@@ -13,45 +13,16 @@ import { removeFromClaudeSettings } from '../src/npx-cli/commands/uninstall.js';
  * remove that key symmetrically so the host CLI's auto-memory is restored
  * to its default state after `claude-mem uninstall`.
  *
- * Mirrors the runtime-style tests in install-disable-auto-memory.test.ts —
- * uses CLAUDE_CONFIG_DIR override to avoid touching the user's settings.
+ * Runtime-only — mirrors install-disable-auto-memory.test.ts, using a
+ * CLAUDE_CONFIG_DIR override so the user's real settings are never
+ * touched. Earlier revisions also had three regex-based source-inspection
+ * tests; greptile (PR #2630) flagged them as fragile (the lazy `\n\}`
+ * anchor breaks silently on refactors with nested column-0 braces or an
+ * indented function declaration), so they were dropped in favour of the
+ * behavioural assertions below, which are strictly stronger.
  */
 
-const uninstallSourcePath = join(
-  __dirname,
-  '..',
-  'src',
-  'npx-cli',
-  'commands',
-  'uninstall.ts',
-);
-const uninstallSource = readFileSync(uninstallSourcePath, 'utf-8');
-
 describe('Uninstall: clear Claude Code auto-memory env var', () => {
-  describe('removeFromClaudeSettings source', () => {
-    it('deletes the CLAUDE_CODE_DISABLE_AUTO_MEMORY env key', () => {
-      const helperBody = uninstallSource.match(
-        /function removeFromClaudeSettings\(\)[\s\S]*?\n\}/,
-      )?.[0];
-      expect(helperBody).toBeDefined();
-      expect(helperBody).toContain('delete settings.env.CLAUDE_CODE_DISABLE_AUTO_MEMORY');
-    });
-
-    it('drops the env block when it becomes empty', () => {
-      const helperBody = uninstallSource.match(
-        /function removeFromClaudeSettings\(\)[\s\S]*?\n\}/,
-      )?.[0];
-      expect(helperBody).toMatch(/Object\.keys\(settings\.env\)\.length === 0[\s\S]{0,80}delete settings\.env/);
-    });
-
-    it('routes the final write through writeJsonFileAtomic', () => {
-      const helperBody = uninstallSource.match(
-        /function removeFromClaudeSettings\(\)[\s\S]*?\n\}/,
-      )?.[0];
-      expect(helperBody).toContain('writeJsonFileAtomic(claudeSettingsPath()');
-    });
-  });
-
   describe('removeFromClaudeSettings runtime behavior', () => {
     let tempDir: string;
     let originalConfigDir: string | undefined;
@@ -71,6 +42,30 @@ describe('Uninstall: clear Claude Code auto-memory env var', () => {
         process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
       }
       rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('PR #2630: preserves a pre-existing CLAUDE_CODE_DISABLE_AUTO_MEMORY value that is not "1"', () => {
+      // The installer only ever writes the literal token "1" and no-ops if
+      // it already finds "1" present. So during uninstall we only strip the
+      // key when its value is exactly "1" — any other value (e.g. "0" to
+      // force auto-memory ON, or some unrelated truthy token the user set
+      // themselves) is user intent that must be preserved, not clobbered.
+      writeFileSync(
+        settingsPath,
+        JSON.stringify({
+          env: { CLAUDE_CODE_DISABLE_AUTO_MEMORY: '0', AWS_REGION: 'us-east-1' },
+        }, null, 2),
+      );
+      const before = readFileSync(settingsPath, 'utf-8');
+
+      removeFromClaudeSettings();
+
+      // No write should have occurred — user's value is untouched.
+      const after = readFileSync(settingsPath, 'utf-8');
+      expect(after).toBe(before);
+      const settings = JSON.parse(after);
+      expect(settings.env.CLAUDE_CODE_DISABLE_AUTO_MEMORY).toBe('0');
+      expect(settings.env.AWS_REGION).toBe('us-east-1');
     });
 
     it('removes CLAUDE_CODE_DISABLE_AUTO_MEMORY from the env block', () => {


### PR DESCRIPTION
## Summary
Symmetric counterpart to the installer's `env.CLAUDE_CODE_DISABLE_AUTO_MEMORY = "1"` write. After running `claude-mem uninstall --yes`, the key was left behind in `~/.claude/settings.json`, so Claude Code's built-in auto-memory stayed disabled even though claude-mem was gone.

## Changes
- `src/npx-cli/commands/uninstall.ts` — `removeFromClaudeSettings()` now also strips `env.CLAUDE_CODE_DISABLE_AUTO_MEMORY` whenever it is present. The single-key delete is gated by a `hasOwnProperty` check, only object-shaped `env` values are touched (malformed strings/arrays are left alone), and a `dirty` flag is used so the file is only rewritten when something actually changed.
- Drops the `env` block entirely if it becomes empty after the key is removed.
- Preserves any other env keys the user may have added themselves (e.g. `ANTHROPIC_AUTH_TOKEN`, `AWS_REGION`).
- Exported the helper so it can be tested directly.
- `tests/uninstall-clear-auto-memory.test.ts` — new test file mirroring the existing `install-disable-auto-memory.test.ts` style (source-inspection + runtime tests against a `CLAUDE_CONFIG_DIR` temp dir). Covers: removal, env-block cleanup, sibling-env preservation, plugin-registration coexistence, missing-file no-op, and malformed-env defensive path. 10 tests, all green locally.

## Test plan
- [ ] Install claude-mem -> confirm key appears in settings.json
- [ ] Uninstall -> confirm key is gone
- [ ] Pre-existing user env keys survive uninstall
- [ ] Run `bun test tests/uninstall-clear-auto-memory.test.ts` and `bun test tests/install-disable-auto-memory.test.ts`

Closes #2579