### PR TITLE
fix(context): drop sub-day clock from injected headers to stop busting prefix cache (closes #2872)

### DIFF
--- a/src/cli/handlers/file-context.ts
+++ b/src/cli/handlers/file-context.ts
@@ -106,17 +106,7 @@ function formatFileTimeline(
     return aEpoch - bEpoch;
   });
 
-  const now = new Date();
-  const currentDate = now.toLocaleDateString('en-CA'); 
-  const currentTime = now.toLocaleTimeString('en-US', {
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true
-  }).toLowerCase().replace(' ', '');
-  const currentTimezone = now.toLocaleTimeString('en-US', { timeZoneName: 'short' }).split(' ').pop();
-
   const lines: string[] = [
-    `Current: ${currentDate} ${currentTime} ${currentTimezone}`,
     `This file has prior observations — supplementary context follows. The Read result below is the full requested section.`,
     `- **Need details on a past observation?** get_observations([IDs]) — ~300 tokens each.`,
     `- **Need a structural map first?** smart_outline("${safePath}") — line numbers only, cheaper than re-reading.`,

--- a/src/services/context/formatters/AgentFormatter.ts
+++ b/src/services/context/formatters/AgentFormatter.ts
@@ -9,21 +9,10 @@ import type {
 import { ModeManager } from '../../domain/ModeManager.js';
 import { formatObservationTokenDisplay } from '../TokenCalculator.js';
 
-function formatHeaderDateTime(): string {
-  const now = new Date();
-  const date = now.toLocaleDateString('en-CA'); 
-  const time = now.toLocaleTimeString('en-US', {
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true
-  }).toLowerCase().replace(' ', '');
-  const tz = now.toLocaleTimeString('en-US', { timeZoneName: 'short' }).split(' ').pop();
-  return `${date} ${time} ${tz}`;
-}
-
 export function renderAgentHeader(project: string): string[] {
+  const date = new Date().toLocaleDateString('en-CA');
   return [
-    `# [${project}] recent context, ${formatHeaderDateTime()}`,
+    `# [${project}] recent context, ${date}`,
     ''
   ];
 }
@@ -156,5 +145,6 @@ export function renderAgentFooter(totalDiscoveryTokens: number, totalReadTokens:
 }
 
 export function renderAgentEmptyState(project: string): string {
-  return `# [${project}] recent context, ${formatHeaderDateTime()}\n\nNo previous sessions found.`;
+  const date = new Date().toLocaleDateString('en-CA');
+  return `# [${project}] recent context, ${date}\n\nNo previous sessions found.`;
 }

--- a/src/services/context/formatters/AgentFormatter.ts
+++ b/src/services/context/formatters/AgentFormatter.ts
@@ -8,9 +8,10 @@ import type {
 } from '../types.js';
 import { ModeManager } from '../../domain/ModeManager.js';
 import { formatObservationTokenDisplay } from '../TokenCalculator.js';
+import { formatIsoDate } from '../../../shared/timeline-formatting.js';
 
 export function renderAgentHeader(project: string): string[] {
-  const date = new Date().toLocaleDateString('en-CA');
+  const date = formatIsoDate();
   return [
     `# [${project}] recent context, ${date}`,
     ''
@@ -145,6 +146,6 @@ export function renderAgentFooter(totalDiscoveryTokens: number, totalReadTokens:
 }
 
 export function renderAgentEmptyState(project: string): string {
-  const date = new Date().toLocaleDateString('en-CA');
+  const date = formatIsoDate();
   return `# [${project}] recent context, ${date}\n\nNo previous sessions found.`;
 }

--- a/src/services/context/formatters/HumanFormatter.ts
+++ b/src/services/context/formatters/HumanFormatter.ts
@@ -9,22 +9,11 @@ import { colors } from '../types.js';
 import { ModeManager } from '../../domain/ModeManager.js';
 import { formatObservationTokenDisplay } from '../TokenCalculator.js';
 
-function formatHeaderDateTime(): string {
-  const now = new Date();
-  const date = now.toLocaleDateString('en-CA'); 
-  const time = now.toLocaleTimeString('en-US', {
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true
-  }).toLowerCase().replace(' ', '');
-  const tz = now.toLocaleTimeString('en-US', { timeZoneName: 'short' }).split(' ').pop();
-  return `${date} ${time} ${tz}`;
-}
-
 export function renderHumanHeader(project: string): string[] {
+  const date = new Date().toLocaleDateString('en-CA');
   return [
     '',
-    `${colors.bright}${colors.cyan}[${project}] recent context, ${formatHeaderDateTime()}${colors.reset}`,
+    `${colors.bright}${colors.cyan}[${project}] recent context, ${date}${colors.reset}`,
     `${colors.gray}${'─'.repeat(60)}${colors.reset}`,
     ''
   ];
@@ -184,5 +173,6 @@ export function renderHumanFooter(totalDiscoveryTokens: number, totalReadTokens:
 }
 
 export function renderHumanEmptyState(project: string): string {
-  return `\n${colors.bright}${colors.cyan}[${project}] recent context, ${formatHeaderDateTime()}${colors.reset}\n${colors.gray}${'─'.repeat(60)}${colors.reset}\n\n${colors.dim}No previous sessions found for this project yet.${colors.reset}\n`;
+  const date = new Date().toLocaleDateString('en-CA');
+  return `\n${colors.bright}${colors.cyan}[${project}] recent context, ${date}${colors.reset}\n${colors.gray}${'─'.repeat(60)}${colors.reset}\n\n${colors.dim}No previous sessions found for this project yet.${colors.reset}\n`;
 }

--- a/src/services/context/formatters/HumanFormatter.ts
+++ b/src/services/context/formatters/HumanFormatter.ts
@@ -8,9 +8,10 @@ import type {
 import { colors } from '../types.js';
 import { ModeManager } from '../../domain/ModeManager.js';
 import { formatObservationTokenDisplay } from '../TokenCalculator.js';
+import { formatIsoDate } from '../../../shared/timeline-formatting.js';
 
 export function renderHumanHeader(project: string): string[] {
-  const date = new Date().toLocaleDateString('en-CA');
+  const date = formatIsoDate();
   return [
     '',
     `${colors.bright}${colors.cyan}[${project}] recent context, ${date}${colors.reset}`,
@@ -173,6 +174,6 @@ export function renderHumanFooter(totalDiscoveryTokens: number, totalReadTokens:
 }
 
 export function renderHumanEmptyState(project: string): string {
-  const date = new Date().toLocaleDateString('en-CA');
+  const date = formatIsoDate();
   return `\n${colors.bright}${colors.cyan}[${project}] recent context, ${date}${colors.reset}\n${colors.gray}${'─'.repeat(60)}${colors.reset}\n\n${colors.dim}No previous sessions found for this project yet.${colors.reset}\n`;
 }

--- a/src/shared/timeline-formatting.ts
+++ b/src/shared/timeline-formatting.ts
@@ -35,6 +35,10 @@ export function formatTime(dateInput: string | number): string {
   });
 }
 
+export function formatIsoDate(date: Date = new Date()): string {
+  return date.toLocaleDateString('en-CA');
+}
+
 export function formatDate(dateInput: string | number): string {
   const date = new Date(dateInput);
   return date.toLocaleString('en-US', {

--- a/tests/context/formatters/agent-formatter.test.ts
+++ b/tests/context/formatters/agent-formatter.test.ts
@@ -96,7 +96,7 @@ describe('AgentFormatter', () => {
       const result = renderAgentHeader('my-project');
 
       expect(result).toHaveLength(2);
-      expect(result[0]).toMatch(/^# \[my-project\] recent context, \d{4}-\d{2}-\d{2} \d{1,2}:\d{2}[ap]m [A-Z]{3,4}$/);
+      expect(result[0]).toMatch(/^# \[my-project\] recent context, \d{4}-\d{2}-\d{2}$/);
       expect(result[1]).toBe('');
     });
 
@@ -109,7 +109,7 @@ describe('AgentFormatter', () => {
     it('should handle empty project name', () => {
       const result = renderAgentHeader('');
 
-      expect(result[0]).toMatch(/^# \[\] recent context, \d{4}-\d{2}-\d{2} \d{1,2}:\d{2}[ap]m [A-Z]{3,4}$/);
+      expect(result[0]).toMatch(/^# \[\] recent context, \d{4}-\d{2}-\d{2}$/);
     });
   });
 


### PR DESCRIPTION
## Summary

Every PreToolUse(Read) file-context block and every SessionStart recent-context header embeds a live wall-clock timestamp at minute granularity. The injected text changes every 60 seconds, so Anthropic's prefix cache treats each turn as a new prompt prefix and can never reuse cached KV state. This PR reduces all injected clock references to date-only (YYYY-MM-DD), which changes at most once per 24 hours and preserves cache coherence across the entire session.

## Why

`formatFileTimeline()` in `src/cli/handlers/file-context.ts:109–119` calls `new Date()` and formats `hour + minute + timezone` into the string `Current: <date> <HH:MMa> <TZ>` that opens every file-context injection. The identical `formatHeaderDateTime()` helper is independently duplicated in `AgentFormatter.ts:12–22` and `HumanFormatter.ts:12–22`; both produce `# [project] recent context, <date> <HH:MMa> <TZ>` for the SessionStart header via `renderAgentHeader` / `renderHumanHeader`. All three call sites resolve to model-visible text that changes every minute.

## Scope

This PR targets only the three injected-clock call sites. It does not:
- Change the `<requested_at>` fields in `buildInitPrompt` / `buildContinuationPrompt`; these are already date-only ISO strings.
- Change per-observation timestamps within the timeline body, which are derived from stored epoch values (stable across turns).
- Alter session routing, DB schema, or hook invocation strings.

## Verification

- [x] `bun test tests/context/formatters/agent-formatter.test.ts` - 40 passed.
- [x] `npm run build` - passed after rebasing onto current `origin/main`; regenerated bundled context/worker artifacts.
- [x] `npm run lint:hook-io` - passed locally.
- [x] `npm run lint:spawn-env` - passed locally.
- [ ] `bun test tests/sdk/prompts.test.ts` and `bun test tests/context-injection.test.ts` - not rerun.
- [ ] `npm run strip-comments:check` - failed against the existing repo-wide comment-stripping baseline in check mode (`Changed: 327`), unrelated to this timestamp branch.

Closes #2872