### PR TITLE
fix(sqlite): reclaim residual prompt and queue bloat (refs #2793)

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -16,6 +16,7 @@ import type { ObservationSearchResult, SessionSummarySearchResult } from './type
 import { computeObservationContentHash } from './observations/store.js';
 import { DEFAULT_PLATFORM_SOURCE, normalizePlatformSource, sortPlatformSources } from '../../shared/platform-source.js';
 import { findRecentDuplicateUserPrompt as findRecentDuplicateUserPromptRecord } from './prompts/get.js';
+import { applyLegacyPromptBloatMaintenance } from './maintenance.js';
 import { normalizeStoredPromptText } from './prompt-storage.js';
 import { applySqliteConnectionPragmas } from './connection.js';
 
@@ -109,6 +110,7 @@ export class SessionStore {
     this.ensurePendingMessagesSessionToolUniqueIndex();
     this.ensureSyncedAtColumns(options.cloudSyncStatePath ?? paths.cloudSyncState());
     this.requeuePromptCloudSyncAfterMapperFix();
+    applyLegacyPromptBloatMaintenance(this.db);
   }
 
   private getIndexColumns(indexName: string): string[] {
@@ -1501,7 +1503,18 @@ export class SessionStore {
     const nowIso = new Date(nowEpoch).toISOString();
     this.db.prepare(`
       UPDATE sdk_sessions
-      SET status = 'completed', completed_at = ?, completed_at_epoch = ?
+      SET status = 'completed',
+          completed_at = ?,
+          completed_at_epoch = ?,
+          user_prompt = CASE
+            WHEN EXISTS (
+              SELECT 1
+              FROM user_prompts up
+              WHERE up.content_session_id = sdk_sessions.content_session_id
+                AND up.prompt_number = 1
+            ) THEN NULL
+            ELSE user_prompt
+          END
       WHERE id = ?
     `).run(nowIso, nowEpoch, sessionDbId);
   }

--- a/src/services/sqlite/maintenance.ts
+++ b/src/services/sqlite/maintenance.ts
@@ -1,0 +1,224 @@
+import type { Database } from 'bun:sqlite';
+import { logger } from '../../utils/logger.js';
+import {
+  MAX_STORED_PROMPT_CHARS,
+  normalizeStoredPromptText,
+  STORED_PROMPT_NORMALIZATION_MARKERS,
+} from './prompt-storage.js';
+
+export const LEGACY_PROMPT_BLOAT_MAINTENANCE_VERSION = 35;
+export const LEGACY_PROMPT_BLOAT_RECLAIM_MIN_BYTES = 512 * 1024;
+
+interface PromptRow {
+  id: number;
+  prompt_text: string;
+}
+
+interface ScalarResult {
+  changes?: number;
+}
+
+interface PragmaValueRow {
+  auto_vacuum?: number;
+  freelist_count?: number;
+  page_size?: number;
+}
+
+export interface PromptBloatCompactionResult {
+  autoVacuumMode: number;
+  error?: string;
+  freeBytesAfter: number;
+  freeBytesBefore: number;
+  freelistCountAfter: number;
+  freelistCountBefore: number;
+  mode: 'failed' | 'incremental_vacuum' | 'vacuum' | 'skipped';
+  pageSize: number;
+  thresholdBytes: number;
+}
+
+export interface PromptBloatMaintenanceResult {
+  clearedSessionPrompts: number;
+  compaction: PromptBloatCompactionResult;
+  normalizedPromptRows: number;
+  versionApplied: boolean;
+}
+
+function getPragmaNumber(db: Database, pragma: 'auto_vacuum' | 'freelist_count' | 'page_size'): number {
+  const row = db.prepare(`PRAGMA ${pragma}`).get() as PragmaValueRow | undefined;
+  return Number(row?.[pragma] ?? 0);
+}
+
+function buildPromptCandidateQuery(): string {
+  const markerChecks = STORED_PROMPT_NORMALIZATION_MARKERS
+    .map(() => 'instr(prompt_text, ?) > 0')
+    .join(' OR ');
+  return `
+    SELECT id, prompt_text
+    FROM user_prompts
+    WHERE length(prompt_text) > ?
+      OR ${markerChecks}
+  `;
+}
+
+function normalizeLegacyPromptRows(db: Database): number {
+  const rows = db.prepare(buildPromptCandidateQuery()).all(
+    MAX_STORED_PROMPT_CHARS,
+    ...STORED_PROMPT_NORMALIZATION_MARKERS
+  ) as PromptRow[];
+  if (rows.length === 0) return 0;
+
+  const updateStmt = db.prepare('UPDATE user_prompts SET prompt_text = ? WHERE id = ?');
+  let normalizedPromptRows = 0;
+
+  for (const row of rows) {
+    const normalizedPrompt = normalizeStoredPromptText(row.prompt_text);
+    if (normalizedPrompt === row.prompt_text) continue;
+    updateStmt.run(normalizedPrompt, row.id);
+    normalizedPromptRows += 1;
+  }
+
+  return normalizedPromptRows;
+}
+
+function clearDuplicateCompletedSessionPrompts(db: Database): number {
+  const result = db.prepare(`
+    UPDATE sdk_sessions
+    SET user_prompt = NULL
+    WHERE user_prompt IS NOT NULL
+      AND status IN ('completed', 'failed')
+      AND EXISTS (
+        SELECT 1
+        FROM user_prompts up
+        WHERE up.content_session_id = sdk_sessions.content_session_id
+          AND up.prompt_number = 1
+      )
+  `).run() as ScalarResult;
+
+  return Number(result.changes ?? 0);
+}
+
+function reclaimPromptCleanupPages(
+  db: Database,
+  changedRows: number,
+  minFreeBytes: number
+): PromptBloatCompactionResult {
+  try {
+    db.run('PRAGMA wal_checkpoint(PASSIVE)');
+  } catch (error) {
+    logger.debug('DB', 'Legacy prompt bloat cleanup could not checkpoint WAL before compaction', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  const pageSize = getPragmaNumber(db, 'page_size');
+  const freelistCountBefore = getPragmaNumber(db, 'freelist_count');
+  const freeBytesBefore = pageSize * freelistCountBefore;
+  const autoVacuumMode = getPragmaNumber(db, 'auto_vacuum');
+
+  if (changedRows === 0 || freeBytesBefore < minFreeBytes) {
+    return {
+      autoVacuumMode,
+      freeBytesAfter: freeBytesBefore,
+      freeBytesBefore,
+      freelistCountAfter: freelistCountBefore,
+      freelistCountBefore,
+      mode: 'skipped',
+      pageSize,
+      thresholdBytes: minFreeBytes,
+    };
+  }
+
+  try {
+    if (autoVacuumMode === 2) {
+      db.run(`PRAGMA incremental_vacuum(${freelistCountBefore})`);
+    } else {
+      db.run('VACUUM');
+    }
+  } catch (error) {
+    const compactionError = error instanceof Error ? error : new Error(String(error));
+    logger.warn('DB', 'Legacy prompt bloat cleanup could not reclaim free pages', {
+      autoVacuumMode,
+      freeBytesBefore,
+      freelistCountBefore,
+    }, compactionError);
+    return {
+      autoVacuumMode,
+      error: compactionError.message,
+      freeBytesAfter: freeBytesBefore,
+      freeBytesBefore,
+      freelistCountAfter: freelistCountBefore,
+      freelistCountBefore,
+      mode: 'failed',
+      pageSize,
+      thresholdBytes: minFreeBytes,
+    };
+  }
+
+  const freelistCountAfter = getPragmaNumber(db, 'freelist_count');
+  return {
+    autoVacuumMode,
+    freeBytesAfter: pageSize * freelistCountAfter,
+    freeBytesBefore,
+    freelistCountAfter,
+    freelistCountBefore,
+    mode: autoVacuumMode === 2 ? 'incremental_vacuum' : 'vacuum',
+    pageSize,
+    thresholdBytes: minFreeBytes,
+  };
+}
+
+export function applyLegacyPromptBloatMaintenance(
+  db: Database,
+  minFreeBytes: number = LEGACY_PROMPT_BLOAT_RECLAIM_MIN_BYTES
+): PromptBloatMaintenanceResult {
+  const applied = db.prepare('SELECT 1 FROM schema_versions WHERE version = ?').get(
+    LEGACY_PROMPT_BLOAT_MAINTENANCE_VERSION
+  ) as { 1: number } | undefined;
+
+  if (applied) {
+    return {
+      clearedSessionPrompts: 0,
+      compaction: reclaimPromptCleanupPages(db, 0, minFreeBytes),
+      normalizedPromptRows: 0,
+      versionApplied: false,
+    };
+  }
+
+  let normalizedPromptRows = 0;
+  let clearedSessionPrompts = 0;
+  db.run('BEGIN TRANSACTION');
+  try {
+    normalizedPromptRows = normalizeLegacyPromptRows(db);
+    clearedSessionPrompts = clearDuplicateCompletedSessionPrompts(db);
+    db.prepare('INSERT OR IGNORE INTO schema_versions (version, applied_at) VALUES (?, ?)').run(
+      LEGACY_PROMPT_BLOAT_MAINTENANCE_VERSION,
+      new Date().toISOString()
+    );
+    db.run('COMMIT');
+  } catch (error) {
+    db.run('ROLLBACK');
+    throw error;
+  }
+
+  const compaction = reclaimPromptCleanupPages(
+    db,
+    normalizedPromptRows + clearedSessionPrompts,
+    minFreeBytes
+  );
+
+  if (normalizedPromptRows > 0 || clearedSessionPrompts > 0) {
+    logger.info('DB', 'Applied legacy prompt bloat maintenance', {
+      normalizedPromptRows,
+      clearedSessionPrompts,
+      compactionMode: compaction.mode,
+      freeBytesBefore: compaction.freeBytesBefore,
+      freeBytesAfter: compaction.freeBytesAfter,
+    });
+  }
+
+  return {
+    clearedSessionPrompts,
+    compaction,
+    normalizedPromptRows,
+    versionApplied: true,
+  };
+}

--- a/src/services/sqlite/maintenance.ts
+++ b/src/services/sqlite/maintenance.ts
@@ -6,7 +6,7 @@ import {
   STORED_PROMPT_NORMALIZATION_MARKERS,
 } from './prompt-storage.js';
 
-export const LEGACY_PROMPT_BLOAT_MAINTENANCE_VERSION = 35;
+export const LEGACY_PROMPT_BLOAT_MAINTENANCE_VERSION = 41;
 export const LEGACY_PROMPT_BLOAT_RECLAIM_MIN_BYTES = 512 * 1024;
 
 interface PromptRow {

--- a/src/services/sqlite/prompt-storage.ts
+++ b/src/services/sqlite/prompt-storage.ts
@@ -2,6 +2,14 @@ import { stripMemoryTags } from '../../utils/tag-stripping.js';
 import { logger } from '../../utils/logger.js';
 
 export const MAX_STORED_PROMPT_CHARS = 4000;
+export const STORED_PROMPT_NORMALIZATION_MARKERS = [
+  '<private',
+  '<claude-mem-context',
+  '<system_instruction',
+  '<system-instruction',
+  '<persisted-output',
+  '<system-reminder',
+] as const;
 
 export function normalizeStoredPromptText(promptText: string): string {
   const trimmedRawPrompt = promptText.trim();

--- a/tests/services/sqlite/session-store-maintenance.test.ts
+++ b/tests/services/sqlite/session-store-maintenance.test.ts
@@ -44,6 +44,9 @@ describe('applyLegacyPromptBloatMaintenance', () => {
 
     const legacyStore = new SessionStore(db);
     cleanup = () => legacyStore.close();
+    for (const version of [35, 40]) {
+      expect(db.prepare('SELECT 1 FROM schema_versions WHERE version = ?').get(version)).toBeTruthy();
+    }
     const completedSessionId = legacyStore.createSDKSession('completed-session', 'project', createLegacyPrompt(40_000));
     legacyStore.saveUserPrompt('completed-session', 1, 'placeholder');
     const activeSessionId = legacyStore.createSDKSession('active-session', 'project', createLegacyPrompt(40_000));
@@ -53,6 +56,8 @@ describe('applyLegacyPromptBloatMaintenance', () => {
     legacyStore.saveUserPrompt('partial-history-session', 2, 'follow-up prompt');
 
     db.prepare('DELETE FROM schema_versions WHERE version = ?').run(LEGACY_PROMPT_BLOAT_MAINTENANCE_VERSION);
+    expect(db.prepare('SELECT version FROM schema_versions WHERE version IN (35, 40) ORDER BY version').all())
+      .toEqual([{ version: 35 }, { version: 40 }]);
     db.prepare('UPDATE sdk_sessions SET status = ?, user_prompt = ?, completed_at = ?, completed_at_epoch = ? WHERE id = ?')
       .run('completed', createLegacyPrompt(40_000), new Date().toISOString(), Date.now(), completedSessionId);
     db.prepare('UPDATE sdk_sessions SET status = ?, user_prompt = ?, completed_at = ?, completed_at_epoch = ? WHERE id = ?')

--- a/tests/services/sqlite/session-store-maintenance.test.ts
+++ b/tests/services/sqlite/session-store-maintenance.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  applyLegacyPromptBloatMaintenance,
+  LEGACY_PROMPT_BLOAT_MAINTENANCE_VERSION,
+} from '../../../src/services/sqlite/maintenance.js';
+import { SessionStore } from '../../../src/services/sqlite/SessionStore.js';
+import { MAX_STORED_PROMPT_CHARS } from '../../../src/services/sqlite/prompt-storage.js';
+
+describe('applyLegacyPromptBloatMaintenance', () => {
+  let tempDir: string;
+  let cleanup: (() => void) | null = null;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'claude-mem-maint-'));
+  });
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = null;
+    try {
+      rmSync(tempDir, { force: true, recursive: true });
+    } catch (error) {
+      if (!(error instanceof Error) || !error.message.includes('EBUSY')) {
+        throw error;
+      }
+    }
+  });
+
+  function createLegacyPrompt(payloadCharCount: number): string {
+    return `<claude-mem-context>hidden</claude-mem-context>${'A'.repeat(payloadCharCount)}`;
+  }
+
+  function createFileDb(name: string): Database {
+    return new Database(join(tempDir, name), { create: true, readwrite: true });
+  }
+
+  it('normalizes legacy prompt rows and clears only duplicate completed-session prompts', () => {
+    const db = createFileDb('legacy-prompt-bloat.sqlite');
+    db.run('PRAGMA foreign_keys = ON');
+
+    const legacyStore = new SessionStore(db);
+    cleanup = () => legacyStore.close();
+    const completedSessionId = legacyStore.createSDKSession('completed-session', 'project', createLegacyPrompt(40_000));
+    legacyStore.saveUserPrompt('completed-session', 1, 'placeholder');
+    const activeSessionId = legacyStore.createSDKSession('active-session', 'project', createLegacyPrompt(40_000));
+    legacyStore.saveUserPrompt('active-session', 1, createLegacyPrompt(40_000));
+    const fallbackSessionId = legacyStore.createSDKSession('fallback-session', 'project', 'fallback prompt');
+    const partialHistorySessionId = legacyStore.createSDKSession('partial-history-session', 'project', 'first prompt fallback');
+    legacyStore.saveUserPrompt('partial-history-session', 2, 'follow-up prompt');
+
+    db.prepare('DELETE FROM schema_versions WHERE version = ?').run(LEGACY_PROMPT_BLOAT_MAINTENANCE_VERSION);
+    db.prepare('UPDATE sdk_sessions SET status = ?, user_prompt = ?, completed_at = ?, completed_at_epoch = ? WHERE id = ?')
+      .run('completed', createLegacyPrompt(40_000), new Date().toISOString(), Date.now(), completedSessionId);
+    db.prepare('UPDATE sdk_sessions SET status = ?, user_prompt = ?, completed_at = ?, completed_at_epoch = ? WHERE id = ?')
+      .run('completed', 'fallback prompt', new Date().toISOString(), Date.now(), fallbackSessionId);
+    db.prepare('UPDATE sdk_sessions SET status = ?, user_prompt = ?, completed_at = ?, completed_at_epoch = ? WHERE id = ?')
+      .run('completed', 'first prompt fallback', new Date().toISOString(), Date.now(), partialHistorySessionId);
+    db.prepare('UPDATE user_prompts SET prompt_text = ? WHERE content_session_id = ?')
+      .run(createLegacyPrompt(40_000), 'completed-session');
+    db.prepare('UPDATE user_prompts SET prompt_text = ? WHERE content_session_id = ?')
+      .run(createLegacyPrompt(40_000), 'active-session');
+
+    const result = applyLegacyPromptBloatMaintenance(db, Number.MAX_SAFE_INTEGER);
+
+    const completed = db.prepare('SELECT user_prompt FROM sdk_sessions WHERE id = ?').get(completedSessionId) as { user_prompt: string | null };
+    const active = db.prepare('SELECT user_prompt FROM sdk_sessions WHERE id = ?').get(activeSessionId) as { user_prompt: string | null };
+    const fallback = db.prepare('SELECT user_prompt FROM sdk_sessions WHERE id = ?').get(fallbackSessionId) as { user_prompt: string | null };
+    const partialHistory = db.prepare('SELECT user_prompt FROM sdk_sessions WHERE id = ?').get(partialHistorySessionId) as { user_prompt: string | null };
+    const prompts = db.prepare(`
+      SELECT content_session_id, prompt_text
+      FROM user_prompts
+      WHERE content_session_id IN ('completed-session', 'active-session')
+      ORDER BY content_session_id
+    `).all() as Array<{ content_session_id: string; prompt_text: string }>;
+    const applied = db.prepare('SELECT 1 FROM schema_versions WHERE version = ?').get(
+      LEGACY_PROMPT_BLOAT_MAINTENANCE_VERSION
+    );
+
+    expect(result.normalizedPromptRows).toBe(2);
+    expect(result.clearedSessionPrompts).toBe(1);
+    expect(completed.user_prompt).toBeNull();
+    expect(active.user_prompt).not.toBeNull();
+    expect(active.user_prompt?.length).toBe(MAX_STORED_PROMPT_CHARS);
+    expect(active.user_prompt?.startsWith('<claude-mem-context>')).toBe(false);
+    expect(fallback.user_prompt).toBe('fallback prompt');
+    expect(partialHistory.user_prompt).toBe('first prompt fallback');
+    expect(prompts.every(prompt => prompt.prompt_text.length === MAX_STORED_PROMPT_CHARS)).toBe(true);
+    expect(prompts.every(prompt => prompt.prompt_text.startsWith('<claude-mem-context>'))).toBe(false);
+    expect(applied).toBeTruthy();
+  });
+
+  it('runs bounded page reclamation after real prompt cleanup when free pages exceed the threshold', () => {
+    const db = createFileDb('legacy-prompt-vacuum.sqlite');
+    db.run('PRAGMA auto_vacuum = INCREMENTAL');
+    db.run('VACUUM');
+    db.run('PRAGMA foreign_keys = ON');
+
+    const store = new SessionStore(db);
+    cleanup = () => store.close();
+    const contentSessionId = 'vacuum-session';
+    const sessionId = store.createSDKSession(contentSessionId, 'project', createLegacyPrompt(300_000));
+    store.saveUserPrompt(contentSessionId, 1, createLegacyPrompt(300_000));
+
+    db.prepare('DELETE FROM schema_versions WHERE version = ?').run(LEGACY_PROMPT_BLOAT_MAINTENANCE_VERSION);
+    db.prepare('UPDATE sdk_sessions SET status = ?, user_prompt = ?, completed_at = ?, completed_at_epoch = ? WHERE id = ?')
+      .run('completed', createLegacyPrompt(300_000), new Date().toISOString(), Date.now(), sessionId);
+    db.prepare('UPDATE user_prompts SET prompt_text = ? WHERE content_session_id = ?')
+      .run(createLegacyPrompt(300_000), contentSessionId);
+
+    const result = applyLegacyPromptBloatMaintenance(db, 1);
+
+    expect(result.normalizedPromptRows).toBe(1);
+    expect(result.clearedSessionPrompts).toBe(1);
+    expect(result.compaction.mode).toBe('incremental_vacuum');
+    expect(result.compaction.freeBytesBefore).toBeGreaterThan(0);
+    expect(result.compaction.freeBytesAfter).toBeLessThanOrEqual(result.compaction.freeBytesBefore);
+  });
+
+  it('does not fail startup maintenance when full vacuum cannot run', () => {
+    const db = createFileDb('legacy-prompt-vacuum-failure.sqlite');
+    db.run('PRAGMA foreign_keys = ON');
+
+    const store = new SessionStore(db);
+    cleanup = () => store.close();
+    const contentSessionId = 'vacuum-failure-session';
+    const sessionId = store.createSDKSession(contentSessionId, 'project', createLegacyPrompt(300_000));
+    store.saveUserPrompt(contentSessionId, 1, createLegacyPrompt(300_000));
+
+    db.prepare('DELETE FROM schema_versions WHERE version = ?').run(LEGACY_PROMPT_BLOAT_MAINTENANCE_VERSION);
+    db.prepare('UPDATE sdk_sessions SET status = ?, user_prompt = ?, completed_at = ?, completed_at_epoch = ? WHERE id = ?')
+      .run('completed', createLegacyPrompt(300_000), new Date().toISOString(), Date.now(), sessionId);
+    db.prepare('UPDATE user_prompts SET prompt_text = ? WHERE content_session_id = ?')
+      .run(createLegacyPrompt(300_000), contentSessionId);
+    db.run('PRAGMA auto_vacuum = NONE');
+    db.run('VACUUM');
+
+    const originalRun = db.run.bind(db);
+    const runSpy = spyOn(db, 'run').mockImplementation((sql: string, ...params: unknown[]) => {
+      if (sql === 'VACUUM') {
+        throw new Error('vacuum unavailable');
+      }
+      return originalRun(sql, ...params);
+    });
+
+    try {
+      const result = applyLegacyPromptBloatMaintenance(db, 1);
+      const applied = db.prepare('SELECT 1 FROM schema_versions WHERE version = ?').get(
+        LEGACY_PROMPT_BLOAT_MAINTENANCE_VERSION
+      );
+      const completed = db.prepare('SELECT user_prompt FROM sdk_sessions WHERE id = ?').get(sessionId) as { user_prompt: string | null };
+
+      expect(result.normalizedPromptRows).toBe(1);
+      expect(result.clearedSessionPrompts).toBe(1);
+      expect(result.compaction.mode).toBe('failed');
+      expect(result.compaction.error).toContain('vacuum unavailable');
+      expect(applied).toBeTruthy();
+      expect(completed.user_prompt).toBeNull();
+    } finally {
+      runSpy.mockRestore();
+    }
+  });
+});

--- a/tests/session_store.test.ts
+++ b/tests/session_store.test.ts
@@ -68,6 +68,50 @@ describe('SessionStore', () => {
     expect(duplicate?.prompt_text.length).toBe(MAX_STORED_PROMPT_CHARS);
   });
 
+  it('should clear sdk_sessions.user_prompt when completed prompt history exists', () => {
+    const contentSessionId = 'completed-canonical-session-store';
+    const sessionId = store.createSDKSession(contentSessionId, 'test-project', 'Initial prompt');
+    store.saveUserPrompt(contentSessionId, 1, 'Initial prompt');
+
+    store.markSessionCompleted(sessionId);
+
+    const row = store.db.prepare(
+      'SELECT status, user_prompt FROM sdk_sessions WHERE id = ?'
+    ).get(sessionId) as { status: string; user_prompt: string | null };
+
+    expect(row.status).toBe('completed');
+    expect(row.user_prompt).toBeNull();
+  });
+
+  it('should preserve sdk_sessions.user_prompt when completed prompt history is absent', () => {
+    const contentSessionId = 'completed-fallback-session-store';
+    const sessionId = store.createSDKSession(contentSessionId, 'test-project', 'Initial prompt');
+
+    store.markSessionCompleted(sessionId);
+
+    const row = store.db.prepare(
+      'SELECT status, user_prompt FROM sdk_sessions WHERE id = ?'
+    ).get(sessionId) as { status: string; user_prompt: string | null };
+
+    expect(row.status).toBe('completed');
+    expect(row.user_prompt).toBe('Initial prompt');
+  });
+
+  it('should preserve sdk_sessions.user_prompt when first completed prompt history is absent', () => {
+    const contentSessionId = 'completed-partial-history-session-store';
+    const sessionId = store.createSDKSession(contentSessionId, 'test-project', 'Initial prompt');
+    store.saveUserPrompt(contentSessionId, 2, 'Follow-up prompt');
+
+    store.markSessionCompleted(sessionId);
+
+    const row = store.db.prepare(
+      'SELECT status, user_prompt FROM sdk_sessions WHERE id = ?'
+    ).get(sessionId) as { status: string; user_prompt: string | null };
+
+    expect(row.status).toBe('completed');
+    expect(row.user_prompt).toBe('Initial prompt');
+  });
+
   it('should hide only older duplicate prompts from paginated prompt results', () => {
     const contentSessionId = 'paginated-duplicate-session-store';
     store.createSDKSession(contentSessionId, 'test-project', 'initial prompt');


### PR DESCRIPTION
## Summary

Long-running installs could still carry residual SQLite bloat after the prompt cap landed because completed sessions kept a duplicate `sdk_sessions.user_prompt` copy and oversized legacy `user_prompts` rows were never rewritten through the new normalizer. This change makes `user_prompts` the canonical completed-session prompt store for completed sessions, adds a one-time version-41 maintenance pass for legacy prompt residue, preserves the existing legacy queue cleanup path, and reclaims SQLite free pages after real cleanup work.

## Why

`createSDKSession()` stores the normalized prompt in `sdk_sessions.user_prompt`, then `saveUserPrompt()` stores the same prompt again in `user_prompts.prompt_text`. `markSessionCompleted()` only updated status and completion timestamps, so the duplicate copy stayed behind even after the session had canonical prompt history. Current schema repair already removes non-live legacy queue rows while dropping dead queue columns, but there was still no reusable post-cap maintenance path for duplicate completed-session prompts, oversized legacy prompt rows, or post-cleanup page reclamation.

The fix keeps the prevention and repair paths separate:
- `markSessionCompleted()` now clears `sdk_sessions.user_prompt` only when `user_prompts` history exists for that session.
- A one-time maintenance pass keyed by schema version 41 runs on legacy databases, normalizes oversized or tag-bearing `user_prompts.prompt_text` rows through `normalizeStoredPromptText()`, clears duplicate completed or failed `sdk_sessions.user_prompt` rows that already have prompt history, and then attempts bounded SQLite compaction only when cleanup actually freed enough pages.

## Scope

This does not remove the `sdk_sessions.user_prompt` column, and it preserves active-session fallback behavior plus completed sessions that never wrote prompt-history rows. It also does not add broad age-based observation retention, Chroma retention, or filesystem transcript retention; those need explicit product-policy thresholds and can be reviewed separately from this storage bloat cleanup.

## Risk

The main risk is deleting prompt text that is still the only display or fallback copy for a session, or regressing the current `pending_messages` legacy cleanup while touching adjacent maintenance code. The implementation avoids that by clearing `sdk_sessions.user_prompt` only for completed or failed sessions with canonical `user_prompts` history, leaving active sessions and sessions without prompt rows untouched, keeping compaction best-effort so `VACUUM` failures do not block startup, and keeping the existing pending-message cleanup path in place with regression coverage for `pending`, `processing`, and `failed` legacy rows.

## Verification

- [x] `bun test tests/session_store.test.ts tests/services/sqlite/session-store-maintenance.test.ts` — 15 passing
- [x] `npm run build` — passed
- [x] `npm run lint:hook-io` — passed
- [x] `npm run lint:spawn-env` — passed
- [ ] `npm run strip-comments:check` — exits non-zero on both this branch and clean `origin/main` with the same 316-change baseline, so this remains a pre-existing repo-wide strip-comments check baseline rather than a branch regression

## Upstream

Closes #2793.
Reported by @limaronaldo.
