### PR TITLE
feat(env): allow corporate proxy + custom CA passthrough via ~/.claude-mem/.env

### DIFF
--- a/docs/corporate-proxy.md
+++ b/docs/corporate-proxy.md
@@ -1,0 +1,82 @@
+# Corporate proxy and custom CA
+
+If you run `claude-mem` from inside a corporate network that requires an outbound HTTP/HTTPS proxy — Zscaler, Cisco Umbrella, on-prem SSL-intercepting firewalls (EANDIS/Fluvius, etc.) — the worker daemon needs an explicit configuration step before it can reach `api.anthropic.com`.
+
+## Why it doesn't "just work"
+
+`claude-mem` deliberately strips proxy environment variables (`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`, …) from the parent shell when it spawns the persistent worker daemon. This is intentional — a session-only proxy silently latching onto a long-lived background daemon is a footgun (the proxy goes away, the daemon keeps trying to reach it). See `src/supervisor/env-sanitizer.ts`.
+
+The trade-off is that, on machines where the proxy is the *only* path to the internet, the daemon's SDK subprocess fails every API call with `SSL certificate verification failed` (the corporate firewall MITMs outbound TLS and presents a self-signed cert that's not in the standard CA bundle).
+
+## Explicit opt-in via `~/.claude-mem/.env`
+
+Declare the proxy and CA bundle in `~/.claude-mem/.env`. The worker reads this file at startup and re-injects the declared values into its own `process.env` (and into the env used to spawn subprocesses).
+
+Example for a typical corporate setup:
+
+```ini
+# ~/.claude-mem/.env
+
+# Outbound HTTP/HTTPS proxy
+HTTPS_PROXY=http://10.87.0.4:3128/
+HTTP_PROXY=http://10.87.0.4:3128/
+NO_PROXY=localhost,127.0.0.1,::1,.internal,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+
+# CA bundle that trusts the corporate root CA. Make sure your IT-provisioned
+# root CA is in this bundle (typically /usr/local/share/ca-certificates/ + run
+# `sudo update-ca-certificates`).
+SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+```
+
+Recognized keys:
+
+| Key                    | Used by                                        |
+|------------------------|------------------------------------------------|
+| `HTTPS_PROXY`          | Node fetch (SDK CLI), Python (`requests`)      |
+| `HTTP_PROXY`           | Same                                            |
+| `NO_PROXY`             | Bypass list — keep `localhost` for the worker  |
+| `SSL_CERT_FILE`        | OpenSSL, Python `ssl`                          |
+| `REQUESTS_CA_BUNDLE`   | Python `requests`                              |
+| `CURL_CA_BUNDLE`       | `curl`                                          |
+| `NODE_EXTRA_CA_CERTS`  | Node `tls` (extends, does not replace, the built-in bundle) |
+
+Lowercase variants (`https_proxy` / `http_proxy` / `no_proxy`) are mirrored automatically for curl-family tooling.
+
+## Verifying
+
+After saving `~/.claude-mem/.env`, restart the worker:
+
+```bash
+claude-mem restart
+```
+
+The worker logs a one-line confirmation at startup when the passthrough fires:
+
+```
+[INFO] [SYSTEM] Applied corporate proxy/CA passthrough from ~/.claude-mem/.env { keys: ["HTTPS_PROXY", "NO_PROXY", "SSL_CERT_FILE", "NODE_EXTRA_CA_CERTS"] }
+```
+
+Check the daemon's environment:
+
+```bash
+W=$(jq -r .pid ~/.claude-mem/worker.pid)
+cat /proc/$W/environ | tr '\0' '\n' | grep -E "HTTPS_PROXY|NODE_EXTRA"
+```
+
+And confirm the SDK subprocess (the `claude` CLI spawned by the worker) inherits the same values via `cat /proc/<sdk-pid>/environ`.
+
+## Notes
+
+- Parent-shell values (a `HTTPS_PROXY` set in your interactive shell when you run `claude-mem start`) still take precedence over `.env` values — passthrough only fills in keys that are not already set.
+- The `~/.claude-mem/.env` file is also where Anthropic / Gemini / OpenRouter credentials live. Permissions are set to `0700` on the data directory; treat the file as sensitive.
+- If your IT team distributes the corporate CA as a `.crt` file, the canonical install is:
+
+  ```bash
+  sudo cp corporate-root.crt /usr/local/share/ca-certificates/
+  sudo update-ca-certificates
+  ```
+
+  After that, `/etc/ssl/certs/ca-certificates.crt` contains the corp CA and pointing `NODE_EXTRA_CA_CERTS` at it is enough.

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -9,7 +9,7 @@ import { getWorkerPort, getWorkerHost } from '../shared/worker-utils.js';
 import { DATA_DIR, DB_PATH, ensureDir } from '../shared/paths.js';
 import { HOOK_TIMEOUTS } from '../shared/hook-constants.js';
 import { SettingsDefaultsManager } from '../shared/SettingsDefaultsManager.js';
