### PR TITLE
fix(codex): emit SessionStart JSON from version check

### DIFF
--- a/plugin/scripts/version-check.js
+++ b/plugin/scripts/version-check.js
@@ -17,16 +17,32 @@ function resolveRoot() {
 }
 
 const ROOT = resolveRoot();
-if (!ROOT) process.exit(0);
+
+let emittedCodexHookOutput = false;
+
+function emitCodexSessionStart(additionalContext) {
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: 'SessionStart',
+    },
+  };
+  if (additionalContext) {
+    output.hookSpecificOutput.additionalContext = additionalContext;
+  }
+  console.log(JSON.stringify(output));
+  emittedCodexHookOutput = true;
+}
+
+if (!ROOT) {
+  if (process.env.CLAUDE_MEM_CODEX_HOOK === '1') {
+    emitCodexSessionStart();
+  }
+  process.exit(0);
+}
 
 function emitUpgradeHint(message) {
   if (process.env.CLAUDE_MEM_CODEX_HOOK === '1') {
-    console.log(JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'SessionStart',
-        additionalContext: message,
-      },
-    }));
+    emitCodexSessionStart(message);
   } else {
     console.error(message);
   }
@@ -65,5 +81,8 @@ try {
   }
 } catch {
   emitUpgradeHint('claude-mem: install marker unreadable - run: npx claude-mem@latest install');
+}
+if (process.env.CLAUDE_MEM_CODEX_HOOK === '1' && !emittedCodexHookOutput) {
+  emitCodexSessionStart();
 }
 process.exit(0);

--- a/tests/plugin-version-check.test.ts
+++ b/tests/plugin-version-check.test.ts
@@ -16,6 +16,13 @@ function runVersionCheck(root: string) {
   });
 }
 
+function runCodexVersionCheck(root: string) {
+  return spawnSync('node', [VERSION_CHECK_SCRIPT], {
+    encoding: 'utf-8',
+    env: { ...process.env, CLAUDE_PLUGIN_ROOT: root, CLAUDE_MEM_CODEX_HOOK: '1' },
+  });
+}
+
 describe('plugin/scripts/version-check.js install marker compatibility', () => {
   let tempDir: string;
 
@@ -61,5 +68,36 @@ describe('plugin/scripts/version-check.js install marker compatibility', () => {
     expect(result.stderr).toContain(
       'claude-mem: upgraded to v12.4.4 - run: npx claude-mem@latest install',
     );
+  });
+
+  it('emits valid SessionStart JSON for a matching marker in Codex hook mode', () => {
+    writeFileSync(join(tempDir, '.install-version'), '12.4.4\n');
+
+    const result = runCodexVersionCheck(tempDir);
+    const output = JSON.parse(result.stdout);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(output).toEqual({
+      hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+      },
+    });
+  });
+
+  it('emits Codex upgrade hints as SessionStart additionalContext', () => {
+    writeFileSync(join(tempDir, '.install-version'), '12.4.3\n');
+
+    const result = runCodexVersionCheck(tempDir);
+    const output = JSON.parse(result.stdout);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(output).toEqual({
+      hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+        additionalContext: 'claude-mem: upgraded to v12.4.4 - run: npx claude-mem@latest install',
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary

- ensure `plugin/scripts/version-check.js` always emits valid `SessionStart` JSON when running as a Codex hook
- preserve the existing Claude Code behavior where no-op version checks stay silent
- add coverage for Codex no-op output and Codex upgrade hints via `additionalContext`

## Why

Codex validates `SessionStart` hook stdout as JSON. When `CLAUDE_MEM_CODEX_HOOK=1` and the install marker is current, `version-check.js` previously exited successfully with empty stdout, which Codex reports as `hook returned invalid session start JSON output`.

## Tests

- `bun test tests/plugin-version-check.test.ts`
- `node --check plugin/scripts/version-check.js`