### PR TITLE
fix(server-beta): initialize ModeManager at startup + support CLAUDE_MEM_MODES_DIR

### DIFF
--- a/src/server/runtime/create-server-beta-service.ts
+++ b/src/server/runtime/create-server-beta-service.ts
@@ -13,6 +13,7 @@ import { GeminiObservationProvider } from '../generation/providers/GeminiObserva
 import { OpenRouterObservationProvider } from '../generation/providers/OpenRouterObservationProvider.js';
 import type { ServerGenerationProvider } from '../generation/providers/shared/types.js';
 import { ServerBetaService } from './ServerBetaService.js';
+import { ModeManager } from '../../services/domain/ModeManager.js';
 import {
   DisabledServerBetaEventBroadcaster,
   DisabledServerBetaGenerationWorkerManager,
@@ -156,6 +157,10 @@ export function validateServerBetaEnv(
 export async function createServerBetaService(
   options: CreateServerBetaServiceOptions = {},
 ): Promise<ServerBetaService> {
+  // Generation prompt-builder requires an active mode; server-beta never went
+  // through the plugin setup path that loads one, so we do it here explicitly.
+  try { ModeManager.getInstance().loadMode('code'); } catch { /* mode files optional */ }
+
   if (!options.skipEnvValidation) {
     validateServerBetaEnv();
   }

--- a/src/server/runtime/create-server-beta-service.ts
+++ b/src/server/runtime/create-server-beta-service.ts
@@ -159,7 +159,16 @@ export async function createServerBetaService(
 ): Promise<ServerBetaService> {
   // Generation prompt-builder requires an active mode; server-beta never went
   // through the plugin setup path that loads one, so we do it here explicitly.
-  try { ModeManager.getInstance().loadMode('code'); } catch { /* mode files optional */ }
+  try {
+    ModeManager.getInstance().loadMode('code');
+  } catch (err) {
+    // Mode files are optional, but surface failures (e.g. malformed JSON in a
+    // CLAUDE_MEM_MODES_DIR file) so an operator can diagnose why custom types
+    // aren't appearing instead of silently falling back to the defaults.
+    logger.warn('SYSTEM', 'server-beta: failed to load mode at startup (mode files optional)', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 
   if (!options.skipEnvValidation) {
     validateServerBetaEnv();

--- a/src/services/domain/ModeManager.ts
+++ b/src/services/domain/ModeManager.ts
@@ -14,6 +14,7 @@ export class ModeManager {
     const packageRoot = getPackageRoot();
     
     const possiblePaths = [
+      ...(process.env.CLAUDE_MEM_MODES_DIR ? [process.env.CLAUDE_MEM_MODES_DIR] : []),
       join(packageRoot, 'modes'),           // Production (plugin/modes)
       join(packageRoot, '..', 'plugin', 'modes'), // Development (src/../plugin/modes)
     ];


### PR DESCRIPTION
Fixes #2443.

## Problem
The generation prompt-builder calls `ModeManager.getActiveMode()`, but server-beta never initializes it, so **every generation job fails** with `No mode loaded. Call loadMode() first.` This affects any server-beta deployment outside the plugin directory (systemd service, Docker, `claude-mem server start`) because ModeManager's hardcoded plugin-relative paths don't resolve there.

## Confirmed in production (2026-05-23)
Upgrading a live server-beta to vanilla 13.3.0 reproduced this exactly: service healthy, events ingesting, but **0 observations generated** — every `session_summary` job completed empty with worker logs showing `No mode loaded`. The generation worker runs in a sandboxed thread, so loading the mode in the entrypoint process doesn't reach it. Applying this fix (loading the mode at service creation + honoring `CLAUDE_MEM_MODES_DIR`) restored generation immediately.

## Fix
- `src/server/runtime/create-server-beta-service.ts` — `ModeManager.getInstance().loadMode('code')` at startup (try/catch; mode files optional)
- `src/services/domain/ModeManager.ts` — include `process.env.CLAUDE_MEM_MODES_DIR` in the mode search paths