### PR TITLE
feat: add 'claude' as alias for 'claude-code' platform

### DIFF
--- a/src/cli/adapters/index.ts
+++ b/src/cli/adapters/index.ts
@@ -8,6 +8,7 @@ import { windsurfAdapter } from './windsurf.js';
 
 export function getPlatformAdapter(platform: string): PlatformAdapter {
   switch (platform) {
+    case 'claude':
     case 'claude-code': return claudeCodeAdapter;
     case 'codex': return codexAdapter;
     case 'cursor': return cursorAdapter;

--- a/src/npx-cli/commands/ide-detection.ts
+++ b/src/npx-cli/commands/ide-detection.ts
@@ -44,7 +44,7 @@ export function detectInstalledIDEs(): IDEInfo[] {
     {
       id: 'claude-code',
       label: 'Claude Code',
-      detected: isCommandInPath('claude'),
+      detected: isCommandInPath('claude') || isCommandInPath('claude-code'),
       supported: true,
       hint: 'recommended',
     },

--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -184,6 +184,7 @@ function makeIDETask(ideId: string, summary: InstallSummary): TaskDescriptor | n
   };
 
   switch (ideId) {
+    case 'claude':
     case 'claude-code': {
       return {
         title: 'Claude Code: registering plugin',


### PR DESCRIPTION
## Summary

- Adds `case 'claude':` in `getPlatformAdapter` so hook commands like `hook claude observation` route to the same adapter as `hook claude-code`
- Adds `case 'claude':` in `makeIDETask` so `npx claude-mem install --ide claude` works identically to `--ide claude-code`
- Extends `claude-code` IDE detection to also check for `claude-code` binary in PATH (in addition to `claude`)

## Motivation

The Claude Code CLI binary is named `claude`, so many users naturally try `--ide claude`. Currently that falls through to the `raw` adapter. This PR makes `claude` a first-class alias so the install and hook pipeline work without knowing the internal `claude-code` ID.

## Test plan

- [ ] `npx claude-mem install --ide claude` completes successfully
- [ ] Hook command `hook claude observation` resolves to `claudeCodeAdapter` 
- [ ] Existing `--ide claude-code` behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)