### PR TITLE
fix(observer): accept prose-empty acknowledgements without poison respawn (closes #2817)

### DIFF
--- a/src/services/worker/agents/ResponseProcessor.ts
+++ b/src/services/worker/agents/ResponseProcessor.ts
@@ -24,6 +24,51 @@ import { telemetryBuffer } from '../../telemetry/buffer.js';
  */
 export const INVALID_OUTPUT_RESPAWN_THRESHOLD = 3;
 
+const MAX_EMPTY_ACK_LENGTH = 200;
+const EMPTY_ACK_PREFIXES = [
+  'no observations to record',
+  'no new observations to record',
+  'no observations found',
+  'no new observations found',
+  'no observations',
+  'no new observations',
+] as const;
+const EMPTY_ACK_CONTENT_SIGNAL = /\b(?:but|however|although|except|identified|discovered|learned|recorded|captured|stored|noted|issue|bug|fix|error|failure)\b/;
+
+function hasEmptyAckPrefix(normalized: string, prefix: string): boolean {
+  return normalized === prefix ||
+    normalized.startsWith(`${prefix} `) ||
+    normalized.startsWith(`${prefix}.`) ||
+    normalized.startsWith(`${prefix}!`) ||
+    normalized.startsWith(`${prefix}-`) ||
+    normalized.startsWith(`${prefix} -`) ||
+    normalized.startsWith(`${prefix} —`) ||
+    normalized.startsWith(`${prefix} –`);
+}
+
+function isRecognizedEmptyObserverAck(text: string, outputClass: ReturnType<typeof classifyObserverOutput>): boolean {
+  if (outputClass === 'idle') {
+    return true;
+  }
+
+  if (outputClass !== 'prose') {
+    return false;
+  }
+
+  const normalized = text.trim().toLowerCase();
+  if (normalized.length === 0 || normalized.length > MAX_EMPTY_ACK_LENGTH) {
+    return false;
+  }
+
+  const matchedPrefix = EMPTY_ACK_PREFIXES.find(prefix => hasEmptyAckPrefix(normalized, prefix));
+  if (!matchedPrefix) {
+    return false;
+  }
+
+  const remainder = normalized.slice(matchedPrefix.length);
+  return !EMPTY_ACK_CONTENT_SIGNAL.test(remainder);
+}
+
 export async function processAgentResponse(
   text: string,
   session: ActiveSession,
@@ -57,6 +102,24 @@ export async function processAgentResponse(
     // (plan-11, #2485). Attach a preview for diagnostics.
     const outputClass = classifyObserverOutput(text);
     const preview = previewOutput(text);
+    const recognizedEmptyAck = isRecognizedEmptyObserverAck(text, outputClass);
+
+    if (recognizedEmptyAck) {
+      // Treat recognized empty acknowledgements as healthy output so a long
+      // run of valid no-op responses does not preserve stale respawn debt.
+      session.consecutiveInvalidOutputs = 0;
+
+      logger.warn('PARSER', `${agentName} returned non-XML empty-ack ${outputClass} response, confirming claimed batch without respawn`, {
+        sessionId: session.sessionDbId,
+        outputClass,
+        preview,
+        consecutiveInvalidOutputs: session.consecutiveInvalidOutputs,
+      });
+
+      await sessionManager.confirmClaimedMessages(session.sessionDbId);
+      session.earliestPendingTimestamp = null;
+      return;
+    }
 
     session.consecutiveInvalidOutputs = (session.consecutiveInvalidOutputs ?? 0) + 1;
 

--- a/src/services/worker/agents/ResponseProcessor.ts
+++ b/src/services/worker/agents/ResponseProcessor.ts
@@ -34,16 +34,52 @@ const EMPTY_ACK_PREFIXES = [
   'no new observations',
 ] as const;
 const EMPTY_ACK_CONTENT_SIGNAL = /\b(?:but|however|although|except|identified|discovered|learned|recorded|captured|stored|noted|issue|bug|fix|error|failure)\b/;
+const EMPTY_ACK_NEUTRAL_REMAINDER_WORDS = new Set([
+  'at',
+  'this',
+  'time',
+  'for',
+  'batch',
+  'investigation',
+  'not',
+  'yet',
+  'started',
+  'no',
+  'tool',
+  'executions',
+  'or',
+  'technical',
+  'findings',
+  'have',
+  'been',
+  'provided',
+]);
 
 function hasEmptyAckPrefix(normalized: string, prefix: string): boolean {
-  return normalized === prefix ||
-    normalized.startsWith(`${prefix} `) ||
-    normalized.startsWith(`${prefix}.`) ||
-    normalized.startsWith(`${prefix}!`) ||
-    normalized.startsWith(`${prefix}-`) ||
-    normalized.startsWith(`${prefix} -`) ||
-    normalized.startsWith(`${prefix} —`) ||
-    normalized.startsWith(`${prefix} –`);
+  if (normalized === prefix) {
+    return true;
+  }
+
+  if (!normalized.startsWith(prefix)) {
+    return false;
+  }
+
+  const nextChar = normalized.charAt(prefix.length);
+  return /[\s.,!?:;\-—–]/.test(nextChar);
+}
+
+function isNeutralEmptyAckRemainder(remainder: string): boolean {
+  const stripped = remainder.replace(/^[\s.,!?:;\-—–]+/, '').trim();
+  if (stripped.length === 0) {
+    return true;
+  }
+
+  const words = stripped.match(/[a-z]+/g);
+  if (!words || words.length === 0) {
+    return true;
+  }
+
+  return words.every(word => EMPTY_ACK_NEUTRAL_REMAINDER_WORDS.has(word));
 }
 
 function isRecognizedEmptyObserverAck(text: string, outputClass: ReturnType<typeof classifyObserverOutput>): boolean {
@@ -66,7 +102,8 @@ function isRecognizedEmptyObserverAck(text: string, outputClass: ReturnType<type
   }
 
   const remainder = normalized.slice(matchedPrefix.length);
-  return !EMPTY_ACK_CONTENT_SIGNAL.test(remainder);
+  return !EMPTY_ACK_CONTENT_SIGNAL.test(remainder) &&
+    isNeutralEmptyAckRemainder(remainder);
 }
 
 export async function processAgentResponse(

--- a/tests/worker/agents/response-processor.test.ts
+++ b/tests/worker/agents/response-processor.test.ts
@@ -378,6 +378,8 @@ describe('ResponseProcessor', () => {
       const examples = [
         'No observations, but I found a stale cache bug.',
         'No observations to record, however I identified an error in the worker.',
+        'No observations to record, the auth module looks clean.',
+        'No observations to record since exploration is early, but I noticed an auth risk.',
       ];
 
       for (const responseText of examples) {

--- a/tests/worker/agents/response-processor.test.ts
+++ b/tests/worker/agents/response-processor.test.ts
@@ -238,6 +238,257 @@ describe('ResponseProcessor', () => {
       expect(session.earliestPendingTimestamp).toBeNull();
       expect(mockStoreObservations).not.toHaveBeenCalled();
     });
+
+    it('treats recognized empty-result prose as a valid no-op and clears invalid output debt', async () => {
+      const confirmClaimedMessages = mock(() => Promise.resolve(0));
+      mockSessionManager = {
+        getMessageIterator: async function* () { yield* []; },
+        getPendingMessageStore: () => ({ confirmProcessed: mock(() => {}) }),
+        confirmClaimedMessages,
+      } as unknown as SessionManager;
+
+      const session = createMockSession({
+        consecutiveInvalidOutputs: 2,
+      });
+      const responseText = 'No observations to record at this time.';
+
+      await processAgentResponse(
+        responseText,
+        session,
+        mockDbManager,
+        mockSessionManager,
+        mockWorker,
+        100,
+        null,
+        'TestAgent'
+      );
+
+      expect(confirmClaimedMessages).toHaveBeenCalledWith(1);
+      expect(session.consecutiveInvalidOutputs).toBe(0);
+      expect(session.earliestPendingTimestamp).toBeNull();
+      expect(mockStoreObservations).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        'PARSER',
+        expect.stringMatching(/^TestAgent returned non-XML empty-ack prose response/),
+        expect.objectContaining({ sessionId: 1, outputClass: 'prose' })
+      );
+    });
+
+    it('accepts the issue-reported no-observations variants as valid empty acknowledgements', async () => {
+      const confirmClaimedMessages = mock(() => Promise.resolve(0));
+      mockSessionManager = {
+        getMessageIterator: async function* () { yield* []; },
+        getPendingMessageStore: () => ({ confirmProcessed: mock(() => {}) }),
+        confirmClaimedMessages,
+      } as unknown as SessionManager;
+
+      const examples = [
+        'No observations to record at this time.',
+        'no observations - investigation not yet started',
+        'No observations to record — no tool executions or technical findings… have been provided yet.',
+      ];
+
+      for (const responseText of examples) {
+        const session = createMockSession({
+          consecutiveInvalidOutputs: 2,
+        });
+
+        await processAgentResponse(
+          responseText,
+          session,
+          mockDbManager,
+          mockSessionManager,
+          mockWorker,
+          100,
+          null,
+          'TestAgent'
+        );
+
+        expect(confirmClaimedMessages).toHaveBeenCalledWith(1);
+        expect(session.consecutiveInvalidOutputs).toBe(0);
+      }
+    });
+
+    it('rejects empty acknowledgements longer than 200 chars that start with no observations', async () => {
+      const confirmClaimedMessages = mock(() => Promise.resolve(0));
+      mockSessionManager = {
+        getMessageIterator: async function* () { yield* []; },
+        getPendingMessageStore: () => ({ confirmProcessed: mock(() => {}) }),
+        confirmClaimedMessages,
+      } as unknown as SessionManager;
+
+      const session = createMockSession({
+        consecutiveInvalidOutputs: 1,
+      });
+      const longText = 'No observations ' + 'x'.repeat(200);
+
+      await processAgentResponse(
+        longText,
+        session,
+        mockDbManager,
+        mockSessionManager,
+        mockWorker,
+        100,
+        null,
+        'TestAgent'
+      );
+
+      expect(session.consecutiveInvalidOutputs).toBe(2);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'PARSER',
+        expect.stringMatching(/^TestAgent returned non-XML prose response/),
+        expect.objectContaining({ sessionId: 1, outputClass: 'prose' })
+      );
+    });
+
+    it('rejects prose starting with observations found', async () => {
+      const confirmClaimedMessages = mock(() => Promise.resolve(0));
+      mockSessionManager = {
+        getMessageIterator: async function* () { yield* []; },
+        getPendingMessageStore: () => ({ confirmProcessed: mock(() => {}) }),
+        confirmClaimedMessages,
+      } as unknown as SessionManager;
+
+      const session = createMockSession({
+        consecutiveInvalidOutputs: 1,
+      });
+
+      await processAgentResponse(
+        'I found 3 observations to record.',
+        session,
+        mockDbManager,
+        mockSessionManager,
+        mockWorker,
+        100,
+        null,
+        'TestAgent'
+      );
+
+      expect(session.consecutiveInvalidOutputs).toBe(2);
+    });
+
+    it('rejects ack-prefixed prose that contains substantive findings', async () => {
+      const confirmClaimedMessages = mock(() => Promise.resolve(0));
+      mockSessionManager = {
+        getMessageIterator: async function* () { yield* []; },
+        getPendingMessageStore: () => ({ confirmProcessed: mock(() => {}) }),
+        confirmClaimedMessages,
+      } as unknown as SessionManager;
+
+      const examples = [
+        'No observations, but I found a stale cache bug.',
+        'No observations to record, however I identified an error in the worker.',
+      ];
+
+      for (const responseText of examples) {
+        const session = createMockSession({
+          consecutiveInvalidOutputs: 1,
+        });
+
+        await processAgentResponse(
+          responseText,
+          session,
+          mockDbManager,
+          mockSessionManager,
+          mockWorker,
+          100,
+          null,
+          'TestAgent'
+        );
+
+        expect(session.consecutiveInvalidOutputs).toBe(2);
+      }
+    });
+
+    it('still counts unrecognized prose toward the invalid-output threshold', async () => {
+      const confirmClaimedMessages = mock(() => Promise.resolve(0));
+      mockSessionManager = {
+        getMessageIterator: async function* () { yield* []; },
+        getPendingMessageStore: () => ({ confirmProcessed: mock(() => {}) }),
+        confirmClaimedMessages,
+      } as unknown as SessionManager;
+
+      const session = createMockSession({
+        consecutiveInvalidOutputs: 1,
+      });
+      const responseText = 'I spent a while thinking about it and have a few ideas.';
+
+      await processAgentResponse(
+        responseText,
+        session,
+        mockDbManager,
+        mockSessionManager,
+        mockWorker,
+        100,
+        null,
+        'TestAgent'
+      );
+
+      expect(confirmClaimedMessages).toHaveBeenCalledWith(1);
+      expect(session.consecutiveInvalidOutputs).toBe(2);
+    });
+
+    it('treats idle outputs as valid no-ops and clears invalid output debt', async () => {
+      const confirmClaimedMessages = mock(() => Promise.resolve(0));
+      mockSessionManager = {
+        getMessageIterator: async function* () { yield* []; },
+        getPendingMessageStore: () => ({ confirmProcessed: mock(() => {}) }),
+        confirmClaimedMessages,
+      } as unknown as SessionManager;
+
+      const session = createMockSession({
+        consecutiveInvalidOutputs: 2,
+      });
+
+      await processAgentResponse(
+        '',
+        session,
+        mockDbManager,
+        mockSessionManager,
+        mockWorker,
+        100,
+        null,
+        'TestAgent'
+      );
+
+      expect(confirmClaimedMessages).toHaveBeenCalledWith(1);
+      expect(session.consecutiveInvalidOutputs).toBe(0);
+      expect(session.earliestPendingTimestamp).toBeNull();
+      expect(mockStoreObservations).not.toHaveBeenCalled();
+    });
+
+    it('does reject prose that does not start with no observations', async () => {
+      const confirmClaimedMessages = mock(() => Promise.resolve(0));
+      mockSessionManager = {
+        getMessageIterator: async function* () { yield* []; },
+        getPendingMessageStore: () => ({ confirmProcessed: mock(() => {}) }),
+        confirmClaimedMessages,
+      } as unknown as SessionManager;
+
+      const session = createMockSession({
+        consecutiveInvalidOutputs: 1,
+      });
+      const responseText = 'I noticed a null-pointer risk while mapping dependencies.';
+
+      await processAgentResponse(
+        responseText,
+        session,
+        mockDbManager,
+        mockSessionManager,
+        mockWorker,
+        100,
+        null,
+        'TestAgent'
+      );
+
+      expect(confirmClaimedMessages).toHaveBeenCalledWith(1);
+      expect(session.consecutiveInvalidOutputs).toBe(2);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'PARSER',
+        expect.stringMatching(/^TestAgent returned non-XML prose response/),
+        expect.objectContaining({ sessionId: 1, outputClass: 'prose' })
+      );
+    });
   });
 
   describe('parsing summary from XML response', () => {

--- a/tests/worker/poison-respawn.test.ts
+++ b/tests/worker/poison-respawn.test.ts
@@ -140,6 +140,44 @@ describe('poison respawn (plan-11 #2485)', () => {
     expect(respawnSpy).toHaveBeenCalledWith(2);
   });
 
+  it('does not respawn on repeated recognized empty-result acknowledgements', async () => {
+    const sm = new SessionManager(makeDbManager());
+    const session = sm.initializeSession(4, 'do the thing', 1);
+    session.memorySessionId = 'mem-4';
+    session.consecutiveInvalidOutputs = INVALID_OUTPUT_RESPAWN_THRESHOLD - 1;
+
+    const respawnSpy = spyOn(sm, 'respawnPoisonedSession');
+
+    for (let i = 0; i < INVALID_OUTPUT_RESPAWN_THRESHOLD + 1; i++) {
+      await processAgentResponse(
+        'No observations to record for this batch.',
+        session, makeDbManager(), sm, mockWorker, 0, null, 'TestAgent'
+      );
+    }
+
+    expect(respawnSpy).not.toHaveBeenCalled();
+    expect(session.consecutiveInvalidOutputs).toBe(0);
+  });
+
+  it('does not respawn on repeated idle outputs', async () => {
+    const sm = new SessionManager(makeDbManager());
+    const session = sm.initializeSession(5, 'do the thing', 1);
+    session.memorySessionId = 'mem-5';
+    session.consecutiveInvalidOutputs = INVALID_OUTPUT_RESPAWN_THRESHOLD - 1;
+
+    const respawnSpy = spyOn(sm, 'respawnPoisonedSession');
+
+    for (let i = 0; i < INVALID_OUTPUT_RESPAWN_THRESHOLD + 1; i++) {
+      await processAgentResponse(
+        '',
+        session, makeDbManager(), sm, mockWorker, 0, null, 'TestAgent'
+      );
+    }
+
+    expect(respawnSpy).not.toHaveBeenCalled();
+    expect(session.consecutiveInvalidOutputs).toBe(0);
+  });
+
   it('respawnPoisonedSession preserves the buffer and resets context', async () => {
     const sm = new SessionManager(makeDbManager());
     const session = sm.initializeSession(3, 'do the thing', 1);


### PR DESCRIPTION
## Summary

Observer sessions could still respawn after valid no-op responses because `processAgentResponse()` counted every non-XML prose or idle output as invalid before distinguishing empty acknowledgements. This revision treats bounded empty-ack prose and idle responses as valid no-op completions: it confirms the claimed batch, resets stale invalid-output debt, and leaves real malformed or poisoned output on the existing respawn path.

## Why

`ResponseProcessor.ts` classifies non-XML output before deciding whether to confirm the batch or respawn the SDK session. The bug was that issue-reported replies such as `No observations to record at this time.`, `no observations - investigation not yet started`, and `No observations to record — no tool executions or technical findings… have been provided yet.` landed in the same invalid-output counter as malformed prose. After three repeats, `INVALID_OUTPUT_RESPAWN_THRESHOLD` killed and respawned the session even though the observer was saying there was no work to store.

The matcher now recognizes only prose/idle no-op forms with `no observations...` prefixes, a 200-character cap, and rejection of content-bearing continuations such as `No observations, but I found...` or `No observations to record, however I identified...`. Poisoned closure strings and unrecognized prose still increment the counter and respawn exactly as before.

## Scope

This PR is now scoped to observer empty-ack handling only. It does not change telemetry consent caching, search-route welcome-hint caching, XML parsing, poison-string classification, or the invalid-output respawn threshold.

The generated `plugin/scripts/worker-service.cjs` bundle is included because `npm run build` regenerates it from the changed worker source.

## Risk

The main risk is accepting prose that actually contains useful findings. The matcher is bounded by output class, length, known empty-ack prefixes, and explicit rejection of ack-prefixed content signals. Tests cover the issue-reported strings, idle output, the 200-character cap, ordinary prose, and ack-prefixed substantive prose.

## Verification / Test plan

- [x] `bun test tests/worker/agents/response-processor.test.ts tests/worker/poison-respawn.test.ts` — 29 passed, 4 existing skips
- [x] `npm run build` — passed
- [x] `npm run lint:hook-io` — passed
- [x] `npm run lint:spawn-env` — passed
- [ ] `npm run strip-comments:check` — fails on the existing repo-wide baseline, `Changed: 327` in check mode

## Upstream

Closes #2817.
Reported by @Patch76.
