### PR TITLE
feat: ignore Codex and Codex-app internal system prompts

### DIFF
--- a/src/cli/handlers/session-init.ts
+++ b/src/cli/handlers/session-init.ts
@@ -10,7 +10,7 @@ import { HOOK_EXIT_CODES } from '../../shared/hook-constants.js';
 import { shouldTrackProject } from '../../shared/should-track-project.js';
 import { loadFromFileOnce } from '../../shared/hook-settings.js';
 import { normalizePlatformSource } from '../../shared/platform-source.js';
-import { isInternalProtocolPayload } from '../../utils/tag-stripping.js';
+import { isInternalProtocolPayload, isInternalSystemPrompt } from '../../utils/tag-stripping.js';
 import { resolveRuntimeContext, logServerBetaFallback } from '../../services/hooks/runtime-selector.js';
 import { isServerBetaClientError } from '../../services/hooks/server-beta-client.js';
 
@@ -42,8 +42,8 @@ export const sessionInitHandler: EventHandler = {
       return { continue: true, suppressOutput: true };
     }
 
-    if (rawPrompt && isInternalProtocolPayload(rawPrompt)) {
-      logger.debug('HOOK', 'session-init: skipping internal protocol payload', {
+    if (rawPrompt && (isInternalProtocolPayload(rawPrompt) || isInternalSystemPrompt(rawPrompt))) {
+      logger.debug('HOOK', 'session-init: skipping internal protocol or system payload', {
         preview: rawPrompt.slice(0, 80),
       });
       return { continue: true, suppressOutput: true };

--- a/src/services/worker/http/routes/SessionRoutes.ts
+++ b/src/services/worker/http/routes/SessionRoutes.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { ingestObservation } from '../shared.js';
 import { validateBody } from '../middleware/validateBody.js';
 import { logger } from '../../../../utils/logger.js';
-import { stripMemoryTagsFromPrompt, isInternalProtocolPayload } from '../../../../utils/tag-stripping.js';
+import { stripMemoryTagsFromPrompt, isInternalProtocolPayload, isInternalSystemPrompt } from '../../../../utils/tag-stripping.js';
 import { SessionManager } from '../../SessionManager.js';
 import { DatabaseManager } from '../../DatabaseManager.js';
 import { ClaudeProvider } from '../../ClaudeProvider.js';
@@ -316,8 +316,8 @@ export class SessionRoutes extends BaseRouteHandler {
     const platformSource = normalizePlatformSource(req.body.platformSource);
     const customTitle = req.body.customTitle || undefined;
 
-    if (rawPrompt && isInternalProtocolPayload(rawPrompt)) {
-      logger.debug('HTTP', 'session-init: skipping internal protocol payload before session creation', { contentSessionId });
+    if (rawPrompt && (isInternalProtocolPayload(rawPrompt) || isInternalSystemPrompt(rawPrompt))) {
+      logger.debug('HTTP', 'session-init: skipping internal protocol or system payload before session creation', { contentSessionId });
       res.json({ skipped: true, reason: 'internal_protocol' });
       return;
     }

--- a/src/utils/tag-stripping.ts
+++ b/src/utils/tag-stripping.ts
@@ -66,3 +66,28 @@ export function isInternalProtocolPayload(text: string): boolean {
   if (text.length > MAX_PROTOCOL_PAYLOAD_BYTES) return false;
   return PROTOCOL_ONLY_REGEX.test(text);
 }
+
+export function isInternalSystemPrompt(text: string): boolean {
+  if (!text) return false;
+
+  const trimmed = text.trim();
+
+  // 1. Codex-app session title generation prompt
+  if (trimmed.startsWith('You are a helpful assistant. You will be presented with a user prompt, and your job is to provide a short title')) {
+    return true;
+  }
+
+  // 2. Memory Writing Agent consolidation prompt
+  if (trimmed.startsWith('## Memory Writing Agent: Phase 2 (Consolidation)') || trimmed.startsWith('## Memory Writing Agent')) {
+    return true;
+  }
+
+  // 3. Codex onboarding/suggestions prompt
+  if (trimmed.startsWith('# Overview\n\nGenerate 0 to 3 hyperpersonalized suggestions') || 
+      trimmed.startsWith('# Overview\r\n\r\nGenerate 0 to 3 hyperpersonalized suggestions') ||
+      trimmed.startsWith('# Overview\nGenerate 0 to 3 hyperpersonalized suggestions')) {
+    return true;
+  }
+
+  return false;
+}

--- a/tests/utils/tag-stripping.test.ts
+++ b/tests/utils/tag-stripping.test.ts
@@ -1,6 +1,6 @@
 
 import { describe, it, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test';
-import { stripMemoryTagsFromPrompt, stripMemoryTagsFromJson, isInternalProtocolPayload } from '../../src/utils/tag-stripping.js';
+import { stripMemoryTagsFromPrompt, stripMemoryTagsFromJson, isInternalProtocolPayload, isInternalSystemPrompt } from '../../src/utils/tag-stripping.js';
 import { logger } from '../../src/utils/logger.js';
 
 let loggerSpies: ReturnType<typeof spyOn>[] = [];
@@ -441,10 +441,38 @@ after`;
       const text = '<task-notification>a</task-notification> hello <task-notification>b</task-notification>';
       expect(isInternalProtocolPayload(text)).toBe(false);
     });
-
     it('returns false for two adjacent protocol blocks (deliberate: deny-list per single block, not concatenations)', () => {
       const text = '<task-notification>a</task-notification><task-notification>b</task-notification>';
       expect(isInternalProtocolPayload(text)).toBe(false);
+    });
+  });
+
+  describe('isInternalSystemPrompt', () => {
+    it('returns false for empty input', () => {
+      expect(isInternalSystemPrompt('')).toBe(false);
+    });
+
+    it('returns false for general user queries', () => {
+      expect(isInternalSystemPrompt('How do I run a backup?')).toBe(false);
+      expect(isInternalSystemPrompt('Memory Writing Agent is cool.')).toBe(false);
+      expect(isInternalSystemPrompt('Tell me about the task title generator.')).toBe(false);
+    });
+
+    it('returns true for Codex-app title generation prompt', () => {
+      expect(isInternalSystemPrompt('You are a helpful assistant. You will be presented with a user prompt, and your job is to provide a short title for a task.')).toBe(true);
+      expect(isInternalSystemPrompt('You are a helpful assistant. You will be presented with a user prompt, and your job is to provide a short title for a ta')).toBe(true);
+      expect(isInternalSystemPrompt('   You are a helpful assistant. You will be presented with a user prompt, and your job is to provide a short title for a task')).toBe(true);
+    });
+
+    it('returns true for Memory Writing Agent consolidation system prompt', () => {
+      expect(isInternalSystemPrompt('## Memory Writing Agent: Phase 2 (Consolidation)\n\nYou are a Memory Writing Agent.\n\nYour job: consolidate raw memories')).toBe(true);
+      expect(isInternalSystemPrompt('## Memory Writing Agent\n\nYour job: consolidate')).toBe(true);
+    });
+
+    it('returns true for Codex onboarding/suggestions prompt', () => {
+      expect(isInternalSystemPrompt('# Overview\n\nGenerate 0 to 3 hyperpersonalized suggestions for what this user can do with Codex in this local project.')).toBe(true);
+      expect(isInternalSystemPrompt('# Overview\r\n\r\nGenerate 0 to 3 hyperpersonalized suggestions for what this user can do')).toBe(true);
+      expect(isInternalSystemPrompt(' # Overview\nGenerate 0 to 3 hyperpersonalized suggestions for what this user can do')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
This PR ignores Codex and Codex-app internal system-initiated prompts (e.g., session title generation, memory consolidation agent, and suggestions overview) to prevent triggering unnecessary session initialization and hook events.