### PR TITLE
fix(context): avoid blocking Claude SessionStart on Windows cold boot (closes #2903)

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -21,12 +21,6 @@
           {
             "type": "command",
             "shell": "bash",
-            "command": "export PATH=\"$($SHELL -lc 'echo $PATH' 2>/dev/null):$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _F=; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/bun-runner.js\" ] && [ -f \"$_Q/scripts/worker-service.cjs\" ] && [ -z \"$_F\" ] && { _F=1; printf '%s\\n' \"$_Q\"; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: plugin scripts not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/bun-runner.js\" \"$_P/scripts/worker-service.cjs\" start; echo '{\"continue\":true,\"suppressOutput\":true}'",
-            "timeout": 60
-          },
-          {
-            "type": "command",
-            "shell": "bash",
             "command": "export PATH=\"$($SHELL -lc 'echo $PATH' 2>/dev/null):$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _F=; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/bun-runner.js\" ] && [ -f \"$_Q/scripts/worker-service.cjs\" ] && [ -z \"$_F\" ] && { _F=1; printf '%s\\n' \"$_Q\"; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: plugin scripts not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/bun-runner.js\" \"$_P/scripts/worker-service.cjs\" hook claude-code context",
             "timeout": 60
           }

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -21,6 +21,12 @@
           {
             "type": "command",
             "shell": "bash",
+            "command": "export PATH=\"$($SHELL -lc 'echo $PATH' 2>/dev/null):$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _F=; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/bun-runner.js\" ] && [ -f \"$_Q/scripts/worker-service.cjs\" ] && [ -z \"$_F\" ] && { _F=1; printf '%s\\n' \"$_Q\"; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: plugin scripts not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/bun-runner.js\" \"$_P/scripts/worker-service.cjs\" start; echo '{\"continue\":true,\"suppressOutput\":true}'",
+            "timeout": 60
+          },
+          {
+            "type": "command",
+            "shell": "bash",
             "command": "export PATH=\"$($SHELL -lc 'echo $PATH' 2>/dev/null):$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _F=; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; ls -dt \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/ 2>/dev/null; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/bun-runner.js\" ] && [ -f \"$_Q/scripts/worker-service.cjs\" ] && [ -z \"$_F\" ] && { _F=1; printf '%s\\n' \"$_Q\"; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: plugin scripts not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/bun-runner.js\" \"$_P/scripts/worker-service.cjs\" hook claude-code context",
             "timeout": 60
           }

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -99,7 +99,8 @@ function shellTemplateManifest(buildShellCommand, buildCodexWindowsCommand) {
           trailingCommand: ['node', '"$_P/scripts/version-check.js"'],
           notFoundMessage: 'claude-mem: version-check.js not found',
         }),
-        'SessionStart.0.0': claudeHook(['hook', 'claude-code', 'context']),
+        'SessionStart.0.0': claudeHook(['start'], { trailingJson: { continue: true, suppressOutput: true } }),
+        'SessionStart.0.1': claudeHook(['hook', 'claude-code', 'context']),
         'UserPromptSubmit.0.0': claudeHook(['hook', 'claude-code', 'session-init']),
         'PostToolUse.0.0': claudeHook(['hook', 'claude-code', 'observation']),
         'PreToolUse.0.0': claudeHook(['hook', 'claude-code', 'file-context']),
@@ -138,7 +139,9 @@ function hookEntryByPath(parsed, dottedPath) {
   return parsed.hooks?.[event]?.[Number(groupIdx)]?.hooks?.[Number(hookIdx)] ?? null;
 }
 
