### PR TITLE
Avoid no-op SDK respawns

### DIFF
--- a/src/services/worker/agents/ResponseProcessor.ts
+++ b/src/services/worker/agents/ResponseProcessor.ts
@@ -17,13 +17,6 @@ import type { WorkerRef, StorageResult } from './types.js';
 import { broadcastObservation, broadcastSummary } from './ObservationBroadcaster.js';
 import { captureEvent } from '../../telemetry/telemetry.js';
 
-/**
- * Consecutive non-XML observer outputs tolerated before we kill and respawn the
- * SDK session (plan-11, #2485). Idle and prose both count; poisoned triggers an
- * immediate respawn regardless of the count.
- */
-export const INVALID_OUTPUT_RESPAWN_THRESHOLD = 3;
-
 export async function processAgentResponse(
   text: string,
   session: ActiveSession,
@@ -58,29 +51,22 @@ export async function processAgentResponse(
     const outputClass = classifyObserverOutput(text);
     const preview = previewOutput(text);
 
-    session.consecutiveInvalidOutputs = (session.consecutiveInvalidOutputs ?? 0) + 1;
-
     logger.warn('PARSER', `${agentName} returned non-XML ${outputClass} response — ignoring queued batch`, {
       sessionId: session.sessionDbId,
       outputClass,
       preview,
-      consecutiveInvalidOutputs: session.consecutiveInvalidOutputs,
+      consecutiveInvalidOutputs: session.consecutiveInvalidOutputs ?? 0,
     });
 
     // Recover from poison (plan-11, #2485): a poisoned closure string means the
-    // SDK session is wedged and will keep emitting garbage — respawn immediately.
-    // For idle/prose, only respawn after N consecutive invalid outputs so we
-    // don't churn the session on benign single-batch misses.
-    const mustRespawn =
-      outputClass === 'poisoned' ||
-      session.consecutiveInvalidOutputs >= INVALID_OUTPUT_RESPAWN_THRESHOLD;
-
-    if (mustRespawn) {
+    // SDK session is wedged and will keep emitting garbage. Idle/prose outputs
+    // are benign no-ops: confirm the claimed batch and keep the session alive.
+    if (outputClass === 'poisoned') {
+      session.consecutiveInvalidOutputs = (session.consecutiveInvalidOutputs ?? 0) + 1;
       logger.error('SESSION', `${agentName} session poisoned — killing and respawning, pending messages preserved`, {
         sessionId: session.sessionDbId,
         outputClass,
         consecutiveInvalidOutputs: session.consecutiveInvalidOutputs,
-        threshold: INVALID_OUTPUT_RESPAWN_THRESHOLD,
       });
       // Respawn-gated telemetry ONLY (never per invalid output — volume).
       // Closed enums and counts; the raw model output never leaves the box.
@@ -101,6 +87,7 @@ export async function processAgentResponse(
     // Plain-text skip responses are intentionally ignored. Re-queueing them
     // creates an observer loop where the same low-signal batch is retried
     // until the restart guard fires or the provider quota is exhausted.
+    session.consecutiveInvalidOutputs = 0;
     await sessionManager.confirmClaimedMessages(session.sessionDbId);
     session.earliestPendingTimestamp = null;
     return;

--- a/tests/worker/poison-respawn.test.ts
+++ b/tests/worker/poison-respawn.test.ts
@@ -37,7 +37,7 @@ mock.module('../../src/services/worker-service.js', () => ({
 }));
 
 import { SessionManager } from '../../src/services/worker/SessionManager.js';
-import { processAgentResponse, INVALID_OUTPUT_RESPAWN_THRESHOLD } from '../../src/services/worker/agents/ResponseProcessor.js';
+import { processAgentResponse } from '../../src/services/worker/agents/ResponseProcessor.js';
 import type { DatabaseManager } from '../../src/services/worker/DatabaseManager.js';
 import type { WorkerRef } from '../../src/services/worker/agents/types.js';
 
@@ -112,7 +112,7 @@ describe('poison respawn (plan-11 #2485)', () => {
     expect(session.consecutiveInvalidOutputs).toBe(0); // reset on respawn
   });
 
-  it('respawns only after N consecutive prose/idle outputs, not on the first', async () => {
+  it('does not respawn on repeated prose/idle outputs', async () => {
     const sm = new SessionManager(makeDbManager());
     const session = sm.initializeSession(2, 'do the thing', 1);
     session.memorySessionId = 'mem-2';
@@ -122,22 +122,14 @@ describe('poison respawn (plan-11 #2485)', () => {
 
     const respawnSpy = spyOn(sm, 'respawnPoisonedSession');
 
-    // First (threshold - 1) prose responses must NOT respawn.
-    for (let i = 0; i < INVALID_OUTPUT_RESPAWN_THRESHOLD - 1; i++) {
+    for (let i = 0; i < 5; i++) {
       await processAgentResponse(
-        'Just some prose, no XML here.',
+        i % 2 === 0 ? 'Just some prose, no XML here.' : '',
         session, makeDbManager(), sm, mockWorker, 0, null, 'TestAgent'
       );
     }
     expect(respawnSpy).not.toHaveBeenCalled();
-    expect(session.consecutiveInvalidOutputs).toBe(INVALID_OUTPUT_RESPAWN_THRESHOLD - 1);
-
-    // The Nth invalid output crosses the threshold and triggers respawn.
-    await processAgentResponse(
-      'Still just prose.',
-      session, makeDbManager(), sm, mockWorker, 0, null, 'TestAgent'
-    );
-    expect(respawnSpy).toHaveBeenCalledWith(2);
+    expect(session.consecutiveInvalidOutputs).toBe(0);
   });
 
   it('respawnPoisonedSession preserves the buffer and resets context', async () => {


### PR DESCRIPTION
Idle/prose observer output is a no-op, not a poisoned SDK session. This keeps claimed batches confirmed without respawning unless the classifier returns poisoned. Tests: bun test tests/worker/poison-respawn.test.ts tests/worker/agents/response-processor.test.ts tests/sdk/output-classifier.test.ts; npm run typecheck; git diff --check. Full bun test was attempted but exceeded 5 minutes locally without a failure summary.