### PR TITLE
feat(worker): make TOTAL_PROCESS_HARD_CAP env-configurable

### DIFF
--- a/docs/production-guide.md
+++ b/docs/production-guide.md
@@ -7,6 +7,7 @@ Practical guide based on 23 days of production usage with 3,400+ observations ac
 | Setting | Default | Recommended | Why |
 |---------|---------|-------------|-----|
 | CLAUDE_MEM_MAX_CONCURRENT_AGENTS | 2 | 3 | Better throughput without overload |
+| CLAUDE_MEM_TOTAL_PROCESS_HARD_CAP | 10 | 10 | Absolute ceiling on concurrent SDK subprocesses, above the per-session pool. Raise only for high-throughput batch backfill against a local model. |
 | CLAUDE_MEM_SEMANTIC_INJECT | true | true | Relevant context >> recent context |
 | CLAUDE_MEM_SEMANTIC_INJECT_LIMIT | 5 | 5 | Sweet spot for token cost vs coverage |
 | CLAUDE_MEM_TIER_ROUTING_ENABLED | true | true | ~52% cost savings, no quality loss |

--- a/src/supervisor/process-registry.ts
+++ b/src/supervisor/process-registry.ts
@@ -486,7 +486,18 @@ export async function ensureSdkProcessExit(
   await Promise.race([sigkillExit, sigkillTimeout]);
 }
 
-const TOTAL_PROCESS_HARD_CAP = 10;
+export const DEFAULT_TOTAL_PROCESS_HARD_CAP = 10;
+
+// Absolute ceiling on concurrent SDK subprocesses, sitting above the per-session
+// CLAUDE_MEM_MAX_CONCURRENT_AGENTS pool. Env-configurable so a high-throughput
+// batch backfill against a local model, where cloud rate limits don't apply, can
+// lift it. Non-positive / unparseable values fall back to the default.
+export function resolveTotalProcessHardCap(raw: string | undefined): number {
+  const parsed = parseInt(raw ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TOTAL_PROCESS_HARD_CAP;
+}
+
+const TOTAL_PROCESS_HARD_CAP = resolveTotalProcessHardCap(process.env.CLAUDE_MEM_TOTAL_PROCESS_HARD_CAP);
 const SLOT_RECHECK_INTERVAL_MS = 5_000;
 const slotWaiters: Array<() => void> = [];
 

--- a/tests/supervisor/process-registry.test.ts
+++ b/tests/supervisor/process-registry.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, it } from 'bun:test';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
-import { createProcessRegistry, isPidAlive } from '../../src/supervisor/process-registry.js';
+import {
+  createProcessRegistry,
+  isPidAlive,
+  resolveTotalProcessHardCap,
+  DEFAULT_TOTAL_PROCESS_HARD_CAP,
+} from '../../src/supervisor/process-registry.js';
 
 function makeTempDir(): string {
   return path.join(tmpdir(), `claude-mem-supervisor-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -410,6 +415,36 @@ describe('supervisor ProcessRegistry', () => {
       expect(reaped).toBe(0);
 
       expect(registry.getAll()).toHaveLength(1);
+    });
+  });
+
+  describe('resolveTotalProcessHardCap', () => {
+    it('parses a positive integer', () => {
+      expect(resolveTotalProcessHardCap('25')).toBe(25);
+    });
+
+    it('falls back to the default when undefined', () => {
+      expect(resolveTotalProcessHardCap(undefined)).toBe(DEFAULT_TOTAL_PROCESS_HARD_CAP);
+    });
+
+    it('falls back to the default when empty', () => {
+      expect(resolveTotalProcessHardCap('')).toBe(DEFAULT_TOTAL_PROCESS_HARD_CAP);
+    });
+
+    it('falls back to the default when zero', () => {
+      expect(resolveTotalProcessHardCap('0')).toBe(DEFAULT_TOTAL_PROCESS_HARD_CAP);
+    });
+
+    it('falls back to the default when negative', () => {
+      expect(resolveTotalProcessHardCap('-5')).toBe(DEFAULT_TOTAL_PROCESS_HARD_CAP);
+    });
+
+    it('falls back to the default when unparseable', () => {
+      expect(resolveTotalProcessHardCap('lots')).toBe(DEFAULT_TOTAL_PROCESS_HARD_CAP);
+    });
+
+    it('takes the leading integer of a mixed string (parseInt semantics)', () => {
+      expect(resolveTotalProcessHardCap('32abc')).toBe(32);
     });
   });
 });


### PR DESCRIPTION
## What

Makes the absolute ceiling on concurrent SDK subprocesses configurable via
`CLAUDE_MEM_TOTAL_PROCESS_HARD_CAP` (default 10). Non-positive or unparseable
values fall back to the default.

## Why

The ceiling was hardcoded at 10, sitting above the per-session
`CLAUDE_MEM_MAX_CONCURRENT_AGENTS` pool. That caps batch backfill throughput
regardless of the per-session setting. Against a local model, where cloud rate
limits don't apply, you may want to lift it.

## How

- Parse logic extracted into an exported `resolveTotalProcessHardCap()` pure
  function so it is unit-testable (the cap itself is a module-load-time const).
- 7 test cases: valid, default/empty/zero/negative/unparseable fallbacks,
  parseInt leading-integer semantics.
- Documented in `docs/production-guide.md`.

## Testing

- `bun test tests/supervisor/process-registry.test.ts` -> 29 pass
- `tsc --noEmit` clean

Note: `main` currently has pre-existing unrelated red CI.
