### PR TITLE
fix(chroma): spawn chroma-mcp via `--from` so uv < 0.5.31 works

### DIFF
--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -204,6 +204,15 @@ export class ChromaMcpManager {
 
     const depOverrideFlags = CHROMA_MCP_DEP_OVERRIDES.flatMap(spec => ['--with', spec]);
 
+    // Invoke the package via `--from chroma-mcp==<ver> chroma-mcp` rather than the
+    // bare `chroma-mcp==<ver>` positional. The bare-positional sugar (`uvx PKG==VER`)
+    // only parses on uv >= 0.5.31 (PEP 508 specifiers in tool requests landed in
+    // astral-sh/uv#11337); on older uv (e.g. mise-pinned 0.5.x) it's rejected with
+    // `error: Not a valid package or extra name`, the subprocess dies in ~13ms, and
+    // it surfaces only as `MCP error -32000: Connection closed`. The `--from` form
+    // is the canonical invocation and works on every uv version.
+    const packageInvocation = ['--from', `chroma-mcp==${CHROMA_MCP_PINNED_VERSION}`, 'chroma-mcp'];
+
     if (chromaMode === 'remote') {
       const chromaHost = settings.CLAUDE_MEM_CHROMA_HOST || '127.0.0.1';
       const chromaPort = settings.CLAUDE_MEM_CHROMA_PORT || '8000';
@@ -215,7 +224,7 @@ export class ChromaMcpManager {
       const args = [
         '--python', pythonVersion,
         ...depOverrideFlags,
-        `chroma-mcp==${CHROMA_MCP_PINNED_VERSION}`,
+        ...packageInvocation,
         '--client-type', 'http',
         '--host', chromaHost,
         '--port', chromaPort
@@ -241,7 +250,7 @@ export class ChromaMcpManager {
     return [
       '--python', pythonVersion,
       ...depOverrideFlags,
-      `chroma-mcp==${CHROMA_MCP_PINNED_VERSION}`,
+      ...packageInvocation,
       '--client-type', 'persistent',
       '--data-dir', DEFAULT_CHROMA_DATA_DIR.replace(/\\/g, '/')
     ];


### PR DESCRIPTION
## What
Change the chroma-mcp invocation in `ChromaMcpManager.buildCommandArgs()` from the bare positional form to the `--from` form:
```diff
- `chroma-mcp==${CHROMA_MCP_PINNED_VERSION}`,
+ '--from', `chroma-mcp==${CHROMA_MCP_PINNED_VERSION}`, 'chroma-mcp',
```
Applied to both the remote (`http`) and local (`persistent`) arg builders via a shared `packageInvocation` constant, with an explanatory comment.

## Why
The bare `uvx <pkg>==<ver>` positional (PEP 508 specifier in a tool request) was only added in **uv 0.5.31** ([astral-sh/uv#11337](https://github.com/astral-sh/uv/pull/11337), [#11345](https://github.com/astral-sh/uv/pull/11345)). On any host whose worker resolves uv ≤ 0.5.30, uvx rejects the spec:
```
error: Not a valid package or extra name: "chroma-mcp==0.2.6".
```
The subprocess dies in ~13 ms and the MCP client only sees `MCP error -32000: Connection closed` → reconnect backoff → semantic search silently falls back to keyword. (`stderr` is piped but never read, so the real uv error is masked.)

`--from <pkg>==<ver> <cmd>` is the long-standing version-specifier form that uv's docs recommend, and is verified here on uv 0.5.29 and 0.8.23 — so it works across uv versions where the bare positional does not.

## Distinct from the Windows issues
All prior chroma-mcp spawn fixes (#2696 direct-spawn, #2790 PATH, #2818/#2861/… cmd.exe quoting) address Windows shell/PATH mechanics and leave the **invocation form** unchanged. This is a separate, cross-platform **uv-version** axis:

| host uv | before | after |
|---|---|---|
| ≥ 0.5.31 | works | works (no change) |
| ≤ 0.5.30 (e.g. mise/pinned 0.5.x) | **MCP -32000, search offline** | **works** |

No regression to the new-uv or Windows paths: the change touches only the args array, adds no cmd.exe metacharacters, and the existing `resolveUvxCommand()` direct-spawn is untouched.

## Testing
Booted `chroma-mcp==0.2.6` over MCP stdio with the new args on **uv 0.5.29 and uv 0.8.23** — both return `serverInfo {"name":"chroma","version":"1.6.0"}`. End-to-end: built 13.5.5, reinstalled locally, `GET /api/chroma/status?deep=1` → `{"status":"healthy", … "stage":"done"}` (semantic round-trip ~88 ms).

Checks run locally on this change:
- `npm run typecheck` — passes
- `npm run build` — passes
- `bun test` over the chroma/spawn suites (`tests/services/sync/`, `spawn-contract-windows`, `chroma-search-strategy`) — 37 pass / 0 fail
- No dependency change, so `plugin/bun.lock` is unchanged (frozen-lockfile CI check is a no-op).

> Verified on **macOS only**. Linux and Windows are not tested; the gate is the uv version (astral-sh/uv#11337), which is platform-agnostic (same Rust binary), so those hosts on uv ≤ 0.5.30 are expected to benefit — flagging the untested platforms for transparency.

Fixes #2879