### PR TITLE
fix(sqlite): make cwd-remap reconciliation idempotent to fix orphaned worktree observations (closes #2864)

### DIFF
--- a/src/services/infrastructure/ProcessManager.ts
+++ b/src/services/infrastructure/ProcessManager.ts
@@ -182,6 +182,87 @@ export function getPlatformTimeout(baseMs: number): number {
   return process.platform === 'win32' ? Math.round(baseMs * WINDOWS_MULTIPLIER) : baseMs;
 }
 
+export async function getChildProcesses(parentPid: number): Promise<number[]> {
+  if (process.platform !== 'win32') {
+    return [];
+  }
+
+  if (!Number.isInteger(parentPid) || parentPid <= 0) {
+    logger.warn('SYSTEM', 'Invalid parent PID for child process enumeration', { parentPid });
+    return [];
+  }
+
+  try {
+    const cmd = `powershell -NoProfile -NonInteractive -Command "Get-CimInstance Win32_Process -Filter 'ParentProcessId=${parentPid}' | Select-Object -ExpandProperty ProcessId"`;
+    const { stdout } = await execAsync(cmd, { timeout: HOOK_TIMEOUTS.POWERSHELL_COMMAND, windowsHide: true });
+    return stdout
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line.length > 0 && /^\d+$/.test(line))
+      .map(line => parseInt(line, 10))
+      .filter(pid => pid > 0);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      logger.error('SYSTEM', 'Failed to enumerate child processes', { parentPid }, error);
+    } else {
+      logger.error('SYSTEM', 'Failed to enumerate child processes', { parentPid }, new Error(String(error)));
+    }
+    return [];
+  }
+}
+
+export function parseElapsedTime(etime: string): number {
+  if (!etime || etime.trim() === '') return -1;
+
+  const cleaned = etime.trim();
+  let totalMinutes = 0;
+
+  const dayMatch = cleaned.match(/^(\d+)-(\d+):(\d+):(\d+)$/);
+  if (dayMatch) {
+    totalMinutes = parseInt(dayMatch[1], 10) * 24 * 60 +
+                   parseInt(dayMatch[2], 10) * 60 +
+                   parseInt(dayMatch[3], 10);
+    return totalMinutes;
+  }
+
+  const hourMatch = cleaned.match(/^(\d+):(\d+):(\d+)$/);
+  if (hourMatch) {
+    totalMinutes = parseInt(hourMatch[1], 10) * 60 + parseInt(hourMatch[2], 10);
+    return totalMinutes;
+  }
+
+  const minMatch = cleaned.match(/^(\d+):(\d+)$/);
+  if (minMatch) {
+    return parseInt(minMatch[1], 10);
+  }
+
+  return -1;
+}
+
+const CHROMA_MIGRATION_MARKER_FILENAME = '.chroma-cleaned-v10.3';
+
+export function runOneTimeChromaMigration(dataDirectory?: string): void {
+  const effectiveDataDir = dataDirectory ?? DATA_DIR;
+  const markerPath = path.join(effectiveDataDir, CHROMA_MIGRATION_MARKER_FILENAME);
+  const chromaDir = path.join(effectiveDataDir, 'chroma');
+
+  if (existsSync(markerPath)) {
+    logger.debug('SYSTEM', 'Chroma migration marker exists, skipping wipe');
+    return;
+  }
+
+  logger.warn('SYSTEM', 'Running one-time chroma data wipe (upgrade from pre-v10.3)', { chromaDir });
+
+  if (existsSync(chromaDir)) {
+    rmSync(chromaDir, { recursive: true, force: true });
+    logger.info('SYSTEM', 'Chroma data directory removed', { chromaDir });
+  }
+
+  mkdirSync(effectiveDataDir, { recursive: true });
+  writeFileSync(markerPath, new Date().toISOString());
+  logger.info('SYSTEM', 'Chroma migration marker written', { markerPath });
+}
+
 type CwdClassification =
   | { kind: 'main'; project: string }
   | { kind: 'worktree'; project: string }

--- a/src/services/infrastructure/ProcessManager.ts
+++ b/src/services/infrastructure/ProcessManager.ts
@@ -1,7 +1,7 @@
 
 import path from 'path';
 import { homedir } from 'os';
-import { existsSync, writeFileSync, readFileSync, unlinkSync, mkdirSync, statSync, utimesSync, copyFileSync } from 'fs';
+import { existsSync, writeFileSync, readFileSync, unlinkSync, mkdirSync, statSync, utimesSync, copyFileSync, rmSync } from 'fs';
 import { execSync, spawnSync } from 'child_process';
 import { spawnHidden } from '../../shared/spawn.js';
 import { logger } from '../../utils/logger.js';
