### PR TITLE
Compact routine OpenClaw feed messages

### DIFF
--- a/openclaw/src/index.test.ts
+++ b/openclaw/src/index.test.ts
@@ -824,6 +824,9 @@ describe("SSE stream integration", () => {
         type: "discovery",
         project: "test",
         prompt_number: 1,
+        narrative: "Discovery observations should keep routine feed messages compact.",
+        facts: JSON.stringify(["Routine detail should not be shown"]),
+        concepts: JSON.stringify(["compact-feed"]),
         created_at_epoch: Date.now(),
       },
       timestamp: Date.now(),
@@ -840,6 +843,57 @@ describe("SSE stream integration", () => {
     assert.equal(sentMessages[0].to, "12345");
     assert.ok(sentMessages[0].text.includes("Test Observation"));
     assert.ok(sentMessages[0].text.includes("Found something interesting"));
+    assert.ok(!sentMessages[0].text.includes("Narrative"));
+    assert.ok(!sentMessages[0].text.includes("Routine detail should not be shown"));
+    assert.ok(!sentMessages[0].text.includes("compact-feed"));
+    assert.ok(sentMessages[0].text.length <= 900);
+
+    await getService().stop({});
+  });
+
+  it("keeps important feed messages more complete", async () => {
+    const { api, sentMessages, getService } = createMockApi({
+      workerPort: serverPort,
+      observationFeed: { enabled: true, channel: "telegram", to: "12345" },
+    });
+    claudeMemPlugin(api);
+
+    await getService().start({});
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    for (const res of serverResponses) {
+      res.write(
+        `data: ${JSON.stringify({
+          type: "new_observation",
+          observation: {
+            id: 2,
+            title: "Important Bugfix",
+            subtitle: "Fixed a regression",
+            type: "bugfix",
+            project: "test",
+            prompt_number: 1,
+            narrative: "This fuller context should stay visible for important feed messages.",
+            facts: JSON.stringify([
+              "Important fact one is preserved",
+              "Important fact two is preserved",
+              "Important fact three is preserved",
+            ]),
+            concepts: JSON.stringify(["important-feed"]),
+            created_at_epoch: Date.now(),
+          },
+          timestamp: Date.now(),
+        })}\n\n`
+      );
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    assert.equal(sentMessages.length, 1);
+    assert.ok(sentMessages[0].text.includes("Narrative"));
+    assert.ok(sentMessages[0].text.includes("This fuller context should stay visible"));
+    assert.ok(sentMessages[0].text.includes("Important fact three is preserved"));
+    assert.ok(sentMessages[0].text.includes("Concepts: important-feed"));
+    assert.ok(sentMessages[0].text.length <= 2200);
 
     await getService().stop({});
   });

--- a/openclaw/src/index.ts
+++ b/openclaw/src/index.ts
@@ -156,6 +156,11 @@ interface SSENewObservationEvent {
 
 type ConnectionState = "disconnected" | "connected" | "reconnecting";
 
+const DETAILED_FEED_TYPES = new Set(["security_alert", "security_note", "bugfix", "decision"]);
+const COMPACT_FEED_MAX_CHARS = 900;
+const DETAILED_FEED_MAX_CHARS = 2200;
+const DETAILED_FACT_LIMIT = 5;
+
 interface FeedEmojiConfig {
   primary?: string;
   claudeCode?: string;
@@ -397,11 +402,50 @@ function formatObservationMessage(
 ): string {
   const title = observation.title || "Untitled";
   const source = getSourceLabel(observation.project);
-  let message = `${source}\n**${title}**`;
+  const isDetailed = DETAILED_FEED_TYPES.has(observation.type);
+  const parts = [`${source}\n**${title}**`];
   if (observation.subtitle) {
-    message += `\n${observation.subtitle}`;
+    parts.push(truncateText(observation.subtitle, isDetailed ? 500 : 260));
   }
-  return message;
+
+  if (!isDetailed) {
+    return truncateText(parts.join("\n"), COMPACT_FEED_MAX_CHARS);
+  }
+
+  if (observation.narrative) {
+    parts.push(`Narrative\n${truncateText(observation.narrative, 900)}`);
+  }
+
+  const facts = parseStringArray(observation.facts).slice(0, DETAILED_FACT_LIMIT);
+  if (facts.length > 0) {
+    parts.push(`Facts\n${facts.map((fact) => `- ${truncateText(fact, 320)}`).join("\n")}`);
+  }
+
+  const concepts = parseStringArray(observation.concepts).slice(0, 8);
+  if (concepts.length > 0) {
+    parts.push(`Concepts: ${concepts.join(", ")}`);
+  }
+
+  return truncateText(parts.join("\n\n"), DETAILED_FEED_MAX_CHARS);
+}
+
+function truncateText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  const hardLimit = Math.max(0, maxChars - 3);
+  const truncated = value.slice(0, hardLimit);
+  const lastWhitespace = truncated.search(/\s+\S*$/);
+  const boundary = lastWhitespace > Math.floor(hardLimit * 0.65) ? lastWhitespace : hardLimit;
+  return `${truncated.slice(0, boundary).trimEnd()}...`;
+}
+
+function parseStringArray(value: string | null | undefined): string[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === "string") : [];
+  } catch {
+    return [];
+  }
 }
 
 const CHANNEL_SEND_MAP: Record<string, { namespace: string; functionName: string }> = {


### PR DESCRIPTION
## Summary
- compact routine OpenClaw observation feed messages to title/subtitle only
- keep richer narrative/facts/concepts for important feed types
- add OpenClaw SSE feed coverage for compact and detailed formatting

## Verification
- bun test openclaw/src/index.test.ts

Note: npm test in openclaw/ could not start because tsc is not installed in that subpackage environment.