### PR TITLE
fix: Windows compatibility for MCP server and hooks

### DIFF
--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,12 +1,14 @@
 {
   "mcpServers": {
-    "mcp-search": {
+    "claude-mem-search": {
       "type": "stdio",
-      "command": "sh",
+      "command": "node",
       "args": [
-        "-c",
-        "_C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; printf '%s\\n' \"$PWD/plugin\" \"$PWD\"; ls -dt \"$HOME/.codex/plugins/cache/claude-mem-local/claude-mem\"/[0-9]*/ \"$HOME/.codex/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/mcp-server.cjs\" ] && { printf '%s\\n' \"$_Q\"; break; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: mcp server not found\" >&2; exit 1; }; exec node \"$_P/scripts/mcp-server.cjs\""
-      ]
+        "${CLAUDE_PLUGIN_ROOT}/scripts/mcp-server.cjs"
+      ],
+      "env": {
+        "NODE_ENV": "production"
+      }
     }
   }
 }

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Claude-mem memory system hooks",
+  "description": "Claude-mem memory system hooks (Windows-compatible version)",
   "hooks": {
     "Setup": [
       {
@@ -7,8 +7,8 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "bash",
-            "command": "export PATH=\"$HOME/.nvm/versions/node/v$(ls \\\"$HOME/.nvm/versions/node\\\" 2>/dev/null | sed 's/^v//' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)/bin:$HOME/.local/bin:/usr/local/bin:/opt/homebrew/bin:$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/version-check.js\" ] && { printf '%s\\n' \"$_Q\"; break; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: version-check.js not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/version-check.js\"",
+            "shell": "node",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hook-entry.cjs ${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs version-check",
             "timeout": 300
           }
         ]
@@ -20,14 +20,14 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "bash",
-            "command": "export PATH=\"$($SHELL -lc 'echo $PATH' 2>/dev/null):$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/bun-runner.js\" ] && [ -f \"$_Q/scripts/worker-service.cjs\" ] && { printf '%s\\n' \"$_Q\"; break; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: plugin scripts not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/bun-runner.js\" \"$_P/scripts/worker-service.cjs\" start; echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "shell": "node",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hook-entry.cjs ${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs start",
             "timeout": 60
           },
           {
             "type": "command",
-            "shell": "bash",
-            "command": "export PATH=\"$($SHELL -lc 'echo $PATH' 2>/dev/null):$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/bun-runner.js\" ] && [ -f \"$_Q/scripts/worker-service.cjs\" ] && { printf '%s\\n' \"$_Q\"; break; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: plugin scripts not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/bun-runner.js\" \"$_P/scripts/worker-service.cjs\" hook claude-code context",
+            "shell": "node",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hook-entry.cjs ${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs hook claude-code context",
             "timeout": 60
           }
         ]
@@ -38,8 +38,8 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "bash",
-            "command": "export PATH=\"$($SHELL -lc 'echo $PATH' 2>/dev/null):$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/bun-runner.js\" ] && [ -f \"$_Q/scripts/worker-service.cjs\" ] && { printf '%s\\n' \"$_Q\"; break; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: plugin scripts not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/bun-runner.js\" \"$_P/scripts/worker-service.cjs\" hook claude-code session-init",
+            "shell": "node",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hook-entry.cjs ${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs hook claude-code session-init",
             "timeout": 60
           }
         ]
@@ -51,8 +51,8 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "bash",
-            "command": "export PATH=\"$($SHELL -lc 'echo $PATH' 2>/dev/null):$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/bun-runner.js\" ] && [ -f \"$_Q/scripts/worker-service.cjs\" ] && { printf '%s\\n' \"$_Q\"; break; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: plugin scripts not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/bun-runner.js\" \"$_P/scripts/worker-service.cjs\" hook claude-code observation",
+            "shell": "node",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hook-entry.cjs ${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs hook claude-code observation",
             "timeout": 120
           }
         ]
@@ -64,8 +64,8 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "bash",
-            "command": "export PATH=\"$($SHELL -lc 'echo $PATH' 2>/dev/null):$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/bun-runner.js\" ] && [ -f \"$_Q/scripts/worker-service.cjs\" ] && { printf '%s\\n' \"$_Q\"; break; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: plugin scripts not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/bun-runner.js\" \"$_P/scripts/worker-service.cjs\" hook claude-code file-context",
+            "shell": "node",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hook-entry.cjs ${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs hook claude-code file-context",
             "timeout": 60
           }
         ]
