### PR TITLE
fix(windows): strip BOM from settings.json + exempt lifecycle subcommands from #2188 stdin guard

### DIFF
--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -142,60 +142,74 @@ if (child.stdin) {
     child.stdin.write(stdinData);
     child.stdin.end();
   } else {
-    // Issue #2188: empty/missing stdin previously masked by `|| '{}'` fallback,
-    // which silently hid WSL bash failures (e.g. hooks invoked under a broken
-    // shell that never piped a payload). Surface the failure mode instead.
-    const dataDir = process.env.CLAUDE_MEM_DATA_DIR || join(homedir(), '.claude-mem');
-    const payloadType = stdinData === null
-      ? 'null (no data event or stream error)'
-      : stdinData === undefined
-        ? 'undefined'
-        : Buffer.isBuffer(stdinData) && stdinData.length === 0
-          ? 'empty Buffer (zero bytes received)'
-          : `unexpected (${typeof stdinData})`;
-    const payloadByteLength = (stdinData && typeof stdinData.length === 'number')
-      ? stdinData.length
-      : 0;
-    const diagnostic = [
-      `[bun-runner] empty stdin payload received — issue #2188`,
-      `  script: ${args[0]}`,
-      `  payload byte length: ${payloadByteLength}`,
-      `  payload type: ${payloadType}`,
-      `  platform: ${process.platform}`,
-      `  shell: ${process.env.SHELL || 'n/a'}`,
-      `  stdin TTY: ${process.stdin.isTTY === true ? 'true' : process.stdin.isTTY === false ? 'false' : 'undefined'}`,
-      `  timestamp: ${new Date().toISOString()}`,
-      `  CLAUDE_PLUGIN_ROOT: ${RESOLVED_PLUGIN_ROOT}`,
-    ].join('\n');
+    // Lifecycle subcommands (start, stop, restart, status) never consume stdin —
+    // they manage the worker daemon, not hook payloads.  Killing the child here
+    // prevents the daemon from starting/stopping on platforms where Claude Code
+    // doesn't pipe a payload for SessionStart (e.g. Windows CC ≤ 2.1.145).
+    const lifecycleCommands = ['start', 'stop', 'restart', 'status'];
+    const isLifecycle = lifecycleCommands.some(cmd => args.includes(cmd));
 
-    // IO discipline (see src/shared/hook-io.ts intent vocabulary):
-    // - this stderr write is a USER_HINT (Claude Code surfaces it inline).
-    // - the CAPTURE_BROKEN marker file below is a DIAGNOSTIC durable signal for
-    //   the next session-start hint.
-    // - exit 0 below is the EXIT_SIGNAL per CLAUDE.md (Windows Terminal tab
-    //   management); the marker file, not the exit code, is the durable failure
-    //   signal. bun-runner runs in its own node process BEFORE hookCommand's
-    //   stderr buffer is installed, so this write is never swallowed.
-    console.error(diagnostic);
+    if (isLifecycle) {
+      // Lifecycle commands don't need stdin — close pipe and let child run.
+      try { child.stdin.end(); } catch {}
+    } else {
+      // Issue #2188: empty/missing stdin previously masked by `|| '{}'` fallback,
+      // which silently hid WSL bash failures (e.g. hooks invoked under a broken
+      // shell that never piped a payload). Surface the failure mode instead.
+      const dataDir = process.env.CLAUDE_MEM_DATA_DIR || join(homedir(), '.claude-mem');
+      const payloadType = stdinData === null
+        ? 'null (no data event or stream error)'
+        : stdinData === undefined
+          ? 'undefined'
+          : Buffer.isBuffer(stdinData) && stdinData.length === 0
+            ? 'empty Buffer (zero bytes received)'
+            : `unexpected (${typeof stdinData})`;
+      const payloadByteLength = (stdinData && typeof stdinData.length === 'number')
+        ? stdinData.length
+        : 0;
+      const diagnostic = [
+        `[bun-runner] empty stdin payload received — issue #2188`,
+        `  script: ${args[0]}`,
+        `  payload byte length: ${payloadByteLength}`,
+        `  payload type: ${payloadType}`,
+        `  platform: ${process.platform}`,
+        `  shell: ${process.env.SHELL || 'n/a'}`,
+        `  stdin TTY: ${process.stdin.isTTY === true ? 'true' : process.stdin.isTTY === false ? 'false' : 'undefined'}`,
+        `  timestamp: ${new Date().toISOString()}`,
+        `  CLAUDE_PLUGIN_ROOT: ${RESOLVED_PLUGIN_ROOT}`,
+      ].join('\n');
 
-    // Persist diagnostic to the runner-errors log and drop a CAPTURE_BROKEN marker
-    // file so the next session-start hint can surface the failure. We exit 0 to
-    // honor the project's exit-code strategy (worker/hook errors exit 0 to
-    // prevent Windows Terminal tab pileup) — the marker file is the durable
-    // signal that something is wrong, not the exit code.
-    try {
-      const logsDir = join(dataDir, 'logs');
-      mkdirSync(logsDir, { recursive: true });
-      appendFileSync(join(logsDir, 'runner-errors.log'), diagnostic + '\n\n');
-      mkdirSync(dataDir, { recursive: true });
-      writeFileSync(join(dataDir, 'CAPTURE_BROKEN'), diagnostic + '\n');
-    } catch (writeErr) {
-      console.error(`[bun-runner] failed to persist diagnostic: ${writeErr && writeErr.message ? writeErr.message : writeErr}`);
+      // IO discipline (see src/shared/hook-io.ts intent vocabulary):
+      // - this stderr write is a USER_HINT (Claude Code surfaces it inline).
+      // - the CAPTURE_BROKEN marker file below is a DIAGNOSTIC durable signal for
+      //   the next session-start hint.
+      // - exit 0 below is the EXIT_SIGNAL per CLAUDE.md (Windows Terminal tab
+      //   management); the marker file, not the exit code, is the durable failure
+      //   signal. bun-runner runs in its own node process BEFORE hookCommand's
+      //   stderr buffer is installed, so this write is never swallowed.
+
+      // Write to stderr so Claude Code surfaces the diagnostic.
+      console.error(diagnostic);
+
+      // Persist diagnostic to the runner-errors log and drop a CAPTURE_BROKEN marker
+      // file so the next session-start hint can surface the failure. We exit 0 to
+      // honor the project's exit-code strategy (worker/hook errors exit 0 to
+      // prevent Windows Terminal tab pileup) — the marker file is the durable
+      // signal that something is wrong, not the exit code.
+      try {
+        const logsDir = join(dataDir, 'logs');
+        mkdirSync(logsDir, { recursive: true });
+        appendFileSync(join(logsDir, 'runner-errors.log'), diagnostic + '\n\n');
+        mkdirSync(dataDir, { recursive: true });
+        writeFileSync(join(dataDir, 'CAPTURE_BROKEN'), diagnostic + '\n');
+      } catch (writeErr) {
+        console.error(`[bun-runner] failed to persist diagnostic: ${writeErr && writeErr.message ? writeErr.message : writeErr}`);
+      }
+
+      try { child.stdin.end(); } catch {}
+      try { child.kill(); } catch {}
+      process.exit(0);
     }
-
-    try { child.stdin.end(); } catch {}
-    try { child.kill(); } catch {}
-    process.exit(0);
   }
 }
 

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -208,7 +208,10 @@ export class SettingsDefaultsManager {
       }
 
       const settingsData = readFileSync(settingsPath, 'utf-8');