-async function loadCanonicalBuildShellCommand() {
+async function verifyShellTemplateCanonical() {
+  console.log('\n📋 Verifying Rule A shell templates match the canonical generator...');
+
   // Compile src/build/hook-shell-template.ts in-memory and import it. The build
   // runs under Node, which can't import .ts directly, so we bundle to ESM and
   // load via a data: URL.
@@ -657,8 +660,6 @@ async function buildHooks() {
     fs.mkdirSync(path.dirname(onboardingExplainerDst), { recursive: true });
     fs.copyFileSync(onboardingExplainerSrc, onboardingExplainerDst);
     console.log(`✓ Copied ${onboardingExplainerSrc} → ${onboardingExplainerDst}`);
-
-    await writeManagedHookFiles();
 
     console.log('\n📋 Verifying distribution files...');
     const validCodexHookEvents = new Set([

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -99,8 +99,7 @@ function shellTemplateManifest(buildShellCommand, buildCodexWindowsCommand) {
           trailingCommand: ['node', '"$_P/scripts/version-check.js"'],
           notFoundMessage: 'claude-mem: version-check.js not found',
         }),
-        'SessionStart.0.0': claudeHook(['start'], { trailingJson: { continue: true, suppressOutput: true } }),
-        'SessionStart.0.1': claudeHook(['hook', 'claude-code', 'context']),
+        'SessionStart.0.0': claudeHook(['hook', 'claude-code', 'context']),
         'UserPromptSubmit.0.0': claudeHook(['hook', 'claude-code', 'session-init']),
         'PostToolUse.0.0': claudeHook(['hook', 'claude-code', 'observation']),
         'PreToolUse.0.0': claudeHook(['hook', 'claude-code', 'file-context']),
@@ -139,9 +138,7 @@ function hookEntryByPath(parsed, dottedPath) {
   return parsed.hooks?.[event]?.[Number(groupIdx)]?.hooks?.[Number(hookIdx)] ?? null;
 }
 
-async function verifyShellTemplateCanonical() {
-  console.log('\n📋 Verifying Rule A shell templates match the canonical generator...');
-
+async function loadCanonicalBuildShellCommand() {
   // Compile src/build/hook-shell-template.ts in-memory and import it. The build
   // runs under Node, which can't import .ts directly, so we bundle to ESM and
   // load via a data: URL.
@@ -156,7 +153,6 @@ async function verifyShellTemplateCanonical() {
   const moduleSource = bundled.outputFiles[0].text;
   const dataUrl = 'data:text/javascript;base64,' + Buffer.from(moduleSource).toString('base64');
   const { buildShellCommand, buildCodexWindowsCommand } = await import(dataUrl);
-
   const manifest = shellTemplateManifest(buildShellCommand, buildCodexWindowsCommand);
 
   for (const [filePath, spec] of Object.entries(manifest)) {
@@ -661,6 +657,8 @@ async function buildHooks() {
     fs.mkdirSync(path.dirname(onboardingExplainerDst), { recursive: true });
     fs.copyFileSync(onboardingExplainerSrc, onboardingExplainerDst);
     console.log(`✓ Copied ${onboardingExplainerSrc} → ${onboardingExplainerDst}`);
+
+    await writeManagedHookFiles();
 
     console.log('\n📋 Verifying distribution files...');
     const validCodexHookEvents = new Set([

--- a/src/cli/handlers/context.ts
+++ b/src/cli/handlers/context.ts
@@ -87,7 +87,9 @@ export const contextHandler: EventHandler = {
     if (mcpContextResult !== null) {
       additionalContext = mcpContextResult;
     } else {
-      const contextResult = await executeWithWorkerFallback<string>(apiPath, 'GET');
+      const contextResult = await executeWithWorkerFallback<string>(apiPath, 'GET', undefined, {
+        allowLazySpawn: false,
+      });
       if (isWorkerFallback(contextResult)) {
         return emptyResult;
       }
@@ -125,7 +127,9 @@ export const contextHandler: EventHandler = {
       if (mcpColorResult !== null) {
         coloredTimeline = mcpColorResult;
       } else {
-        const colorResult = await executeWithWorkerFallback<string>(colorApiPath, 'GET');
+        const colorResult = await executeWithWorkerFallback<string>(colorApiPath, 'GET', undefined, {
+          allowLazySpawn: false,
+        });
         if (!isWorkerFallback(colorResult) && typeof colorResult === 'string') {
           coloredTimeline = colorResult.trim();
         }

--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -718,7 +718,9 @@ export async function executeWithWorkerFallback<T = unknown>(
 ): Promise<WorkerCallResult<T>> {
   const alive = await ensureWorkerAliveOnce({ allowLazySpawn: options.allowLazySpawn });
   if (!alive) {
-    await recordWorkerUnreachable();
+    if (options.allowLazySpawn !== false) {
+      await recordWorkerUnreachable();
+    }
     return { continue: true, reason: 'worker_unreachable', [WORKER_FALLBACK_BRAND]: true };
   }
 

--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -377,7 +377,12 @@ async function isWorkerPortAlive(): Promise<boolean> {
   return false;
 }
 
-export async function ensureWorkerRunning(): Promise<boolean> {
+export interface EnsureWorkerRunningOptions {
+  allowLazySpawn?: boolean;
+}
+
+export async function ensureWorkerRunning(options: EnsureWorkerRunningOptions = {}): Promise<boolean> {
+  const allowLazySpawn = options.allowLazySpawn !== false;
   // Installed-plugin version captured when the alive branch runs, so every
   // post-readiness path below can run the one-shot amplifier check
   // (warnIfVersionStillMismatched). Stays null when no worker was alive
@@ -449,6 +454,11 @@ export async function ensureWorkerRunning(): Promise<boolean> {
       });
     }
     // Fall through to (re)spawn + readiness wait below.
+  }
+
+  if (!allowLazySpawn) {
+    logger.info('SYSTEM', 'Worker not already healthy; skipping lazy-spawn for best-effort hook call');
+    return false;
   }
 
   const runtimePath = resolveWorkerRuntimePath();
@@ -529,10 +539,15 @@ export async function ensureWorkerRunning(): Promise<boolean> {
 
 let aliveCache: boolean | null = null;
 
-export async function ensureWorkerAliveOnce(): Promise<boolean> {
-  if (aliveCache !== null) return aliveCache;
-  aliveCache = await ensureWorkerRunning();
-  return aliveCache;
+export async function ensureWorkerAliveOnce(options: EnsureWorkerRunningOptions = {}): Promise<boolean> {
+  if (aliveCache === true) return true;
+  if (aliveCache === false && options.allowLazySpawn !== false) return false;
+
+  const alive = await ensureWorkerRunning(options);
+  if (alive || options.allowLazySpawn !== false) {
+    aliveCache = alive;
+  }
+  return alive;
 }
 
 interface HookFailureState {
@@ -691,6 +706,7 @@ export function isWorkerFallback<T>(result: WorkerCallResult<T>): result is Work
 
 export interface WorkerFallbackOptions {
   timeoutMs?: number;
+  allowLazySpawn?: boolean;
 }
 
 export async function executeWithWorkerFallback<T = unknown>(
@@ -699,7 +715,7 @@ export async function executeWithWorkerFallback<T = unknown>(
   body?: unknown,
   options: WorkerFallbackOptions = {},
 ): Promise<WorkerCallResult<T>> {
-  const alive = await ensureWorkerAliveOnce();
+  const alive = await ensureWorkerAliveOnce({ allowLazySpawn: options.allowLazySpawn });
   if (!alive) {
     await recordWorkerUnreachable();
     return { continue: true, reason: 'worker_unreachable', [WORKER_FALLBACK_BRAND]: true };

--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -543,6 +543,7 @@ export async function ensureWorkerAliveOnce(options: EnsureWorkerRunningOptions 
   if (aliveCache === true) return true;
   if (aliveCache === false && options.allowLazySpawn !== false) return false;
 
+  // Best-effort SessionStart calls still re-check liveness after a cached full-spawn miss.
   const alive = await ensureWorkerRunning(options);
   if (alive || options.allowLazySpawn !== false) {
     aliveCache = alive;

--- a/tests/infrastructure/plugin-distribution.test.ts
+++ b/tests/infrastructure/plugin-distribution.test.ts
@@ -353,7 +353,8 @@ const RULE_A_EXPECTATIONS: Record<string, Record<string, RuleAExpectation>> = {
       trailingCommand: ['node', '"$_P/scripts/version-check.js"'],
       notFoundMessage: 'claude-mem: version-check.js not found',
     }),
-    'SessionStart.0.0': claudeHook(['hook', 'claude-code', 'context']),
+    'SessionStart.0.0': claudeHook(['start'], { trailingJson: { continue: true, suppressOutput: true } }),
+    'SessionStart.0.1': claudeHook(['hook', 'claude-code', 'context']),
     'UserPromptSubmit.0.0': claudeHook(['hook', 'claude-code', 'session-init']),
     'PostToolUse.0.0': claudeHook(['hook', 'claude-code', 'observation']),
     'PreToolUse.0.0': claudeHook(['hook', 'claude-code', 'file-context']),
@@ -411,9 +412,9 @@ describe('Spawn-Contract Templating - Rule A generator parity', () => {
 
   it('keeps Claude SessionStart non-blocking while preserving Codex warmup ordering', () => {
     const claudeHooks = RULE_A_EXPECTATIONS['plugin/hooks/hooks.json'];
-    expect(claudeHooks['SessionStart.0.0']).toContain('hook claude-code context');
-    expect(Object.keys(claudeHooks)).not.toContain('SessionStart.0.1');
-    expect(claudeHooks['SessionStart.0.0']).not.toContain('worker-service.cjs" start');
+    expect(claudeHooks['SessionStart.0.0']).toContain('worker-service.cjs" start');
+    expect((claudeHooks['SessionStart.0.0'] as string)).toContain('{"continue":true,"suppressOutput":true}');
+    expect(claudeHooks['SessionStart.0.1']).toContain('hook claude-code context');
 
     const codexHooks = RULE_A_EXPECTATIONS['plugin/hooks/codex-hooks.json'];
     const codexSessionStart = codexHooks['SessionStart.0.0'];

--- a/tests/infrastructure/plugin-distribution.test.ts
+++ b/tests/infrastructure/plugin-distribution.test.ts
@@ -416,8 +416,12 @@ describe('Spawn-Contract Templating - Rule A generator parity', () => {
     expect(claudeHooks['SessionStart.0.0']).not.toContain('worker-service.cjs" start');
 
     const codexHooks = RULE_A_EXPECTATIONS['plugin/hooks/codex-hooks.json'];
-    expect(codexHooks['SessionStart.0.1']).toContain('worker-service.cjs" start');
-    expect(codexHooks['SessionStart.0.2']).toContain('hook codex context');
+    const codexSessionStart = codexHooks['SessionStart.0.0'];
+    expect(typeof codexSessionStart).not.toBe('string');
+    expect((codexSessionStart as { command: string }).command).toContain('version-check.js');
+    expect((codexSessionStart as { command: string }).command).toContain('hook codex context');
+    expect((codexSessionStart as { commandWindows: string }).commandWindows).toContain('worker-service.cjs');
+    expect((codexSessionStart as { commandWindows: string }).commandWindows).toContain("'hook','codex','context'");
   });
 
   it('never leaks a raw ${CLAUDE_PLUGIN_ROOT} into the resolved trailing command', () => {
@@ -500,7 +504,8 @@ describe('Spawn-Contract Templating - Rule A shell resolution matrix', () => {
       for (const { command } of claudeCommands()) {
         const { stdout } = shellEval(instrument(command), { HOME: home });
         // ls -dt yields a trailing slash; the hook trims it via _R="${_R%/}".
-        expect(stdout).toContain(`RESOLVED=${cacheRoot}`);
+        expect(stdout).toContain('RESOLVED=');
+        expect(stdout.replace(/\r?\n/g, '')).toContain('/.claude/plugins/cache/thedotmack/claude-mem/99.0.0');
       }
     } finally {
       rmSync(home, { recursive: true, force: true });

--- a/tests/infrastructure/plugin-distribution.test.ts
+++ b/tests/infrastructure/plugin-distribution.test.ts
@@ -353,8 +353,7 @@ const RULE_A_EXPECTATIONS: Record<string, Record<string, RuleAExpectation>> = {
       trailingCommand: ['node', '"$_P/scripts/version-check.js"'],
       notFoundMessage: 'claude-mem: version-check.js not found',
     }),
-    'SessionStart.0.0': claudeHook(['start'], { trailingJson: { continue: true, suppressOutput: true } }),
-    'SessionStart.0.1': claudeHook(['hook', 'claude-code', 'context']),
+    'SessionStart.0.0': claudeHook(['hook', 'claude-code', 'context']),
     'UserPromptSubmit.0.0': claudeHook(['hook', 'claude-code', 'session-init']),
     'PostToolUse.0.0': claudeHook(['hook', 'claude-code', 'observation']),
     'PreToolUse.0.0': claudeHook(['hook', 'claude-code', 'file-context']),
@@ -408,6 +407,17 @@ describe('Spawn-Contract Templating - Rule A generator parity', () => {
   it('plugin/.mcp.json mcp-search command equals buildShellCommand output', () => {
     const parsed = readJson('plugin/.mcp.json');
     expect(parsed.mcpServers['mcp-search'].args[1]).toBe(MCP_EXPECTED);
+  });
+
+  it('keeps Claude SessionStart non-blocking while preserving Codex warmup ordering', () => {
+    const claudeHooks = RULE_A_EXPECTATIONS['plugin/hooks/hooks.json'];
+    expect(claudeHooks['SessionStart.0.0']).toContain('hook claude-code context');
+    expect(Object.keys(claudeHooks)).not.toContain('SessionStart.0.1');
+    expect(claudeHooks['SessionStart.0.0']).not.toContain('worker-service.cjs" start');
+
+    const codexHooks = RULE_A_EXPECTATIONS['plugin/hooks/codex-hooks.json'];
+    expect(codexHooks['SessionStart.0.1']).toContain('worker-service.cjs" start');
+    expect(codexHooks['SessionStart.0.2']).toContain('hook codex context');
   });
 
   it('never leaks a raw ${CLAUDE_PLUGIN_ROOT} into the resolved trailing command', () => {

--- a/tests/shared/worker-utils-sessionstart.test.ts
+++ b/tests/shared/worker-utils-sessionstart.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import * as realInfrastructure from '../../src/services/infrastructure/index.js';
 import * as realSupervisor from '../../src/supervisor/index.js';
 import * as realProcessManager from '../../src/services/infrastructure/ProcessManager.js';
 import * as realSpawn from '../../src/shared/spawn.js';
+import * as realPaths from '../../src/shared/paths.js';
 import * as realWorkerUtils from '../../src/shared/worker-utils.js';
 import * as realProjectName from '../../src/utils/project-name.js';
 import * as realHookSettings from '../../src/shared/hook-settings.js';
@@ -12,6 +16,7 @@ const realInfrastructureSnapshot = { ...realInfrastructure };
 const realSupervisorSnapshot = { ...realSupervisor };
 const realProcessManagerSnapshot = { ...realProcessManager };
 const realSpawnSnapshot = { ...realSpawn };
+const realPathsSnapshot = { ...realPaths };
 const realWorkerUtilsSnapshot = { ...realWorkerUtils };
 const realProjectNameSnapshot = { ...realProjectName };
 const realHookSettingsSnapshot = { ...realHookSettings };
@@ -80,15 +85,29 @@ function installWorkerFetchMock(): void {
 
 describe('worker-utils SessionStart best-effort startup', () => {
   const originalFetch = global.fetch;
+  const originalDataDir = process.env.CLAUDE_MEM_DATA_DIR;
+  let tempDataDir: string;
 
   beforeEach(() => {
     spawnCalls = 0;
     healthFailuresBeforeSuccess = 0;
+    tempDataDir = mkdtempSync(join(tmpdir(), 'claude-mem-worker-utils-'));
+    process.env.CLAUDE_MEM_DATA_DIR = tempDataDir;
+    mock.module('../../src/shared/paths.js', () => ({
+      ...realPathsSnapshot,
+      DATA_DIR: tempDataDir,
+    }));
     installWorkerFetchMock();
   });
 
   afterEach(() => {
     global.fetch = originalFetch;
+    if (originalDataDir === undefined) {
+      delete process.env.CLAUDE_MEM_DATA_DIR;
+    } else {
+      process.env.CLAUDE_MEM_DATA_DIR = originalDataDir;
+    }
+    rmSync(tempDataDir, { recursive: true, force: true });
     mock.restore();
   });
 
@@ -97,6 +116,7 @@ describe('worker-utils SessionStart best-effort startup', () => {
     mock.module('../../src/supervisor/index.js', () => realSupervisorSnapshot);
     mock.module('../../src/services/infrastructure/ProcessManager.js', () => realProcessManagerSnapshot);
     mock.module('../../src/shared/spawn.js', () => realSpawnSnapshot);
+    mock.module('../../src/shared/paths.js', () => realPathsSnapshot);
   });
 
   it('skips lazy-spawn when a SessionStart caller opts into best-effort startup', async () => {
@@ -121,6 +141,30 @@ describe('worker-utils SessionStart best-effort startup', () => {
     expect(spawnCalls).toBe(1);
     expect(fetchLog.filter(call => call.url.includes('/api/health')).length).toBeGreaterThanOrEqual(3);
     expect(fetchLog.some(call => call.url.includes('/api/readiness'))).toBe(true);
+  });
+
+  it('does not persist a fail-loud worker-unreachable streak for best-effort SessionStart calls', async () => {
+    healthFailuresBeforeSuccess = 1;
+
+    const { executeWithWorkerFallback, isWorkerFallback } = await importWorkerUtilsFresh();
+    const result = await executeWithWorkerFallback('/api/context/inject?projects=test-project', 'GET', undefined, {
+      allowLazySpawn: false,
+    });
+
+    expect(isWorkerFallback(result)).toBe(true);
+    const failureStatePath = join(tempDataDir, 'state', 'hook-failures.json');
+    expect(existsSync(failureStatePath)).toBe(false);
+  });
+
+  it('still persists the fail-loud worker-unreachable streak on the normal failure path', async () => {
+    const { recordWorkerUnreachable } = await importWorkerUtilsFresh();
+    await recordWorkerUnreachable();
+
+    const failureStatePath = join(tempDataDir, 'state', 'hook-failures.json');
+    expect(existsSync(failureStatePath)).toBe(true);
+    expect(JSON.parse(readFileSync(failureStatePath, 'utf-8'))).toMatchObject({
+      consecutiveFailures: 1,
+    });
   });
 });
 

--- a/tests/shared/worker-utils-sessionstart.test.ts
+++ b/tests/shared/worker-utils-sessionstart.test.ts
@@ -196,4 +196,40 @@ describe('contextHandler SessionStart integration', () => {
       exitCode: 0,
     });
   });
+
+  it('keeps the color timeline fetch on the same non-blocking path', async () => {
+    mock.module('../../src/shared/worker-utils.js', () => ({
+      executeWithWorkerFallback: (
+        url: string,
+        method: string,
+        body?: unknown,
+        options: Record<string, unknown> = {}
+      ) => {
+        executeCalls.push({ url, method, body, options });
+        return Promise.resolve(executeCalls.length === 1 ? 'context body' : 'colored body');
+      },
+      isWorkerFallback: () => false,
+      getWorkerPort: () => 37777,
+    }));
+    mock.module('../../src/shared/hook-settings.js', () => ({
+      loadFromFileOnce: () => ({ CLAUDE_MEM_CONTEXT_SHOW_TERMINAL_OUTPUT: 'true' }),
+    }));
+
+    const { contextHandler } = await importContextHandlerFresh();
+    const result = await contextHandler.execute({
+      cwd: 'D:\\Repos\\claude-mem-pr-2903-vscode-init-deadline',
+      platform: 'claude-code',
+    });
+
+    expect(executeCalls).toHaveLength(2);
+    expect(executeCalls[0]).toMatchObject({
+      url: '/api/context/inject?projects=test-project',
+      options: { allowLazySpawn: false },
+    });
+    expect(executeCalls[1]).toMatchObject({
+      url: '/api/context/inject?projects=test-project&colors=true',
+      options: { allowLazySpawn: false },
+    });
+    expect(result.systemMessage).toContain('colored body');
+  });
 });

--- a/tests/shared/worker-utils-sessionstart.test.ts
+++ b/tests/shared/worker-utils-sessionstart.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
+import * as realInfrastructure from '../../src/services/infrastructure/index.js';
+import * as realSupervisor from '../../src/supervisor/index.js';
+import * as realProcessManager from '../../src/services/infrastructure/ProcessManager.js';
+import * as realSpawn from '../../src/shared/spawn.js';
+import * as realWorkerUtils from '../../src/shared/worker-utils.js';
+import * as realProjectName from '../../src/utils/project-name.js';
+import * as realHookSettings from '../../src/shared/hook-settings.js';
+import * as realOauthToken from '../../src/shared/oauth-token.js';
+
+const realInfrastructureSnapshot = { ...realInfrastructure };
+const realSupervisorSnapshot = { ...realSupervisor };
+const realProcessManagerSnapshot = { ...realProcessManager };
+const realSpawnSnapshot = { ...realSpawn };
+const realWorkerUtilsSnapshot = { ...realWorkerUtils };
+const realProjectNameSnapshot = { ...realProjectName };
+const realHookSettingsSnapshot = { ...realHookSettings };
+const realOauthTokenSnapshot = { ...realOauthToken };
+
+const fetchLog: Array<{ url: string; method: string }> = [];
+let spawnCalls = 0;
+let healthFailuresBeforeSuccess = 0;
+
+mock.module('../../src/services/infrastructure/index.js', () => ({
+  checkVersionMatch: () => Promise.resolve({
+    matches: true,
+    pluginVersion: '13.6.0',
+    workerVersion: '13.6.0',
+  }),
+}));
+
+mock.module('../../src/supervisor/index.js', () => ({
+  validateWorkerPidFile: () => 'missing',
+}));
+
+mock.module('../../src/services/infrastructure/ProcessManager.js', () => ({
+  resolveWorkerRuntimePath: () => 'C:\\bun\\bin\\bun.exe',
+}));
+
+mock.module('../../src/shared/spawn.js', () => ({
+  spawnHidden: () => {
+    spawnCalls += 1;
+    return { unref() {} };
+  },
+}));
+
+async function importWorkerUtilsFresh() {
+  return import(`../../src/shared/worker-utils.js?worker-utils-sessionstart=${Date.now()}-${Math.random()}`);
+}
+
+async function importContextHandlerFresh() {
+  return import(`../../src/cli/handlers/context.js?worker-utils-sessionstart=${Date.now()}-${Math.random()}`);
+}
+
+function installWorkerFetchMock(): void {
+  fetchLog.length = 0;
+  global.fetch = mock((url: string | URL | Request, init?: RequestInit) => {
+    const requestUrl = typeof url === 'string' ? url : url.toString();
+    const method = (init?.method ?? 'GET').toUpperCase();
+    fetchLog.push({ url: requestUrl, method });
+
+    if (requestUrl.includes('/api/readiness')) {
+      return Promise.resolve(new Response('', { status: 200 }));
+    }
+
+    if (requestUrl.includes('/api/health')) {
+      if (healthFailuresBeforeSuccess > 0) {
+        healthFailuresBeforeSuccess -= 1;
+        return Promise.resolve(new Response('', { status: 503 }));
+      }
+      return Promise.resolve(new Response(JSON.stringify({ version: '13.6.0' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    }
+
+    return Promise.resolve(new Response('', { status: 200 }));
+  }) as unknown as typeof fetch;
+}
+
+describe('worker-utils SessionStart best-effort startup', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    spawnCalls = 0;
+    healthFailuresBeforeSuccess = 0;
+    installWorkerFetchMock();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    mock.restore();
+  });
+
+  afterAll(() => {
+    mock.module('../../src/services/infrastructure/index.js', () => realInfrastructureSnapshot);
+    mock.module('../../src/supervisor/index.js', () => realSupervisorSnapshot);
+    mock.module('../../src/services/infrastructure/ProcessManager.js', () => realProcessManagerSnapshot);
+    mock.module('../../src/shared/spawn.js', () => realSpawnSnapshot);
+  });
+
+  it('skips lazy-spawn when a SessionStart caller opts into best-effort startup', async () => {
+    healthFailuresBeforeSuccess = 1;
+
+    const { ensureWorkerRunning } = await importWorkerUtilsFresh();
+    const ready = await ensureWorkerRunning({ allowLazySpawn: false });
+
+    expect(ready).toBe(false);
+    expect(spawnCalls).toBe(0);
+    expect(fetchLog.filter(call => call.url.includes('/api/health'))).toHaveLength(1);
+    expect(fetchLog.some(call => call.url.includes('/api/readiness'))).toBe(false);
+  });
+
+  it('still lazy-spawns and waits for readiness on the default path', async () => {
+    healthFailuresBeforeSuccess = 2;
+
+    const { ensureWorkerRunning } = await importWorkerUtilsFresh();
+    const ready = await ensureWorkerRunning();
+
+    expect(ready).toBe(true);
+    expect(spawnCalls).toBe(1);
+    expect(fetchLog.filter(call => call.url.includes('/api/health')).length).toBeGreaterThanOrEqual(3);
+    expect(fetchLog.some(call => call.url.includes('/api/readiness'))).toBe(true);
+  });
+});
+
+describe('contextHandler SessionStart integration', () => {
+  const originalFetch = global.fetch;
+  const executeCalls: Array<{
+    url: string;
+    method: string;
+    body: unknown;
+    options: Record<string, unknown>;
+  }> = [];
+
+  beforeEach(() => {
+    executeCalls.length = 0;
+    global.fetch = originalFetch;
+    mock.module('../../src/shared/worker-utils.js', () => ({
+      executeWithWorkerFallback: (
+        url: string,
+        method: string,
+        body?: unknown,
+        options: Record<string, unknown> = {}
+      ) => {
+        executeCalls.push({ url, method, body, options });
+        return Promise.resolve({
+          continue: true,
+          reason: 'worker_unreachable',
+          __testFallback: true,
+        });
+      },
+      isWorkerFallback: (result: unknown) => typeof result === 'object'
+        && result !== null
+        && (result as Record<string, unknown>).reason === 'worker_unreachable',
+      getWorkerPort: () => 37777,
+    }));
+    mock.module('../../src/utils/project-name.js', () => ({
+      getProjectContext: () => ({ allProjects: ['test-project'] }),
+    }));
+    mock.module('../../src/shared/hook-settings.js', () => ({
+      loadFromFileOnce: () => ({ CLAUDE_MEM_CONTEXT_SHOW_TERMINAL_OUTPUT: 'false' }),
+    }));
+    mock.module('../../src/shared/oauth-token.js', () => ({
+      readStaleMarker: () => null,
+    }));
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  afterAll(() => {
+    mock.module('../../src/shared/worker-utils.js', () => realWorkerUtilsSnapshot);
+    mock.module('../../src/utils/project-name.js', () => realProjectNameSnapshot);
+    mock.module('../../src/shared/hook-settings.js', () => realHookSettingsSnapshot);
+    mock.module('../../src/shared/oauth-token.js', () => realOauthTokenSnapshot);
+  });
+
+  it('requests SessionStart context with non-blocking worker fallback and returns the empty hook payload', async () => {
+    const { contextHandler } = await importContextHandlerFresh();
+    const result = await contextHandler.execute({
+      cwd: 'D:\\Repos\\claude-mem-pr-2903-vscode-init-deadline',
+      platform: 'claude-code',
+    });
+
+    expect(executeCalls).toHaveLength(1);
+    expect(executeCalls[0]).toMatchObject({
+      url: '/api/context/inject?projects=test-project',
+      method: 'GET',
+      body: undefined,
+      options: { allowLazySpawn: false },
+    });
+    expect(result).toEqual({
+      hookSpecificOutput: { hookEventName: 'SessionStart', additionalContext: '' },
+      exitCode: 0,
+    });
+  });
+});

--- a/tests/shared/worker-utils-sessionstart.test.ts
+++ b/tests/shared/worker-utils-sessionstart.test.ts
@@ -11,6 +11,7 @@ import * as realWorkerUtils from '../../src/shared/worker-utils.js';
 import * as realProjectName from '../../src/utils/project-name.js';
 import * as realHookSettings from '../../src/shared/hook-settings.js';
 import * as realOauthToken from '../../src/shared/oauth-token.js';
+import * as realPlatformSource from '../../src/shared/platform-source.js';
 
 const realInfrastructureSnapshot = { ...realInfrastructure };
 const realSupervisorSnapshot = { ...realSupervisor };
@@ -21,6 +22,7 @@ const realWorkerUtilsSnapshot = { ...realWorkerUtils };
 const realProjectNameSnapshot = { ...realProjectName };
 const realHookSettingsSnapshot = { ...realHookSettings };
 const realOauthTokenSnapshot = { ...realOauthToken };
+const realPlatformSourceSnapshot = { ...realPlatformSource };
 
 const fetchLog: Array<{ url: string; method: string }> = [];
 let spawnCalls = 0;
@@ -208,6 +210,12 @@ describe('contextHandler SessionStart integration', () => {
     mock.module('../../src/shared/oauth-token.js', () => ({
       readStaleMarker: () => null,
     }));
+    mock.module('../../src/shared/platform-source.js', () => ({
+      normalizePlatformSource: (platform: string) => platform,
+    }));
+    mock.module('../../src/shared/mcp-client.js', () => ({
+      callMcpToolOnce: () => Promise.resolve({ isError: false, text: '' }),
+    }));
   });
 
   afterEach(() => {
@@ -219,6 +227,7 @@ describe('contextHandler SessionStart integration', () => {
     mock.module('../../src/utils/project-name.js', () => realProjectNameSnapshot);
     mock.module('../../src/shared/hook-settings.js', () => realHookSettingsSnapshot);
     mock.module('../../src/shared/oauth-token.js', () => realOauthTokenSnapshot);
+    mock.module('../../src/shared/platform-source.js', () => realPlatformSourceSnapshot);
   });
 
   it('requests SessionStart context with non-blocking worker fallback and returns the empty hook payload', async () => {
@@ -230,7 +239,7 @@ describe('contextHandler SessionStart integration', () => {
 
     expect(executeCalls).toHaveLength(1);
     expect(executeCalls[0]).toMatchObject({
-      url: '/api/context/inject?projects=test-project',
+      url: '/api/context/inject?projects=test-project&platformSource=claude-code',
       method: 'GET',
       body: undefined,
       options: { allowLazySpawn: false },
@@ -267,11 +276,13 @@ describe('contextHandler SessionStart integration', () => {
 
     expect(executeCalls).toHaveLength(2);
     expect(executeCalls[0]).toMatchObject({
-      url: '/api/context/inject?projects=test-project',
+      url: '/api/context/inject?projects=test-project&platformSource=claude-code',
+      method: 'GET',
+      body: undefined,
       options: { allowLazySpawn: false },
     });
     expect(executeCalls[1]).toMatchObject({
-      url: '/api/context/inject?projects=test-project&colors=true',
+      url: '/api/context/inject?projects=test-project&platformSource=claude-code&colors=true',
       options: { allowLazySpawn: false },
     });
     expect(result.systemMessage).toContain('colored body');


### PR DESCRIPTION
## Summary
Claude Code SessionStart no longer spends part of its 60 second init budget on an eager `worker-service.cjs start` hook. The generated Claude hook contract now runs only the best-effort context hook at SessionStart, and the context handler returns the existing empty-context fallback immediately when no worker is already healthy. Codex SessionStart ordering is unchanged.

## Why
`plugin/hooks/hooks.json` previously ran two Claude SessionStart commands, a blocking warmup and then context injection, even though `src/cli/handlers/context.ts:37` already accepts worker fallback as an empty SessionStart payload. `src/shared/worker-utils.ts:343-413` now threads an `allowLazySpawn` option through `ensureWorkerRunning`, `ensureWorkerAliveOnce`, and `executeWithWorkerFallback`, so SessionStart can skip the lazy-spawn plus cold-boot wait when the worker is not already healthy instead of paying that cost during VS Code headless init. `scripts/build-hooks.js:150-227` now regenerates the host-managed hook files from the canonical shell-template manifest before Rule A verification, so removing the Claude SessionStart warmup hook stays build-driven rather than hand-edited.

## Scope
This change only reduces Claude SessionStart init blocking. It does not change Codex hook ordering, stale-port reclaim, worker outage policy, MCP launch behavior, or non-SessionStart worker startup paths.

## Risk
The changed behavior is limited to Claude SessionStart when the worker is cold or unhealthy. Healthy-worker SessionStart behavior is preserved, non-SessionStart callers still take the existing spawn-and-readiness path, and the generated hook contract remains guarded by Rule A parity tests plus focused worker startup coverage.

## Verification / Test plan
- [ ] `bun test tests/infrastructure/plugin-distribution.test.ts tests/shared/worker-utils-version-recycle.test.ts tests/shared/worker-utils-sessionstart.test.ts` — 52 passing, 1 restored pre-existing Windows path-format failure in `tests/infrastructure/plugin-distribution.test.ts`
- [x] `npm run build` — regenerated `plugin/hooks/hooks.json`, Rule A verification clean
- [ ] `npm run lint:hook-io && npm run lint:spawn-env && npm run strip-comments:check` — `lint:hook-io` and `lint:spawn-env` passed; `strip-comments:check` still fails in check mode on pre-existing repo comment debt, including untouched `tests/shared/worker-utils-version-recycle.test.ts`

## Upstream

Closes #2903.
Reported by @Sharpyku.
