### PR TITLE
Add accelerator/VC application datasets

### DIFF
--- a/applications/00-company-dossier.md
+++ b/applications/00-company-dossier.md
@@ -1,0 +1,204 @@
+# Claude-Mem — Company Dossier (Master Application Dataset)
+
+> This is the canonical, reusable source of truth for every accelerator/VC
+> application in this folder. Every per-program file pulls from these facts and
+> answer snippets. Update a number here once and reuse it everywhere.
+>
+> **Last verified:** 2026-05-25. Star/fork counts and any metric change daily —
+> re-check the live numbers before you hit submit (see the checklist in
+> `README.md`).
+
+---
+
+## 1. One-liners (pick by length limit)
+
+- **8 words:** Persistent memory for every AI coding agent.
+- **50 chars:** Persistent memory for AI coding agents.
+- **One sentence:** Claude-Mem gives AI coding agents persistent, searchable memory across
+  sessions — it captures everything the agent does, compresses it with AI, and injects
+  the relevant context back into future sessions, automatically.
+- **Tweet-length:** Your AI coding agent forgets everything when a session ends. Claude-Mem
+  fixes that. Install once, work normally, and your agent remembers your project across
+  every session — across Claude Code, Cursor, Codex, Gemini, Copilot and more. 77k+ GitHub
+  stars, Apache-2.0.
+
+## 2. Elevator pitch (≈100 words)
+
+Every AI coding agent — Claude Code, Cursor, Copilot, Gemini, Codex — starts every session
+with amnesia. The context you built up yesterday is gone. Developers waste hours re-explaining
+their codebase, re-discovering decisions, and re-pasting the same context. Claude-Mem solves
+this at the harness layer: it hooks into the agent's lifecycle, captures every tool call and
+decision, compresses those into structured "observations" with an LLM, and automatically
+injects the relevant memories into future sessions. Install once with one command; the
+developer does nothing different. It's open-source (Apache-2.0), works across 9+ agents and
+28 languages, and has 77k+ GitHub stars in nine months.
+
+## 3. The problem
+
+- AI coding agents are stateless. Every new session is a blank slate — the model has no memory
+  of prior sessions, decisions, dead ends, or the shape of your codebase.
+- Developers compensate manually: re-explaining architecture, re-pasting context, maintaining
+  hand-written `CLAUDE.md`/rules files, and repeating themselves to the agent. This burns time
+  and tokens and produces worse output.
+- On teams it's worse: knowledge an agent "learned" in one engineer's session never reaches
+  the rest of the team. Tacit knowledge evaporates when a session, or an engineer, leaves.
+- Existing fixes are partial: bigger context windows are expensive and still reset; native
+  "memory" features are shallow, vendor-locked, and don't span tools or teams.
+
+## 4. The solution
+
+Claude-Mem is a persistent memory layer that sits underneath the agent and works automatically:
+
+1. **Capture** — lifecycle hooks observe every tool call (reads, edits, commands, decisions)
+   during a session. Zero manual effort from the developer.
+2. **Compress** — an asynchronous worker uses the Claude Agent SDK to distill raw activity into
+   structured, typed observations (bugfix, decision, architecture, etc.).
+3. **Recall** — at the start of the next session, the most relevant observations are injected
+   as context. Developers (and the agent) can also search history in natural language via MCP
+   tools and a skill, with progressive disclosure to keep token cost low.
+
+The defining property: **"it just works."** Install once, work normally, get memory as a side
+effect. No prompt engineering, no manual note-taking, no behavior change.
+
+## 5. What's novel / why it's hard
+
+- **Harness-layer capture, not app-layer.** Claude-Mem hooks the agent's lifecycle rather than
+  asking the user to curate memories. Capture is invisible and complete.
+- **Compression, not storage.** It doesn't just dump transcripts; it uses an LLM to extract
+  durable, typed, searchable observations — and a 3-layer progressive-disclosure search pattern
+  that delivers ~10x token savings (index → timeline → fetch details).
+- **Cross-agent + cross-language.** One memory layer spanning Claude Code, Cursor, Codex,
+  Gemini CLI, Windsurf, OpenCode, OpenClaw, Copilot, Hermes — and 28 human languages.
+- **A team-scale substrate already built.** The server architecture (Postgres + BullMQ/Valkey)
+  carries a full identity triad (api_key × actor × request) per event, enabling team/org shared
+  memory with tenant isolation and a compliance-grade audit chain — the foundation of the
+  commercial product.
+
+## 6. Product & technology
+
+- **Stack:** TypeScript, Bun, Node ≥20. SQLite (`bun:sqlite`) for single-user; Postgres +
+  BullMQ/Valkey for the multi-tenant server. Chroma for vector embeddings. Express HTTP API.
+  React web viewer UI. Built on the Claude Agent SDK and MCP (Model Context Protocol).
+- **Architecture:** 5–6 lifecycle hooks → unified worker service (async LLM processing) →
+  SQLite/Postgres → FTS5 + vector hybrid search → context injection. Web viewer streams a
+  real-time "memory stream" via SSE.
+- **Search:** 3-layer MCP workflow — `search` (compact index) → `timeline` (chronological
+  context) → `get_observations` (full details for filtered IDs only).
+- **Distribution:** one-command install (`npx claude-mem install`), Claude Code plugin
+  marketplace, npm SDK, and an OpenClaw gateway installer.
+- **Privacy:** `<private>` tags strip sensitive content at the hook (edge) layer before it ever
+  reaches storage. Server adds tenant scoping + per-action audit logs.
+- **License:** Apache-2.0 (open core).
+
+## 7. Traction (verify live before submitting)
+
+- **GitHub:** 77,854 stars, 6,706 forks (repo created 2025-08-31 → ~9 months). TypeScript.
+- **Mind-share:** featured on Trendshift; listed in "Awesome Claude Code"; active Discord
+  community; official X account @Claude_Memory.
+- **Founder reach:** Alex Newman — 1,612 GitHub followers.
+- **Breadth:** supports 9+ agent harnesses and 28 languages; published on npm and the Claude
+  Code plugin marketplace.
+- **Velocity:** shipping continuously (v13.x), with a multi-tenant team-memory server merged
+  and in beta.
+
+> `[FILL IN before submitting]` npm weekly downloads, install/active counts, Discord member
+> count, marketplace install count, week-over-week star growth, and any waitlist signups for
+> the Pro/team product. These quantitative deltas are what reviewers weight most.
+
+## 8. Market
+
+- **Wedge market:** developers using AI coding agents — one of the fastest-growing software
+  categories (Claude Code, Cursor, Copilot, Gemini, Codex, etc.), already millions of users and
+  growing fast.
+- **Category:** AI agent memory / context infrastructure — a hot, early infra layer.
+  Comparables/competitors include Mem0, Supermemory, Zep, Letta (MemGPT), and the native memory
+  features inside each coding tool.
+- **Expansion:** individual developer memory → team/org shared memory (the substrate is built)
+  → a general memory/context layer for *any* agent (CI bots, MCP clients, IDE extensions,
+  autonomous agents).
+- **Why now:** agentic coding went mainstream in 2025; context windows are still finite and
+  expensive; and every vendor's memory is siloed. A neutral, cross-agent, open memory layer is
+  the natural infrastructure play, and the hooks/MCP standards to build it only just shipped.
+
+## 9. Business model (open core)
+
+- **Free & open (Apache-2.0):** the full single-user memory engine, CLI, SDKs, MCP tools,
+  adapters, and the self-hostable server. This drives adoption and is the top of the funnel.
+- **Commercial (Pro / Team / Enterprise — in development):** Magic Recall hosted cloud,
+  team/org memory sync, admin dashboard, SSO/SAML/SCIM, enterprise RBAC, audit-log UI,
+  DLP/policy engine, premium knowledge agents, managed evals, enterprise observability, and
+  SLA/support. Gated by license validation, layered on top of — not replacing — the open core.
+- **Monetization motion:** bottom-up developer adoption (free) → team plans (shared memory,
+  per-seat) → enterprise (compliance, SSO, audit, support). Classic open-core/PLG.
+
+## 10. Competition & moat
+
+- **Competitors:** Mem0, Supermemory, OpenMemory, Zep, Letta/MemGPT; plus native memory in
+  Cursor/Copilot/etc.
+- **Differentiation / moat:**
+  - **Zero-config harness-layer capture** — competitors mostly expose an API the developer must
+    call; Claude-Mem captures automatically.
+  - **Cross-agent neutrality** — not locked to one vendor's tool.
+  - **Distribution + community** — 77k+ stars and a real install base are a hard-to-copy
+    distribution moat.
+  - **Team substrate + audit chain** — the compliance-grade, multi-tenant memory layer is the
+    enterprise wedge and is already engineered.
+  - **Compounding data** — the more an org uses it, the larger and more valuable its private
+    memory corpus becomes (switching cost + network effect within a team).
+
+## 11. Founder
+
+**Alex Newman** — founder & creator of Claude-Mem.
+- GitHub: [@thedotmack](https://github.com/thedotmack) (1,612 followers, 118 public repos).
+- X / Twitter: [@Claude_Memory](https://x.com/Claude_Memory).
+- Email: thedotmack@gmail.com.
+- Built Claude-Mem from zero to 77k+ stars in ~9 months as the primary author; ships
+  continuously and runs the community (Discord, docs, marketplace).
+
+> `[FILL IN]` Full bio, location, prior companies/exits, technical background, why you're
+> uniquely suited to this, and co-founder details (or your stance on being a solo founder and
+> your hiring plan). See `00-founder-bio.md` for ready-to-paste bio variants — complete the
+> placeholders there.
+
+## 12. Vision
+
+Claude-Mem becomes the **memory layer for all AI agents** — the neutral, open substrate that
+lets any agent (coding, ops, support, autonomous) remember, share, and build on context across
+sessions, tools, people, and time. Start with the developer's own memory, expand to the team's
+shared brain, and end as the infrastructure layer every agent plugs into for durable, attributed,
+searchable memory.
+
+## 13. Honest risks / things to address (don't volunteer unless asked)
+
+- **Platform dependency:** built closely on the Claude Agent SDK / Claude Code ecosystem.
+  Mitigation: already cross-agent (9+ harnesses), neutral MCP-based design.
+- **Big-vendor "memory" features:** the coding tools may build native memory. Mitigation:
+  neutrality across tools, open ecosystem, team/enterprise depth they won't prioritize.
+- **Monetization is early:** pre-revenue; the commercial layer is in development. Frame as
+  "massive top-of-funnel adoption proven; now converting to team/enterprise."
+- **Solo founder (if applicable):** address hiring plan and any key contributors.
+- **$CMEM token:** a community Solana token was created by a third party and publicly embraced
+  by the founder. It is **not** the business model or a fundraising vehicle for the company.
+  Many institutional VCs view memecoins as a distraction or red flag — recommend **omitting it**
+  from VC/accelerator applications unless directly asked, and if asked, framing it strictly as a
+  community/marketing phenomenon separate from the cap table and product.
+
+## 14. Quick reference table
+
+| Field | Value |
+|---|---|
+| Company / project | Claude-Mem |
+| Website | https://docs.claude-mem.ai |
+| Repo | https://github.com/thedotmack/claude-mem |
+| One-liner | Persistent memory for every AI coding agent |
+| Founded | 2025 (repo created 2025-08-31) |
+| Founder | Alex Newman (@thedotmack) |
+| Contact | thedotmack@gmail.com |
+| License | Apache-2.0 (open core) |
+| Stack | TypeScript, Bun, SQLite/Postgres, Chroma, MCP, Claude Agent SDK |
+| GitHub stars | 77,854 (verify live) |
+| Forks | 6,706 (verify live) |
+| Stage | Pre-seed / open-source with massive adoption, pre-revenue |
+| Location | `[FILL IN]` |
+| Incorporated? | `[FILL IN — entity type & state]` |
+| Raised to date | `[FILL IN — likely $0 / bootstrapped]` |

--- a/applications/00-founder-bio.md
+++ b/applications/00-founder-bio.md
@@ -1,0 +1,64 @@
+# Founder Bio — Alex Newman (@thedotmack)
+
+> Ready-to-paste bio variants at multiple lengths. Complete the `[FILL IN]`
+> placeholders with your real background — accelerators weight founder
+> credibility heavily, so the specifics matter more than the prose.
+
+## Verified facts (from public profiles)
+
+- Name: Alex Newman
+- GitHub: [@thedotmack](https://github.com/thedotmack) — 1,612 followers, 118 public repos,
+  account since 2011.
+- X / Twitter: [@Claude_Memory](https://x.com/Claude_Memory).
+- Email: thedotmack@gmail.com.
+- Creator and primary author of Claude-Mem (77k+ GitHub stars, Apache-2.0), built from zero in
+  ~9 months (repo created Aug 2025).
+
+## `[FILL IN]` — gather these before submitting
+
+- Location (city / country) and willingness to relocate (YC, Pear, Antler, etc. often ask).
+- Age / years of experience as relevant.
+- Education (schools, degrees) — some forms ask, many don't.
+- Prior work: companies, roles, notable products shipped, any exits or acquisitions.
+- Technical depth: languages/systems you're expert in, anything that proves you can build hard
+  infra (you clearly can — name the receipts).
+- Prior startup/founder experience, open-source track record beyond Claude-Mem.
+- Why you, specifically — the "founder-market fit" story. Why are you the person obsessed with
+  agent memory?
+- Co-founders (names, roles, equity) or your explicit position as a solo founder + hiring plan.
+- Any notable advisors, investors, or community leaders backing you.
+
+---
+
+## Bio — 1 sentence
+
+Alex Newman is the founder of Claude-Mem, the open-source persistent-memory layer for AI coding
+agents that reached 77k+ GitHub stars in its first nine months.
+
+## Bio — 50 words
+
+Alex Newman (@thedotmack) is the founder and creator of Claude-Mem, an open-source persistent
+memory layer for AI coding agents. He took it from zero to 77k+ GitHub stars in nine months,
+shipping continuously across 9+ agent harnesses. `[FILL IN: 1 line of prior background that
+proves you can build and distribute hard developer infrastructure.]`
+
+## Bio — 100 words
+
+Alex Newman is the founder and primary author of Claude-Mem, the open-source persistent memory
+layer that gives AI coding agents durable, searchable context across sessions. Since starting
+the project in August 2025 he has grown it to 77k+ GitHub stars and 6.7k+ forks, built
+integrations across 9+ agent harnesses (Claude Code, Cursor, Codex, Gemini, Copilot and more)
+and 28 languages, and architected a multi-tenant team-memory server. He runs the project's
+community, docs, and release cadence solo. `[FILL IN: prior companies/roles, technical
+background, and the personal "why" behind your obsession with agent memory.]`
+
+## Bio — founder-market fit paragraph (for "why you?")
+
+`[FILL IN, using this scaffold:]` I've spent `[N years]` building `[type of systems]`, and I
+live inside AI coding agents every day. I felt the amnesia problem viscerally — re-explaining
+my own codebase to the agent session after session — and I had the systems background to fix it
+at the right layer (the harness, not the app). I shipped Claude-Mem, and developers responded:
+77k+ stars in nine months with zero paid marketing. I understand both the deep technical
+substrate (hooks, MCP, multi-tenant Postgres, vector search) and the distribution motion
+(open-source, community, PLG) required to make agent memory ubiquitous. `[Add: specific prior
+evidence — products shipped, audiences built, hard problems solved.]`

--- a/applications/500-global.md
+++ b/applications/500-global.md
@@ -1,0 +1,70 @@
+# 500 Global — Flagship Accelerator Application
+
+- **Portal:** https://500.co/accelerators (apply to the relevant program/track; @500GlobalVC)
+- **Profile:** global, multiple tracks, rolling. Growth-/metrics-driven accelerator with a large
+  international network; strong on distribution, growth marketing, and follow-on.
+- **Source of facts:** `00-company-dossier.md`. Verify live numbers before submit.
+
+> 500 is metrics- and growth-focused. Lead with the numbers and the growth story; show you
+> understand your funnel and the path from adoption to revenue.
+
+---
+
+## Company
+
+- **Company:** Claude-Mem
+- **Website / repo:** https://docs.claude-mem.ai · https://github.com/thedotmack/claude-mem
+- **One-liner:** Persistent memory for every AI coding agent.
+- **Founder:** Alex Newman (thedotmack@gmail.com) · **Location:** `[FILL IN]`
+- **Stage:** Pre-seed; open-source with 77k+ stars; pre-revenue, commercial layer in development.
+- **Track:** `[FILL IN — confirm the 500 program/track and location.]`
+
+## What does your company do? (concise)
+
+Claude-Mem gives AI coding agents persistent memory. Agents forget everything between sessions;
+Claude-Mem captures their activity automatically, compresses it with an LLM into structured
+observations, and injects relevant context into future sessions. Open-source, cross-agent (9+
+harnesses), 28 languages, with a multi-tenant team-memory server for the commercial tier.
+
+## Metrics & growth (500 weights this most — fill in live numbers)
+
+- GitHub: **77,854 stars, 6,706 forks** in ~9 months, **zero paid marketing**.
+- Distribution channels: one-command npx install, Claude Code plugin marketplace, npm SDK.
+- `[FILL IN — the growth numbers 500 will ask for:]`
+  - npm weekly downloads + trend
+  - install / active counts + WoW or MoM growth
+  - plugin marketplace installs
+  - Discord/community size + growth
+  - star growth rate (stars/week)
+  - any revenue / paid waitlist / design partners
+- Acquisition: organic / community-led (developers share it); CAC effectively ~$0 to date.
+
+## Problem, market, why now
+
+Stateless AI agents waste developer time and lose team knowledge. AI coding is one of the
+fastest-growing software categories; the memory/context layer is unowned and forming now (Mem0,
+Supermemory, Zep, Letta). We have the distribution lead in a category that becomes infrastructure.
+
+## Business model & unit economics path
+
+Open-core PLG: free core (adoption) → team plans, per seat (revenue) → enterprise (SSO/RBAC/audit,
+hosted cloud, SLA). `[FILL IN: pricing hypothesis, target ACV for team vs. enterprise, and the
+conversion assumption from free installs → paid teams.]`
+
+## Competition / moat
+
+Mem0, Supermemory, Zep, Letta, native memory in coding tools. Moat: zero-config harness-layer
+capture, cross-agent neutrality, 77k-star distribution, and a built team/enterprise substrate;
+private team memory corpora compound (switching cost).
+
+## Team
+
+Alex Newman — founder, creator, primary author; built the full stack solo and drove all growth
+organically. `[FILL IN: founder-market fit, hiring plan from 00-founder-bio.md.]`
+
+## Raise & ask
+
+- **Raised to date:** `[FILL IN]`
+- **Raising:** `[FILL IN]`
+- **What we want from 500:** growth/distribution playbook for converting massive OSS adoption to
+  revenue, international expansion, and follow-on investor access. `[Refine.]`

--- a/applications/README.md
+++ b/applications/README.md
@@ -1,0 +1,84 @@
+# Accelerator & VC Applications — Claude-Mem
+
+Ready-to-submit application datasets for the programs in the May 2026 "YC extended S26 + save
+these too" list. Each file is a self-contained set of answers tailored to that program's actual
+application, drawing from a shared, reusable dossier so you only maintain facts once.
+
+**Founder:** Alex Newman (@thedotmack) · **Project:** Claude-Mem · thedotmack@gmail.com
+
+---
+
+## How to use these
+
+1. **Start with the shared files** and fill in every `[FILL IN]`:
+   - [`00-company-dossier.md`](00-company-dossier.md) — the master dataset (one-liners, problem,
+     solution, traction, market, business model, competition, vision, risks, quick-reference
+     table). Update a number here and it applies everywhere.
+   - [`00-founder-bio.md`](00-founder-bio.md) — bio variants (1 sentence → 100 words →
+     founder-market-fit paragraph). Complete the personal placeholders once.
+2. **Open the per-program file**, paste its answers into that program's form, and tighten any
+   `[FILL IN]`s the dossier didn't cover.
+3. **Verify live numbers** (stars, forks, downloads) on submission day — they change daily.
+4. **Record the YC founder video** using the script in `y-combinator-s26.md` (after editing).
+
+---
+
+## Programs (from the post) + portals + cadence
+
+| # | Program | File | Portal | Cadence / deadline |
+|---|---------|------|--------|--------------------|
+| 1 | **Y Combinator (S26)** | [`y-combinator-s26.md`](y-combinator-s26.md) | https://www.ycombinator.com/apply | **Deadline extended to May 25** — apply now |
+| 2 | **Pear VC (PearX)** | [`pear-vc.md`](pear-vc.md) | https://pear.vc/pearx/ | 2 batches/yr, SF; S26 kicks off July |
+| 3 | **Creative Destruction Lab** | [`creative-destruction-lab.md`](creative-destruction-lab.md) | https://creativedestructionlab.com/apply/ | 23 streams, equity- & fee-free, apps open |
+| 4 | **Antler** | [`antler.md`](antler.md) | https://www.antler.co/apply | Rolling; NYC / Austin / SF |
+| 5 | **Plug and Play** | [`plug-and-play.md`](plug-and-play.md) | https://www.plugandplaytechcenter.com/apply | Rolling; vertical tracks; multi-location |
+| 6 | **Alchemist Accelerator** | [`alchemist.md`](alchemist.md) | https://alchemistaccelerator.com/apply | B2B/enterprise, SF, 2 batches/yr |
+| 7 | **gener8tor** | [`gener8tor.md`](gener8tor.md) | https://www.gener8tor.com/apply | Rolling; 45 cities / 20+ states |
+| 8 | **500 Global** | [`500-global.md`](500-global.md) | https://500.co/accelerators | Global, multiple tracks, rolling |
+| 9 | **Techstars** | [`techstars.md`](techstars.md) | https://www.techstars.com/apply | Rolling; 6+ cities + remote; next ~June |
+| 10 | **South Park Commons** | [`south-park-commons.md`](south-park-commons.md) | https://www.southparkcommons.com/founder-fellowship | Pre-idea/frontier tech, rolling |
+
+> Portal URLs are best-known entry points; confirm each is current before applying. Verify exact
+> deadlines on each site — only YC's May 25 date is fixed by the source post.
+
+---
+
+## Positioning cheat-sheet (how each program differs)
+
+- **YC / Pear / 500** — traction & growth machines. Lead with numbers (stars → downloads →
+  revenue path) and crisp thinking.
+- **Alchemist / Plug and Play** — B2B/enterprise. Lead with the **team/enterprise** product, the
+  audit/compliance substrate, and the path to enterprise revenue.
+- **Techstars** — **team-first.** Lead with the founder + execution velocity.
+- **Antler / South Park Commons** — **founder/person-first.** Lead with your story, edge, and
+  frontier thesis; Claude-Mem is the proof, not just the pitch.
+- **CDL** — **objective-driven & equity-free.** Lead with defensible technology and measurable
+  90-day objectives.
+
+---
+
+## Pre-submission checklist (do once, reuse everywhere)
+
+- [ ] Fill in all `[FILL IN]` in `00-company-dossier.md` and `00-founder-bio.md`.
+- [ ] **Numbers (verify live the day you submit):** GitHub stars/forks, npm weekly downloads,
+      install/active counts, marketplace installs, Discord size, growth rates.
+- [ ] **Revenue/commercial signal:** any paying/waitlisted teams, design partners, LOIs.
+- [ ] **Founder details:** location, full bio, prior companies, co-founder status / hiring plan.
+- [ ] **Company legal:** incorporated? entity/state? cap table? raised to date? amount raising?
+- [ ] **Assets:** demo video/GIF link, logo, headshot, deck (if a program wants one).
+- [ ] **YC:** record the 1-minute founder video (script in `y-combinator-s26.md`).
+- [ ] **$CMEM token decision:** recommend **omitting** the community Solana token from these
+      applications unless directly asked; if asked, frame it as a community/marketing phenomenon
+      separate from the company, product, and cap table (see dossier §13).
+- [ ] Tailor the per-program "what we want from you / use of funds" ask to each program.
+
+---
+
+## Snapshot (verify live before submitting)
+
+- GitHub: **77,854 stars · 6,706 forks** · Apache-2.0 · TypeScript · created Aug 2025 (~9 months).
+- Cross-agent: Claude Code, Cursor, Codex, Gemini CLI, Windsurf, OpenCode, OpenClaw, Copilot,
+  Hermes · 28 languages.
+- Distribution: `npx claude-mem install`, Claude Code plugin marketplace, npm; active Discord;
+  Trendshift feature.
+- Commercial: multi-tenant team/enterprise memory server merged and in beta (open-core model).

--- a/applications/alchemist.md
+++ b/applications/alchemist.md
@@ -1,0 +1,78 @@
+# Alchemist Accelerator — Application
+
+- **Portal:** https://alchemistaccelerator.com/apply (@AlchemistAcc)
+- **Profile:** the enterprise/B2B accelerator. SF, 2 batches/year. Selects almost exclusively
+  for startups whose **revenue comes from enterprises** (sell-to-business, not consumer).
+- **Source of facts:** `00-company-dossier.md`. Verify live numbers before submit.
+
+> Alchemist screens hard on "is this B2B/enterprise?" Frame Claude-Mem around the team/enterprise
+> product and the path to enterprise revenue, not the consumer-dev OSS tool alone. Be candid that
+> revenue is forthcoming while showing the enterprise wedge is real and engineered.
+
+---
+
+## Company
+
+- **Company:** Claude-Mem
+- **Website / repo:** https://docs.claude-mem.ai · https://github.com/thedotmack/claude-mem
+- **One-liner (B2B framing):** Shared, auditable memory for AI agents across an engineering org.
+- **Location:** `[FILL IN]` · **Founder:** Alex Newman (thedotmack@gmail.com)
+- **Stage:** Pre-seed; open-source with 77k+ stars; enterprise product in development.
+
+## Is your revenue (or future revenue) from enterprises? (Alchemist's key question)
+
+Yes. The free open-source core drives bottom-up adoption inside engineering teams; monetization
+is **B2B**: team plans (shared memory, per seat) and enterprise contracts (SSO/SAML/SCIM, RBAC,
+audit-log UI, DLP/policy engine, managed cloud, SLA). The buyer is the engineering org. The
+enterprise substrate — multi-tenant Postgres with a per-event identity triad (api key × actor ×
+request) and a compliance-grade audit chain — is already built, which is exactly what enterprise
+security/compliance review requires.
+
+## What does the company do?
+
+AI coding agents forget everything between sessions, so engineering teams lose context, repeat
+decisions, and watch tacit knowledge evaporate. Claude-Mem is a memory layer that captures agent
+activity automatically, compresses it into structured observations with an LLM, and injects
+relevant memory into future sessions. At org scale it becomes a **shared team brain**: any
+engineer (or CI/agent) can search what the team has learned, with every memory attributable,
+tenant-isolated, and auditable.
+
+## Why enterprises buy this
+
+- **Onboarding & ramp time:** new engineers query the team's lived knowledge, not stale docs.
+- **Knowledge retention:** when people leave, their reasoning persists as attributed observations.
+- **Compliance & trust:** every AI-written memory ties to an api key, actor, request, and model —
+  revocable and audit-ready (the precondition for enterprises trusting AI-written shared data).
+- **Privacy:** `<private>` redaction at the edge; tenant scoping enforced at every layer.
+- **Cost & quality:** less re-explaining, better agent output, knowledge that compounds.
+
+## Traction
+
+- 77,854 GitHub stars, 6,706 forks (~9 months, zero paid marketing) — proven developer demand,
+  the top of the enterprise funnel.
+- Multi-tenant team/enterprise server merged and in beta.
+- Distributed via npx, plugin marketplace, npm; active Discord.
+- `[FILL IN: downloads/active installs, any enterprise design partners, LOIs, pilot conversations.
+  Alchemist values early B2B signal — list any company names or titles you've talked to.]`
+
+## Market & business model
+
+Wedge: AI-coding-agent users (millions). B2B expansion: per-seat team plans → enterprise
+contracts. Category: AI agent memory infrastructure (vs. Mem0, Supermemory, Zep, Letta).
+Open-core; enterprise revenue is the model.
+
+## Competition / moat
+
+Zero-config harness-layer capture, cross-agent neutrality, 77k-star distribution, and an
+enterprise-grade audit/tenant substrate competitors haven't built. Private org memory corpora
+compound — switching cost grows with use.
+
+## Team
+
+Alex Newman — founder, creator, primary author; built the full enterprise substrate solo. `[FILL
+IN: founder-market fit, enterprise/technical credibility, hiring plan from 00-founder-bio.md.]`
+
+## Ask / use of funds
+
+`[FILL IN: e.g., first enterprise GTM hire, design-partner program, SOC2 path, and the round to
+convert OSS adoption into enterprise revenue.]`

--- a/applications/antler.md
+++ b/applications/antler.md
@@ -1,0 +1,67 @@
+# Antler — Application
+
+- **Portal:** https://www.antler.co/apply (@AntlerGlobal)
+- **Profile:** "day-zero" investor; rolling admissions; locations include NYC, Austin, SF.
+  Antler invests in *founders* — often pre-team/pre-idea — then helps form teams and writes the
+  first check. Application is heavily founder-centric.
+- **Source of facts:** `00-company-dossier.md` and `00-founder-bio.md`. Verify live numbers.
+
+> Antler selects on the *founder* first. Lead with your story, drive, and proof of building
+> ability — Claude-Mem is your evidence, not just the pitch. Be honest about team status.
+
+---
+
+## About you (the core of an Antler application)
+
+- **Name:** Alex Newman
+- **Contact:** thedotmack@gmail.com · GitHub @thedotmack · X @Claude_Memory
+- **Location / preferred Antler site:** `[FILL IN — e.g., NYC / Austin / SF]`
+- **Current status:** `[FILL IN — full-time on Claude-Mem? employed? available to start when?]`
+
+**Tell us about yourself / your background.**
+`[FILL IN from 00-founder-bio.md: career history, technical depth, prior products, education.]`
+Headline proof point: I created Claude-Mem and grew it from zero to 77k+ GitHub stars in nine
+months with no paid marketing — an open-source memory layer for AI coding agents now running
+across 9+ agent harnesses.
+
+**Why do you want to be a founder / why entrepreneurship?**
+`[FILL IN: your authentic motivation.]` I've already been operating as one: shipping a product
+daily, building a 1.6k-follower developer audience, running a community, and architecting
+enterprise-grade infrastructure solo. Antler is where I turn proven adoption into a company.
+
+**What's your superpower / why will you succeed?**
+I can both build deep systems (lifecycle hooks, multi-tenant Postgres, vector search, MCP) and
+distribute them (77k+ stars, zero ad spend). That full-stack-plus-distribution combination is
+rare and is exactly what an infrastructure company at the agent layer needs. `[FILL IN: a
+specific story that demonstrates resilience/drive.]`
+
+**Do you have a co-founder, or are you looking for one?**
+`[FILL IN — Antler explicitly helps with co-founder matching. State whether you're solo and open
+to a co-founder (e.g., a commercial/GTM partner), or already have a team.]`
+
+## The idea (Antler will also ask what you'd build)
+
+**Claude-Mem — persistent memory for every AI coding agent.** AI agents forget everything between
+sessions; Claude-Mem captures their activity at the harness layer, compresses it into structured
+observations with an LLM, and injects relevant context into future sessions automatically. Open
+core (Apache-2.0); a multi-tenant team-memory server (with a compliance-grade audit chain) is the
+commercial wedge. Category: AI agent memory/context infrastructure (vs. Mem0, Supermemory, Zep,
+Letta) — forming now, and we have the distribution lead.
+
+## Traction proof
+
+- 77,854 GitHub stars, 6,706 forks (~9 months, zero paid marketing); Trendshift feature.
+- Runs across 9+ agents and 28 languages; distributed via npx, plugin marketplace, npm.
+- Multi-tenant team/enterprise server merged and in beta.
+- `[FILL IN: downloads, active installs, community size, growth.]`
+
+## Why Antler / what you want from the program
+
+`[FILL IN: e.g., co-founder/early-team matching, first institutional check, GTM support to
+commercialize, and the chosen location. Tie to Antler's day-zero, founder-first model.]`
+
+## Commitment & logistics
+
+- Able to commit full-time: `[FILL IN — yes/when]`
+- Able to be in-person at the `[site]` location for the program: `[FILL IN]`
+- Visa/work authorization if relevant: `[FILL IN]`

--- a/applications/creative-destruction-lab.md
+++ b/applications/creative-destruction-lab.md
@@ -1,0 +1,82 @@
+# Creative Destruction Lab (CDL) — Application
+
+- **Portal:** https://creativedestructionlab.com/apply/ (@creativedlab)
+- **Profile:** objectives-based, equity-free, no-fee program for massively scalable,
+  science-/tech-based ventures. 23 streams across multiple sites. Mentor-driven; you set and
+  hit 90-day objectives across 5 sessions.
+- **Source of facts:** `00-company-dossier.md`. Verify live numbers before submit.
+
+> CDL is mentor/objective-driven and takes equity-free — it's about coachability and a
+> defensible, scalable technology. Emphasize the technical substrate, measurable objectives, and
+> why this is a category-defining infrastructure play.
+
+---
+
+## Venture overview
+
+- **Venture:** Claude-Mem
+- **Website / repo:** https://docs.claude-mem.ai · https://github.com/thedotmack/claude-mem
+- **One-line description:** A persistent, searchable memory layer for AI agents.
+- **Stream fit:** AI / developer infrastructure (map to the most relevant CDL stream, e.g. an AI
+  or software stream). `[FILL IN: chosen stream + site preference.]`
+- **Stage:** Open-source product with 77k+ GitHub stars; pre-revenue; commercial team/enterprise
+  layer in development.
+
+## Describe your venture
+
+Claude-Mem is a persistent memory layer for AI coding agents and, increasingly, any AI agent. AI
+agents are stateless — they forget everything between sessions — so developers and teams lose
+context, decisions, and hard-won knowledge constantly. Claude-Mem captures agent activity at the
+harness layer, compresses it into structured observations using an LLM, and injects relevant
+memories into future sessions automatically. It works across 9+ agent harnesses and 28 languages,
+is open-source (Apache-2.0), and includes a multi-tenant server for team/org shared memory with a
+compliance-grade audit chain.
+
+## What is the defensible technology / what's hard about it?
+
+- **Harness-layer capture:** invisible, complete capture via lifecycle hooks — not an API the
+  user must call. Requires deep integration across many agent runtimes.
+- **AI compression + progressive disclosure:** distilling raw activity into typed, searchable
+  observations and a 3-layer retrieval pattern (~10x token savings).
+- **Multi-tenant memory substrate:** Postgres + queue-backed generation with a full per-event
+  identity triad (api_key × actor × request) and audit logs — the basis for team/enterprise and
+  for trustworthy, attributable AI memory.
+- **Distribution moat:** 77k+ stars and an active install base are hard to replicate.
+
+## Market & scalability
+
+Wedge: developers using AI coding agents (millions, fast-growing). Expansion: team/org shared
+memory, then a general agent-memory infrastructure layer. The AI-agent-memory category (Mem0,
+Supermemory, Zep, Letta) is forming now; massively scalable as a software/infra layer with
+PLG + enterprise motion.
+
+## Traction & validation
+
+- 77,854 GitHub stars, 6,706 forks in ~9 months, zero paid marketing.
+- Trendshift feature; "Awesome Claude Code" listing; active Discord.
+- Distributed via npx, plugin marketplace, npm; shipping continuously (v13.x).
+- `[FILL IN: downloads, active installs, community size, growth rates, any design partners.]`
+
+## Proposed 90-day objectives (CDL is objective-driven — make these measurable)
+
+`[FILL IN / refine — examples:]`
+1. Ship the commercial team product (shared memory + billing) and onboard `[N]` paying teams.
+2. Reach `[X]` weekly active installs / `[Y]` npm weekly downloads (measurable growth target).
+3. Sign `[N]` enterprise design partners for SSO/audit/compliance features.
+4. Hire `[role(s)]` to support the commercial motion.
+5. Define pricing and validate willingness-to-pay with `[N]` customer conversations.
+
+## Team
+
+Alex Newman — founder, creator, primary author; built the full technical stack solo. `[FILL IN:
+technical credibility, founder-market fit from 00-founder-bio.md, advisors, hiring plan.]`
+
+## Why CDL?
+
+`[FILL IN: which CDL mentors/site, what coaching you want (commercialization of open-source infra,
+enterprise GTM, fundraising), and why equity-free objective-based mentorship fits your stage.]`
+
+## Business model
+
+Open-core: free Apache-2.0 core for adoption; revenue from team plans and enterprise (SSO/SAML/
+SCIM, RBAC, audit-log UI, DLP, hosted cloud, SLA). See `00-company-dossier.md` §9.

--- a/applications/gener8tor.md
+++ b/applications/gener8tor.md
@@ -1,0 +1,75 @@
+# gener8tor — Application
+
+- **Portal:** https://www.gener8tor.com/apply (@gener8tor)
+- **Profile:** rolling programs across 45+ cities / 20+ states. Concierge, mentorship-driven
+  accelerator (gBETA is free/equity-free; the flagship accelerator is investment + equity).
+  Strong regional networks.
+- **Source of facts:** `00-company-dossier.md`. Verify live numbers and pick the program/city.
+
+> gener8tor is mentorship-heavy and regional. Pick the right program (gBETA vs. flagship
+> accelerator) and city, and be concrete about traction and what mentorship you need.
+
+---
+
+## Program selection
+
+- **Program:** `[FILL IN — gBETA (free, equity-free) or gener8tor accelerator (investment +
+  equity)]`
+- **City / location:** `[FILL IN]`
+
+## Company
+
+- **Company:** Claude-Mem
+- **Website / repo:** https://docs.claude-mem.ai · https://github.com/thedotmack/claude-mem
+- **One-liner:** Persistent memory for every AI coding agent.
+- **Founder:** Alex Newman (thedotmack@gmail.com) · **Location:** `[FILL IN]`
+- **Stage:** Pre-seed; open-source with 77k+ stars; pre-revenue, commercial layer in development.
+
+## What does your company do?
+
+Claude-Mem is a persistent memory layer for AI coding agents. Agents forget everything between
+sessions, so developers re-explain their codebase and lose context constantly. Claude-Mem captures
+agent activity automatically, compresses it into structured observations with an LLM, and injects
+relevant memory into future sessions. Open-source (Apache-2.0); runs across 9+ agents and 28
+languages; includes a multi-tenant server for team/org shared memory.
+
+## Problem, market, why now
+
+Stateless agents waste developer time and lose team knowledge. AI coding adoption is exploding,
+the standards to build a neutral memory layer just shipped, and no one owns the cross-agent open
+memory layer yet. Category forming now (Mem0, Supermemory, Zep, Letta); we have the distribution
+lead.
+
+## Traction
+
+- 77,854 GitHub stars, 6,706 forks (~9 months, zero paid marketing); Trendshift feature.
+- Distributed via npx, plugin marketplace, npm; active Discord.
+- Multi-tenant team/enterprise server merged and in beta.
+- `[FILL IN: downloads, active installs, community size, growth rates.]`
+
+## Business model
+
+Open-core PLG: free core for adoption → team plans (per seat) → enterprise (SSO/RBAC/audit, hosted
+cloud, SLA).
+
+## Competition / differentiation
+
+Mem0, Supermemory, Zep, Letta, and native memory in coding tools. We win on zero-config
+harness-layer capture, cross-agent neutrality, a 77k-star distribution moat, and a built team/
+enterprise substrate.
+
+## Team
+
+Alex Newman — founder, creator, primary author; built the full stack solo. `[FILL IN: bio,
+founder-market fit, hiring plan from 00-founder-bio.md.]`
+
+## What do you want from gener8tor?
+
+`[FILL IN: mentorship for commercializing open-source infra, GTM for the team product,
+investor introductions in the region, and first commercial hires. Tie to the chosen program/city
+and gener8tor's concierge model.]`
+
+## Funding
+
+- **Raised to date:** `[FILL IN — likely none/bootstrapped]`
+- **Raising:** `[FILL IN]`

--- a/applications/pear-vc.md
+++ b/applications/pear-vc.md
@@ -1,0 +1,86 @@
+# Pear VC — PearX Application
+
+- **Portal:** https://pear.vc/pearx/ (apply via the PearX page)
+- **Cadence:** 2 batches/year, in person in SF. The post notes S26 kicks off July.
+- **Profile:** seed-stage; Pear backs very early, technical founders and is hands-on.
+- **Source of facts:** `00-company-dossier.md`. Verify live numbers before submit.
+
+> Pear weighs founder quality, a real wedge, and early signal. Be concrete about traction and
+> the path from open-source adoption to revenue.
+
+---
+
+## Company basics
+
+- **Company:** Claude-Mem
+- **Website / repo:** https://docs.claude-mem.ai · https://github.com/thedotmack/claude-mem
+- **One-liner:** Persistent memory for every AI coding agent.
+- **Location:** `[FILL IN]`
+- **Stage:** Pre-seed; open-source with massive adoption, pre-revenue.
+- **Founder:** Alex Newman (thedotmack@gmail.com)
+
+## What does your company do?
+
+Claude-Mem is a persistent memory layer for AI coding agents. AI agents like Claude Code,
+Cursor, and Copilot start every session with no memory of the last one, so developers constantly
+re-explain their codebase and re-paste context. Claude-Mem hooks into the agent's lifecycle,
+captures everything it does, compresses that into structured observations with an LLM, and
+injects the relevant context into future sessions — automatically, with zero behavior change.
+It's open-source (Apache-2.0) and runs across 9+ agents and 28 languages.
+
+## What's the problem and why now?
+
+AI coding agents went mainstream in 2025, but they're stateless: context resets every session.
+Developers burn hours and tokens compensating manually. Bigger context windows are expensive and
+still reset; native memory is shallow and vendor-locked. Now is the moment because (1) agentic
+coding adoption is exploding, (2) the hook/MCP standards needed to build a neutral memory layer
+just shipped, and (3) no one owns the cross-agent, open memory layer yet. The first credible,
+widely-adopted one wins the category.
+
+## Why is this a big opportunity?
+
+Wedge: developers using AI coding agents — already millions, growing fast. Expansion: from one
+developer's memory → a team's shared memory (substrate already built) → the memory/context layer
+for *every* agent (coding, ops, autonomous). If agents are the new default interface, durable
+memory underneath them is infrastructure-scale. The AI-agent-memory category (Mem0, Supermemory,
+Zep, Letta) is forming right now; we have the distribution lead.
+
+## Traction
+
+- 77,854 GitHub stars, 6,706 forks in ~9 months (created Aug 2025), zero paid marketing.
+- Featured on Trendshift; listed in "Awesome Claude Code"; active Discord community.
+- Distributed via one-command `npx` install, the Claude Code plugin marketplace, and npm.
+- Shipping continuously (v13.x); multi-tenant team-memory server merged and in beta.
+- `[FILL IN: npm weekly downloads, install/active users, Discord size, WoW growth, any team/
+  enterprise waitlist or design partners.]`
+
+## Business model & path to revenue
+
+Open-core. Free OSS core fuels bottom-up adoption; revenue from team plans (shared memory, per
+seat) and enterprise (SSO/SAML/SCIM, RBAC, audit-log UI, DLP, hosted Magic Recall cloud, SLA).
+The team substrate (multi-tenant Postgres + audit chain) is engineered; commercial packaging is
+the next milestone. `[FILL IN: pricing hypothesis and first paid milestone.]`
+
+## Competition / why you win
+
+Mem0, Supermemory, Zep, Letta, plus native memory inside coding tools. We win on (1) zero-config
+harness-layer capture vs. API-you-must-call competitors, (2) cross-agent neutrality vs. siloed
+native memory, (3) a distribution moat of 77k+ stars, and (4) a built team/enterprise substrate
+with compliance-grade audit. Private team memory corpora compound — switching cost grows with use.
+
+## Team
+
+Alex Newman — founder, creator, primary author; built the full stack solo (hooks → worker →
+multi-tenant server → search → UI) and runs the community. `[FILL IN: founder-market-fit story
+from 00-founder-bio.md; co-founders or hiring plan; why you're the person to build this.]`
+
+## What do you need from Pear / why PearX?
+
+`[FILL IN: be specific — e.g., go-to-market for the team/enterprise product, first commercial
+hires, enterprise design-partner intros, and seed financing to convert massive OSS adoption into
+revenue. Mention Pear's hands-on, technical-founder support if it fits.]`
+
+## How much are you raising / use of funds?
+
+`[FILL IN — target round size and the milestones it buys: e.g., 12–18 months to ship the team
+product, land N paying teams, and validate enterprise.]`

--- a/applications/plug-and-play.md
+++ b/applications/plug-and-play.md
@@ -1,0 +1,77 @@
+# Plug and Play Tech Center — Application
+
+- **Portal:** https://www.plugandplaytechcenter.com/apply (@PlugandPlayTC)
+- **Profile:** rolling admissions; vertical/industry tracks; multiple locations; equity-light /
+  corporate-innovation network. Strong on enterprise/customer introductions via corporate
+  partners. Often no/low equity to join an accelerator cohort.
+- **Source of facts:** `00-company-dossier.md`. Verify live numbers before submit.
+
+> Plug and Play pairs startups with corporate partners. Emphasize enterprise applicability,
+> the team/org product, and which track you fit. Concrete traction and a clear ask matter.
+
+---
+
+## Company snapshot
+
+- **Company:** Claude-Mem
+- **Website / repo:** https://docs.claude-mem.ai · https://github.com/thedotmack/claude-mem
+- **One-liner:** Persistent memory for every AI coding agent.
+- **HQ / location:** `[FILL IN]`
+- **Founded:** 2025 · **Founder:** Alex Newman (thedotmack@gmail.com)
+- **Track / vertical:** Enterprise Tech / AI / Developer Infrastructure. `[FILL IN: confirm the
+  Plug and Play track you're applying to.]`
+- **Stage:** Pre-seed; open-source with 77k+ stars; pre-revenue, commercial layer in development.
+
+## What does your company do?
+
+Claude-Mem is a persistent memory layer for AI coding agents. Agents like Claude Code, Cursor,
+and Copilot forget everything between sessions, so developers and teams constantly lose context.
+Claude-Mem captures agent activity at the harness layer, compresses it into structured
+observations with an LLM, and injects relevant memory into future sessions — automatically, with
+no behavior change. It's open-source, runs across 9+ agents and 28 languages, and includes a
+multi-tenant server for team/org shared memory with a compliance-grade audit chain.
+
+## Problem & solution
+
+Problem: stateless agents → lost context, wasted developer time, and tacit team knowledge that
+evaporates. Solution: an automatic, cross-agent memory layer; for enterprises, a shared,
+auditable team-memory substrate (every observation attributable to an api key × actor × request,
+with tenant isolation and `<private>`-tag edge redaction).
+
+## Why it matters to enterprises (relevant to corporate partners)
+
+- Onboarding: new hires query the team's lived knowledge instead of stale docs.
+- Compliance: every AI-written memory is attributable and revocable — audit-ready.
+- Cost & quality: less re-explaining, better agent output, knowledge that compounds across the org.
+- Self-hostable open-core core; SSO/SAML/SCIM, RBAC, audit UI, DLP in the enterprise tier.
+
+## Traction
+
+- 77,854 GitHub stars, 6,706 forks (~9 months, zero paid marketing); Trendshift feature.
+- Distributed via npx, the Claude Code plugin marketplace, and npm; active Discord.
+- Multi-tenant team/enterprise server merged and in beta.
+- `[FILL IN: downloads, active installs, community size, growth, design partners.]`
+
+## Business model
+
+Open-core PLG: free Apache-2.0 core for adoption → team plans (shared memory, per seat) →
+enterprise (SSO/SAML/SCIM, RBAC, audit-log UI, DLP, hosted cloud, SLA).
+
+## Competition / differentiation
+
+Mem0, Supermemory, Zep, Letta, plus native memory in coding tools. We differentiate on
+zero-config harness-layer capture, cross-agent neutrality, a 77k-star distribution moat, and a
+built enterprise-grade team substrate.
+
+## Funding & ask
+
+- **Raised to date:** `[FILL IN — likely none/bootstrapped]`
+- **Raising:** `[FILL IN]`
+- **What we want from Plug and Play:** enterprise customer/design-partner introductions through
+  your corporate partner network, GTM support for the team/enterprise product, and pilot
+  opportunities with partners who run large engineering orgs. `[Refine.]`
+
+## Team
+
+Alex Newman — founder, creator, primary author (built the full stack solo). `[FILL IN: bio,
+founder-market fit, hiring plan from 00-founder-bio.md.]`

--- a/applications/south-park-commons.md
+++ b/applications/south-park-commons.md
@@ -1,0 +1,68 @@
+# South Park Commons (SPC) — Founder Fellowship Application
+
+- **Portal:** https://www.southparkcommons.com/founder-fellowship (@southpkcommons)
+- **Profile:** pre-idea / frontier-tech, rolling. SPC backs exceptional people *before* (or right
+  at) the idea stage — the "zero-to-one" community. The Founder Fellowship gives early capital +
+  a dense technical community. Application is person- and exploration-centric.
+- **Source of facts:** `00-company-dossier.md` and `00-founder-bio.md`. Verify live numbers.
+
+> SPC selects for the *person* and the *thinking* — depth, curiosity, and a genuine edge in a
+> frontier area. You're past pre-idea (you have a hit OSS project), so position Claude-Mem as the
+> beachhead of a larger frontier thesis about agent memory, and lead with your unique insight.
+
+---
+
+## About you
+
+- **Name:** Alex Newman · **Contact:** thedotmack@gmail.com · @thedotmack · X @Claude_Memory
+- **Location:** `[FILL IN]`
+- **Current status:** `[FILL IN — full-time on this? available when?]`
+
+**Who are you and what's your edge?**
+`[FILL IN from 00-founder-bio.md: background + the specific technical edge.]` Proof of edge: I
+built Claude-Mem — an open-source memory layer for AI agents — from zero to 77k+ GitHub stars in
+nine months, solo, with no paid marketing, spanning 9+ agent harnesses and a multi-tenant
+enterprise substrate. I both build deep systems and earn developer trust at scale.
+
+## What frontier are you exploring?
+
+**Memory and continuity for AI agents.** Today's agents are brilliant and amnesiac — they reset
+every session, can't accumulate experience, and can't share what they learn across people, tools,
+or time. I believe the next unlock for agents isn't a bigger model, it's **durable, attributable,
+shared memory** — the substrate that lets agents (and the humans working with them) compound
+knowledge. Claude-Mem is my beachhead: start with the coding agent's own memory, expand to a
+team's shared brain, and end as the neutral memory layer every agent plugs into.
+
+## Why is this non-obvious / what do you understand that others don't?
+
+- Memory belongs at the **harness layer**, captured invisibly — not as an API users must
+  remember to call. That's why adoption requires zero behavior change.
+- The hard, valuable part isn't storage; it's **compression into attributable, searchable
+  observations** and the **trust substrate** (identity triad + audit chain) that makes teams
+  willing to let AI write to shared memory.
+- The category will be won by the **neutral, open** layer with distribution — not by any single
+  tool's siloed feature. I have the distribution lead.
+
+## What have you built / traction
+
+- 77,854 GitHub stars, 6,706 forks (~9 months, zero paid marketing); Trendshift feature.
+- Cross-agent (9+ harnesses), 28 languages; distributed via npx, plugin marketplace, npm.
+- Multi-tenant team/enterprise memory server merged and in beta.
+- `[FILL IN: downloads, active installs, community size, growth.]`
+
+## Where could this go (the ambition)
+
+The memory/context infrastructure layer for all AI agents — coding, ops, support, autonomous.
+If agents become the default computing interface, the durable memory underneath them is one of
+the most important and defensible layers in the stack. `[FILL IN: your 10-year version of this.]`
+
+## Why SPC?
+
+`[FILL IN: the community of technical peers, permission to think at frontier scope, early capital,
+and zero-to-one support as you turn a beloved OSS project into a category-defining company. Be
+authentic about what you'd get from the SPC network.]`
+
+## Logistics
+
+- Co-founder status: `[FILL IN — solo + open to co-founder, or existing team]`
+- Able to engage with the SPC community (SF / NYC): `[FILL IN]`

--- a/applications/techstars.md
+++ b/applications/techstars.md
@@ -1,0 +1,76 @@
+# Techstars — Application
+
+- **Portal:** https://www.techstars.com/apply (@Techstars)
+- **Profile:** rolling; 6+ cities + remote (next deadlines ~June per the post). Mentorship-driven,
+  3-month program; standard deal is investment for equity. Famous for "mentorship-driven" and a
+  heavy emphasis on **team**.
+- **Source of facts:** `00-company-dossier.md`. Verify live numbers; pick the program/city.
+
+> Techstars' #1 selection criterion is the team ("Team, Team, Team, Market, Product, Traction,
+> Idea" — roughly in that order). Make the founder story and execution velocity central.
+
+---
+
+## Program selection
+
+- **Program / city:** `[FILL IN — pick the most relevant Techstars program, e.g., an AI / dev-tools
+  program, or remote.]`
+
+## Company
+
+- **Company:** Claude-Mem
+- **Website / repo:** https://docs.claude-mem.ai · https://github.com/thedotmack/claude-mem
+- **One-liner:** Persistent memory for every AI coding agent.
+- **Founder:** Alex Newman (thedotmack@gmail.com) · **Location:** `[FILL IN]`
+- **Stage:** Pre-seed; open-source with 77k+ stars; pre-revenue, commercial layer in development.
+
+## Team (lead with this for Techstars)
+
+Alex Newman — founder, creator, and primary author. Built the entire product solo: lifecycle
+hooks, the async LLM compression worker, a multi-tenant Postgres/queue server, hybrid vector +
+FTS search, MCP tooling, and a React viewer — then distributed it to 77k+ GitHub stars with zero
+paid marketing in nine months. This is direct evidence of rare full-stack-plus-distribution
+execution. `[FILL IN: prior experience, founder-market fit from 00-founder-bio.md; co-founders or
+explicit solo-founder stance + hiring plan — Techstars will probe team depth, so address it
+head-on.]`
+
+## What does your company do?
+
+Claude-Mem is a persistent memory layer for AI coding agents. Agents forget everything between
+sessions; Claude-Mem captures their activity automatically, compresses it into structured
+observations with an LLM, and injects relevant memory into future sessions. Open-source, runs
+across 9+ agents and 28 languages, with a multi-tenant server for team/org shared memory.
+
+## Market
+
+Wedge: AI-coding-agent users (millions, fast-growing). Expansion: team/org shared memory → the
+memory layer for every agent. Category forming now (Mem0, Supermemory, Zep, Letta); infrastructure-
+scale if agents become the default interface.
+
+## Product & traction
+
+- 77,854 GitHub stars, 6,706 forks (~9 months, zero paid marketing); Trendshift feature.
+- Distributed via npx, plugin marketplace, npm; active Discord; shipping continuously (v13.x).
+- Multi-tenant team/enterprise server merged and in beta.
+- `[FILL IN: downloads, active installs, community size, growth, any paying/waitlisted teams.]`
+
+## Business model
+
+Open-core PLG: free core → team plans (per seat) → enterprise (SSO/RBAC/audit, hosted cloud, SLA).
+
+## Competition / why you win
+
+Mem0, Supermemory, Zep, Letta, and native memory in coding tools. We win on zero-config
+harness-layer capture, cross-agent neutrality, a 77k-star distribution moat, and a built team/
+enterprise substrate.
+
+## Why Techstars / what you need
+
+`[FILL IN: mentorship to commercialize OSS infra, GTM + first commercial hires, investor network
+for the seed round, and the specific program/city. Techstars wants to know you're coachable and
+will use the network.]`
+
+## Funding
+
+- **Raised to date:** `[FILL IN — likely none/bootstrapped]`
+- **Raising:** `[FILL IN]`

--- a/applications/y-combinator-s26.md
+++ b/applications/y-combinator-s26.md
@@ -1,0 +1,154 @@
+# Y Combinator — Summer 2026 (S26) Application
+
+- **Portal:** https://www.ycombinator.com/apply
+- **Deadline:** extended to **May 25th** (apply this weekend). S26 batch context.
+- **Format:** online form + a 1-minute founder video (record after drafting).
+- **Source of facts:** `00-company-dossier.md`. Verify live star/metric numbers before submit.
+
+> YC values: clear thinking, real traction, and founders who ship. Keep answers blunt,
+> specific, and number-driven. Drop adjectives; lead with evidence. Edit my `[FILL IN]`s.
+
+---
+
+## Company
+
+**Company name:** Claude-Mem
+
+**Company URL:** https://github.com/thedotmack/claude-mem (docs: https://docs.claude-mem.ai)
+
+**Demo video / product:** `[FILL IN: link to a 1–2 min screen recording of install → memory
+recall. The README GIF (docs/public/cm-preview.gif) is a starting point.]`
+
+**What is your company going to make? (one sentence)**
+Claude-Mem is a persistent memory layer for AI coding agents — it automatically captures what
+the agent does, compresses it with AI, and injects the relevant context back into future
+sessions, so the agent stops forgetting your project.
+
+**Describe what your company does in 50 characters or less.**
+Persistent memory for AI coding agents.
+
+---
+
+## The idea
+
+**Why did you pick this idea to work on? Do you have domain expertise? How do you know people
+need what you're making?**
+Every AI coding agent starts each session with total amnesia — the context you built yesterday
+is gone, so you re-explain your codebase, re-paste decisions, and repeat yourself constantly. I
+live in these tools daily and felt the pain acutely, so I built the fix at the harness layer
+(hooks), where capture can be invisible and complete. People need it: with zero paid marketing,
+Claude-Mem hit 77k+ GitHub stars and 6.7k+ forks in nine months, was featured on Trendshift,
+and developers run it across 9+ agent harnesses. `[FILL IN: your specific domain expertise —
+prior infra/dev-tools work that proves you can build and ship this.]`
+
+**What's new about what you're making? What substitutes do people resort to?**
+New: capture at the harness/lifecycle layer (not an API the user has to call), AI *compression*
+into typed, searchable observations (not raw transcript dumps), and a token-efficient 3-layer
+progressive-disclosure search (~10x token savings). Substitutes today: bigger/more expensive
+context windows that still reset; hand-maintained `CLAUDE.md`/rules files; copy-pasting context
+every session; or shallow, vendor-locked native "memory." None work across tools or teams; we
+do, across 9+ agents and 28 languages, open-source.
+
+**Who are your competitors, and who might become competitors? Who do you fear most?**
+Direct: Mem0, Supermemory, Zep, Letta/MemGPT. Potential: native memory built into Cursor,
+Copilot, Claude Code, etc. We fear the platform vendors most — but their memory will be siloed
+to their own tool, while our wedge is cross-agent neutrality, an open ecosystem, and team/
+enterprise depth (shared memory + compliance-grade audit) that single-tool vendors won't
+prioritize. Distribution (77k+ stars) is a real head start.
+
+---
+
+## Progress
+
+**How far along are you?**
+Live and widely used. v13.x shipping continuously; 77k+ stars, 6.7k+ forks; published on npm
+and the Claude Code plugin marketplace; one-command install. The single-user product is mature.
+A multi-tenant team-memory server (Postgres + BullMQ/Valkey, full per-event identity triad and
+audit chain) is merged and in beta — the foundation of the paid product.
+
+**How long have you been working on this? How many full-time, part-time?**
+Since August 2025 (~9 months). `[FILL IN: full-time/part-time, team size — and if solo, say so
+plus your hiring plan.]`
+
+**Are people using your product? How many active users/customers? Are you growing? How much?**
+Yes — distributed via npx, the plugin marketplace, and npm, with an active Discord community.
+`[FILL IN — CRITICAL: npm weekly downloads, install/active counts, marketplace installs,
+week-over-week star and download growth. YC weighs this most; put real numbers here.]`
+
+**Do you have revenue? How much?**
+Pre-revenue. The open-source core drives adoption (top of funnel); the commercial layer
+(hosted Magic Recall cloud, team memory sync, SSO/RBAC, audit UI, enterprise) is in development.
+`[FILL IN: any waitlist, design-partner, or LOI signal for the team/enterprise product.]`
+
+**If you've applied or been part of YC before, how has it changed since?**
+`[FILL IN — likely "N/A, first time applying" or note prior progress.]`
+
+---
+
+## Tech & business
+
+**Tech stack:** TypeScript, Bun, Node ≥20. SQLite (single-user) → Postgres + BullMQ/Valkey
+(multi-tenant server). Chroma vector DB for semantic search; FTS5 for keyword. Express HTTP API,
+React viewer UI. Built on the Claude Agent SDK and MCP.
+
+**How will you make money? How big could the company be?**
+Open-core PLG: free OSS core drives bottom-up adoption → paid team plans (shared memory, per
+seat) → enterprise (SSO/SAML/SCIM, RBAC, audit-log UI, DLP, managed cloud, SLA). The wedge is
+the fastest-growing developer category (AI coding agents, already millions of users); the
+expansion is the memory/context layer for *every* agent. If agents are the new default
+interface, the durable memory layer underneath them is infrastructure-scale.
+
+**Where do you live now, and where would the company be based after YC?**
+`[FILL IN — current location; YC expects in-person in the Bay Area during the batch.]`
+
+---
+
+## Founders
+
+**Founder(s) and roles:** Alex Newman — founder, creator, primary author. `[FILL IN: co-founders
+if any; if solo, state it and your plan to hire.]`
+
+**Founder bio (paste from `00-founder-bio.md`, ~100-word version, with your `[FILL IN]`s done).**
+
+**How do the founders know each other / how long?** `[FILL IN, or N/A if solo.]`
+
+**Who writes code, or does other technical work? Did any of you take an unusual route to
+where you are now?** Alex builds the product end-to-end (hooks, worker, multi-tenant server,
+search, UI). `[FILL IN: unusual-route story — YC loves these.]`
+
+---
+
+## Equity & legal
+
+- **Have you incorporated?** `[FILL IN]`
+- **Cap table / prior funding:** `[FILL IN — likely none/bootstrapped]`
+- **Equity split among founders:** `[FILL IN]`
+
+---
+
+## Anything else / what do you understand that others don't?
+
+We understand that **memory, not model size, is the next bottleneck for agents** — and that the
+right place to solve it is the harness layer, invisibly, so adoption requires zero behavior
+change. We've proven the demand (77k+ stars, no paid marketing) and already built the team-scale
+substrate that turns a beloved dev tool into enterprise infrastructure. The hard part — earning
+millions of developers' trust to sit underneath their agents — is the part we've already started
+winning.
+
+---
+
+## 1-minute founder video — script (record after editing)
+
+> YC asks for a ~1 minute video of the founder(s) talking to the camera. Be natural, fast, and
+> specific. Rough script (~150 words ≈ 60s):
+
+"Hi YC, I'm Alex Newman, founder of Claude-Mem. Every AI coding agent — Claude Code, Cursor,
+Copilot — forgets everything the moment a session ends. So developers waste hours every week
+re-explaining their own codebase to the agent. Claude-Mem fixes that. You install it with one
+command, you work normally, and it quietly captures everything the agent does, compresses it
+with AI, and feeds the right context back into your next session. The agent just... remembers.
+I shipped it nine months ago. With zero paid marketing it's at 77,000+ GitHub stars, it works
+across nine different coding agents, and I've already built the multi-tenant server for team
+and enterprise memory — which is how we make money. Memory, not model size, is the next
+bottleneck for AI agents, and we're the open layer everyone's already installing. `[FILL IN:
+one sentence on why you're the person to build this.]` Thanks for watching."


### PR DESCRIPTION
## Summary

Ready-to-submit application materials for the accelerators/VCs in the "YC extended S26 + save these too" post, tailored to Claude-Mem and Alex Newman (@thedotmack). Adds a new `applications/` folder.

- **Shared, reusable source of truth** so facts are maintained once:
  - `00-company-dossier.md` — one-liners, problem, solution, traction, market, business model, competition, vision, risks, quick-reference table
  - `00-founder-bio.md` — bio variants (1 sentence → 100 words → founder-market-fit paragraph)
- **One tailored application per program** (10): Y Combinator S26 (with 1-min founder video script), Pear VC, Creative Destruction Lab, Antler, Plug and Play, Alchemist, gener8tor, 500 Global, Techstars, South Park Commons
- **`README.md`** index with portals, cadence/deadlines, a positioning cheat-sheet (which program weights team vs. traction vs. founder vs. B2B), and a one-time pre-submission checklist

Each program file is positioned to that program's actual selection criteria (e.g. Alchemist → B2B/enterprise + audit substrate; Techstars → team-first; Antler/SPC → founder/frontier-thesis; CDL → equity-free + measurable 90-day objectives).

## Notes before submitting
- Every file contains clearly-marked `[FILL IN]` placeholders for details I can't source (location, full bio, co-founder/hiring status, incorporation, revenue/downloads/active installs, amount raising).
- **Verify live numbers** on submission day — GitHub stars/forks/downloads change daily. Snapshot used: 77,854 stars / 6,706 forks (Apache-2.0, TypeScript, created Aug 2025).
- **$CMEM token:** recommend omitting from VC applications unless directly asked (see dossier §13).
- Only YC's deadline (May 25) is fixed by the source post; confirm each portal URL and deadline before applying.

## Test plan
- [ ] Fill in all `[FILL IN]` placeholders in the two `00-*` shared files
- [ ] Verify live metrics the day of submission
- [ ] Record the YC 1-minute founder video from the included script
- [ ] Paste each program's answers into its portal and submit

https://claude.ai/code/session_01Lechbu2Yq3X6sNAtXXnrba

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lechbu2Yq3X6sNAtXXnrba)_