### PR TITLE
fix(setup): restore tree-sitter CLI on clean Windows installs (closes #2910)

### DIFF
--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs';
-import { execSync, spawn, spawnSync } from 'child_process';
+import * as childProcess from 'child_process';
 import { createRequire } from 'module';
 import { join } from 'path';
 import { homedir } from 'os';
@@ -72,7 +72,7 @@ function markerPath(targetDir: string): string {
 
 function getBunPath(): string | null {
   try {
-    const result = spawnSync('bun', ['--version'], {
+    const result = childProcess.spawnSync('bun', ['--version'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       shell: IS_WINDOWS,
@@ -94,7 +94,7 @@ function getBunVersion(): string | null {
   if (!bunPath) return null;
 
   try {
-    const result = spawnSync(bunPath, ['--version'], {
+    const result = childProcess.spawnSync(bunPath, ['--version'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       shell: IS_WINDOWS,
@@ -107,7 +107,7 @@ function getBunVersion(): string | null {
 
 function getUvPath(): string | null {
   try {
-    const result = spawnSync('uv', ['--version'], {
+    const result = childProcess.spawnSync('uv', ['--version'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       shell: IS_WINDOWS,
@@ -129,7 +129,7 @@ function getUvVersion(): string | null {
   if (!uvPath) return null;
 
   try {
-    const result = spawnSync(uvPath, ['--version'], {
+    const result = childProcess.spawnSync(uvPath, ['--version'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       shell: IS_WINDOWS,
@@ -157,13 +157,13 @@ function describeExecError(error: unknown): string {
 function installBun(): void {
   try {
     if (IS_WINDOWS) {
-      execSync('powershell -c "irm bun.sh/install.ps1 | iex"', {
+      childProcess.execSync('powershell -c "irm bun.sh/install.ps1 | iex"', {
         stdio: 'pipe',
         timeout: INSTALL_TIMEOUT_MS,
         shell: process.env.ComSpec ?? 'cmd.exe',
       });
     } else {
-      execSync('curl -fsSL https://bun.sh/install | bash', {
+      childProcess.execSync('curl -fsSL https://bun.sh/install | bash', {
         stdio: 'pipe',
         timeout: INSTALL_TIMEOUT_MS,
         shell: '/bin/bash',
@@ -189,13 +189,13 @@ function installBun(): void {
 function installUv(): void {
   try {
     if (IS_WINDOWS) {
-      execSync('powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"', {
+      childProcess.execSync('powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"', {
         stdio: 'pipe',
         timeout: INSTALL_TIMEOUT_MS,
         shell: process.env.ComSpec ?? 'cmd.exe',
       });
     } else {
-      execSync('curl -LsSf https://astral.sh/uv/install.sh | sh', {
+      childProcess.execSync('curl -LsSf https://astral.sh/uv/install.sh | sh', {
         stdio: 'pipe',
         timeout: INSTALL_TIMEOUT_MS,
         shell: '/bin/bash',
@@ -414,7 +414,7 @@ export async function installPluginDependencies(targetDir: string, bunPath: stri
     // Async spawn (not spawnSync): a blocked event loop freezes the installer's
     // clack spinner for the duration of the install, which reads as a stall.
     await new Promise<void>((resolve, reject) => {
-      const child = spawn(bunPath, installArgs, {
+      const child = childProcess.spawn(bunPath, installArgs, {
         cwd: targetDir,
         shell: false,
         stdio: ['pipe', 'pipe', 'pipe'],

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -422,7 +422,9 @@ export async function installPluginDependencies(targetDir: string, bunPath: stri
 
       const stdoutChunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];
+      let timedOut = false;
       const timer = setTimeout(() => {
+        timedOut = true;
         child.kill();
       }, INSTALL_TIMEOUT_MS);
 
@@ -445,6 +447,17 @@ export async function installPluginDependencies(targetDir: string, bunPath: stri
         clearTimeout(timer);
         if (code === 0) {
           resolve();
+          return;
+        }
+
+        if (timedOut) {
+          reject(Object.assign(
+            new Error(`bun install timed out after ${INSTALL_TIMEOUT_MS}ms`),
+            {
+              stdout: Buffer.concat(stdoutChunks).toString('utf-8'),
+              stderr: Buffer.concat(stderrChunks).toString('utf-8'),
+            },
+          ));
           return;
         }
 

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs';
-import { exec, execSync, spawnSync } from 'child_process';
+import { execSync, spawn, spawnSync } from 'child_process';
 import { createRequire } from 'module';
 import { join } from 'path';
 import { homedir } from 'os';
@@ -404,30 +404,69 @@ export async function installPluginDependencies(targetDir: string, bunPath: stri
     throw new Error(`installPluginDependencies: no package.json at ${targetDir}`);
   }
 
-  const bunCmd = IS_WINDOWS && bunPath.includes(' ') ? `"${bunPath}"` : bunPath;
+  const installArgs = getPluginDependencyInstallArgs();
 
   try {
     // Per CHANGELOG v12.6.1 -> v12.6.2: tree-sitter-swift's nested
     // tree-sitter-cli postinstall downloads a Rust binary and can hang the
-    // install. Bun honors trustedDependencies; npm does not. We additionally
-    // pass --ignore-scripts as belt-and-suspenders and bound it with a timeout.
-    // Async exec (not execSync): a blocked event loop freezes the installer's
+    // install. Bun honors trustedDependencies; npm does not, so we rely on Bun's
+    // trustedDependencies gate here and still bound the install with a timeout.
+    // Async spawn (not spawnSync): a blocked event loop freezes the installer's
     // clack spinner for the duration of the install, which reads as a stall.
     await new Promise<void>((resolve, reject) => {
-      exec(`${bunCmd} install --frozen-lockfile --ignore-scripts`, {
+      const child = spawn(bunPath, installArgs, {
         cwd: targetDir,
-        timeout: INSTALL_TIMEOUT_MS,
-        maxBuffer: 16 * 1024 * 1024,
-        ...(IS_WINDOWS ? { shell: process.env.ComSpec ?? 'cmd.exe' } : {}),
-      }, (error, stdout, stderr) =>
-        // exec errors don't carry stdio; attach so describeExecError can report it.
-        error ? reject(Object.assign(error, { stdout, stderr })) : resolve());
+        shell: false,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      const stdoutChunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+      const timer = setTimeout(() => {
+        child.kill();
+      }, INSTALL_TIMEOUT_MS);
+
+      child.stdout.on('data', (chunk: Buffer) => {
+        stdoutChunks.push(chunk);
+      });
+      child.stderr.on('data', (chunk: Buffer) => {
+        stderrChunks.push(chunk);
+      });
+
+      child.on('error', (error) => {
+        clearTimeout(timer);
+        reject(Object.assign(error, {
+          stdout: Buffer.concat(stdoutChunks).toString('utf-8'),
+          stderr: Buffer.concat(stderrChunks).toString('utf-8'),
+        }));
+      });
+
+      child.on('close', (code, signal) => {
+        clearTimeout(timer);
+        if (code === 0) {
+          resolve();
+          return;
+        }
+
+        const signalSuffix = signal ? ` (signal: ${signal})` : '';
+        reject(Object.assign(
+          new Error(`bun install exited with code ${code ?? 'null'}${signalSuffix}`),
+          {
+            stdout: Buffer.concat(stdoutChunks).toString('utf-8'),
+            stderr: Buffer.concat(stderrChunks).toString('utf-8'),
+          },
+        ));
+      });
     });
   } catch (error) {
     throw new Error(`bun install failed in ${targetDir}\n${describeExecError(error)}`);
   }
 
   verifyCriticalModules(targetDir);
+}
+
+export function getPluginDependencyInstallArgs(): string[] {
+  return ['install', '--frozen-lockfile'];
 }
 
 export function readInstallMarker(targetDir: string): MarkerSchema | null {

--- a/src/services/smart-file-read/parser.ts
+++ b/src/services/smart-file-read/parser.ts
@@ -504,7 +504,7 @@ export function setTreeSitterBinDepsForTests(
   treeSitterBinDeps.resolvePackageJson = overrides?.resolvePackageJson ?? ((id: string) => _require.resolve(id));
 }
 
-export function getTreeSitterBinForTests(): string {
+export function getTreeSitterBin(): string {
   if (cachedBinPath) return cachedBinPath;
 
   try {
@@ -550,7 +550,7 @@ function runQuery(queryFile: string, sourceFile: string, grammarPath: string): R
 function runBatchQuery(queryFile: string, sourceFiles: string[], grammarPath: string): Map<string, RawMatch[]> {
   if (sourceFiles.length === 0) return new Map();
 
-  const bin = getTreeSitterBinForTests();
+  const bin = getTreeSitterBin();
   const execArgs = ["query", "-p", grammarPath, queryFile, ...sourceFiles];
 
   let output: string;

--- a/src/services/smart-file-read/parser.ts
+++ b/src/services/smart-file-read/parser.ts
@@ -480,16 +480,45 @@ function getQueryFile(queryKey: string): string {
 }
 
 let cachedBinPath: string | null = null;
+type TreeSitterBinDeps = {
+  platform: NodeJS.Platform;
+  fileExists: typeof existsSync;
+  resolvePackageJson: (id: string) => string;
+};
 
-function getTreeSitterBin(): string {
+const treeSitterBinDeps: TreeSitterBinDeps = {
+  platform: process.platform,
+  fileExists: existsSync,
+  resolvePackageJson: (id: string) => _require.resolve(id),
+};
+
+export function resetTreeSitterBinCacheForTests(): void {
+  cachedBinPath = null;
+}
+
+export function setTreeSitterBinDepsForTests(
+  overrides?: Partial<TreeSitterBinDeps>,
+): void {
+  treeSitterBinDeps.platform = overrides?.platform ?? process.platform;
+  treeSitterBinDeps.fileExists = overrides?.fileExists ?? existsSync;
+  treeSitterBinDeps.resolvePackageJson = overrides?.resolvePackageJson ?? ((id: string) => _require.resolve(id));
+}
+
+export function getTreeSitterBinForTests(): string {
   if (cachedBinPath) return cachedBinPath;
 
   try {
-    const pkgPath = _require.resolve("tree-sitter-cli/package.json");
-    const binPath = join(dirname(pkgPath), "tree-sitter");
-    if (existsSync(binPath)) {
-      cachedBinPath = binPath;
-      return binPath;
+    const pkgPath = treeSitterBinDeps.resolvePackageJson("tree-sitter-cli/package.json");
+    const candidateNames = treeSitterBinDeps.platform === "win32"
+      ? ["tree-sitter.exe", "tree-sitter"]
+      : ["tree-sitter"];
+
+    for (const candidateName of candidateNames) {
+      const binPath = join(dirname(pkgPath), candidateName);
+      if (treeSitterBinDeps.fileExists(binPath)) {
+        cachedBinPath = binPath;
+        return binPath;
+      }
     }
   } catch {
     // [ANTI-PATTERN IGNORED]: tree-sitter-cli not in node_modules is expected; falls back to PATH
@@ -521,7 +550,7 @@ function runQuery(queryFile: string, sourceFile: string, grammarPath: string): R
 function runBatchQuery(queryFile: string, sourceFiles: string[], grammarPath: string): Map<string, RawMatch[]> {
   if (sourceFiles.length === 0) return new Map();
 
-  const bin = getTreeSitterBin();
+  const bin = getTreeSitterBinForTests();
   const execArgs = ["query", "-p", grammarPath, queryFile, ...sourceFiles];
 
   let output: string;

--- a/tests/services/smart-file-read/tree-sitter-bin.test.ts
+++ b/tests/services/smart-file-read/tree-sitter-bin.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { dirname, join } from 'node:path';
+import {
+  getTreeSitterBinForTests,
+  resetTreeSitterBinCacheForTests,
+  setTreeSitterBinDepsForTests,
+} from '../../../src/services/smart-file-read/parser.js';
+
+describe('tree-sitter binary resolution', () => {
+  const fakePackageJsonPath = join('C:', 'repo', 'node_modules', 'tree-sitter-cli', 'package.json');
+
+  afterEach(() => {
+    resetTreeSitterBinCacheForTests();
+    setTreeSitterBinDepsForTests();
+  });
+
+  it('prefers package-local tree-sitter.exe on Windows', () => {
+    setTreeSitterBinDepsForTests({
+      platform: 'win32',
+      resolvePackageJson: (id: string) => {
+        if (id === 'tree-sitter-cli/package.json') return fakePackageJsonPath;
+        throw new Error(`unexpected resolve: ${id}`);
+      },
+      fileExists: (candidatePath: string) => {
+        return candidatePath === join(dirname(fakePackageJsonPath), 'tree-sitter.exe');
+      },
+    });
+
+    expect(getTreeSitterBinForTests()).toBe(join(dirname(fakePackageJsonPath), 'tree-sitter.exe'));
+  });
+
+  it('falls back to PATH when no package-local binary exists', () => {
+    setTreeSitterBinDepsForTests({
+      platform: 'win32',
+      resolvePackageJson: () => fakePackageJsonPath,
+      fileExists: () => false,
+    });
+
+    expect(getTreeSitterBinForTests()).toBe('tree-sitter');
+  });
+});

--- a/tests/services/smart-file-read/tree-sitter-bin.test.ts
+++ b/tests/services/smart-file-read/tree-sitter-bin.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'bun:test';
 import { dirname, join } from 'node:path';
 import {
-  getTreeSitterBinForTests,
+  getTreeSitterBin,
   resetTreeSitterBinCacheForTests,
   setTreeSitterBinDepsForTests,
 } from '../../../src/services/smart-file-read/parser.js';
@@ -26,7 +26,7 @@ describe('tree-sitter binary resolution', () => {
       },
     });
 
-    expect(getTreeSitterBinForTests()).toBe(join(dirname(fakePackageJsonPath), 'tree-sitter.exe'));
+    expect(getTreeSitterBin()).toBe(join(dirname(fakePackageJsonPath), 'tree-sitter.exe'));
   });
 
   it('falls back to PATH when no package-local binary exists', () => {
@@ -36,6 +36,20 @@ describe('tree-sitter binary resolution', () => {
       fileExists: () => false,
     });
 
-    expect(getTreeSitterBinForTests()).toBe('tree-sitter');
+    expect(getTreeSitterBin()).toBe('tree-sitter');
+  });
+
+  it('uses the bare tree-sitter name on non-Windows platforms', () => {
+    const fakeUnixPackageJsonPath = join('/repo', 'node_modules', 'tree-sitter-cli', 'package.json');
+    setTreeSitterBinDepsForTests({
+      platform: 'linux',
+      resolvePackageJson: () => fakeUnixPackageJsonPath,
+      fileExists: (candidatePath: string) => {
+        expect(candidatePath.endsWith('tree-sitter.exe')).toBe(false);
+        return candidatePath === join(dirname(fakeUnixPackageJsonPath), 'tree-sitter');
+      },
+    });
+
+    expect(getTreeSitterBin()).toBe(join(dirname(fakeUnixPackageJsonPath), 'tree-sitter'));
   });
 });

--- a/tests/setup-runtime.test.ts
+++ b/tests/setup-runtime.test.ts
@@ -4,6 +4,7 @@ import { spawnSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
+  getPluginDependencyInstallArgs,
   readInstallMarker,
   writeInstallMarker,
   isInstallCurrent,
@@ -148,6 +149,13 @@ describe('setup-runtime install marker', () => {
       expect(text.length).toBeGreaterThan(0);
       expect(text.toLowerCase()).toContain('uv');
       expect(text).toContain('claude-mem install');
+    });
+  });
+
+  describe('installPluginDependencies argv', () => {
+    it('keeps frozen-lockfile and does not suppress trusted install scripts', () => {
+      expect(getPluginDependencyInstallArgs()).toEqual(['install', '--frozen-lockfile']);
+      expect(getPluginDependencyInstallArgs()).not.toContain('--ignore-scripts');
     });
   });
 });

--- a/tests/setup-runtime.test.ts
+++ b/tests/setup-runtime.test.ts
@@ -1,8 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync } from 'fs';
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
 import { spawnSync } from 'child_process';
+import * as childProcess from 'child_process';
+import { EventEmitter } from 'events';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { PassThrough } from 'stream';
 import {
   getPluginDependencyInstallArgs,
   readInstallMarker,
@@ -26,6 +29,7 @@ function probeBunVersion(): string | null {
 
 describe('setup-runtime install marker', () => {
   let tempDir: string;
+  let spawnSpy: ReturnType<typeof spyOn> | undefined;
 
   beforeEach(() => {
     tempDir = join(
@@ -36,6 +40,8 @@ describe('setup-runtime install marker', () => {
   });
 
   afterEach(() => {
+    spawnSpy?.mockRestore();
+    spawnSpy = undefined;
     try {
       rmSync(tempDir, { recursive: true, force: true });
     } catch {
@@ -160,22 +166,29 @@ describe('setup-runtime install marker', () => {
 
     it('reports installer timeouts explicitly when the child is killed', async () => {
       writeFileSync(join(tempDir, 'package.json'), '{}');
-      const fakeBunPath = process.platform === 'win32'
-        ? join(tempDir, 'fake-bun.cmd')
-        : join(tempDir, 'fake-bun');
-      if (process.platform === 'win32') {
-        writeFileSync(fakeBunPath, '@echo off\r\nping -n 60 127.0.0.1 >nul\r\n');
-      } else {
-        writeFileSync(fakeBunPath, '#!/usr/bin/env bash\nsleep 60\n');
-        chmodSync(fakeBunPath, 0o755);
-      }
-
       const originalTimeoutOverride = process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS;
       process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS = '1';
 
       try {
+        spawnSpy = spyOn(childProcess, 'spawn').mockImplementation(() => {
+          const fakeChild = new EventEmitter() as EventEmitter & {
+            stdout: PassThrough;
+            stderr: PassThrough;
+            kill: () => boolean;
+          };
+          fakeChild.stdout = new PassThrough();
+          fakeChild.stderr = new PassThrough();
+          fakeChild.kill = () => {
+            setTimeout(() => {
+              fakeChild.emit('close', null, 'SIGTERM');
+            }, 0);
+            return true;
+          };
+          return fakeChild as unknown as ReturnType<typeof childProcess.spawn>;
+        });
+
         const runtime = await import(`../src/npx-cli/install/setup-runtime.ts?timeout-test=${Date.now()}`);
-        await expect(runtime.installPluginDependencies(tempDir, fakeBunPath)).rejects.toThrow(
+        await expect(runtime.installPluginDependencies(tempDir, 'fake-bun')).rejects.toThrow(
           'bun install timed out after 1ms'
         );
       } finally {

--- a/tests/setup-runtime.test.ts
+++ b/tests/setup-runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
 import { spawnSync } from 'child_process';
 import { join } from 'path';
@@ -156,6 +156,48 @@ describe('setup-runtime install marker', () => {
     it('keeps frozen-lockfile and does not suppress trusted install scripts', () => {
       expect(getPluginDependencyInstallArgs()).toEqual(['install', '--frozen-lockfile']);
       expect(getPluginDependencyInstallArgs()).not.toContain('--ignore-scripts');
+    });
+
+    it('reports installer timeouts explicitly when the child is killed', async () => {
+      writeFileSync(join(tempDir, 'package.json'), '{}');
+
+      const originalSetTimeout = global.setTimeout;
+      const originalClearTimeout = global.clearTimeout;
+      global.setTimeout = ((callback: (...args: any[]) => void) => {
+        callback();
+        return 1 as unknown as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout;
+      global.clearTimeout = (() => {}) as typeof clearTimeout;
+
+      mock.module('child_process', () => {
+        const original = require('node:child_process');
+        return {
+          ...original,
+          spawn: () => {
+            const child = {
+              stdout: { on: () => child.stdout },
+              stderr: { on: () => child.stderr },
+              kill: () => {},
+              on: (event: string, cb: (...args: any[]) => void) => {
+                if (event === 'close') queueMicrotask(() => cb(1, null));
+                return child;
+              },
+            };
+            return child;
+          },
+        };
+      });
+
+      try {
+        const runtime = await import(`../src/npx-cli/install/setup-runtime.ts?timeout-test=${Date.now()}`);
+        await expect(runtime.installPluginDependencies(tempDir, 'bun')).rejects.toThrow(
+          'bun install timed out after 300000ms'
+        );
+      } finally {
+        global.setTimeout = originalSetTimeout;
+        global.clearTimeout = originalClearTimeout;
+        mock.restore();
+      }
     });
   });
 });

--- a/tests/setup-runtime.test.ts
+++ b/tests/setup-runtime.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
-import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync } from 'fs';
 import { spawnSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -160,43 +160,30 @@ describe('setup-runtime install marker', () => {
 
     it('reports installer timeouts explicitly when the child is killed', async () => {
       writeFileSync(join(tempDir, 'package.json'), '{}');
+      const fakeBunPath = process.platform === 'win32'
+        ? join(tempDir, 'fake-bun.cmd')
+        : join(tempDir, 'fake-bun');
+      if (process.platform === 'win32') {
+        writeFileSync(fakeBunPath, '@echo off\r\nping -n 60 127.0.0.1 >nul\r\n');
+      } else {
+        writeFileSync(fakeBunPath, '#!/usr/bin/env bash\nsleep 60\n');
+        chmodSync(fakeBunPath, 0o755);
+      }
 
-      const originalSetTimeout = global.setTimeout;
-      const originalClearTimeout = global.clearTimeout;
-      global.setTimeout = ((callback: (...args: any[]) => void) => {
-        callback();
-        return 1 as unknown as ReturnType<typeof setTimeout>;
-      }) as typeof setTimeout;
-      global.clearTimeout = (() => {}) as typeof clearTimeout;
-
-      mock.module('child_process', () => {
-        const original = require('node:child_process');
-        return {
-          ...original,
-          spawn: () => {
-            const child = {
-              stdout: { on: () => child.stdout },
-              stderr: { on: () => child.stderr },
-              kill: () => {},
-              on: (event: string, cb: (...args: any[]) => void) => {
-                if (event === 'close') queueMicrotask(() => cb(1, null));
-                return child;
-              },
-            };
-            return child;
-          },
-        };
-      });
+      const originalTimeoutOverride = process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS;
+      process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS = '1';
 
       try {
         const runtime = await import(`../src/npx-cli/install/setup-runtime.ts?timeout-test=${Date.now()}`);
-        await expect(runtime.installPluginDependencies(tempDir, 'bun')).rejects.toThrow(
-          'bun install timed out after 300000ms'
+        await expect(runtime.installPluginDependencies(tempDir, fakeBunPath)).rejects.toThrow(
+          'bun install timed out after 1ms'
         );
       } finally {
-        global.setTimeout = originalSetTimeout;
-        global.clearTimeout = originalClearTimeout;
-        mock.restore();
+        if (originalTimeoutOverride === undefined) {
+          delete process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS;
+        } else {
+          process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS = originalTimeoutOverride;
+        }
       }
     });
   });


### PR DESCRIPTION
## Summary
Clean Windows installs were suppressing the trusted `tree-sitter-cli` bootstrap, then the smart-file-read parser ignored the resulting `tree-sitter.exe` even when it existed locally. This patch restores Bun's trusted install-script path in the installer, resolves the package-local Windows binary before PATH fallback, and adds focused regression coverage for both behaviors.

## Why
`installPluginDependencies()` in `src/npx-cli/install/setup-runtime.ts:403-469` previously invoked Bun through a string command with `--ignore-scripts`, which prevented Bun from running the trusted `tree-sitter-cli` install hook at all. The fix switches that call to array-based `spawn()` args, keeps `--frozen-lockfile`, drops `--ignore-scripts`, and preserves the existing timeout plus stdout/stderr error reporting so the installer still fails loudly when Bun hangs or exits non-zero.

`getTreeSitterBinForTests()` in `src/services/smart-file-read/parser.ts:483-528` now checks `tree-sitter.exe` before the extensionless binary when the resolver is running on Windows. `runBatchQuery()` at `src/services/smart-file-read/parser.ts:551-561` continues to share the same cached path and PATH fallback behavior, but it no longer discards a valid package-local Windows binary.

The regression tests anchor both execution paths. `tests/setup-runtime.test.ts:155-160` asserts that the install argv preserves `--frozen-lockfile` and no longer includes `--ignore-scripts`, and `tests/services/smart-file-read/tree-sitter-bin.test.ts:9-40` verifies Windows `.exe` preference plus bare-PATH fallback.

## Scope
This PR does not change the existing empty-result behavior when tree-sitter still cannot be executed for some other reason. It also does not rewrite smart-file-read to use WASM or bundle per-platform binaries; it keeps the native CLI path and only repairs the supported installer plus Windows resolver flow.

## Risk
The installer now permits Bun to execute trusted dependency scripts again, which is the intended package policy and is narrower than enabling arbitrary npm scripts. The spawn path remains array-based with `shell: false`, the timeout guard is preserved, and the parser's binary lookup only adds the Windows `.exe` candidate ahead of the existing fallback chain.

## Verification / Test plan
- [x] `bun test tests/setup-runtime.test.ts tests/services/smart-file-read/tree-sitter-bin.test.ts` - 17 passing
- [x] `npm run build`
- [ ] `npm run lint:hook-io && npm run lint:spawn-env && npm run strip-comments:check` - hook IO and spawn-env passed, `strip-comments:check` reports a pre-existing repo-wide failure (`Changed: 330`) in check mode

## Upstream

Closes #2910.
Reported by @jyepe.
