### PR TITLE
[codex] fix logs clear with empty request body

### DIFF
--- a/src/services/worker/http/middleware.ts
+++ b/src/services/worker/http/middleware.ts
@@ -20,8 +20,8 @@ export function createMiddleware(
   middlewares.push((req: Request, res: Response, next: NextFunction) => {
     const staticExtensions = ['.html', '.js', '.css', '.svg', '.png', '.jpg', '.jpeg', '.webp', '.woff', '.woff2', '.ttf', '.eot'];
     const isStaticAsset = staticExtensions.some(ext => req.path.endsWith(ext));
-    const isPollingEndpoint = req.path === '/api/logs'; 
-    if (req.path.startsWith('/health') || req.path === '/' || isStaticAsset || isPollingEndpoint) {
+    const isQuietLogsEndpoint = req.path === '/api/logs' || req.path === '/api/logs/clear';
+    if (req.path.startsWith('/health') || req.path === '/' || isStaticAsset || isQuietLogsEndpoint) {
       return next();
     }
 

--- a/src/services/worker/http/routes/LogsRoutes.ts
+++ b/src/services/worker/http/routes/LogsRoutes.ts
@@ -1,14 +1,10 @@
 
-import express, { Request, Response } from 'express';
-import { z } from 'zod';
+import type { Application, Request, Response } from 'express';
 import { openSync, fstatSync, readSync, closeSync, existsSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { logger } from '../../../../utils/logger.js';
 import { SettingsDefaultsManager } from '../../../../shared/SettingsDefaultsManager.js';
 import { BaseRouteHandler } from '../BaseRouteHandler.js';
-import { validateBody } from '../middleware/validateBody.js';
-
-const clearLogsSchema = z.object({}).passthrough();
 
 export function readLastLines(filePath: string, lineCount: number): { lines: string; totalEstimate: number } {
   const fd = openSync(filePath, 'r');
@@ -84,9 +80,9 @@ export class LogsRoutes extends BaseRouteHandler {
     return join(dataDir, 'logs');
   }
 
-  setupRoutes(app: express.Application): void {
+  setupRoutes(app: Application): void {
     app.get('/api/logs', this.handleGetLogs.bind(this));
-    app.post('/api/logs/clear', validateBody(clearLogsSchema), this.handleClearLogs.bind(this));
+    app.post('/api/logs/clear', this.handleClearLogs.bind(this));
   }
 
   private handleGetLogs = this.wrapHandler((req: Request, res: Response): void => {

--- a/tests/services/logs-routes-tail-read.test.ts
+++ b/tests/services/logs-routes-tail-read.test.ts
@@ -1,9 +1,9 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
+import { writeFileSync, mkdirSync, rmSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { readLastLines } from '../../src/services/worker/http/routes/LogsRoutes.js';
+import { LogsRoutes, readLastLines } from '../../src/services/worker/http/routes/LogsRoutes.js';
 
 describe('readLastLines (#1203 OOM fix)', () => {
   const testDir = join(tmpdir(), `claude-mem-logs-test-${Date.now()}`);
@@ -111,5 +111,82 @@ describe('readLastLines (#1203 OOM fix)', () => {
     for (const l of resultLines) {
       expect(l).toBe('A'.repeat(100));
     }
+  });
+});
+
+describe('/api/logs/clear', () => {
+  let testDir: string;
+  let previousDataDir: string | undefined;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `claude-mem-clear-logs-test-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    previousDataDir = process.env.CLAUDE_MEM_DATA_DIR;
+    process.env.CLAUDE_MEM_DATA_DIR = testDir;
+    mkdirSync(join(testDir, 'logs'), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (previousDataDir === undefined) {
+      delete process.env.CLAUDE_MEM_DATA_DIR;
+    } else {
+      process.env.CLAUDE_MEM_DATA_DIR = previousDataDir;
+    }
+
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('accepts an empty POST body and removes existing log content', () => {
+    const date = new Date().toISOString().split('T')[0];
+    const logFile = join(testDir, 'logs', `claude-mem-${date}.log`);
+    writeFileSync(logFile, 'line1\nline2\n', 'utf-8');
+
+    const clearHandlers: Array<(req: any, res: any, next: () => void) => void> = [];
+    const app = {
+      get: () => {},
+      post: (path: string, ...handlers: Array<(req: any, res: any, next: () => void) => void>) => {
+        if (path === '/api/logs/clear') {
+          clearHandlers.push(...handlers);
+        }
+      },
+    };
+
+    new LogsRoutes().setupRoutes(app as any);
+
+    let statusCode = 200;
+    let responseBody: unknown;
+    const response = {
+      status: (code: number) => {
+        statusCode = code;
+        return response;
+      },
+      json: (body: unknown) => {
+        responseBody = body;
+        return response;
+      },
+    };
+
+    const request = { body: undefined, path: '/api/logs/clear' };
+    for (const handler of clearHandlers) {
+      let nextCalled = false;
+      handler(request, response, () => {
+        nextCalled = true;
+      });
+
+      if (!nextCalled) {
+        break;
+      }
+    }
+
+    expect(statusCode).toBe(200);
+    expect(responseBody).toMatchObject({
+      success: true,
+      message: 'Log file cleared',
+      path: logFile,
+    });
+    const logContent = readFileSync(logFile, 'utf-8');
+    expect(logContent).not.toContain('line1');
+    expect(logContent).not.toContain('line2');
   });
 });


### PR DESCRIPTION
## Summary

- Allow `POST /api/logs/clear` to run without a request body, matching the viewer's bodyless clear request.
- Keep the existing `Log file cleared via UI` audit log entry after a successful clear.
- Treat `/api/logs/clear` as a quiet logs endpoint in HTTP request logging so DEBUG request/response logging does not add extra clear-request lines.

## Reproduction

1. Start the local claude-mem viewer and open the Console drawer.
2. Click the trash / clear logs button.
3. Confirm the clear action.

Before this change, the viewer showed `Failed to clear logs: Bad Request` and the log file was not truncated.

## Expected Behavior

The bodyless clear request should return success and remove the previous log contents.

The route still records the existing `Log file cleared via UI` audit entry after a successful clear.

## Root Cause

The viewer calls `authFetch('/api/logs/clear', { method: 'POST' })` without a body. The route previously wrapped the handler in `validateBody(z.object({}).passthrough())`, so `req.body === undefined` failed validation and returned `400 Bad Request` before the log file was truncated.

## Validation

- `bun test tests/services/logs-routes-tail-read.test.ts`

This includes a regression test that invokes the clear route with `body: undefined` and verifies the pre-existing log contents are removed.