### PR TITLE
fix(hooks): bun-runner.js parses on pre-ES2020 Node (closes #2791)

### DIFF
--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -66,7 +66,15 @@ function isPluginDisabledInClaudeSettings() {
     const settingsPath = join(configDir, 'settings.json');
     if (!existsSync(settingsPath)) return false;
     const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-    return settings?.enabledPlugins?.['claude-mem@thedotmack'] === false;
+    // No optional chaining (?.) here: this launcher must parse on the oldest
+    // Node that any host might invoke it with. Some Claude Code installs run
+    // hooks under a bundled pre-ES2020 Node whose ESM loader throws
+    // "SyntaxError: Unexpected token '.'" on `?.` (issue #2791).
+    return Boolean(
+      settings &&
+      settings.enabledPlugins &&
+      settings.enabledPlugins['claude-mem@thedotmack'] === false
+    );
   } catch {
     return false;
   }

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -175,6 +175,19 @@ async function verifyShellTemplateCanonical() {
     );
   }
 
+  // Parser-compat guard (issue #2791): bun-runner.js is invoked by hosts that
+  // may run a pre-ES2020 Node whose ESM loader throws on optional chaining.
+  // Strip comments, then forbid `?.` / `??` in executable code.
+  const bunRunnerCode = bunRunner
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+  if (/\?\.|\?\?/.test(bunRunnerCode)) {
+    throw new Error(
+      'plugin/scripts/bun-runner.js uses optional chaining (?.) or nullish coalescing (??) — ' +
+      'this launcher must parse on pre-ES2020 Node (issue #2791). Rewrite with explicit guards.'
+    );
+  }
+
   console.log('✓ Rule A shell templates match the canonical generator');
 }
 


### PR DESCRIPTION
## Bug (#2791)
The Stop hook crashes **every session** with:
```
SyntaxError: Unexpected token '.'
  at Loader.moduleStrategy (internal/modules/esm/translators.js:140:18)
```
`bun-runner.js` is invoked by some hosts under a bundled pre-ES2020 Node whose ESM loader rejects optional chaining (`?.`). The only `?.` site (`isPluginDisabledInClaudeSettings`) trips it.

## Fix
- Rewrite the single `settings?.enabledPlugins?.[...]` expression with explicit `&&` guards (identical semantics, parses on old Node).
- Add a build-time guard in `scripts/build-hooks.js` that strips comments and **forbids `?.` / `??` in `bun-runner.js`**, so the launcher can't regress into syntax a legacy loader can't parse.

## Verification
- `node --check plugin/scripts/bun-runner.js` ✅
- `npm run build` ✅ (new guard passes; throws if `?.`/`??` reintroduced — fault-injection verified)

Closes #2791