### PR TITLE
fix(chroma): spawn uvx directly on Windows instead of via cmd.exe

### DIFF
--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -43,23 +43,13 @@ const CHROMA_MCP_DEP_OVERRIDES: ReadonlyArray<string> = [
   'protobuf<7',
 ];
 
-// Issue #2696: on Windows the chroma-mcp subprocess is spawned via
-// `cmd.exe /c uvx ...`. cmd.exe interprets `<`, `>`, `|`, `&`, `^`, and `(` `)`
-// as shell metacharacters BEFORE uvx ever sees them, so a dep-override spec
-// like `protobuf<7` is parsed as an input redirection (`protobuf < 7`) and the
-// command line breaks. Node's spawn arg-quoting only quotes args containing
-// spaces/quotes, not these cmd.exe operators, so we must wrap any arg that
-// contains one in double quotes ourselves. Args without metacharacters are
-// returned unchanged so the normal command line is byte-identical to before.
-const CMD_EXE_METACHARACTERS = /[<>|&^()]/;
-export function quoteForCmdExe(arg: string): string {
-  if (!CMD_EXE_METACHARACTERS.test(arg)) {
-    return arg;
-  }
-  // Escape any embedded double quotes, then wrap. Inside double quotes cmd.exe
-  // does not perform redirection/grouping on these metacharacters.
-  return `"${arg.replace(/"/g, '\\"')}"`;
-}
+// Issue #2696 (revised): chroma-mcp is now spawned by invoking uvx DIRECTLY on
+// every platform — see ChromaMcpManager.resolveUvxCommand(). The previous
+// `cmd.exe /c uvx ...` path, and the cmd.exe metacharacter-quoting helper that
+// went with it, were removed: even with the dep-override specs wrapped in double
+// quotes, Node's child_process arg-quoting for cmd.exe re-mangled the `>`/`<` in
+// `onnxruntime>=1.20` / `protobuf<7`, so cmd.exe parsed them as redirection and
+// died with "The directory name is invalid" in ~10ms — killing semantic search.
 
 export class ChromaMcpManager {
   private static instance: ChromaMcpManager | null = null;
@@ -123,11 +113,13 @@ export class ChromaMcpManager {
     const spawnEnvironment = this.getSpawnEnv();
     getSupervisor().assertCanSpawn('chroma mcp');
 
-    const isWindows = process.platform === 'win32';
-    const uvxSpawnCommand = isWindows ? (process.env.ComSpec || 'cmd.exe') : 'uvx';
-    const uvxSpawnArgs = isWindows
-      ? ['/c', 'uvx', ...commandArgs.map(quoteForCmdExe)]
-      : commandArgs;
+    // Spawn uvx DIRECTLY (no `cmd.exe /c` shell). On Windows, routing through
+    // cmd.exe makes it parse the `>`/`<` in the dep-override specs as shell
+    // redirection before uvx sees them; a shell-less spawn passes them literally.
+    // resolveUvxCommand returns the absolute uvx.exe path on Windows (Node won't
+    // PATHEXT-resolve a bare `uvx`) and bare `uvx` elsewhere (#2696).
+    const uvxSpawnCommand = ChromaMcpManager.resolveUvxCommand();
+    const uvxSpawnArgs = commandArgs;
 
     logger.info('CHROMA_MCP', 'Connecting to chroma-mcp via MCP stdio', {
       command: uvxSpawnCommand,
@@ -689,6 +681,49 @@ export class ChromaMcpManager {
         return d;
       }
     });
+  }
+
+  /**
+   * Resolve the command used to launch uvx.
+   *
+   * On Windows we MUST spawn uvx.exe DIRECTLY rather than via `cmd.exe /c uvx`:
+   * cmd.exe parses the `>`/`<` in the dep-override specs (onnxruntime>=1.20,
+   * protobuf<7) as shell redirection before uvx sees them, and Node's
+   * child_process arg-quoting for cmd.exe re-mangles even pre-quoted args, so
+   * cmd.exe dies with "The directory name is invalid" in ~10ms. The MCP
+   * transport then reports "Connection closed", the manager backs off, and
+   * semantic search silently degrades to keyword-only (#2696 follow-up).
+   *
+   * Node's shell-less spawn won't resolve a bare `uvx` via PATHEXT on Windows,
+   * so we resolve the absolute path to uvx.exe from the same uv bin dirs that
+   * ensureUvOnPath() adds to the child PATH (honouring CLAUDE_MEM_CHROMA_UVX_PATH
+   * when it points straight at a binary), falling back to bare 'uvx.exe'.
+   */
+  static resolveUvxCommand(platform: NodeJS.Platform = process.platform): string {
+    if (platform !== 'win32') {
+      return 'uvx';
+    }
+    const override = process.env.CLAUDE_MEM_CHROMA_UVX_PATH;
+    if (override) {
+      try {
+        if (fs.existsSync(override) && fs.statSync(override).isFile()) {
+          return override;
+        }
+      } catch {
+        // fall through to scanning the known uv bin dirs
+      }
+    }
+    for (const dir of ChromaMcpManager.uvBinDirs()) {
+      const candidate = path.join(dir, 'uvx.exe');
+      try {
+        if (fs.existsSync(candidate)) {
+          return candidate;
+        }
+      } catch {
+        // ignore and try the next candidate
+      }
+    }
+    return 'uvx.exe';
   }
 
   private static ensureUvOnPath(env: Record<string, string>): void {

--- a/tests/services/integrations/spawn-contract-windows.test.ts
+++ b/tests/services/integrations/spawn-contract-windows.test.ts
@@ -1,46 +1,39 @@
 import { describe, it, expect } from 'bun:test';
-import { quoteForCmdExe } from '../../../src/services/sync/ChromaMcpManager.js';
+import { ChromaMcpManager } from '../../../src/services/sync/ChromaMcpManager.js';
 import { codexSpawn } from '../../../src/services/integrations/CodexCliInstaller.js';
 
-// Windows spawn-contract fixes folded into plans/02-spawn-contract-templating.md:
-//   #2696 — ChromaDB MCP subprocess: unquoted `protobuf<7` in cmd.exe /c
+// Windows spawn-contract fixes:
+//   #2696 — ChromaDB MCP subprocess: spawn uvx.exe DIRECTLY, never `cmd.exe /c uvx`.
+//           cmd.exe parses the `>`/`<` in the dep-override specs (onnxruntime>=1.20,
+//           protobuf<7) as shell redirection — even pre-quoted, Node's cmd.exe
+//           arg-quoting re-mangles them — so cmd.exe dies with "The directory name
+//           is invalid" and semantic search silently degrades to keyword-only.
 //   #2695 — Codex CLI: spawnSync ENOENT for codex.cmd
 
-describe('Windows #2696 - cmd.exe metacharacter quoting for chroma-mcp deps', () => {
-  it('quotes dep specs containing cmd.exe redirection operators', () => {
-    expect(quoteForCmdExe('protobuf<7')).toBe('"protobuf<7"');
-    expect(quoteForCmdExe('onnxruntime>=1.20')).toBe('"onnxruntime>=1.20"');
+describe('Windows #2696 - chroma-mcp spawns uvx directly (never cmd.exe)', () => {
+  it('resolves a uvx.exe command on Windows — never cmd.exe', () => {
+    const command = ChromaMcpManager.resolveUvxCommand('win32');
+    expect(command.toLowerCase()).not.toContain('cmd.exe');
+    expect(command.toLowerCase().endsWith('uvx.exe')).toBe(true);
   });
 
-  it('leaves ordinary args (no metacharacters) byte-identical', () => {
-    expect(quoteForCmdExe('--with')).toBe('--with');
-    expect(quoteForCmdExe('--python')).toBe('--python');
-    expect(quoteForCmdExe('3.13')).toBe('3.13');
-    expect(quoteForCmdExe('chroma-mcp==0.2.6')).toBe('chroma-mcp==0.2.6');
-    expect(quoteForCmdExe('--client-type')).toBe('--client-type');
-    expect(quoteForCmdExe('persistent')).toBe('persistent');
+  it('uses a bare `uvx` on non-Windows platforms', () => {
+    expect(ChromaMcpManager.resolveUvxCommand('linux')).toBe('uvx');
+    expect(ChromaMcpManager.resolveUvxCommand('darwin')).toBe('uvx');
   });
 
-  it('quotes pipe/ampersand/caret/paren metacharacters too', () => {
-    expect(quoteForCmdExe('a|b')).toBe('"a|b"');
-    expect(quoteForCmdExe('a&b')).toBe('"a&b"');
-    expect(quoteForCmdExe('a^b')).toBe('"a^b"');
-    expect(quoteForCmdExe('a(b)')).toBe('"a(b)"');
-  });
-
-  it('escapes embedded double quotes before wrapping', () => {
-    expect(quoteForCmdExe('a"<b')).toBe('"a\\"<b"');
-  });
-
-  it('the actual chroma dep-override specs become cmd.exe-safe', () => {
-    // These are the exact specs the manager passes through cmd.exe /c uvx ...
-    const specs = ['onnxruntime>=1.20', 'protobuf<7'];
-    for (const spec of specs) {
-      const quoted = quoteForCmdExe(spec);
-      expect(quoted.startsWith('"')).toBe(true);
-      expect(quoted.endsWith('"')).toBe(true);
-      // The inner content is preserved so uvx still sees the real spec.
-      expect(quoted.slice(1, -1)).toBe(spec);
+  it('honours CLAUDE_MEM_CHROMA_UVX_PATH when it points at a real binary', () => {
+    const previous = process.env.CLAUDE_MEM_CHROMA_UVX_PATH;
+    // process.execPath is guaranteed to exist and be a file (the bun/node binary).
+    process.env.CLAUDE_MEM_CHROMA_UVX_PATH = process.execPath;
+    try {
+      expect(ChromaMcpManager.resolveUvxCommand('win32')).toBe(process.execPath);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.CLAUDE_MEM_CHROMA_UVX_PATH;
+      } else {
+        process.env.CLAUDE_MEM_CHROMA_UVX_PATH = previous;
+      }
     }
   });
 });


### PR DESCRIPTION
# fix(chroma): spawn uvx directly on Windows instead of via `cmd.exe`

## Summary

On Windows, semantic (Chroma) search silently degrades to keyword-only. The
`chroma-mcp` subprocess never connects — the deep probe sits in a perpetual
`Connection closed` → 10s-backoff loop — so every query falls back to SQLite
keyword search with no error surfaced to the user.

## Root cause

`ChromaMcpManager.connectInternal()` spawns `chroma-mcp` on Windows via:

```
cmd.exe /c uvx --python 3.13 --with onnxruntime>=1.20 --with protobuf<7 chroma-mcp==0.2.6 ...
```

`cmd.exe` interprets the `>` / `<` in the dep-override specs (`onnxruntime>=1.20`,
`protobuf<7`) as **shell redirection**. The existing #2696 fix wraps those args in
double quotes (`quoteForCmdExe`), but `StdioClientTransport` spawns through
Node's `child_process`, whose Windows cmd.exe **arg-quoting re-mangles the
already-quoted specs**. `cmd.exe` then parses `>` as a redirect to an invalid
target and exits in **~10 ms** with `The directory name is invalid.`

The MCP transport reports `Connection closed` (MCP error -32000); the manager
records a connection failure and enters its `RECONNECT_BACKOFF_MS` (10s) loop.
Result: `connected:false` forever, keyword-only fallback.

### Reproduction (Node, mirroring StdioClientTransport's spawn)

```js
spawn('cmd.exe',
  ['/c','uvx','--python','3.13','--with','"onnxruntime>=1.20"','--with','"protobuf<7"',
   'chroma-mcp==0.2.6','--client-type','persistent','--data-dir', dataDir],
  { stdio: ['pipe','pipe','pipe'] });
// -> [9ms] EXIT code=1   STDERR: "The directory name is invalid."
```

The same args spawned **directly against `uvx.exe`** (no `cmd.exe`) start the
server normally and stay alive.

## Fix

Spawn `uvx` **directly** (no `cmd.exe /c` shell) on every platform. With no
shell, `>` / `<` are passed through literally and never interpreted.

Because Node's shell-less spawn does not PATHEXT-resolve a bare `uvx` on Windows,
a new `ChromaMcpManager.resolveUvxCommand()` resolves the **absolute `uvx.exe`
path** from the same uv bin dirs `ensureUvOnPath()` already uses (and honours
`CLAUDE_MEM_CHROMA_UVX_PATH` when it points straight at a binary), falling back
to bare `uvx.exe`. On non-Windows it returns bare `uvx` (unchanged behaviour).

The now-obsolete `quoteForCmdExe` / `CMD_EXE_METACHARACTERS` helper is removed,
and its Windows spawn-contract test is rewritten to assert the new invariant:
**the command resolves to `uvx.exe`, never `cmd.exe`.**

## Verification

- **Windows 11** (uv 0.11.18, Python 3.13, chroma-mcp 0.2.6): with this change
  the deep probe goes from the perpetual `Connection closed` backoff to
  `{"status":"healthy","connected":true,"probe":{"ok":true,"stage":"done"}}`
  (connect → list → query round-trip), and the `mem-search` MCP tool returns
  semantic results instead of the keyword fallback.
- `bun test tests/services/integrations/spawn-contract-windows.test.ts` → 4 pass.
- `tsc --noEmit` → clean.

## Files changed

- `src/services/sync/ChromaMcpManager.ts` — add `resolveUvxCommand()`; spawn uvx
  directly with raw args; remove `quoteForCmdExe` / `CMD_EXE_METACHARACTERS`.
- `tests/services/integrations/spawn-contract-windows.test.ts` — rewrite the
  #2696 block to assert the direct-uvx-spawn contract (the #2695 codex test is
  unchanged).
