### PR TITLE
fix(worker): recycle stale worker on version mismatch instead of reusing it

### DIFF
--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -9,6 +9,7 @@ import { MARKETPLACE_ROOT, DATA_DIR } from "./paths.js";
 import { loadFromFileOnce } from "./hook-settings.js";
 import { validateWorkerPidFile } from "../supervisor/index.js";
 import { emitBlockingError } from "./hook-io.js";
+import { checkVersionMatch } from "../services/infrastructure/index.js";
 
 function readTimeoutEnv(
   envName: string,
@@ -130,64 +131,6 @@ async function isWorkerReady(): Promise<boolean> {
   return response.ok;
 }
 
-function getPluginVersion(): string {
-  try {
-    const packageJsonPath = path.join(MARKETPLACE_ROOT, 'package.json');
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
-    return packageJson.version;
-  } catch (error: unknown) {
-    const code = error instanceof Error ? (error as NodeJS.ErrnoException).code : undefined;
-    if (code === 'ENOENT' || code === 'EBUSY') {
-      logger.debug('SYSTEM', 'Could not read plugin version (shutdown race)', { code });
-      return 'unknown';
-    }
-    throw error;
-  }
-}
-
-async function getWorkerVersion(): Promise<string> {
-  const response = await workerHttpRequest('/api/version', { timeoutMs: HEALTH_CHECK_TIMEOUT_MS });
-  if (!response.ok) {
-    throw new Error(`Failed to get worker version: ${response.status}`);
-  }
-  const data = await response.json() as { version: string };
-  return data.version;
-}
-
-async function checkWorkerVersion(): Promise<void> {
-  let pluginVersion: string;
-  try {
-    pluginVersion = getPluginVersion();
-  } catch (error: unknown) {
-    logger.debug('SYSTEM', 'Version check failed reading plugin version', {
-      error: error instanceof Error ? error.message : String(error)
-    });
-    return;
-  }
-
-  if (pluginVersion === 'unknown') return;
-
-  let workerVersion: string;
-  try {
-    workerVersion = await getWorkerVersion();
-  } catch (error: unknown) {
-    logger.debug('SYSTEM', 'Version check failed reading worker version', {
-      error: error instanceof Error ? error.message : String(error)
-    });
-    return;
-  }
-
-  if (workerVersion === 'unknown') return;
-
-  if (pluginVersion !== workerVersion) {
-    logger.debug('SYSTEM', 'Version check', {
-      pluginVersion,
-      workerVersion,
-      note: 'Mismatch will be auto-restarted by worker-service start command'
-    });
-  }
-}
-
 function resolveWorkerScriptPath(): string | null {
   const candidates = [
     path.join(MARKETPLACE_ROOT, 'plugin', 'scripts', 'worker-service.cjs'),
@@ -270,20 +213,48 @@ async function isWorkerPortAlive(): Promise<boolean> {
   if (!healthy) return false;
 
   const pidStatus = validateWorkerPidFile({ logAlive: false });
-  if (pidStatus === 'missing') return true;     
-  if (pidStatus === 'alive') return true;       
-  return false;                                 
+  if (pidStatus === 'missing') return true;
+  if (pidStatus === 'alive') return true;
+  return false;
 }
 
 export async function ensureWorkerRunning(): Promise<boolean> {
   if (await isWorkerPortAlive()) {
-    await checkWorkerVersion();
-    const ready = await waitForWorkerReadiness();
-    if (!ready) {
-      logger.warn('SYSTEM', 'Worker is healthy but not ready; skipping hook API call');
-      return false;
+    // A worker is already alive. If it is a DIFFERENT version than the
+    // installed plugin (e.g. the user upgraded but the previous worker is
+    // still squatting the port), recycle it so the current version takes
+    // over — otherwise the stale worker keeps serving indefinitely.
+    //
+    // Previously this branch only logged the mismatch (debug level) and
+    // returned, so a stale worker was reused across upgrades. We now act on
+    // it: ask the running worker to restart via its localhost-only admin
+    // endpoint, then fall through to the lazy-spawn + readiness path so the
+    // current-version worker is (re)started and awaited.
+    const { matches, pluginVersion, workerVersion } = await checkVersionMatch(getWorkerPort());
+    if (matches) {
+      const ready = await waitForWorkerReadiness();
+      if (!ready) {
+        logger.warn('SYSTEM', 'Worker is healthy but not ready; skipping hook API call');
+        return false;
+      }
+      return true;
     }
-    return true;
+
+    logger.info('SYSTEM', 'Worker version mismatch — recycling stale worker', {
+      pluginVersion,
+      workerVersion,
+    });
+    try {
+      await workerHttpRequest('/api/admin/restart', {
+        method: 'POST',
+        timeoutMs: HEALTH_CHECK_TIMEOUT_MS,
+      });
+    } catch (error: unknown) {
+      logger.debug('SYSTEM', 'Worker restart request failed; falling through to lazy-spawn', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    // Fall through to (re)spawn + readiness wait below.
   }
 
   const runtimePath = resolveBunRuntime();
@@ -422,7 +393,7 @@ function recordWorkerUnreachable(): number {
 
 function resetWorkerFailureCounter(): void {
   const state = readHookFailureState();
-  if (state.consecutiveFailures === 0) return;       
+  if (state.consecutiveFailures === 0) return;
   writeHookFailureStateAtomic({ consecutiveFailures: 0, lastFailureAt: 0 });
 }
 

--- a/tests/shared/worker-utils-version-recycle.test.ts
+++ b/tests/shared/worker-utils-version-recycle.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+
+// Record every HTTP call the worker layer makes, so we can assert whether a
+// restart was (or was not) issued. fetch is what workerHttpRequest ultimately
+// calls via fetchWithTimeout.
+const fetchLog: Array<{ url: string; method: string }> = [];
+
+// Controls what checkVersionMatch reports for a given test.
+let versionMatchResult: { matches: boolean; pluginVersion: string; workerVersion: string | null } = {
+  matches: true,
+  pluginVersion: '13.4.0',
+  workerVersion: '13.4.0',
+};
+
+// A worker is "alive" (healthy + pid ok) for these tests; we exercise the
+// version-mismatch branch, not the lazy-spawn-from-dead path.
+mock.module('../../src/services/infrastructure/index.js', () => ({
+  checkVersionMatch: () => Promise.resolve(versionMatchResult),
+}));
+
+mock.module('../../src/supervisor/index.js', () => ({
+  validateWorkerPidFile: () => 'alive',
+}));
+
+function installFetchMock(): void {
+  fetchLog.length = 0;
+  global.fetch = mock((url: string | URL | Request, init?: RequestInit) => {
+    const u = typeof url === 'string' ? url : url.toString();
+    const method = (init?.method ?? 'GET').toUpperCase();
+    fetchLog.push({ url: u, method });
+
+    // /api/health and /api/readiness must report OK so the worker is "alive"
+    // and "ready"; /api/admin/restart and anything else also returns OK.
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(''),
+      json: () => Promise.resolve({}),
+    } as unknown as Response);
+  }) as unknown as typeof fetch;
+}
+
+describe('ensureWorkerRunning — stale-worker recycle on version mismatch', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    installFetchMock();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    mock.restore();
+  });
+
+  it('POSTs /api/admin/restart when the running worker version differs', async () => {
+    versionMatchResult = { matches: false, pluginVersion: '13.4.0', workerVersion: '13.3.0' };
+
+    const { ensureWorkerRunning } = await import('../../src/shared/worker-utils.js');
+    await ensureWorkerRunning();
+
+    const restartCalls = fetchLog.filter(
+      c => c.url.includes('/api/admin/restart') && c.method === 'POST'
+    );
+    expect(restartCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does NOT restart when versions match', async () => {
+    versionMatchResult = { matches: true, pluginVersion: '13.4.0', workerVersion: '13.4.0' };
+
+    const { ensureWorkerRunning } = await import('../../src/shared/worker-utils.js');
+    await ensureWorkerRunning();
+
+    const restartCalls = fetchLog.filter(c => c.url.includes('/api/admin/restart'));
+    expect(restartCalls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

`ensureWorkerRunning()` (in `src/shared/worker-utils.ts`) reuses **any** alive worker. When a worker is already up it calls `checkWorkerVersion()`, which on a version mismatch only logs at `debug` level and returns — its own comment claims:

```ts
note: 'Mismatch will be auto-restarted by worker-service start command'
```

…but nothing on this lazy-spawn path ever restarts it. So after an upgrade, the **old** worker keeps squatting the port and the newly-installed version never takes over until the old process happens to die.

### Observed in the wild

A `13.3.0` worker stayed alive for ~36h while `13.4.0` sat unused in the plugin cache. Symptoms:
- `GET /api/observations/by-file` flooded with `500`s (`SQLite query expected N values, received 2` — an older query bug already fixed in 13.4.0, but the stale 13.3.0 worker kept hitting it).
- Session summaries silently stopped being generated.
- `worker-cli start` reported success but the new version never bound the port (the old one held it), so each start "died during startup".

The version skew was invisible because the only signal was a `debug`-level log line.

## Fix

Make the code do what the comment always claimed. In `ensureWorkerRunning()`'s "worker already alive" branch:

1. Use the existing, already-tested `checkVersionMatch()` primitive from `src/services/infrastructure` (it returns `{ matches, pluginVersion, workerVersion }`).
2. On **match** → behave exactly as before (readiness wait, return).
3. On **mismatch** → log at `info`, `POST /api/admin/restart` (the existing localhost-only admin endpoint), then fall through to the existing lazy-spawn + readiness path so the current-version worker (re)starts and is awaited.

Also removes the now-dead local `checkWorkerVersion()`, `getWorkerVersion()`, and `getPluginVersion()` (confirmed no other callers — they were `worker-utils.ts`-local, non-exported).

### Why `/api/admin/restart`

It's the supported, localhost-guarded recycle path (`requireLocalhost` in `Server.ts`) and per the CHANGELOG it guarantees `process.exit()` + chroma-mcp cascade cleanup, avoiding the zombie-worker problem a raw kill would risk. We call it from `127.0.0.1`, satisfying the guard.

## Tests

`tests/shared/worker-utils-version-recycle.test.ts`:
- version mismatch ⇒ `POST /api/admin/restart` is issued
- versions match ⇒ no restart

(`checkVersionMatch` itself is already covered by `tests/infrastructure/health-monitor.test.ts`.)

## Risk / scope

Single-file behavior change in `worker-utils.ts` plus one test. Matched-version path is unchanged. Mismatch path now self-heals instead of silently serving a stale worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)