### PR TITLE
feat(project-name): CLAUDE_MEM_PROJECT_NAME_SOURCE=git-remote for stable org/repo slugs

### DIFF
--- a/docs/public/configuration.mdx
+++ b/docs/public/configuration.mdx
@@ -65,6 +65,7 @@ Use [LiteLLM Gateway](configuration/litellm-gateway) when you want `CLAUDE_MEM_P
 | `CLAUDE_MEM_LOG_LEVEL`        | `INFO`                          | Log verbosity (DEBUG, INFO, WARN, ERROR, SILENT) |
 | `CLAUDE_MEM_PYTHON_VERSION`   | `3.13`                          | Python version for chroma-mcp         |
 | `CLAUDE_CODE_PATH`            | _(auto-detect)_                 | Path to Claude Code CLI (for Windows) |
+| `CLAUDE_MEM_PROJECT_NAME_SOURCE` | `path`                       | How the project name is derived: `path` (folder/git-root basename) or `git-remote` (stable `org/repo` slug from the git `origin` URL — survives directory renames). Opt-in; `path` preserves existing behavior |
 
 ## Model Configuration
 

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -82,6 +82,7 @@ export interface SettingsDefaults {
   CLAUDE_MEM_SERVER_BETA_URL: string;
   CLAUDE_MEM_SERVER_BETA_API_KEY: string;
   CLAUDE_MEM_SERVER_BETA_PROJECT_ID: string;
+  CLAUDE_MEM_PROJECT_NAME_SOURCE: string;
 }
 
 export class SettingsDefaultsManager {
@@ -163,6 +164,7 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_SERVER_BETA_URL: `http://127.0.0.1:${process.env.CLAUDE_MEM_SERVER_PORT ?? String(37877 + ((process.getuid?.() ?? 77) % 100))}`,  // Default server-beta runtime URL — UID-derived for multi-account isolation
     CLAUDE_MEM_SERVER_BETA_API_KEY: '',                     // Local hook API key, populated by installer when runtime=server-beta
     CLAUDE_MEM_SERVER_BETA_PROJECT_ID: '',                  // Default Postgres project_id used by hooks when runtime=server-beta
