### PR TITLE
feat(transcripts): Claude Code transcript backfill via historical-framing replay (#2690)

### DIFF
--- a/docs/public/docs.json
+++ b/docs/public/docs.json
@@ -43,6 +43,7 @@
           "usage/claude-desktop",
           "usage/private-tags",
           "usage/export-import",
+          "usage/transcript-backfill",
           "usage/manual-recovery",
           "usage/folder-context",
           "beta-features",

--- a/docs/public/usage/transcript-backfill.mdx
+++ b/docs/public/usage/transcript-backfill.mdx
@@ -1,0 +1,90 @@
+---
+title: "Transcript Backfill"
+description: "Import historical Claude Code session transcripts into memory, with a zero-spend dry-run cost gate (#2690)"
+---
+
+# Transcript Backfill
+
+`claude-mem transcript ingest` imports **historical Claude Code session
+transcripts** (`~/.claude/projects/<encoded-cwd>/*.jsonl`) into your memory
+database, so memory you accumulated before installing claude-mem (or in projects
+it never watched) still becomes searchable.
+
+Unlike [memory ingest](/usage/memory-ingest), which stores already-distilled
+markdown directly with no model, transcript backfill **replays raw session
+JSONL through the observation generator**. Each tool use is re-observed with
+*historical framing* (the generator is told this is a past replay, so it records
+rather than narrates as if live) and paced turns. This is the spend path: it
+runs generation (e.g. Haiku), so always dry-run first.
+
+## Usage
+
+Always **dry-run first** — it parses, normalizes, and counts everything,
+including a token + cost estimate, with **zero spend**:
+
+```bash
+# Estimate what a directory of sessions would produce, no spend
+claude-mem transcript ingest --source ~/.claude/projects/-home-you-code-app --dry-run
+
+# Single session file
+claude-mem transcript ingest --source ~/.claude/projects/-home-you-code-app/<session>.jsonl --dry-run
+
+# Include subagent sessions in the estimate
+claude-mem transcript ingest --source <dir> --include-subagents --dry-run
+```
+
+Then run the real ingest (drives the worker over HTTP; long-running for large
+histories):
+
+```bash
+claude-mem transcript ingest --source <dir>
+claude-mem transcript ingest --source <dir> --include-subagents
+```
+
+### Flags
+
+| Flag | Effect |
+|------|--------|
+| `--source <dir\|file>` | Required. A directory of `*.jsonl` sessions, or a single session file. |
+| `--dry-run` | Zero-spend scan + parse + count + token/cost estimate. Run this first. |
+| `--include-subagents` | Also ingest subagent sessions (`agent-<id>`), not just parent sessions. |
+
+## Dry-run cost estimate
+
+The dry-run reports, per session and in total, how many observations and
+summaries a real ingest would generate, plus an estimated input/output token
+count and cost. The estimate is **explicit and tunable, not a billing
+guarantee**: treat the input-token figure as a **floor**, because the worker's
+generator may prepend per-session conversation history to each call, and the
+estimate uses list pricing (set to 0 if your worker runs generation on a
+subscription rather than metered API).
+
+## Idempotency (and an important caveat)
+
+Re-running the same backfill is safe: already-ingested transcript content is
+content-hash deduplicated and reported as `already-indexed`; only new
+sessions/turns are generated.
+
+```
+INGESTED: 142 new, 318 already-indexed, 0 failed
+```
+
+**Caveat — do not backfill sessions claude-mem already captured live.** The dedup
+is a content hash of the *generated* observation text. A backfill regenerates
+observations independently of the real-time capture, so the text won't match and
+you will get **duplicate** observations for that session. Backfill is intended
+for history claude-mem never saw (pre-install, or projects it didn't watch), not
+for re-importing sessions that were observed live.
+
+## How it runs
+
+- **`--dry-run`** runs entirely client-side (scan + normalize + count). No
+  worker, no DB writes, no model calls.
+- The **real ingest** drives the worker daemon over HTTP
+  (`POST /api/transcript/ingest`), because generation needs the worker's ingest
+  context. It is not time-limited; large histories can take a while.
+
+## Related
+
+- [Memory Ingest](/usage/memory-ingest) — the zero-spend sibling for
+  already-distilled auto-memory markdown (no generation).

--- a/src/npx-cli/commands/runtime.ts
+++ b/src/npx-cli/commands/runtime.ts
@@ -263,3 +263,7 @@ export function runTranscriptWatchCommand(): void {
     process.exit(exitCode ?? 0);
   });
 }
+
+export function runTranscriptIngestCommand(extraArgs: string[] = []): void {
+  spawnBunWorkerCommand('transcript', ['ingest', ...extraArgs]);
+}