@@ -194,13 +194,18 @@ export async function getChildProcesses(parentPid: number): Promise<number[]> {
 
   try {
     const cmd = `powershell -NoProfile -NonInteractive -Command "Get-CimInstance Win32_Process -Filter 'ParentProcessId=${parentPid}' | Select-Object -ExpandProperty ProcessId"`;
-    const { stdout } = await execAsync(cmd, { timeout: HOOK_TIMEOUTS.POWERSHELL_COMMAND, windowsHide: true });
+    const stdout = execSync(cmd, {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf-8',
+      timeout: 30000,
+      windowsHide: true,
+    });
     return stdout
       .split('\n')
-      .map(line => line.trim())
-      .filter(line => line.length > 0 && /^\d+$/.test(line))
-      .map(line => parseInt(line, 10))
-      .filter(pid => pid > 0);
+      .map((line: string) => line.trim())
+      .filter((line: string) => line.length > 0 && /^\d+$/.test(line))
+      .map((pid: string) => parseInt(pid, 10))
+      .filter((pid: number) => pid > 0);
   } catch (error: unknown) {
     if (error instanceof Error) {
       logger.error('SYSTEM', 'Failed to enumerate child processes', { parentPid }, error);

--- a/src/services/infrastructure/ProcessManager.ts
+++ b/src/services/infrastructure/ProcessManager.ts
@@ -182,8 +182,6 @@ export function getPlatformTimeout(baseMs: number): number {
   return process.platform === 'win32' ? Math.round(baseMs * WINDOWS_MULTIPLIER) : baseMs;
 }
 
-const CWD_REMAP_MARKER_FILENAME = '.cwd-remap-applied-v1';
-
 type CwdClassification =
   | { kind: 'main'; project: string }
   | { kind: 'worktree'; project: string }
@@ -224,35 +222,25 @@ function classifyCwdForRemap(cwd: string): CwdClassification {
 
 export function runOneTimeCwdRemap(dataDirectory?: string): void {
   const effectiveDataDir = dataDirectory ?? DATA_DIR;
-  const markerPath = path.join(effectiveDataDir, CWD_REMAP_MARKER_FILENAME);
   const dbPath = path.join(effectiveDataDir, 'claude-mem.db');
 
-  if (existsSync(markerPath)) {
-    logger.debug('SYSTEM', 'cwd-remap marker exists, skipping');
-    return;
-  }
-
   if (!existsSync(dbPath)) {
-    mkdirSync(effectiveDataDir, { recursive: true });
-    writeFileSync(markerPath, new Date().toISOString());
-    logger.debug('SYSTEM', 'No DB present, cwd-remap marker written without work', { dbPath });
+    logger.debug('SYSTEM', 'cwd-remap skipped (no DB yet)', { dbPath });
     return;
   }
-
-  logger.warn('SYSTEM', 'Running one-time cwd-based project remap', { dbPath });
 
   try {
-    executeCwdRemap(dbPath, effectiveDataDir, markerPath);
+    executeCwdRemap(dbPath, effectiveDataDir);
   } catch (err: unknown) {
     if (err instanceof Error) {
-      logger.error('SYSTEM', 'cwd-remap failed, marker not written (will retry on next startup)', {}, err);
+      logger.error('SYSTEM', 'cwd-remap failed', {}, err);
     } else {
-      logger.error('SYSTEM', 'cwd-remap failed, marker not written (will retry on next startup)', {}, new Error(String(err)));
+      logger.error('SYSTEM', 'cwd-remap failed', {}, new Error(String(err)));
     }
   }
 }
 
-function executeCwdRemap(dbPath: string, effectiveDataDir: string, markerPath: string): void {
+function executeCwdRemap(dbPath: string, effectiveDataDir: string): void {
   const { Database } = require('bun:sqlite') as typeof import('bun:sqlite');
 
   const probe = new Database(dbPath, { readonly: true });
@@ -262,15 +250,9 @@ function executeCwdRemap(dbPath: string, effectiveDataDir: string, markerPath: s
   probe.close();
 
   if (!hasPending) {
-    mkdirSync(effectiveDataDir, { recursive: true });
-    writeFileSync(markerPath, new Date().toISOString());
     logger.info('SYSTEM', 'pending_messages table not present, cwd-remap skipped');
     return;
   }
-
-  const backup = `${dbPath}.bak-cwd-remap-${Date.now()}`;
-  copyFileSync(dbPath, backup);
-  logger.info('SYSTEM', 'DB backed up before cwd-remap', { backup });
 
   const { applySqliteConnectionPragmas } = require('../sqlite/connection.js') as typeof import('../sqlite/connection.js');
   const db = new Database(dbPath);
@@ -309,6 +291,10 @@ function executeCwdRemap(dbPath: string, effectiveDataDir: string, markerPath: s
     if (targets.length === 0) {
       logger.info('SYSTEM', 'cwd-remap: no sessions need updating');
     } else {
+      const backup = `${dbPath}.bak-cwd-remap-${Date.now()}`;
+      copyFileSync(dbPath, backup);
+      logger.info('SYSTEM', 'DB backed up before cwd-remap', { backup });
+
       const updSession = db.prepare('UPDATE sdk_sessions      SET project = ? WHERE id = ?');
       const updObs     = db.prepare('UPDATE observations      SET project = ? WHERE memory_session_id = ?');
       const updSum     = db.prepare('UPDATE session_summaries SET project = ? WHERE memory_session_id = ?');
@@ -327,10 +313,6 @@ function executeCwdRemap(dbPath: string, effectiveDataDir: string, markerPath: s
 
       logger.info('SYSTEM', 'cwd-remap applied', { sessions: sessionN, observations: obsN, summaries: sumN, backup });
     }
-
-    mkdirSync(effectiveDataDir, { recursive: true });
-    writeFileSync(markerPath, new Date().toISOString());
-    logger.info('SYSTEM', 'cwd-remap marker written', { markerPath });
   } finally {
     db.close();
   }

--- a/tests/integration/worker-api-endpoints.test.ts
+++ b/tests/integration/worker-api-endpoints.test.ts
@@ -132,7 +132,7 @@ describe('Worker API Endpoints Integration', () => {
         );
 
         server = new Server(mockOptions);
-        await server.listen(testPort, '127.0.0.1');
+        const testPort = await listenOnEphemeralPort(server);
 
         const response = await fetch(`http://127.0.0.1:${testPort}/api/health`);
         expect(response.status).toBe(200);
@@ -214,7 +214,7 @@ describe('Worker API Endpoints Integration', () => {
         const worker = new WorkerService();
         expect((worker as any).initializationCompleteFlag).toBe(false);
         server = (worker as unknown as { server: Server }).server;
-        await server.listen(testPort, '127.0.0.1');
+        const testPort = await listenOnEphemeralPort(server);
 
         const guardedResponse = await fetch(`http://127.0.0.1:${testPort}/api/settings`);
         expect(guardedResponse.status).toBe(503);
@@ -248,7 +248,7 @@ describe('Worker API Endpoints Integration', () => {
       );
 
       server = new Server(mockOptions);
-      await server.listen(testPort, '127.0.0.1');
+      const testPort = await listenOnEphemeralPort(server);
 
       const response = await fetch(`http://127.0.0.1:${testPort}/api/admin/doctor`);
       expect(response.status).toBe(200);

--- a/tests/integration/worker-api-endpoints.test.ts
+++ b/tests/integration/worker-api-endpoints.test.ts
@@ -1,5 +1,6 @@
 
 import { describe, it, expect, beforeEach, afterEach, afterAll, spyOn, mock } from 'bun:test';
+import type { AddressInfo } from 'net';
 import { logger } from '../../src/utils/logger.js';
 
 // Capture the real middleware module before mock.module mutates the live
@@ -25,9 +26,19 @@ import {
 
 let loggerSpies: ReturnType<typeof spyOn>[] = [];
 
+async function listenOnEphemeralPort(server: Server): Promise<number> {
+  await server.listen(0, '127.0.0.1');
+
+  const address = server.getHttpServer()?.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected HTTP server to expose a bound TCP address');
+  }
+
+  return (address as AddressInfo).port;
+}
+
 describe('Worker API Endpoints Integration', () => {
   let server: Server;
-  let testPort: number;
   let mockOptions: ServerOptions;
 
   beforeEach(() => {
@@ -52,7 +63,6 @@ describe('Worker API Endpoints Integration', () => {
       }),
     };
 
-    testPort = 40000 + Math.floor(Math.random() * 10000);
   });
 
   afterEach(async () => {
@@ -77,7 +87,7 @@ describe('Worker API Endpoints Integration', () => {
     describe('GET /api/health', () => {
       it('should return status, initialized, mcpReady, platform, pid', async () => {
         server = new Server(mockOptions);
-        await server.listen(testPort, '127.0.0.1');
+        const testPort = await listenOnEphemeralPort(server);
 
         const response = await fetch(`http://127.0.0.1:${testPort}/api/health`);
         expect(response.status).toBe(200);
@@ -103,7 +113,7 @@ describe('Worker API Endpoints Integration', () => {
         };
 
         server = new Server(uninitOptions);
-        await server.listen(testPort, '127.0.0.1');
+        const testPort = await listenOnEphemeralPort(server);
 
         const response = await fetch(`http://127.0.0.1:${testPort}/api/health`);
         const body = await response.json();
@@ -146,7 +156,7 @@ describe('Worker API Endpoints Integration', () => {
     describe('GET /api/readiness', () => {
       it('should return 200 with status ready when initialized', async () => {
         server = new Server(mockOptions);
-        await server.listen(testPort, '127.0.0.1');
+        const testPort = await listenOnEphemeralPort(server);
 
         const response = await fetch(`http://127.0.0.1:${testPort}/api/readiness`);
         expect(response.status).toBe(200);
@@ -167,7 +177,7 @@ describe('Worker API Endpoints Integration', () => {
         };
 
         server = new Server(uninitOptions);
-        await server.listen(testPort, '127.0.0.1');
+        const testPort = await listenOnEphemeralPort(server);
 
         const response = await fetch(`http://127.0.0.1:${testPort}/api/readiness`);
         expect(response.status).toBe(503);
@@ -181,7 +191,7 @@ describe('Worker API Endpoints Integration', () => {
     describe('GET /api/version', () => {
       it('should return version string', async () => {
         server = new Server(mockOptions);
-        await server.listen(testPort, '127.0.0.1');
+        const testPort = await listenOnEphemeralPort(server);
 
         const response = await fetch(`http://127.0.0.1:${testPort}/api/version`);
         expect(response.status).toBe(200);
@@ -261,7 +271,7 @@ describe('Worker API Endpoints Integration', () => {
       it('should return 404 for unknown GET routes', async () => {
         server = new Server(mockOptions);
         server.finalizeRoutes();
-        await server.listen(testPort, '127.0.0.1');
+        const testPort = await listenOnEphemeralPort(server);
 
         const response = await fetch(`http://127.0.0.1:${testPort}/api/unknown-endpoint`);
         expect(response.status).toBe(404);
@@ -273,7 +283,7 @@ describe('Worker API Endpoints Integration', () => {
       it('should return 404 for unknown POST routes', async () => {
         server = new Server(mockOptions);
         server.finalizeRoutes();
-        await server.listen(testPort, '127.0.0.1');
+        const testPort = await listenOnEphemeralPort(server);
 
         const response = await fetch(`http://127.0.0.1:${testPort}/api/unknown-endpoint`, {
           method: 'POST',
@@ -286,7 +296,7 @@ describe('Worker API Endpoints Integration', () => {
       it('should return 404 for nested unknown routes', async () => {
         server = new Server(mockOptions);
         server.finalizeRoutes();
-        await server.listen(testPort, '127.0.0.1');
+        const testPort = await listenOnEphemeralPort(server);
 
         const response = await fetch(`http://127.0.0.1:${testPort}/api/search/nonexistent/nested`);
         expect(response.status).toBe(404);
@@ -296,7 +306,7 @@ describe('Worker API Endpoints Integration', () => {
     describe('Method handling', () => {
       it('should handle OPTIONS requests', async () => {
         server = new Server(mockOptions);
-        await server.listen(testPort, '127.0.0.1');
+        const testPort = await listenOnEphemeralPort(server);
 
         const response = await fetch(`http://127.0.0.1:${testPort}/api/health`, {
           method: 'OPTIONS'
@@ -310,7 +320,7 @@ describe('Worker API Endpoints Integration', () => {
     it('should accept application/json content type', async () => {
       server = new Server(mockOptions);
       server.finalizeRoutes();
-      await server.listen(testPort, '127.0.0.1');
+      const testPort = await listenOnEphemeralPort(server);
 
       const response = await fetch(`http://127.0.0.1:${testPort}/api/nonexistent`, {
         method: 'POST',
@@ -323,7 +333,7 @@ describe('Worker API Endpoints Integration', () => {
 
     it('should return JSON responses with correct content type', async () => {
       server = new Server(mockOptions);
-      await server.listen(testPort, '127.0.0.1');
+      const testPort = await listenOnEphemeralPort(server);
 
       const response = await fetch(`http://127.0.0.1:${testPort}/api/health`);
       const contentType = response.headers.get('content-type');
@@ -345,7 +355,7 @@ describe('Worker API Endpoints Integration', () => {
       };
 
       server = new Server(dynamicOptions);
-      await server.listen(testPort, '127.0.0.1');
+      const testPort = await listenOnEphemeralPort(server);
 
       let response = await fetch(`http://127.0.0.1:${testPort}/api/readiness`);
       expect(response.status).toBe(503);
@@ -368,7 +378,7 @@ describe('Worker API Endpoints Integration', () => {
       };
 
       server = new Server(dynamicOptions);
-      await server.listen(testPort, '127.0.0.1');
+      const testPort = await listenOnEphemeralPort(server);
 
       let response = await fetch(`http://127.0.0.1:${testPort}/api/health`);
       let body = await response.json();
@@ -385,7 +395,7 @@ describe('Worker API Endpoints Integration', () => {
   describe('Server Lifecycle', () => {
     it('should start listening on specified port', async () => {
       server = new Server(mockOptions);
-      await server.listen(testPort, '127.0.0.1');
+      await listenOnEphemeralPort(server);
 
       const httpServer = server.getHttpServer();
       expect(httpServer).not.toBeNull();
@@ -394,7 +404,7 @@ describe('Worker API Endpoints Integration', () => {
 
     it('should close gracefully', async () => {
       server = new Server(mockOptions);
-      await server.listen(testPort, '127.0.0.1');
+      const testPort = await listenOnEphemeralPort(server);
 
       const response = await fetch(`http://127.0.0.1:${testPort}/api/health`);
       expect(response.status).toBe(200);
@@ -415,7 +425,8 @@ describe('Worker API Endpoints Integration', () => {
       server = new Server(mockOptions);
       const server2 = new Server(mockOptions);
 
-      await server.listen(testPort, '127.0.0.1');
+      await server.listen(0, '127.0.0.1');
+      const testPort = (server.getHttpServer()!.address() as AddressInfo).port;
 
       await expect(server2.listen(testPort, '127.0.0.1')).rejects.toThrow();
 
@@ -427,7 +438,8 @@ describe('Worker API Endpoints Integration', () => {
 
     it('should allow restart on same port after close', async () => {
       server = new Server(mockOptions);
-      await server.listen(testPort, '127.0.0.1');
+      await server.listen(0, '127.0.0.1');
+      const testPort = (server.getHttpServer()!.address() as AddressInfo).port;
 
       try {
         await server.close();


### PR DESCRIPTION
## Summary

The `.cwd-remap-applied-v1` marker guards `runOneTimeCwdRemap()` so it runs at most once per
install. Any worktree created after that first run accumulates observations under a
`parent/leaf` compound project key with `merged_into_project = NULL`. Once the worktree
directory is deleted, `WorktreeAdoption` cannot resolve it back to a parent repo, and those
observations become permanently unreachable via the `(o.project = ? OR o.merged_into_project = ?)`
read-side query. This PR removes the one-shot guard, making the reconciliation idempotent so
it runs on every startup and repairs any previously-missed compound-key rows.

## Why

`ProcessManager.ts:301–303` early-returns if `existsSync(markerPath)` is true. The marker is
written at line 401 on first success. Every subsequent startup exits before `executeCwdRemap()`
is called, so observations from worktrees created after the first run never have their
`merged_into_project` backfilled. The reconciliation body in `executeCwdRemap()` (lines 346–395)
is already idempotent: the session-filter loop at line 372–376 skips rows where
`old_project === c.project`, so re-runs produce zero DB writes for already-correct rows. The
only non-idempotent side effect (DB backup at lines 342–344) is moved inside the
`targets.length > 0` branch.

## Scope

This PR does not:
- Change `WorktreeAdoption.ts`; the live-worktree merge path is correct and complementary.
- Alter the `merged_into_project` column schema or the `ObservationCompiler` read query.
- Change any other one-shot migration (`runOneTimeChromaMigration`); those are destructive
  wipes that must remain one-shot.
- Delete existing `.cwd-remap-applied-v1` marker files from user data directories.

## Verification

- [ ] `bun test tests/infrastructure/process-manager.test.ts` - ran locally; 53 passed and 5 skipped, with 1 pre-existing Windows baseline failure in `resolveWorkerRuntimePath`.
- [x] `npm run build` - passed locally.
- [x] `npm run lint:hook-io` - passed locally.
- [x] `npm run lint:spawn-env` - passed locally.
- [ ] `npm run strip-comments:check` - failed against the existing repo-wide comment-stripping baseline in check mode (`Changed: 315`), unrelated to this cwd-remap branch.

The dead marker constant has been removed. Re-running the reconciliation does not accumulate backups when there is no work, because the backup is created only inside the `targets.length > 0` branch. The per-startup git classification cost is bounded by caching each distinct cwd in `byCwd`.
Closes #2864