### PR TITLE
fix(worker): classify Anthropic invalid_request_error as unrecoverable when .status is dropped by SDK (closes #2656)

### DIFF
--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -134,17 +134,15 @@ export function classifyClaudeError(err: unknown): ClassifiedProviderError {
     );
   }
 
-  // Some SDK call paths surface Anthropic 400 invalid_request errors as
-  // wrapped exceptions WITHOUT a `.status` field — only the canonical message
-  // text or a structured `error.type === 'invalid_request_error'` body
-  // survives the wrapping. Without this fallback, model-identifier rejections
-  // fall through to the default `transient` branch and the worker retries
-  // forever while `/health` keeps reporting `ok` (#2656). Conservative match:
-  // only the canonical phrases the Anthropic API emits for permanent 400s.
+  // Status-less Anthropic 400s — SDK wrapping can drop `.status`, leaving only
+  // the message or an `invalid_request_error` body; classify those as
+  // unrecoverable so the worker stops retrying a permanent config error (#2656).
+  // The status guard keeps statused 4xx/5xx on their own branches.
   if (
-    errAny.error?.type === 'invalid_request_error' ||
-    /\bthe provided model identifier is invalid\b/i.test(message) ||
-    /\binvalid_request_error\b/i.test(message)
+    typeof errAny.status !== 'number' &&
+    (errAny.error?.type === 'invalid_request_error' ||
+      /\bthe provided model identifier is invalid\b/i.test(message) ||
+      /\binvalid_request_error\b/i.test(message))
   ) {
     return new ClassifiedProviderError(message, { kind: 'unrecoverable', cause: err });
   }

--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -134,6 +134,21 @@ export function classifyClaudeError(err: unknown): ClassifiedProviderError {
     );
   }
 
+  // Some SDK call paths surface Anthropic 400 invalid_request errors as
+  // wrapped exceptions WITHOUT a `.status` field — only the canonical message
+  // text or a structured `error.type === 'invalid_request_error'` body
+  // survives the wrapping. Without this fallback, model-identifier rejections
+  // fall through to the default `transient` branch and the worker retries
+  // forever while `/health` keeps reporting `ok` (#2656). Conservative match:
+  // only the canonical phrases the Anthropic API emits for permanent 400s.
+  if (
+    errAny.error?.type === 'invalid_request_error' ||
+    /\bthe provided model identifier is invalid\b/i.test(message) ||
+    /\binvalid_request_error\b/i.test(message)
+  ) {
+    return new ClassifiedProviderError(message, { kind: 'unrecoverable', cause: err });
+  }
+
   // Server errors → transient.
   if (typeof errAny.status === 'number' && errAny.status >= 500 && errAny.status < 600) {
     return new ClassifiedProviderError(message, { kind: 'transient', cause: err });

--- a/tests/claude-provider-error-classifier.test.ts
+++ b/tests/claude-provider-error-classifier.test.ts
@@ -120,3 +120,65 @@ describe('classifyClaudeError — sibling status codes (regression sanity)', () 
     expect(classified.kind).toBe('transient');
   });
 });
