### PR TITLE
fix(server-beta): accept X-Api-Key as fallback to Bearer in auth middleware

### DIFF
--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -62,7 +62,10 @@ export function requireServerAuth(
     }
 
     if (!rawKey) {
-      res.status(401).json({ error: 'Unauthorized', message: 'Missing bearer API key' });
+      res.status(401).json({
+        error: 'Unauthorized',
+        message: 'Missing API key (Authorization: Bearer <key> or X-Api-Key: <key>)',
+      });
       return;
     }
 

--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -33,7 +33,11 @@ export function requireServerAuth(
   return (req: Request, res: Response, next: NextFunction) => {
     const authMode = options.authMode ?? process.env.CLAUDE_MEM_AUTH_MODE ?? 'api-key';
     const authorization = req.header('authorization') ?? '';
-    const rawKey = parseBearerToken(authorization);
+    const xApiKey = req.header('x-api-key')?.trim() ?? '';
+    // Bearer is canonical; raw X-Api-Key is a fallback so clients using
+    // @better-auth/api-key defaults (e.g. the worker bundle shipped from the
+    // Windows-canary line) authenticate without a per-client custom config.
+    const rawKey = parseBearerToken(authorization) || xApiKey || null;
 
     const allowLocalDevBypass = options.allowLocalDevBypass ?? process.env.CLAUDE_MEM_ALLOW_LOCAL_DEV_BYPASS === '1';
     if (

--- a/src/server/middleware/postgres-auth.ts
+++ b/src/server/middleware/postgres-auth.ts
@@ -34,7 +34,11 @@ export function requirePostgresServerAuth(
     try {
       const authMode = options.authMode ?? process.env.CLAUDE_MEM_AUTH_MODE ?? 'api-key';
       const authorization = req.header('authorization') ?? '';
-      const rawKey = parseBearerToken(authorization);
+      const xApiKey = req.header('x-api-key')?.trim() ?? '';
+      // Bearer is canonical; raw X-Api-Key is a fallback so clients using
+      // @better-auth/api-key defaults (e.g. the worker bundle shipped from the
+      // Windows-canary line) authenticate without a per-client custom config.
+      const rawKey = parseBearerToken(authorization) || xApiKey || null;
 
       const allowLocalDevBypass = options.allowLocalDevBypass
         ?? process.env.CLAUDE_MEM_ALLOW_LOCAL_DEV_BYPASS === '1';

--- a/src/server/middleware/postgres-auth.ts
+++ b/src/server/middleware/postgres-auth.ts
@@ -65,7 +65,10 @@ export function requirePostgresServerAuth(
       }
 
       if (!rawKey) {
-        res.status(401).json({ error: 'Unauthorized', message: 'Missing bearer API key' });
+        res.status(401).json({
+          error: 'Unauthorized',
+          message: 'Missing API key (Authorization: Bearer <key> or X-Api-Key: <key>)',
+        });
         return;
       }
 

--- a/tests/server/auth-api-key.test.ts
+++ b/tests/server/auth-api-key.test.ts
@@ -290,4 +290,119 @@ describe('server API key auth', () => {
       scopes: ['memories:write'],
     });
   });
+
+  it('middleware accepts X-Api-Key header as fallback when Bearer is absent', () => {
+    // Clients using @better-auth/api-key defaults (e.g. the worker bundle
+    // shipped from the Windows-canary line) send raw API keys via X-Api-Key
+    // instead of "Authorization: Bearer ...". The middleware accepts either
+    // so the server-beta runtime works with both client shapes out of the box.
+    const team = new TeamsRepository(db).create({ name: 'Core' });
+    const project = new ProjectsRepository(db).create({ name: 'Project' });
+    const created = createServerApiKey(db, {
+      name: 'XApiKey client',
+      teamId: team.id,
+      projectId: project.id,
+      scopes: ['memories:write'],
+    });
+    const middleware = requireServerAuth(() => db, {
+      authMode: 'api-key',
+      requiredScopes: ['memories:write'],
+    });
+    const req: any = {
+      ip: '10.0.0.5',
+      socket: {},
+      header: (name: string) => name.toLowerCase() === 'x-api-key' ? created.rawKey : undefined,
+    };
+    const res: any = {
+      status: () => res,
+      json: () => {},
+    };
+    let calledNext = false;
+
+    middleware(req, res, () => {
+      calledNext = true;
+    });
+
+    expect(calledNext).toBe(true);
+    expect(req.authContext).toMatchObject({
+      mode: 'api-key',
+      apiKeyId: created.record.id,
+      teamId: team.id,
+      projectId: project.id,
+      scopes: ['memories:write'],
+    });
+  });
+
+  it('middleware prefers Bearer over X-Api-Key when both are present', () => {
+    // Defense-in-depth: if a client sends both, Bearer wins. Avoids surprises
+    // where an unrelated X-Api-Key sneaks in via a proxy or a stale env var.
+    const team = new TeamsRepository(db).create({ name: 'Core' });
+    const bearerKey = createServerApiKey(db, {
+      name: 'Bearer key',
+      teamId: team.id,
+      projectId: null,
+      scopes: ['memories:write'],
+    });
+    const xApiKeyKey = createServerApiKey(db, {
+      name: 'X-Api-Key key',
+      teamId: team.id,
+      projectId: null,
+      scopes: ['memories:write'],
+    });
+    const middleware = requireServerAuth(() => db, {
+      authMode: 'api-key',
+      requiredScopes: ['memories:write'],
+    });
+    const req: any = {
+      ip: '10.0.0.5',
+      socket: {},
+      header: (name: string) => {
+        const normalized = name.toLowerCase();
+        if (normalized === 'authorization') return `Bearer ${bearerKey.rawKey}`;
+        if (normalized === 'x-api-key') return xApiKeyKey.rawKey;
+        return undefined;
+      },
+    };
+    const res: any = {
+      status: () => res,
+      json: () => {},
+    };
+    let calledNext = false;
+
+    middleware(req, res, () => {
+      calledNext = true;
+    });
+
+    expect(calledNext).toBe(true);
+    expect(req.authContext?.apiKeyId).toBe(bearerKey.record.id);
+  });
+
+  it('middleware rejects requests with neither Bearer nor X-Api-Key', () => {
+    const middleware = requireServerAuth(() => db, { authMode: 'api-key' });
+    const req: any = {
+      ip: '10.0.0.5',
+      socket: {},
+      header: (_name: string) => undefined,
+    };
+    const res: any = {
+      statusCode: 200,
+      body: null,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(body: unknown) {
+        this.body = body;
+      },
+    };
+    let calledNext = false;
+
+    middleware(req, res, () => {
+      calledNext = true;
+    });
+
+    expect(calledNext).toBe(false);
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ error: 'Unauthorized', message: 'Missing bearer API key' });
+  });
 });