-      const settings = JSON.parse(settingsData);
+      // Strip UTF-8 BOM if present — Windows tools (editors, formatters, CLI
+      // hooks) may prepend U+FEFF which Bun's JSON.parse rejects silently,
+      // causing a full fallback to defaults and breaking server-beta routing.
+      const settings = JSON.parse(settingsData.replace(/^\uFEFF/, ''));
 
       let flatSettings = settings;
       if (settings.env && typeof settings.env === 'object') {


### PR DESCRIPTION
## Summary

Two defense-in-depth fixes for Windows environments discovered while debugging the server-beta pipeline on Windows CC 2.1.145:

- **SettingsDefaultsManager.ts**: Strip UTF-8 BOM (U+FEFF) before `JSON.parse`. Windows tools (editors, formatters, Claude Code `Edit` hook) may prepend BOM to `settings.json`, which Bun rejects with `JSON Parse error: Unrecognized token '﻿'`, causing a **silent fallback to defaults** that breaks server-beta routing, health checks, and observation delivery.

- **bun-runner.js**: Exempt lifecycle subcommands (`start`/`stop`/`restart`/`status`) from the #2188 empty-stdin guard. These subcommands manage the worker daemon and never consume stdin. The current guard kills the child process on empty stdin, which prevents the daemon from starting on platforms where Claude Code does not pipe a payload for `SessionStart` (e.g. Windows CC ≤ 2.1.145).

## Root cause

On Windows, the `Edit` tool's PostToolUse formatter hook can add a UTF-8 BOM to `~/.claude-mem/settings.json`. On the next hook invocation, Bun's `JSON.parse` rejects the BOM → settings loader falls back to defaults → `CLAUDE_MEM_WORKER_PORT` reverts to default → health check fails → observations are silently lost. No error is surfaced to the user.

For bun-runner.js, the `SessionStart` hook runs `worker-service.cjs start` which does not need stdin. But the #2188 guard kills the child because stdin is empty, preventing the worker daemon from starting.

## Test plan

- [ ] Write `settings.json` with BOM prefix, verify settings load correctly
- [ ] Run `bun-runner.js worker-service.cjs start` without stdin, verify daemon starts
- [ ] Run `bun-runner.js worker-service.cjs hook claude-code observation` without stdin, verify #2188 guard still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)