-import { getAuthMethodDescription } from '../shared/EnvManager.js';
+import { getAuthMethodDescription, applyProxyAndCaFromEnvFile } from '../shared/EnvManager.js';
 import { logger } from '../utils/logger.js';
 import { ChromaMcpManager } from './sync/ChromaMcpManager.js';
 import { ChromaSync } from './sync/ChromaSync.js';
@@ -1177,6 +1177,19 @@ async function main() {
 
     case '--daemon':
     default: {
+      // Corporate proxy / custom CA: read ~/.claude-mem/.env and inject any
+      // declared proxy + CA env vars into process.env before any subprocess
+      // (chroma-mcp, SDK CLI, hook helpers) is spawned. Documented opt-in
+      // for users behind Zscaler-style TLS-intercepting corporate proxies.
+      try {
+        const applied = applyProxyAndCaFromEnvFile();
+        if (applied.length > 0) {
+          logger.info('SYSTEM', 'Applied corporate proxy/CA passthrough from ~/.claude-mem/.env', { keys: applied });
+        }
+      } catch (error) {
+        logger.warn('SYSTEM', 'Failed to apply proxy/CA passthrough from ~/.claude-mem/.env', {}, error instanceof Error ? error : new Error(String(error)));
+      }
+
       const existingPidInfo = readPidFile();
       if (verifyPidFileOwnership(existingPidInfo)) {
         logger.info('SYSTEM', 'Worker already running (PID alive), refusing to start duplicate', {

--- a/src/shared/EnvManager.ts
+++ b/src/shared/EnvManager.ts
@@ -42,7 +42,40 @@ export interface ClaudeMemEnv {
   ANTHROPIC_AUTH_TOKEN?: string;
   GEMINI_API_KEY?: string;
   OPENROUTER_API_KEY?: string;
+  // Corporate-proxy / custom-CA passthrough (issue: behind Zscaler/EANDIS-style MITM
+  // proxies the daemon can't reach api.anthropic.com because session proxy + CA env
+  // are stripped by env-sanitizer. Declaring them here is the explicit opt-in.)
+  HTTPS_PROXY?: string;
+  HTTP_PROXY?: string;
+  NO_PROXY?: string;
+  SSL_CERT_FILE?: string;
+  REQUESTS_CA_BUNDLE?: string;
+  CURL_CA_BUNDLE?: string;
+  NODE_EXTRA_CA_CERTS?: string;
 }
+
+/**
+ * Keys in ~/.claude-mem/.env that, when set, should be propagated to the
+ * worker daemon's process.env at boot. These are exactly the corporate
+ * connectivity vars stripped by env-sanitizer (proxy) plus the standard
+ * CA-bundle vars (so Node fetch / Python requests / curl all trust the
+ * corporate root CA when running through a TLS-intercepting proxy).
+ *
+ * They are intentionally NOT read from the parent shell environment —
+ * the daemon should only honor them when the operator declares them
+ * explicitly in the persistent .env file. This keeps the strict default
+ * (session proxy never silently latches onto the daemon) while giving
+ * corporate-network users a clean configuration path.
+ */
+export const PROXY_AND_CA_PASSTHROUGH_KEYS = [
+  'HTTPS_PROXY',
+  'HTTP_PROXY',
+  'NO_PROXY',
+  'SSL_CERT_FILE',
+  'REQUESTS_CA_BUNDLE',
+  'CURL_CA_BUNDLE',
+  'NODE_EXTRA_CA_CERTS',
+] as const;
 
 function parseEnvFile(content: string): Record<string, string> {
   const result: Record<string, string> = {};
@@ -105,6 +138,10 @@ export function loadClaudeMemEnv(): ClaudeMemEnv {
     if (parsed.ANTHROPIC_AUTH_TOKEN) result.ANTHROPIC_AUTH_TOKEN = parsed.ANTHROPIC_AUTH_TOKEN;
     if (parsed.GEMINI_API_KEY) result.GEMINI_API_KEY = parsed.GEMINI_API_KEY;
     if (parsed.OPENROUTER_API_KEY) result.OPENROUTER_API_KEY = parsed.OPENROUTER_API_KEY;
+    for (const key of PROXY_AND_CA_PASSTHROUGH_KEYS) {
+      const value = parsed[key];
+      if (value) (result as Record<string, string>)[key] = value;
+    }
 
     return result;
   } catch (error: unknown) {
@@ -209,6 +246,15 @@ export function buildIsolatedEnv(includeCredentials: boolean = true): Record<str
       isolatedEnv.OPENROUTER_API_KEY = credentials.OPENROUTER_API_KEY;
     }
 
+    // Corporate proxy / custom CA: when declared explicitly in ~/.claude-mem/.env
+    // we re-inject these into the spawned subprocess env. env-sanitizer otherwise
+    // strips proxy vars from the parent shell to prevent silent session-bound
+    // latching; this path is the documented opt-in for corporate networks.
+    for (const key of PROXY_AND_CA_PASSTHROUGH_KEYS) {
+      const value = (credentials as Record<string, string | undefined>)[key];
+      if (value) isolatedEnv[key] = value;
+    }
+
     // Note: CLAUDE_CODE_OAUTH_TOKEN is intentionally NOT copied from
     // process.env here. OAuth tokens have refresh semantics that this
     // sync path cannot model — copying a parent-process token captured
@@ -217,6 +263,47 @@ export function buildIsolatedEnv(includeCredentials: boolean = true): Record<str
   }
 
   return isolatedEnv;
+}
+
+/**
+ * Apply proxy and CA passthrough values from ~/.claude-mem/.env onto the
+ * current process.env. This is intended to be called once at worker daemon
+ * startup so that:
+ *   - the worker itself (Node fetch in plugin code paths) honors the proxy
+ *   - subprocess spawns that inherit process.env (chroma-mcp, hook helpers)
+ *     get the proxy and CA chain without needing case-by-case wiring
+ *   - explicit isolated-env builds via buildIsolatedEnv() still pick them up
+ *     because they read from loadClaudeMemEnv() (file-of-record), not env.
+ *
+ * Existing env vars are NOT overwritten — a parent-shell value still wins.
+ * This preserves the test fixtures that set explicit values via env.
+ *
+ * Safe to call multiple times. Returns the list of keys actually applied
+ * (useful for boot-time logging).
+ */
+export function applyProxyAndCaFromEnvFile(): string[] {
+  const credentials = loadClaudeMemEnv();
+  const applied: string[] = [];
+  for (const key of PROXY_AND_CA_PASSTHROUGH_KEYS) {
+    const value = (credentials as Record<string, string | undefined>)[key];
+    if (value && !process.env[key]) {
+      process.env[key] = value;
+      applied.push(key);
+      // Mirror the upper/lowercase variants for proxy vars so libraries that
+      // only consult one casing (curl-style lowercase vs Node's uppercase)
+      // both see the value.
+      if (key === 'HTTPS_PROXY' && !process.env.https_proxy) {
+        process.env.https_proxy = value;
+      }
+      if (key === 'HTTP_PROXY' && !process.env.http_proxy) {
+        process.env.http_proxy = value;
+      }
+      if (key === 'NO_PROXY' && !process.env.no_proxy) {
+        process.env.no_proxy = value;
+      }
+    }
+  }
+  return applied;
 }
 
 /**

--- a/tests/env-proxy-passthrough.test.ts
+++ b/tests/env-proxy-passthrough.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import * as fs from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  envFilePath,
+  loadClaudeMemEnv,
+  buildIsolatedEnv,
+  applyProxyAndCaFromEnvFile,
+  PROXY_AND_CA_PASSTHROUGH_KEYS,
+} from '../src/shared/EnvManager.js';
+
+/**
+ * Tests for corporate-proxy / custom-CA passthrough via ~/.claude-mem/.env.
+ *
+ * Context: env-sanitizer deliberately strips HTTPS_PROXY / HTTP_PROXY / NO_PROXY
+ * from the parent shell env so the persistent daemon never silently latches
+ * onto a session-only proxy. For users behind Zscaler-style TLS-intercepting
+ * corporate proxies that path makes api.anthropic.com unreachable: the daemon
+ * tries a direct connection, the firewall presents a self-signed cert, Node
+ * fetch rejects it, every observation-generation call fails.
+ *
+ * The fix is an opt-in: when HTTPS_PROXY / NODE_EXTRA_CA_CERTS / etc. are
+ * declared in ~/.claude-mem/.env, they are:
+ *   (a) read by loadClaudeMemEnv()
+ *   (b) injected into the daemon's own process.env via applyProxyAndCaFromEnvFile()
+ *   (c) propagated into buildIsolatedEnv() output so spawned subprocesses inherit
+ *
+ * Tests use CLAUDE_MEM_ENV_FILE override so the real ~/.claude-mem/.env is
+ * never touched.
+ */
+
+const TEST_DATA_DIR = fs.mkdtempSync(join(tmpdir(), 'claude-mem-proxy-test-'));
+const TEST_ENV_FILE = join(TEST_DATA_DIR, '.env');
+const ORIGINAL_ENV_FILE = process.env.CLAUDE_MEM_ENV_FILE;
+
+// Snapshot env vars we may mutate so the test never leaks state.
+const SNAPSHOT_KEYS = [
+  ...PROXY_AND_CA_PASSTHROUGH_KEYS,
+  'https_proxy',
+  'http_proxy',
+  'no_proxy',
+] as const;
+const original: Record<string, string | undefined> = {};
+
+function snapshotEnv() {
+  for (const k of SNAPSHOT_KEYS) original[k] = process.env[k];
+}
+function restoreEnv() {
+  for (const k of SNAPSHOT_KEYS) {
+    if (original[k] === undefined) delete process.env[k];
+    else process.env[k] = original[k];
+  }
+}
+
+beforeAll(() => {
+  process.env.CLAUDE_MEM_ENV_FILE = TEST_ENV_FILE;
+});
+
+afterAll(() => {
+  if (ORIGINAL_ENV_FILE === undefined) delete process.env.CLAUDE_MEM_ENV_FILE;
+  else process.env.CLAUDE_MEM_ENV_FILE = ORIGINAL_ENV_FILE;
+  try {
+    fs.rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+});
+
+beforeEach(() => {
+  snapshotEnv();
+  // start each test from a clean .env
+  try { fs.unlinkSync(TEST_ENV_FILE); } catch { /* ignore */ }
+  // and a clean process.env for the keys we care about
+  for (const k of SNAPSHOT_KEYS) delete process.env[k];
+});
+
+describe('proxy + CA passthrough via ~/.claude-mem/.env', () => {
+  it('loadClaudeMemEnv reads HTTPS_PROXY and NODE_EXTRA_CA_CERTS', () => {
+    fs.writeFileSync(TEST_ENV_FILE,
+      'HTTPS_PROXY=http://corp-proxy.example.com:3128/\n' +
+      'NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt\n'
+    );
+
+    const env = loadClaudeMemEnv();
+    expect(env.HTTPS_PROXY).toBe('http://corp-proxy.example.com:3128/');
+    expect(env.NODE_EXTRA_CA_CERTS).toBe('/etc/ssl/certs/ca-certificates.crt');
+
+    restoreEnv();
+  });
+
+  it('applyProxyAndCaFromEnvFile injects values into process.env when absent', () => {
+    fs.writeFileSync(TEST_ENV_FILE,
+      'HTTPS_PROXY=http://corp-proxy.example.com:3128/\n' +
+      'NO_PROXY=localhost,127.0.0.1\n' +
+      'SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt\n'
+    );
+
+    const applied = applyProxyAndCaFromEnvFile();
+    expect(applied).toContain('HTTPS_PROXY');
+    expect(applied).toContain('NO_PROXY');
+    expect(applied).toContain('SSL_CERT_FILE');
+
+    expect(process.env.HTTPS_PROXY).toBe('http://corp-proxy.example.com:3128/');
+    expect(process.env.NO_PROXY).toBe('localhost,127.0.0.1');
+    expect(process.env.SSL_CERT_FILE).toBe('/etc/ssl/certs/ca-certificates.crt');
+
+    // Lowercase mirroring for proxy vars (curl-family tooling)
+    expect(process.env.https_proxy).toBe('http://corp-proxy.example.com:3128/');
+    expect(process.env.no_proxy).toBe('localhost,127.0.0.1');
+
+    restoreEnv();
+  });
+
+  it('applyProxyAndCaFromEnvFile does NOT overwrite values already set in process.env', () => {
+    fs.writeFileSync(TEST_ENV_FILE, 'HTTPS_PROXY=http://from-envfile.example.com:3128/\n');
+
+    process.env.HTTPS_PROXY = 'http://from-shell.example.com:8080/';
+    const applied = applyProxyAndCaFromEnvFile();
+
+    expect(applied).not.toContain('HTTPS_PROXY');
+    expect(process.env.HTTPS_PROXY).toBe('http://from-shell.example.com:8080/');
+
+    restoreEnv();
+  });
+
+  it('buildIsolatedEnv propagates proxy + CA vars to subprocess env', () => {
+    fs.writeFileSync(TEST_ENV_FILE,
+      'HTTPS_PROXY=http://corp-proxy.example.com:3128/\n' +
+      'NODE_EXTRA_CA_CERTS=/opt/corp-ca.pem\n'
+    );
+
+    const isolated = buildIsolatedEnv(true);
+    expect(isolated.HTTPS_PROXY).toBe('http://corp-proxy.example.com:3128/');
+    expect(isolated.NODE_EXTRA_CA_CERTS).toBe('/opt/corp-ca.pem');
+
+    restoreEnv();
+  });
+
+  it('buildIsolatedEnv with credentials=false does NOT inject proxy/CA (matches existing semantics)', () => {
+    fs.writeFileSync(TEST_ENV_FILE, 'HTTPS_PROXY=http://corp-proxy.example.com:3128/\n');
+
+    const isolated = buildIsolatedEnv(false);
+    expect(isolated.HTTPS_PROXY).toBeUndefined();
+
+    restoreEnv();
+  });
+
+  it('returns empty list when no proxy/CA keys declared', () => {
+    fs.writeFileSync(TEST_ENV_FILE,
+      'ANTHROPIC_API_KEY=sk-ant-test-not-real\n'
+    );
+
+    const applied = applyProxyAndCaFromEnvFile();
+    expect(applied).toEqual([]);
+    expect(process.env.HTTPS_PROXY).toBeUndefined();
+
+    restoreEnv();
+  });
+
+  it('handles missing ~/.claude-mem/.env gracefully', () => {
+    // no file written this test
+    expect(() => applyProxyAndCaFromEnvFile()).not.toThrow();
+    const applied = applyProxyAndCaFromEnvFile();
+    expect(applied).toEqual([]);
+    restoreEnv();
+  });
+});


### PR DESCRIPTION
## Summary

Adds an explicit opt-in for users behind TLS-intercepting corporate proxies (Zscaler, on-prem firewalls, transparent-MITM appliances) to declare `HTTPS_PROXY`, `NO_PROXY`, `NODE_EXTRA_CA_CERTS`, etc. in `~/.claude-mem/.env`. The worker reads these at daemon boot and injects them into its own `process.env` and the spawned-subprocess env, so `api.anthropic.com` becomes reachable through the corporate proxy with the corporate root CA trusted.

## Problem

`env-sanitizer.ts` deliberately strips proxy vars from the parent shell when spawning the persistent worker daemon. The intent is sound — a session-only proxy silently latching onto a long-lived background daemon is a footgun (proxy goes away, daemon keeps trying to reach it).

The trade-off is that on machines where the corporate proxy is the only outbound path, every SDK call fails:

`````
[SDK   ] [session-1] ← Response received (120 chars)
API Error: Unable to connect to API: SSL certificate verification failed.
Check your proxy or corporate firewall...
`````

…because the corp firewall MITMs `api.anthropic.com` (presenting a self-signed leaf cert), and the daemon both (a) bypasses the proxy and (b) doesn't trust the corp root CA. Net effect: every observation-generation call fails, the viewer queue counter spins forever, no new observations land.

## Approach

Strict default unchanged. New recognized keys in `~/.claude-mem/.env`:

- `HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY` — proxy for outbound HTTPS/HTTP from the daemon and its subprocesses
- `SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS` — CA bundle(s) that include the corporate root CA

Worker daemon boot calls `applyProxyAndCaFromEnvFile()` (new helper in `EnvManager`) once before any subprocess is spawned. The function:
- reads `~/.claude-mem/.env` via the existing `loadClaudeMemEnv` path
- copies declared keys into `process.env`, but **only when the key is not already set** (parent-shell values still win — preserves the test-fixture / power-user override path)
- mirrors lowercase variants (`https_proxy`, `http_proxy`, `no_proxy`) for curl-family tooling
- emits one info log line listing the applied keys when any fire

`buildIsolatedEnv()` is also extended so SDK spawn paths (which build env from scratch rather than inheriting) pick up the same values.

Example user config:

`````ini
# ~/.claude-mem/.env
HTTPS_PROXY=http://corp-proxy.example.com:3128/
HTTP_PROXY=http://corp-proxy.example.com:3128/
NO_PROXY=localhost,127.0.0.1,::1,.internal,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
`````

## Files

- `src/shared/EnvManager.ts` — extend `ClaudeMemEnv`, export `PROXY_AND_CA_PASSTHROUGH_KEYS`, extend `loadClaudeMemEnv` + `buildIsolatedEnv`, new `applyProxyAndCaFromEnvFile()`
- `src/services/worker-service.ts` — call helper at daemon boot, log applied keys
- `tests/env-proxy-passthrough.test.ts` — new, 7 tests
- `docs/corporate-proxy.md` — new user-facing guide

## Test plan

- [x] New suite: `bun test tests/env-proxy-passthrough.test.ts` → 7 / 7 pass
- [x] Regression: `bun test tests/supervisor/env-sanitizer.test.ts tests/env-isolation.test.ts tests/env-proxy-passthrough.test.ts` → 21 / 21 pass
- [x] Manual verification on a corporate-network workstation where the egress firewall transparently intercepts TLS to `api.anthropic.com` (returns a leaf cert signed by an internal CA that is not in the standard system trust store):
  - Before the patch: SDK subprocess `/proc/<pid>/environ` had no proxy vars; every call returned `SSL certificate verification failed`; the observation queue stayed at 22+ pending forever
  - After the patch: both worker and SDK subprocess inherit `HTTPS_PROXY` + `NODE_EXTRA_CA_CERTS`; observation queue drains; new `<observation>` payloads start landing within ~10 seconds

## Notes

- Parent-shell `HTTPS_PROXY` (set in the user's interactive session) still wins over the `.env` value — passthrough only fills keys that are not already set. Preserves the strict default for users who *want* the daemon to be detached from session-only proxy state.
- No new dependencies. No public API change beyond the new exported helper.
- Docs file covers verification steps (`cat /proc/<worker-pid>/environ | grep HTTPS_PROXY`) and the canonical IT-issued root-CA install (`sudo cp corp.crt /usr/local/share/ca-certificates/ && sudo update-ca-certificates`).