+
+/**
+ * Regression coverage for #2656: when the Anthropic Agent SDK wraps a 400
+ * `invalid_request_error` (e.g. "The provided model identifier is invalid")
+ * the `.status` field can be lost in the wrapping. Without a message-based
+ * fallback the error fell through to the default `transient` branch and the
+ * worker retried indefinitely while `/health` kept reporting `ok`.
+ */
+describe('classifyClaudeError — model identifier rejections without .status (#2656)', () => {
+  let warnSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    __resetEffortHintLatchForTesting();
+    warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    __resetEffortHintLatchForTesting();
+  });
+
+  it('classifies "The provided model identifier is invalid" as unrecoverable even without a status field', () => {
+    const sdkErr = new Error('The provided model identifier is invalid');
+    const classified = classifyClaudeError(sdkErr);
+    expect(classified.kind).toBe('unrecoverable');
+  });
+
+  it('classifies wrapped errors exposing error.type=invalid_request_error as unrecoverable', () => {
+    const sdkErr = Object.assign(
+      new Error('Anthropic SDK error'),
+      { error: { type: 'invalid_request_error' } },
+    );
+    const classified = classifyClaudeError(sdkErr);
+    expect(classified.kind).toBe('unrecoverable');
+  });
+
+  it('classifies errors carrying the "invalid_request_error" string in the message as unrecoverable', () => {
+    const sdkErr = new Error('Request failed: invalid_request_error from upstream');
+    const classified = classifyClaudeError(sdkErr);
+    expect(classified.kind).toBe('unrecoverable');
+  });
+
+  it('does not match unrelated messages containing the word "invalid"', () => {
+    const sdkErr = new Error('Some unrelated invalid input from a tool');
+    const classified = classifyClaudeError(sdkErr);
+    // Must NOT be unrecoverable just because the word "invalid" appears —
+    // matching is anchored on the canonical Anthropic phrases only.
+    expect(classified.kind).toBe('transient');
+  });
+
+  it('still routes statused 400s through the existing branch (does not fall through)', () => {
+    const sdkErr = Object.assign(
+      new Error('The provided model identifier is invalid'),
+      { status: 400 },
+    );
+    const classified = classifyClaudeError(sdkErr);
+    expect(classified.kind).toBe('unrecoverable');
+    // The pre-existing status=400 branch handles this case before the new
+    // fallback runs; no effort-hint should fire (no effort marker present).
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/claude-provider-error-classifier.test.ts
+++ b/tests/claude-provider-error-classifier.test.ts
@@ -181,4 +181,13 @@ describe('classifyClaudeError — model identifier rejections without .status (#
     // fallback runs; no effort-hint should fire (no effort marker present).
     expect(warnSpy).not.toHaveBeenCalled();
   });
+
+  it('keeps a statused 5xx carrying invalid_request_error transient (status guard)', () => {
+    const sdkErr = Object.assign(
+      new Error('gateway error: invalid_request_error from upstream'),
+      { status: 503, error: { type: 'invalid_request_error' } },
+    );
+    const classified = classifyClaudeError(sdkErr);
+    expect(classified.kind).toBe('transient');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #2656: when the Anthropic Agent SDK wraps a `400 invalid_request_error` (e.g. *"The provided model identifier is invalid"*) the `.status` field can be lost in the wrapping. The pre-existing `errAny.status === 400` branch in `classifyClaudeError` is the only guard for these errors; without `.status` they fell through to the default `transient` branch and the worker retried the same permanent configuration error indefinitely while `/health` continued to report `ok`.

This adds a conservative message-anchored fallback **after** the existing status=400 branch so:
- Statused 400s still go through the existing path (the #2357 effort-hint logging is untouched).
- Status-less 400s with the canonical Anthropic phrases are now classified `unrecoverable`, so the retry loop stops and the dispatch site in `worker-service.ts` short-circuits (`hadUnrecoverableError = true`).

## What changes

Three canonical shapes are now treated as `unrecoverable`:

1. `error.type === 'invalid_request_error'` (Anthropic API body shape)
2. The canonical phrase `the provided model identifier is invalid` (anchored by `\b`)
3. Any error message that carries `invalid_request_error` as a token

The match is intentionally tight — unrelated messages that merely contain the word `invalid` still classify as `transient` (verified by a regression test).

## Scope

- `src/services/worker/ClaudeProvider.ts` — adds the fallback branch between the existing status=400 handler and the 5xx handler.
- `tests/claude-provider-error-classifier.test.ts` — adds 5 regression tests under `#2656`. The existing 7 tests still pass (12/12 ✓ on `bun test`).

Out of scope (explicitly listed as out-of-scope in the issue):
- The env-leak root cause already fixed by #2629.
- The `/health` degradation / `last_error` surface — left for a follow-up since it's a separate concern and a separate review surface; this PR keeps the diff minimal and focused on the retry-classifier symptom.

## Test plan

- [x] `bun test tests/claude-provider-error-classifier.test.ts` — 12 pass / 0 fail (5 new, 7 pre-existing)
- [x] `bunx tsc --noEmit` — no new TypeScript errors introduced (pre-existing unrelated errors in `CorpusRoutes.ts` and `find-claude-executable.ts` remain on `main`)
- [ ] Manual reviewer verification of the regex anchors against any other Anthropic 400 messages I may have missed

Marked as **draft** so the maintainer can verify the regex scope before review.

---

cc @YOMXXX @greptile-apps (per the issue thread)