### PR TITLE
fix(windows): don't misdetect npm-global Claude CLI as desktop app (#2723)

### DIFF
--- a/src/shared/find-claude-executable.ts
+++ b/src/shared/find-claude-executable.ts
@@ -14,8 +14,16 @@ import { SettingsDefaultsManager } from './SettingsDefaultsManager.js';
 import { USER_SETTINGS_PATH } from './paths.js';
 import { logger, type Component } from '../utils/logger.js';
 
-/** How long to wait for `claude --version` before giving up (ms). */
-const VERSION_CHECK_TIMEOUT_MS = 3_000;
+/**
+ * How long to wait for `claude --version` before giving up (ms).
+ *
+ * The native `claude` binary is large (~225 MB) and a cold start on Windows
+ * (first run after install, antivirus real-time scan) can take several seconds.
+ * A too-tight timeout makes a perfectly good CLI look unusable, which on a
+ * Windows npm-global path then surfaces as a misleading "desktop app" error.
+ * Warm `--version` calls return in ~0.5 s, so 10 s only bites on cold starts.
+ */
+const VERSION_CHECK_TIMEOUT_MS = 10_000;
 
 /**
  * Returns true if the path looks like a Windows desktop-app installation
@@ -23,6 +31,13 @@ const VERSION_CHECK_TIMEOUT_MS = 3_000;
  */
 function looksLikeDesktopAppPath(candidatePath: string): boolean {
   const normalized = candidatePath.replace(/\\/g, '/').toLowerCase();
+  // npm / Node CLI installs on Windows live under %AppData%\Roaming\npm\node_modules\…
+  // — the exact location `npm install -g @anthropic-ai/claude-code` uses. Those contain
+  // "appdata" but are NOT the desktop app; treating them as such tells users to reinstall
+  // the CLI they already have. Bail out for any npm/node_modules path first. (See #2723.)
+  if (normalized.includes('/node_modules/') || normalized.includes('/npm/')) {
+    return false;
+  }
   return (
     normalized.includes('appdata') ||
     normalized.includes('program files') ||


### PR DESCRIPTION
Fixes the false `Found desktop app … but it doesn't support headless mode` error for **npm-global Claude Code installs on Windows**. Closes #2723.

## Problem

`looksLikeDesktopAppPath()` treats any path containing `appdata` as the desktop app. But npm's global prefix on Windows is `%AppData%\Roaming\npm\…`, so a CLI installed via `npm install -g @anthropic-ai/claude-code` — **the exact command the error message recommends** — is mis-classified. The guidance contradicts itself, and headless observation generation fails.

The desktop-app branch is only reached when `verifyClaudeVersion()` returns `null`. `VERSION_CHECK_TIMEOUT_MS = 3000` is too tight for a cold start of the ~225 MB native `claude.exe` on Windows (first run / AV scan), which is why the failure is intermittent.

## Changes

- **`looksLikeDesktopAppPath()`** — return `false` for paths under `/node_modules/` or `/npm/` before the `appdata`/`program files` check. Real desktop-app locations (`%LocalAppData%\Programs\claude\…`, Program Files) are unaffected.
- **`VERSION_CHECK_TIMEOUT_MS`** — `3s → 10s`. Warm `--version` is ~0.5 s (measured under Node 24 and Bun 1.3.14), so this only matters on cold starts.

## Verification

- `claude -p "…"` returns output and `claude --help` lists `-p/--print` / `--output-format` → the binary **does** support headless mode.
- `execFileSync(claudeExe, ['--version'], { timeout: 3000, stdio: ['ignore','pipe','ignore'] })` → `"2.1.158 (Claude Code)"` in ~540 ms, warm, under both Node and Bun.
- Repro env: Windows 11, claude-mem 13.4.0, Claude Code 2.1.158, worker runtime Bun 1.3.14.

## Notes

- Only the TypeScript source is changed — the bundled `plugin/scripts/*` artifacts should be regenerated via `npm run build` / the binary build.
- #2723 also documents two **unrelated** secondary findings on the same host (SDK `non-XML idle response` retry/poison loop; `chroma-mcp` connection failures via `uvx` on Windows) — left out of this PR on purpose to keep it focused.
