### PR TITLE
refactor: remove redundant 50ms parse-delay timer in stdin-reader

### DIFF
--- a/src/cli/stdin-reader.ts
+++ b/src/cli/stdin-reader.ts
@@ -35,8 +35,6 @@ function tryParseJson(input: string): { success: true; value: unknown } | { succ
 
 const SAFETY_TIMEOUT_MS = 30000;
 
-const PARSE_DELAY_MS = 50;
-
 export async function readJsonFromStdin(): Promise<unknown> {
   if (!isStdinAvailable()) {
     return undefined;
@@ -45,7 +43,6 @@ export async function readJsonFromStdin(): Promise<unknown> {
   return new Promise((resolve, reject) => {
     let input = '';
     let resolved = false;
-    let parseDelayId: ReturnType<typeof setTimeout> | null = null;
 
     const cleanup = () => {
       try {
@@ -60,7 +57,6 @@ export async function readJsonFromStdin(): Promise<unknown> {
     const resolveWith = (value: unknown) => {
       if (resolved) return;
       resolved = true;
-      if (parseDelayId) clearTimeout(parseDelayId);
       clearTimeout(safetyTimeoutId);
       cleanup();
       resolve(value);
@@ -69,7 +65,6 @@ export async function readJsonFromStdin(): Promise<unknown> {
     const rejectWith = (error: Error) => {
       if (resolved) return;
       resolved = true;
-      if (parseDelayId) clearTimeout(parseDelayId);
       clearTimeout(safetyTimeoutId);
       cleanup();
       reject(error);
@@ -99,18 +94,9 @@ export async function readJsonFromStdin(): Promise<unknown> {
     const onData = (chunk: Buffer | string) => {
       input += chunk;
 
-      if (parseDelayId) {
-        clearTimeout(parseDelayId);
-        parseDelayId = null;
-      }
-
       if (tryResolveWithJson()) {
         return;
       }
-
-      parseDelayId = setTimeout(() => {
-        tryResolveWithJson();
-      }, PARSE_DELAY_MS);
     };
 
     const onEnd = () => {


### PR DESCRIPTION
## Summary
- Remove `PARSE_DELAY_MS` (50ms) debounce timer and `parseDelayId` from `src/cli/stdin-reader.ts`
- The timer retried `JSON.parse` on the identical input string that just failed — since no new data arrives between the immediate parse attempt and the 50ms callback, the retry could never succeed

## Why it was redundant
The timer was added in `830d7a2b` as part of migrating from a 5s inactivity timeout to per-chunk parsing. The commit comment said it "handles multi-chunk delivery" but:
- If immediate parse fails (incomplete JSON) → 50ms later, same input → still fails
- If a new chunk arrives → `onData` fires, cancels the timer, tries parse again immediately
- The actual resolution paths are: immediate parse per chunk, `onEnd` fallback, and the 30s safety timeout

## Test plan
- [x] Verify hooks still receive and parse stdin JSON correctly
- [x] Confirm multi-chunk delivery still works (immediate parse on each chunk handles this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)