### PR TITLE
fix(observer): strip base64 image blobs from tool payloads before building observer prompt (closes #2866)

### DIFF
--- a/src/sdk/prompts.ts
+++ b/src/sdk/prompts.ts
@@ -78,32 +78,46 @@ ${mode.prompts.footer}
 ${mode.prompts.header_memory_start}`;
 }
 
-// Per-field character budget for the <parameters> / <outcome> blocks in an
-// observation prompt. Each field is allowed up to OBS_PROMPT_FIELD_MAX_CHARS;
-// content past that is replaced with a head + tail slice plus an explicit
-// <elided ...> marker so the observer model can see *that* truncation
-// happened (and won't fabricate detail about the missing range).
-//
-// 16k chars ≈ ~4k tokens (4 chars/token rough estimate). Two fields per
-// observation → ~8k tokens of variable input. With a 128k-token observer
-// model that leaves ample room for the system prompt, conversation
-// history, and the model's own response — and prevents a single oversized
-// Read tool result (issue #2468 reports a 130k-char file) from blowing
-// the entire context window and forcing the SDK session to abort with
-// "prompt is too long".
-//
-// Head/tail ratio (60% / 30%) keeps the start of the field (where most
-// tools put their canonical signal — file path, error message, command
-// header) and the tail (where errors / final-line context typically sit)
-// while dropping the middle. The 10% remainder is the elision marker.
 const OBS_PROMPT_FIELD_MAX_CHARS = 16_000;
 const OBS_PROMPT_FIELD_HEAD_RATIO = 0.6;
 const OBS_PROMPT_FIELD_TAIL_RATIO = 0.3;
 
+function stripBase64ImageBlocks(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+
+  if (Array.isArray(value)) {
+    return value.map(item => stripBase64ImageBlocks(item));
+  }
+
+  const obj = value as Record<string, unknown>;
+
+  if (
+    obj.type === 'image' &&
+    obj.source !== null &&
+    typeof obj.source === 'object' &&
+    (obj.source as Record<string, unknown>).type === 'base64'
+  ) {
+    const src = obj.source as Record<string, unknown>;
+    const dataLen = typeof src.data === 'string' ? src.data.length : 0;
+    const sizeKb = Math.round((dataLen * 3) / 4 / 1024); 
+    return {
+      type: 'image',
+      source: {
+        type: 'base64',
+        media_type: src.media_type ?? 'unknown',
+        data: `[image omitted: ${src.media_type ?? 'unknown'}, ~${sizeKb} KB]`,
+      },
+    };
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    result[k] = stripBase64ImageBlocks(v);
+  }
+  return result;
+}
+
 function truncateObservationField(value: unknown, maxChars: number = OBS_PROMPT_FIELD_MAX_CHARS): string {
-  // JSON.stringify returns undefined for undefined / functions / symbols;
-  // fall back to empty string so the call sites (template literal output)
-  // and the length check below stay well-defined.
   const raw = JSON.stringify(value, null, 2) ?? '';
   if (raw.length <= maxChars) return raw;
   const headChars = Math.max(0, Math.floor(maxChars * OBS_PROMPT_FIELD_HEAD_RATIO));
@@ -135,6 +149,9 @@ export function buildObservationPrompt(obs: Observation): string {
     }, error instanceof Error ? error : new Error(String(error)));
     toolOutput = obs.tool_output;
   }
+
+  toolInput = stripBase64ImageBlocks(toolInput);
+  toolOutput = stripBase64ImageBlocks(toolOutput);
 
   return `<observed_from_primary_session>
   <what_happened>${obs.tool_name}</what_happened>

--- a/src/sdk/prompts.ts
+++ b/src/sdk/prompts.ts
@@ -78,6 +78,7 @@ ${mode.prompts.footer}
 ${mode.prompts.header_memory_start}`;
 }
 
+// Observer prompt budgets keep oversized Read payloads from exhausting context while preserving the command header and final error lines.
 const OBS_PROMPT_FIELD_MAX_CHARS = 16_000;
 const OBS_PROMPT_FIELD_HEAD_RATIO = 0.6;
 const OBS_PROMPT_FIELD_TAIL_RATIO = 0.3;

--- a/src/sdk/prompts.ts
+++ b/src/sdk/prompts.ts
@@ -99,7 +99,7 @@ function stripBase64ImageBlocks(value: unknown): unknown {
   ) {
     const src = obj.source as Record<string, unknown>;
     const dataLen = typeof src.data === 'string' ? src.data.length : 0;
-    const sizeKb = Math.round((dataLen * 3) / 4 / 1024); 
+    const sizeKb = Math.round((dataLen * 3) / 4 / 1024);
     return {
       type: 'image',
       source: {
@@ -120,6 +120,7 @@ function stripBase64ImageBlocks(value: unknown): unknown {
 function truncateObservationField(value: unknown, maxChars: number = OBS_PROMPT_FIELD_MAX_CHARS): string {
   const raw = JSON.stringify(value, null, 2) ?? '';
   if (raw.length <= maxChars) return raw;
+  // Keep more head than tail because the tool name and error prefix usually carry the debugging signal.
   const headChars = Math.max(0, Math.floor(maxChars * OBS_PROMPT_FIELD_HEAD_RATIO));
   const tailChars = Math.max(0, Math.floor(maxChars * OBS_PROMPT_FIELD_TAIL_RATIO));
   const head = raw.slice(0, headChars);

--- a/tests/sdk/prompts.test.ts
+++ b/tests/sdk/prompts.test.ts
@@ -33,10 +33,8 @@ describe('buildObservationPrompt oversized field truncation (#2468)', () => {
 
     expect(prompt).toContain('<elided');
     expect(prompt).toContain('reason="oversize"');
-    // head and tail of the raw value are preserved
     expect(prompt).toContain('HEAD_SENTINEL');
     expect(prompt).toContain('TAIL_SENTINEL');
-    // the oversized field is actually shrunk well below its raw 60k size
     expect(prompt.length).toBeLessThan(40_000);
   });
 
@@ -50,8 +48,93 @@ describe('buildObservationPrompt oversized field truncation (#2468)', () => {
       cwd: '/repo',
     });
 
-    // The prompt always carries a static "<elided chars=... />" instruction line,
-    // so assert on the actual truncation marker (reason="oversize") instead.
     expect(prompt).not.toContain('reason="oversize"');
+  });
+});
+
+describe('buildObservationPrompt base64 image stripping (#2866)', () => {
+  it('strips a single large base64 image content block from tool_response', () => {
+    const largeBase64 = 'A'.repeat(500 * 1024);
+    const prompt = buildObservationPrompt({
+      id: 1,
+      tool_name: 'screenshot',
+      tool_input: JSON.stringify({ window: 'primary' }),
+      tool_output: JSON.stringify({
+        content: [
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: 'image/png',
+              data: largeBase64,
+            },
+          },
+        ],
+      }),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(prompt).not.toContain(largeBase64);
+    expect(prompt).toContain('[image omitted:');
+    expect(prompt).toContain('image/png');
+    expect(prompt.length).toBeLessThan(10_000);
+  });
+
+  it('strips multiple base64 images from a nested tool_response', () => {
+    const base64Image1 = 'B'.repeat(300 * 1024);
+    const base64Image2 = 'C'.repeat(200 * 1024);
+    const prompt = buildObservationPrompt({
+      id: 2,
+      tool_name: 'vision_tool',
+      tool_input: JSON.stringify({
+        images: [
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: 'image/jpeg',
+              data: base64Image1,
+            },
+          },
+        ],
+      }),
+      tool_output: JSON.stringify({
+        results: [
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: 'image/webp',
+              data: base64Image2,
+            },
+          },
+        ],
+      }),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(prompt).not.toContain(base64Image1);
+    expect(prompt).not.toContain(base64Image2);
+    expect(prompt).toContain('[image omitted:');
+    expect((prompt.match(/\[image omitted:/g) || []).length).toBeGreaterThanOrEqual(2);
+    expect(prompt).toContain('image/jpeg');
+    expect(prompt).toContain('image/webp');
+  });
+
+  it('does not strip text-only tool_response (no false-positive stripping)', () => {
+    const textOutput = 'This is some normal text output with no images';
+    const prompt = buildObservationPrompt({
+      id: 3,
+      tool_name: 'exec_command',
+      tool_input: JSON.stringify({ cmd: 'echo hello' }),
+      tool_output: JSON.stringify({ output: textOutput }),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(prompt).toContain(textOutput);
+    expect(prompt).not.toContain('[image omitted:');
   });
 });


### PR DESCRIPTION
## Summary

When a tool result contains a base64-encoded image block (e.g. a screenshot or vision-tool
response), `buildObservationPrompt` forwards the raw blob to `truncateObservationField`,
which slices it to a 16 KB head/tail fragment. The fragment is still ~12 000 tokens of
meaningless binary-encoded data, leaving the observer prompt at or above the model input
limit. This PR adds a `stripBase64ImageBlocks` pre-processor that replaces each base64 image
source with a compact placeholder before the field reaches the truncation step.

## Why

`ClaudeProvider.ts:442–449` constructs the observer prompt by calling `buildObservationPrompt`
with `tool_input: JSON.stringify(message.tool_input)` and
`tool_output: JSON.stringify(message.tool_response)`. Inside `buildObservationPrompt`
(`src/sdk/prompts.ts:117–151`), both fields are JSON-parsed and forwarded to
`truncateObservationField`. The truncation threshold is 16 000 characters (~4 000 tokens). A
single PNG screenshot encoded as base64 is typically 200–800 KB. Even at the 16 000-char limit
the surviving fragment is ~4 000 tokens of base64, which carries no semantic value for the
observer. The fix applies `stripBase64ImageBlocks()` to both parsed values immediately after
JSON.parse and before `truncateObservationField`, so the truncation budget is spent on
informative text context rather than discarded image data.

## Scope

This PR does not:
- Change the `unrecoverable` classification for "Prompt is too long" in `ClaudeProvider.ts`.
- Change `OBS_PROMPT_FIELD_MAX_CHARS` or the head/tail truncation ratios.
- Handle URL-referenced images (`type: "url"`).
- Strip non-image binary content (e.g. PDF base64).

## Verification

- [x] `bun test tests/sdk/prompts.test.ts` - 6 passed, including the base64-strip coverage.
- [x] `npm run build` - passed locally.
- [x] `npm run lint:hook-io` - passed locally.
- [x] `npm run lint:spawn-env` - passed locally.
- [ ] `npm run strip-comments:check` - failed against the existing repo-wide comment-stripping baseline in check mode (`Changed: 1`), due to the intentionally retained truncation-budget rationale comment in this branch.

Closes #2866