### PR TITLE
chore(sqlite): unify worker DB init through MigrationRunner

### DIFF
--- a/src/services/sqlite/migrations/runner.ts
+++ b/src/services/sqlite/migrations/runner.ts
@@ -23,12 +23,14 @@ export class MigrationRunner {
     this.ensureDiscoveryTokensColumn();
     this.createPendingMessagesTable();
     this.renameSessionIdColumns();
+    this.markRepairSessionIdColumnRename();
     this.addFailedAtEpochColumn();
     this.addOnUpdateCascadeToForeignKeys();
     this.addObservationContentHashColumn();
     this.addSessionCustomTitleColumn();
     this.createObservationFeedbackTable();
     this.addSessionPlatformSourceColumn();
+    this.addObservationModelColumns();
     this.ensureMergedIntoProjectColumns();
     this.addObservationSubagentColumns();
     this.rebuildPendingMessagesForSelfHealingClaim();
@@ -488,6 +490,10 @@ export class MigrationRunner {
     }
   }
 
+  private markRepairSessionIdColumnRename(): void {
+    this.db.prepare('INSERT OR IGNORE INTO schema_versions (version, applied_at) VALUES (?, ?)').run(19, new Date().toISOString());
+  }
+
   private addFailedAtEpochColumn(): void {
     const applied = this.db.prepare('SELECT version FROM schema_versions WHERE version = ?').get(20) as SchemaVersion | undefined;
     if (applied) return;
@@ -748,6 +754,23 @@ export class MigrationRunner {
     }
 
     this.db.prepare('INSERT OR IGNORE INTO schema_versions (version, applied_at) VALUES (?, ?)').run(25, new Date().toISOString());
+  }
+
+  private addObservationModelColumns(): void {
+    const columns = this.db.query('PRAGMA table_info(observations)').all() as TableColumnInfo[];
+    const hasGeneratedByModel = columns.some(col => col.name === 'generated_by_model');
+    const hasRelevanceCount = columns.some(col => col.name === 'relevance_count');
+
+    if (!hasGeneratedByModel) {
+      this.db.run('ALTER TABLE observations ADD COLUMN generated_by_model TEXT');
+      logger.debug('DB', 'Added generated_by_model column to observations table');
+    }
+    if (!hasRelevanceCount) {
+      this.db.run('ALTER TABLE observations ADD COLUMN relevance_count INTEGER DEFAULT 0');
+      logger.debug('DB', 'Added relevance_count column to observations table');
+    }
+
+    this.db.prepare('INSERT OR IGNORE INTO schema_versions (version, applied_at) VALUES (?, ?)').run(26, new Date().toISOString());
   }
 
   private ensureMergedIntoProjectColumns(): void {

--- a/src/services/sqlite/migrations/runner.ts
+++ b/src/services/sqlite/migrations/runner.ts
@@ -757,6 +757,9 @@ export class MigrationRunner {
   }
 
   private addObservationModelColumns(): void {
+    const applied = this.db.prepare('SELECT version FROM schema_versions WHERE version = ?').get(26) as SchemaVersion | undefined;
+    if (applied) return;
+
     const columns = this.db.query('PRAGMA table_info(observations)').all() as TableColumnInfo[];
     const hasGeneratedByModel = columns.some(col => col.name === 'generated_by_model');
     const hasRelevanceCount = columns.some(col => col.name === 'relevance_count');

--- a/src/services/sqlite/schema.sql
+++ b/src/services/sqlite/schema.sql
@@ -74,6 +74,7 @@ CREATE TABLE IF NOT EXISTS observations (
   agent_id             TEXT,
   merged_into_project  TEXT,
   generated_by_model   TEXT,
+  relevance_count      INTEGER DEFAULT 0,
   metadata             TEXT,
   created_at           TEXT    NOT NULL,
   created_at_epoch     INTEGER NOT NULL,

--- a/src/services/worker/DatabaseManager.ts
+++ b/src/services/worker/DatabaseManager.ts
@@ -2,6 +2,7 @@
 import { Database } from 'bun:sqlite';
 import { SessionStore } from '../sqlite/SessionStore.js';
 import { SessionSearch } from '../sqlite/SessionSearch.js';
+import { MigrationRunner } from '../sqlite/migrations/runner.js';
 import { ChromaSync } from '../sync/ChromaSync.js';
 import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js';
 import { USER_SETTINGS_PATH, DB_PATH } from '../../shared/paths.js';
@@ -16,7 +17,9 @@ export class DatabaseManager {
 
   async initialize(): Promise<void> {
     this.db = new Database(DB_PATH);
-    
+
+    new MigrationRunner(this.db).runAllMigrations();
+
     this.sessionStore = new SessionStore(this.db);
     this.sessionSearch = new SessionSearch(this.db);
 

--- a/tests/services/sqlite/migration-runner.test.ts
+++ b/tests/services/sqlite/migration-runner.test.ts
@@ -430,6 +430,7 @@ describe('MigrationRunner', () => {
       expect(() => new SessionStore(db)).not.toThrow();
 
       const after = snapshotSchema(db);
+      expect(after.tables).toEqual(before.tables);
       expect(after.columnsByTable.observations).toEqual(before.columnsByTable.observations);
       expect(after.columnsByTable.sdk_sessions).toEqual(before.columnsByTable.sdk_sessions);
       expect(after.columnsByTable.pending_messages).toEqual(before.columnsByTable.pending_messages);

--- a/tests/services/sqlite/migration-runner.test.ts
+++ b/tests/services/sqlite/migration-runner.test.ts
@@ -431,10 +431,7 @@ describe('MigrationRunner', () => {
 
       const after = snapshotSchema(db);
       expect(after.tables).toEqual(before.tables);
-      expect(after.columnsByTable.observations).toEqual(before.columnsByTable.observations);
-      expect(after.columnsByTable.sdk_sessions).toEqual(before.columnsByTable.sdk_sessions);
-      expect(after.columnsByTable.pending_messages).toEqual(before.columnsByTable.pending_messages);
-      expect(after.columnsByTable.session_summaries).toEqual(before.columnsByTable.session_summaries);
+      expect(after.columnsByTable).toEqual(before.columnsByTable);
       expect(after.versions).toEqual(before.versions);
     });
 

--- a/tests/services/sqlite/migration-runner.test.ts
+++ b/tests/services/sqlite/migration-runner.test.ts
@@ -133,6 +133,7 @@ describe('MigrationRunner', () => {
       expect(versions).toContain(11);
       expect(versions).toContain(16);
       expect(versions).toContain(17);
+      expect(versions).toContain(19);
       expect(versions).toContain(20);
       expect(versions).toContain(21);
       expect(versions).toContain(22);

--- a/tests/services/sqlite/migration-runner.test.ts
+++ b/tests/services/sqlite/migration-runner.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { MigrationRunner } from '../../../src/services/sqlite/migrations/runner.js';
+import { SessionStore } from '../../../src/services/sqlite/SessionStore.js';
 
 interface TableNameRow {
   name: string;
@@ -113,6 +114,8 @@ describe('MigrationRunner', () => {
       expect(columnNames).toContain('prompt_number');
       expect(columnNames).toContain('discovery_tokens');
       expect(columnNames).toContain('content_hash');
+      expect(columnNames).toContain('generated_by_model');
+      expect(columnNames).toContain('relevance_count');
     });
 
     it('should record all migration versions', () => {
@@ -120,20 +123,21 @@ describe('MigrationRunner', () => {
       runner.runAllMigrations();
 
       const versions = getSchemaVersions(db);
-      expect(versions).toContain(4);   
-      expect(versions).toContain(5);   
-      expect(versions).toContain(6);   
-      expect(versions).toContain(7);   
-      expect(versions).toContain(8);   
-      expect(versions).toContain(9);   
-      expect(versions).toContain(10);  
-      expect(versions).toContain(11);  
-      expect(versions).toContain(16);  
-      expect(versions).toContain(17);  
-      expect(versions).toContain(20);  
-      expect(versions).toContain(21);  
-      expect(versions).toContain(22);  
-      expect(versions).toContain(30);  
+      expect(versions).toContain(4);
+      expect(versions).toContain(5);
+      expect(versions).toContain(6);
+      expect(versions).toContain(7);
+      expect(versions).toContain(8);
+      expect(versions).toContain(9);
+      expect(versions).toContain(10);
+      expect(versions).toContain(11);
+      expect(versions).toContain(16);
+      expect(versions).toContain(17);
+      expect(versions).toContain(20);
+      expect(versions).toContain(21);
+      expect(versions).toContain(22);
+      expect(versions).toContain(26);
+      expect(versions).toContain(30);
       expect(versions).toContain(33);
       expect(versions).toContain(34);
     });
@@ -400,6 +404,55 @@ describe('MigrationRunner', () => {
       expect(memorySessionFk).toBeDefined();
       expect(memorySessionFk!.on_update).toBe('CASCADE');
       expect(memorySessionFk!.on_delete).toBe('CASCADE');
+    });
+  });
+
+  describe('schema convergence with SessionStore inline migrations', () => {
+    function snapshotSchema(db: Database) {
+      const tables = getTableNames(db);
+      const columnsByTable: Record<string, string[]> = {};
+      for (const table of tables) {
+        columnsByTable[table] = getColumns(db, table).map(c => c.name).sort();
+      }
+      return {
+        tables: [...tables].sort(),
+        columnsByTable,
+        versions: getSchemaVersions(db),
+      };
+    }
+
+    it('SessionStore on top of MigrationRunner does not drift the schema', () => {
+      const runner = new MigrationRunner(db);
+      runner.runAllMigrations();
+
+      const before = snapshotSchema(db);
+
+      expect(() => new SessionStore(db)).not.toThrow();
+
+      const after = snapshotSchema(db);
+      expect(after.columnsByTable.observations).toEqual(before.columnsByTable.observations);
+      expect(after.columnsByTable.sdk_sessions).toEqual(before.columnsByTable.sdk_sessions);
+      expect(after.columnsByTable.pending_messages).toEqual(before.columnsByTable.pending_messages);
+      expect(after.columnsByTable.session_summaries).toEqual(before.columnsByTable.session_summaries);
+      expect(after.versions).toEqual(before.versions);
+    });
+
+    it('MigrationRunner produces every column the worker SessionStore expects', () => {
+      const runner = new MigrationRunner(db);
+      runner.runAllMigrations();
+
+      const obsCols = getColumns(db, 'observations').map(c => c.name);
+      expect(obsCols).toContain('generated_by_model');
+      expect(obsCols).toContain('relevance_count');
+      expect(obsCols).toContain('agent_type');
+      expect(obsCols).toContain('agent_id');
+      expect(obsCols).toContain('metadata');
+      expect(obsCols).toContain('merged_into_project');
+
+      const pendingCols = getColumns(db, 'pending_messages').map(c => c.name);
+      expect(pendingCols).toContain('tool_use_id');
+      expect(pendingCols).toContain('agent_type');
+      expect(pendingCols).toContain('agent_id');
     });
   });
 


### PR DESCRIPTION
## Why

Two database initialization paths existed and had drifted apart:

| Path | Used by | Schema source | Missing |
|------|---------|---------------|---------|
| `ClaudeMemDatabase` (`src/services/sqlite/Database.ts`) | hooks, CLI | `MigrationRunner.runAllMigrations()` | v26 `generated_by_model` / `relevance_count` |
| `worker/DatabaseManager` (`src/services/worker/DatabaseManager.ts`) | worker process | `new SessionStore(db)` inline migrations | v24 `observation_feedback`, v33 server tables, v34 pending-queue rebuild |

This is the latent bug the dedup-fold PR (#2627) walked into and patched around with an inline self-heal in `SessionStore`. Now that the fold work is on its own branch, this cleans up the underlying split so future schema work doesn't need to author two migrations.

## What

1. **Port v26 to `MigrationRunner`.** `addObservationModelColumns()` was only in `SessionStore`. Lifted verbatim, scheduled between v25 and v27. Fixes the `generated_by_model` / `relevance_count` gap on the hooks path.
2. **Backfill v19 marker.** `SessionStore.repairSessionIdColumnRename()` only writes a `schema_versions` row — added `markRepairSessionIdColumnRename()` to runner so SessionStore is a true no-op on a freshly-migrated DB.
3. **Wire MigrationRunner into worker init.** `worker/DatabaseManager.initialize()` now runs `new MigrationRunner(this.db).runAllMigrations()` before constructing `SessionStore`. Both are idempotent so layering is safe; this just guarantees worker also gets v24/v33/v34.
4. **Sync `schema.sql`.** Added `observations.relevance_count` (the doc was already drifted on this).

## Convergence test

Added to `migration-runner.test.ts`:

```ts
it('SessionStore on top of MigrationRunner does not drift the schema', () => {
  const runner = new MigrationRunner(db);
  runner.runAllMigrations();
  const before = snapshotSchema(db);
  expect(() => new SessionStore(db)).not.toThrow();
  const after = snapshotSchema(db);
  expect(after.columnsByTable.observations).toEqual(before.columnsByTable.observations);
  // ... same for sdk_sessions, pending_messages, session_summaries, versions
});
```

Locks in that "MigrationRunner then SessionStore" produces no diff in any table, column, or `schema_versions` row.

## Test plan

- [x] `bun test tests/services/sqlite/migration-runner.test.ts` — 18 pass (16 existing + 2 new convergence)
- [x] Full suite: no new failures vs. main (`schema-repair`, `session-manager-queue`, `GeminiProvider` failures are pre-existing)
- [x] `npm run build` succeeds

## Out of scope

- Removing `SessionStore` inline migrations entirely (would let us delete ~30 methods). Convergence test makes this safe to do in a follow-up but leaving in for now to keep the diff narrow and the rollback path obvious.
- Worker DB connection PRAGMA settings (`worker/DatabaseManager` skips the `journal_mode = WAL` etc. that `ClaudeMemDatabase` sets, because it passes an open `Database` instance to `SessionStore`). Separate latent issue.