--- a/src/npx-cli/index.ts
+++ b/src/npx-cli/index.ts
@@ -210,9 +210,13 @@ async function main(): Promise<void> {
       if (subCommand === 'watch') {
         const { runTranscriptWatchCommand } = await import('./commands/runtime.js');
         runTranscriptWatchCommand();
+      } else if (subCommand === 'ingest') {
+        const { runTranscriptIngestCommand } = await import('./commands/runtime.js');
+        runTranscriptIngestCommand(args.slice(2));
       } else {
         console.error(pc.red(`Unknown transcript subcommand: ${subCommand ?? '(none)'}`));
-        console.error(`Usage: npx claude-mem transcript watch`);
+        console.error(`Usage: npx claude-mem transcript <watch|ingest>`);
+        console.error(`  ingest --source <dir|file> [--dry-run] [--include-subagents]`);
         process.exit(1);
       }
       break;

--- a/src/sdk/prompts.ts
+++ b/src/sdk/prompts.ts
@@ -21,7 +21,95 @@ export interface SDKSession {
   last_assistant_message?: string;
 }
 
-export function buildInitPrompt(project: string, sessionId: string, userPrompt: string, mode: ModeConfig): string {
+/**
+ * Backfill prompt framing (#2690): when a session is replaying a COMPLETED
+ * transcript (session.backfill), the observer is framed for historical replay —
+ * "this already happened, record what was done" — instead of the live "watching
+ * work happen RIGHT NOW" framing, which makes the model skip everything as
+ * not-yet-actionable. Selected per-session via the `backfill` argument on
+ * buildInitPrompt / buildObservationPrompt / buildContinuationPrompt.
+ */
+const BACKFILL_SYSTEM_IDENTITY = `You are Claude-Mem, a specialized tool creating searchable memory FOR FUTURE SESSIONS from a COMPLETED Claude Code session being replayed from the archive.
+
+CRITICAL: This session ALREADY HAPPENED — you are processing a finished transcript, NOT watching live work. For each tool use provided, record what was LEARNED/BUILT/FIXED/DEPLOYED/CONFIGURED/DISCOVERED.
+
+You do not have access to tools. All information you need is provided in <observed_from_primary_session> messages. Create observations from what you observe - no investigation needed.`;
+
+const BACKFILL_OBSERVER_ROLE = `Your job is to read a COMPLETED Claude Code session tool-use by tool-use and record durable observations of the work that was done. The session is already finished; you are reconstructing memory from the historical record. These tool uses represent real work that already occurred — prefer recording over skipping.`;
+
+const BACKFILL_RECORDING_FOCUS = `WHAT TO RECORD
+--------------
+Record durable technical signal from each tool use:
+- What the system NOW DOES differently (new capabilities)
+- What shipped (features, fixes, configs, docs)
+- Changes in technical domains (auth, data, UI, infra, DevOps, docs)
+- Concrete debugging/investigative findings from logs, traces, queue state, database rows, code-path inspection
+
+Use verbs like: implemented, fixed, deployed, configured, migrated, optimized, added, refactored, discovered, confirmed, traced.`;
+
+const BACKFILL_SKIP_GUIDANCE = `WHEN TO SKIP
+------------
+Prefer recording. Only return an empty response for a GENUINELY contentless tool use:
+- An empty status check that revealed nothing
+- A file read/listing that returned nothing or "not found"
+If a tool use produced real output or advanced the work, record it. Do not skip merely because the operation looks routine — in a historical replay the cumulative record is the value. If skipping, return an empty response only; never explain the skip in prose.`;
+
+function buildBackfillInitPrompt(project: string, sessionId: string, userPrompt: string, mode: ModeConfig): string {
+  return `${BACKFILL_SYSTEM_IDENTITY}
+
+<observed_from_primary_session>
+  <user_request>${userPrompt}</user_request>
+  <requested_at>${new Date().toISOString().split('T')[0]}</requested_at>
+</observed_from_primary_session>
+
+${BACKFILL_OBSERVER_ROLE}
+
+${mode.prompts.spatial_awareness}
+
+${BACKFILL_RECORDING_FOCUS}
+
+${BACKFILL_SKIP_GUIDANCE}
+
+${mode.prompts.output_format_header}
+
+<observation>
+  <type>[ ${mode.observation_types.map(t => t.id).join(' | ')} ]</type>
+  <!--
+    ${mode.prompts.type_guidance}
+  -->
+  <title>${mode.prompts.xml_title_placeholder}</title>
+  <subtitle>${mode.prompts.xml_subtitle_placeholder}</subtitle>
+  <facts>
+    <fact>${mode.prompts.xml_fact_placeholder}</fact>
+    <fact>${mode.prompts.xml_fact_placeholder}</fact>
+    <fact>${mode.prompts.xml_fact_placeholder}</fact>
+  </facts>
+  <!--
+    ${mode.prompts.field_guidance}
+  -->
+  <narrative>${mode.prompts.xml_narrative_placeholder}</narrative>
+  <concepts>
+    <concept>${mode.prompts.xml_concept_placeholder}</concept>
+    <concept>${mode.prompts.xml_concept_placeholder}</concept>
+  </concepts>
+  <files_read>
+    <file>${mode.prompts.xml_file_placeholder}</file>
+  </files_read>
+  <files_modified>
+    <file>${mode.prompts.xml_file_placeholder}</file>
+  </files_modified>
+</observation>
+${mode.prompts.format_examples}
+
+${mode.prompts.footer}
+
+${mode.prompts.header_memory_start}`;
+}
+
+export function buildInitPrompt(project: string, sessionId: string, userPrompt: string, mode: ModeConfig, backfill = false): string {
+  if (backfill) {
+    return buildBackfillInitPrompt(project, sessionId, userPrompt, mode);
+  }
   return `${mode.prompts.system_identity}
 
 <observed_from_primary_session>
@@ -114,7 +202,7 @@ function truncateObservationField(value: unknown, maxChars: number = OBS_PROMPT_
   return `${head}\n... <elided chars="${elidedChars}" original_size_chars="${raw.length}" reason="oversize" /> ...\n${tail}`;
 }
 
-export function buildObservationPrompt(obs: Observation): string {
+export function buildObservationPrompt(obs: Observation, backfill = false): string {
   let toolInput: any;
   let toolOutput: any;
 
@@ -136,6 +224,14 @@ export function buildObservationPrompt(obs: Observation): string {
     toolOutput = obs.tool_output;
   }
 
+  const trailer = backfill
+    ? `Record what this tool use accomplished as one or more <observation>...</observation> blocks. This is a historical replay — prefer recording over skipping; return an empty response ONLY if the tool use is genuinely contentless.
+Concrete debugging findings from logs, queue state, database rows, session routing, or code-path inspection count as durable discoveries and should be recorded.
+Never reply with prose such as "Skipping", "No observations to record", or any explanation outside XML. Non-XML text is discarded.`
+    : `Return either one or more <observation>...</observation> blocks, or an empty response if this tool use should be skipped.
+Concrete debugging findings from logs, queue state, database rows, session routing, or code-path inspection count as durable discoveries and should be recorded.
+Never reply with prose such as "Skipping", "No substantive tool executions", or any explanation outside XML. Non-XML text is discarded.`;
+
   return `<observed_from_primary_session>
   <what_happened>${obs.tool_name}</what_happened>
   <occurred_at>${new Date(obs.created_at_epoch).toISOString()}</occurred_at>${obs.cwd ? `\n  <working_directory>${obs.cwd}</working_directory>` : ''}
@@ -145,9 +241,7 @@ export function buildObservationPrompt(obs: Observation): string {
 
 If a <parameters> or <outcome> block above contains an "<elided chars=... />" marker, that field was truncated to fit the observer's context window. Describe only what you can see in the kept portion and do not infer details about the elided range.
 
-Return either one or more <observation>...</observation> blocks, or an empty response if this tool use should be skipped.
-Concrete debugging findings from logs, queue state, database rows, session routing, or code-path inspection count as durable discoveries and should be recorded.
-Never reply with prose such as "Skipping", "No substantive tool executions", or any explanation outside XML. Non-XML text is discarded.`;
+${trailer}`;
 }
 
 export function buildSummaryPrompt(session: SDKSession, mode: ModeConfig): string {
@@ -184,7 +278,12 @@ REMINDER: Your response MUST use <summary> as the root tag, NOT <observation>.
 ${mode.prompts.summary_footer}`;
 }
 
-export function buildContinuationPrompt(userPrompt: string, promptNumber: number, contentSessionId: string, mode: ModeConfig): string {
+export function buildContinuationPrompt(userPrompt: string, promptNumber: number, contentSessionId: string, mode: ModeConfig, backfill = false): string {
+  if (backfill) {
+    // Backfill continuation (e.g. after a respawn mid-replay) reuses the
+    // historical framing; the START/CONTINUED header difference is cosmetic.
+    return buildBackfillInitPrompt('', contentSessionId, userPrompt, mode);
+  }
   return `${mode.prompts.continuation_greeting}
 
 <observed_from_primary_session>

--- a/src/services/transcripts/claude-code.ts
+++ b/src/services/transcripts/claude-code.ts
@@ -15,12 +15,17 @@
  */
 import type { TranscriptSchema } from './types.js';
 
-/** Synthetic per-block event type, carried on the `__cc` field. */
+/**
+ * Synthetic per-block event type, carried on the `__cc` field.
+ * `session_end` is never produced by the normalizer — the ingest orchestrator
+ * emits it once at end-of-file to flush the session summary.
+ */
 export type ClaudeCodeEventType =
   | 'user_prompt'
   | 'assistant_text'
   | 'tool_use'
-  | 'tool_result';
+  | 'tool_result'
+  | 'session_end';
 
 /** A flattened, schema-ready event derived from one Claude Code content block. */
 export interface ClaudeCodeFlatEvent {
@@ -183,6 +188,12 @@ export const CLAUDE_CODE_SCHEMA: TranscriptSchema = {
         toolId: 'toolId',
         toolResponse: 'toolResponse',
       },
+    },
+    {
+      name: 'session-end',
+      match: { path: '__cc', equals: 'session_end' },
+      action: 'session_end',
+      fields: { sessionId: 'sessionId', cwd: 'cwd' },
     },
   ],
 };

--- a/src/services/transcripts/claude-code.ts
+++ b/src/services/transcripts/claude-code.ts
@@ -1,0 +1,188 @@
+/**
+ * Claude Code transcript normalizer (upstream #2690).
+ *
+ * The generic schema DSL (`field-utils.ts`) cannot fan out arrays: it can read
+ * a fixed index (`content[0]`) but cannot iterate. Claude Code packs multiple
+ * content blocks per JSONL line (one assistant message = text + N `tool_use`;
+ * one user message = N `tool_result`). A plain schema would silently drop every
+ * block past the first.
+ *
+ * Rather than extend the DSL, we flatten each JSONL line's `message.content`
+ * into one *synthetic flat event per block*, tagged with a `__cc` type field,
+ * then feed each flat event through the existing `TranscriptEventProcessor`
+ * keyed on a small schema (`CLAUDE_CODE_SCHEMA`). This reuses ALL existing
+ * session-state / pendingTools / ingestObservation / summary logic unchanged.
+ */
+import type { TranscriptSchema } from './types.js';
+
+/** Synthetic per-block event type, carried on the `__cc` field. */
+export type ClaudeCodeEventType =
+  | 'user_prompt'
+  | 'assistant_text'
+  | 'tool_use'
+  | 'tool_result';
+
+/** A flattened, schema-ready event derived from one Claude Code content block. */
+export interface ClaudeCodeFlatEvent {
+  __cc: ClaudeCodeEventType;
+  sessionId?: string;
+  cwd?: string;
+  /** Original ISO timestamp of the source line (informational; not backdated — see ingest.ts). */
+  ts?: string;
+  prompt?: string;
+  message?: string;
+  toolId?: string;
+  toolName?: string;
+  toolInput?: unknown;
+  toolResponse?: unknown;
+}
+
+interface RawContentBlock {
+  type?: string;
+  text?: string;
+  // tool_use
+  id?: string;
+  name?: string;
+  input?: unknown;
+  // tool_result
+  tool_use_id?: string;
+  content?: unknown;
+}
+
+interface RawLine {
+  type?: string;
+  sessionId?: string;
+  cwd?: string;
+  timestamp?: string;
+  message?: { role?: string; content?: unknown };
+}
+
+/** Line `type` values that carry conversational content we ingest. */
+const CONTENT_LINE_TYPES = new Set(['user', 'assistant']);
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+/**
+ * Flatten one Claude Code JSONL line into zero or more schema-ready flat events.
+ * Non-conversational lines (`permission-mode`, `file-history-snapshot`,
+ * `attachment`, `system`, `last-prompt`, …) produce no events.
+ */
+export function normalizeClaudeCodeLine(raw: unknown): ClaudeCodeFlatEvent[] {
+  if (!raw || typeof raw !== 'object') return [];
+  const line = raw as RawLine;
+  if (!line.type || !CONTENT_LINE_TYPES.has(line.type)) return [];
+
+  const base = {
+    sessionId: asString(line.sessionId),
+    cwd: asString(line.cwd),
+    ts: asString(line.timestamp),
+  };
+
+  const content = line.message?.content;
+
+  // String content: a plain user prompt or assistant text reply.
+  if (typeof content === 'string') {
+    if (!content.trim()) return [];
+    return line.type === 'user'
+      ? [{ ...base, __cc: 'user_prompt', prompt: content }]
+      : [{ ...base, __cc: 'assistant_text', message: content }];
+  }
+
+  if (!Array.isArray(content)) return [];
+
+  const events: ClaudeCodeFlatEvent[] = [];
+  for (const rawBlock of content) {
+    if (!rawBlock || typeof rawBlock !== 'object') continue;
+    const block = rawBlock as RawContentBlock;
+    switch (block.type) {
+      case 'text': {
+        const text = asString(block.text);
+        if (!text) break;
+        events.push(
+          line.type === 'user'
+            ? { ...base, __cc: 'user_prompt', prompt: text }
+            : { ...base, __cc: 'assistant_text', message: text }
+        );
+        break;
+      }
+      case 'tool_use': {
+        events.push({
+          ...base,
+          __cc: 'tool_use',
+          toolId: asString(block.id),
+          toolName: asString(block.name),
+          toolInput: block.input,
+        });
+        break;
+      }
+      case 'tool_result': {
+        events.push({
+          ...base,
+          __cc: 'tool_result',
+          toolId: asString(block.tool_use_id),
+          toolResponse: block.content,
+        });
+        break;
+      }
+      // thinking / image / redacted_thinking / etc. — intentionally ignored.
+      default:
+        break;
+    }
+  }
+  return events;
+}
+
+/**
+ * Schema mapping the synthetic flat events onto existing processor actions.
+ * Keyed on `__cc`; every field reads a top-level key set by the normalizer.
+ *
+ * Mirrors the Codex pattern of treating each user message as a `session_init`
+ * (bumps the prompt number) — see CODEX_SAMPLE_SCHEMA.
+ */
+export const CLAUDE_CODE_SCHEMA: TranscriptSchema = {
+  name: 'claude',
+  version: '1.0',
+  description: 'Claude Code JSONL transcripts, normalized one synthetic event per content block (#2690).',
+  eventTypePath: '__cc',
+  sessionIdPath: 'sessionId',
+  cwdPath: 'cwd',
+  events: [
+    {
+      name: 'user-prompt',
+      match: { path: '__cc', equals: 'user_prompt' },
+      action: 'session_init',
+      fields: { sessionId: 'sessionId', cwd: 'cwd', prompt: 'prompt' },
+    },
+    {
+      name: 'assistant-text',
+      match: { path: '__cc', equals: 'assistant_text' },
+      action: 'assistant_message',
+      fields: { sessionId: 'sessionId', cwd: 'cwd', message: 'message' },
+    },
+    {
+      name: 'tool-use',
+      match: { path: '__cc', equals: 'tool_use' },
+      action: 'tool_use',
+      fields: {
+        sessionId: 'sessionId',
+        cwd: 'cwd',
+        toolId: 'toolId',
+        toolName: 'toolName',
+        toolInput: 'toolInput',
+      },
+    },
+    {
+      name: 'tool-result',
+      match: { path: '__cc', equals: 'tool_result' },
+      action: 'tool_result',
+      fields: {
+        sessionId: 'sessionId',
+        cwd: 'cwd',
+        toolId: 'toolId',
+        toolResponse: 'toolResponse',
+      },
+    },
+  ],
+};

--- a/src/services/transcripts/cli.ts
+++ b/src/services/transcripts/cli.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_CONFIG_PATH, DEFAULT_STATE_PATH, expandHomePath, loadTranscriptWatchConfig, writeSampleConfig } from './config.js';
 import { TranscriptWatcher } from './watcher.js';
 import { dryRunSource, formatDryRunReport } from './ingest.js';
+import { ensureWorkerRunning, workerHttpRequest } from '../../shared/worker-utils.js';
 
 function getArgValue(args: string[], name: string): string | null {
   const index = args.indexOf(name);
@@ -78,13 +79,35 @@ export async function runTranscriptCommand(subcommand: string | undefined, args:
       }
 
       // Real ingest calls ingestObservation, which requires the worker's
-      // setIngestContext — it must run inside the worker over HTTP, not here.
-      // That path lands in the follow-up PR. Until then, fail loudly rather
-      // than spend Haiku from a context that cannot honor idempotency.
-      console.error(
-        'Real ingest (worker-driven) is not wired yet. Run with --dry-run for the cost preview.'
+      // setIngestContext, so it runs INSIDE the worker. Drive it over HTTP.
+      const workerReady = await ensureWorkerRunning();
+      if (!workerReady) {
+        console.error('Worker is not running and could not be started. Cannot ingest.');
+        return 1;
+      }
+      const response = await workerHttpRequest('/api/transcript/ingest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ source, includeSubagents }),
+        timeoutMs: 0, // backfill can be long; do not time out
+      });
+      if (!response.ok) {
+        console.error(`Ingest failed: HTTP ${response.status} ${await response.text()}`);
+        return 1;
+      }
+      const report = await response.json() as {
+        found: number; ingested: number; alreadyIndexed: number; failed: number;
+        sessions: Array<{ sessionId: string; isSubagent: boolean; status: string; observations: number; reason?: string }>;
+      };
+      for (const s of report.sessions) {
+        const tag = s.isSubagent ? '  subagent' : 'session';
+        console.log(`${tag} ${s.sessionId}: ${s.status}${s.reason ? ` (${s.reason})` : ''}, ${s.observations} obs`);
+      }
+      console.log(
+        `INGESTED: ${report.ingested} new, ${report.alreadyIndexed} already-indexed, ` +
+          `${report.failed} failed, of ${report.found} found.`
       );
-      return 2;
+      return report.failed > 0 ? 1 : 0;
     }
     default:
       console.log('Usage: claude-mem transcript <init|watch|validate|ingest> [--config <path>]');

--- a/src/services/transcripts/cli.ts
+++ b/src/services/transcripts/cli.ts
@@ -1,10 +1,15 @@
 import { DEFAULT_CONFIG_PATH, DEFAULT_STATE_PATH, expandHomePath, loadTranscriptWatchConfig, writeSampleConfig } from './config.js';
 import { TranscriptWatcher } from './watcher.js';
+import { dryRunSource, formatDryRunReport } from './ingest.js';
 
 function getArgValue(args: string[], name: string): string | null {
   const index = args.indexOf(name);
   if (index === -1) return null;
   return args[index + 1] ?? null;
+}
+
+function hasFlag(args: string[], name: string): boolean {
+  return args.includes(name);
 }
 
 export async function runTranscriptCommand(subcommand: string | undefined, args: string[]): Promise<number> {
@@ -58,8 +63,31 @@ export async function runTranscriptCommand(subcommand: string | undefined, args:
       console.log(`Config OK: ${expandHomePath(configPath)}`);
       return 0;
     }
+    case 'ingest': {
+      const source = getArgValue(args, '--source');
+      if (!source) {
+        console.error('Usage: claude-mem transcript ingest --source <dir|file> [--dry-run] [--include-subagents]');
+        return 1;
+      }
+      const includeSubagents = hasFlag(args, '--include-subagents');
+
+      if (hasFlag(args, '--dry-run')) {
+        const report = dryRunSource(source, { includeSubagents });
+        console.log(formatDryRunReport(report));
+        return 0;
+      }
+
+      // Real ingest calls ingestObservation, which requires the worker's
+      // setIngestContext — it must run inside the worker over HTTP, not here.
+      // That path lands in the follow-up PR. Until then, fail loudly rather
+      // than spend Haiku from a context that cannot honor idempotency.
+      console.error(
+        'Real ingest (worker-driven) is not wired yet. Run with --dry-run for the cost preview.'
+      );
+      return 2;
+    }
     default:
-      console.log('Usage: claude-mem transcript <init|watch|validate> [--config <path>]');
+      console.log('Usage: claude-mem transcript <init|watch|validate|ingest> [--config <path>]');
       return 1;
   }
 }

