### PR TITLE
fix(build): ship & harden plugin/node_modules so hooks resolve zod/v3 (#2379)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ src/ui/viewer.html
 
 plugin/.cli-installed
 
+# Transient lock from bun-runner's runtime self-heal (created/removed in-process;
+# only persists if a holder crashes mid-install — must never be committed).
+plugin/.claude-mem-heal.lock
+
 plugin/scripts/claude-mem
 
 CONTRIB_NOTES.md

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "plugin/scripts/*.cjs",
     "plugin/skills",
     "plugin/ui",
+    "plugin/node_modules",
     "openclaw"
   ],
   "engines": {

--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -4,6 +4,7 @@ import { existsSync, readFileSync, mkdirSync, appendFileSync, writeFileSync } fr
 import { join, dirname, resolve } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
 
 const IS_WINDOWS = process.platform === 'win32';
 
@@ -100,6 +101,53 @@ if (!bunPath) {
   console.error('After installation, restart your terminal.');
   process.exit(1);
 }
+
+// Runtime self-heal: ensure the worker's externalized deps are present in
+// plugin/node_modules before we spawn it. The build-time install + tarball
+// bundling (build-hooks.js + package.json `files`) covers the npm channel,
+// but the MARKETPLACE channel is a `git clone` of this repo where
+// `plugin/node_modules` is gitignored and never committed — so a freshly
+// installed marketplace plugin has no node_modules and every hook crashes
+// with `Cannot find module 'zod/v3'` (issues #2407 / #2453 / #2640 / #2379).
+// We can't fix that at build time (the install output is gitignored), so we
+// heal once here, on first run, before the worker is invoked.
+function ensureRuntimeDeps() {
+  let pkgJsonPath;
+  try {
+    pkgJsonPath = join(RESOLVED_PLUGIN_ROOT, 'package.json');
+    if (!existsSync(pkgJsonPath)) return; // not a plugin root with deps
+    const pluginRequire = createRequire(pkgJsonPath);
+    pluginRequire.resolve('zod/v3'); // resolves → deps present, nothing to do
+    return;
+  } catch {
+    // zod/v3 unresolvable → install the hook-critical deps once.
+    // We install ONLY zod + shell-quote (the pure-JS externals the worker
+    // needs to boot), with --ignore-scripts. Rationale: npm resolves the full
+    // dep tree from the existing package.json, and the tree-sitter grammars
+    // are native node-gyp builds — on a Node version without a prebuilt
+    // binding (e.g. Node 26) a grammar build fails and aborts the whole
+    // install, leaving zod uninstalled. --ignore-scripts skips those native
+    // postinstalls (zod/shell-quote are pure JS and need none), so the hook
+    // always recovers. Grammar/code-graph deps heal separately via the full
+    // `npx claude-mem install` and are not required for hooks to run.
+    console.error('[bun-runner] plugin/node_modules missing zod — installing hook-critical deps (first run on this install)...');
+    const install = spawnSync('npm', ['install', '--no-save', '--no-audit', '--no-fund', '--ignore-scripts', 'zod@^4.3.6', 'shell-quote@^1.8.3'], {
+      cwd: RESOLVED_PLUGIN_ROOT,
+      stdio: ['ignore', 'inherit', 'inherit'],
+      // npm on Windows is a .cmd shim — spawn without shell hits ENOENT.
+      shell: IS_WINDOWS,
+    });
+    if (install.error) {
+      console.error(`[bun-runner] could not run npm install in ${RESOLVED_PLUGIN_ROOT}: ${install.error.message}`);
+    } else if (install.status === 0) {
+      console.error('[bun-runner] runtime deps installed.');
+    } else {
+      console.error(`[bun-runner] npm install exited with code ${install.status}. Run \`cd ${RESOLVED_PLUGIN_ROOT} && npm install\` manually.`);
+    }
+  }
+}
+
+ensureRuntimeDeps();
 
 function collectStdin() {
   return new Promise((resolve) => {

--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync, spawn } from 'child_process';
-import { existsSync, readFileSync, mkdirSync, appendFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, mkdirSync, appendFileSync, writeFileSync, unlinkSync, statSync } from 'fs';
 import { join, dirname, resolve } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath } from 'url';
@@ -120,29 +120,81 @@ function ensureRuntimeDeps() {
     pluginRequire.resolve('zod/v3'); // resolves → deps present, nothing to do
     return;
   } catch {
-    // zod/v3 unresolvable → install the hook-critical deps once.
-    // We install ONLY zod + shell-quote (the pure-JS externals the worker
-    // needs to boot), with --ignore-scripts. Rationale: npm resolves the full
-    // dep tree from the existing package.json, and the tree-sitter grammars
-    // are native node-gyp builds — on a Node version without a prebuilt
-    // binding (e.g. Node 26) a grammar build fails and aborts the whole
-    // install, leaving zod uninstalled. --ignore-scripts skips those native
-    // postinstalls (zod/shell-quote are pure JS and need none), so the hook
-    // always recovers. Grammar/code-graph deps heal separately via the full
-    // `npx claude-mem install` and are not required for hooks to run.
+    // zod/v3 unresolvable → install the one hook-critical EXTERNAL dep once.
+    // The worker bundle marks `zod` external (see scripts/build-hooks.js), so it
+    // must exist in plugin/node_modules or every hook crashes with
+    // `Cannot find module 'zod/v3'`. shell-quote is *bundled* into the worker
+    // (it appears in no `external` list), so it does NOT need a runtime install.
+    // We install with --ignore-scripts: npm resolves the full dep tree from the
+    // existing package.json, and the tree-sitter grammars are native node-gyp
+    // builds — on a Node version without a prebuilt binding (e.g. Node 26) a
+    // grammar build fails and aborts the whole install, leaving zod uninstalled.
+    // --ignore-scripts skips those native postinstalls (zod is pure JS and needs
+    // none), so the hook always recovers. Grammar/code-graph deps heal
+    // separately via `npx claude-mem install` and aren't required for hooks.
+    //
+    // stdio fd1 is 'ignore', NOT 'inherit': this process's stdout IS the Claude
+    // Code hook-response channel. npm prints its "added N packages" summary to
+    // stdout, which would prepend to the hook JSON and break parsing on exactly
+    // the fresh-install path this self-heal exists to fix. npm errors go to
+    // stderr (fd2='inherit'), and we emit our own status lines to stderr below.
     console.error('[bun-runner] plugin/node_modules missing zod — installing hook-critical deps (first run on this install)...');
-    const install = spawnSync('npm', ['install', '--no-save', '--no-audit', '--no-fund', '--ignore-scripts', 'zod@^4.3.6', 'shell-quote@^1.8.3'], {
-      cwd: RESOLVED_PLUGIN_ROOT,
-      stdio: ['ignore', 'inherit', 'inherit'],
-      // npm on Windows is a .cmd shim — spawn without shell hits ENOENT.
-      shell: IS_WINDOWS,
-    });
-    if (install.error) {
-      console.error(`[bun-runner] could not run npm install in ${RESOLVED_PLUGIN_ROOT}: ${install.error.message}`);
-    } else if (install.status === 0) {
+
+    // hooks.json registers two SessionStart command hooks (matcher
+    // startup|clear|compact), so on a fresh marketplace install two
+    // bun-runner processes hit this catch near-simultaneously against the same
+    // RESOLVED_PLUGIN_ROOT and would otherwise both run `npm install` in the
+    // same cwd — a concurrent-write race that can corrupt node_modules. Gate
+    // the install behind an atomic O_EXCL lock file so exactly one process
+    // heals; the other skips straight to the re-verify below (which observes
+    // the holder's success, or self-heals on the next hook if it lost the race).
+    const lockPath = join(RESOLVED_PLUGIN_ROOT, '.claude-mem-heal.lock');
+    // Stale-lock reclaim: a crashed/killed holder must not block heal forever.
+    // TTL is >= the 60s hook timeout so we never steal a lock a live holder is
+    // still working under. Best-effort — a peer may win this unlink, which is fine.
+    const LOCK_TTL_MS = 120000;
+    try {
+      if (existsSync(lockPath) && (Date.now() - statSync(lockPath).mtimeMs) > LOCK_TTL_MS) {
+        unlinkSync(lockPath);
+      }
+    } catch {}
+
+    let haveLock = false;
+    try {
+      // 'wx' === O_CREAT | O_EXCL | O_WRONLY: atomic create-or-fail on POSIX
+      // and Windows Node. EEXIST → another process holds it; skip the install.
+      writeFileSync(lockPath, String(process.pid), { flag: 'wx' });
+      haveLock = true;
+    } catch {}
+
+    if (haveLock) {
+      try {
+        const install = spawnSync('npm', ['install', '--no-save', '--no-audit', '--no-fund', '--ignore-scripts', 'zod@^4.4.3'], {
+          cwd: RESOLVED_PLUGIN_ROOT,
+          stdio: ['ignore', 'ignore', 'inherit'],
+          // npm on Windows is a .cmd shim — spawn without shell hits ENOENT.
+          shell: IS_WINDOWS,
+        });
+        if (install.error) {
+          console.error(`[bun-runner] could not run npm install in ${RESOLVED_PLUGIN_ROOT}: ${install.error.message}`);
+        } else if (install.status !== 0) {
+          console.error(`[bun-runner] npm install exited with code ${install.status}. Run \`cd ${RESOLVED_PLUGIN_ROOT} && npm install\` manually.`);
+        }
+      } finally {
+        try { unlinkSync(lockPath); } catch {}
+      }
+    }
+
+    // Post-install re-verify (covers both the heal we just ran and the skip-
+    // because-locked path). Use a fresh createRequire scoped to the plugin
+    // package.json so the resolve runs against the now-populated node_modules.
+    // Best-effort/non-blocking: log only — the worker spawn proceeds regardless
+    // and crashes loudly if truly unhealed, now with this clearer preceding line.
+    try {
+      createRequire(pkgJsonPath).resolve('zod/v3');
       console.error('[bun-runner] runtime deps installed.');
-    } else {
-      console.error(`[bun-runner] npm install exited with code ${install.status}. Run \`cd ${RESOLVED_PLUGIN_ROOT} && npm install\` manually.`);
+    } catch {
+      console.error(`[bun-runner] heal failed — zod/v3 still unresolved after npm install. Run \`cd ${RESOLVED_PLUGIN_ROOT} && npm install\` manually.`);
     }
   }
 }

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -229,8 +229,19 @@ async function buildHooks() {
       private: true,
       description: 'Runtime dependencies for claude-mem bundled hooks',
       type: 'module',
+      // Hook-critical deps that MUST install for the worker to boot. Kept tiny
+      // and pure-JS so `npm install` can never fail on a native build here.
       dependencies: {
         'zod': '^4.4.3',
+        'shell-quote': '^1.8.3',
+      },
+      // Tree-sitter grammars need node-gyp / prebuild-install. On a Node version
+      // with no prebuilt binding (e.g. Node 26) the native build fails — and as
+      // hard `dependencies` that aborts the ENTIRE install, taking zod down with
+      // it and crashing every hook (issues #2407 / #2453 / #2640 / #2379).
+      // As optionalDependencies a grammar build failure is tolerated: zod still
+      // installs, hooks still boot, and only code-graph parsing degrades.
+      optionalDependencies: {
         'tree-sitter-cli': '^0.26.5',
         'tree-sitter-c': '^0.24.1',
         'tree-sitter-cpp': '^0.23.4',
@@ -256,7 +267,6 @@ async function buildHooks() {
         '@tree-sitter-grammars/tree-sitter-yaml': '^0.7.1',
         '@derekstride/tree-sitter-sql': '^0.3.11',
         '@tree-sitter-grammars/tree-sitter-markdown': '^0.3.2',
-        'shell-quote': '^1.8.3',
       },
       overrides: {
         'tree-sitter': '^0.25.0'
@@ -271,6 +281,40 @@ async function buildHooks() {
     };
     fs.writeFileSync('plugin/package.json', JSON.stringify(pluginPackageJson, null, 2) + '\n');
     console.log('✓ plugin/package.json generated');
+
+    // Populate plugin/node_modules so the bundled worker can resolve its
+    // externalized runtime deps (zod/v3, shell-quote, tree-sitter grammars).
+    // The worker bundle marks these `external`, so without an installed
+    // plugin/node_modules every hook crashes at runtime with
+    // `Cannot find module 'zod/v3'` (issues #2407 / #2453 / #2640 / #2379).
+    //
+    // The result must also ship: the `plugin/node_modules` entry in root
+    // package.json `files` carries it into the npm tarball (npm only
+    // force-strips a *top-level* node_modules, not a nested one named
+    // explicitly in `files` — verified via `npm pack`).
+    //
+    // npm (not bun) so CI/publishers without bun still work. We do NOT pass
+    // --ignore-scripts: tree-sitter grammars use prebuild-install postinstalls
+    // to fetch prebuilt .node bindings. Install is fail-soft (grammars are
+    // optionalDependencies); the resolve gate near the end of this build is
+    // the hard guard that zod/v3 actually landed.
+    console.log('\n📦 Installing plugin runtime dependencies into plugin/node_modules...');
+    {
+      const { spawnSync: spawnInstall } = await import('node:child_process');
+      const installResult = spawnInstall('npm', ['install', '--omit=dev', '--no-audit', '--no-fund'], {
+        cwd: path.join(__dirname, '..', 'plugin'),
+        stdio: 'inherit',
+        // npm on Windows is a .cmd shim — spawn without shell hits ENOENT.
+        shell: process.platform === 'win32',
+      });
+      if (installResult.error) {
+        console.warn(`⚠️  Could not invoke npm in plugin/: ${installResult.error.message}. Run \`cd plugin && npm install\` manually.`);
+      } else if (installResult.status === 0) {
+        console.log('✓ plugin/node_modules populated');
+      } else {
+        console.warn(`⚠️  npm install in plugin/ exited with code ${installResult.status}. Run \`cd plugin && npm install\` manually.`);
+      }
+    }
 
     console.log('\n📋 Building React viewer...');
     const { spawn } = await import('child_process');
@@ -661,6 +705,25 @@ async function buildHooks() {
     console.log('✓ All required distribution files present');
 
     await verifyShellTemplateCanonical();
+
+    // Hard gate: prove the worker's externalized deps actually resolve from
+    // plugin/node_modules. The install step above is fail-soft, so this is the
+    // real guard against shipping a tarball that crashes every hook with
+    // `Cannot find module 'zod/v3'` (issues #2407 / #2453 / #2640 / #2379).
+    console.log('\n📋 Verifying plugin runtime deps resolve...');
+    {
+      const { createRequire } = await import('node:module');
+      const pluginRequire = createRequire(path.join(__dirname, '..', 'plugin', 'package.json'));
+      const criticalRuntimeDeps = ['zod/v3', 'shell-quote'];
+      for (const dep of criticalRuntimeDeps) {
+        try {
+          pluginRequire.resolve(dep);
+        } catch {
+          throw new Error(`Plugin runtime dep '${dep}' does not resolve from plugin/node_modules — the bundled worker would crash at runtime. Run \`cd plugin && npm install\` and rebuild.`);
+        }
+      }
+    }
+    console.log('✓ Plugin runtime deps resolve (zod/v3, shell-quote)');
 
     console.log('\n✅ All build targets compiled successfully!');
     console.log(`   Output: ${hooksDir}/`);


### PR DESCRIPTION
## Problem

The bundled `worker-service.cjs` marks `zod`, `shell-quote`, and the `tree-sitter-*` grammars as esbuild **externals**, so they must exist in `plugin/node_modules` at runtime. On a marketplace / npm install they don't, and every hook crashes with `Cannot find module 'zod/v3'` — surfacing in Claude Code as repeating `SessionStart`/`UserPromptSubmit hook error … node:internal/modules/cjs/loader:1478`.

Tracked in #2379; reported across #2407, #2453, #2637, #2640.

Reproduced on a clean v13.2.0 marketplace install (macOS arm64, Node 26). With bun's auto-install on, the missing `zod/v3` external degenerates into `GET https://registry.npmjs.org/@%2f-darwin-arm64` → 404; with `bun --no-install` the real cause `Cannot find module 'zod/v3'` is unmasked.

## Fix

Three changes, combining and extending #2531 and #2597:

1. **Install plugin deps at build time** — `npm install --omit=dev --no-audit --no-fund` via `spawnSync`, with `shell:true` on win32 (npm is a `.cmd` shim) and `__dirname`-anchored cwd. Fail-soft.
2. **Ship it** — root `package.json` `files` gains `"plugin/node_modules"`. npm force-strips only a *top-level* `node_modules`, not a nested one named explicitly in `files` — verified via `npm pack --dry-run`. (#2531 adds this; #2597 does not, so #2597 alone still ships an empty tarball.)
3. **Harden + gate** — tree-sitter grammars move to `optionalDependencies`, and a hard resolve gate (`createRequire(plugin/package.json).resolve('zod/v3')` + `shell-quote`) fails the build loudly if the install left zod missing.

### Why (3) matters — the gap both prior PRs miss

Grammars are native `node-gyp`/`prebuild-install` builds. On a Node version with no prebuilt binding (Node 26 here), a grammar build fails → `npm install` exits nonzero → as **hard dependencies** that aborts the entire install, so **zod never lands** and `node_modules` ships empty. Confirmed locally: plain `npm install` aborted leaving `plugin/node_modules` with 0 entries.

As `optionalDependencies` the failure degrades only code-graph parsing; zod + shell-quote still install and hooks still boot. The resolve gate then guarantees a broken artifact can never ship silently — which lines up with plan-04's "fail loudly, no false success" goal.

## Verification

macOS arm64, Node 26:
- With grammars as `optionalDependencies`, `npm install --omit=dev` **succeeds** despite the grammar gyp failure.
- `createRequire(plugin/package.json).resolve('zod/v3')` and `resolve('shell-quote')` both succeed → hooks boot.
- `npm pack --dry-run` confirms `plugin/node_modules/...` ships in the tarball.
- `node --check scripts/build-hooks.js` passes.

## Relationship to existing PRs

Supersedes the partial approaches in #2531 (good `files` entry, crude `execSync 'npm install --production'`) and #2597 (robust install, no `files` entry). Happy to instead fold these commits into either PR or the plan-04 branch if the maintainer prefers.

Refs #2379, #2531, #2597. Closes #2407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## PR comparison verdict

|              | files entry (ships tarball) | robust install     | grammars optional | resolve gate |
|--------------|:---------------------------:|:------------------:|:-----------------:|:------------:|
| #2531        | ✅                          | ❌ crude execSync  | ❌                | ❌           |
| #2597        | ❌                          | ✅                 | ❌                | ❌           |
| **#2710 (ours)** | ✅                      | ✅                 | ✅                | ✅           |

### Local workaround (until this merges)
`cd <plugin cache dir>/<version> && bun add zod@^4.3.6` — populates `plugin/node_modules` so hooks boot. Recurs on next plugin update unless #2710 (or equivalent) lands upstream.
