### PR TITLE
fix: auto-install plugin dependencies on first hook invocation

### DIFF
--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -93,6 +93,36 @@ if (!bunPath) {
   process.exit(1);
 }
 
+// Ensure plugin runtime dependencies are installed (e.g. zod).
+// The plugin marketplace extracts files but does not run `bun install`,
+// so node_modules may be missing on fresh installs (gh #2637, #2640).
+function ensurePluginDependencies(pluginRoot) {
+  const pkgPath = join(pluginRoot, 'package.json');
+  if (!existsSync(pkgPath)) return;
+
+  // Check if the critical runtime dependency (zod) is already available.
+  const zodPath = join(pluginRoot, 'node_modules', 'zod');
+  if (existsSync(zodPath)) return;
+
+  // Run `bun install --production` to install plugin dependencies.
+  // This is a synchronous one-time operation that runs on the first
+  // hook invocation after a fresh plugin install.
+  try {
+    spawnSync(bunPath, ['install', '--production'], {
+      cwd: pluginRoot,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 30000,
+      windowsHide: true,
+    });
+  } catch (_) {
+    // Silently continue — worker will report the missing module error
+    // if dependencies are still unavailable.
+  }
+}
+
+ensurePluginDependencies(RESOLVED_PLUGIN_ROOT);
+
 function collectStdin() {
   return new Promise((resolve) => {
     if (process.stdin.isTTY) {

--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -10,6 +10,10 @@ const IS_WINDOWS = process.platform === 'win32';
 const __bun_runner_dirname = dirname(fileURLToPath(import.meta.url));
 const RESOLVED_PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || resolve(__bun_runner_dirname, '..');
 
+const BUN_INSTALL_ARGS = Object.freeze(['install', '--production']);
+const BUN_INSTALL_TIMEOUT_MS = 30_000;
+const BUN_RUNNER_LOG_PREFIX = '[bun-runner]';
+
 function fixBrokenScriptPath(argPath) {
   if (argPath.startsWith('/scripts/') && !existsSync(argPath)) {
     const fixedPath = join(RESOLVED_PLUGIN_ROOT, argPath);
@@ -100,24 +104,34 @@ function ensurePluginDependencies(pluginRoot) {
   const pkgPath = join(pluginRoot, 'package.json');
   if (!existsSync(pkgPath)) return;
 
-  // Check if the critical runtime dependency (zod) is already available.
-  const zodPath = join(pluginRoot, 'node_modules', 'zod');
-  if (existsSync(zodPath)) return;
+  // Guard on node_modules (package-manager marker) rather than a specific
+  // package so the check stays correct if zod is later removed/renamed.
+  const nodeModulesPath = join(pluginRoot, 'node_modules');
+  if (existsSync(nodeModulesPath)) return;
 
-  // Run `bun install --production` to install plugin dependencies.
-  // This is a synchronous one-time operation that runs on the first
-  // hook invocation after a fresh plugin install.
+  let result;
   try {
-    spawnSync(bunPath, ['install', '--production'], {
+    result = spawnSync(bunPath, BUN_INSTALL_ARGS, {
       cwd: pluginRoot,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 30000,
+      timeout: BUN_INSTALL_TIMEOUT_MS,
       windowsHide: true,
     });
-  } catch (_) {
-    // Silently continue — worker will report the missing module error
-    // if dependencies are still unavailable.
+  } catch (err) {
+    const reason = err && err.message ? err.message : String(err);
+    console.error(`${BUN_RUNNER_LOG_PREFIX} bun install threw (${reason}); worker may crash with missing module errors`);
+    return;
+  }
+
+  // spawnSync does not throw on a failed child — surface .error (ENOENT,
+  // ETIMEDOUT, etc.) or non-zero/null .status so the user knows auto-install
+  // was attempted but failed (gh #2644 review).
+  if (result.error || (result.status !== null && result.status !== 0)) {
+    const reason = result.error
+      ? result.error.message
+      : `exit ${result.status}`;
+    console.error(`${BUN_RUNNER_LOG_PREFIX} bun install failed (${reason}); worker may crash with missing module errors`);
   }
 }
 

--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -125,12 +125,21 @@ function ensurePluginDependencies(pluginRoot) {
   }
 
   // spawnSync does not throw on a failed child — surface .error (ENOENT,
-  // ETIMEDOUT, etc.) or non-zero/null .status so the user knows auto-install
+  // ETIMEDOUT, etc.), a non-zero exit, or signal-killed termination (SIGKILL
+  // from the OOM killer, SIGTERM, etc. — in that case .status is null AND
+  // .error is undefined, only .signal is set) so the user knows auto-install
   // was attempted but failed (gh #2644 review).
-  if (result.error || (result.status !== null && result.status !== 0)) {
-    const reason = result.error
-      ? result.error.message
-      : `exit ${result.status}`;
+  const killedBySignal = result.status === null && !!result.signal;
+  const nonZeroExit = result.status !== null && result.status !== 0;
+  if (result.error || nonZeroExit || killedBySignal) {
+    let reason;
+    if (result.error) {
+      reason = result.error.message;
+    } else if (killedBySignal) {
+      reason = `killed by ${result.signal}`;
+    } else {
+      reason = `exit ${result.status}`;
+    }
     console.error(`${BUN_RUNNER_LOG_PREFIX} bun install failed (${reason}); worker may crash with missing module errors`);
   }
 }

--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -109,6 +109,11 @@ function ensurePluginDependencies(pluginRoot) {
   const nodeModulesPath = join(pluginRoot, 'node_modules');
   if (existsSync(nodeModulesPath)) return;
 
+  // First-run install is blocking (hook critical path). Surface a progress
+  // line so the user understands the hang is auto-install, not a freeze
+  // (gh #2644 review nit).
+  console.error(`${BUN_RUNNER_LOG_PREFIX} installing plugin dependencies (first run, one-time)...`);
+
   let result;
   try {
     result = spawnSync(bunPath, BUN_INSTALL_ARGS, {

--- a/tests/plugin-bun-runner-ensure-deps.test.ts
+++ b/tests/plugin-bun-runner-ensure-deps.test.ts
@@ -86,6 +86,30 @@ describe('bun-runner ensurePluginDependencies failure diagnostics', () => {
     expect(stderr).toContain('exit 42');
   });
 
+  test('logs a stderr diagnostic when bun install is killed by signal (OOM / SIGKILL / SIGTERM)', async () => {
+    // Reproduces gh#2644 greptile review: spawnSync sets status=null AND
+    // leaves .error undefined when the child is killed by an external signal —
+    // only .signal carries the cause. Without an explicit signal branch the
+    // failure is swallowed silently. Fake bun raises SIGTERM against itself.
+    const pluginRoot = join(tmpRoot, 'plugin-signal');
+    mkdirSync(pluginRoot, { recursive: true });
+    writeFileSync(join(pluginRoot, 'package.json'), JSON.stringify({ name: 'fake-plugin', version: '0.0.0' }));
+
+    const fakeBinDir = join(pluginRoot, '.bin');
+    mkdirSync(fakeBinDir, { recursive: true });
+    const fakeBunPath = join(fakeBinDir, 'bun');
+    writeFileSync(
+      fakeBunPath,
+      `#!/usr/bin/env bash\nif [ "$1" = "install" ]; then\n  kill -TERM $$\n  sleep 5\nfi\nexit 0\n`,
+    );
+    chmodSync(fakeBunPath, 0o755);
+
+    const { stderr } = await runRunner(pluginRoot, fakeBinDir);
+
+    expect(stderr).toContain(EXPECTED_DIAGNOSTIC);
+    expect(stderr).toContain('killed by SIGTERM');
+  });
+
   test('does not log diagnostic when node_modules already present', async () => {
     const pluginRoot = join(tmpRoot, 'plugin-ok');
     mkdirSync(join(pluginRoot, 'node_modules'), { recursive: true });

--- a/tests/plugin-bun-runner-ensure-deps.test.ts
+++ b/tests/plugin-bun-runner-ensure-deps.test.ts
@@ -1,0 +1,108 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { spawn } from 'child_process';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+
+const REPO_ROOT = resolve(import.meta.dir, '..');
+const BUN_RUNNER_PATH = join(REPO_ROOT, 'plugin', 'scripts', 'bun-runner.js');
+const FAKE_SCRIPT_ARG = 'fake-script.cjs';
+const SPAWN_TIMEOUT_MS = 15_000;
+const EXPECTED_DIAGNOSTIC = '[bun-runner] bun install failed';
+
+let tmpRoot: string;
+
+function runRunner(pluginRoot: string, fakeBinDir: string): Promise<{ stderr: string; code: number | null }> {
+  return new Promise((resolveResult, reject) => {
+    const child = spawn(process.execPath, [BUN_RUNNER_PATH, FAKE_SCRIPT_ARG], {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        PATH: `${fakeBinDir}:${process.env.PATH ?? ''}`,
+        CLAUDE_PLUGIN_ROOT: pluginRoot,
+        CLAUDE_MEM_DATA_DIR: join(pluginRoot, '.claude-mem'),
+        CLAUDE_CONFIG_DIR: join(pluginRoot, '.claude'),
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stderr = '';
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    try {
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk.toString();
+      });
+
+      child.stdin.end();
+
+      timer = setTimeout(() => {
+        try { child.kill('SIGKILL'); } catch {}
+        reject(new Error(`bun-runner subprocess exceeded ${SPAWN_TIMEOUT_MS}ms`));
+      }, SPAWN_TIMEOUT_MS);
+
+      child.on('close', (code) => {
+        if (timer) clearTimeout(timer);
+        resolveResult({ stderr, code });
+      });
+      child.on('error', (err) => {
+        if (timer) clearTimeout(timer);
+        reject(err);
+      });
+    } catch (err) {
+      if (timer) clearTimeout(timer);
+      try { child.kill('SIGKILL'); } catch {}
+      reject(err);
+    }
+  });
+}
+
+beforeAll(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'bun-runner-deps-'));
+});
+
+afterAll(() => {
+  try { rmSync(tmpRoot, { recursive: true, force: true }); } catch {}
+});
+
+describe('bun-runner ensurePluginDependencies failure diagnostics', () => {
+  test('logs a stderr diagnostic when bun install exits non-zero', async () => {
+    const pluginRoot = join(tmpRoot, 'plugin-fail');
+    mkdirSync(pluginRoot, { recursive: true });
+    writeFileSync(join(pluginRoot, 'package.json'), JSON.stringify({ name: 'fake-plugin', version: '0.0.0' }));
+
+    const fakeBinDir = join(pluginRoot, '.bin');
+    mkdirSync(fakeBinDir, { recursive: true });
+    const fakeBunPath = join(fakeBinDir, 'bun');
+    writeFileSync(
+      fakeBunPath,
+      `#!/usr/bin/env bash\nif [ "$1" = "install" ]; then\n  echo "fake bun install failure" 1>&2\n  exit 42\nfi\nexit 0\n`,
+    );
+    chmodSync(fakeBunPath, 0o755);
+
+    const { stderr } = await runRunner(pluginRoot, fakeBinDir);
+
+    expect(stderr).toContain(EXPECTED_DIAGNOSTIC);
+    expect(stderr).toContain('exit 42');
+  });
+
+  test('does not log diagnostic when node_modules already present', async () => {
+    const pluginRoot = join(tmpRoot, 'plugin-ok');
+    mkdirSync(join(pluginRoot, 'node_modules'), { recursive: true });
+    writeFileSync(join(pluginRoot, 'package.json'), JSON.stringify({ name: 'fake-plugin', version: '0.0.0' }));
+
+    const fakeBinDir = join(pluginRoot, '.bin');
+    mkdirSync(fakeBinDir, { recursive: true });
+    const fakeBunPath = join(fakeBinDir, 'bun');
+    writeFileSync(
+      fakeBunPath,
+      `#!/usr/bin/env bash\nif [ "$1" = "install" ]; then\n  echo "should-not-be-called" 1>&2\n  exit 99\nfi\nexit 0\n`,
+    );
+    chmodSync(fakeBunPath, 0o755);
+
+    const { stderr } = await runRunner(pluginRoot, fakeBinDir);
+
+    expect(stderr).not.toContain(EXPECTED_DIAGNOSTIC);
+    expect(stderr).not.toContain('should-not-be-called');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #2640 and #2637 — the worker silently crashes with `Cannot find module 'zod/v3'` on fresh plugin installs because the plugin marketplace extracts files but does not run `bun install` in the cache directory.

## Root Cause

The plugin marketplace extracts plugin files to `~/.claude/plugins/cache/thedotmack/claude-mem/{version}/` but never installs `node_modules`. Even though `plugin/package.json` declares zod as a dependency, it's never actually installed, causing `worker-service.cjs` to crash immediately on first hook invocation.

## Fix

Added `ensurePluginDependencies()` to `bun-runner.js` that checks for `node_modules/zod` before spawning the worker. On a fresh install where zod is missing, it runs `bun install --production` in the plugin root automatically. This is a one-time operation — subsequent invocations skip the check when zod is already present.

## Verification

- Build succeeds without errors
- The fix is minimal: 30 lines added to `plugin/scripts/bun-runner.js`
- Pre-existing test failures (#2537 `.npmignore` CLAUDE.md) are unaffected
- No breaking changes to existing behavior

## Issues

Closes #2640  
Closes #2637