### PR TITLE
refactor: consolidate parseJsonArrayColumn into utils/json-utils

### DIFF
--- a/src/services/worker/http/routes/DataRoutes.ts
+++ b/src/services/worker/http/routes/DataRoutes.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import path from 'path';
 import { readFileSync, statSync, existsSync } from 'fs';
 import { logger } from '../../../../utils/logger.js';
+import { parseJsonArrayColumn } from '../../../../utils/json-utils.js';
 import { getPackageRoot, paths } from '../../../../shared/paths.js';
 import { getWorkerPort } from '../../../../shared/worker-utils.js';
 import { PaginationHelper } from '../../PaginationHelper.js';
@@ -352,21 +353,17 @@ export class DataRoutes extends BaseRouteHandler {
       const chromaSync = this.dbManager.getChromaSync();
       if (chromaSync && importedObservations.length > 0) {
         const CHROMA_SYNC_CONCURRENCY = 8;
-        const safeParseJson = (val: string | null): string[] => {
-          if (!val) return [];
-          try { return JSON.parse(val); } catch { return []; }
-        };
 
         const syncOne = async ({ id, obs }: { id: number; obs: any }) => {
           const parsedObs = {
             type: obs.type || 'discovery',
             title: obs.title || null,
             subtitle: obs.subtitle || null,
-            facts: safeParseJson(obs.facts),
+            facts: parseJsonArrayColumn(obs.facts),
             narrative: obs.narrative || null,
-            concepts: safeParseJson(obs.concepts),
-            files_read: safeParseJson(obs.files_read),
-            files_modified: safeParseJson(obs.files_modified),
+            concepts: parseJsonArrayColumn(obs.concepts),
+            files_read: parseJsonArrayColumn(obs.files_read),
+            files_modified: parseJsonArrayColumn(obs.files_modified),
           };
 
           await chromaSync.syncObservation(

--- a/src/services/worker/knowledge/CorpusBuilder.ts
+++ b/src/services/worker/knowledge/CorpusBuilder.ts
@@ -90,14 +90,25 @@ export class CorpusBuilder {
       title: row.title || '',
       subtitle: row.subtitle || null,
       narrative: row.narrative || null,
-      facts: parseJsonArrayColumn(row.facts),
-      concepts: parseJsonArrayColumn(row.concepts),
-      files_read: parseJsonArrayColumn(row.files_read),
-      files_modified: parseJsonArrayColumn(row.files_modified),
+      facts: this.parseCorpusColumn(row.facts, 'facts'),
+      concepts: this.parseCorpusColumn(row.concepts, 'concepts'),
+      files_read: this.parseCorpusColumn(row.files_read, 'files_read'),
+      files_modified: this.parseCorpusColumn(row.files_modified, 'files_modified'),
       project: row.project,
       created_at: row.created_at,
       created_at_epoch: row.created_at_epoch,
     };
+  }
+
+  private parseCorpusColumn(value: unknown, column: string): string[] {
+    return parseJsonArrayColumn(value, (error, rawValue) => {
+      logger.warn(
+        'WORKER',
+        `Malformed JSON in observation column "${column}"; defaulting to empty array`,
+        { column, rawPreview: rawValue.slice(0, 100) },
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    });
   }
 
   private calculateStats(observations: CorpusObservation[]): CorpusStats {

--- a/src/services/worker/knowledge/CorpusBuilder.ts
+++ b/src/services/worker/knowledge/CorpusBuilder.ts
@@ -1,27 +1,12 @@
 
 import { logger } from '../../../utils/logger.js';
+import { parseJsonArrayColumn } from '../../../utils/json-utils.js';
 import type { ObservationSearchResult } from '../../sqlite/types.js';
 import type { SessionStore } from '../../sqlite/SessionStore.js';
 import type { SearchOrchestrator } from '../search/SearchOrchestrator.js';
 import { CorpusRenderer } from './CorpusRenderer.js';
 import { CorpusStore } from './CorpusStore.js';
 import type { CorpusFile, CorpusFilter, CorpusObservation, CorpusStats } from './types.js';
-
-function safeParseJsonArray(value: unknown): string[] {
-  if (Array.isArray(value)) return value.filter((v): v is string => typeof v === 'string');
-  if (typeof value !== 'string') return [];
-  try {
-    const parsed = JSON.parse(value);
-    return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string') : [];
-  } catch (error) {
-    if (error instanceof Error) {
-      logger.warn('WORKER', 'Failed to parse JSON array field', {}, error);
-    } else {
-      logger.warn('WORKER', 'Failed to parse JSON array field (non-Error thrown)', { thrownValue: String(error) });
-    }
-    return [];
-  }
-}
 
 export class CorpusBuilder {
   private renderer: CorpusRenderer;
@@ -105,10 +90,10 @@ export class CorpusBuilder {
       title: row.title || '',
       subtitle: row.subtitle || null,
       narrative: row.narrative || null,
-      facts: safeParseJsonArray(row.facts),
-      concepts: safeParseJsonArray(row.concepts),
-      files_read: safeParseJsonArray(row.files_read),
-      files_modified: safeParseJsonArray(row.files_modified),
+      facts: parseJsonArrayColumn(row.facts),
+      concepts: parseJsonArrayColumn(row.concepts),
+      files_read: parseJsonArrayColumn(row.files_read),
+      files_modified: parseJsonArrayColumn(row.files_modified),
       project: row.project,
       created_at: row.created_at,
       created_at_epoch: row.created_at_epoch,

--- a/src/utils/json-utils.ts
+++ b/src/utils/json-utils.ts
@@ -10,3 +10,14 @@ export function readJsonSafe<T>(filePath: string, defaultValue: T): T {
     throw new Error(`Corrupt JSON file, refusing to overwrite: ${filePath}: ${error instanceof Error ? error.message : String(error)}`);
   }
 }
+
+export function parseJsonArrayColumn(value: unknown): string[] {
+  if (Array.isArray(value)) return value.filter((v): v is string => typeof v === 'string');
+  if (typeof value !== 'string' || value.length === 0) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string') : [];
+  } catch {
+    return [];
+  }
+}

--- a/src/utils/json-utils.ts
+++ b/src/utils/json-utils.ts
@@ -16,9 +16,11 @@ export function parseJsonArrayColumn(
   onParseError?: (error: unknown, rawValue: string) => void,
 ): string[] {
   if (Array.isArray(value)) return value.filter((v): v is string => typeof v === 'string');
-  if (typeof value !== 'string' || value.length === 0) return [];
+  if (typeof value !== 'string') return [];
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return [];
   try {
-    const parsed = JSON.parse(value);
+    const parsed = JSON.parse(trimmed);
     return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string') : [];
   } catch (error) {
     onParseError?.(error, value);

--- a/src/utils/json-utils.ts
+++ b/src/utils/json-utils.ts
@@ -11,13 +11,17 @@ export function readJsonSafe<T>(filePath: string, defaultValue: T): T {
   }
 }
 
-export function parseJsonArrayColumn(value: unknown): string[] {
+export function parseJsonArrayColumn(
+  value: unknown,
+  onParseError?: (error: unknown, rawValue: string) => void,
+): string[] {
   if (Array.isArray(value)) return value.filter((v): v is string => typeof v === 'string');
   if (typeof value !== 'string' || value.length === 0) return [];
   try {
     const parsed = JSON.parse(value);
     return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === 'string') : [];
-  } catch {
+  } catch (error) {
+    onParseError?.(error, value);
     return [];
   }
 }

--- a/tests/json-utils.test.ts
+++ b/tests/json-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { mkdirSync, writeFileSync, existsSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -146,6 +146,23 @@ describe('JSON Utils', () => {
     it('filters non-string elements out of arrays', () => {
       expect(parseJsonArrayColumn(['a', 1, null, 'b'])).toEqual(['a', 'b']);
       expect(parseJsonArrayColumn('["a",1,null,"b"]')).toEqual(['a', 'b']);
+    });
+
+    it('invokes onParseError with the raw value when JSON.parse throws', () => {
+      const errors: Array<{ error: unknown; rawValue: string }> = [];
+      const result = parseJsonArrayColumn('not json', (error, rawValue) => {
+        errors.push({ error, rawValue });
+      });
+      expect(result).toEqual([]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].rawValue).toBe('not json');
+      expect(errors[0].error).toBeInstanceOf(SyntaxError);
+    });
+
+    it('does not invoke onParseError on success', () => {
+      const onParseError = mock(() => {});
+      parseJsonArrayColumn('["a","b"]', onParseError);
+      expect(onParseError).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/json-utils.test.ts
+++ b/tests/json-utils.test.ts
@@ -164,5 +164,20 @@ describe('JSON Utils', () => {
       parseJsonArrayColumn('["a","b"]', onParseError);
       expect(onParseError).not.toHaveBeenCalled();
     });
+
+    it('does not invoke onParseError when JSON parses to a non-array', () => {
+      const onParseError = mock(() => {});
+      expect(parseJsonArrayColumn('{"a":1}', onParseError)).toEqual([]);
+      expect(parseJsonArrayColumn('42', onParseError)).toEqual([]);
+      expect(parseJsonArrayColumn('"a string"', onParseError)).toEqual([]);
+      expect(onParseError).not.toHaveBeenCalled();
+    });
+
+    it('treats whitespace-only strings as empty without invoking onParseError', () => {
+      const onParseError = mock(() => {});
+      expect(parseJsonArrayColumn('   ', onParseError)).toEqual([]);
+      expect(parseJsonArrayColumn('\n\t', onParseError)).toEqual([]);
+      expect(onParseError).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/json-utils.test.ts
+++ b/tests/json-utils.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdirSync, writeFileSync, existsSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { readJsonSafe } from '../src/utils/json-utils';
+import { readJsonSafe, parseJsonArrayColumn } from '../src/utils/json-utils';
 
 describe('JSON Utils', () => {
   let tempDir: string;
@@ -115,6 +115,37 @@ describe('JSON Utils', () => {
       const result = readJsonSafe(filePath, {});
 
       expect(result).toEqual({ ok: true });
+    });
+  });
+
+  describe('parseJsonArrayColumn', () => {
+    it('passes through string arrays unchanged', () => {
+      expect(parseJsonArrayColumn(['a', 'b'])).toEqual(['a', 'b']);
+    });
+
+    it('returns empty array for empty string', () => {
+      expect(parseJsonArrayColumn('')).toEqual([]);
+    });
+
+    it('returns empty array for null', () => {
+      expect(parseJsonArrayColumn(null)).toEqual([]);
+    });
+
+    it('parses a JSON-encoded array of strings', () => {
+      expect(parseJsonArrayColumn('["a","b"]')).toEqual(['a', 'b']);
+    });
+
+    it('returns empty array for invalid JSON', () => {
+      expect(parseJsonArrayColumn('not json')).toEqual([]);
+    });
+
+    it('returns empty array when JSON is not an array', () => {
+      expect(parseJsonArrayColumn('{"a":1}')).toEqual([]);
+    });
+
+    it('filters non-string elements out of arrays', () => {
+      expect(parseJsonArrayColumn(['a', 1, null, 'b'])).toEqual(['a', 'b']);
+      expect(parseJsonArrayColumn('["a",1,null,"b"]')).toEqual(['a', 'b']);
     });
   });
 });


### PR DESCRIPTION
## Why

Two near-identical copies of the same parse-string-or-JSON-array helper had grown in the codebase:

- `src/services/worker/knowledge/CorpusBuilder.ts` — local `safeParseJsonArray()` with a string filter
- `src/services/worker/http/routes/DataRoutes.ts` — inline `safeParseJson()` closure

Both decode a SQLite column that may be a JSON-array string, a stray bare string, `null`, or already an array, and both want a `string[]` back. Same shape, same failure modes — should live in one place.

## What

Added `parseJsonArrayColumn(value: unknown): string[]` to `src/utils/json-utils.ts` and replaced both call sites.

```ts
export function parseJsonArrayColumn(value: unknown): string[] {
  if (Array.isArray(value)) return value.filter((v): v is string => typeof v === 'string');
  if (typeof value !== 'string') return [];
  const trimmed = value.trim();
  if (!trimmed) return [];
  try {
    const parsed = JSON.parse(trimmed);
    return Array.isArray(parsed)
      ? parsed.filter((v): v is string => typeof v === 'string')
      : [];
  } catch {
    return [];
  }
}
```

Notes:
- Kept the `typeof v === 'string'` filter that `CorpusBuilder` had. `DataRoutes` previously skipped this filter — that path was looser; this PR tightens it (intentional: every caller expects `string[]`).
- Dropped `CorpusBuilder`'s old `logger.warn` on parse-failure. The util is pure (no logger dep). Acceptable observability tradeoff since both call sites use the result to populate a UI list, not for routing decisions.

A third copy lives in `SessionManager.safeParseJson()` (PR #2627). Left alone here to keep this PR focused; it'll converge once #2627 lands.

## Test plan

- [x] `tests/json-utils.test.ts` — 7 new tests covering: array passthrough, empty string, `null`, valid JSON array, invalid JSON, non-array JSON, string filtering
- [x] Full suite: no new failures vs. main
- [x] `npm run build` succeeds