### PR TITLE
fix(build): bundle zod into worker-service.cjs to survive node_modules churn (closes #2831)

### DIFF
--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -54,14 +54,6 @@ function stripHardcodedDirname(filePath) {
   }
 }
 
-/**
- * Rule A canonical-template manifest: maps each host-managed config file's
- * command string to the buildShellCommand() options that generate it. The
- * build asserts the hand-maintained files still match the generator output so
- * the defensive shell prelude can't drift between the three files (issues
- * #1215, #1533). See src/build/hook-shell-template.ts and CLAUDE.md →
- * "Spawn-Contract Resolution".
- */
 function shellTemplateManifest(buildShellCommand) {
   const ccTrailing = (...tail) => [
     'node', '"$_P/scripts/bun-runner.js"', '"$_P/scripts/worker-service.cjs"', ...tail,
@@ -111,8 +103,6 @@ function shellTemplateManifest(buildShellCommand) {
     'plugin/.mcp.json': {
       kind: 'mcp',
       command: buildShellCommand({
-        // The mcp Node launcher derives its spawn target from requireFile, so
-        // no trailingCommand is needed (it is ignored for this host).
         host: 'mcp', requireFile: 'mcp-server.cjs',
         notFoundMessage: 'claude-mem: mcp server not found',
         mcpExtraCandidates: ['$PWD/plugin', '$PWD'],
@@ -133,9 +123,6 @@ function hookCommandByPath(parsed, dottedPath) {
 async function verifyShellTemplateCanonical() {
   console.log('\n📋 Verifying Rule A shell templates match the canonical generator...');
 
-  // Compile src/build/hook-shell-template.ts in-memory and import it. The build
-  // runs under Node, which can't import .ts directly, so we bundle to ESM and
-  // load via a data: URL.
   const bundled = await build({
     entryPoints: ['src/build/hook-shell-template.ts'],
     bundle: true,
@@ -173,7 +160,6 @@ async function verifyShellTemplateCanonical() {
     }
   }
 
-  // Rule C safety net (bun-runner.js fixBrokenScriptPath) must stay documented.
   const bunRunner = fs.readFileSync('plugin/scripts/bun-runner.js', 'utf-8');
   if (!bunRunner.includes('function fixBrokenScriptPath')) {
     throw new Error(
@@ -181,9 +167,6 @@ async function verifyShellTemplateCanonical() {
     );
   }
 
-  // Parser-compat guard (issue #2791): bun-runner.js is invoked by hosts that
-  // may run a pre-ES2020 Node whose ESM loader throws on optional chaining.
-  // Strip comments, then forbid `?.` / `??` in executable code.
   const bunRunnerCode = bunRunner
     .replace(/\/\*[\s\S]*?\*\//g, '')
     .replace(/(^|[^:])\/\/.*$/gm, '$1');
@@ -292,18 +275,10 @@ async function buildHooks() {
       logLevel: 'error', // Suppress warnings (import.meta warning is benign)
       external: [
         'bun:sqlite',
-        'zod',
         'cohere-ai',
         'ollama',
         '@chroma-core/default-embed',
         'onnxruntime-node',
-        // better-auth (~3.7MB) is only reachable through BetterAuthRoutes' request-time
-        // dynamic import('better-auth/node') / import('./auth.js'). esbuild otherwise
-        // inlines that dynamic-import target into the worker bundle, dragging in the full
-        // better-auth library (kysely, oauth, nanoid, …) even though the worker never
-        // exercises it (the dep isn't in the worker's runtime plugin/package.json deps,
-        // and the route handler already wraps the import in try/catch → graceful 500).
-        // Keeping it external strips the dead weight from worker-service.cjs. See #2584.
         'better-auth',
         'better-auth/node',
         'better-auth/plugins',
@@ -311,10 +286,6 @@ async function buildHooks() {
       ],
       define: {
         '__DEFAULT_PACKAGE_VERSION__': `"${version}"`,
-        // Polyfill import.meta.url for ESM deps bundled into CJS output.
-        // @anthropic-ai/claude-agent-sdk's *.mjs files use createRequire(import.meta.url)
-        // and `new URL(rel, import.meta.url)`. We map import.meta.url to a file:// URL
-        // (not the raw __filename path) so URL construction preserves its semantics.
         'import.meta.url': '__IMPORT_META_URL__'
       },
       banner: {
@@ -341,6 +312,15 @@ async function buildHooks() {
       console.warn(
         `⚠️  worker-service.cjs is ${(workerStats.size / 1024).toFixed(2)} KB (advisory budget ${(WORKER_SERVICE_MAX_BYTES / 1024).toFixed(0)} KB). ` +
         `If this jumped unexpectedly, check whether a server-only dependency leaked into the worker bundle (see #2584).`
+      );
+    }
+
+    const workerBundleContent = fs.readFileSync(`${hooksDir}/${WORKER_SERVICE.name}.cjs`, 'utf-8');
+    const workerZodRequireRegex = /require\(\s*["']zod(?:\/[^"']*)?["']\s*\)/;
+    const workerZodRequireMatch = workerBundleContent.match(workerZodRequireRegex);
+    if (workerZodRequireMatch) {
+      throw new Error(
+        `worker-service.cjs contains external ${workerZodRequireMatch[0]}. Zod must be bundled into the worker service so the hook client process does not fail when plugin node_modules is unavailable after a version upgrade. See issue #2831.`
       );
     }
 
@@ -483,10 +463,6 @@ async function buildHooks() {
       outfile: `${hooksDir}/${TRANSCRIPT_WATCHER.name}.cjs`,
       minify: true,
       logLevel: 'error',
-      // Externalize zod for consistency with worker-service / server-beta-service —
-      // any zod usage in the processor.ts import chain should resolve at runtime
-      // against plugin/node_modules instead of being inlined (avoids duplicate-
-      // instance hazards and keeps the bundle slim).
       external: ['bun:sqlite', 'zod'],
       define: {
         '__DEFAULT_PACKAGE_VERSION__': `"${version}"`

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -491,6 +491,10 @@ async function buildHooks() {
       outfile: `${hooksDir}/${TRANSCRIPT_WATCHER.name}.cjs`,
       minify: true,
       logLevel: 'error',
+      // Externalize zod for consistency with worker-service / server-beta-service —
+      // any zod usage in the processor.ts import chain should resolve at runtime
+      // against plugin/node_modules instead of being inlined (avoids duplicate-
+      // instance hazards and keeps the bundle slim).
       external: ['bun:sqlite', 'zod'],
       define: {
         '__DEFAULT_PACKAGE_VERSION__': `"${version}"`

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -54,6 +54,14 @@ function stripHardcodedDirname(filePath) {
   }
 }
 
+/**
+ * Rule A canonical-template manifest: maps each host-managed config file's
+ * command string to the buildShellCommand() options that generate it. The
+ * build asserts the hand-maintained files still match the generator output so
+ * the defensive shell prelude can't drift between the three files (issues
+ * #1215, #1533). See src/build/hook-shell-template.ts and CLAUDE.md →
+ * "Spawn-Contract Resolution".
+ */
 function shellTemplateManifest(buildShellCommand) {
   const ccTrailing = (...tail) => [
     'node', '"$_P/scripts/bun-runner.js"', '"$_P/scripts/worker-service.cjs"', ...tail,
@@ -103,6 +111,8 @@ function shellTemplateManifest(buildShellCommand) {
     'plugin/.mcp.json': {
       kind: 'mcp',
       command: buildShellCommand({
+        // The mcp Node launcher derives its spawn target from requireFile, so
+        // no trailingCommand is needed (it is ignored for this host).
         host: 'mcp', requireFile: 'mcp-server.cjs',
         notFoundMessage: 'claude-mem: mcp server not found',
         mcpExtraCandidates: ['$PWD/plugin', '$PWD'],
@@ -123,6 +133,9 @@ function hookCommandByPath(parsed, dottedPath) {
 async function verifyShellTemplateCanonical() {
   console.log('\n📋 Verifying Rule A shell templates match the canonical generator...');
 
+  // Compile src/build/hook-shell-template.ts in-memory and import it. The build
+  // runs under Node, which can't import .ts directly, so we bundle to ESM and
+  // load via a data: URL.
   const bundled = await build({
     entryPoints: ['src/build/hook-shell-template.ts'],
     bundle: true,
@@ -160,6 +173,7 @@ async function verifyShellTemplateCanonical() {
     }
   }
 
+  // Rule C safety net (bun-runner.js fixBrokenScriptPath) must stay documented.
   const bunRunner = fs.readFileSync('plugin/scripts/bun-runner.js', 'utf-8');
   if (!bunRunner.includes('function fixBrokenScriptPath')) {
     throw new Error(
@@ -167,6 +181,9 @@ async function verifyShellTemplateCanonical() {
     );
   }
 
+  // Parser-compat guard (issue #2791): bun-runner.js is invoked by hosts that
+  // may run a pre-ES2020 Node whose ESM loader throws on optional chaining.
+  // Strip comments, then forbid `?.` / `??` in executable code.
   const bunRunnerCode = bunRunner
     .replace(/\/\*[\s\S]*?\*\//g, '')
     .replace(/(^|[^:])\/\/.*$/gm, '$1');
@@ -279,7 +296,13 @@ async function buildHooks() {
         'ollama',
         '@chroma-core/default-embed',
         'onnxruntime-node',
-        // better-auth stays external because dynamic server routes otherwise drag server-only deps into worker-service.cjs (#2584).
+        // better-auth (~3.7MB) is only reachable through BetterAuthRoutes' request-time
+        // dynamic import('better-auth/node') / import('./auth.js'). esbuild otherwise
+        // inlines that dynamic-import target into the worker bundle, dragging in the full
+        // better-auth library (kysely, oauth, nanoid, …) even though the worker never
+        // exercises it (the dep isn't in the worker's runtime plugin/package.json deps,
+        // and the route handler already wraps the import in try/catch → graceful 500).
+        // Keeping it external strips the dead weight from worker-service.cjs. See #2584.
         'better-auth',
         'better-auth/node',
         'better-auth/plugins',
@@ -287,6 +310,10 @@ async function buildHooks() {
       ],
       define: {
         '__DEFAULT_PACKAGE_VERSION__': `"${version}"`,
+        // Polyfill import.meta.url for ESM deps bundled into CJS output.
+        // @anthropic-ai/claude-agent-sdk's *.mjs files use createRequire(import.meta.url)
+        // and `new URL(rel, import.meta.url)`. We map import.meta.url to a file:// URL
+        // (not the raw __filename path) so URL construction preserves its semantics.
         'import.meta.url': '__IMPORT_META_URL__'
       },
       banner: {

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -510,9 +510,7 @@ async function buildHooks() {
     const transcriptWatcherStats = fs.statSync(`${hooksDir}/${TRANSCRIPT_WATCHER.name}.cjs`);
     console.log(`✓ transcript-watcher built (${(transcriptWatcherStats.size / 1024).toFixed(2)} KB)`);
 
-    // Guard against accidental imports of heavy modules (worker-service,
-    // SDK runtimes, etc.) into the watcher's processor.ts chain. The watcher
-    // is a thin file-tail loop and should stay well under 200 KB.
+    // Advisory only — the watcher is meant to be a thin file-tail loop.
     const TRANSCRIPT_WATCHER_MAX_BYTES = 200 * 1024;
     if (transcriptWatcherStats.size > TRANSCRIPT_WATCHER_MAX_BYTES) {
       console.warn(

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -279,6 +279,7 @@ async function buildHooks() {
         'ollama',
         '@chroma-core/default-embed',
         'onnxruntime-node',
+        // better-auth stays external because dynamic server routes otherwise drag server-only deps into worker-service.cjs (#2584).
         'better-auth',
         'better-auth/node',
         'better-auth/plugins',

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -506,7 +506,9 @@ async function buildHooks() {
     const transcriptWatcherStats = fs.statSync(`${hooksDir}/${TRANSCRIPT_WATCHER.name}.cjs`);
     console.log(`✓ transcript-watcher built (${(transcriptWatcherStats.size / 1024).toFixed(2)} KB)`);
 
-    // Advisory only — the watcher is meant to be a thin file-tail loop.
+    // Guard against accidental imports of heavy modules (worker-service,
+    // SDK runtimes, etc.) into the watcher's processor.ts chain. The watcher
+    // is a thin file-tail loop and should stay well under 200 KB.
     const TRANSCRIPT_WATCHER_MAX_BYTES = 200 * 1024;
     if (transcriptWatcherStats.size > TRANSCRIPT_WATCHER_MAX_BYTES) {
       console.warn(


### PR DESCRIPTION
## Summary

When plugin upgrades leave `plugin/node_modules/zod` briefly missing or mismatched, any `worker-service.cjs` build that still treats `zod` as external can crash hook clients with a missing-module error. This PR removes `zod` from the worker-service esbuild `external` list and adds a post-build guard that fails the build if a `require("zod...")` ever reappears in the worker output.

## Why

`scripts/build-hooks.js` still allowed the worker bundle to emit an external `require("zod")` path. The MCP build already protects against this class of regression with an output check, but the worker build did not. Removing `zod` from the worker external list forces it to inline into `worker-service.cjs`, and the new `workerZodRequireRegex` guard keeps that invariant locked in on future edits.

## Scope

This PR changes only the worker-service build entry in `scripts/build-hooks.js`. It does not change the server-beta, context-generator, or transcript-watcher bundling strategy, and it keeps the existing plugin/package dependency declarations intact for the other bundled consumers that still resolve `zod` at runtime.

## Verification

- [x] `npm run build` - passed locally; `worker-service.cjs` built at 2754.35 KB and the new guard confirmed no external `require("zod...")` remains.
- [x] `bun test tests/infrastructure/plugin-distribution.test.ts --test-name-pattern "Build Script Verification|Required Files"` - 8 passed.
- [x] `npm run lint:hook-io` - passed locally.
- [x] `npm run lint:spawn-env` - passed locally.
- [x] `npm run strip-comments:check` - matched the current repo baseline in check mode (`Changed: 330`).

Closes #2831