### PR TITLE
feat(skills): failfund — refund auditor for overworked sessions (half a joke)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ logs/run_evaluation/
 .docker-blowout-data/
 .scratch/
 docker/install-test/
+reports/*.pdf

--- a/plugin/skills/failfund/SKILL.md
+++ b/plugin/skills/failfund/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: failfund
+description: Audit the current Claude Code session for overwork and produce a refund request. Use this whenever the user feels Claude wasted their tokens or money — phrases like "failfund", "request a refund", "I want my money back", "you overworked", "you did way more than I asked", "you built that without asking", "you ignored my directive", "that was a waste of tokens", "why did you do all that", or any frustration that Claude went out of scope, kept going after being told to stop, gold-plated, or burned tokens on work the user never requested. Reads the real session transcript, tallies token usage per turn, flags genuine overwork with evidence, quantifies the wasted tokens, and writes a submittable refund request.
+---
+
+# failfund
+
+Turn a frustrating session into evidence. failfund reads the current chat's transcript, finds where Claude overworked — ignored a clear directive, built or changed things without permission, went out of scope, or burned tokens on work the user never asked for — quantifies the waste in tokens, and writes a refund request the user can actually submit.
+
+The point is an **honest, evidence-backed** accounting, not a grievance generator. A refund request that fabricates violations is worse than useless: it wastes the user's credibility. So flag only real overwork, and if the session was clean, say so plainly.
+
+## When to use
+
+Trigger when the user is unhappy about wasted effort or money in *this* session: "failfund", "I want a refund", "you wasted my tokens", "you did a bunch of stuff I never asked for", "you ignored what I told you", "you kept going after I said stop", "why did you build all that". The user is asking you to indict the session's behavior and produce something they can send to Anthropic.
+
+## How a session gets charged (so you attribute waste correctly)
+
+Each assistant turn reports four token counts. They are NOT equal in how cleanly you can blame a turn for them:
+
+- **output** — what Claude generated that turn. This is the most directly attributable cost of a turn. If a turn did unrequested work, its `output` tokens are squarely wasted.
+- **input / cache creation** — context sent up / written to cache for that turn.
+- **cache read** — the entire prior conversation replayed on every subsequent turn. This is why a multi-turn detour compounds: each extra turn Claude took down a wrong path also forced the whole context to be re-read on the turns after it.
+
+So the floor for waste is the summed `output` of the offending turns. The fuller cost includes the cache-read those detour turns induced on everything that followed. Report the floor as the hard number and mention the induced cost qualitatively.
+
+## Workflow
+
+### Step 1 — Extract the transcript audit view
+
+Run the bundled analyzer. It locates this session's transcript, dedups Claude Code's per-content-block line duplication (one API response is written as several JSONL lines that each repeat the same usage — counting per line would inflate the tally several-fold), tallies tokens once per turn, and prints a compact, token-attributed, turn-by-turn view.
+
+```bash
+node "<SKILL_DIR>/scripts/analyze-transcript.cjs"
+```
+
+`<SKILL_DIR>` is this skill's own directory — the path you were given when the skill activated (under the installed plugin, `${CLAUDE_PLUGIN_ROOT}/skills/failfund`). The analyzer defaults to the current working directory's session; if the user is in a different project or you need a specific chat, pass an explicit `.jsonl` path or project dir as the first argument, or `--cwd <dir>`.
+
+**Use the analyzer's output as your source of truth.** Do not read the raw transcript JSONL — it is often enormous and reading it would itself be the kind of token waste this skill exists to call out. Only go back to the raw file (with Read + a line range) if you need an exact verbatim quote for evidence.
+
+If the analyzer exits with an error (no transcript found), surface its message — it lists candidate project dirs. Don't guess a transcript; auditing the wrong chat produces a false refund request.
+
+### Step 2 — Audit for overwork
+
+Read the turn-by-turn view and the user's prompts. Judge each stretch of assistant work against what the user actually asked for in the surrounding prompts. Flag genuine instances in these four categories:
+
+1. **Directive violation** — Claude did the opposite of, or ignored, an explicit instruction. Pay attention to emphasis and capitalization in the user's prompts and to any standing directives in context (e.g. "plan first", "don't change scope", "ask before X"). Continuing after being told to stop belongs here.
+2. **Built without permission** — Claude created/edited files, ran installs/builds/deploys, committed, or otherwise *implemented* when the user only asked to plan, design, discuss, investigate, or look. The tell is a prompt asking for thinking or a decision, followed by tool calls that mutate state.
+3. **Out of scope** — Work beyond the request: extra features, speculative abstraction, refactors nobody asked for, gold-plating, "while I was in there" expansions. YAGNI in reverse.
+4. **Token waste** — Re-reading files already read, redundant or overlapping searches, retry loops around a mistake, building something then abandoning it, long meta-commentary, or re-deriving facts already established. Wrong turns that got walked back.
+
+For each finding capture: the governing **directive or scope** (quote the user), **what Claude did** (which `A#` turns, what action), **why it's overwork**, and the **attributable cost** (sum the `output` of those turns; note induced cache-read if it was a multi-turn detour).
+
+**Be fair.** Necessary work is not waste: reasonable research before acting, one correction of a genuine mistake, work the user did ask for. Reading three files to answer a question is doing the job; reading the same file three times is waste. Don't inflate the count — a credible request with three real findings beats a padded one with ten weak ones. If you find nothing chargeable, say so and stop (see Step 5).
+
+### Step 3 — Tally the waste
+
+Sum the `output` tokens across all flagged turns. Compute the wasted share of the session's total output. This is the quantitative backbone of the request — keep it grounded in the analyzer's numbers, don't invent figures.
+
+### Step 4 — Write the refund request
+
+Write the request to `./failfund-refund-request-<YYYY-MM-DD>.md` in the user's working directory. Use this structure:
+
+```markdown
+# Refund Request
+
+- **Date:** <date>
+- **Session:** <session id>
+- **Model:** <model(s)>
+- **Wasted output tokens:** <N> of <session total> (<percent>%)
+
+## Summary
+
+<2–4 sentences: what the user asked for, the ways Claude overworked, and the
+total attributable waste. Plain and factual.>
+
+## Findings
+
+### 1. <short title> — <category>
+
+- **You asked:** "<quote of the directive or the scope of the request>"
+- **What Claude did:** A<#>–A<#> — <description of the unrequested/contrary work>
+- **Why it's overwork:** <one or two sentences>
+- **Attributable cost:** ~<N> output tokens<, plus induced cache-read across the
+  N turns that followed the detour>
+
+### 2. ...
+
+## Token waste tally
+
+| Category | Turns | Output tokens | Note |
+| --- | --- | --- | --- |
+| <category> | A#, A# | <N> | <note> |
+| **Total wasted** | | **<N>** | **<percent>% of session output** |
+
+## Requested remedy
+
+<A specific, proportionate ask — e.g. a credit for the wasted portion of the
+session — stated in plain language.>
+```
+
+Then print the **Summary** and the **tally table** inline in the chat so the user sees the verdict immediately, and tell them the full request was saved to the file path.
+
+### Step 5 — Be honest about submission and about clean sessions
+
+- **Submission:** There is no public API that auto-files this. failfund produces the *document* the user submits. Tell them to send it to Anthropic Support (support.anthropic.com) or their billing contact, with the session id attached. Do not claim a refund was filed or approved.
+- **Clean session:** If the audit turns up no genuine overwork, do not manufacture findings to justify a refund. Report it straight: "I reviewed N turns / X output tokens and didn't find chargeable overwork — the work tracked what you asked for." Optionally note the single biggest cost so the user can judge for themselves. A skill that cries wolf is worth nothing the day there's a real wolf.
+
+## Example
+
+User: "failfund — you were supposed to just plan this and you went and rewrote half my auth module"
+
+1. Run the analyzer → audit view shows the user asked for a plan at the USER turn, then A3–A9 ran `Edit`/`Write` on auth files.
+2. Flag one **Built without permission** finding (plan requested, implementation delivered) and any **Token waste** from work later reverted.
+3. Tally: e.g. 7,400 output tokens across A3–A9 = 38% of session output.
+4. Write `./failfund-refund-request-2026-05-25.md`, print the summary + tally, point the user at Anthropic Support.

--- a/plugin/skills/failfund/scripts/analyze-transcript.cjs
+++ b/plugin/skills/failfund/scripts/analyze-transcript.cjs
@@ -38,7 +38,10 @@ function parseArgs(argv) {
   for (let i = 2; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--json') args.json = true;
-    else if (a === '--cwd') args.cwd = argv[++i];
+    else if (a === '--cwd') {
+      if (i + 1 >= argv.length) throw new Error('--cwd requires a path argument');
+      args.cwd = argv[++i];
+    }
     else if (!args.positional) args.positional = a;
   }
   return args;

--- a/plugin/skills/failfund/scripts/analyze-transcript.cjs
+++ b/plugin/skills/failfund/scripts/analyze-transcript.cjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+/**
+ * failfund transcript analyzer
+ *
+ * Locates the current Claude Code session transcript, tallies token usage
+ * per turn, and emits a compact, token-attributed audit view that the model
+ * can reason over WITHOUT reading the raw (often enormous) JSONL.
+ *
+ * Why a script and not inline parsing: this work is deterministic and
+ * repetitive (find file -> parse JSONL -> sum usage -> truncate). Doing it
+ * once here keeps every failfund invocation cheap and consistent, and means
+ * the audit step spends its tokens on judgment, not on re-deriving the same
+ * per-turn table.
+ *
+ * Usage:
+ *   node analyze-transcript.cjs [transcriptPathOrProjectDir] [--cwd <dir>] [--json]
+ *
+ * Resolution order for the transcript:
+ *   1. An explicit .jsonl path passed as the first arg.
+ *   2. A project dir passed as the first arg -> newest .jsonl inside it.
+ *   3. The encoded dir for --cwd (or process.cwd()) under
+ *      ~/.claude/projects/<encoded> -> newest .jsonl inside it.
+ *
+ * Claude Code encodes the working directory into the projects dir name by
+ * replacing every "/" and "." with "-". We reproduce that mapping. If the
+ * encoded dir does not exist we FAIL LOUDLY with the path we looked for
+ * rather than silently grabbing some other session's transcript — picking
+ * the wrong transcript would quietly produce a refund request about work
+ * that happened in a different chat.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+function parseArgs(argv) {
+  const args = { positional: null, cwd: process.cwd(), json: false };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--json') args.json = true;
+    else if (a === '--cwd') args.cwd = argv[++i];
+    else if (!args.positional) args.positional = a;
+  }
+  return args;
+}
+
+function encodeCwd(cwd) {
+  // Matches Claude Code's projects-dir encoding: "/" and "." -> "-".
+  return cwd.replace(/[/.]/g, '-');
+}
+
+function newestJsonlIn(dir) {
+  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) return null;
+  const files = fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith('.jsonl'))
+    .map((f) => {
+      const full = path.join(dir, f);
+      return { full, mtime: fs.statSync(full).mtimeMs };
+    })
+    .sort((a, b) => b.mtime - a.mtime);
+  return files.length ? files[0].full : null;
+}
+
+function resolveTranscript(args) {
+  if (args.positional) {
+    if (args.positional.endsWith('.jsonl')) {
+      if (!fs.existsSync(args.positional)) {
+        throw new Error(`Transcript path does not exist: ${args.positional}`);
+      }
+      return args.positional;
+    }
+    const found = newestJsonlIn(args.positional);
+    if (!found) throw new Error(`No .jsonl transcripts found in: ${args.positional}`);
+    return found;
+  }
+
+  const projectsRoot = path.join(os.homedir(), '.claude', 'projects');
+  const encoded = encodeCwd(args.cwd);
+  const dir = path.join(projectsRoot, encoded);
+  const found = newestJsonlIn(dir);
+  if (found) return found;
+
+  // Fail loud: list nearby candidates so the user can pass one explicitly.
+  let hint = '';
+  if (fs.existsSync(projectsRoot)) {
+    const base = path.basename(args.cwd);
+    const candidates = fs
+      .readdirSync(projectsRoot)
+      .filter((d) => d.includes(base))
+      .slice(0, 10);
+    if (candidates.length) {
+      hint =
+        `\nProject dirs that mention "${base}":\n` +
+        candidates.map((c) => `  ${path.join(projectsRoot, c)}`).join('\n') +
+        `\nPass the right one (or a .jsonl path) as the first argument.`;
+    }
+  }
+  throw new Error(
+    `No transcript dir for cwd:\n  ${args.cwd}\nExpected:\n  ${dir}${hint}`
+  );
+}
+
+function asText(content) {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .filter((c) => c && c.type === 'text' && typeof c.text === 'string')
+      .map((c) => c.text)
+      .join('\n');
+  }
+  return '';
+}
+
+function toolUses(content) {
+  if (!Array.isArray(content)) return [];
+  return content
+    .filter((c) => c && c.type === 'tool_use')
+    .map((c) => {
+      const input = c.input || {};
+      // A short, human-readable summary of the most telling input field.
+      const summary =
+        input.command ||
+        input.file_path ||
+        input.path ||
+        input.pattern ||
+        input.prompt ||
+        input.description ||
+        input.url ||
+        '';
+      return { name: c.name, summary: String(summary).replace(/\s+/g, ' ').slice(0, 160) };
+    });
+}
+
+function truncate(s, n) {
+  s = (s || '').replace(/\s+$/g, '');
+  return s.length > n ? s.slice(0, n) + ` …[+${s.length - n} chars]` : s;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const transcriptPath = resolveTranscript(args);
+  const raw = fs.readFileSync(transcriptPath, 'utf-8');
+  const lines = raw.split('\n').filter((l) => l.trim());
+
+  const totals = { input: 0, cache_creation: 0, cache_read: 0, output: 0 };
+  const turns = [];
+  const models = new Set();
+  let sessionId = null;
+  let assistantIndex = 0;
+
+  // Claude Code writes ONE assistant API response as MULTIPLE JSONL lines —
+  // one per content block (thinking, text, tool_use, tool_use, …) — and every
+  // one of those lines repeats the SAME message.usage. Counting per line would
+  // multiply the token tally by the number of blocks. So we group by the API
+  // message id: usage is counted once per id, and the blocks are merged back
+  // into a single turn.
+  const assistantTurnsById = new Map();
+
+  for (const line of lines) {
+    let obj;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      continue; // tolerate truncated/partial lines
+    }
+    if (obj.sessionId && !sessionId) sessionId = obj.sessionId;
+    // Skip subagent sidechains — they are charged work but not the main
+    // conversation the user is judging. Note their presence separately.
+    const isSidechain = obj.isSidechain === true;
+
+    if (obj.type === 'user' && obj.message && !isSidechain) {
+      const text = asText(obj.message.content);
+      // Tool results come back as role:user too; only keep real user prose.
+      const hasToolResult =
+        Array.isArray(obj.message.content) &&
+        obj.message.content.some((c) => c && c.type === 'tool_result');
+      if (text.trim() && !hasToolResult) {
+        turns.push({ role: 'user', text, ts: obj.timestamp });
+      }
+    } else if (obj.type === 'assistant' && obj.message) {
+      const msgId = obj.message.id || `${obj.uuid || turns.length}`;
+      if (obj.message.model) models.add(obj.message.model);
+
+      let turn = assistantTurnsById.get(msgId);
+      if (!turn) {
+        // First line for this response: count its usage exactly once.
+        const u = obj.message.usage || {};
+        const usage = {
+          out: u.output_tokens || 0,
+          inp: u.input_tokens || 0,
+          cc: u.cache_creation_input_tokens || 0,
+          cr: u.cache_read_input_tokens || 0,
+        };
+        totals.output += usage.out;
+        totals.input += usage.inp;
+        totals.cache_creation += usage.cc;
+        totals.cache_read += usage.cr;
+        assistantIndex += 1;
+        turn = {
+          role: 'assistant',
+          idx: assistantIndex,
+          text: '',
+          tools: [],
+          usage,
+          sidechain: isSidechain,
+          ts: obj.timestamp,
+        };
+        assistantTurnsById.set(msgId, turn);
+        turns.push(turn);
+      }
+      // Merge this line's blocks into the turn (text and tool_use arrive on
+      // separate lines for the same message id).
+      const text = asText(obj.message.content);
+      if (text.trim()) turn.text = turn.text ? `${turn.text}\n${text}` : text;
+      turn.tools.push(...toolUses(obj.message.content));
+    }
+  }
+
+  const result = {
+    transcriptPath,
+    sessionId,
+    models: [...models],
+    totals,
+    turns,
+  };
+
+  if (args.json) {
+    process.stdout.write(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  // Markdown audit view -------------------------------------------------
+  const fmt = (n) => n.toLocaleString('en-US');
+  const out = [];
+  out.push(`# Transcript audit source`);
+  out.push(``);
+  out.push(`- File: ${transcriptPath}`);
+  out.push(`- Session: ${sessionId || 'unknown'}`);
+  out.push(`- Model(s): ${[...models].join(', ') || 'unknown'}`);
+  out.push(
+    `- Turns: ${turns.filter((t) => t.role === 'user').length} user / ${assistantIndex} assistant`
+  );
+  out.push(``);
+  out.push(`## Session token totals`);
+  out.push(`| metric | tokens |`);
+  out.push(`| --- | --- |`);
+  out.push(`| output (generated by Claude) | ${fmt(totals.output)} |`);
+  out.push(`| input (fresh) | ${fmt(totals.input)} |`);
+  out.push(`| cache creation | ${fmt(totals.cache_creation)} |`);
+  out.push(`| cache read (context replayed each turn) | ${fmt(totals.cache_read)} |`);
+  out.push(``);
+  out.push(
+    `> Attribution note: \`output\` is the most directly attributable cost of a turn — ` +
+      `it is what Claude actually generated that turn. Every extra assistant turn ALSO ` +
+      `forces the whole prior context to be re-read (the \`cache read\` column), so a ` +
+      `multi-turn detour compounds. When tallying waste, sum the \`out\` of the flagged ` +
+      `turns as the floor, and note the induced cache-read cost of the turns that followed.`
+  );
+  out.push(``);
+  out.push(`## Turn-by-turn`);
+  out.push(``);
+
+  for (const t of turns) {
+    if (t.role === 'user') {
+      out.push(`### USER`);
+      out.push('```');
+      out.push(truncate(t.text, 2000));
+      out.push('```');
+      out.push(``);
+    } else {
+      const u = t.usage;
+      const tag = t.sidechain ? ' (subagent sidechain)' : '';
+      out.push(
+        `### A${t.idx}${tag} — out=${fmt(u.out)} in=${fmt(u.inp)} cache_create=${fmt(
+          u.cc
+        )} cache_read=${fmt(u.cr)}`
+      );
+      const text = truncate(t.text, 1000);
+      if (text.trim()) {
+        out.push(text);
+      }
+      if (t.tools.length) {
+        out.push(``);
+        out.push(
+          `tools: ` + t.tools.map((x) => `${x.name}(${x.summary})`).join(' · ')
+        );
+      }
+      out.push(``);
+    }
+  }
+
+  process.stdout.write(out.join('\n'));
+}
+
+try {
+  main();
+} catch (err) {
+  // Fail fast and loud — a wrong/empty transcript must not silently yield a
+  // bogus refund request.
+  process.stderr.write(`[failfund] ${err.message}\n`);
+  process.exit(1);
+}

--- a/reports/failfund.md
+++ b/reports/failfund.md
@@ -1,0 +1,79 @@
+# failfund: Turn an Overworked Session Into a Refund
+
+## The feeling that starts it
+
+You asked for one thing. You got that thing — plus three other things you never asked for, a refactor of a file you didn't mention, a new abstraction "to be safe," and a wall of explanation you skimmed and closed. Somewhere in the middle, you said "just plan it," and the assistant went ahead and wrote the code anyway. The work got done, eventually. But you can feel it: a lot of that motion was for nobody. It cost you tokens, and tokens cost money.
+
+That feeling — *I paid for work I didn't order* — is the whole reason `failfund` exists.
+
+`failfund` is a Claude Code skill. You invoke it when a session has left you with that taste in your mouth. It reads the real transcript of the chat you just had, finds the places where Claude overworked, measures the waste in actual tokens, and writes you a refund request you can submit. Not a vague complaint. An itemized, evidence-backed bill for the work you never authorized.
+
+The name is a small joke with a serious spine. "Fail fast" is a principle good engineers live by: surface problems loudly instead of letting them rot in silence. `failfund` applies that same spirit to the bill. When a session fails you by overworking, it fails *loudly* — with receipts.
+
+## What "overworking" actually means
+
+It is worth being precise, because the word can sound like a complaint about effort, and that is not it. Effort spent on what you asked for is the job. Overworking is effort spent on things you did *not* ask for. `failfund` sorts it into four honest categories.
+
+**Directive violations.** You gave a clear instruction and the assistant did the opposite, or ignored it. You wrote "PLAN — don't touch the code yet," in caps, and the next thing that happened was a file edit. You said "stop," and it kept going. Capitalization and emphasis in your prompts are not decoration; they are the loudest signal you have, and overriding them is the most direct form of overwork.
+
+**Building without permission.** You asked to think, to discuss, to design, to investigate — and instead of an answer you got an implementation. The tell is simple: a prompt that asks for a decision, immediately followed by tool calls that change files, install packages, run a build, or make a commit. Sometimes the work is even good work. It is still work you did not order, on a clock you are paying for.
+
+**Out of scope.** The request had edges, and the assistant colored outside them. Extra features nobody mentioned. A speculative abstraction "in case we need it later." A refactor of code that was working fine. Gold-plating — polishing a corner that did not need polishing. This is the YAGNI principle turned inside out: building it before anyone needs it, and charging you for the privilege.
+
+**Token waste.** The quiet one. Re-reading a file that was already read. Running three overlapping searches that each return the same thing. Going down a wrong path, hitting a wall, walking it back — and the walking-back is on your tab too. Long meta-commentary you did not need. Re-deriving a fact established four turns ago. None of it is dramatic. All of it adds up.
+
+## How the bill actually works
+
+To write an honest refund request, you have to understand what you are actually being charged for. `failfund` does, and it teaches the model that runs it to attribute waste correctly instead of waving its hands.
+
+Every turn the assistant takes reports four different token counts, and they are not equal in how cleanly you can blame a turn for them.
+
+The cleanest one is **output** — the tokens the assistant actually generated on that turn. If a turn did unrequested work, its output tokens are squarely, unarguably wasted. This is the floor of any honest claim.
+
+Then there is the sneaky one: **cache read**. On every single turn, the entire prior conversation is replayed so the model can see it. This means a detour does not just cost its own output. Every turn that comes *after* the detour now has to re-read the detour, forever, for the rest of the session. A five-turn wander down the wrong path is not five turns of waste — it is five turns of output *plus* the weight of those five turns dragged across every turn that follows. Waste compounds. `failfund` reports the output as the hard number and names the compounding cost so the picture is honest rather than inflated.
+
+This matters because a refund request that fabricates or exaggerates is worse than no request at all. It burns your credibility for the day you have a real grievance. So `failfund` is built to be fair on purpose.
+
+## The fairness principle
+
+This is the heart of the skill, and the thing that keeps it from being a grievance generator.
+
+`failfund` only flags work that is genuinely chargeable. Reading three files to answer your question is doing the job; reading the *same* file three times is waste — and the skill knows the difference. One honest correction of a real mistake is part of working, not something to bill you for. Research before acting, when the task warranted it, is the assistant earning its keep.
+
+And when a session is clean — when the assistant did what you asked and not much else — `failfund` says so, plainly, and declines to invent violations to justify a refund. It will tell you "I reviewed your session and didn't find chargeable overwork; the work tracked what you asked for," and it will even point at the single biggest cost so you can judge for yourself.
+
+A skill that cries wolf is worth nothing on the day there is a real wolf. Three true findings beat ten padded ones. That restraint is what makes the document worth submitting.
+
+## What you get back
+
+When `failfund` finds real overwork, it writes you a refund request. A clean, dated document with your session id and the model that ran it. A short summary in plain language: what you asked for, the ways the assistant overworked, and the total you are owed. Then the findings, itemized — for each one, the exact instruction or scope you set (quoted from your own words), what the assistant did instead and on which turns, why it counts as overwork, and the token cost attributable to it. Finally a tally table that sums the wasted output and shows it as a percentage of the whole session, and a specific, proportionate ask for a credit.
+
+The summary and the table also print straight into the chat, so you see the verdict immediately. The full request lands in a file next to your work, ready to send.
+
+And `failfund` is honest about the last mile: there is no magic button that files a refund for you. No public API auto-submits it. What the skill produces is the *document* — the evidence you take to Anthropic Support, session id attached. It never pretends a refund was filed or approved. It hands you a well-built case and lets you make it.
+
+## The story of building it — and eating its own cooking
+
+`failfund` was built in a single session, and the most fitting test in the world was to point it at that very session's transcript. Building a tool that audits a chat, then auditing the chat that built it, is a kind of honesty you cannot fake.
+
+Two real bugs surfaced in that mirror, and both are worth telling because they are exactly the kind of thing the skill is supposed to be principled about.
+
+The first was a token-counting bug, and it was a big one. Claude Code does not write one assistant response as one line in the transcript. It writes it as several — one line for the thinking, one for the text, one for each tool call — and every single one of those lines repeats the *same* usage numbers. The first version of the analyzer counted per line, which meant a response split into four blocks got its tokens counted four times. The tally was inflated several-fold. A tool whose entire job is to quantify waste was, at first, wildly overstating it. The fix was to group lines by the response's message id and count the usage exactly once. The irony was not lost on anyone: the refund auditor almost padded its own bill.
+
+The second was about trust. The analyzer finds the transcript by deriving a folder name from your working directory. If that folder does not exist — if anything about the path is unexpected — the safe-looking move is to grab the most recent transcript from anywhere and carry on. That would be a disaster: it would quietly produce a refund request about a *different chat*. So the analyzer was built to fail loudly instead. If it cannot find the right transcript, it stops and shows you the candidate folders, and refuses to guess. Auditing the wrong session is worse than auditing none.
+
+Both fixes come from the same conviction the skill preaches to its users: be accurate, be fair, and when you are not sure, say so out loud rather than fake confidence.
+
+## How you use it
+
+You do not need to remember a command. You just say what you feel. "failfund." "I want a refund." "You wasted my tokens." "You did a bunch of stuff I never asked for." "You ignored what I told you." "Why did you build all that?" Any of those frustrations brings the skill to life.
+
+From there it does the work: it pulls your session's transcript, lays it out turn by turn with the token cost attached to each, reads it against what you actually asked for, flags the genuine overwork, adds up the damage, and writes the request. A minute later you have a summary on screen and a document on disk. If it found nothing real, it tells you that instead — and you can trust it, because it is built not to lie to you.
+
+## Why it matters
+
+Most of the time you will never run `failfund`, and that is the point. It is not there to nickel-and-dime a tool that mostly does its job. It is there for the sessions that go sideways — and for the quieter effect of simply existing.
+
+An assistant that knows its work can be audited, line by line, token by token, against the instructions it was given, has every reason to stay in scope, to ask before building, to honor the words in caps, and to stop when told. `failfund` turns a vague feeling of "that was wasteful" into something specific, fair, and submittable. It gives the frustration a shape and a number.
+
+You asked for one thing. You should pay for one thing. `failfund` makes sure the difference is visible — and that, when it matters, you can get it back.


### PR DESCRIPTION
> 🪙 **Half a joke.** The other half is a working skill.

## What this is

`failfund` is a Claude Code skill you invoke when a session left you feeling like you paid for work you never asked for. It reads the current chat's transcript, flags genuine overwork, tallies the wasted tokens, and writes you a submittable refund request.

It sorts overwork into four categories:
- **Directive violation** — did the opposite of / ignored a clear instruction (incl. emphasis & caps)
- **Built without permission** — implemented when only asked to plan/discuss/investigate
- **Out of scope** — extra features, speculative abstraction, gold-plating
- **Token waste** — re-reads, redundant searches, walked-back wrong turns

**Fair by design:** it only flags real overwork, attributes cost honestly (output tokens as the floor; notes the compounding cache-read of multi-turn detours), and reports clean sessions straight instead of fabricating findings. A skill that cries wolf is worth nothing on the day there's a real wolf.

## Contents
- `plugin/skills/failfund/SKILL.md` — the skill (auto-discovered, no manifest entry needed)
- `plugin/skills/failfund/scripts/analyze-transcript.cjs` — locates the session transcript, dedups Claude Code's per-content-block line duplication (counts usage once per message id), emits a compact token-attributed turn-by-turn audit view
- `reports/failfund.md` — narrative source doc used to generate a demo deck

## Verification
Ran end-to-end against this session's own transcript. Caught two real bugs while building: token over-counting (responses are written as multiple JSONL lines that each repeat usage → fixed by deduping on message id) and silent wrong-transcript selection (→ now fails loud with candidate paths).

## Notes
- Demo deck PDFs are gitignored (`reports/*.pdf`) — they were 14 MB of generated binaries, not worth keeping in history.
- No refund API exists; the skill produces the *document* you submit to Anthropic Support. It never claims to auto-file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)