+    CLAUDE_MEM_PROJECT_NAME_SOURCE: 'path',                 // 'path' (default) = folder/git-root basename; 'git-remote' = derive a stable org/repo slug from the git `origin` URL (survives directory renames). Opt-in; default preserves existing behavior.
   };
 
   static getAllDefaults(): SettingsDefaults {

--- a/src/utils/project-name.ts
+++ b/src/utils/project-name.ts
@@ -3,6 +3,66 @@ import path from 'path';
 import { execFileSync } from 'child_process';
 import { logger } from './logger.js';
 import { detectWorktree } from './worktree.js';
+import { loadFromFileOnce } from '../shared/hook-settings.js';
+
+/**
+ * Opt-in (CLAUDE_MEM_PROJECT_NAME_SOURCE=git-remote): derive the project name from
+ * the git `origin` remote instead of the folder basename. Default ('path')
+ * preserves existing behavior. Reading settings is cached (loadFromFileOnce).
+ */
+function useRemoteProjectName(): boolean {
+  try {
+    return String(loadFromFileOnce().CLAUDE_MEM_PROJECT_NAME_SOURCE ?? 'path')
+      .trim()
+      .toLowerCase() === 'git-remote';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve a stable `org/repo` slug from the repo's `origin` remote URL. This is
+ * stable across directory renames (unlike the folder basename) and identical
+ * across a repo's worktrees (they share remotes). Handles scp-style
+ * (`git@host:org/repo.git`) and URL forms (`https://host/org/repo.git`).
+ * Returns null when there is no `origin` remote or the URL can't be parsed.
+ */
+function deriveSlugFromRemote(dir: string): string | null {
+  let url: string;
+  try {
+    url = execFileSync('git', ['remote', 'get-url', 'origin'], {
+      cwd: dir,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+  return parseOriginUrlToSlug(url);
+}
+
+/**
+ * Pure parser: turn a git remote URL into an `org/repo` slug. Handles scp-style
+ * (`git@host:org/repo.git`) and URL forms (`https://host/org/repo.git`, with or
+ * without a trailing slash or `.git`). Returns the last two path segments
+ * (`org/repo`), a single segment when that's all there is, or null when the URL
+ * is empty/unparseable. Exported for unit testing.
+ */
+export function parseOriginUrlToSlug(url: string): string | null {
+  if (!url || !url.trim()) return null;
+  const cleaned = url.trim().replace(/\.git$/, '').replace(/\/+$/, '');
+  // scp-style: user@host:org/repo  → capture the part after the colon.
+  const scp = cleaned.match(/^[^/@]+@[^:]+:(.+)$/);
+  const pathPart = scp
+    ? scp[1]
+    // URL form: scheme://host/org/repo → strip scheme + host.
+    : cleaned.replace(/^[a-z][a-z0-9+.-]*:\/\/[^/]+\//i, '');
+
+  const segments = pathPart.split('/').filter(Boolean);
+  if (segments.length >= 2) return segments.slice(-2).join('/');
+  if (segments.length === 1) return segments[0];
+  return null;
+}
 
 function expandTilde(p: string): string {
   if (p === '~' || p.startsWith('~/')) {
@@ -44,6 +104,14 @@ export function getProjectName(cwd: string | null | undefined): string {
   // the name is stable across subdirectories/worktrees. Fall back to the cwd
   // basename when not in a repo.
   const repoRoot = findGitRepoRoot(expanded);
+
+  // Opt-in: derive a stable org/repo slug from the origin remote. Falls through
+  // to the folder-basename logic below when disabled, no remote, or unparseable.
+  if (repoRoot && useRemoteProjectName()) {
+    const slug = deriveSlugFromRemote(repoRoot);
+    if (slug) return slug;
+  }
+
   const nameSource = repoRoot ?? expanded;
 
   const basename = path.basename(nameSource);
@@ -82,6 +150,18 @@ export function getProjectContext(cwd: string | null | undefined): ProjectContex
 
   const expandedCwd = expandTilde(cwd);
   const worktreeInfo = detectWorktree(expandedCwd);
+
+  // In remote mode the origin URL is the canonical repo identity, and a repo's
+  // worktrees share its remotes — so cwdProjectName already collapses worktrees
+  // onto the parent repo. Skip the parent/child compositing to avoid doubling.
+  if (useRemoteProjectName()) {
+    return {
+      primary: cwdProjectName,
+      parent: null,
+      isWorktree: worktreeInfo.isWorktree,
+      allProjects: [cwdProjectName]
+    };
+  }
 
   if (worktreeInfo.isWorktree && worktreeInfo.parentProjectName) {
     const composite = `${worktreeInfo.parentProjectName}/${cwdProjectName}`;

--- a/tests/utils/project-name.test.ts
+++ b/tests/utils/project-name.test.ts
@@ -1,7 +1,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
 import { homedir } from 'os';
-import { getProjectName, getProjectContext } from '../../src/utils/project-name.js';
+import { getProjectName, getProjectContext, parseOriginUrlToSlug } from '../../src/utils/project-name.js';
 
 describe('getProjectName', () => {
   describe('tilde expansion', () => {
@@ -173,5 +173,44 @@ describe('getProjectContext', () => {
       expect(project).not.toBe('main-repo');
       expect(project).not.toBe('my-worktree');
     });
+  });
+});
+
+describe('parseOriginUrlToSlug — CLAUDE_MEM_PROJECT_NAME_SOURCE=git-remote', () => {
+  it('parses scp-style ssh URLs', () => {
+    expect(parseOriginUrlToSlug('git@github.com:thedotmack/claude-mem.git')).toBe('thedotmack/claude-mem');
+  });
+
+  it('parses https URLs', () => {
+    expect(parseOriginUrlToSlug('https://github.com/thedotmack/claude-mem.git')).toBe('thedotmack/claude-mem');
+  });
+
+  it('parses ssh:// URLs', () => {
+    expect(parseOriginUrlToSlug('ssh://git@github.com/thedotmack/claude-mem.git')).toBe('thedotmack/claude-mem');
+  });
+
+  it('tolerates a missing .git suffix', () => {
+    expect(parseOriginUrlToSlug('https://github.com/thedotmack/claude-mem')).toBe('thedotmack/claude-mem');
+  });
+
+  it('tolerates a trailing slash', () => {
+    expect(parseOriginUrlToSlug('https://github.com/thedotmack/claude-mem/')).toBe('thedotmack/claude-mem');
+  });
+
+  it('takes the last two segments for nested groups (e.g. GitLab subgroups)', () => {
+    expect(parseOriginUrlToSlug('https://gitlab.com/group/subgroup/repo.git')).toBe('subgroup/repo');
+  });
+
+  it('handles self-hosted hosts with ports (scp-style)', () => {
+    expect(parseOriginUrlToSlug('git@frango:money-marathon/prolific.git')).toBe('money-marathon/prolific');
+  });
+
+  it('returns a single segment when that is all there is', () => {
+    expect(parseOriginUrlToSlug('git@github.com:solorepo.git')).toBe('solorepo');
+  });
+
+  it('returns null for empty / blank input', () => {
+    expect(parseOriginUrlToSlug('')).toBeNull();
+    expect(parseOriginUrlToSlug('   ')).toBeNull();
   });
 });


### PR DESCRIPTION
## Problem

claude-mem derives the project name from the folder / git-root **basename**. That name silently changes if a checkout directory is renamed, and two unrelated repos that happen to share a folder name collide into the same project — scattering or merging memory incorrectly.

## Fix

Add an opt-in setting `CLAUDE_MEM_PROJECT_NAME_SOURCE` (default `path`). When set to `git-remote`, the project name becomes a stable `org/repo` slug parsed from the git `origin` remote URL — stable across directory renames and identical across a repo's worktrees (they share the remote).

- **Default `path` is a no-op** for existing users — behavior is unchanged unless you opt in.
- In `git-remote` mode, worktree parent/child compositing is skipped (a repo's worktrees share its origin and already resolve to one slug).
- `parseOriginUrlToSlug` is a pure, exported helper covering scp-style (`git@host:org/repo.git`), `https://`, and `ssh://` forms, optional `.git`/trailing slash, and nested subgroups — with unit tests.

## Changes

- New setting + resolver (`src/utils/project-name.ts`, `src/shared/SettingsDefaultsManager.ts`).
- Unit tests for `parseOriginUrlToSlug`.
- Documented the setting in the configuration reference.

## Note on CI

`main` currently has unrelated pre-existing failures (PID-file / process-manager and logger-standards tests, plus a duplicate `ModeManager` import typecheck error). This change is isolated to project-name resolution; the `project-name` test suite passes (29/29).

Relates to upstream discussion on stable project identity (#2663, #2711).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
