### PR TITLE
Fix OpenCode plugin registration during install

### DIFF
--- a/src/services/integrations/OpenCodeInstaller.ts
+++ b/src/services/integrations/OpenCodeInstaller.ts
@@ -7,6 +7,14 @@ import { logger } from '../../utils/logger.js';
 import { CONTEXT_TAG_OPEN, CONTEXT_TAG_CLOSE, injectContextIntoMarkdownFile } from '../../utils/context-injection.js';
 import { getWorkerPort } from '../../shared/worker-utils.js';
 
+const OPENCODE_PLUGIN_CONFIG_PATH = './plugins/claude-mem.js';
+
+type OpenCodeConfig = {
+  $schema?: string;
+  plugin?: unknown;
+  [key: string]: unknown;
+};
+
 export function getOpenCodeConfigDirectory(): string {
   if (process.env.OPENCODE_CONFIG_DIR) {
     return process.env.OPENCODE_CONFIG_DIR;
@@ -18,12 +26,52 @@ export function getOpenCodePluginsDirectory(): string {
   return path.join(getOpenCodeConfigDirectory(), 'plugins');
 }
 
+export function getOpenCodeConfigPath(): string {
+  return path.join(getOpenCodeConfigDirectory(), 'opencode.json');
+}
+
 export function getOpenCodeAgentsMdPath(): string {
   return path.join(getOpenCodeConfigDirectory(), 'AGENTS.md');
 }
 
 export function getInstalledPluginPath(): string {
   return path.join(getOpenCodePluginsDirectory(), 'claude-mem.js');
+}
+
+export function addOpenCodePluginReference(config: OpenCodeConfig): OpenCodeConfig {
+  const existingPlugins = Array.isArray(config.plugin) ? config.plugin : [];
+  if (existingPlugins.includes(OPENCODE_PLUGIN_CONFIG_PATH)) {
+    return config;
+  }
+
+  return {
+    ...config,
+    plugin: [...existingPlugins, OPENCODE_PLUGIN_CONFIG_PATH],
+  };
+}
+
+export function registerOpenCodePluginInConfig(): number {
+  const configPath = getOpenCodeConfigPath();
+  const defaultConfig: OpenCodeConfig = {
+    $schema: 'https://opencode.ai/config.json',
+  };
+
+  try {
+    const config = existsSync(configPath)
+      ? JSON.parse(readFileSync(configPath, 'utf-8')) as OpenCodeConfig
+      : defaultConfig;
+    const updatedConfig = addOpenCodePluginReference(config);
+
+    writeFileSync(configPath, `${JSON.stringify(updatedConfig, null, 2)}\n`, 'utf-8');
+    console.log(`  Plugin registered in: ${configPath}`);
+    logger.info('OPENCODE', 'Plugin registered in config', { path: configPath });
+
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Failed to register OpenCode plugin in config: ${message}`);
+    return 1;
+  }
 }
 
 export function findBuiltPluginPath(): string | null {
@@ -64,6 +112,11 @@ export function installOpenCodePlugin(): number {
 
     console.log(`  Plugin installed to: ${destinationPath}`);
     logger.info('OPENCODE', 'Plugin installed', { destination: destinationPath });
+
+    const registerResult = registerOpenCodePluginInConfig();
+    if (registerResult !== 0) {
+      return registerResult;
+    }
 
     return 0;
   } catch (error) {

--- a/src/services/integrations/OpenCodeInstaller.ts
+++ b/src/services/integrations/OpenCodeInstaller.ts
@@ -38,8 +38,15 @@ export function getInstalledPluginPath(): string {
   return path.join(getOpenCodePluginsDirectory(), 'claude-mem.js');
 }
 
+function getOpenCodePluginEntries(config: OpenCodeConfig): unknown[] {
+  if (Array.isArray(config.plugin)) {
+    return config.plugin;
+  }
+  return config.plugin === undefined ? [] : [config.plugin];
+}
+
 export function addOpenCodePluginReference(config: OpenCodeConfig): OpenCodeConfig {
-  const existingPlugins = Array.isArray(config.plugin) ? config.plugin : [];
+  const existingPlugins = getOpenCodePluginEntries(config);
   if (existingPlugins.includes(OPENCODE_PLUGIN_CONFIG_PATH)) {
     return config;
   }
@@ -47,6 +54,15 @@ export function addOpenCodePluginReference(config: OpenCodeConfig): OpenCodeConf
   return {
     ...config,
     plugin: [...existingPlugins, OPENCODE_PLUGIN_CONFIG_PATH],
+  };
+}
+
+export function removeOpenCodePluginReference(config: OpenCodeConfig): OpenCodeConfig {
+  return {
+    ...config,
+    plugin: getOpenCodePluginEntries(config).filter(
+      (plugin) => plugin !== OPENCODE_PLUGIN_CONFIG_PATH,
+    ),
   };
 }
 
@@ -70,6 +86,28 @@ export function registerOpenCodePluginInConfig(): number {
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`Failed to register OpenCode plugin in config: ${message}`);
+    return 1;
+  }
+}
+
+export function deregisterOpenCodePluginFromConfig(): number {
+  const configPath = getOpenCodeConfigPath();
+  if (!existsSync(configPath)) {
+    return 0;
+  }
+
+  try {
+    const config = JSON.parse(readFileSync(configPath, 'utf-8')) as OpenCodeConfig;
+    const updatedConfig = removeOpenCodePluginReference(config);
+
+    writeFileSync(configPath, `${JSON.stringify(updatedConfig, null, 2)}\n`, 'utf-8');
+    console.log(`  Plugin deregistered from: ${configPath}`);
+    logger.info('OPENCODE', 'Plugin deregistered from config', { path: configPath });
+
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Failed to deregister OpenCode plugin from config: ${message}`);
     return 1;
   }
 }
@@ -210,6 +248,10 @@ export function uninstallOpenCodePlugin(): number {
       console.error(`  Failed to remove plugin: ${message}`);
       hasErrors = true;
     }
+  }
+
+  if (deregisterOpenCodePluginFromConfig() !== 0) {
+    hasErrors = true;
   }
 
   const agentsMdPath = getOpenCodeAgentsMdPath();

