### PR TITLE
fix(chroma): spawn uvx directly on Windows instead of via cmd.exe (closes #2667)

### DIFF
--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -105,9 +105,21 @@ export class ChromaMcpManager {
     const spawnEnvironment = this.getSpawnEnv();
     getSupervisor().assertCanSpawn('chroma mcp');
 
-    const isWindows = process.platform === 'win32';
-    const uvxSpawnCommand = isWindows ? (process.env.ComSpec || 'cmd.exe') : 'uvx';
-    const uvxSpawnArgs = isWindows ? ['/c', 'uvx', ...commandArgs] : commandArgs;
+    // Spawn uvx directly on every platform. Wrapping it inside `cmd.exe /c` on
+    // Windows is unsafe: cmd.exe interprets shell-metacharacters in its /c
+    // argument string BEFORE handing them to uvx, and Node's arg-array quoting
+    // does not survive that re-parse (per the cmd.exe parser's documented
+    // behavior of stripping the outer quote pair from /c). The chroma-mcp
+    // command emitted by buildCommandArgs() contains `--with onnxruntime>=1.20`
+    // and `--with protobuf<7`; cmd.exe parses `>=1.20` as `>` redirection to a
+    // file named `=1.20` and `<7` as `<` redirection from a file named `7`,
+    // truncating the uvx invocation. The result is an immediate exit with
+    // "The system cannot find the file specified" and every Chroma sync fails
+    // with `MCP error -32000: Connection closed` on Windows. uvx ships as
+    // uvx.exe (a real executable) on Windows installs, so Node's child_process
+    // can spawn it directly via CreateProcess without a shell.
+    const uvxSpawnCommand = 'uvx';
+    const uvxSpawnArgs = commandArgs;
 
     logger.info('CHROMA_MCP', 'Connecting to chroma-mcp via MCP stdio', {
       command: uvxSpawnCommand,


### PR DESCRIPTION
## Summary

Fixes #2667 — Chroma vector search is broken on Windows because `cmd.exe /c uvx ...` interprets `>=1.20` and `<7` in the dep-override args as I/O redirection.

## The change

`src/services/sync/ChromaMcpManager.ts:108-110` — spawn `uvx` directly on every platform instead of wrapping it in `cmd.exe /c` on Windows.

```diff
-    const isWindows = process.platform === 'win32';
-    const uvxSpawnCommand = isWindows ? (process.env.ComSpec || 'cmd.exe') : 'uvx';
-    const uvxSpawnArgs = isWindows ? ['/c', 'uvx', ...commandArgs] : commandArgs;
+    // Spawn uvx directly on every platform. Wrapping it inside `cmd.exe /c` on
+    // Windows is unsafe: cmd.exe interprets shell-metacharacters in its /c
+    // argument string BEFORE handing them to uvx, and Node's arg-array quoting
+    // does not survive that re-parse (per the cmd.exe parser's documented
+    // behavior of stripping the outer quote pair from /c). [...full reasoning
+    // in commit message and inline comment...]
+    const uvxSpawnCommand = 'uvx';
+    const uvxSpawnArgs = commandArgs;
```

The `StdioClientTransport` call below this code is unchanged — it receives the same `{ command, args, env, cwd, stderr }` shape; only the values flip.

## Why removing the cmd.exe wrapper is safe

- `uvx` ships as `uvx.exe` (real PE executable) on Windows, installed by the `uv` installer at `%LOCALAPPDATA%\Microsoft\WinGet\Links\uvx.exe` or `%USERPROFILE%\.local\bin\uvx.exe`. Confirmed by running `(Get-Command uvx).CommandType` → `Application`.
- Node's `child_process.spawn(command, args, ...)` invokes Windows `CreateProcess` and applies its own arg-quoting for `.exe` targets, which preserves characters like `>`, `<`, `=` inside args.
- The CVE-2024-27980 batch-file constraint (must use `shell: true` for `.cmd`/`.bat`) doesn't apply — uvx is a `.exe`.

## Verification

Reproduced the bug, applied the fix, verified Chroma works end-to-end on Windows 11 + Node 22.22.2 + Bun 1.3.14 + uv 0.11.8:

```
$ curl http://127.0.0.1:37777/api/chroma/status?deep=1
{
  "status": "healthy",
  "connected": true,
  "details": "chroma-mcp semantic search round-trip succeeded",
  "probe": {"ok": true, "stage": "done", "queryLatencyMs": 648}
}
```

Captured ~5 observations after the fix; all synced to Chroma successfully (no more `MCP error -32000: Connection closed` warnings in worker log).

## Test plan

- [x] Manual reproduction of bug with current main (`status: unhealthy, error: chroma-mcp connection in backoff`).
- [x] Manual verification after fix (`status: healthy`, semantic round-trip ~650ms).
- [x] Observations created post-fix successfully sync to Chroma (verified via `CHROMA_SYNC: Synced observation` log lines).
- [ ] CI (not run locally; please run the existing test suite — no test changes needed).

## Notes

- macOS and Linux are unchanged behaviorally (previously took the `else` branch which already spawned uvx directly; the new code unifies all platforms onto the same path).
- Related: first-time `uvx` spawn re-downloads ~47 MB of deps which races claude-mem's MCP connection timeout. That's a separate issue (worth pre-warming the uv cache at install time on Windows) — I can open a follow-up PR for the installer if interested.

cc @thedotmack