--- a/src/services/transcripts/ingest.ts
+++ b/src/services/transcripts/ingest.ts
@@ -15,7 +15,8 @@
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { basename, dirname, join } from 'path';
 import { expandHomePath } from './config.js';
-import { normalizeClaudeCodeLine } from './claude-code.js';
+import { normalizeClaudeCodeLine, CLAUDE_CODE_SCHEMA } from './claude-code.js';
+import type { TranscriptSchema, WatchTarget } from './types.js';
 
 export interface SubagentRef {
   /** content_session_id used for the subagent: `agent-<id>`. */
@@ -248,6 +249,178 @@ export function dryRunSource(source: string, options: ScanOptions = {}): DryRunR
       estimatedCostUsd,
     },
   };
+}
+
+// ───────────────────────────── real ingest ──────────────────────────────
+//
+// The spending path. Runs INSIDE the worker process (ingestObservation needs
+// setIngestContext), driven by an injected processor + idempotency check so it
+// stays unit-testable without a live worker.
+
+/** Minimal slice of TranscriptEventProcessor the orchestrator needs. */
+export interface IngestProcessor {
+  processEntry(
+    entry: unknown,
+    watch: WatchTarget,
+    schema: TranscriptSchema,
+    sessionIdOverride?: string | null
+  ): Promise<void>;
+}
+
+export interface IngestDeps {
+  processor: IngestProcessor;
+  /** True if a session with this content_session_id already exists (skip it). */
+  sessionExists: (contentSessionId: string) => boolean;
+}
+
+export interface IngestSessionResult {
+  sessionId: string;
+  isSubagent: boolean;
+  status: 'ingested' | 'skipped' | 'failed';
+  /** tool_use blocks fed through — proxy for observations queued. */
+  observations: number;
+  reason?: string;
+}
+
+export interface IngestReport {
+  source: string;
+  includeSubagents: boolean;
+  found: number;
+  ingested: number;
+  alreadyIndexed: number;
+  failed: number;
+  sessions: IngestSessionResult[];
+}
+
+/** Resolve the project root from a parent transcript's first line carrying cwd. */
+function firstCwd(filePath: string): string | undefined {
+  const raw = readFileSync(filePath, 'utf-8');
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const cwd = (JSON.parse(trimmed) as { cwd?: unknown }).cwd;
+      if (typeof cwd === 'string' && cwd.trim()) return cwd;
+    } catch {
+      // ignore non-JSON lines
+    }
+  }
+  return undefined;
+}
+
+interface SessionToIngest {
+  sessionId: string;
+  filePath: string;
+  isSubagent: boolean;
+  /** Project root cwd. Drives stored project; for subagents this is the PARENT's. */
+  cwd?: string;
+  /** When true, strip each line's own cwd so it falls back to the parent cwd. */
+  forceCwd?: boolean;
+}
+
+async function ingestOneSession(
+  deps: IngestDeps,
+  report: IngestReport,
+  s: SessionToIngest
+): Promise<void> {
+  report.found++;
+  const result: IngestSessionResult = {
+    sessionId: s.sessionId,
+    isSubagent: s.isSubagent,
+    status: 'ingested',
+    observations: 0,
+  };
+
+  // Idempotency: a pre-existing content_session_id (from a prior backfill OR
+  // from live capture) is left untouched. platform_source is set via watch.name.
+  if (deps.sessionExists(s.sessionId)) {
+    result.status = 'skipped';
+    result.reason = 'already-indexed';
+    report.alreadyIndexed++;
+    report.sessions.push(result);
+    return;
+  }
+
+  const watch: WatchTarget = {
+    name: 'claude',
+    path: s.filePath,
+    schema: CLAUDE_CODE_SCHEMA,
+    workspace: s.cwd,
+  };
+
+  try {
+    const raw = readFileSync(s.filePath, 'utf-8');
+    for (const line of raw.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      for (const ev of normalizeClaudeCodeLine(parsed)) {
+        // Force the canonical content_session_id via the override (strip the
+        // per-event sessionId so the override wins), and for subagents strip
+        // the per-line cwd so project inherits the parent's (watch.workspace).
+        const e: Record<string, unknown> = { ...ev, sessionId: undefined };
+        if (s.forceCwd) e.cwd = undefined;
+        if (ev.__cc === 'tool_use') result.observations++;
+        await deps.processor.processEntry(e, watch, CLAUDE_CODE_SCHEMA, s.sessionId);
+      }
+    }
+    // Flush the session summary at EOF.
+    await deps.processor.processEntry({ __cc: 'session_end' }, watch, CLAUDE_CODE_SCHEMA, s.sessionId);
+    report.ingested++;
+  } catch (err) {
+    result.status = 'failed';
+    result.reason = err instanceof Error ? err.message : String(err);
+    report.failed++;
+  }
+  report.sessions.push(result);
+}
+
+/**
+ * Backfill every session under `source` into memory. Idempotent by
+ * content_session_id. Subagents (when included) inherit the parent's project.
+ */
+export async function ingestSource(
+  source: string,
+  options: ScanOptions,
+  deps: IngestDeps
+): Promise<IngestReport> {
+  const includeSubagents = options.includeSubagents ?? false;
+  const refs = scanSource(source, { includeSubagents });
+
+  const report: IngestReport = {
+    source: expandHomePath(source),
+    includeSubagents,
+    found: 0,
+    ingested: 0,
+    alreadyIndexed: 0,
+    failed: 0,
+    sessions: [],
+  };
+
+  for (const ref of refs) {
+    const repoCwd = firstCwd(ref.filePath);
+    await ingestOneSession(deps, report, {
+      sessionId: ref.sessionId,
+      filePath: ref.filePath,
+      isSubagent: false,
+      cwd: repoCwd,
+    });
+    for (const sub of ref.subagents) {
+      await ingestOneSession(deps, report, {
+        sessionId: sub.sessionId,
+        filePath: sub.filePath,
+        isSubagent: true,
+        cwd: repoCwd, // inherit parent project, NOT the subagent worktree
+        forceCwd: true,
+      });
+    }
+  }
+  return report;
 }
 
 /** Render a dry-run report as human-readable lines for the CLI. */

