### PR TITLE
fix(observer): truncate oversized observation prompt fields to prevent context overflow (#2468)

### DIFF
--- a/src/sdk/prompts.ts
+++ b/src/sdk/prompts.ts
@@ -78,6 +78,42 @@ ${mode.prompts.footer}
 ${mode.prompts.header_memory_start}`;
 }
 
+// Per-field character budget for the <parameters> / <outcome> blocks in an
+// observation prompt. Each field is allowed up to OBS_PROMPT_FIELD_MAX_CHARS;
+// content past that is replaced with a head + tail slice plus an explicit
+// <elided ...> marker so the observer model can see *that* truncation
+// happened (and won't fabricate detail about the missing range).
+//
+// 16k chars ≈ ~4k tokens (4 chars/token rough estimate). Two fields per
+// observation → ~8k tokens of variable input. With a 128k-token observer
+// model that leaves ample room for the system prompt, conversation
+// history, and the model's own response — and prevents a single oversized
+// Read tool result (issue #2468 reports a 130k-char file) from blowing
+// the entire context window and forcing the SDK session to abort with
+// "prompt is too long".
+//
+// Head/tail ratio (60% / 30%) keeps the start of the field (where most
+// tools put their canonical signal — file path, error message, command
+// header) and the tail (where errors / final-line context typically sit)
+// while dropping the middle. The 10% remainder is the elision marker.
+const OBS_PROMPT_FIELD_MAX_CHARS = 16_000;
+const OBS_PROMPT_FIELD_HEAD_RATIO = 0.6;
+const OBS_PROMPT_FIELD_TAIL_RATIO = 0.3;
+
+function truncateObservationField(value: unknown, maxChars: number = OBS_PROMPT_FIELD_MAX_CHARS): string {
+  // JSON.stringify returns undefined for undefined / functions / symbols;
+  // fall back to empty string so the call sites (template literal output)
+  // and the length check below stay well-defined.
+  const raw = JSON.stringify(value, null, 2) ?? '';
+  if (raw.length <= maxChars) return raw;
+  const headChars = Math.max(0, Math.floor(maxChars * OBS_PROMPT_FIELD_HEAD_RATIO));
+  const tailChars = Math.max(0, Math.floor(maxChars * OBS_PROMPT_FIELD_TAIL_RATIO));
+  const head = raw.slice(0, headChars);
+  const tail = tailChars > 0 ? raw.slice(-tailChars) : '';
+  const elidedChars = Math.max(0, raw.length - head.length - tail.length);
+  return `${head}\n... <elided chars="${elidedChars}" original_size_chars="${raw.length}" reason="oversize" /> ...\n${tail}`;
+}
+
 export function buildObservationPrompt(obs: Observation): string {
   let toolInput: any;
   let toolOutput: any;
@@ -103,9 +139,11 @@ export function buildObservationPrompt(obs: Observation): string {
   return `<observed_from_primary_session>
   <what_happened>${obs.tool_name}</what_happened>
   <occurred_at>${new Date(obs.created_at_epoch).toISOString()}</occurred_at>${obs.cwd ? `\n  <working_directory>${obs.cwd}</working_directory>` : ''}
-  <parameters>${JSON.stringify(toolInput, null, 2)}</parameters>
-  <outcome>${JSON.stringify(toolOutput, null, 2)}</outcome>
+  <parameters>${truncateObservationField(toolInput)}</parameters>
+  <outcome>${truncateObservationField(toolOutput)}</outcome>
 </observed_from_primary_session>
+
+If a <parameters> or <outcome> block above contains an "<elided chars=... />" marker, that field was truncated to fit the observer's context window. Describe only what you can see in the kept portion and do not infer details about the elided range.
 
 Return either one or more <observation>...</observation> blocks, or an empty response if this tool use should be skipped.
 Concrete debugging findings from logs, queue state, database rows, session routing, or code-path inspection count as durable discoveries and should be recorded.

--- a/tests/sdk/prompts.test.ts
+++ b/tests/sdk/prompts.test.ts
@@ -18,3 +18,40 @@ describe('buildObservationPrompt', () => {
     expect(prompt).toContain('Never reply with prose such as "Skipping", "No substantive tool executions"');
   });
 });
+
+describe('buildObservationPrompt oversized field truncation (#2468)', () => {
+  it('truncates an oversized outcome field with an elided marker, keeping head and tail', () => {
+    const huge = 'HEAD_SENTINEL' + 'A'.repeat(60_000) + 'TAIL_SENTINEL';
+    const prompt = buildObservationPrompt({
+      id: 1,
+      tool_name: 'Read',
+      tool_input: JSON.stringify({ file: 'big.txt' }),
+      tool_output: JSON.stringify({ content: huge }),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(prompt).toContain('<elided');
+    expect(prompt).toContain('reason="oversize"');
+    // head and tail of the raw value are preserved
+    expect(prompt).toContain('HEAD_SENTINEL');
+    expect(prompt).toContain('TAIL_SENTINEL');
+    // the oversized field is actually shrunk well below its raw 60k size
+    expect(prompt.length).toBeLessThan(40_000);
+  });
+
+  it('leaves a small field untouched (no elided marker)', () => {
+    const prompt = buildObservationPrompt({
+      id: 2,
+      tool_name: 'exec_command',
+      tool_input: JSON.stringify({ cmd: 'pwd' }),
+      tool_output: JSON.stringify({ output: '/repo' }),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    // The prompt always carries a static "<elided chars=... />" instruction line,
+    // so assert on the actual truncation marker (reason="oversize") instead.
+    expect(prompt).not.toContain('reason="oversize"');
+  });
+});


### PR DESCRIPTION
## Summary

`buildObservationPrompt` now truncates oversized `<parameters>` / `<outcome>` fields (> 16k chars) with a head (60%) + tail (30%) slice and an explicit `<elided chars="…" original_size_chars="…" reason="oversize" />` marker. This prevents a single oversized tool result — e.g. a 130k-char `Read` (#2468) — from blowing the observer's context window and aborting the SDK session with "prompt is too long". The observer is instructed to describe only the kept portion and not infer the elided range.

Head/tail ratio keeps the start of the field (path, error, command header) and the end (final-line context / errors) while dropping the middle.

## Why this is a fresh PR (relationship to #2602)

This is the still-relevant half of #2602, rebased on current `main`. #2602 also changed `GeneratorExitHandler.ts` to keep overflowed observations alive via a pending-restart path — but upstream `61fe70a2` (`refactor: remove retry/observation queue, replace with SessionMessageBuffer`) removed that whole mechanism, so that half is now obsolete. Only the prompt-field truncation remains useful, and it's fully independent of the queue/buffer architecture. This PR carries just that, plus tests it was missing.

Build artifacts (`worker-service.cjs`) are intentionally not included to avoid product-file merge conflicts; rebuild on merge.

## Test plan

- [x] `bun test tests/sdk/prompts.test.ts` — 3 pass (oversize field → elided marker + head/tail preserved + shrunk; small field untouched)