### PR TITLE
fix(smart-file-read): use a JS-valid tree-sitter query for plain .js files

### DIFF
--- a/src/services/smart-file-read/parser.ts
+++ b/src/services/smart-file-read/parser.ts
@@ -273,6 +273,19 @@ const QUERIES: Record<string, string> = {
 (export_statement) @exp
 `,
 
+  // Plain JavaScript: the tree-sitter-javascript grammar has no type_identifier,
+  // interface_declaration, type_alias_declaration or enum_declaration nodes, so it
+  // cannot share the jsts query — tree-sitter aborts query compilation on the first
+  // unknown node type. Class names are (identifier) here, not (type_identifier).
+  js: `
+(function_declaration name: (identifier) @name) @func
+(lexical_declaration (variable_declarator name: (identifier) @name value: [(arrow_function) (function_expression)])) @const_func
+(class_declaration name: (identifier) @name) @cls
+(method_definition name: (property_identifier) @name) @method
+(import_statement) @imp
+(export_statement) @exp
+`,
+
   python: `
 (function_definition name: (identifier) @name) @func
 (class_definition name: (identifier) @name) @cls
@@ -422,6 +435,7 @@ const QUERIES: Record<string, string> = {
 function getQueryKey(language: string): string {
   switch (language) {
     case "javascript":
+      return "js";
     case "typescript":
     case "tsx":
       return "jsts";


### PR DESCRIPTION
## Problem

`smart_outline` / `smart_search` silently return **zero symbols for every plain `.js` / `.mjs` / `.cjs` file**. TypeScript and JSX/TSX work fine.

Root cause: `javascript`, `typescript` and `tsx` all share the `jsts` tree-sitter query, but that query references node types that exist only in the TypeScript grammar:

- `type_identifier` (used for the class name)
- `interface_declaration`
- `type_alias_declaration`
- `enum_declaration`

`tree-sitter` **0.26.x** no longer silently ignores unknown node types — it aborts query compilation:

```
Error: Query compilation failed
Caused by: Query error at 4:27. Invalid node type "type_identifier"
```

`runBatchQuery` catches the thrown CLI error and returns an empty `Map`, so the failure is completely silent — the file just looks "unparseable".

This is the exact fragility predicted in #1654 (closed `wontfix`): *"If tree-sitter changes to fail on unrecognized node types, all `.js` file parsing breaks."* It now has, in the wild. Reported as #2750.

## Fix

Add a dedicated `js` query and route the `javascript` language to it. Class names in `tree-sitter-javascript` are `(identifier)` (not `(type_identifier)`), and the TS-only declaration patterns are dropped. `typescript` and `tsx` keep using `jsts` unchanged.

```diff
   switch (language) {
     case "javascript":
+      return "js";
     case "typescript":
     case "tsx":
       return "jsts";
```

The `language` value stays `"javascript"`, so grammar resolution (`tree-sitter-javascript`) and `isExported()` are unaffected — only the query key changes.

14-line diff, no behavior change for TS/TSX.

## Verification

The new `js` query compiles cleanly against `tree-sitter-javascript` and captures every symbol kind:

```
$ tree-sitter query -p node_modules/tree-sitter-javascript js.scm sample.js
pattern 0  capture func        -> function foo
pattern 1  capture const_func  -> const bar = (n) => ...   /  const z = function(){...}
pattern 2  capture cls         -> class Baz
pattern 3  capture method      -> qux
pattern 4  capture imp         -> import x from "y"
pattern 5  capture exp         -> export ...
```

End-to-end via `smart_outline`: a real **10,755-line vanilla-JS file** went from `Could not parse` (0 symbols) to a full **334-symbol** outline.

## Alternatives considered

- **Map `.js` → `tsx` grammar.** `tsx` is a JS superset and the `jsts` query is valid against it; smallest change, but parses plain JS under the TSX dialect. Works, but a JS-specific query is cleaner.
- **Make `runBatchQuery` tolerant** — compile patterns individually, skip (and log) the ones a grammar rejects. Worth doing separately: it future-proofs every grammar/query pair and removes the *silent* empty-result failure mode that masked this bug.

Fixes #2750.
