### PR TITLE
fix(integrations): correct Antigravity MCP config path so install wires it

### DIFF
--- a/docs/public/antigravity/setup.mdx
+++ b/docs/public/antigravity/setup.mdx
@@ -1,0 +1,81 @@
+---
+title: "Antigravity Setup"
+description: "Add claude-mem's memory search tools to Google Antigravity"
+---
+
+# Antigravity Setup
+
+> **Search your claude-mem memory from inside [Antigravity](https://antigravity.google).**
+
+Antigravity is an MCP-only integration: claude-mem registers its **memory search tools** (an MCP server) so the Antigravity agent can query the observations, decisions, and patterns captured across your sessions.
+
+<Info>
+**What this does — and doesn't.** Antigravity does not expose lifecycle hooks, so claude-mem does **not** capture observations *from* Antigravity sessions. It gives Antigravity **read access** to memory captured by your hook-enabled tools (e.g. Claude Code) that share the same local worker. Capture stays with those tools; Antigravity gets search.
+</Info>
+
+## Prerequisites
+
+- [Antigravity](https://antigravity.google) installed (CLI `agy` and/or the desktop IDE)
+- [Node.js](https://nodejs.org/) 18+
+- The `~/.gemini` directory exists (created by Antigravity / Gemini CLI on first run)
+- A running claude-mem worker with some memory in it (install claude-mem in Claude Code first if you have no observations yet)
+
+## Installation
+
+```bash
+npx claude-mem install
+```
+
+The installer will:
+
+1. Detect Antigravity
+2. Prompt you to select **Antigravity** from the IDE picker
+3. Write the claude-mem MCP server into **`~/.gemini/config/mcp_config.json`** — the path Antigravity reads for MCP servers
+
+<Note>
+Antigravity reads MCP servers from `~/.gemini/config/mcp_config.json` (shared with the Gemini CLI config home, resolved by Antigravity's bundled Cascade language server). It is **not** `~/.gemini/antigravity/mcp_config.json`.
+</Note>
+
+## Verify installation
+
+Restart Antigravity, then ask the agent to use the claude-mem `search` tool — for example:
+
+```
+Use the claude-mem MCP server to search memory for "<a topic from a past session>".
+```
+
+You should get back matching observations. You can also confirm the entry was written:
+
+```bash
+cat ~/.gemini/config/mcp_config.json
+```
+
+Look for a `claude-mem` entry under `mcpServers`.
+
+## What you get
+
+The claude-mem MCP server exposes its memory **search tools** (search, timeline, observation lookup) to the Antigravity agent, so it can pull relevant history into a session on demand.
+
+## Troubleshooting
+
+### The claude-mem tools don't appear
+
+1. Confirm the entry exists in `~/.gemini/config/mcp_config.json` under `mcpServers`.
+2. Fully restart Antigravity after installing.
+3. Re-run the installer: `npx claude-mem install`.
+
+### Search returns nothing
+
+You need existing memory to search. Run at least one claude-mem-enabled session in a hook-capable tool (e.g. Claude Code) first, and make sure the worker is running:
+
+```bash
+npx claude-mem status
+```
+
+## Uninstalling
+
+```bash
+npx claude-mem uninstall
+```
+
+This removes the claude-mem entry from `~/.gemini/config/mcp_config.json`.

--- a/docs/public/docs.json
+++ b/docs/public/docs.json
@@ -66,6 +66,13 @@
         ]
       },
       {
+        "group": "Antigravity Integration",
+        "icon": "rocket",
+        "pages": [
+          "antigravity/setup"
+        ]
+      },
+      {
         "group": "Best Practices",
         "icon": "lightbulb",
         "pages": [

--- a/src/services/integrations/McpIntegrations.ts
+++ b/src/services/integrations/McpIntegrations.ts
@@ -130,7 +130,7 @@ const COPILOT_CLI_CONFIG: McpInstallerConfig = {
   },
 };
 
-const ANTIGRAVITY_CONFIG: McpInstallerConfig = {
+export const ANTIGRAVITY_CONFIG: McpInstallerConfig = {
   ideId: 'antigravity',
   ideLabel: 'Antigravity',
   configPath: path.join(homedir(), '.gemini', 'config', 'mcp_config.json'),

--- a/src/services/integrations/McpIntegrations.ts
+++ b/src/services/integrations/McpIntegrations.ts
@@ -133,7 +133,7 @@ const COPILOT_CLI_CONFIG: McpInstallerConfig = {
 const ANTIGRAVITY_CONFIG: McpInstallerConfig = {
   ideId: 'antigravity',
   ideLabel: 'Antigravity',
-  configPath: path.join(homedir(), '.gemini', 'antigravity', 'mcp_config.json'),
+  configPath: path.join(homedir(), '.gemini', 'config', 'mcp_config.json'),
   configKey: 'mcpServers',
   contextFile: {
     path: path.join(process.cwd(), '.agents', 'rules', 'claude-mem-context.md'),

--- a/tests/mcp-integrations.test.ts
+++ b/tests/mcp-integrations.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
 import { join } from 'path';
-import { tmpdir } from 'os';
+import { tmpdir, homedir } from 'os';
 
 import { readJsonSafe } from '../src/utils/json-utils';
 import { injectContextIntoMarkdownFile, CONTEXT_TAG_OPEN, CONTEXT_TAG_CLOSE } from '../src/utils/context-injection';
+import { ANTIGRAVITY_CONFIG } from '../src/services/integrations/McpIntegrations';
 
 function buildMcpServerEntry(mcpServerPath: string): { command: string; args: string[] } {
   return {
@@ -260,6 +261,21 @@ describe('MCP Integrations', () => {
       const config = JSON.parse(readFileSync(configPath, 'utf-8'));
       expect(config.version).toBe(1);
       expect(config.mcpServers['claude-mem']).toBeDefined();
+    });
+  });
+
+  describe('Antigravity config path (regression)', () => {
+    it('targets ~/.gemini/config/mcp_config.json, the path Antigravity actually reads', () => {
+      // Antigravity resolves MCP servers from ~/.gemini/config/mcp_config.json (shared
+      // Cascade language_server resolution, verified against Antigravity CLI `agy` v1.0.6).
+      // It was previously ~/.gemini/antigravity/mcp_config.json — a path the tool never
+      // reads, so `claude-mem install` silently no-op'd for Antigravity.
+      expect(ANTIGRAVITY_CONFIG.configPath).toBe(
+        join(homedir(), '.gemini', 'config', 'mcp_config.json'),
+      );
+      expect(ANTIGRAVITY_CONFIG.configPath).not.toContain(
+        join('.gemini', 'antigravity'),
+      );
     });
   });
 


### PR DESCRIPTION
## Problem

`claude-mem install` for Antigravity writes the MCP server config to `~/.gemini/antigravity/mcp_config.json` — a path Antigravity does not read — so the install **silently no-ops**: no claude-mem tools show up in Antigravity.

## Fix

Point `ANTIGRAVITY_CONFIG.configPath` at `~/.gemini/config/mcp_config.json`, the path Antigravity actually reads (resolved by its bundled Cascade `language_server`; the same location for both the `agy` CLI and the desktop IDE).

**Verified** against Antigravity CLI `agy` v1.0.6: a server placed at `~/.gemini/antigravity/mcp_config.json` never registers, while one at `~/.gemini/config/mcp_config.json` is picked up on every launch.

## Changes

- One-line `configPath` fix.
- Regression test asserting the path (exports `ANTIGRAVITY_CONFIG` for testability).
- `docs/public/antigravity/setup.mdx` setup page + nav entry.

## Note on CI

`main` currently has unrelated pre-existing failures (PID-file / process-manager and logger-standards tests, plus a duplicate `ModeManager` import typecheck error). This change is isolated to the Antigravity MCP integration path and doesn't touch those areas; the new `mcp-integrations` test suite passes (21/21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
