### PR TITLE
fix(setup): auto-install plugin dependencies at Setup phase (2649)

### DIFF
--- a/plugin/scripts/version-check.js
+++ b/plugin/scripts/version-check.js
@@ -1,7 +1,111 @@
 #!/usr/bin/env node
+import { spawnSync } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
+import { homedir } from 'os';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+
+const IS_WINDOWS = process.platform === 'win32';
+const VERSION_CHECK_LOG_PREFIX = '[version-check]';
+const BUN_INSTALL_ARGS = Object.freeze(['install', '--production']);
+const BUN_INSTALL_TIMEOUT_MS = 120_000;
+const NODE_MODULES_DIRNAME = 'node_modules';
+
+function findBun() {
+  const pathCheck = IS_WINDOWS
+    ? spawnSync('where bun', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], shell: true })
+    : spawnSync('which', ['bun'], { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+
+  if (pathCheck.status === 0 && pathCheck.stdout.trim()) {
+    if (IS_WINDOWS) {
+      const bunCmdPath = pathCheck.stdout.split('\n').find((line) => line.trim().endsWith('bun.cmd'));
+      if (bunCmdPath) return bunCmdPath.trim();
+    }
+    return 'bun';
+  }
+
+  const bunPaths = IS_WINDOWS
+    ? [join(homedir(), '.bun', 'bin', 'bun.exe')]
+    : [
+        join(homedir(), '.bun', 'bin', 'bun'),
+        '/usr/local/bin/bun',
+        '/opt/homebrew/bin/bun',
+        '/home/linuxbrew/.linuxbrew/bin/bun',
+      ];
+
+  for (const bunPath of bunPaths) {
+    if (existsSync(bunPath)) return bunPath;
+  }
+
+  return null;
+}
+
+// Setup-phase auto-install of plugin runtime dependencies.
+//
+// The plugin marketplace extracts files into ~/.claude/plugins/cache/...
+// but does not run `bun install`. On fresh installs the worker crashes
+// with `Cannot find module 'zod/v3'` on the very first hook invocation
+// (gh #2640, #2637). The previous defense-in-depth fix (gh #2644) ran
+// the install on the SessionStart / UserPromptSubmit hot path; review
+// (gh #2649 — YOMXXX) flagged that as the wrong architectural home
+// because it makes proxy / offline / OOM failures land on the user's
+// first prompt instead of at install time.
+//
+// Running it here at Setup keeps the install off the hot path: Setup
+// has a 300s timeout (vs 60s for SessionStart), runs once per Claude
+// Code launch, and is the only standalone hook script — the natural
+// place to materialise plugin runtime state.
+function ensurePluginDependencies(pluginRoot) {
+  if (!existsSync(join(pluginRoot, 'package.json'))) return;
+
+  // Guard on node_modules (package-manager marker) rather than a specific
+  // package, so the check stays correct if dependencies are later renamed.
+  if (existsSync(join(pluginRoot, NODE_MODULES_DIRNAME))) return;
+
+  const bunPath = findBun();
+  if (!bunPath) {
+    console.error(`${VERSION_CHECK_LOG_PREFIX} bun not found on PATH; cannot auto-install plugin dependencies`);
+    return;
+  }
+
+  // Progress diagnostic so users understand the (one-time) Setup hang.
+  console.error(`${VERSION_CHECK_LOG_PREFIX} installing plugin dependencies (first run, one-time)...`);
+
+  let result;
+  try {
+    result = spawnSync(bunPath, BUN_INSTALL_ARGS, {
+      cwd: pluginRoot,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: BUN_INSTALL_TIMEOUT_MS,
+      windowsHide: true,
+    });
+  } catch (err) {
+    const reason = err && err.message ? err.message : String(err);
+    console.error(`${VERSION_CHECK_LOG_PREFIX} bun install threw (${reason}); worker may crash with missing module errors`);
+    return;
+  }
+
+  // spawnSync does NOT throw on a failed child. Three distinct failure
+  // modes must be surfaced explicitly:
+  //   1. result.error set (ENOENT / ETIMEDOUT / ...)
+  //   2. non-zero exit code
+  //   3. signal-killed (OOM SIGKILL, SIGTERM, ...) where result.status is
+  //      null AND result.error is undefined — only result.signal is set.
+  const killedBySignal = result.status === null && !!result.signal;
+  const nonZeroExit = result.status !== null && result.status !== 0;
+  if (result.error || nonZeroExit || killedBySignal) {
+    let reason;
+    if (result.error) {
+      reason = result.error.message;
+    } else if (killedBySignal) {
+      reason = `killed by ${result.signal}`;
+    } else {
+      reason = `exit ${result.status}`;
+    }
+    console.error(`${VERSION_CHECK_LOG_PREFIX} bun install failed (${reason}); worker may crash with missing module errors`);
+  }
+}
 
 function resolveRoot() {
   if (process.env.CLAUDE_PLUGIN_ROOT) {
@@ -18,6 +122,8 @@ function resolveRoot() {
 
 const ROOT = resolveRoot();
 if (!ROOT) process.exit(0);
+
+ensurePluginDependencies(ROOT);
 
 function emitUpgradeHint(message) {
   if (process.env.CLAUDE_MEM_CODEX_HOOK === '1') {

--- a/plugin/scripts/version-check.js
+++ b/plugin/scripts/version-check.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from 'child_process';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, rmSync } from 'fs';
 import { homedir } from 'os';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -104,6 +104,24 @@ function ensurePluginDependencies(pluginRoot) {
       reason = `exit ${result.status}`;
     }
     console.error(`${VERSION_CHECK_LOG_PREFIX} bun install failed (${reason}); worker may crash with missing module errors`);
+    // `bun install` often creates `node_modules/` BEFORE the failure point
+    // (network timeout mid-fetch, OOM kill, registry 5xx after partial
+    // resolution). The existence guard above would then permanently skip
+    // retry on every subsequent Setup run, leaving the plugin broken with
+    // no recovery path short of manual `rm -rf node_modules`. Remove the
+    // partial dir so the next Setup invocation can retry automatically
+    // (gh #2650 review).
+    try {
+      rmSync(join(pluginRoot, NODE_MODULES_DIRNAME), { recursive: true, force: true });
+    } catch (rmErr) {
+      const rmReason = rmErr && rmErr.message ? rmErr.message : String(rmErr);
+      console.error(`${VERSION_CHECK_LOG_PREFIX} failed to clean up partial node_modules (${rmReason}); next Setup run may skip retry`);
+    }
+  } else {
+    // Close the diagnostic loop: a Setup hook that can block for up to
+    // 120s needs an explicit completion line so users can distinguish a
+    // hung install from one that finished silently (gh #2650 review).
+    console.error(`${VERSION_CHECK_LOG_PREFIX} plugin dependencies installed successfully`);
   }
 }
 

--- a/tests/plugin-version-check-ensure-deps.test.ts
+++ b/tests/plugin-version-check-ensure-deps.test.ts
@@ -8,6 +8,8 @@ const REPO_ROOT = resolve(import.meta.dir, '..');
 const VERSION_CHECK_PATH = join(REPO_ROOT, 'plugin', 'scripts', 'version-check.js');
 const SPAWN_TIMEOUT_MS = 15_000;
 const INSTALL_DIAGNOSTIC = '[version-check] installing plugin dependencies';
+const INSTALL_SUCCESS_DIAGNOSTIC = '[version-check] plugin dependencies installed successfully';
+const INSTALL_FAILURE_DIAGNOSTIC = '[version-check] bun install failed';
 const FAKE_INSTALLED_MARKER_REL = join('node_modules', 'zod', 'v3', 'index.js');
 const SKIP_NON_UNIX = process.platform === 'win32';
 
@@ -58,7 +60,9 @@ function runVersionCheck(pluginRoot: string, fakeBinDir: string): Promise<{ stde
   });
 }
 
-function makeFreshPlugin(name: string): { pluginRoot: string; fakeBinDir: string } {
+type BunBehavior = 'success' | 'partial-then-fail';
+
+function makeFreshPlugin(name: string, bunBehavior: BunBehavior = 'success'): { pluginRoot: string; fakeBinDir: string } {
   const pluginRoot = join(tmpRoot, name);
   mkdirSync(pluginRoot, { recursive: true });
   writeFileSync(join(pluginRoot, 'package.json'), JSON.stringify({
@@ -71,16 +75,29 @@ function makeFreshPlugin(name: string): { pluginRoot: string; fakeBinDir: string
   const fakeBinDir = join(pluginRoot, '.bin');
   mkdirSync(fakeBinDir, { recursive: true });
 
-  // Fake bun: on `install --production`, simulate successful install by
-  // creating `node_modules/zod/v3/index.js` so the test can verify Setup
-  // actually invoked dependency installation (not just logged about it).
+  // Fake bun behaviors:
+  //   - success: creates the install marker file and exits 0 (happy path).
+  //   - partial-then-fail: creates the partial node_modules dir THEN exits
+  //     non-zero. Mirrors real bun's behavior under network timeout / OOM /
+  //     registry 5xx where node_modules already exists when the failure
+  //     surfaces. Required to cover the gh #2650 review-fix path that
+  //     cleans up the partial dir so the next Setup run can retry.
   const fakeBunPath = join(fakeBinDir, 'bun');
+  const installBody = bunBehavior === 'success'
+    ? [
+        `  mkdir -p "${pluginRoot}/node_modules/zod/v3"`,
+        `  : > "${pluginRoot}/node_modules/zod/v3/index.js"`,
+        '  exit 0',
+      ]
+    : [
+        `  mkdir -p "${pluginRoot}/node_modules"`,
+        '  echo "fake bun install failure mid-fetch" 1>&2',
+        '  exit 42',
+      ];
   const fakeBunScript = [
     '#!/usr/bin/env bash',
     'if [ "$1" = "install" ]; then',
-    `  mkdir -p "${pluginRoot}/node_modules/zod/v3"`,
-    `  : > "${pluginRoot}/node_modules/zod/v3/index.js"`,
-    '  exit 0',
+    ...installBody,
     'fi',
     'exit 0',
   ].join('\n') + '\n';
@@ -110,7 +127,30 @@ describe.skipIf(SKIP_NON_UNIX)('version-check Setup-phase ensurePluginDependenci
 
     expect(code).toBe(0);
     expect(stderr).toContain(INSTALL_DIAGNOSTIC);
+    expect(stderr).toContain(INSTALL_SUCCESS_DIAGNOSTIC);
     expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(true);
+  });
+
+  test('cleans up partial node_modules after a failed install so next Setup can retry (gh #2650 review)', async () => {
+    // Reproduces the Greptile review concern: `bun install` often creates
+    // the node_modules directory BEFORE it fails (mid-fetch network
+    // timeout, registry 5xx, OOM kill). Without explicit cleanup, the
+    // `existsSync(node_modules)` guard would permanently short-circuit
+    // every subsequent Setup run and the user has no recovery path short
+    // of a manual `rm -rf node_modules`. Verify that after a failed
+    // install the partial dir is removed.
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-partial-fail', 'partial-then-fail');
+
+    // Sanity-check the failure path: node_modules MUST exist before our
+    // cleanup runs (otherwise we are not exercising the gh #2650 scenario).
+    // Run version-check once and confirm both the failure diagnostic and
+    // the post-cleanup absence of node_modules.
+    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
+    expect(stderr).toContain(INSTALL_FAILURE_DIAGNOSTIC);
+    expect(stderr).toContain('exit 42');
+    expect(existsSync(join(pluginRoot, 'node_modules'))).toBe(false);
   });
 
   test('skips install when node_modules is already present', async () => {

--- a/tests/plugin-version-check-ensure-deps.test.ts
+++ b/tests/plugin-version-check-ensure-deps.test.ts
@@ -1,0 +1,131 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { spawn } from 'child_process';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+
+const REPO_ROOT = resolve(import.meta.dir, '..');
+const VERSION_CHECK_PATH = join(REPO_ROOT, 'plugin', 'scripts', 'version-check.js');
+const SPAWN_TIMEOUT_MS = 15_000;
+const INSTALL_DIAGNOSTIC = '[version-check] installing plugin dependencies';
+const FAKE_INSTALLED_MARKER_REL = join('node_modules', 'zod', 'v3', 'index.js');
+const SKIP_NON_UNIX = process.platform === 'win32';
+
+let tmpRoot: string;
+
+function runVersionCheck(pluginRoot: string, fakeBinDir: string): Promise<{ stderr: string; stdout: string; code: number | null }> {
+  return new Promise((resolveResult, reject) => {
+    const child = spawn(process.execPath, [VERSION_CHECK_PATH], {
+      cwd: pluginRoot,
+      env: {
+        ...process.env,
+        PATH: `${fakeBinDir}:${process.env.PATH ?? ''}`,
+        CLAUDE_PLUGIN_ROOT: pluginRoot,
+        CLAUDE_MEM_DATA_DIR: join(pluginRoot, '.claude-mem'),
+        CLAUDE_CONFIG_DIR: join(pluginRoot, '.claude'),
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stderr = '';
+    let stdout = '';
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    try {
+      child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+      child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+
+      child.stdin.end();
+
+      timer = setTimeout(() => {
+        try { child.kill('SIGKILL'); } catch {}
+        reject(new Error(`version-check subprocess exceeded ${SPAWN_TIMEOUT_MS}ms`));
+      }, SPAWN_TIMEOUT_MS);
+
+      child.on('close', (code) => {
+        if (timer) clearTimeout(timer);
+        resolveResult({ stderr, stdout, code });
+      });
+      child.on('error', (err) => {
+        if (timer) clearTimeout(timer);
+        reject(err);
+      });
+    } catch (err) {
+      if (timer) clearTimeout(timer);
+      try { child.kill('SIGKILL'); } catch {}
+      reject(err);
+    }
+  });
+}
+
+function makeFreshPlugin(name: string): { pluginRoot: string; fakeBinDir: string } {
+  const pluginRoot = join(tmpRoot, name);
+  mkdirSync(pluginRoot, { recursive: true });
+  writeFileSync(join(pluginRoot, 'package.json'), JSON.stringify({
+    name: 'fake-plugin',
+    version: '0.0.0',
+    dependencies: { zod: '^3.0.0' },
+  }));
+  writeFileSync(join(pluginRoot, '.install-version'), JSON.stringify({ version: '0.0.0' }));
+
+  const fakeBinDir = join(pluginRoot, '.bin');
+  mkdirSync(fakeBinDir, { recursive: true });
+
+  // Fake bun: on `install --production`, simulate successful install by
+  // creating `node_modules/zod/v3/index.js` so the test can verify Setup
+  // actually invoked dependency installation (not just logged about it).
+  const fakeBunPath = join(fakeBinDir, 'bun');
+  const fakeBunScript = [
+    '#!/usr/bin/env bash',
+    'if [ "$1" = "install" ]; then',
+    `  mkdir -p "${pluginRoot}/node_modules/zod/v3"`,
+    `  : > "${pluginRoot}/node_modules/zod/v3/index.js"`,
+    '  exit 0',
+    'fi',
+    'exit 0',
+  ].join('\n') + '\n';
+  writeFileSync(fakeBunPath, fakeBunScript);
+  chmodSync(fakeBunPath, 0o755);
+
+  return { pluginRoot, fakeBinDir };
+}
+
+beforeAll(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'version-check-deps-'));
+});
+
+afterAll(() => {
+  try { rmSync(tmpRoot, { recursive: true, force: true }); } catch {}
+});
+
+describe.skipIf(SKIP_NON_UNIX)('version-check Setup-phase ensurePluginDependencies (gh #2649)', () => {
+  test('installs plugin dependencies when node_modules is missing on fresh extract', async () => {
+    // This is the gh #2640 / #2637 scenario: marketplace extracts files but
+    // never runs `bun install`. Setup MUST detect the missing node_modules and
+    // invoke dependency installation, otherwise the next hook (SessionStart
+    // worker spawn) crashes with `Cannot find module 'zod/v3'`.
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-fresh');
+
+    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
+    expect(stderr).toContain(INSTALL_DIAGNOSTIC);
+    expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(true);
+  });
+
+  test('skips install when node_modules is already present', async () => {
+    // Setup runs on every Claude Code launch. If node_modules already exists,
+    // the install MUST be skipped — otherwise we re-run a 100 MB+ install on
+    // every cold start and burn the user's bandwidth.
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-already-installed');
+    mkdirSync(join(pluginRoot, 'node_modules'), { recursive: true });
+
+    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
+    expect(stderr).not.toContain(INSTALL_DIAGNOSTIC);
+    // The fake bun would have created zod/v3/index.js if invoked — its
+    // absence proves the install path was not taken.
+    expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(false);
+  });
+});

--- a/tests/plugin-version-check.test.ts
+++ b/tests/plugin-version-check.test.ts
@@ -26,6 +26,10 @@ describe('plugin/scripts/version-check.js install marker compatibility', () => {
     );
     mkdirSync(tempDir, { recursive: true });
     writeFileSync(join(tempDir, 'package.json'), JSON.stringify({ version: '12.4.4' }));
+    // Pre-create node_modules so version-check's Setup-phase dependency
+    // auto-install (gh #2649) short-circuits — these tests are about
+    // .install-version marker compatibility, not dependency materialisation.
+    mkdirSync(join(tempDir, 'node_modules'), { recursive: true });
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

Move the plugin-dependency auto-install (originally added in #2644 to fix #2640 / #2637) **off the SessionStart / UserPromptSubmit hot path** and into the Setup-phase `version-check.js` script.

Fixes 2649.

## Why

Reviewer feedback on #2644 (YOMXXX, tracked in 2649):

> Running dependency installation in the hook path changes the critical path for SessionStart/UserPromptSubmit, and it is exactly where corporate proxies, offline machines, permissions, and registry timeouts are most likely to make the failure harder to diagnose. […] Consider moving this to Setup/repair/build-time rather than every hook runner startup.

Setup is the right home:
- 300s timeout (vs 60s on SessionStart) — install has room to breathe under proxy / cold-cache conditions.
- Runs once per Claude Code launch, not per hook invocation.
- `version-check.js` is already the only standalone hook script — natural place to materialise plugin runtime state.

## What changed

- `plugin/scripts/version-check.js` — new `ensurePluginDependencies(ROOT)`:
  - Cheap `existsSync(node_modules)` guard short-circuits subsequent invocations.
  - All three `spawnSync` failure modes surfaced explicitly: `result.error` (ENOENT / ETIMEDOUT), non-zero exit, signal-killed (OOM SIGKILL, SIGTERM — where `status === null` AND `error === undefined`, only `signal` is set).
  - One-line progress diagnostic so users understand the (one-time) Setup hang.
- `tests/plugin-version-check-ensure-deps.test.ts` — new test covering the fresh-install install path and the skip-when-present path.
- `tests/plugin-version-check.test.ts` — `beforeEach` now pre-creates `node_modules` so existing marker-compat assertions (`stderr === ''`) are unaffected by the new Setup-phase install path.

## RED → GREEN proof (real test runs, captured to disk)

**RED — test against the unpatched `version-check.js`** (`/tmp/issue-2649-proof/RED.log`):

```
expect(received).toContain(expected)

Expected to contain: "[version-check] installing plugin dependencies"
Received: ""

(fail) version-check Setup-phase ensurePluginDependencies (gh #2649) > installs plugin dependencies when node_modules is missing on fresh extract

 1 pass
 1 fail
 5 expect() calls
```

**GREEN — same test against the patched `version-check.js`** (`/tmp/issue-2649-proof/GREEN.log`):

```
bun test v1.3.9 (cf6cdbbb)

 2 pass
 0 fail
 6 expect() calls
Ran 2 tests across 1 file. [148.00ms]
```

**Full-suite baseline preserved** (`/tmp/issue-2649-proof/full-suite-{BASELINE,GREEN-v2}.log`):

- Before fix: `1803 pass / 19 skip / 55 fail` (1877 tests)
- After fix:  `1805 pass / 19 skip / 55 fail` (1879 tests)
- Delta: +2 pass (new tests in this PR), 0 new fails, 0 regressions. The 55 pre-existing failures are unchanged.

## Test plan

- [x] New tests pass: `bun test tests/plugin-version-check-ensure-deps.test.ts`
- [x] Updated existing tests pass: `bun test tests/plugin-version-check.test.ts`
- [x] Full suite baseline unchanged (same 55 pre-existing failures, no new ones).
- [x] RED log + GREEN log persisted to disk (real, not simulated).

## Relationship to other open PRs

- #2610 — root packaging fix that inlines zod into the worker bundle. **Primary fix; should land first.**
- #2644 — original defense-in-depth fix that put auto-install on the hook hot path. **This PR moves the same logic to its correct architectural home.** Once this lands, #2644 can be closed (or trimmed to remove the hot-path duplication).