### PR TITLE
feat(memory): zero-spend ingest of Claude Code auto-memory into observations

### DIFF
--- a/docs/public/docs.json
+++ b/docs/public/docs.json
@@ -43,6 +43,7 @@
           "usage/claude-desktop",
           "usage/private-tags",
           "usage/export-import",
+          "usage/memory-ingest",
           "usage/manual-recovery",
           "usage/folder-context",
           "beta-features",

--- a/docs/public/usage/memory-ingest.mdx
+++ b/docs/public/usage/memory-ingest.mdx
@@ -1,0 +1,115 @@
+---
+title: "Memory Ingest"
+description: "Import Claude Code's auto-memory markdown files directly into claude-mem as observations — no model spend"
+---
+
+# Memory Ingest
+
+Claude Code maintains its own **auto-memory** — markdown it distills for itself — under:
+
+```
+~/.claude/projects/<encoded-cwd>/memory/MEMORY.md   (a link-only index)
+~/.claude/projects/<encoded-cwd>/memory/<topic>.md  (distilled prose, one fact per file)
+```
+
+`<encoded-cwd>` is the repo's absolute path with every `/` replaced by `-` (e.g.
+`/home/you/code/app` → `-home-you-code-app`).
+
+`claude-mem memory ingest` imports those topic files **directly** into your
+memory database as observations.
+
+## Why it doesn't cost anything
+
+Auto-memory is **already distilled** — each topic file is the same *kind* of
+artifact the observation generator produces. So memory-ingest does **not** run
+the Haiku generation pipeline. It stores each file's prose directly through
+claude-mem's existing observation seam (content-hash dedup + Chroma sync).
+Re-running generation on already-distilled prose would be lossy and pay for
+negative value.
+
+The `MEMORY.md` index is skipped — it's just links and carries no knowledge of
+its own.
+
+## Usage
+
+Always **dry-run first** — it's a zero-spend, DB-free scan + count:
+
+```bash
+# Scan the current repo's memory dir and report what would be stored
+npx claude-mem memory ingest --dry-run
+
+# Sweep every project under ~/.claude/projects/*/memory/
+npx claude-mem memory ingest --all --dry-run
+```
+
+Then run the real ingest:
+
+```bash
+# Ingest the current repo's memory (default source = cwd)
+npx claude-mem memory ingest
+
+# Ingest from an explicit directory
+npx claude-mem memory ingest --source ~/.claude/projects/-home-you-code-app/memory
+
+# Ingest everything
+npx claude-mem memory ingest --all
+```
+
+### Flags
+
+| Flag | Effect |
+|------|--------|
+| *(none)* | Source = the current repo's memory dir, resolved from `cwd`. |
+| `--source <dir>` | Ingest from an explicit `memory/` directory. |
+| `--all` | Sweep every `~/.claude/projects/*/memory/` directory. |
+| `--dry-run` | Zero-spend parse + count only. No worker, no DB writes. Run this first. |
+| `--require-cwd` | Skip orphaned project dirs whose originating `cwd` cannot be resolved (instead of ingesting them under a fallback project). |
+
+## How it runs
+
+- **`--dry-run`** is pure parse + count — it runs entirely in the CLI process,
+  touches no worker and no database, and spends nothing.
+- The **real ingest** stores into the SQLite observation database, which lives
+  in the worker. The CLI starts the worker if needed and drives the import over
+  HTTP (`POST /api/memory/ingest`), mirroring how transcript ingest and
+  summaries reach the worker. Bulk imports are not time-limited.
+
+## Frontmatter
+
+Topic files carry a small YAML frontmatter block, which is preserved as
+observation metadata:
+
+```markdown
+---
+name: recent-work
+description: "What was done in the most recent session"
+metadata:
+  node_type: memory
+  type: project
+  originSessionId: 74e59070-...
+---
+
+<the distilled prose — stored as the observation body>
+```
+
+`metadata.type` (e.g. `project`, `feedback`, `reference`, `user`) and
+`metadata.originSessionId` are carried through; files without frontmatter are
+stored using their body as-is.
+
+## Idempotency
+
+Ingest is safe to re-run. Observations are content-hash deduplicated on insert,
+so already-imported files are reported as `already-imported` and skipped — only
+new or changed files are stored.
+
+The summary line reports the outcome:
+
+```
+MEMORY INGEST: 12 stored, 38 already-imported, 0 skipped, 0 failed, of 50 files across 1 dirs
+```
+
+## Related
+
+- [Memory Export/Import](/usage/export-import) — share memory sets between installations.
+- Transcript backfill (`claude-mem transcript ingest`) — the sibling path that
+  imports raw Claude Code session JSONL and *does* run generation.

--- a/src/npx-cli/commands/runtime.ts
+++ b/src/npx-cli/commands/runtime.ts
@@ -263,3 +263,7 @@ export function runTranscriptWatchCommand(): void {
     process.exit(exitCode ?? 0);
   });
 }
+
+export function runMemoryIngestCommand(extraArgs: string[] = []): void {
+  spawnBunWorkerCommand('memory', ['ingest', ...extraArgs]);
+}

--- a/src/npx-cli/index.ts
+++ b/src/npx-cli/index.ts
@@ -218,6 +218,19 @@ async function main(): Promise<void> {
       break;
     }
 