--- a/tests/integration/opencode-installer.test.ts
+++ b/tests/integration/opencode-installer.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  addOpenCodePluginReference,
+  getOpenCodeConfigPath,
+  registerOpenCodePluginInConfig,
+} from '../../src/services/integrations/OpenCodeInstaller.js';
+
+describe('OpenCode installer config registration', () => {
+  let tempDir: string;
+  let previousConfigDir: string | undefined;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `opencode-installer-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tempDir, { recursive: true });
+    previousConfigDir = process.env.OPENCODE_CONFIG_DIR;
+    process.env.OPENCODE_CONFIG_DIR = tempDir;
+  });
+
+  afterEach(() => {
+    if (previousConfigDir === undefined) {
+      delete process.env.OPENCODE_CONFIG_DIR;
+    } else {
+      process.env.OPENCODE_CONFIG_DIR = previousConfigDir;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('adds claude-mem to an existing plugin array', () => {
+    const config = addOpenCodePluginReference({
+      plugin: ['context-mode'],
+      mcp: { context7: { enabled: true } },
+    });
+
+    expect(config.plugin).toEqual(['context-mode', './plugins/claude-mem.js']);
+    expect(config.mcp).toEqual({ context7: { enabled: true } });
+  });
+
+  it('does not duplicate an existing claude-mem plugin reference', () => {
+    const config = addOpenCodePluginReference({
+      plugin: ['context-mode', './plugins/claude-mem.js'],
+    });
+
+    expect(config.plugin).toEqual(['context-mode', './plugins/claude-mem.js']);
+  });
+
+  it('creates opencode.json when missing', () => {
+    const result = registerOpenCodePluginInConfig();
+
+    expect(result).toBe(0);
+    expect(existsSync(getOpenCodeConfigPath())).toBe(true);
+
+    const config = JSON.parse(readFileSync(getOpenCodeConfigPath(), 'utf-8'));
+    expect(config.$schema).toBe('https://opencode.ai/config.json');
+    expect(config.plugin).toEqual(['./plugins/claude-mem.js']);
+  });
+
+  it('preserves existing config fields when registering the plugin', () => {
+    writeFileSync(getOpenCodeConfigPath(), JSON.stringify({
+      $schema: 'https://opencode.ai/config.json',
+      plugin: ['context-mode'],
+      provider: { openai: { models: {} } },
+    }), 'utf-8');
+
+    const result = registerOpenCodePluginInConfig();
+
+    expect(result).toBe(0);
+    const config = JSON.parse(readFileSync(getOpenCodeConfigPath(), 'utf-8'));
+    expect(config.plugin).toEqual(['context-mode', './plugins/claude-mem.js']);
+    expect(config.provider).toEqual({ openai: { models: {} } });
+  });
+});

--- a/tests/integration/opencode-installer.test.ts
+++ b/tests/integration/opencode-installer.test.ts
@@ -4,7 +4,9 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import {
   addOpenCodePluginReference,
+  deregisterOpenCodePluginFromConfig,
   getOpenCodeConfigPath,
+  removeOpenCodePluginReference,
   registerOpenCodePluginInConfig,
 } from '../../src/services/integrations/OpenCodeInstaller.js';
 
@@ -46,6 +48,24 @@ describe('OpenCode installer config registration', () => {
     expect(config.plugin).toEqual(['context-mode', './plugins/claude-mem.js']);
   });
 
+  it('preserves an existing single-string plugin entry', () => {
+    const config = addOpenCodePluginReference({
+      plugin: 'context-mode',
+    });
+
+    expect(config.plugin).toEqual(['context-mode', './plugins/claude-mem.js']);
+  });
+
+  it('removes only claude-mem from plugin entries', () => {
+    const config = removeOpenCodePluginReference({
+      plugin: ['context-mode', './plugins/claude-mem.js'],
+      provider: { openai: { models: {} } },
+    });
+
+    expect(config.plugin).toEqual(['context-mode']);
+    expect(config.provider).toEqual({ openai: { models: {} } });
+  });
+
   it('creates opencode.json when missing', () => {
     const result = registerOpenCodePluginInConfig();
 
@@ -70,5 +90,18 @@ describe('OpenCode installer config registration', () => {
     const config = JSON.parse(readFileSync(getOpenCodeConfigPath(), 'utf-8'));
     expect(config.plugin).toEqual(['context-mode', './plugins/claude-mem.js']);
     expect(config.provider).toEqual({ openai: { models: {} } });
+  });
+
+  it('removes the plugin reference from opencode.json during deregistration', () => {
+    writeFileSync(getOpenCodeConfigPath(), JSON.stringify({
+      $schema: 'https://opencode.ai/config.json',
+      plugin: ['context-mode', './plugins/claude-mem.js'],
+    }), 'utf-8');
+
+    const result = deregisterOpenCodePluginFromConfig();
+
+    expect(result).toBe(0);
+    const config = JSON.parse(readFileSync(getOpenCodeConfigPath(), 'utf-8'));
+    expect(config.plugin).toEqual(['context-mode']);
   });
 });


### PR DESCRIPTION
## Summary

- register the installed OpenCode plugin in `~/.config/opencode/opencode.json`
- preserve existing OpenCode config fields and plugin entries
- avoid duplicate `./plugins/claude-mem.js` entries on repeated installs

Fixes #2669.

## Tests

- `bun test ./tests/integration/opencode-installer.test.ts`
- `npm run build`

Note: `npm run typecheck:root` currently fails on pre-existing unrelated TypeScript errors outside this change.