### PR TITLE
fix(worker): detect real port occupation cross-platform and reclaim stale workers

### DIFF
--- a/src/services/infrastructure/HealthMonitor.ts
+++ b/src/services/infrastructure/HealthMonitor.ts
@@ -21,28 +21,17 @@ async function httpRequestToWorker(
 }
 
 export async function isPortInUse(port: number): Promise<boolean> {
-  if (process.platform === 'win32') {
-    try {
-      const response = await fetch(`http://127.0.0.1:${port}/api/health`);
-      return response.ok;
-    } catch (error) {
-      if (error instanceof Error) {
-        logger.debug('SYSTEM', 'Windows health check failed (port not in use)', {}, error);
-      } else {
-        logger.debug('SYSTEM', 'Windows health check failed (port not in use)', { error: String(error) });
-      }
-      return false;
-    }
-  }
-
+  // Detect real TCP occupation on every platform by attempting to bind. This is
+  // deliberately NOT conflated with "a healthy worker is answering": a stale or
+  // zombie worker can hold the socket without responding to /api/health (health
+  // is a separate question, answered by waitForHealth). The previous Windows
+  // branch probed /api/health here, so a zombie holding the port read as "free",
+  // every caller spawned a duplicate that died on bind with EADDRINUSE, and the
+  // worker re-spawn looped forever until the zombie was killed by hand.
   return new Promise((resolve) => {
     const server = net.createServer();
     server.once('error', (err: NodeJS.ErrnoException) => {
-      if (err.code === 'EADDRINUSE') {
-        resolve(true);
-      } else {
-        resolve(false);
-      }
+      resolve(err.code === 'EADDRINUSE');
     });
     server.once('listening', () => {
       server.close(() => resolve(false));

--- a/src/services/infrastructure/ProcessManager.ts
+++ b/src/services/infrastructure/ProcessManager.ts
@@ -10,6 +10,7 @@ import { HOOK_TIMEOUTS } from '../../shared/hook-constants.js';
 import { sanitizeEnv } from '../../supervisor/env-sanitizer.js';
 import { getSupervisor, validateWorkerPidFile, type ValidateWorkerPidStatus } from '../../supervisor/index.js';
 import { paths } from '../../shared/paths.js';
+import { waitForPortFree } from './HealthMonitor.js';
 
 const execAsync = promisify(exec);
 
@@ -562,5 +563,94 @@ export function touchPidFile(): void {
 
 export function cleanStalePidFile(): ValidateWorkerPidStatus {
   return validateWorkerPidFile({ logAlive: false });
+}
+
+async function findPortOwnerPid(port: number): Promise<number | null> {
+  try {
+    if (process.platform === 'win32') {
+      const cmd = `powershell -NoProfile -NonInteractive -Command "(Get-NetTCPConnection -LocalPort ${port} -State Listen -ErrorAction SilentlyContinue | Select-Object -First 1).OwningProcess"`;
+      const { stdout } = await execAsync(cmd, { timeout: HOOK_TIMEOUTS.POWERSHELL_COMMAND, windowsHide: true });
+      const pid = parseInt(stdout.trim(), 10);
+      return Number.isInteger(pid) && pid > 0 ? pid : null;
+    }
+    const { stdout } = await execAsync(`lsof -ti tcp:${port} -sTCP:LISTEN`, { timeout: 5000 });
+    const pid = parseInt((stdout.split('\n')[0] ?? '').trim(), 10);
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch (error: unknown) {
+    logger.debug('SYSTEM', 'Could not determine port owner PID', { port },
+      error instanceof Error ? error : new Error(String(error)));
+    return null;
+  }
+}
+
+async function getProcessCommandLine(pid: number): Promise<string | null> {
+  try {
+    if (process.platform === 'win32') {
+      const cmd = `powershell -NoProfile -NonInteractive -Command "(Get-CimInstance Win32_Process -Filter 'ProcessId=${pid}').CommandLine"`;
+      const { stdout } = await execAsync(cmd, { timeout: HOOK_TIMEOUTS.POWERSHELL_COMMAND, windowsHide: true });
+      const line = stdout.trim();
+      return line.length > 0 ? line : null;
+    }
+    const { stdout } = await execAsync(`ps -p ${pid} -o args=`, { timeout: 5000 });
+    const line = stdout.trim();
+    return line.length > 0 ? line : null;
+  } catch (error: unknown) {
+    logger.debug('SYSTEM', 'Could not read process command line', { pid },
+      error instanceof Error ? error : new Error(String(error)));
+    return null;
+  }
+}
+
+function isOwnedByClaudeMem(pid: number, commandLine: string | null): boolean {
+  const recorded = readPidFile();
+  if (recorded && recorded.pid === pid) return true;
+  if (commandLine && /worker-service|claude-mem/i.test(commandLine)) return true;
+  return false;
+}
+
+async function terminateProcess(pid: number): Promise<boolean> {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    if (process.platform === 'win32') {
+      await execAsync(`taskkill /F /PID ${pid}`, { timeout: HOOK_TIMEOUTS.POWERSHELL_COMMAND, windowsHide: true });
+    } else {
+      process.kill(pid, 'SIGKILL');
+    }
+    return true;
+  } catch (error: unknown) {
+    logger.warn('SYSTEM', 'Failed to terminate process', { pid },
+      error instanceof Error ? error : new Error(String(error)));
+    return false;
+  }
+}
+
+/**
+ * When the worker port is held but no healthy worker answers, a stale/zombie
+ * claude-mem worker is most likely still bound to the socket. Identify the
+ * owning PID, confirm it belongs to claude-mem (recorded PID file OR a command
+ * line marker — never kill an unrelated process), terminate it, and wait for
+ * the port to free. Returns true only if the port is verifiably free afterward.
+ */
+export async function reclaimStaleWorkerPort(port: number): Promise<boolean> {
+  const pid = await findPortOwnerPid(port);
+  if (pid === null) {
+    logger.warn('SYSTEM', 'Port held but owning PID could not be determined — not reclaiming', { port });
+    return false;
+  }
+  const commandLine = await getProcessCommandLine(pid);
+  if (!isOwnedByClaudeMem(pid, commandLine)) {
+    logger.error('SYSTEM', 'Port held by a non-claude-mem process — refusing to kill', { port, pid, commandLine });
+    return false;
+  }
+  logger.warn('SYSTEM', 'Reclaiming port from unresponsive claude-mem worker', { port, pid });
+  if (!(await terminateProcess(pid))) return false;
+  const freed = await waitForPortFree(port, getPlatformTimeout(HOOK_TIMEOUTS.PORT_IN_USE_WAIT));
+  if (!freed) {
+    logger.error('SYSTEM', 'Terminated stale worker but port did not free in time', { port, pid });
+    return false;
+  }
+  removePidFile();
+  logger.info('SYSTEM', 'Stale worker terminated and port reclaimed', { port, pid });
+  return true;
 }
 

--- a/src/services/worker-spawner.ts
+++ b/src/services/worker-spawner.ts
@@ -7,6 +7,7 @@ import { SettingsDefaultsManager } from '../shared/SettingsDefaultsManager.js';
 import {
   cleanStalePidFile,
   getPlatformTimeout,
+  reclaimStaleWorkerPort,
   spawnDaemon,
   touchPidFile,
 } from './infrastructure/ProcessManager.js';
@@ -119,8 +120,16 @@ export async function ensureWorkerStarted(
       logger.info('SYSTEM', 'Worker is now healthy');
       return ready ? 'ready' : 'warming';
     }
-    logger.error('SYSTEM', 'Port in use but worker not responding to health checks');
-    return 'dead';
+    // Port held but nothing healthy answering → almost certainly a stale/zombie
+    // worker still bound to the socket. Reclaim it (validated kill) and fall
+    // through to a fresh spawn below. If reclaim fails, give up cleanly instead
+    // of letting every subsequent hook re-spawn a daemon that dies on bind.
+    const reclaimed = await reclaimStaleWorkerPort(port);
+    if (!reclaimed) {
+      logger.error('SYSTEM', 'Port in use but worker not responding and reclaim failed');
+      return 'dead';
+    }
+    clearWorkerSpawnAttempted();
   }
 
   if (shouldSkipSpawnOnWindows()) {


### PR DESCRIPTION
## Problem

On Windows, `isPortInUse()` probed `/api/health` instead of testing the socket. A stale/zombie worker that still holds the port but no longer answers health checks therefore read as **"port free"**. Every hook then spawned a duplicate daemon, which collided on `bind` with `EADDRINUSE`, logged `Worker failed to start. Is port <port> in use?`, and exited — repeating on every subsequent hook in a tight loop until the zombie was killed manually.

Observed in the wild on port `37777`: the worker re-spawned and failed every ~30s for minutes, with no automatic recovery.

## Root cause

`isPortInUse` conflated two different questions:

- **Is the port occupied?** — a TCP-level fact
- **Is a healthy worker answering?** — an application-level fact

The POSIX branch answered the first correctly (`bind` + `EADDRINUSE`); the Windows branch answered the second (`fetch /api/health`). So a port held by an unhealthy/zombie process was invisible to every "don't spawn a duplicate" guard on Windows.

## Fix

1. **`HealthMonitor.isPortInUse`** — detect real TCP occupation on every platform via a bind attempt (the previous POSIX behaviour). Health stays a separate concern handled by `waitForHealth`. *This alone stops the loop*: the duplicate daemon now hits the `isPortInUse` guard and exits cleanly (`Port already in use, refusing to start duplicate`) instead of colliding on bind.
2. **`ProcessManager.reclaimStaleWorkerPort`** — automatic recovery: when the port is held but nothing healthy answers, find the owning PID, **confirm it belongs to claude-mem** (recorded PID file *or* a `worker-service`/`claude-mem` command-line marker — it will never kill an unrelated process), terminate it, wait for the port to free, and clear the PID file.
3. **`worker-spawner`** — use the reclaim in the "port in use but unhealthy" branch, then fall through to a fresh spawn; if reclaim fails, give up cleanly instead of re-spawning on every hook.

## Notes

- Cross-platform: PID discovery uses `Get-NetTCPConnection` on Windows and `lsof` on POSIX; termination uses `taskkill /F` / `SIGKILL`.
- The reclaim is deliberately conservative — it refuses to act unless ownership is positively confirmed, so it can never kill an unrelated process bound to the port.
- Build artifacts (`plugin/scripts/*.cjs`) are intentionally omitted; CI regenerates them via `npm run build`.

## Testing

- `tsc --noEmit`: clean for the changed files (pre-existing errors elsewhere are unrelated).
- `tests/infrastructure/health-monitor.test.ts` (covers `isPortInUse`): passes.
- Rebuilt the worker bundle from this source and verified on Windows that it starts identically to the original (no regression) and that the duplicate-spawn loop no longer occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