+    case 'memory': {
+      const subCommand = args[1]?.toLowerCase();
+      if (subCommand === 'ingest') {
+        const { runMemoryIngestCommand } = await import('./commands/runtime.js');
+        runMemoryIngestCommand(args.slice(2));
+      } else {
+        console.error(pc.red(`Unknown memory subcommand: ${subCommand ?? '(none)'}`));
+        console.error(`Usage: npx claude-mem memory ingest [--source <dir> | --all] [--dry-run] [--require-cwd]`);
+        process.exit(1);
+      }
+      break;
+    }
+
     default: {
       console.error(pc.red(`Unknown command: ${command}`));
       console.error(`Run ${pc.bold('npx claude-mem --help')} for usage information.`);

--- a/src/services/memory/cli.ts
+++ b/src/services/memory/cli.ts
@@ -1,0 +1,89 @@
+import {
+  dryRunMemorySource,
+  formatMemoryDryRunReport,
+  memoryDirForCwd,
+  claudeProjectsDir,
+  type MemoryIngestReport,
+} from './ingest.js';
+import { ensureWorkerRunning, workerHttpRequest } from '../../shared/worker-utils.js';
+
+function getArgValue(args: string[], name: string): string | null {
+  const index = args.indexOf(name);
+  if (index === -1) return null;
+  return args[index + 1] ?? null;
+}
+
+function hasFlag(args: string[], name: string): boolean {
+  return args.includes(name);
+}
+
+const USAGE =
+  'Usage: claude-mem memory ingest [--source <dir> | --all] [--dry-run] [--require-cwd]\n' +
+  '  default: the current repo\'s memory dir (cwd)\n' +
+  '  --all:   sweep every ~/.claude/projects/*/memory/\n' +
+  '  --dry-run:     zero-spend scan + count (do this first)\n' +
+  '  --require-cwd: skip orphaned dirs whose cwd cannot be resolved';
+
+/** Resolve the effective source dir from flags (default = current repo's memory). */
+function resolveSource(args: string[]): { source: string; all: boolean } {
+  const all = hasFlag(args, '--all');
+  if (all) return { source: claudeProjectsDir(), all: true };
+  const explicit = getArgValue(args, '--source');
+  if (explicit) return { source: explicit, all: false };
+  return { source: memoryDirForCwd(process.cwd()), all: false };
+}
+
+export async function runMemoryCommand(subcommand: string | undefined, args: string[]): Promise<number> {
+  switch (subcommand) {
+    case 'ingest': {
+      const { source, all } = resolveSource(args);
+
+      // Dry-run is pure parse + count — no worker, no spend — so run it here.
+      if (hasFlag(args, '--dry-run')) {
+        try {
+          console.log(formatMemoryDryRunReport(dryRunMemorySource(source, { all })));
+          return 0;
+        } catch (error) {
+          console.error(error instanceof Error ? error.message : String(error));
+          return 1;
+        }
+      }
+
+      // Real ingest stores into the SQLite observation DB, which lives in the
+      // worker. Drive it over HTTP (mirroring transcript ingest + summaries).
+      const workerReady = await ensureWorkerRunning();
+      if (!workerReady) {
+        console.error('Worker is not running and could not be started. Cannot ingest.');
+        return 1;
+      }
+      const response = await workerHttpRequest('/api/memory/ingest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ source, all, requireCwd: hasFlag(args, '--require-cwd') }),
+        timeoutMs: 0, // bulk import can be long; do not time out
+      });
+      if (!response.ok) {
+        console.error(`Memory ingest failed: HTTP ${response.status} ${await response.text()}`);
+        return 1;
+      }
+
+      const report = (await response.json()) as MemoryIngestReport;
+      for (const f of report.files) {
+        if (f.status === 'stored' || f.status === 'failed') {
+          console.log(`${f.project}/${f.file}: ${f.status}${f.reason ? ` (${f.reason})` : ''}` +
+            (f.observationId ? ` -> obs #${f.observationId}` : ''));
+        }
+      }
+      console.log(
+        `MEMORY INGEST: ${report.stored} stored, ${report.deduped} already-imported, ` +
+          `${report.skipped} skipped, ${report.failed} failed, of ${report.found} files ` +
+          `across ${report.dirs} dirs` +
+          (report.cwdUnresolvedDirs ? ` (${report.cwdUnresolvedDirs} orphaned/cwd-unresolved)` : '')
+      );
+      return report.failed > 0 ? 1 : 0;
+    }
+    default:
+      console.log(USAGE);
+      return subcommand ? 1 : 0;
+  }
+}

