### PR TITLE
fix(windows): restore plugin runtime deps after auto-upgrade

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -6,6 +6,8 @@
   "type": "module",
   "dependencies": {
     "zod": "^4.3.6",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "tree-sitter-cli": "^0.26.5",
     "tree-sitter-c": "^0.24.1",
     "tree-sitter-cpp": "^0.23.4",

--- a/plugin/scripts/version-check.js
+++ b/plugin/scripts/version-check.js
@@ -1,7 +1,69 @@
 #!/usr/bin/env node
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, statSync, mkdirSync, writeFileSync, openSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { homedir } from 'os';
+import { spawn } from 'child_process';
+
+// Throttle window between detached auto-install attempts (install may still be
+// running, or it keeps failing — do not respawn every session).
+const DEPS_INSTALL_COOLDOWN_MS = 10 * 60 * 1000;
+
+function dataDir() {
+  return process.env.CLAUDE_MEM_DATA_DIR || join(homedir(), '.claude-mem');
+}
+
+// When the host auto-upgrades the plugin it creates a fresh version directory in the
+// plugin cache WITHOUT node_modules, so the worker and MCP server cannot resolve their
+// runtime deps (zod, ajv via @modelcontextprotocol/sdk, tree-sitter grammars, ...) and
+// claude-mem silently stops working until the user happens to run the install command.
+// Kick off a detached, throttled `bun install` to self-heal. This is a no-op when
+// node_modules already exists, so healthy installs are completely unaffected — it only
+// acts on the broken post-upgrade state.
+function ensureRuntimeDeps(root) {
+  try {
+    if (existsSync(join(root, 'node_modules'))) return; // healthy — nothing to do
+  } catch {
+    return;
+  }
+
+  const dir = dataDir();
+  const marker = join(dir, '.deps-install-attempted');
+  try {
+    if (existsSync(marker) && Date.now() - statSync(marker).mtimeMs < DEPS_INSTALL_COOLDOWN_MS) {
+      return;
+    }
+  } catch {}
+
+  try {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(marker, String(Date.now()));
+  } catch {
+    // If we cannot record the throttle marker, skip rather than risk a respawn loop.
+    return;
+  }
+
+  let out = 'ignore';
+  try {
+    out = openSync(join(dir, 'deps-install.log'), 'a');
+  } catch {}
+
+  try {
+    // shell:true lets the host PATH resolve `bun` (bun.cmd on Windows, bun on Unix).
+    // detached + unref keeps the Setup hook non-blocking; deps land within ~1 min.
+    const child = spawn('bun install', {
+      cwd: root,
+      detached: true,
+      shell: true,
+      windowsHide: true,
+      stdio: ['ignore', out, out],
+    });
+    child.on('error', () => {});
+    child.unref();
+  } catch {
+    // best-effort; the upgrade hint below still explains the manual recovery command.
+  }
+}
 
 function resolveRoot() {
   if (process.env.CLAUDE_PLUGIN_ROOT) {
@@ -18,6 +80,8 @@ function resolveRoot() {
 
 const ROOT = resolveRoot();
 if (!ROOT) process.exit(0);
+
+ensureRuntimeDeps(ROOT);
 
 function emitUpgradeHint(message) {
   if (process.env.CLAUDE_MEM_CODEX_HOOK === '1') {

--- a/plugin/scripts/version-check.js
+++ b/plugin/scripts/version-check.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, readFileSync, statSync, mkdirSync, writeFileSync, openSync } from 'fs';
+import { existsSync, readFileSync, statSync, mkdirSync, writeFileSync, openSync, closeSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { homedir } from 'os';
@@ -27,8 +27,10 @@ function ensureRuntimeDeps(root) {
     return;
   }
 
-  const dir = dataDir();
-  const marker = join(dir, '.deps-install-attempted');
+  // Scope the cooldown marker to this version directory (not the global data dir),
+  // so a second upgrade landing within the window still installs its own deps. `root`
+  // is writable — `bun install` writes node_modules into it below.
+  const marker = join(root, '.deps-install-attempted');
   try {
     if (existsSync(marker) && Date.now() - statSync(marker).mtimeMs < DEPS_INSTALL_COOLDOWN_MS) {
       return;
@@ -36,15 +38,16 @@ function ensureRuntimeDeps(root) {
   } catch {}
 
   try {
-    mkdirSync(dir, { recursive: true });
     writeFileSync(marker, String(Date.now()));
   } catch {
     // If we cannot record the throttle marker, skip rather than risk a respawn loop.
     return;
   }
 
+  const dir = dataDir();
   let out = 'ignore';
   try {
+    mkdirSync(dir, { recursive: true });
     out = openSync(join(dir, 'deps-install.log'), 'a');
   } catch {}
 
@@ -60,6 +63,10 @@ function ensureRuntimeDeps(root) {
     });
     child.on('error', () => {});
     child.unref();
+    // Hand the log fd entirely to the detached child; the parent does not need it.
+    if (typeof out === 'number') {
+      try { closeSync(out); } catch {}
+    }
   } catch {
     // best-effort; the upgrade hint below still explains the manual recovery command.
   }

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -78,6 +78,13 @@ async function buildHooks() {
       type: 'module',
       dependencies: {
         'zod': '^4.3.6',
+        // @modelcontextprotocol/sdk validates tool schemas with Ajv. mcp-server.cjs
+        // bundles the SDK, but Ajv emits compiled validators that require its runtime
+        // helpers by package path (e.g. require("ajv/dist/runtime/equal")), which
+        // esbuild leaves external. Without Ajv in the plugin's node_modules the MCP
+        // server crashes on the first tool call. See also the zod guardrail below.
+        'ajv': '^8.20.0',
+        'ajv-formats': '^3.0.1',
         'tree-sitter-cli': '^0.26.5',
         'tree-sitter-c': '^0.24.1',
         'tree-sitter-cpp': '^0.23.4',
@@ -272,6 +279,19 @@ async function buildHooks() {
       throw new Error(
         `mcp-server.cjs contains external ${zodRequireMatch[0]}. Claude Desktop can launch this bundle without plugin node_modules available, so Zod must be bundled into the MCP server.`
       );
+    }
+    // Ajv (via @modelcontextprotocol/sdk) emits compiled validators that require
+    // their runtime helpers by package path, which esbuild cannot inline. Those
+    // externals are acceptable ONLY if the package is declared in the plugin's
+    // dependencies so `bun install` provides them at runtime. Guard against the
+    // silent regression where the require survives the bundle but the dep is missing.
+    for (const ajvPkg of ['ajv', 'ajv-formats']) {
+      const ajvRequireRegex = new RegExp(`require\\(\\s*["']${ajvPkg}(?:/[^"']*)?["']\\s*\\)`);
+      if (ajvRequireRegex.test(mcpBundleContent) && !pluginPackageJson.dependencies[ajvPkg]) {
+        throw new Error(
+          `mcp-server.cjs requires external "${ajvPkg}" but it is missing from the generated plugin/package.json dependencies. Add it to the dependencies list in scripts/build-hooks.js so the plugin cache install can resolve it at runtime.`
+        );
+      }
     }
 
     const MCP_SERVER_MAX_BYTES = 600 * 1024;


### PR DESCRIPTION
## Problem

On Windows, claude-mem stops working after every version upgrade. Real case (13.2.0 -> 13.3.0):

- When the host auto-upgrades the plugin, a fresh version directory is created in the cache (`~/.claude/plugins/cache/thedotmack/claude-mem/<version>/`) **without `node_modules`**. Nothing re-runs setup — `version-check` only prints an easy-to-miss hint.
- Without `node_modules`, the **worker** fails to resolve `zod/v3` (`EINVAL` under Bun) and the **MCP server** fails to resolve `ajv/dist/runtime/*`.
- `ajv`/`ajv-formats` (transitive deps of `@modelcontextprotocol/sdk`, used to validate tool schemas) were **never declared** in the generated `plugin/package.json`, so even a correct `bun install` did not fetch them.

## Changes

**1. `fix(build)`** — declare `ajv`/`ajv-formats` in the generated plugin dependencies (`scripts/build-hooks.js`). `mcp-server.cjs` bundles the SDK, but Ajv emits compiled validators that `require("ajv/dist/runtime/...")` by package path (esbuild cannot inline them). Adds a **build guardrail** that fails if `mcp-server.cjs` requires `ajv`/`ajv-formats` while they are undeclared, mirroring the existing `zod` guardrail.

**2. `fix(setup)`** — the Setup-phase `version-check` now kicks off a **detached, throttled** `bun install` in the resolved plugin root when `node_modules` is absent:
- **No-op on healthy installs** (node_modules present) — zero behavior change outside the broken post-upgrade state.
- **Detached + unref** so the Setup hook stays non-blocking; deps land within ~1 min.
- **10-minute cooldown** marker so a running/failing install does not respawn every session.
- `shell:true` so the host PATH resolves `bun` (`bun.cmd` on Windows, `bun` on Unix).
- **Best-effort**: any failure is swallowed and the existing upgrade hint still documents manual recovery.

## Tests

- Distribution + version-consistency suites: passing (24 + 8).
- `version-check` exercised on all 3 paths: broken (spawns install, writes marker, exits 0 non-blocking), cooldown (no respawn), healthy (no-op).

## Notes

Complementary to #2489 (MCP launcher via `node` on Windows). This PR covers the **runtime deps**; #2489 covers the **launcher spawn**. Together they restore claude-mem on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)