--- a/src/services/transcripts/ingest.ts
+++ b/src/services/transcripts/ingest.ts
@@ -1,0 +1,226 @@
+/**
+ * Claude Code transcript backfill (upstream #2690) — scan + dry-run.
+ *
+ * This module is the client-side, spend-free half of the backfill:
+ *  - `scanSource()` enumerates the parent sessions (one `*.jsonl` per session)
+ *    and, when requested, their subagent sessions.
+ *  - `dryRunSource()` parses + normalizes every line and counts what a real
+ *    ingest WOULD produce, WITHOUT calling `ingestObservation` (i.e. without
+ *    any Haiku spend). This is the cost gate: see the per-session and total
+ *    observation/summary estimates before spending.
+ *
+ * The real (spending) ingest is driven inside the worker process over HTTP
+ * (ingestObservation needs setIngestContext) and lands in a follow-up.
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { basename, dirname, join } from 'path';
+import { expandHomePath } from './config.js';
+import { normalizeClaudeCodeLine } from './claude-code.js';
+
+export interface SubagentRef {
+  /** content_session_id used for the subagent: `agent-<id>`. */
+  sessionId: string;
+  filePath: string;
+  agentType?: string;
+  description?: string;
+}
+
+export interface SessionRef {
+  /** content_session_id (the parent session UUID, = filename without .jsonl). */
+  sessionId: string;
+  filePath: string;
+  subagents: SubagentRef[];
+}
+
+export interface ScanOptions {
+  includeSubagents?: boolean;
+}
+
+const JSONL_EXT = '.jsonl';
+
+function listSubagents(parentFilePath: string, sessionId: string): SubagentRef[] {
+  // Subagents live at <dir>/<sessionId>/subagents/agent-<id>.jsonl with a
+  // sibling agent-<id>.meta.json ({ agentType, description, [worktreePath] }).
+  const subDir = join(dirname(parentFilePath), sessionId, 'subagents');
+  if (!existsSync(subDir) || !statSync(subDir).isDirectory()) return [];
+
+  const refs: SubagentRef[] = [];
+  for (const name of readdirSync(subDir)) {
+    if (!name.startsWith('agent-') || !name.endsWith(JSONL_EXT)) continue;
+    const filePath = join(subDir, name);
+    const agentId = basename(name, JSONL_EXT); // e.g. agent-a7a74e8d...
+    const ref: SubagentRef = { sessionId: agentId, filePath };
+
+    const metaPath = join(subDir, `${agentId}.meta.json`);
+    if (existsSync(metaPath)) {
+      try {
+        const meta = JSON.parse(readFileSync(metaPath, 'utf-8')) as {
+          agentType?: string;
+          description?: string;
+        };
+        if (typeof meta.agentType === 'string') ref.agentType = meta.agentType;
+        if (typeof meta.description === 'string') ref.description = meta.description;
+      } catch {
+        // Malformed meta is non-fatal — ingest the agent session without it.
+      }
+    }
+    refs.push(ref);
+  }
+  return refs;
+}
+
+/**
+ * Enumerate parent sessions (and optionally subagents) under `source`.
+ * `source` may be a single `*.jsonl` file or a directory of them (one repo).
+ */
+export function scanSource(source: string, options: ScanOptions = {}): SessionRef[] {
+  const resolved = expandHomePath(source);
+  if (!existsSync(resolved)) {
+    throw new Error(`ingest source not found: ${resolved}`);
+  }
+
+  let parentFiles: string[];
+  const stat = statSync(resolved);
+  if (stat.isFile()) {
+    if (!resolved.endsWith(JSONL_EXT)) {
+      throw new Error(`ingest source file is not a .jsonl: ${resolved}`);
+    }
+    parentFiles = [resolved];
+  } else {
+    parentFiles = readdirSync(resolved)
+      .filter(name => name.endsWith(JSONL_EXT))
+      .map(name => join(resolved, name))
+      .filter(p => statSync(p).isFile());
+  }
+
+  return parentFiles.map(filePath => {
+    const sessionId = basename(filePath, JSONL_EXT);
+    const subagents = options.includeSubagents ? listSubagents(filePath, sessionId) : [];
+    return { sessionId, filePath, subagents };
+  });
+}
+
+export interface SessionCounts {
+  sessionId: string;
+  filePath: string;
+  isSubagent: boolean;
+  agentType?: string;
+  lines: number;
+  parseFailures: number;
+  userPrompts: number;
+  assistantTexts: number;
+  toolUses: number;
+  toolResults: number;
+}
+
+export interface DryRunReport {
+  source: string;
+  includeSubagents: boolean;
+  sessions: SessionCounts[];
+  totals: {
+    sessions: number;
+    parseFailures: number;
+    /** Each completed tool call becomes one observation (one Haiku generation). */
+    estimatedObservations: number;
+    /** One summary per session (one Haiku generation) at session_end. */
+    estimatedSummaries: number;
+    /** estimatedObservations + estimatedSummaries — the Haiku-call proxy. */
+    estimatedHaikuCalls: number;
+  };
+}
+
+function countFile(filePath: string): Omit<SessionCounts, 'sessionId' | 'isSubagent' | 'agentType'> {
+  const counts = {
+    filePath,
+    lines: 0,
+    parseFailures: 0,
+    userPrompts: 0,
+    assistantTexts: 0,
+    toolUses: 0,
+    toolResults: 0,
+  };
+
+  const raw = readFileSync(filePath, 'utf-8');
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    counts.lines++;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      counts.parseFailures++;
+      continue;
+    }
+    for (const ev of normalizeClaudeCodeLine(parsed)) {
+      switch (ev.__cc) {
+        case 'user_prompt': counts.userPrompts++; break;
+        case 'assistant_text': counts.assistantTexts++; break;
+        case 'tool_use': counts.toolUses++; break;
+        case 'tool_result': counts.toolResults++; break;
+      }
+    }
+  }
+  return counts;
+}
+
+/**
+ * Parse + normalize every session under `source` and report what a real ingest
+ * would produce. No `ingestObservation`, no worker, no Haiku spend.
+ */
+export function dryRunSource(source: string, options: ScanOptions = {}): DryRunReport {
+  const includeSubagents = options.includeSubagents ?? false;
+  const refs = scanSource(source, { includeSubagents });
+
+  const sessions: SessionCounts[] = [];
+  for (const ref of refs) {
+    sessions.push({ ...countFile(ref.filePath), sessionId: ref.sessionId, isSubagent: false });
+    for (const sub of ref.subagents) {
+      sessions.push({
+        ...countFile(sub.filePath),
+        sessionId: sub.sessionId,
+        isSubagent: true,
+        agentType: sub.agentType,
+      });
+    }
+  }
+
+  const estimatedObservations = sessions.reduce((n, s) => n + s.toolUses, 0);
+  const estimatedSummaries = sessions.length;
+  return {
+    source: expandHomePath(source),
+    includeSubagents,
+    sessions,
+    totals: {
+      sessions: sessions.length,
+      parseFailures: sessions.reduce((n, s) => n + s.parseFailures, 0),
+      estimatedObservations,
+      estimatedSummaries,
+      estimatedHaikuCalls: estimatedObservations + estimatedSummaries,
+    },
+  };
+}
+
+/** Render a dry-run report as human-readable lines for the CLI. */
+export function formatDryRunReport(report: DryRunReport): string {
+  const lines: string[] = [];
+  lines.push(`Dry-run (no Haiku spend) — source: ${report.source}`);
+  lines.push(`Subagents: ${report.includeSubagents ? 'included' : 'excluded'}`);
+  lines.push('');
+  for (const s of report.sessions) {
+    const tag = s.isSubagent ? `  subagent${s.agentType ? ` (${s.agentType})` : ''}` : 'session';
+    lines.push(
+      `${tag} ${s.sessionId}: ${s.toolUses} obs, ${s.userPrompts} prompts, ` +
+        `${s.assistantTexts} replies, ${s.toolResults} results, ${s.lines} lines` +
+        (s.parseFailures ? `, ${s.parseFailures} parse-failures` : '')
+    );
+  }
+  lines.push('');
+  const t = report.totals;
+  lines.push(
+    `TOTAL: ${t.sessions} sessions → ~${t.estimatedObservations} observations + ` +
+      `~${t.estimatedSummaries} summaries = ~${t.estimatedHaikuCalls} Haiku calls` +
+      (t.parseFailures ? ` (${t.parseFailures} parse-failures)` : '')
+  );
+  return lines.join('\n');
+}

