### PR TITLE
feat: add C# as a builtin smart-explore language

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "remark-parse": "^11.0.0",
     "tree-sitter-bash": "^0.25.1",
     "tree-sitter-c": "^0.24.1",
+    "tree-sitter-c-sharp": "^0.23.5",
     "tree-sitter-cli": "^0.26.8",
     "tree-sitter-cpp": "^0.23.4",
     "tree-sitter-css": "^0.25.0",
@@ -198,6 +199,7 @@
   "trustedDependencies": [
     "esbuild",
     "tree-sitter-c",
+    "tree-sitter-c-sharp",
     "tree-sitter-cli",
     "tree-sitter-cpp",
     "tree-sitter-go",

--- a/plugin/skills/smart-explore/SKILL.md
+++ b/plugin/skills/smart-explore/SKILL.md
@@ -162,6 +162,7 @@ Smart-explore uses **tree-sitter AST parsing** for structural analysis. Unsuppor
 | Java | `.java` |
 | C | `.c`, `.h` |
 | C++ | `.cpp`, `.cc`, `.cxx`, `.hpp`, `.hh` |
+| C# | `.cs` |
 
 Files with unrecognized extensions are parsed as plain text — `smart_search` still works (grep-style), but `smart_outline` and `smart_unfold` will not extract structured symbols.
 

--- a/src/services/smart-file-read/parser.ts
+++ b/src/services/smart-file-read/parser.ts
@@ -46,6 +46,7 @@ const LANG_MAP: Record<string, string> = {
   ".java": "java",
   ".c": "c",
   ".h": "c",
+  ".cs": "csharp",
   ".cpp": "cpp",
   ".cc": "cpp",
   ".cxx": "cpp",
@@ -191,6 +192,7 @@ const GRAMMAR_PACKAGES: Record<string, string> = {
   java: "tree-sitter-java",
   c: "tree-sitter-c",
   cpp: "tree-sitter-cpp",
+  csharp: "tree-sitter-c-sharp",
   kotlin: "tree-sitter-kotlin",
   swift: "tree-sitter-swift",
   php: "tree-sitter-php/php",
@@ -261,6 +263,17 @@ export function resolveGrammarPathWithFallback(language: string, projectRoot?: s
 }
 
 const QUERIES: Record<string, string> = {
+  csharp: `
+(class_declaration name: (identifier) @name) @cls
+(interface_declaration name: (identifier) @name) @iface
+(struct_declaration name: (identifier) @name) @struct_def
+(enum_declaration name: (identifier) @name) @enm
+(record_declaration name: (identifier) @name) @cls
+(method_declaration name: (identifier) @name) @method
+(constructor_declaration name: (identifier) @name) @method
+(property_declaration name: (identifier) @name) @prop
+(using_directive) @imp
+`,
   jsts: `
 (function_declaration name: (identifier) @name) @func
 (lexical_declaration (variable_declarator name: (identifier) @name value: [(arrow_function) (function_expression)])) @const_func
@@ -430,6 +443,7 @@ function getQueryKey(language: string): string {
     case "rust": return "rust";
     case "ruby": return "ruby";
     case "java": return "java";
+    case "csharp": return "csharp";
     case "kotlin": return "kotlin";
     case "swift": return "swift";
     case "php": return "php";
@@ -568,6 +582,7 @@ const KIND_MAP: Record<string, CodeSymbol["kind"]> = {
   const_func: "function",
   cls: "class",
   method: "method",
+  prop: "property",
   iface: "interface",
   tdef: "type",
   enm: "enum",


### PR DESCRIPTION
Adds C# to the bundled smart-explore languages.

- `tree-sitter-c-sharp@^0.23.5` dependency (+ `trustedDependencies`)
- `.cs` → `csharp` extension mapping, `GRAMMAR_PACKAGES` and `getQueryKey` entries
- Dedicated query: classes, interfaces, structs, enums, records, methods, constructors, properties, using directives
- New `prop` capture mapped to the existing `"property"` symbol kind
- SKILL.md language table row

Receipts from a production .NET monorepo: `smart_search` indexes ~1,600 symbols per service repo with signatures and XML-doc comments; `smart_outline` folds a 467-line service class into its member skeleton; `smart_unfold` returns exact AST-bounded member bodies.

Note: C# uses the same CLI pipeline as the other builtins — grammar compilation needs a C compiler at runtime (same constraint as #1247).

Note: the `prop` capture introduced here also becomes available to custom-grammar query authors; the capture vocabulary list in SKILL.md (rewritten in #2774) gains `@prop` as a one-line follow-up once both PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)