--- a/src/services/memory/ingest.ts
+++ b/src/services/memory/ingest.ts
@@ -1,0 +1,542 @@
+/**
+ * Claude Code auto-memory ingest (sibling to the transcript backfill #2690).
+ *
+ * Claude Code writes "auto memory" — markdown it distills for itself — to
+ *   ~/.claude/projects/<encoded-cwd>/memory/MEMORY.md   (an index of links)
+ *   ~/.claude/projects/<encoded-cwd>/memory/<topic>.md  (distilled prose)
+ * where <encoded-cwd> is the repo's absolute path with '/' replaced by '-'.
+ *
+ * Unlike transcripts, memory is ALREADY distilled — each topic file is the same
+ * KIND of artifact the observation generator produces. So memory-ingest does NOT
+ * run the Haiku generation pipeline. It stores each file's prose DIRECTLY as an
+ * observation (mechanical store-direct), reusing claude-mem's existing
+ * `storeObservation` seam (content-hash dedup + Chroma sync). Re-running Haiku on
+ * already-distilled prose would be lossy and pay for negative value.
+ *
+ * This module is the spend-free, DB-free half: enumerate + parse + count. The
+ * real store path (ingest.ts `ingestMemorySource`, added alongside) runs inside
+ * the worker where the SQLite store lives.
+ */
+import { existsSync, readFileSync, readdirSync, statSync, openSync, readSync, closeSync } from 'fs';
+import { basename, dirname, join } from 'path';
+import { homedir } from 'os';
+import { getProjectContext } from '../../utils/project-name.js';
+
+const MD_EXT = '.md';
+const JSONL_EXT = '.jsonl';
+/** The link-only index Claude Code maintains; carries no knowledge of its own. */
+const INDEX_FILE = 'MEMORY.md';
+const MEMORY_SUBDIR = 'memory';
+/** Bytes of a sibling transcript to sniff for the project's real cwd. */
+const CWD_SNIFF_BYTES = 16_384;
+
+/** Default root that holds every `<encoded-cwd>/memory/` directory. */
+export function claudeProjectsDir(): string {
+  return join(homedir(), '.claude', 'projects');
+}
+
+/** Minimal `~` expansion — kept local so this module is PR-independent of #2690. */
+export function expandHome(p: string): string {
+  if (p === '~') return homedir();
+  if (p.startsWith('~/')) return join(homedir(), p.slice(2));
+  return p;
+}
+
+// ───────────────────────────── frontmatter ──────────────────────────────
+//
+// Topic files carry a small YAML frontmatter block, e.g.
+//   ---
+//   name: recent-work
+//   description: "What was done in the most recent session"
+//   metadata:
+//     node_type: memory
+//     type: project
+//     originSessionId: 74e59070-...
+//   ---
+// We hand-roll a parser for exactly this shape rather than add a YAML dep.
+
+export interface MemoryFrontmatter {
+  name?: string;
+  description?: string;
+  /** metadata.type — e.g. project | feedback | reference | user. */
+  type?: string;
+  /** metadata.originSessionId — the session that produced this memory. */
+  originSessionId?: string;
+  /** metadata.node_type — e.g. "memory". */
+  nodeType?: string;
+}
+
+function unquote(value: string): string {
+  const v = value.trim();
+  if (v.length >= 2 && ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'")))) {
+    return v.slice(1, -1);
+  }
+  return v;
+}
+
+/**
+ * Split leading `--- ... ---` frontmatter from the body. Returns parsed (known)
+ * keys and the remaining markdown body. Files without frontmatter return `{}`
+ * and the original text as body.
+ */
+export function parseMemoryFrontmatter(raw: string): { frontmatter: MemoryFrontmatter; body: string } {
+  if (!raw.startsWith('---')) return { frontmatter: {}, body: raw };
+
+  const lines = raw.split('\n');
+  // First line is the opening '---'; find the closing one.
+  let close = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') { close = i; break; }
+  }
+  if (close === -1) return { frontmatter: {}, body: raw };
+
+  const fm: MemoryFrontmatter = {};
+  let inMetadata = false;
+  for (let i = 1; i < close; i++) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+    const indented = /^\s+/.test(line);
+    const colon = line.indexOf(':');
+    if (colon === -1) continue;
+    const key = line.slice(0, colon).trim();
+    const value = line.slice(colon + 1).trim();
+
+    if (!indented) {
+      inMetadata = key === 'metadata';
+      if (key === 'name') fm.name = unquote(value);
+      else if (key === 'description') fm.description = unquote(value);
+      continue;
+    }
+    // Indented: a child of `metadata:`.
+    if (inMetadata) {
+      if (key === 'type') fm.type = unquote(value);
+      else if (key === 'originSessionId') fm.originSessionId = unquote(value);
+      else if (key === 'node_type') fm.nodeType = unquote(value);
+    }
+  }
+
+  const body = lines.slice(close + 1).join('\n').replace(/^\n+/, '');
+  return { frontmatter: fm, body };
+}
+
+/** Derive a human title: frontmatter name → first H1 → first H2 → filename stem. */
+export function deriveTitle(fileName: string, frontmatter: MemoryFrontmatter, body: string): string {
+  if (frontmatter.name && frontmatter.name.trim()) return frontmatter.name.trim();
+  for (const line of body.split('\n')) {
+    const h1 = line.match(/^#\s+(.+)/);
+    if (h1) return h1[1].trim();
+  }
+  for (const line of body.split('\n')) {
+    const h2 = line.match(/^##\s+(.+)/);
+    if (h2) return h2[1].trim();
+  }
+  return basename(fileName, MD_EXT);
+}
+
+// ───────────────────────────── enumeration ──────────────────────────────
+
+export interface MemoryFileRef {
+  filePath: string;
+  fileName: string;
+  /** True for the MEMORY.md link index — excluded from ingest. */
+  isIndex: boolean;
+  bytes: number;
+  /** File mtime in epoch ms — used to backdate the stored observation. */
+  mtimeEpoch: number;
+  title: string;
+  frontmatter: MemoryFrontmatter;
+  /** Markdown body with the frontmatter block stripped — the stored narrative. */
+  body: string;
+}
+
+export interface MemoryDirRef {
+  memoryDir: string;
+  /** The `<encoded-cwd>` directory name (parent of memory/). */
+  encodedName: string;
+  /** Resolved absolute repo cwd (from a sibling transcript), if found. */
+  cwd?: string;
+  /** Project key — MUST match live capture's getProjectContext so recall merges. */
+  project: string;
+  /** Non-index topic files (the ingestable knowledge). */
+  files: MemoryFileRef[];
+  /** The MEMORY.md index, recorded for reporting but never ingested. */
+  indexFile?: MemoryFileRef;
+}
+
+export interface ScanOptions {
+  /** Treat `source` as the projects root and sweep every `<encoded>/memory/`. */
+  all?: boolean;
+}
+
+/** Read the first JSONL line that carries a `cwd` from a sibling transcript. */
+function sniffCwd(projectDir: string): string | undefined {
+  let names: string[];
+  try {
+    names = readdirSync(projectDir).filter(n => n.endsWith(JSONL_EXT));
+  } catch {
+    return undefined;
+  }
+  for (const name of names) {
+    const filePath = join(projectDir, name);
+    let fd: number | undefined;
+    try {
+      fd = openSync(filePath, 'r');
+      const buf = Buffer.alloc(CWD_SNIFF_BYTES);
+      const read = readSync(fd, buf, 0, CWD_SNIFF_BYTES, 0);
+      const chunk = buf.toString('utf-8', 0, read);
+      for (const line of chunk.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const cwd = (JSON.parse(trimmed) as { cwd?: unknown }).cwd;
+          if (typeof cwd === 'string' && cwd.trim()) return cwd;
+        } catch {
+          // Partial last line from the fixed-size read, or a non-JSON line.
+        }
+      }
+    } catch {
+      // Unreadable transcript — try the next sibling.
+    } finally {
+      if (fd !== undefined) closeSync(fd);
+    }
+  }
+  return undefined;
+}
+
+/** Best-effort project key when no sibling transcript reveals the cwd. */
+function fallbackProject(cwd: string | undefined, encodedName: string): string {
+  if (cwd) {
+    try {
+      const primary = getProjectContext(cwd).primary;
+      if (primary && primary.trim()) return primary;
+    } catch {
+      // getProjectContext may probe git; fall through to the basename.
+    }
+    const segs = cwd.split('/').filter(Boolean);
+    if (segs.length) return segs[segs.length - 1];
+  }
+  // Last resort: the trailing segment of the encoded dir name.
+  const segs = encodedName.replace(/^-+/, '').split('-').filter(Boolean);
+  return segs.length ? segs[segs.length - 1] : encodedName;
+}
+
+function readMemoryDir(memoryDir: string): MemoryDirRef {
+  const projectDir = dirname(memoryDir);
+  const encodedName = basename(projectDir);
+  const cwd = sniffCwd(projectDir);
+  const project = fallbackProject(cwd, encodedName);
+
+  const ref: MemoryDirRef = { memoryDir, encodedName, cwd, project, files: [] };
+
+  for (const name of readdirSync(memoryDir)) {
+    if (!name.endsWith(MD_EXT)) continue;
+    const filePath = join(memoryDir, name);
+    const stat = statSync(filePath);
+    if (!stat.isFile()) continue;
+
+    const raw = readFileSync(filePath, 'utf-8');
+    const { frontmatter, body } = parseMemoryFrontmatter(raw);
+    const isIndex = name === INDEX_FILE;
+    const fileRef: MemoryFileRef = {
+      filePath,
+      fileName: name,
+      isIndex,
+      bytes: stat.size,
+      mtimeEpoch: Math.round(stat.mtimeMs),
+      title: deriveTitle(name, frontmatter, body),
+      frontmatter,
+      body,
+    };
+    if (isIndex) ref.indexFile = fileRef;
+    else ref.files.push(fileRef);
+  }
+
+  ref.files.sort((a, b) => a.fileName.localeCompare(b.fileName));
+  return ref;
+}
+
+function hasMemorySubdir(dir: string): boolean {
+  const sub = join(dir, MEMORY_SUBDIR);
+  return existsSync(sub) && statSync(sub).isDirectory();
+}
+
+/**
+ * Enumerate memory directories under `source`.
+ *
+ * `source` may be:
+ *   - a `memory/` directory itself,
+ *   - a `<encoded-cwd>` project directory that contains a `memory/` subdir,
+ *   - (with `all: true`) the projects root, swept for every `<encoded>/memory/`.
+ */
+export function scanMemorySource(source: string, options: ScanOptions = {}): MemoryDirRef[] {
+  const resolved = expandHome(source);
+  if (!existsSync(resolved)) {
+    throw new Error(`memory ingest source not found: ${resolved}`);
+  }
+  if (!statSync(resolved).isDirectory()) {
+    throw new Error(`memory ingest source is not a directory: ${resolved}`);
+  }
+
+  if (options.all) {
+    const refs: MemoryDirRef[] = [];
+    for (const name of readdirSync(resolved)) {
+      const projectDir = join(resolved, name);
+      try {
+        if (!statSync(projectDir).isDirectory()) continue;
+      } catch {
+        continue;
+      }
+      if (hasMemorySubdir(projectDir)) {
+        refs.push(readMemoryDir(join(projectDir, MEMORY_SUBDIR)));
+      }
+    }
+    refs.sort((a, b) => a.encodedName.localeCompare(b.encodedName));
+    return refs;
+  }
+
+  // Single target: accept either the memory/ dir or its parent project dir.
+  if (basename(resolved) === MEMORY_SUBDIR) {
+    return [readMemoryDir(resolved)];
+  }
+  if (hasMemorySubdir(resolved)) {
+    return [readMemoryDir(join(resolved, MEMORY_SUBDIR))];
+  }
+  // A directory of *.md with no memory/ subdir — treat it as a memory dir.
+  return [readMemoryDir(resolved)];
+}
+
+// ───────────────────────────── dry-run ──────────────────────────────
+
+export interface MemoryDirCounts {
+  encodedName: string;
+  project: string;
+  cwd?: string;
+  cwdResolved: boolean;
+  files: number;
+  indexSkipped: boolean;
+  bytes: number;
+}
+
+export interface MemoryDryRunReport {
+  source: string;
+  all: boolean;
+  dirs: MemoryDirCounts[];
+  totals: {
+    dirs: number;
+    /** One observation per non-index file (the store count — NO Haiku). */
+    files: number;
+    bytes: number;
+    cwdUnresolved: number;
+  };
+}
+
+/**
+ * Enumerate + parse every memory dir under `source` and report what a real
+ * ingest WOULD store. No DB, no Haiku — memory is stored mechanically, so the
+ * file count IS the observation count (modulo content-hash dedup at store time).
+ */
+export function dryRunMemorySource(source: string, options: ScanOptions = {}): MemoryDryRunReport {
+  const refs = scanMemorySource(source, options);
+  const dirs: MemoryDirCounts[] = refs.map(ref => ({
+    encodedName: ref.encodedName,
+    project: ref.project,
+    cwd: ref.cwd,
+    cwdResolved: !!ref.cwd,
+    files: ref.files.length,
+    indexSkipped: !!ref.indexFile,
+    bytes: ref.files.reduce((n, f) => n + f.bytes, 0),
+  }));
+
+  return {
+    source: expandHome(source),
+    all: !!options.all,
+    dirs,
+    totals: {
+      dirs: dirs.length,
+      files: dirs.reduce((n, d) => n + d.files, 0),
+      bytes: dirs.reduce((n, d) => n + d.bytes, 0),
+      cwdUnresolved: dirs.filter(d => !d.cwdResolved).length,
+    },
+  };
+}
+
+/** Render a dry-run report as human-readable CLI lines. */
+export function formatMemoryDryRunReport(report: MemoryDryRunReport): string {
+  const lines: string[] = [];
+  lines.push(`Memory dry-run (no Haiku, mechanical store) — source: ${report.source}`);
+  lines.push(`Mode: ${report.all ? 'all projects' : 'single'}`);
+  lines.push('');
+  for (const d of report.dirs) {
+    const cwdTag = d.cwdResolved ? d.project : `${d.project} (cwd UNRESOLVED)`;
+    lines.push(
+      `${cwdTag}: ${d.files} files → ${d.files} obs, ${(d.bytes / 1024).toFixed(1)} KB` +
+        (d.indexSkipped ? ', index skipped' : '')
+    );
+  }
+  lines.push('');
+  const t = report.totals;
+  lines.push(
+    `TOTAL: ${t.dirs} memory dirs → ${t.files} files = ~${t.files} observations ` +
+      `(${(t.bytes / 1024).toFixed(1)} KB prose)`
+  );
+  if (t.cwdUnresolved) {
+    lines.push(
+      `WARNING: ${t.cwdUnresolved} dir(s) had no sibling transcript to resolve cwd — ` +
+        `project key is a best-effort guess and may not merge with live capture.`
+    );
+  }
+  lines.push('NOTE: mechanical store — memory prose is stored as-is, no model spend. Dedup by content_hash.');
+  return lines.join('\n');
+}
+
+// ───────────────────────────── real ingest ──────────────────────────────
+//
+// The store path. Mechanical — NO Haiku. Each memory file becomes one
+// observation whose `narrative` IS the file body. Runs inside the worker (the
+// SQLite store lives there), driven by injected deps so it stays unit-testable
+// without a live worker — mirroring the transcript ingest orchestrator.
+
+/** One observation to store, derived purely from a memory file (no model). */
+export interface MemoryObservationToStore {
+  project: string;
+  type: string;
+  title: string;
+  subtitle: string;
+  narrative: string;
+  concepts: string[];
+  /** Backdate to the file's mtime so imported memory sorts chronologically. */
+  createdAtEpoch: number;
+  /** Provenance (informational; not all fields are persisted by the store). */
+  sourceFile: string;
+  originSessionId?: string;
+}
+
+export interface MemoryIngestDeps {
+  /**
+   * Persist one observation mechanically (storeObservation + Chroma sync) and
+   * report whether it was newly inserted or collapsed onto an existing row by
+   * content_hash. Implemented by the worker route; faked in tests.
+   */
+  storeMemoryObservation(obs: MemoryObservationToStore): Promise<{ id: number; deduped: boolean }>;
+}
+
+export interface MemoryIngestOptions extends ScanOptions {
+  /** Skip dirs whose cwd could not be resolved (avoids best-effort project keys). */
+  requireCwd?: boolean;
+}
+
+export interface MemoryFileIngestResult {
+  project: string;
+  file: string;
+  status: 'stored' | 'deduped' | 'skipped' | 'failed';
+  observationId?: number;
+  reason?: string;
+}
+
+export interface MemoryIngestReport {
+  source: string;
+  all: boolean;
+  dirs: number;
+  found: number;
+  stored: number;
+  deduped: number;
+  skipped: number;
+  failed: number;
+  cwdUnresolvedDirs: number;
+  files: MemoryFileIngestResult[];
+}
+
+/**
+ * Map a memory file onto an observation. Pure (no I/O) → directly unit-testable.
+ * Provenance rides in `subtitle` + `concepts` because storeObservation does not
+ * persist a metadata column.
+ */
+export function buildMemoryObservation(ref: MemoryDirRef, file: MemoryFileRef): MemoryObservationToStore {
+  const memoryType = file.frontmatter.type ?? 'topic';
+  const concepts = ['memory-import', `memory-type:${memoryType}`, `file:${file.fileName}`];
+  if (file.frontmatter.originSessionId) {
+    concepts.push(`origin-session:${file.frontmatter.originSessionId}`);
+  }
+  const description = file.frontmatter.description?.trim();
+  const subtitle = description && description.length
+    ? description.slice(0, 300)
+    : `Imported memory (${memoryType})`;
+
+  return {
+    project: ref.project,
+    type: 'discovery',
+    title: file.title.slice(0, 200),
+    subtitle,
+    narrative: file.body,
+    concepts,
+    createdAtEpoch: file.mtimeEpoch,
+    sourceFile: file.fileName,
+    originSessionId: file.frontmatter.originSessionId,
+  };
+}
+
+/**
+ * Store every memory file under `source` as an observation. Idempotent by
+ * content_hash (re-runs dedupe). Orphaned memory (no sibling transcript to
+ * resolve cwd) is ingested by default with a best-effort project key — that is
+ * the whole point of memory-direct ingest; pass `requireCwd` to skip it instead.
+ */
+export async function ingestMemorySource(
+  source: string,
+  options: MemoryIngestOptions,
+  deps: MemoryIngestDeps
+): Promise<MemoryIngestReport> {
+  const refs = scanMemorySource(source, { all: options.all });
+
+  const report: MemoryIngestReport = {
+    source: expandHome(source),
+    all: !!options.all,
+    dirs: refs.length,
+    found: 0,
+    stored: 0,
+    deduped: 0,
+    skipped: 0,
+    failed: 0,
+    cwdUnresolvedDirs: refs.filter(r => !r.cwd).length,
+    files: [],
+  };
+
+  for (const ref of refs) {
+    for (const file of ref.files) {
+      report.found++;
+      const result: MemoryFileIngestResult = { project: ref.project, file: file.fileName, status: 'stored' };
+
+      if (options.requireCwd && !ref.cwd) {
+        result.status = 'skipped';
+        result.reason = 'cwd-unresolved';
+        report.skipped++;
+        report.files.push(result);
+        continue;
+      }
+      if (!file.body.trim()) {
+        result.status = 'skipped';
+        result.reason = 'empty-body';
+        report.skipped++;
+        report.files.push(result);
+        continue;
+      }
+
+      try {
+        const { id, deduped } = await deps.storeMemoryObservation(buildMemoryObservation(ref, file));
+        result.observationId = id;
+        if (deduped) {
+          result.status = 'deduped';
+          report.deduped++;
+        } else {
+          report.stored++;
+        }
+      } catch (err) {
+        result.status = 'failed';
+        result.reason = err instanceof Error ? err.message : String(err);
+        report.failed++;
+      }
+      report.files.push(result);
+    }
+  }
+  return report;
+}

--- a/src/services/memory/ingest.ts
+++ b/src/services/memory/ingest.ts
@@ -42,6 +42,16 @@ export function expandHome(p: string): string {
   return p;
 }
 
+/**
+ * The `memory/` dir for a repo cwd, using Claude Code's path encoding
+ * (absolute path with every '/' replaced by '-'). E.g.
+ *   /home/u/code/mm/observability → -home-u-code-mm-observability/memory
+ */
+export function memoryDirForCwd(cwd: string): string {
+  const encoded = cwd.replace(/\//g, '-');
+  return join(claudeProjectsDir(), encoded, MEMORY_SUBDIR);
+}
+
 // ───────────────────────────── frontmatter ──────────────────────────────
 //
 // Topic files carry a small YAML frontmatter block, e.g.
@@ -404,9 +414,10 @@ export interface MemoryObservationToStore {
   subtitle: string;
   narrative: string;
   concepts: string[];
+  /** Persisted JSON provenance (SessionStore.storeObservation writes `metadata`). */
+  metadata: Record<string, unknown>;
   /** Backdate to the file's mtime so imported memory sorts chronologically. */
   createdAtEpoch: number;
-  /** Provenance (informational; not all fields are persisted by the store). */
   sourceFile: string;
   originSessionId?: string;
 }
@@ -448,19 +459,25 @@ export interface MemoryIngestReport {
 
 /**
  * Map a memory file onto an observation. Pure (no I/O) → directly unit-testable.
- * Provenance rides in `subtitle` + `concepts` because storeObservation does not
- * persist a metadata column.
+ * Full provenance rides in `metadata` (persisted by SessionStore.storeObservation);
+ * a couple of lightweight `concepts` tags make imported memory searchable.
  */
 export function buildMemoryObservation(ref: MemoryDirRef, file: MemoryFileRef): MemoryObservationToStore {
   const memoryType = file.frontmatter.type ?? 'topic';
-  const concepts = ['memory-import', `memory-type:${memoryType}`, `file:${file.fileName}`];
-  if (file.frontmatter.originSessionId) {
-    concepts.push(`origin-session:${file.frontmatter.originSessionId}`);
-  }
+  const concepts = ['memory-import', `memory-type:${memoryType}`];
   const description = file.frontmatter.description?.trim();
   const subtitle = description && description.length
     ? description.slice(0, 300)
     : `Imported memory (${memoryType})`;
+
+  const metadata: Record<string, unknown> = {
+    source: 'memory-import',
+    file: file.fileName,
+    memoryType,
+    encodedDir: ref.encodedName,
+  };
+  if (file.frontmatter.originSessionId) metadata.originSessionId = file.frontmatter.originSessionId;
+  if (ref.cwd) metadata.cwd = ref.cwd;
 
   return {
     project: ref.project,
@@ -469,6 +486,7 @@ export function buildMemoryObservation(ref: MemoryDirRef, file: MemoryFileRef): 
     subtitle,
     narrative: file.body,
     concepts,
+    metadata,
     createdAtEpoch: file.mtimeEpoch,
     sourceFile: file.fileName,
     originSessionId: file.frontmatter.originSessionId,

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -90,6 +90,7 @@ import { SessionCompletionHandler } from './worker/session/SessionCompletionHand
 import { setIngestContext, attachIngestGeneratorStarter } from './worker/http/shared.js';
 import { DEFAULT_CONFIG_PATH, DEFAULT_STATE_PATH, expandHomePath, filterNativeHookBackedCodexWatches, loadTranscriptWatchConfig } from './transcripts/config.js';
 import { TranscriptWatcher } from './transcripts/watcher.js';
+import { runMemoryCommand } from './memory/cli.js';
 
 import { ViewerRoutes } from './worker/http/routes/ViewerRoutes.js';
 import { SessionRoutes } from './worker/http/routes/SessionRoutes.js';
@@ -98,6 +99,7 @@ import { SearchRoutes } from './worker/http/routes/SearchRoutes.js';
 import { SettingsRoutes } from './worker/http/routes/SettingsRoutes.js';
 import { LogsRoutes } from './worker/http/routes/LogsRoutes.js';
 import { MemoryRoutes } from './worker/http/routes/MemoryRoutes.js';
+import { MemoryIngestRoutes } from './worker/http/routes/MemoryIngestRoutes.js';
 import { CorpusRoutes } from './worker/http/routes/CorpusRoutes.js';
 import { ChromaRoutes } from './worker/http/routes/ChromaRoutes.js';
 
@@ -333,6 +335,7 @@ export class WorkerService implements WorkerRef {
     this.server.registerRoutes(new SettingsRoutes(this.settingsManager));
     this.server.registerRoutes(new LogsRoutes());
     this.server.registerRoutes(new MemoryRoutes(this.dbManager, 'claude-mem'));
+    this.server.registerRoutes(new MemoryIngestRoutes(this.dbManager));
     this.server.registerRoutes(new ServerV1Routes({
       getDatabase: () => this.dbManager.getConnection(),
     }));
@@ -1188,6 +1191,15 @@ async function main() {
       const subcommand = process.argv[3];
       const cursorResult = await handleCursorCommand(subcommand, process.argv.slice(4));
       process.exit(cursorResult);
+      break;
+    }
+
+    case 'memory': {
+      // Auto-memory ingest (sibling to transcript). Dry-run runs client-side;
+      // the real store reaches the worker over HTTP from inside runMemoryCommand.
+      const subcommand = process.argv[3];
+      const memoryResult = await runMemoryCommand(subcommand, process.argv.slice(4));
+      process.exit(memoryResult);
       break;
     }
 

--- a/src/services/worker/http/routes/MemoryIngestRoutes.ts
+++ b/src/services/worker/http/routes/MemoryIngestRoutes.ts
@@ -1,0 +1,103 @@
+import express, { Request, Response } from 'express';
+import { BaseRouteHandler } from '../BaseRouteHandler.js';
+import { DatabaseManager } from '../../DatabaseManager.js';
+import {
+  ingestMemorySource,
+  claudeProjectsDir,
+  type MemoryIngestDeps,
+  type MemoryObservationToStore,
+} from '../../../memory/ingest.js';
+import { computeObservationContentHash } from '../../../sqlite/observations/store.js';
+import { logger } from '../../../../utils/logger.js';
+
+/**
+ * Auto-memory ingest route (sibling to TranscriptRoutes). Stores Claude Code
+ * memory files DIRECTLY as observations — mechanical, no Haiku — reusing the
+ * same `storeObservation` + Chroma-sync seam as POST /api/memory/save, looped
+ * over a directory tree. Runs inside the worker because the SQLite store lives
+ * here; the CLI is a thin client that POSTs (dry-run stays client-side).
+ */
+export class MemoryIngestRoutes extends BaseRouteHandler {
+  constructor(private dbManager: DatabaseManager) {
+    super();
+  }
+
+  setupRoutes(app: express.Application): void {
+    app.post('/api/memory/ingest', this.wrapHandler(this.handleIngest.bind(this)));
+  }
+
+  /** Build the store deps: a mechanical store-direct per observation with dedup. */
+  private buildDeps(): MemoryIngestDeps {
+    const sessionStore = this.dbManager.getSessionStore();
+    const chromaSync = this.dbManager.getChromaSync();
+
+    return {
+      storeMemoryObservation: async (obs: MemoryObservationToStore) => {
+        const memorySessionId = sessionStore.getOrCreateManualSession(obs.project);
+        const observation = {
+          type: obs.type,
+          title: obs.title,
+          subtitle: obs.subtitle,
+          facts: [] as string[],
+          narrative: obs.narrative,
+          concepts: obs.concepts,
+          files_read: [] as string[],
+          files_modified: [] as string[],
+          metadata: JSON.stringify(obs.metadata),
+        };
+
+        // Pre-check the content_hash so we can report deduped vs newly stored
+        // accurately (storeObservation's ON CONFLICT collapses silently).
+        const contentHash = computeObservationContentHash(memorySessionId, observation.title, observation.narrative);
+        const existing = sessionStore.db
+          .prepare('SELECT id FROM observations WHERE memory_session_id = ? AND content_hash = ? LIMIT 1')
+          .get(memorySessionId, contentHash) as { id: number } | undefined;
+        if (existing) return { id: existing.id, deduped: true };
+
+        // Backdate to the file mtime via overrideTimestampEpoch.
+        const result = sessionStore.storeObservation(
+          memorySessionId,
+          obs.project,
+          observation,
+          0,
+          0,
+          obs.createdAtEpoch
+        );
+
+        if (chromaSync) {
+          chromaSync
+            .syncObservation(result.id, memorySessionId, obs.project, observation, 0, result.createdAtEpoch, 0)
+            .catch((err: unknown) => {
+              logger.error('CHROMA', 'memory-ingest Chroma sync failed', { id: result.id }, err as Error);
+            });
+        }
+
+        return { id: result.id, deduped: false };
+      },
+    };
+  }
+
+  private async handleIngest(req: Request, res: Response): Promise<void> {
+    const body = (req.body ?? {}) as { source?: unknown; all?: unknown; requireCwd?: unknown };
+    const source = typeof body.source === 'string' ? body.source.trim() : '';
+    const all = body.all === true;
+    if (!source && !all) {
+      this.badRequest(res, 'source is required (or pass all=true)');
+      return;
+    }
+    const requireCwd = body.requireCwd === true;
+    const effectiveSource = source || claudeProjectsDir();
+
+    logger.info('INGEST', 'Memory ingest starting', { source: effectiveSource, all, requireCwd });
+    const report = await ingestMemorySource(effectiveSource, { all, requireCwd }, this.buildDeps());
+    logger.info('INGEST', 'Memory ingest complete', {
+      found: report.found,
+      stored: report.stored,
+      deduped: report.deduped,
+      skipped: report.skipped,
+      failed: report.failed,
+    });
+
+    res.json(report);
+  }
+}

--- a/tests/memory/memory-ingest.test.ts
+++ b/tests/memory/memory-ingest.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  parseMemoryFrontmatter,
+  deriveTitle,
+  scanMemorySource,
+  dryRunMemorySource,
+  buildMemoryObservation,
+  ingestMemorySource,
+  memoryDirForCwd,
+  type MemoryDirRef,
+  type MemoryFileRef,
+  type MemoryObservationToStore,
+} from '../../src/services/memory/ingest.js';
+
+const FM = [
+  '---',
+  'name: recent-work',
+  'description: "What was done last session"',
+  'metadata:',
+  '  node_type: memory',
+  '  type: project',
+  '  originSessionId: abc-123',
+  '---',
+  '',
+  '## Recent Work',
+  '',
+  '- did a thing with alertmanager',
+].join('\n');
+
+describe('parseMemoryFrontmatter', () => {
+  it('extracts name/description and nested metadata.type/originSessionId, strips body', () => {
+    const { frontmatter, body } = parseMemoryFrontmatter(FM);
+    expect(frontmatter.name).toBe('recent-work');
+    expect(frontmatter.description).toBe('What was done last session');
+    expect(frontmatter.type).toBe('project');
+    expect(frontmatter.originSessionId).toBe('abc-123');
+    expect(frontmatter.nodeType).toBe('memory');
+    expect(body.startsWith('## Recent Work')).toBe(true);
+    expect(body).not.toContain('originSessionId');
+  });
+
+  it('returns empty frontmatter and original body when there is no block', () => {
+    const raw = '# Just markdown\n\nno frontmatter here';
+    const { frontmatter, body } = parseMemoryFrontmatter(raw);
+    expect(frontmatter).toEqual({});
+    expect(body).toBe(raw);
+  });
+
+  it('does not treat an unterminated --- as frontmatter', () => {
+    const raw = '---\nname: x\n(no close)';
+    const { frontmatter, body } = parseMemoryFrontmatter(raw);
+    expect(frontmatter).toEqual({});
+    expect(body).toBe(raw);
+  });
+});
+
+describe('deriveTitle', () => {
+  it('prefers frontmatter name', () => {
+    expect(deriveTitle('f.md', { name: 'the-name' }, '# H1\n')).toBe('the-name');
+  });
+  it('falls back to first H1 then H2 then filename', () => {
+    expect(deriveTitle('f.md', {}, '## only h2\n')).toBe('only h2');
+    expect(deriveTitle('topic.md', {}, 'plain text, no heading')).toBe('topic');
+    expect(deriveTitle('f.md', {}, '# the h1\n## later h2')).toBe('the h1');
+  });
+});
+
+describe('memoryDirForCwd', () => {
+  it('encodes the cwd path with dashes', () => {
+    expect(memoryDirForCwd('/home/u/code/mm/obs')).toContain('-home-u-code-mm-obs/memory');
+  });
+});
+
+describe('scanMemorySource', () => {
+  let root: string;
+  let memDir: string;
+
+  beforeEach(() => {
+    // Layout: <root>/<encoded>/{*.jsonl, memory/{MEMORY.md, recent-work.md, empty.md}}
+    root = mkdtempSync(join(tmpdir(), 'memscan-'));
+    const projectDir = join(root, '-home-u-code-mm-obs');
+    memDir = join(projectDir, 'memory');
+    mkdirSync(memDir, { recursive: true });
+    // Sibling transcript carrying cwd, so project resolves.
+    writeFileSync(
+      join(projectDir, 's.jsonl'),
+      JSON.stringify({ type: 'user', cwd: '/home/u/code/mm/obs', message: { content: 'hi' } }) + '\n'
+    );
+    writeFileSync(join(memDir, 'MEMORY.md'), '# Index\n- [recent](recent-work.md)\n');
+    writeFileSync(join(memDir, 'recent-work.md'), FM);
+    writeFileSync(join(memDir, 'empty.md'), '---\nname: empty\n---\n');
+  });
+
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('enumerates topic files, skips the MEMORY.md index, resolves cwd', () => {
+    const [ref] = scanMemorySource(memDir);
+    expect(ref.indexFile?.fileName).toBe('MEMORY.md');
+    const names = ref.files.map(f => f.fileName);
+    expect(names).toContain('recent-work.md');
+    expect(names).not.toContain('MEMORY.md');
+    expect(ref.cwd).toBe('/home/u/code/mm/obs');
+    expect(ref.project).toBe('obs');
+  });
+
+  it('accepts the parent project dir and finds its memory/ subdir', () => {
+    const [ref] = scanMemorySource(join(root, '-home-u-code-mm-obs'));
+    expect(ref.files.some(f => f.fileName === 'recent-work.md')).toBe(true);
+  });
+
+  it('dry-run counts ingestable files and skips the index', () => {
+    const report = dryRunMemorySource(memDir);
+    // recent-work.md + empty.md are ingestable; MEMORY.md is not.
+    expect(report.totals.files).toBe(2);
+    expect(report.dirs[0].indexSkipped).toBe(true);
+    expect(report.totals.cwdUnresolved).toBe(0);
+  });
+
+  it('throws on a missing source', () => {
+    expect(() => scanMemorySource(join(root, 'nope'))).toThrow();
+  });
+});
+
+describe('buildMemoryObservation', () => {
+  const ref = { project: 'obs', cwd: '/home/u/code/mm/obs', encodedName: '-enc' } as MemoryDirRef;
+  const file = {
+    fileName: 'recent-work.md',
+    title: 'recent-work',
+    body: '## Recent Work\n- thing',
+    mtimeEpoch: 1_700_000_000_000,
+    frontmatter: { type: 'project', originSessionId: 'abc-123', description: 'desc' },
+  } as MemoryFileRef;
+
+  it('maps body→narrative, backdates to mtime, carries provenance', () => {
+    const obs = buildMemoryObservation(ref, file);
+    expect(obs.project).toBe('obs');
+    expect(obs.type).toBe('discovery');
+    expect(obs.title).toBe('recent-work');
+    expect(obs.narrative).toBe('## Recent Work\n- thing');
+    expect(obs.createdAtEpoch).toBe(1_700_000_000_000);
+    expect(obs.concepts).toContain('memory-import');
+    expect(obs.concepts).toContain('memory-type:project');
+    expect(obs.metadata.originSessionId).toBe('abc-123');
+    expect(obs.metadata.source).toBe('memory-import');
+    expect(obs.subtitle).toBe('desc');
+  });
+});
+
+describe('ingestMemorySource (fake deps)', () => {
+  let root: string;
+  let memDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'memingest-'));
+    const projectDir = join(root, '-home-u-code-mm-obs');
+    memDir = join(projectDir, 'memory');
+    mkdirSync(memDir, { recursive: true });
+    writeFileSync(
+      join(projectDir, 's.jsonl'),
+      JSON.stringify({ type: 'user', cwd: '/home/u/code/mm/obs', message: { content: 'hi' } }) + '\n'
+    );
+    writeFileSync(join(memDir, 'MEMORY.md'), '# Index\n');
+    writeFileSync(join(memDir, 'a.md'), FM);
+    writeFileSync(join(memDir, 'empty.md'), '---\nname: empty\n---\n');
+  });
+
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('stores non-index, non-empty files and skips empty bodies', async () => {
+    const stored: MemoryObservationToStore[] = [];
+    const report = await ingestMemorySource(memDir, {}, {
+      storeMemoryObservation: async obs => {
+        stored.push(obs);
+        return { id: stored.length, deduped: false };
+      },
+    });
+    expect(report.found).toBe(2); // a.md + empty.md (MEMORY.md excluded at scan)
+    expect(report.stored).toBe(1); // a.md only
+    expect(report.skipped).toBe(1); // empty.md skipped (empty body)
+    expect(stored.map(o => o.title)).toEqual(['recent-work']);
+  });
+
+  it('reports deduped when the store says so (idempotency)', async () => {
+    const report = await ingestMemorySource(memDir, {}, {
+      storeMemoryObservation: async () => ({ id: 1, deduped: true }),
+    });
+    expect(report.stored).toBe(0);
+    expect(report.deduped).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Adds `claude-mem memory ingest`, which imports Claude Code's own "auto-memory"
markdown (`~/.claude/projects/<encoded-cwd>/memory/*.md`) directly into the
memory database as observations.

## Why

Auto-memory is *already distilled* prose, the same kind of artifact the
observation generator produces. So this stores each topic file directly through
the existing observation seam (content-hash dedup + Chroma sync) and **does not
run the Haiku generation pipeline**. Re-generating over already-distilled prose
would be lossy and pay for negative value. The `MEMORY.md` link index is skipped.

This is the mechanical, **zero-model-spend** sibling to the transcript backfill
(#2690): transcripts need generation, distilled memory does not.

## How

- `src/services/memory/ingest.ts`: enumerate + parse (hand-rolled frontmatter
  parser, no YAML dep) + content-hash store orchestrator. Dry-run is DB-free and
  worker-free.
- `src/services/memory/cli.ts` + npx wiring: `memory ingest [--source <dir> |
  --all] [--dry-run] [--require-cwd]`. Dry-run runs client-side; the real store
  drives the worker over HTTP.
- `src/services/worker/http/routes/MemoryIngestRoutes.ts`: `POST /api/memory/ingest`.
- Tests: frontmatter parsing, scan, mapping, ingest orchestrator (13 cases).
- Docs: `usage/memory-ingest.mdx` + nav entry.

All changes are additive; no existing behavior changes.

## Testing

- `bun test tests/memory/memory-ingest.test.ts` -> 13 pass
- `tsc --noEmit` clean

We have been running this in our own claude-mem deployment (worker/SQLite) since
Thursday 4 June. We used it to import an existing project's accumulated memory
files, which made the transition painless: we did not have to start memory from
scratch. It was quick and easy.

Note: `main` currently has pre-existing unrelated red CI.