--- a/src/services/transcripts/ingest.ts
+++ b/src/services/transcripts/ingest.ts
@@ -38,6 +38,24 @@ export interface ScanOptions {
 
 const JSONL_EXT = '.jsonl';
 
+/**
+ * Cost-estimate constants. These are deliberately explicit and tunable — they
+ * are an ESTIMATE, not a billing guarantee.
+ *
+ * Caveat: the worker's observation generator may prepend per-session
+ * conversation history to each call, so real input can exceed the raw payload
+ * bytes counted here. Treat the input-token figure as a floor.
+ */
+const CHARS_PER_TOKEN = 4; // rough industry approximation (JSON skews a bit denser)
+const PROMPT_OVERHEAD_TOKENS = 400; // scaffolding/instructions sent per generation call
+const OUTPUT_TOKENS_PER_OBSERVATION = 250;
+const OUTPUT_TOKENS_PER_SUMMARY = 400;
+// Claude Haiku 4.5 list pricing (USD per million tokens). Adjust if the worker
+// is pointed at a different model, or set to 0 if Haiku runs on subscription
+// budget rather than metered API billing.
+const HAIKU_USD_PER_MTOK_INPUT = 1.0;
+const HAIKU_USD_PER_MTOK_OUTPUT = 5.0;
+
 function listSubagents(parentFilePath: string, sessionId: string): SubagentRef[] {
   // Subagents live at <dir>/<sessionId>/subagents/agent-<id>.jsonl with a
   // sibling agent-<id>.meta.json ({ agentType, description, [worktreePath] }).
@@ -111,6 +129,8 @@ export interface SessionCounts {
   assistantTexts: number;
   toolUses: number;
   toolResults: number;
+  /** Bytes of model-visible content (tool inputs/responses, prompts, replies). */
+  contentBytes: number;
 }
 
 export interface DryRunReport {
@@ -126,6 +146,12 @@ export interface DryRunReport {
     estimatedSummaries: number;
     /** estimatedObservations + estimatedSummaries — the Haiku-call proxy. */
     estimatedHaikuCalls: number;
+    contentBytes: number;
+    /** Estimated input tokens (content + per-call prompt overhead). A floor. */
+    estimatedInputTokens: number;
+    estimatedOutputTokens: number;
+    /** Estimated metered cost in USD at the Haiku rates above (0 if on subscription). */
+    estimatedCostUsd: number;
   };
 }
 
@@ -138,6 +164,13 @@ function countFile(filePath: string): Omit<SessionCounts, 'sessionId' | 'isSubag
     assistantTexts: 0,
     toolUses: 0,
     toolResults: 0,
+    contentBytes: 0,
+  };
+
+  const byteLen = (value: unknown): number => {
+    if (value === undefined || value === null) return 0;
+    const s = typeof value === 'string' ? value : JSON.stringify(value);
+    return Buffer.byteLength(s, 'utf-8');
   };
 
   const raw = readFileSync(filePath, 'utf-8');
@@ -154,10 +187,10 @@ function countFile(filePath: string): Omit<SessionCounts, 'sessionId' | 'isSubag
     }
     for (const ev of normalizeClaudeCodeLine(parsed)) {
       switch (ev.__cc) {
-        case 'user_prompt': counts.userPrompts++; break;
-        case 'assistant_text': counts.assistantTexts++; break;
-        case 'tool_use': counts.toolUses++; break;
-        case 'tool_result': counts.toolResults++; break;
+        case 'user_prompt': counts.userPrompts++; counts.contentBytes += byteLen(ev.prompt); break;
+        case 'assistant_text': counts.assistantTexts++; counts.contentBytes += byteLen(ev.message); break;
+        case 'tool_use': counts.toolUses++; counts.contentBytes += byteLen(ev.toolInput); break;
+        case 'tool_result': counts.toolResults++; counts.contentBytes += byteLen(ev.toolResponse); break;
       }
     }
   }
@@ -187,6 +220,18 @@ export function dryRunSource(source: string, options: ScanOptions = {}): DryRunR
 
   const estimatedObservations = sessions.reduce((n, s) => n + s.toolUses, 0);
   const estimatedSummaries = sessions.length;
+  const estimatedHaikuCalls = estimatedObservations + estimatedSummaries;
+  const contentBytes = sessions.reduce((n, s) => n + s.contentBytes, 0);
+
+  const estimatedInputTokens =
+    Math.round(contentBytes / CHARS_PER_TOKEN) + estimatedHaikuCalls * PROMPT_OVERHEAD_TOKENS;
+  const estimatedOutputTokens =
+    estimatedObservations * OUTPUT_TOKENS_PER_OBSERVATION +
+    estimatedSummaries * OUTPUT_TOKENS_PER_SUMMARY;
+  const estimatedCostUsd =
+    (estimatedInputTokens / 1_000_000) * HAIKU_USD_PER_MTOK_INPUT +
+    (estimatedOutputTokens / 1_000_000) * HAIKU_USD_PER_MTOK_OUTPUT;
+
   return {
     source: expandHomePath(source),
     includeSubagents,
@@ -196,7 +241,11 @@ export function dryRunSource(source: string, options: ScanOptions = {}): DryRunR
       parseFailures: sessions.reduce((n, s) => n + s.parseFailures, 0),
       estimatedObservations,
       estimatedSummaries,
-      estimatedHaikuCalls: estimatedObservations + estimatedSummaries,
+      estimatedHaikuCalls,
+      contentBytes,
+      estimatedInputTokens,
+      estimatedOutputTokens,
+      estimatedCostUsd,
     },
   };
 }
@@ -217,10 +266,24 @@ export function formatDryRunReport(report: DryRunReport): string {
   }
   lines.push('');
   const t = report.totals;
+  const mTokIn = (t.estimatedInputTokens / 1_000_000).toFixed(2);
+  const mTokOut = (t.estimatedOutputTokens / 1_000_000).toFixed(2);
   lines.push(
     `TOTAL: ${t.sessions} sessions → ~${t.estimatedObservations} observations + ` +
       `~${t.estimatedSummaries} summaries = ~${t.estimatedHaikuCalls} Haiku calls` +
       (t.parseFailures ? ` (${t.parseFailures} parse-failures)` : '')
+  );
+  lines.push(
+    `TOKENS (est): ~${mTokIn}M input + ~${mTokOut}M output ` +
+      `(from ${(t.contentBytes / 1_000_000).toFixed(2)} MB content + ${PROMPT_OVERHEAD_TOKENS}tok/call overhead)`
+  );
+  lines.push(
+    `COST (est): ~$${t.estimatedCostUsd.toFixed(2)} ` +
+      `at Haiku $${HAIKU_USD_PER_MTOK_INPUT}/$${HAIKU_USD_PER_MTOK_OUTPUT} per Mtok in/out`
+  );
+  lines.push(
+    'NOTE: input is a floor — the generator may prepend per-session history. ' +
+      'If Haiku runs on subscription budget, the $ figure is not metered.'
   );
   return lines.join('\n');
 }

