### PR TITLE
fix(worker): defend v12.4.3 disk gate against statfsSync bsize=0 on darwin-x64

### DIFF
--- a/src/services/infrastructure/CleanupV12_4_3.ts
+++ b/src/services/infrastructure/CleanupV12_4_3.ts
@@ -113,10 +113,38 @@ function executeCleanup(dbPath: string, effectiveDataDir: string, markerPath: st
   let backupPath: string | null = null;
   try {
     const fs = statfsSync(effectiveDataDir);
-    const free = Number(fs.bavail) * Number(fs.bsize);
-    if (free < required) {
-      logger.error('SYSTEM', 'Insufficient disk for v12.4.3 backup; skipping cleanup (will retry on next startup)', { dbSize, free, required });
-      return;
+    const bsize = Number(fs.bsize);
+    const bavail = Number(fs.bavail);
+
+    // Bun <= 1.3.14 on darwin-x64 returns a misaligned statfs struct
+    // (bsize = 0, fields shifted by one slot). Tracking issue:
+    //   https://github.com/oven-sh/bun/issues/31133
+    // Fix landed upstream in:
+    //   https://github.com/oven-sh/bun/pull/31139
+    // and will ship in the next Bun release after 1.3.14. Until then, any
+    // `bavail * bsize` math returns 0 and this gate would permanently skip
+    // the cleanup with a misleading `free=0` error. Treat non-credible
+    // readings (bsize <= 0, NaN, or non-finite) as "skip the gate" rather
+    // than "disk is full" -- a real out-of-space condition will still
+    // surface from the subsequent VACUUM INTO / copyFileSync.
+    if (!Number.isFinite(bsize) || !Number.isFinite(bavail) || bsize <= 0) {
+      logger.warn(
+        'SYSTEM',
+        'statfsSync returned non-credible values; proceeding without disk-space pre-flight',
+        {
+          bsize,
+          bavail,
+          runtime: typeof Bun !== 'undefined' ? `bun ${Bun.version}` : 'node',
+          platform: `${process.platform}-${process.arch}`,
+          hint: 'see https://github.com/oven-sh/bun/issues/31133 for the darwin-x64 case',
+        },
+      );
+    } else {
+      const free = bavail * bsize;
+      if (free < required) {
+        logger.error('SYSTEM', 'Insufficient disk for v12.4.3 backup; skipping cleanup (will retry on next startup)', { dbSize, free, required });
+        return;
+      }
     }
   } catch (err: unknown) {
     const error = err instanceof Error ? err : new Error(String(err));

--- a/tests/infrastructure/cleanup-v12_4_3.test.ts
+++ b/tests/infrastructure/cleanup-v12_4_3.test.ts
@@ -172,7 +172,6 @@ describe('runOneTimeV12_4_3Cleanup', () => {
     const dbPath = path.join(tmpDataDir, 'claude-mem.db');
     seedDatabase(dbPath, { observerSessions: 2, stuckCount: 10 });
 
-    const realStatfsSync = fs.statfsSync;
     const statfsSpy = spyOn(fs, 'statfsSync').mockImplementation(() => ({
       type: 0,
       bsize: 0, // ← the bug: should be 4096 on APFS
@@ -181,7 +180,7 @@ describe('runOneTimeV12_4_3Cleanup', () => {
       bavail: 977028249,
       files: 0,
       ffree: 0,
-    }) as unknown as ReturnType<typeof realStatfsSync>);
+    }) as unknown as ReturnType<typeof fs.statfsSync>);
 
     try {
       runOneTimeV12_4_3Cleanup(tmpDataDir);
@@ -196,6 +195,19 @@ describe('runOneTimeV12_4_3Cleanup', () => {
     expect(payload.counts.stuckPendingMessages).toBe(10);
     expect(payload.backupPath).toBeTruthy();
     expect(existsSync(payload.backupPath)).toBe(true);
+
+    // Guard against the spy silently failing to intercept the named ESM import
+    // inside CleanupV12_4_3.ts. If the production code is still calling the
+    // real statfsSync (which returns ~1 TB free on this machine), the cleanup
+    // still completes and every assertion above passes vacuously. The WARN
+    // log line is only emitted on the defensive branch, so asserting on it
+    // disambiguates "spy worked, defensive branch fired" from "spy silently
+    // bypassed, normal branch fired".
+    expect(logger.warn).toHaveBeenCalledWith(
+      'SYSTEM',
+      expect.stringContaining('non-credible'),
+      expect.objectContaining({ bsize: 0 }),
+    );
   });
 
   it('honors CLAUDE_MEM_SKIP_CLEANUP_V12_4_3=1 by exiting without writing the marker', () => {

--- a/tests/infrastructure/cleanup-v12_4_3.test.ts
+++ b/tests/infrastructure/cleanup-v12_4_3.test.ts
@@ -1,5 +1,6 @@
 
 import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import * as fs from 'fs';
 import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync, readFileSync, readdirSync } from 'fs';
 import path from 'path';
 import { tmpdir } from 'os';
@@ -159,6 +160,42 @@ describe('runOneTimeV12_4_3Cleanup', () => {
     runOneTimeV12_4_3Cleanup(tmpDataDir);
     const backupsAfterSecond = readdirSync(path.join(tmpDataDir, 'backups'));
     expect(backupsAfterSecond).toEqual(backupsAfterFirst);
+  });
+
+  it('proceeds with cleanup when statfsSync returns non-credible values (Bun darwin-x64 #31133)', () => {
+    // Reproduce the Bun 1.3.14 darwin-x64 statfs misalignment: bsize comes back
+    // as 0 and the other fields are shifted by one slot.
+    // Before the defensive patch, this caused the cleanup to compute
+    // free = bavail * bsize = 0 and skip with a misleading "Insufficient disk"
+    // error. After the patch, the gate should be bypassed with a WARN and the
+    // cleanup should run to completion.
+    const dbPath = path.join(tmpDataDir, 'claude-mem.db');
+    seedDatabase(dbPath, { observerSessions: 2, stuckCount: 10 });
+
+    const realStatfsSync = fs.statfsSync;
+    const statfsSpy = spyOn(fs, 'statfsSync').mockImplementation(() => ({
+      type: 0,
+      bsize: 0, // ← the bug: should be 4096 on APFS
+      blocks: 4096,
+      bfree: 1048576,
+      bavail: 977028249,
+      files: 0,
+      ffree: 0,
+    }) as unknown as ReturnType<typeof realStatfsSync>);
+
+    try {
+      runOneTimeV12_4_3Cleanup(tmpDataDir);
+    } finally {
+      statfsSpy.mockRestore();
+    }
+
+    const markerPath = path.join(tmpDataDir, '.cleanup-v12.4.3-applied');
+    expect(existsSync(markerPath)).toBe(true);
+    const payload = JSON.parse(readFileSync(markerPath, 'utf8'));
+    expect(payload.counts.observerSessions).toBe(2);
+    expect(payload.counts.stuckPendingMessages).toBe(10);
+    expect(payload.backupPath).toBeTruthy();
+    expect(existsSync(payload.backupPath)).toBe(true);
   });
 
   it('honors CLAUDE_MEM_SKIP_CLEANUP_V12_4_3=1 by exiting without writing the marker', () => {


### PR DESCRIPTION
Fixes #2683

## Summary

The v12.4.3 cleanup permanently fails with `Insufficient disk for v12.4.3 backup; skipping cleanup` on darwin-x64 (Intel macOS) even with terabytes free, because Bun ≤ 1.3.14 returns a misaligned `statfs` struct (`bsize=0`, fields shifted by one slot). With `bsize=0`, the gate's `bavail * bsize` math always returns `0`, and the `.cleanup-v12.4.3-applied` marker is never written.

This PR adds a defensive guard so that a non-credible `statfsSync` reading (`bsize <= 0`, `NaN`, or non-finite) skips the gate with a `[WARN]` rather than reporting a phantom out-of-space condition. A real out-of-space error still surfaces from the subsequent `VACUUM INTO` / `copyFileSync` calls.

## Root cause

Upstream Bun issue: [oven-sh/bun#31133](https://github.com/oven-sh/bun/issues/31133)
Upstream fix: [oven-sh/bun#31139](https://github.com/oven-sh/bun/pull/31139) (merged 2026-05-21, not yet released — latest Bun is v1.3.14 from 2026-05-13)

`libc::statfs` on x86_64 Apple targets links to the `statfs$INODE64` symbol, which writes the legacy pre-Leopard struct layout into Rust's modern 64-bit-inode buffer. Reading the buffer back through `libc::statfs`'s field offsets leaves `f_bsize` reading the first two `short` fields as zero, with every subsequent `long` field landing one slot later than expected. darwin-arm64 is unaffected because the symbol there is unsuffixed and points at the modern layout.

```
                              expected     got
type     ───────────────────  26           0
bsize    ───────────────────  4096         0    ← the bug
blocks   ───────────────────  ~488 M       4096
bfree    ───────────────────  ~473 M       1048576
bavail   ───────────────────  ~473 M       ~488 M
```

## Reproduction

On any darwin-x64 host with Bun ≤ 1.3.14:

```bash
$ uname -m
x86_64

$ bun --version
1.3.14

$ bun -e 'console.log(require("fs").statfsSync("/").bsize)'
0n                          # ← bug

$ node -e 'console.log(require("fs").statfsSync("/").bsize)'
4096                        # ← correct
```

With `bsize=0n`, every cold worker boot emits:
```
[ERROR] [SYSTEM] Insufficient disk for v12.4.3 backup; skipping cleanup (will retry on next startup)
        {dbSize=239882240, free=0, required=392716288}
```

…and the marker file is never written, so the cleanup re-attempts indefinitely.

## The fix

`src/services/infrastructure/CleanupV12_4_3.ts`, function `executeCleanup`:

- Coerce `bsize` and `bavail` to `Number` and probe for `bsize <= 0`, `NaN`, or non-finite.
- On a non-credible reading: emit a `[WARN]` with platform + runtime + bsize/bavail context (and a link to oven-sh/bun#31133 so anyone hitting it understands why) and fall through to the cleanup. The existing `VACUUM INTO` / `copyFileSync` paths still surface a real disk-full condition.
- On a credible reading: existing behaviour is unchanged — compute `free = bavail * bsize`, compare against `required`, log `[ERROR] Insufficient disk …` if too small.

The existing `catch` block (which handles `statfsSync` *throwing*) is preserved verbatim.

## Test plan

Adds a regression test in `tests/infrastructure/cleanup-v12_4_3.test.ts` that:

1. Seeds the temp DB with observer-sessions and stuck pending messages.
2. `spyOn`s `fs.statfsSync` to return the exact broken Bun output (`{bsize: 0, bavail: 977028249, bfree: 1048576, blocks: 4096, …}`).
3. Invokes `runOneTimeV12_4_3Cleanup`.
4. Asserts the marker file IS written (cleanup did not skip).
5. Asserts the observer-sessions purge, stuck-pending purge, and backup file all happened.
6. Restores the spy in `finally`.

Local results on `1.4.0-canary.1+4ee835b75` (Bun's main branch post-#31139):

```
bun test v1.4.0-canary.1 (4ee835b75)

 6 pass
 0 fail
 29 expect() calls
Ran 6 tests across 1 file. [346.00ms]
```

The 5 existing `runOneTimeV12_4_3Cleanup` test cases continue to pass unchanged; the new case is the 6th.

Validated end-to-end on the affected platform (`Darwin … RELEASE_X86_64`, Intel Xeon W-2150B) by rebuilding `plugin/scripts/worker-service.cjs` and swapping it into the local plugin cache. The defensive code is also runtime-verified to be transparent under Bun ≥ 1.3.15 / canary builds, where `bsize` returns 4096 correctly and the new branch is not taken.

## Risk

Low. The patch only changes behaviour in the path where the runtime returns garbage. Production behaviour on healthy runtimes is byte-identical to before. If a future runtime returns a different flavour of garbage (e.g. `bavail` is the broken field instead of `bsize`), this guard would let the cleanup proceed and the underlying disk write would surface a real `ENOSPC` if applicable.

## Refs

- Upstream Bun issue: https://github.com/oven-sh/bun/issues/31133
- Upstream Bun fix PR: https://github.com/oven-sh/bun/pull/31139
- Local RCA: full root-cause analysis available on request