@@ -76,8 +76,8 @@
         "hooks": [
           {
             "type": "command",
-            "shell": "bash",
-            "command": "export PATH=\"$($SHELL -lc 'echo $PATH' 2>/dev/null):$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/bun-runner.js\" ] && [ -f \"$_Q/scripts/worker-service.cjs\" ] && { printf '%s\\n' \"$_Q\"; break; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: plugin scripts not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/bun-runner.js\" \"$_P/scripts/worker-service.cjs\" hook claude-code summarize",
+            "shell": "node",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hook-entry.cjs ${CLAUDE_PLUGIN_ROOT}/scripts/worker-service.cjs hook claude-code summarize",
             "timeout": 120
           }
         ]

--- a/plugin/scripts/hook-entry.cjs
+++ b/plugin/scripts/hook-entry.cjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Windows-compatible hook entry point for claude-mem
+ * Replaces complex bash path resolution with cross-platform Node.js logic
+ */
+
+const { existsSync } = require('fs');
+const { join, resolve } = require('path');
+const { homedir } = require('os');
+const { spawn } = require('child_process');
+
+const IS_WINDOWS = process.platform === 'win32';
+
+function findPluginRoot() {
+  const configDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+
+  // Priority 1: CLAUDE_PLUGIN_ROOT environment variable
+  if (process.env.CLAUDE_PLUGIN_ROOT) {
+    const root = process.env.CLAUDE_PLUGIN_ROOT;
+    if (existsSync(join(root, 'scripts', 'bun-runner.js'))) {
+      return root;
+    }
+  }
+
+  // Priority 2: Cache directory (versioned installations)
+  const cacheDir = join(configDir, 'plugins', 'cache', 'thedotmack', 'claude-mem');
+  if (existsSync(cacheDir)) {
+    const versions = require('fs').readdirSync(cacheDir)
+      .filter(v => /^\d+\.\d+\.\d+$/.test(v))
+      .sort((a, b) => {
+        const [aMaj, aMin, aPatch] = a.split('.').map(Number);
+        const [bMaj, bMin, bPatch] = b.split('.').map(Number);
+        return (bMaj - aMaj) || (bMin - aMin) || (bPatch - aPatch);
+      });
+
+    for (const version of versions) {
+      const pluginRoot = join(cacheDir, version);
+      if (existsSync(join(pluginRoot, 'scripts', 'bun-runner.js'))) {
+        return pluginRoot;
+      }
+    }
+  }
+
+  // Priority 3: Marketplace directory
+  const marketplaceDir = join(configDir, 'plugins', 'marketplaces', 'thedotmack', 'plugin');
+  if (existsSync(join(marketplaceDir, 'scripts', 'bun-runner.js'))) {
+    return marketplaceDir;
+  }
+
+  console.error('claude-mem: plugin root not found');
+  process.exit(1);
+}
+
+function main() {
+  const pluginRoot = findPluginRoot();
+  const bunRunnerPath = join(pluginRoot, 'scripts', 'bun-runner.js');
+
+  // Forward all arguments to bun-runner.js
+  const args = process.argv.slice(2);
+
+  const child = spawn(process.execPath, [bunRunnerPath, ...args], {
+    stdio: ['inherit', 'inherit', 'inherit'],
+    env: {
+      ...process.env,
+      CLAUDE_PLUGIN_ROOT: pluginRoot
+    },
+    windowsHide: true
+  });
+
+  child.on('error', (err) => {
+    console.error(`Failed to start bun-runner: ${err.message}`);
+    process.exit(1);
+  });
+
+  child.on('close', (code) => {
+    process.exit(code || 0);
+  });
+}
+
+main();


### PR DESCRIPTION
- Replace bash-dependent hooks with cross-platform node entry point
- Simplify .mcp.json to use direct node execution
- Add hook-entry.cjs for Windows-compatible path resolution
- Remove dependency on bash/sh/Git Bash for Windows users

Fixes:
- MCP server startup on Windows (sh command issue)
- Hook execution on pure Windows systems (bash hardcoding)
- Path resolution using Node.js native APIs
- Automatic plugin root discovery across installation methods

Related: Issue #2446, Issue #2188