--- a/src/services/transcripts/processor.ts
+++ b/src/services/transcripts/processor.ts
@@ -25,6 +25,14 @@ interface SessionState {
 export class TranscriptEventProcessor {
   private sessions = new Map<string, SessionState>();
 
+  /**
+   * @param options.backfill when true, observations queued by this processor are
+   * marked as backfill (#2690): the worker then uses historical prompt framing
+   * and paced one-observation-per-turn generation. Live transcript watching
+   * constructs the processor without it, so live behavior is unchanged.
+   */
+  constructor(private readonly options: { backfill?: boolean } = {}) {}
+
   async processEntry(
     entry: unknown,
     watch: WatchTarget,
@@ -246,6 +254,7 @@ export class TranscriptEventProcessor {
 
     const result = await ingestObservation({
       contentSessionId: session.sessionId,
+      backfill: this.options.backfill,
       cwd: session.cwd ?? process.cwd(),
       toolName,
       toolInput: this.maybeParseJson(fields.toolInput),

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -90,6 +90,7 @@ import { SessionCompletionHandler } from './worker/session/SessionCompletionHand
 import { setIngestContext, attachIngestGeneratorStarter } from './worker/http/shared.js';
 import { DEFAULT_CONFIG_PATH, DEFAULT_STATE_PATH, expandHomePath, filterNativeHookBackedCodexWatches, loadTranscriptWatchConfig } from './transcripts/config.js';
 import { TranscriptWatcher } from './transcripts/watcher.js';
+import { runTranscriptCommand } from './transcripts/cli.js';
 
 import { ViewerRoutes } from './worker/http/routes/ViewerRoutes.js';
 import { SessionRoutes } from './worker/http/routes/SessionRoutes.js';
@@ -98,6 +99,7 @@ import { SearchRoutes } from './worker/http/routes/SearchRoutes.js';
 import { SettingsRoutes } from './worker/http/routes/SettingsRoutes.js';
 import { LogsRoutes } from './worker/http/routes/LogsRoutes.js';
 import { MemoryRoutes } from './worker/http/routes/MemoryRoutes.js';
+import { TranscriptRoutes } from './worker/http/routes/TranscriptRoutes.js';
 import { CorpusRoutes } from './worker/http/routes/CorpusRoutes.js';
 import { ChromaRoutes } from './worker/http/routes/ChromaRoutes.js';
 
@@ -333,6 +335,7 @@ export class WorkerService implements WorkerRef {
     this.server.registerRoutes(new SettingsRoutes(this.settingsManager));
     this.server.registerRoutes(new LogsRoutes());
     this.server.registerRoutes(new MemoryRoutes(this.dbManager, 'claude-mem'));
+    this.server.registerRoutes(new TranscriptRoutes(this.dbManager));
     this.server.registerRoutes(new ServerV1Routes({
       getDatabase: () => this.dbManager.getConnection(),
     }));
@@ -1188,6 +1191,15 @@ async function main() {
       const subcommand = process.argv[3];
       const cursorResult = await handleCursorCommand(subcommand, process.argv.slice(4));
       process.exit(cursorResult);
+      break;
+    }
+
+    case 'transcript': {
+      // Transient CLI dispatch (watch / validate / init / ingest). The real
+      // ingest reaches the worker daemon over HTTP from inside runTranscriptCommand.
+      const subcommand = process.argv[3];
+      const transcriptResult = await runTranscriptCommand(subcommand, process.argv.slice(4));
+      process.exit(transcriptResult);
       break;
     }
 

--- a/src/services/worker-types.ts
+++ b/src/services/worker-types.ts
@@ -33,6 +33,12 @@ export interface ActiveSession {
    */
   consecutiveInvalidOutputs: number;
   forceInit?: boolean;
+  /**
+   * Backfill (#2690): this session is replaying a FINISHED transcript, so it
+   * uses historical prompt framing and paced one-observation-per-turn
+   * generation. In-memory only (set at queue time); live capture never sets it.
+   */
+  backfill?: boolean;
   idleTimedOut?: boolean;  
   lastGeneratorActivity: number;
   modelOverride?: string;
@@ -81,6 +87,7 @@ export interface PendingMessageWithId extends PendingMessage {
 }
 
 export interface ObservationData {
+  backfill?: boolean;
   tool_name: string;
   tool_input: any;
   tool_response: any;

--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -160,6 +160,42 @@ export function classifyClaudeError(err: unknown): ClassifiedProviderError {
   return new ClassifiedProviderError(message, { kind: 'transient', cause: err });
 }
 
+/**
+ * One-permit gate that applies backpressure between the message generator
+ * (producer) and the SDK response consumer during backfill (#2690). Without it,
+ * the generator yields the whole pre-queued batch back-to-back, the streaming
+ * SDK coalesces those user messages into a couple of turns, and a single empty
+ * response confirms-away the entire batch un-judged. `wait()` blocks the
+ * generator after each observation until the consumer `release()`s that turn;
+ * a release arriving before its matching wait is latched (counted) so the two
+ * coroutines cannot deadlock regardless of which runs first. Backfill-only —
+ * live capture never constructs a gate, so its behavior is unchanged.
+ */
+class TurnGate {
+  private pending = 0;
+  private resolver: (() => void) | null = null;
+
+  wait(): Promise<void> {
+    if (this.pending > 0) {
+      this.pending--;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.resolver = resolve;
+    });
+  }
+
+  release(): void {
+    if (this.resolver) {
+      const resolve = this.resolver;
+      this.resolver = null;
+      resolve();
+    } else {
+      this.pending++;
+    }
+  }
+}
+
 export class ClaudeProvider {
   private dbManager: DatabaseManager;
   private sessionManager: SessionManager;
@@ -187,7 +223,16 @@ export class ClaudeProvider {
     // accumulator starts from zero — reset the per-turn cost baseline with it.
     session.lastResultTotalCostUsd = null;
 
-    const messageGenerator = this.createMessageGenerator(session, cwdTracker);
+    // Backfill pacing (#2690): gate the generator to one observation per
+    // assistant turn so the pre-queued batch isn't flooded into the SDK and
+    // confirmed-away un-judged. The gate is consulted only when session.backfill
+    // is set — read FRESH in both the generator and the consumer below, never
+    // snapshotted here. session.backfill can flip true just after startSession
+    // begins but before the async generator's body first runs, so capturing it
+    // now would race; we always build the gate and let the runtime checks decide.
+    // Live never sets session.backfill, so it never waits → behavior unchanged.
+    const turnGate = new TurnGate();
+    const messageGenerator = this.createMessageGenerator(session, cwdTracker, turnGate);
 
     const hasRealMemorySessionId = !!session.memorySessionId;
     const shouldResume = hasRealMemorySessionId && session.lastPromptNumber > 1 && !session.forceInit;
@@ -388,6 +433,13 @@ export class ClaudeProvider {
             cwdTracker.lastCwd,
             modelId
           );
+
+          // Release the backfill pacing gate now that this turn is fully
+          // processed, letting the generator yield the next observation. Only
+          // active for backfill; live never waits, so it never needs releasing.
+          if (session.backfill) {
+            turnGate.release();
+          }
         }
 
         if (message.type === 'result') {
@@ -458,7 +510,8 @@ export class ClaudeProvider {
 
   private async *createMessageGenerator(
     session: ActiveSession,
-    cwdTracker: { lastCwd: string | undefined }
+    cwdTracker: { lastCwd: string | undefined },
+    turnGate: TurnGate | null = null
   ): AsyncIterableIterator<SDKUserMessage> {
     const mode = ModeManager.getInstance().getActiveMode();
 
@@ -471,9 +524,10 @@ export class ClaudeProvider {
       promptType: isInitPrompt ? 'INIT' : 'CONTINUATION'
     });
 
+    const backfill = session.backfill ?? false;
     const initPrompt = isInitPrompt
-      ? buildInitPrompt(session.project, session.contentSessionId, session.userPrompt, mode)
-      : buildContinuationPrompt(session.userPrompt, session.lastPromptNumber, session.contentSessionId, mode);
+      ? buildInitPrompt(session.project, session.contentSessionId, session.userPrompt, mode, backfill)
+      : buildContinuationPrompt(session.userPrompt, session.lastPromptNumber, session.contentSessionId, mode, backfill);
 
     session.conversationHistory.push({ role: 'user', content: initPrompt });
 
@@ -510,7 +564,7 @@ export class ClaudeProvider {
           tool_output: JSON.stringify(message.tool_response),
           created_at_epoch: Date.now(),
           cwd: message.cwd
-        });
+        }, session.backfill ?? false);
 
         session.conversationHistory.push({ role: 'user', content: obsPrompt });
 
@@ -526,6 +580,14 @@ export class ClaudeProvider {
           parent_tool_use_id: null,
           isSynthetic: true
         };
+
+        // Backfill pacing: block until the consumer has processed this
+        // observation's turn before yielding the next, so each observation gets
+        // its own record/skip decision instead of being batch-confirmed. Only
+        // active for backfill; live never waits.
+        if (session.backfill && turnGate) {
+          await turnGate.wait();
+        }
       } else if (message.type === 'summarize') {
         const summaryPrompt = buildSummaryPrompt({
           id: session.sessionDbId,

--- a/src/services/worker/SessionManager.ts
+++ b/src/services/worker/SessionManager.ts
@@ -159,6 +159,12 @@ export class SessionManager {
       session = this.initializeSession(sessionDbId);
     }
 
+    // Backfill (#2690) is a session-level attribute: once any observation marks
+    // the session as backfill, generation uses historical framing + paced turns.
+    if (data.backfill) {
+      session.backfill = true;
+    }
+
     const message: PendingMessage = {
       type: 'observation',
       tool_name: data.tool_name,

--- a/src/services/worker/http/routes/TranscriptRoutes.ts
+++ b/src/services/worker/http/routes/TranscriptRoutes.ts
@@ -1,0 +1,58 @@
+import express, { Request, Response } from 'express';
+import { BaseRouteHandler } from '../BaseRouteHandler.js';
+import { DatabaseManager } from '../../DatabaseManager.js';
+import { TranscriptEventProcessor } from '../../../transcripts/processor.js';
+import { ingestSource, type IngestDeps } from '../../../transcripts/ingest.js';
+import { logger } from '../../../../utils/logger.js';
+
+/**
+ * Transcript backfill route (#2690). Runs the real, spending ingest INSIDE the
+ * worker process — the only place ingestObservation's context is set. The CLI
+ * is a thin client that POSTs here (mirroring how summaries reach the worker).
+ *
+ * Dry-run is intentionally NOT served here: it is pure parse + count with no
+ * model spend, so the CLI runs it client-side.
+ */
+export class TranscriptRoutes extends BaseRouteHandler {
+  constructor(private dbManager: DatabaseManager) {
+    super();
+  }
+
+  setupRoutes(app: express.Application): void {
+    app.post('/api/transcript/ingest', this.wrapHandler(this.handleIngest.bind(this)));
+  }
+
+  private sessionExists(contentSessionId: string): boolean {
+    const row = this.dbManager
+      .getSessionStore()
+      .db.prepare('SELECT 1 FROM sdk_sessions WHERE content_session_id = ? LIMIT 1')
+      .get(contentSessionId);
+    return row !== null && row !== undefined;
+  }
+
+  private async handleIngest(req: Request, res: Response): Promise<void> {
+    const body = (req.body ?? {}) as { source?: unknown; includeSubagents?: unknown };
+    const source = typeof body.source === 'string' ? body.source.trim() : '';
+    if (!source) {
+      this.badRequest(res, 'source is required');
+      return;
+    }
+    const includeSubagents = body.includeSubagents === true;
+
+    const deps: IngestDeps = {
+      processor: new TranscriptEventProcessor(),
+      sessionExists: id => this.sessionExists(id),
+    };
+
+    logger.info('TRANSCRIPT', 'Backfill ingest starting', { source, includeSubagents });
+    const report = await ingestSource(source, { includeSubagents }, deps);
+    logger.info('TRANSCRIPT', 'Backfill ingest complete', {
+      found: report.found,
+      ingested: report.ingested,
+      alreadyIndexed: report.alreadyIndexed,
+      failed: report.failed,
+    });
+
+    res.json(report);
+  }
+}

--- a/src/services/worker/http/routes/TranscriptRoutes.ts
+++ b/src/services/worker/http/routes/TranscriptRoutes.ts
@@ -40,7 +40,7 @@ export class TranscriptRoutes extends BaseRouteHandler {
     const includeSubagents = body.includeSubagents === true;
 
     const deps: IngestDeps = {
-      processor: new TranscriptEventProcessor(),
+      processor: new TranscriptEventProcessor({ backfill: true }),
       sessionExists: id => this.sessionExists(id),
     };
 

--- a/src/services/worker/http/shared.ts
+++ b/src/services/worker/http/shared.ts
@@ -84,6 +84,7 @@ export type IngestResult =
 
 export interface ObservationPayload {
   contentSessionId: string;
+  backfill?: boolean;
   toolName: string;
   toolInput: unknown;
   toolResponse: unknown;
@@ -159,6 +160,7 @@ export async function ingestObservation(payload: ObservationPayload): Promise<In
     : '{}';
 
   await sessionManager.queueObservation(sessionDbId, {
+    backfill: payload.backfill,
     tool_name: payload.toolName,
     tool_input: cleanedToolInput,
     tool_response: cleanedToolResponse,

--- a/tests/transcripts/claude-code-ingest.test.ts
+++ b/tests/transcripts/claude-code-ingest.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { scanSource, dryRunSource } from '../../src/services/transcripts/ingest.js';
+
+// #2690 backfill: scan enumerates parents + subagents, dry-run counts what a
+// real ingest would produce with zero Haiku spend.
+function line(obj: unknown): string {
+  return JSON.stringify(obj);
+}
+
+describe('ingest scan + dry-run', () => {
+  let root: string;
+  const parentId = '11111111-1111-1111-1111-111111111111';
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'cc-ingest-'));
+
+    // Parent session: 1 prompt, 1 assistant text + 2 tool_use, 2 tool_result.
+    writeFileSync(
+      join(root, `${parentId}.jsonl`),
+      [
+        line({ type: 'permission-mode', permissionMode: 'default' }),
+        line({ type: 'user', sessionId: parentId, cwd: '/repo', message: { content: 'do the thing' } }),
+        line({
+          type: 'assistant',
+          sessionId: parentId,
+          message: {
+            content: [
+              { type: 'text', text: 'on it' },
+              { type: 'tool_use', id: 't1', name: 'Read', input: { file_path: '/a' } },
+              { type: 'tool_use', id: 't2', name: 'Bash', input: { command: 'ls' } },
+            ],
+          },
+        }),
+        line({
+          type: 'user',
+          sessionId: parentId,
+          message: {
+            content: [
+              { type: 'tool_result', tool_use_id: 't1', content: 'aaa' },
+              { type: 'tool_result', tool_use_id: 't2', content: 'bbb' },
+            ],
+          },
+        }),
+        'this is not json',
+      ].join('\n') + '\n'
+    );
+
+    // Subagent for the parent: 1 tool_use.
+    const subDir = join(root, parentId, 'subagents');
+    mkdirSync(subDir, { recursive: true });
+    writeFileSync(
+      join(subDir, 'agent-aaa.jsonl'),
+      line({
+        type: 'assistant',
+        sessionId: parentId,
+        message: { content: [{ type: 'tool_use', id: 's1', name: 'Grep', input: { pattern: 'x' } }] },
+      }) + '\n'
+    );
+    writeFileSync(join(subDir, 'agent-aaa.meta.json'), line({ agentType: 'general-purpose', description: 'sub work' }));
+  });
+
+  afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+  it('scan finds the parent and excludes subagents by default', () => {
+    const refs = scanSource(root);
+    expect(refs).toHaveLength(1);
+    expect(refs[0].sessionId).toBe(parentId);
+    expect(refs[0].subagents).toHaveLength(0);
+  });
+
+  it('scan includes subagents (with meta) when requested', () => {
+    const refs = scanSource(root, { includeSubagents: true });
+    expect(refs[0].subagents).toHaveLength(1);
+    expect(refs[0].subagents[0]).toMatchObject({
+      sessionId: 'agent-aaa',
+      agentType: 'general-purpose',
+      description: 'sub work',
+    });
+  });
+
+  it('dry-run counts blocks and estimates Haiku calls (parent only)', () => {
+    const report = dryRunSource(root);
+    expect(report.totals.sessions).toBe(1);
+    const s = report.sessions[0];
+    expect(s.userPrompts).toBe(1);
+    expect(s.assistantTexts).toBe(1);
+    expect(s.toolUses).toBe(2);
+    expect(s.toolResults).toBe(2);
+    expect(s.parseFailures).toBe(1);
+    // 2 observations (tool_use) + 1 summary (the session)
+    expect(report.totals.estimatedObservations).toBe(2);
+    expect(report.totals.estimatedSummaries).toBe(1);
+    expect(report.totals.estimatedHaikuCalls).toBe(3);
+  });
+
+  it('dry-run with subagents adds the subagent session and its observation', () => {
+    const report = dryRunSource(root, { includeSubagents: true });
+    expect(report.totals.sessions).toBe(2);
+    // parent 2 + subagent 1 = 3 observations; 2 summaries → 5 Haiku calls
+    expect(report.totals.estimatedObservations).toBe(3);
+    expect(report.totals.estimatedSummaries).toBe(2);
+    expect(report.totals.estimatedHaikuCalls).toBe(5);
+    expect(report.sessions.some(s => s.isSubagent && s.sessionId === 'agent-aaa')).toBe(true);
+  });
+
+  it('scan rejects a missing source', () => {
+    expect(() => scanSource(join(root, 'nope'))).toThrow(/not found/);
+  });
+});

--- a/tests/transcripts/claude-code-ingest.test.ts
+++ b/tests/transcripts/claude-code-ingest.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { scanSource, dryRunSource } from '../../src/services/transcripts/ingest.js';
+import { scanSource, dryRunSource, ingestSource, type IngestProcessor } from '../../src/services/transcripts/ingest.js';
+import type { WatchTarget, TranscriptSchema } from '../../src/services/transcripts/types.js';
 
 // #2690 backfill: scan enumerates parents + subagents, dry-run counts what a
 // real ingest would produce with zero Haiku spend.
@@ -108,5 +109,61 @@ describe('ingest scan + dry-run', () => {
 
   it('scan rejects a missing source', () => {
     expect(() => scanSource(join(root, 'nope'))).toThrow(/not found/);
+  });
+
+  // Records every processEntry call so we can assert the orchestrator's behavior
+  // without a live worker.
+  interface Recorded {
+    entry: Record<string, unknown>;
+    override: string | null | undefined;
+    workspace?: string;
+  }
+  function fakeProcessor(): { proc: IngestProcessor; calls: Recorded[] } {
+    const calls: Recorded[] = [];
+    const proc: IngestProcessor = {
+      async processEntry(entry: unknown, watch: WatchTarget, _schema: TranscriptSchema, override?: string | null) {
+        calls.push({ entry: entry as Record<string, unknown>, override, workspace: watch.workspace });
+      },
+    };
+    return { proc, calls };
+  }
+
+  it('ingests a new parent, forces the content_session_id, and flushes session_end', async () => {
+    const { proc, calls } = fakeProcessor();
+    const report = await ingestSource(root, {}, { processor: proc, sessionExists: () => false });
+
+    expect(report.found).toBe(1);
+    expect(report.ingested).toBe(1);
+    expect(report.alreadyIndexed).toBe(0);
+    // every call overrides to the parent UUID, and per-event sessionId is stripped
+    expect(calls.every(c => c.override === parentId)).toBe(true);
+    expect(calls.every(c => c.entry.sessionId === undefined)).toBe(true);
+    // exactly one session_end, emitted last
+    const ends = calls.filter(c => c.entry.__cc === 'session_end');
+    expect(ends).toHaveLength(1);
+    expect(calls[calls.length - 1].entry.__cc).toBe('session_end');
+  });
+
+  it('skips a session whose content_session_id already exists', async () => {
+    const { proc, calls } = fakeProcessor();
+    const report = await ingestSource(root, {}, { processor: proc, sessionExists: () => true });
+
+    expect(report.found).toBe(1);
+    expect(report.ingested).toBe(0);
+    expect(report.alreadyIndexed).toBe(1);
+    expect(calls).toHaveLength(0); // nothing processed for a skipped session
+  });
+
+  it('subagents inherit the parent cwd and strip their own per-line cwd', async () => {
+    const { proc, calls } = fakeProcessor();
+    const report = await ingestSource(root, { includeSubagents: true }, { processor: proc, sessionExists: () => false });
+
+    expect(report.found).toBe(2);
+    expect(report.ingested).toBe(2);
+    const subCalls = calls.filter(c => c.override === 'agent-aaa');
+    expect(subCalls.length).toBeGreaterThan(0);
+    // forceCwd: the subagent's own cwd is removed so it falls back to parent (watch.workspace)
+    expect(subCalls.every(c => c.entry.cwd === undefined)).toBe(true);
+    expect(subCalls.every(c => c.workspace === '/repo')).toBe(true);
   });
 });

--- a/tests/transcripts/claude-code-normalizer.test.ts
+++ b/tests/transcripts/claude-code-normalizer.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'bun:test';
+import { normalizeClaudeCodeLine, CLAUDE_CODE_SCHEMA } from '../../src/services/transcripts/claude-code.js';
+import { matchesRule } from '../../src/services/transcripts/field-utils.js';
+
+// #2690: the generic schema DSL cannot fan out content-block arrays, so the
+// Claude Code normalizer flattens each JSONL line into one synthetic event per
+// block. These tests pin that fan-out and the schema routing.
+describe('normalizeClaudeCodeLine', () => {
+  it('maps a string user message to a single user_prompt', () => {
+    const events = normalizeClaudeCodeLine({
+      type: 'user',
+      sessionId: 's1',
+      cwd: '/repo',
+      timestamp: '2026-05-04T00:00:00Z',
+      message: { role: 'user', content: 'hello there' },
+    });
+    expect(events).toEqual([
+      { __cc: 'user_prompt', sessionId: 's1', cwd: '/repo', ts: '2026-05-04T00:00:00Z', prompt: 'hello there' },
+    ]);
+  });
+
+  it('maps a string assistant message to a single assistant_text', () => {
+    const events = normalizeClaudeCodeLine({
+      type: 'assistant',
+      sessionId: 's1',
+      message: { role: 'assistant', content: 'sure, here you go' },
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0].__cc).toBe('assistant_text');
+    expect(events[0].message).toBe('sure, here you go');
+  });
+
+  it('fans out an assistant line with text + multiple tool_use blocks', () => {
+    const events = normalizeClaudeCodeLine({
+      type: 'assistant',
+      sessionId: 's1',
+      cwd: '/repo',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'let me check two things' },
+          { type: 'tool_use', id: 't1', name: 'Read', input: { file_path: '/a' } },
+          { type: 'tool_use', id: 't2', name: 'Bash', input: { command: 'ls' } },
+        ],
+      },
+    });
+    expect(events.map(e => e.__cc)).toEqual(['assistant_text', 'tool_use', 'tool_use']);
+    expect(events[1]).toMatchObject({ toolId: 't1', toolName: 'Read', toolInput: { file_path: '/a' } });
+    expect(events[2]).toMatchObject({ toolId: 't2', toolName: 'Bash', toolInput: { command: 'ls' } });
+  });
+
+  it('fans out a user line carrying tool_result blocks (no spurious prompt)', () => {
+    const events = normalizeClaudeCodeLine({
+      type: 'user',
+      sessionId: 's1',
+      message: {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 't1', content: 'file contents' },
+          { type: 'tool_result', tool_use_id: 't2', content: 'a\nb' },
+        ],
+      },
+    });
+    expect(events.map(e => e.__cc)).toEqual(['tool_result', 'tool_result']);
+    expect(events[0]).toMatchObject({ toolId: 't1', toolResponse: 'file contents' });
+    // critically, no user_prompt was synthesized for a tool-result-only line
+    expect(events.some(e => e.__cc === 'user_prompt')).toBe(false);
+  });
+
+  it('ignores non-conversational line types and empty content', () => {
+    expect(normalizeClaudeCodeLine({ type: 'permission-mode', permissionMode: 'default' })).toEqual([]);
+    expect(normalizeClaudeCodeLine({ type: 'file-history-snapshot' })).toEqual([]);
+    expect(normalizeClaudeCodeLine({ type: 'attachment' })).toEqual([]);
+    expect(normalizeClaudeCodeLine({ type: 'system' })).toEqual([]);
+    expect(normalizeClaudeCodeLine({ type: 'user', message: { content: '   ' } })).toEqual([]);
+    expect(normalizeClaudeCodeLine(null)).toEqual([]);
+    expect(normalizeClaudeCodeLine('not an object')).toEqual([]);
+  });
+
+  it('skips unknown block types (thinking/image) but keeps siblings', () => {
+    const events = normalizeClaudeCodeLine({
+      type: 'assistant',
+      sessionId: 's1',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'hmm' },
+          { type: 'text', text: 'done' },
+        ],
+      },
+    });
+    expect(events.map(e => e.__cc)).toEqual(['assistant_text']);
+  });
+});
+
+describe('CLAUDE_CODE_SCHEMA routing', () => {
+  // Each flat event must match exactly one schema event, routing to the right action.
+  const route = (cc: string) =>
+    CLAUDE_CODE_SCHEMA.events.filter(ev => matchesRule({ __cc: cc }, ev.match, CLAUDE_CODE_SCHEMA));
+
+  it('routes each synthetic type to a single, correct action', () => {
+    expect(route('user_prompt').map(e => e.action)).toEqual(['session_init']);
+    expect(route('assistant_text').map(e => e.action)).toEqual(['assistant_message']);
+    expect(route('tool_use').map(e => e.action)).toEqual(['tool_use']);
+    expect(route('tool_result').map(e => e.action)).toEqual(['tool_result']);
+  });
+
+  it('is keyed on __cc so foreign lines never match', () => {
+    expect(route('something_else')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What
Adds `claude-mem transcript ingest` — imports historical Claude Code session
JSONL (`~/.claude/projects/<encoded-cwd>/*.jsonl`) into memory, so pre-install
or unwatched-project history becomes searchable. Implements #2690.

## How
- `transcripts/claude-code.ts` — JSONL normalizer + schema for Claude Code sessions.
- `transcripts/ingest.ts` — `scanSource`/`dryRunSource` (client-side, spend-free) +
  a worker-driven `ingestSource` orchestrator with `session_end`.
- Dry-run gives a per-session + total observation/summary count and a token/cost
  estimate (explicit, tunable; input is a floor) so you see spend before running.
- `transcript ingest --source <dir|file> [--dry-run] [--include-subagents]`,
  worker route `POST /api/transcript/ingest`.
- Generation uses *historical framing* + paced turns (`buildObservationPrompt(obs, backfill)`,
  ClaudeProvider/SessionManager) so replayed tool uses are recorded as past work.
- Content-hash dedup → re-running the same backfill reports `already-indexed`. (Caveat documented: dedup is on generated-text hash, so it does NOT dedupe against sessions already captured live — backfill is for history claude-mem never saw, not re-importing live-observed sessions.)

## Testing
- `bun test tests/transcripts/` → 44 pass
- `tsc --noEmit` clean
- Live **dry-run** on 47 real Claude Code session transcripts: full scan + parse + per-session counts + token/cost estimate, no spend. Works end to end.
- The **spending** generation path (real `ingestObservation` over the worker) has unit coverage but is not exercised live here, it's the long/metered backfill run, not a CI-friendly operation.

Note: `main` currently has pre-existing unrelated red CI.