--- a/tests/server/auth-api-key.test.ts
+++ b/tests/server/auth-api-key.test.ts
@@ -403,6 +403,9 @@ describe('server API key auth', () => {
 
     expect(calledNext).toBe(false);
     expect(res.statusCode).toBe(401);
-    expect(res.body).toMatchObject({ error: 'Unauthorized', message: 'Missing bearer API key' });
+    expect(res.body).toMatchObject({
+      error: 'Unauthorized',
+      message: 'Missing API key (Authorization: Bearer <key> or X-Api-Key: <key>)',
+    });
   });
 });


### PR DESCRIPTION
## Summary

`requireServerAuth` / `requirePostgresServerAuth` currently only read `Authorization: Bearer <key>`. Clients using `@better-auth/api-key` default config send raw keys via `X-Api-Key` — including the worker bundle shipped from the Windows-canary line (#2699). The mismatch produces:

```
POST /v1/events  X-Api-Key: cmem_...
→ 401 {"error":"Unauthorized","message":"Missing bearer API key"}
```

Direct-LAN setups don't hit this because no proxy strips/normalizes headers and the worker's own retry path round-trips through other endpoints. **Remote setups behind a proxy** (e.g. Cloudflare → Express) fail closed and never capture against the public hostname.

This PR makes the middleware accept either header:
- Bearer remains canonical — existing clients unaffected.
- `X-Api-Key` is the fallback when Bearer is absent.
- When both are present, Bearer wins (defense-in-depth — avoids surprises if an unrelated `X-Api-Key` leaks in via a proxy or stale env var).

Same change applied to:
- `src/server/middleware/auth.ts` (bun:sqlite-backed)
- `src/server/middleware/postgres-auth.ts` (PG-backed — what the `server-beta` runtime actually uses)

## End-to-end verification

Against a `server-beta` deployment behind Cloudflare (`mem.late.app.br` → Express):

| | Before | After |
|---|---|---|
| `X-Api-Key: cmem_...` on `POST /v1/events` | 401 "Missing bearer API key" | **400 ValidationError** (auth ok, body invalid — expected) |
| `Authorization: Bearer cmem_...` (control) | 400 ValidationError | **400** (no regression) |

## Tests

New tests in `tests/server/auth-api-key.test.ts`:
- `middleware accepts X-Api-Key header as fallback when Bearer is absent`
- `middleware prefers Bearer over X-Api-Key when both are present`
- `middleware rejects requests with neither Bearer nor X-Api-Key`

```
bun test tests/server/auth-api-key.test.ts
 15 pass / 0 fail / 43 expect() calls
```

No new test for `postgres-auth.ts` — the existing repo has no suite that wires a real PG pool for the middleware. The parser logic is byte-identical to `auth.ts`, so the bun:sqlite suite covers the behavioral contract.

## Test plan

- [x] Existing 12 tests in `auth-api-key.test.ts` still pass (Bearer canonical path unchanged)
- [x] 3 new tests pass (X-Api-Key fallback, Bearer-wins precedence, both-absent rejection)
- [x] Live probe against `server-beta` deployment via Cloudflare confirms regression fixed
- [ ] Reviewer to verify `postgres-auth.ts` change is equivalent (same 3-line edit, comments inline)

Related: #2699 (Windows Canary — bundle includes the client using `@better-auth/api-key` default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)