### PR TITLE
fix(installer): make launchable + add uninstall option

### DIFF
--- a/installer/build.mjs
+++ b/installer/build.mjs
@@ -1,4 +1,7 @@
 import { build } from 'esbuild';
+import { chmodSync } from 'fs';
+
+const outfile = 'dist/index.js';
 
 await build({
   entryPoints: ['src/index.ts'],
@@ -6,11 +9,15 @@ await build({
   format: 'esm',
   platform: 'node',
   target: 'node18',
-  outfile: 'dist/index.js',
+  outfile,
   banner: {
     js: '#!/usr/bin/env node',
   },
   external: [],
 });
+
+// The bin entry starts with a shebang, so it must be executable for `npx`
+// and direct invocation to work. esbuild does not set the execute bit.
+chmodSync(outfile, 0o755);
 
 console.log('Build complete: dist/index.js');

--- a/installer/dist/index.js
+++ b/installer/dist/index.js
@@ -25,6 +25,62 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
+// node_modules/sisteransi/src/index.js
+var require_src = __commonJS({
+  "node_modules/sisteransi/src/index.js"(exports, module) {
+    "use strict";
+    var ESC2 = "\x1B";
+    var CSI2 = `${ESC2}[`;
+    var beep = "\x07";
+    var cursor3 = {
+      to(x, y) {
+        if (!y) return `${CSI2}${x + 1}G`;
+        return `${CSI2}${y + 1};${x + 1}H`;
+      },
+      move(x, y) {
+        let ret = "";
+        if (x < 0) ret += `${CSI2}${-x}D`;
+        else if (x > 0) ret += `${CSI2}${x}C`;
+        if (y < 0) ret += `${CSI2}${-y}A`;
+        else if (y > 0) ret += `${CSI2}${y}B`;
+        return ret;
+      },
+      up: (count = 1) => `${CSI2}${count}A`,
+      down: (count = 1) => `${CSI2}${count}B`,
+      forward: (count = 1) => `${CSI2}${count}C`,
+      backward: (count = 1) => `${CSI2}${count}D`,
+      nextLine: (count = 1) => `${CSI2}E`.repeat(count),
+      prevLine: (count = 1) => `${CSI2}F`.repeat(count),
+      left: `${CSI2}G`,
+      hide: `${CSI2}?25l`,
+      show: `${CSI2}?25h`,
+      save: `${ESC2}7`,
+      restore: `${ESC2}8`
+    };
+    var scroll = {
+      up: (count = 1) => `${CSI2}S`.repeat(count),
+      down: (count = 1) => `${CSI2}T`.repeat(count)
+    };
+    var erase3 = {
+      screen: `${CSI2}2J`,
+      up: (count = 1) => `${CSI2}1J`.repeat(count),
+      down: (count = 1) => `${CSI2}J`.repeat(count),
+      line: `${CSI2}2K`,
+      lineEnd: `${CSI2}K`,
+      lineStart: `${CSI2}1K`,
+      lines(count) {
+        let clear = "";
+        for (let i2 = 0; i2 < count; i2++)
+          clear += this.line + (i2 < count - 1 ? cursor3.up() : "");
+        if (count)
+          clear += cursor3.left;
+        return clear;
+      }
+    };
+    module.exports = { cursor: cursor3, scroll, erase: erase3, beep };
+  }
+});
+
 // node_modules/picocolors/picocolors.js
 var require_picocolors = __commonJS({
   "node_modules/picocolors/picocolors.js"(exports, module) {
@@ -37,13 +93,13 @@ var require_picocolors = __commonJS({
       return ~index ? open + replaceClose(string, close, replace, index) + close : open + string + close;
     };
     var replaceClose = (string, close, replace, index) => {
-      let result = "", cursor = 0;
+      let result = "", cursor3 = 0;
       do {
-        result += string.substring(cursor, index) + replace;
-        cursor = index + close.length;
-        index = string.indexOf(close, cursor);
+        result += string.substring(cursor3, index) + replace;
+        cursor3 = index + close.length;
+        index = string.indexOf(close, cursor3);
       } while (~index);
-      return result + string.substring(cursor);
+      return result + string.substring(cursor3);
     };
     var createColors = (enabled = isColorSupported) => {
       let f = enabled ? formatter : () => String;
@@ -97,294 +153,488 @@ var require_picocolors = __commonJS({
   }
 });
 
-// node_modules/sisteransi/src/index.js
-var require_src = __commonJS({
-  "node_modules/sisteransi/src/index.js"(exports, module) {
-    "use strict";
-    var ESC = "\x1B";
-    var CSI = `${ESC}[`;
-    var beep = "\x07";
-    var cursor = {
-      to(x3, y2) {
-        if (!y2) return `${CSI}${x3 + 1}G`;
-        return `${CSI}${y2 + 1};${x3 + 1}H`;
-      },
-      move(x3, y2) {
-        let ret = "";
-        if (x3 < 0) ret += `${CSI}${-x3}D`;
-        else if (x3 > 0) ret += `${CSI}${x3}C`;
-        if (y2 < 0) ret += `${CSI}${-y2}A`;
-        else if (y2 > 0) ret += `${CSI}${y2}B`;
-        return ret;
-      },
-      up: (count = 1) => `${CSI}${count}A`,
-      down: (count = 1) => `${CSI}${count}B`,
-      forward: (count = 1) => `${CSI}${count}C`,
-      backward: (count = 1) => `${CSI}${count}D`,
-      nextLine: (count = 1) => `${CSI}E`.repeat(count),
-      prevLine: (count = 1) => `${CSI}F`.repeat(count),
-      left: `${CSI}G`,
-      hide: `${CSI}?25l`,
-      show: `${CSI}?25h`,
-      save: `${ESC}7`,
-      restore: `${ESC}8`
-    };
-    var scroll = {
-      up: (count = 1) => `${CSI}S`.repeat(count),
-      down: (count = 1) => `${CSI}T`.repeat(count)
-    };
-    var erase = {
-      screen: `${CSI}2J`,
-      up: (count = 1) => `${CSI}1J`.repeat(count),
-      down: (count = 1) => `${CSI}J`.repeat(count),
-      line: `${CSI}2K`,
-      lineEnd: `${CSI}K`,
-      lineStart: `${CSI}1K`,
-      lines(count) {
-        let clear = "";
-        for (let i = 0; i < count; i++)
-          clear += this.line + (i < count - 1 ? cursor.up() : "");
-        if (count)
-          clear += cursor.left;
-        return clear;
-      }
-    };
-    module.exports = { cursor, scroll, erase, beep };
-  }
-});
-
 // node_modules/@clack/core/dist/index.mjs
-var import_picocolors = __toESM(require_picocolors(), 1);
-var import_sisteransi = __toESM(require_src(), 1);
-import { stdout as R, stdin as q } from "node:process";
-import * as k from "node:readline";
-import ot from "node:readline";
-import { ReadStream as J } from "node:tty";
-function B(t, e2, s) {
-  if (!s.some((u) => !u.disabled)) return t;
-  const i = t + e2, r = Math.max(s.length - 1, 0), n = i < 0 ? r : i > r ? 0 : i;
-  return s[n].disabled ? B(n, e2 < 0 ? -1 : 1, s) : n;
-}
-var at = (t) => t === 161 || t === 164 || t === 167 || t === 168 || t === 170 || t === 173 || t === 174 || t >= 176 && t <= 180 || t >= 182 && t <= 186 || t >= 188 && t <= 191 || t === 198 || t === 208 || t === 215 || t === 216 || t >= 222 && t <= 225 || t === 230 || t >= 232 && t <= 234 || t === 236 || t === 237 || t === 240 || t === 242 || t === 243 || t >= 247 && t <= 250 || t === 252 || t === 254 || t === 257 || t === 273 || t === 275 || t === 283 || t === 294 || t === 295 || t === 299 || t >= 305 && t <= 307 || t === 312 || t >= 319 && t <= 322 || t === 324 || t >= 328 && t <= 331 || t === 333 || t === 338 || t === 339 || t === 358 || t === 359 || t === 363 || t === 462 || t === 464 || t === 466 || t === 468 || t === 470 || t === 472 || t === 474 || t === 476 || t === 593 || t === 609 || t === 708 || t === 711 || t >= 713 && t <= 715 || t === 717 || t === 720 || t >= 728 && t <= 731 || t === 733 || t === 735 || t >= 768 && t <= 879 || t >= 913 && t <= 929 || t >= 931 && t <= 937 || t >= 945 && t <= 961 || t >= 963 && t <= 969 || t === 1025 || t >= 1040 && t <= 1103 || t === 1105 || t === 8208 || t >= 8211 && t <= 8214 || t === 8216 || t === 8217 || t === 8220 || t === 8221 || t >= 8224 && t <= 8226 || t >= 8228 && t <= 8231 || t === 8240 || t === 8242 || t === 8243 || t === 8245 || t === 8251 || t === 8254 || t === 8308 || t === 8319 || t >= 8321 && t <= 8324 || t === 8364 || t === 8451 || t === 8453 || t === 8457 || t === 8467 || t === 8470 || t === 8481 || t === 8482 || t === 8486 || t === 8491 || t === 8531 || t === 8532 || t >= 8539 && t <= 8542 || t >= 8544 && t <= 8555 || t >= 8560 && t <= 8569 || t === 8585 || t >= 8592 && t <= 8601 || t === 8632 || t === 8633 || t === 8658 || t === 8660 || t === 8679 || t === 8704 || t === 8706 || t === 8707 || t === 8711 || t === 8712 || t === 8715 || t === 8719 || t === 8721 || t === 8725 || t === 8730 || t >= 8733 && t <= 8736 || t === 8739 || t === 8741 || t >= 8743 && t <= 8748 || t === 8750 || t >= 8756 && t <= 8759 || t === 8764 || t === 8765 || t === 8776 || t === 8780 || t === 8786 || t === 8800 || t === 8801 || t >= 8804 && t <= 8807 || t === 8810 || t === 8811 || t === 8814 || t === 8815 || t === 8834 || t === 8835 || t === 8838 || t === 8839 || t === 8853 || t === 8857 || t === 8869 || t === 8895 || t === 8978 || t >= 9312 && t <= 9449 || t >= 9451 && t <= 9547 || t >= 9552 && t <= 9587 || t >= 9600 && t <= 9615 || t >= 9618 && t <= 9621 || t === 9632 || t === 9633 || t >= 9635 && t <= 9641 || t === 9650 || t === 9651 || t === 9654 || t === 9655 || t === 9660 || t === 9661 || t === 9664 || t === 9665 || t >= 9670 && t <= 9672 || t === 9675 || t >= 9678 && t <= 9681 || t >= 9698 && t <= 9701 || t === 9711 || t === 9733 || t === 9734 || t === 9737 || t === 9742 || t === 9743 || t === 9756 || t === 9758 || t === 9792 || t === 9794 || t === 9824 || t === 9825 || t >= 9827 && t <= 9829 || t >= 9831 && t <= 9834 || t === 9836 || t === 9837 || t === 9839 || t === 9886 || t === 9887 || t === 9919 || t >= 9926 && t <= 9933 || t >= 9935 && t <= 9939 || t >= 9941 && t <= 9953 || t === 9955 || t === 9960 || t === 9961 || t >= 9963 && t <= 9969 || t === 9972 || t >= 9974 && t <= 9977 || t === 9979 || t === 9980 || t === 9982 || t === 9983 || t === 10045 || t >= 10102 && t <= 10111 || t >= 11094 && t <= 11097 || t >= 12872 && t <= 12879 || t >= 57344 && t <= 63743 || t >= 65024 && t <= 65039 || t === 65533 || t >= 127232 && t <= 127242 || t >= 127248 && t <= 127277 || t >= 127280 && t <= 127337 || t >= 127344 && t <= 127373 || t === 127375 || t === 127376 || t >= 127387 && t <= 127404 || t >= 917760 && t <= 917999 || t >= 983040 && t <= 1048573 || t >= 1048576 && t <= 1114109;
-var lt = (t) => t === 12288 || t >= 65281 && t <= 65376 || t >= 65504 && t <= 65510;
-var ht = (t) => t >= 4352 && t <= 4447 || t === 8986 || t === 8987 || t === 9001 || t === 9002 || t >= 9193 && t <= 9196 || t === 9200 || t === 9203 || t === 9725 || t === 9726 || t === 9748 || t === 9749 || t >= 9800 && t <= 9811 || t === 9855 || t === 9875 || t === 9889 || t === 9898 || t === 9899 || t === 9917 || t === 9918 || t === 9924 || t === 9925 || t === 9934 || t === 9940 || t === 9962 || t === 9970 || t === 9971 || t === 9973 || t === 9978 || t === 9981 || t === 9989 || t === 9994 || t === 9995 || t === 10024 || t === 10060 || t === 10062 || t >= 10067 && t <= 10069 || t === 10071 || t >= 10133 && t <= 10135 || t === 10160 || t === 10175 || t === 11035 || t === 11036 || t === 11088 || t === 11093 || t >= 11904 && t <= 11929 || t >= 11931 && t <= 12019 || t >= 12032 && t <= 12245 || t >= 12272 && t <= 12287 || t >= 12289 && t <= 12350 || t >= 12353 && t <= 12438 || t >= 12441 && t <= 12543 || t >= 12549 && t <= 12591 || t >= 12593 && t <= 12686 || t >= 12688 && t <= 12771 || t >= 12783 && t <= 12830 || t >= 12832 && t <= 12871 || t >= 12880 && t <= 19903 || t >= 19968 && t <= 42124 || t >= 42128 && t <= 42182 || t >= 43360 && t <= 43388 || t >= 44032 && t <= 55203 || t >= 63744 && t <= 64255 || t >= 65040 && t <= 65049 || t >= 65072 && t <= 65106 || t >= 65108 && t <= 65126 || t >= 65128 && t <= 65131 || t >= 94176 && t <= 94180 || t === 94192 || t === 94193 || t >= 94208 && t <= 100343 || t >= 100352 && t <= 101589 || t >= 101632 && t <= 101640 || t >= 110576 && t <= 110579 || t >= 110581 && t <= 110587 || t === 110589 || t === 110590 || t >= 110592 && t <= 110882 || t === 110898 || t >= 110928 && t <= 110930 || t === 110933 || t >= 110948 && t <= 110951 || t >= 110960 && t <= 111355 || t === 126980 || t === 127183 || t === 127374 || t >= 127377 && t <= 127386 || t >= 127488 && t <= 127490 || t >= 127504 && t <= 127547 || t >= 127552 && t <= 127560 || t === 127568 || t === 127569 || t >= 127584 && t <= 127589 || t >= 127744 && t <= 127776 || t >= 127789 && t <= 127797 || t >= 127799 && t <= 127868 || t >= 127870 && t <= 127891 || t >= 127904 && t <= 127946 || t >= 127951 && t <= 127955 || t >= 127968 && t <= 127984 || t === 127988 || t >= 127992 && t <= 128062 || t === 128064 || t >= 128066 && t <= 128252 || t >= 128255 && t <= 128317 || t >= 128331 && t <= 128334 || t >= 128336 && t <= 128359 || t === 128378 || t === 128405 || t === 128406 || t === 128420 || t >= 128507 && t <= 128591 || t >= 128640 && t <= 128709 || t === 128716 || t >= 128720 && t <= 128722 || t >= 128725 && t <= 128727 || t >= 128732 && t <= 128735 || t === 128747 || t === 128748 || t >= 128756 && t <= 128764 || t >= 128992 && t <= 129003 || t === 129008 || t >= 129292 && t <= 129338 || t >= 129340 && t <= 129349 || t >= 129351 && t <= 129535 || t >= 129648 && t <= 129660 || t >= 129664 && t <= 129672 || t >= 129680 && t <= 129725 || t >= 129727 && t <= 129733 || t >= 129742 && t <= 129755 || t >= 129760 && t <= 129768 || t >= 129776 && t <= 129784 || t >= 131072 && t <= 196605 || t >= 196608 && t <= 262141;
-var O = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/y;
-var y = /[\x00-\x08\x0A-\x1F\x7F-\x9F]{1,1000}/y;
-var L = /\t{1,1000}/y;
-var P = new RegExp("[\\u{1F1E6}-\\u{1F1FF}]{2}|\\u{1F3F4}[\\u{E0061}-\\u{E007A}]{2}[\\u{E0030}-\\u{E0039}\\u{E0061}-\\u{E007A}]{1,3}\\u{E007F}|(?:\\p{Emoji}\\uFE0F\\u20E3?|\\p{Emoji_Modifier_Base}\\p{Emoji_Modifier}?|\\p{Emoji_Presentation})(?:\\u200D(?:\\p{Emoji_Modifier_Base}\\p{Emoji_Modifier}?|\\p{Emoji_Presentation}|\\p{Emoji}\\uFE0F\\u20E3?))*", "yu");
-var M = /(?:[\x20-\x7E\xA0-\xFF](?!\uFE0F)){1,1000}/y;
-var ct = new RegExp("\\p{M}+", "gu");
-var ft = { limit: 1 / 0, ellipsis: "" };
-var X = (t, e2 = {}, s = {}) => {
-  const i = e2.limit ?? 1 / 0, r = e2.ellipsis ?? "", n = e2?.ellipsisWidth ?? (r ? X(r, ft, s).width : 0), u = s.ansiWidth ?? 0, a = s.controlWidth ?? 0, l = s.tabWidth ?? 8, E = s.ambiguousWidth ?? 1, g = s.emojiWidth ?? 2, m = s.fullWidthWidth ?? 2, A = s.regularWidth ?? 1, V2 = s.wideWidth ?? 2;
-  let h = 0, o = 0, p = t.length, v = 0, F = false, d2 = p, b = Math.max(0, i - n), C2 = 0, w = 0, c = 0, f = 0;
-  t: for (; ; ) {
-    if (w > C2 || o >= p && o > h) {
-      const ut = t.slice(C2, w) || t.slice(h, o);
-      v = 0;
-      for (const Y of ut.replaceAll(ct, "")) {
-        const $ = Y.codePointAt(0) || 0;
-        if (lt($) ? f = m : ht($) ? f = V2 : E !== A && at($) ? f = E : f = A, c + f > b && (d2 = Math.min(d2, Math.max(C2, h) + v)), c + f > i) {
-          F = true;
-          break t;
+import { styleText } from "node:util";
+import { stdout, stdin } from "node:process";
+import * as l from "node:readline";
+import l__default from "node:readline";
+
+// node_modules/fast-string-truncated-width/dist/utils.js
+var getCodePointsLength = /* @__PURE__ */ (() => {
+  const SURROGATE_PAIR_RE = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g;
+  return (input) => {
+    let surrogatePairsNr = 0;
+    SURROGATE_PAIR_RE.lastIndex = 0;
+    while (SURROGATE_PAIR_RE.test(input)) {
+      surrogatePairsNr += 1;
+    }
+    return input.length - surrogatePairsNr;
+  };
+})();
+var isFullWidth = (x) => {
+  return x === 12288 || x >= 65281 && x <= 65376 || x >= 65504 && x <= 65510;
+};
+var isWideNotCJKTNotEmoji = (x) => {
+  return x === 8987 || x === 9001 || x >= 12272 && x <= 12287 || x >= 12289 && x <= 12350 || x >= 12441 && x <= 12543 || x >= 12549 && x <= 12591 || x >= 12593 && x <= 12686 || x >= 12688 && x <= 12771 || x >= 12783 && x <= 12830 || x >= 12832 && x <= 12871 || x >= 12880 && x <= 19903 || x >= 65040 && x <= 65049 || x >= 65072 && x <= 65106 || x >= 65108 && x <= 65126 || x >= 65128 && x <= 65131 || x >= 127488 && x <= 127490 || x >= 127504 && x <= 127547 || x >= 127552 && x <= 127560 || x >= 131072 && x <= 196605 || x >= 196608 && x <= 262141;
+};
+
+// node_modules/fast-string-truncated-width/dist/index.js
+var ANSI_RE = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]|\u001b\]8;[^;]*;.*?(?:\u0007|\u001b\u005c)/y;
+var CONTROL_RE = /[\x00-\x08\x0A-\x1F\x7F-\x9F]{1,1000}/y;
+var CJKT_WIDE_RE = /(?:(?![\uFF61-\uFF9F\uFF00-\uFFEF])[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\p{Script=Tangut}]){1,1000}/yu;
+var TAB_RE = /\t{1,1000}/y;
+var EMOJI_RE = new RegExp("[\\u{1F1E6}-\\u{1F1FF}]{2}|\\u{1F3F4}[\\u{E0061}-\\u{E007A}]{2}[\\u{E0030}-\\u{E0039}\\u{E0061}-\\u{E007A}]{1,3}\\u{E007F}|(?:\\p{Emoji}\\uFE0F\\u20E3?|\\p{Emoji_Modifier_Base}\\p{Emoji_Modifier}?|\\p{Emoji_Presentation})(?:\\u200D(?:\\p{Emoji_Modifier_Base}\\p{Emoji_Modifier}?|\\p{Emoji_Presentation}|\\p{Emoji}\\uFE0F\\u20E3?))*", "yu");
+var LATIN_RE = /(?:[\x20-\x7E\xA0-\xFF](?!\uFE0F)){1,1000}/y;
+var MODIFIER_RE = new RegExp("\\p{M}+", "gu");
+var NO_TRUNCATION = { limit: Infinity, ellipsis: "" };
+var getStringTruncatedWidth = (input, truncationOptions = {}, widthOptions = {}) => {
+  const LIMIT = truncationOptions.limit ?? Infinity;
+  const ELLIPSIS = truncationOptions.ellipsis ?? "";
+  const ELLIPSIS_WIDTH = truncationOptions?.ellipsisWidth ?? (ELLIPSIS ? getStringTruncatedWidth(ELLIPSIS, NO_TRUNCATION, widthOptions).width : 0);
+  const ANSI_WIDTH = 0;
+  const CONTROL_WIDTH = widthOptions.controlWidth ?? 0;
+  const TAB_WIDTH = widthOptions.tabWidth ?? 8;
+  const EMOJI_WIDTH = widthOptions.emojiWidth ?? 2;
+  const FULL_WIDTH_WIDTH = 2;
+  const REGULAR_WIDTH = widthOptions.regularWidth ?? 1;
+  const WIDE_WIDTH = widthOptions.wideWidth ?? FULL_WIDTH_WIDTH;
+  const PARSE_BLOCKS = [
+    [LATIN_RE, REGULAR_WIDTH],
+    [ANSI_RE, ANSI_WIDTH],
+    [CONTROL_RE, CONTROL_WIDTH],
+    [TAB_RE, TAB_WIDTH],
+    [EMOJI_RE, EMOJI_WIDTH],
+    [CJKT_WIDE_RE, WIDE_WIDTH]
+  ];
+  let indexPrev = 0;
+  let index = 0;
+  let length = input.length;
+  let lengthExtra = 0;
+  let truncationEnabled = false;
+  let truncationIndex = length;
+  let truncationLimit = Math.max(0, LIMIT - ELLIPSIS_WIDTH);
+  let unmatchedStart = 0;
+  let unmatchedEnd = 0;
+  let width = 0;
+  let widthExtra = 0;
+  outer: while (true) {
+    if (unmatchedEnd > unmatchedStart || index >= length && index > indexPrev) {
+      const unmatched = input.slice(unmatchedStart, unmatchedEnd) || input.slice(indexPrev, index);
+      lengthExtra = 0;
+      for (const char of unmatched.replaceAll(MODIFIER_RE, "")) {
+        const codePoint = char.codePointAt(0) || 0;
+        if (isFullWidth(codePoint)) {
+          widthExtra = FULL_WIDTH_WIDTH;
+        } else if (isWideNotCJKTNotEmoji(codePoint)) {
+          widthExtra = WIDE_WIDTH;
+        } else {
+          widthExtra = REGULAR_WIDTH;
         }
-        v += Y.length, c += f;
+        if (width + widthExtra > truncationLimit) {
+          truncationIndex = Math.min(truncationIndex, Math.max(unmatchedStart, indexPrev) + lengthExtra);
+        }
+        if (width + widthExtra > LIMIT) {
+          truncationEnabled = true;
+          break outer;
+        }
+        lengthExtra += char.length;
+        width += widthExtra;
       }
-      C2 = w = 0;
+      unmatchedStart = unmatchedEnd = 0;
     }
-    if (o >= p) break;
-    if (M.lastIndex = o, M.test(t)) {
-      if (v = M.lastIndex - o, f = v * A, c + f > b && (d2 = Math.min(d2, o + Math.floor((b - c) / A))), c + f > i) {
-        F = true;
-        break;
+    if (index >= length) {
+      break outer;
+    }
+    for (let i2 = 0, l2 = PARSE_BLOCKS.length; i2 < l2; i2++) {
+      const [BLOCK_RE, BLOCK_WIDTH] = PARSE_BLOCKS[i2];
+      BLOCK_RE.lastIndex = index;
+      if (BLOCK_RE.test(input)) {
+        lengthExtra = BLOCK_RE === CJKT_WIDE_RE ? getCodePointsLength(input.slice(index, BLOCK_RE.lastIndex)) : BLOCK_RE === EMOJI_RE ? 1 : BLOCK_RE.lastIndex - index;
+        widthExtra = lengthExtra * BLOCK_WIDTH;
+        if (width + widthExtra > truncationLimit) {
+          truncationIndex = Math.min(truncationIndex, index + Math.floor((truncationLimit - width) / BLOCK_WIDTH));
+        }
+        if (width + widthExtra > LIMIT) {
+          truncationEnabled = true;
+          break outer;
+        }
+        width += widthExtra;
+        unmatchedStart = indexPrev;
+        unmatchedEnd = index;
+        index = indexPrev = BLOCK_RE.lastIndex;
+        continue outer;
       }
-      c += f, C2 = h, w = o, o = h = M.lastIndex;
-      continue;
     }
-    if (O.lastIndex = o, O.test(t)) {
-      if (c + u > b && (d2 = Math.min(d2, o)), c + u > i) {
-        F = true;
-        break;
-      }
-      c += u, C2 = h, w = o, o = h = O.lastIndex;
-      continue;
-    }
-    if (y.lastIndex = o, y.test(t)) {
-      if (v = y.lastIndex - o, f = v * a, c + f > b && (d2 = Math.min(d2, o + Math.floor((b - c) / a))), c + f > i) {
-        F = true;
-        break;
-      }
-      c += f, C2 = h, w = o, o = h = y.lastIndex;
-      continue;
-    }
-    if (L.lastIndex = o, L.test(t)) {
-      if (v = L.lastIndex - o, f = v * l, c + f > b && (d2 = Math.min(d2, o + Math.floor((b - c) / l))), c + f > i) {
-        F = true;
-        break;
-      }
-      c += f, C2 = h, w = o, o = h = L.lastIndex;
-      continue;
-    }
-    if (P.lastIndex = o, P.test(t)) {
-      if (c + g > b && (d2 = Math.min(d2, o)), c + g > i) {
-        F = true;
-        break;
-      }
-      c += g, C2 = h, w = o, o = h = P.lastIndex;
-      continue;
-    }
-    o += 1;
+    index += 1;
   }
-  return { width: F ? b : c, index: F ? d2 : p, truncated: F, ellipsed: F && i >= n };
+  return {
+    width: truncationEnabled ? truncationLimit : width,
+    index: truncationEnabled ? truncationIndex : length,
+    truncated: truncationEnabled,
+    ellipsed: truncationEnabled && LIMIT >= ELLIPSIS_WIDTH
+  };
 };
-var pt = { limit: 1 / 0, ellipsis: "", ellipsisWidth: 0 };
-var S = (t, e2 = {}) => X(t, pt, e2).width;
-var W = "\x1B";
-var Z = "\x9B";
-var Ft = 39;
-var j = "\x07";
-var Q = "[";
-var dt = "]";
-var tt = "m";
-var U = `${dt}8;;`;
-var et = new RegExp(`(?:\\${Q}(?<code>\\d+)m|\\${U}(?<uri>.*)${j})`, "y");
-var mt = (t) => {
-  if (t >= 30 && t <= 37 || t >= 90 && t <= 97) return 39;
-  if (t >= 40 && t <= 47 || t >= 100 && t <= 107) return 49;
-  if (t === 1 || t === 2) return 22;
-  if (t === 3) return 23;
-  if (t === 4) return 24;
-  if (t === 7) return 27;
-  if (t === 8) return 28;
-  if (t === 9) return 29;
-  if (t === 0) return 0;
+var dist_default = getStringTruncatedWidth;
+
+// node_modules/fast-string-width/dist/index.js
+var NO_TRUNCATION2 = {
+  limit: Infinity,
+  ellipsis: "",
+  ellipsisWidth: 0
 };
-var st = (t) => `${W}${Q}${t}${tt}`;
-var it = (t) => `${W}${U}${t}${j}`;
-var gt = (t) => t.map((e2) => S(e2));
-var G = (t, e2, s) => {
-  const i = e2[Symbol.iterator]();
-  let r = false, n = false, u = t.at(-1), a = u === void 0 ? 0 : S(u), l = i.next(), E = i.next(), g = 0;
-  for (; !l.done; ) {
-    const m = l.value, A = S(m);
-    a + A <= s ? t[t.length - 1] += m : (t.push(m), a = 0), (m === W || m === Z) && (r = true, n = e2.startsWith(U, g + 1)), r ? n ? m === j && (r = false, n = false) : m === tt && (r = false) : (a += A, a === s && !E.done && (t.push(""), a = 0)), l = E, E = i.next(), g += m.length;
+var fastStringWidth = (input, options = {}) => {
+  return dist_default(input, NO_TRUNCATION2, options).width;
+};
+var dist_default2 = fastStringWidth;
+
+// node_modules/fast-wrap-ansi/lib/main.js
+var ESC = "\x1B";
+var CSI = "\x9B";
+var END_CODE = 39;
+var ANSI_ESCAPE_BELL = "\x07";
+var ANSI_CSI = "[";
+var ANSI_OSC = "]";
+var ANSI_SGR_TERMINATOR = "m";
+var ANSI_ESCAPE_LINK = `${ANSI_OSC}8;;`;
+var GROUP_REGEX = new RegExp(`(?:\\${ANSI_CSI}(?<code>\\d+)m|\\${ANSI_ESCAPE_LINK}(?<uri>.*)${ANSI_ESCAPE_BELL})`, "y");
+var getClosingCode = (openingCode) => {
+  if (openingCode >= 30 && openingCode <= 37)
+    return 39;
+  if (openingCode >= 90 && openingCode <= 97)
+    return 39;
+  if (openingCode >= 40 && openingCode <= 47)
+    return 49;
+  if (openingCode >= 100 && openingCode <= 107)
+    return 49;
+  if (openingCode === 1 || openingCode === 2)
+    return 22;
+  if (openingCode === 3)
+    return 23;
+  if (openingCode === 4)
+    return 24;
+  if (openingCode === 7)
+    return 27;
+  if (openingCode === 8)
+    return 28;
+  if (openingCode === 9)
+    return 29;
+  if (openingCode === 0)
+    return 0;
+  return void 0;
+};
+var wrapAnsiCode = (code) => `${ESC}${ANSI_CSI}${code}${ANSI_SGR_TERMINATOR}`;
+var wrapAnsiHyperlink = (url) => `${ESC}${ANSI_ESCAPE_LINK}${url}${ANSI_ESCAPE_BELL}`;
+var wrapWord = (rows, word, columns) => {
+  const characters = word[Symbol.iterator]();
+  let isInsideEscape = false;
+  let isInsideLinkEscape = false;
+  let lastRow = rows.at(-1);
+  let visible = lastRow === void 0 ? 0 : dist_default2(lastRow);
+  let currentCharacter = characters.next();
+  let nextCharacter = characters.next();
+  let rawCharacterIndex = 0;
+  while (!currentCharacter.done) {
+    const character = currentCharacter.value;
+    const characterLength = dist_default2(character);
+    if (visible + characterLength <= columns) {
+      rows[rows.length - 1] += character;
+    } else {
+      rows.push(character);
+      visible = 0;
+    }
+    if (character === ESC || character === CSI) {
+      isInsideEscape = true;
+      isInsideLinkEscape = word.startsWith(ANSI_ESCAPE_LINK, rawCharacterIndex + 1);
+    }
+    if (isInsideEscape) {
+      if (isInsideLinkEscape) {
+        if (character === ANSI_ESCAPE_BELL) {
+          isInsideEscape = false;
+          isInsideLinkEscape = false;
+        }
+      } else if (character === ANSI_SGR_TERMINATOR) {
+        isInsideEscape = false;
+      }
+    } else {
+      visible += characterLength;
+      if (visible === columns && !nextCharacter.done) {
+        rows.push("");
+        visible = 0;
+      }
+    }
+    currentCharacter = nextCharacter;
+    nextCharacter = characters.next();
+    rawCharacterIndex += character.length;
   }
-  u = t.at(-1), !a && u !== void 0 && u.length > 0 && t.length > 1 && (t[t.length - 2] += t.pop());
+  lastRow = rows.at(-1);
+  if (!visible && lastRow !== void 0 && lastRow.length && rows.length > 1) {
+    rows[rows.length - 2] += rows.pop();
+  }
 };
-var vt = (t) => {
-  const e2 = t.split(" ");
-  let s = e2.length;
-  for (; s > 0 && !(S(e2[s - 1]) > 0); ) s--;
-  return s === e2.length ? t : e2.slice(0, s).join(" ") + e2.slice(s).join("");
+var stringVisibleTrimSpacesRight = (string) => {
+  const words = string.split(" ");
+  let last = words.length;
+  while (last) {
+    if (dist_default2(words[last - 1])) {
+      break;
+    }
+    last--;
+  }
+  if (last === words.length) {
+    return string;
+  }
+  return words.slice(0, last).join(" ") + words.slice(last).join("");
 };
-var Et = (t, e2, s = {}) => {
-  if (s.trim !== false && t.trim() === "") return "";
-  let i = "", r, n;
-  const u = t.split(" "), a = gt(u);
-  let l = [""];
-  for (const [h, o] of u.entries()) {
-    s.trim !== false && (l[l.length - 1] = (l.at(-1) ?? "").trimStart());
-    let p = S(l.at(-1) ?? "");
-    if (h !== 0 && (p >= e2 && (s.wordWrap === false || s.trim === false) && (l.push(""), p = 0), (p > 0 || s.trim === false) && (l[l.length - 1] += " ", p++)), s.hard && a[h] > e2) {
-      const v = e2 - p, F = 1 + Math.floor((a[h] - v - 1) / e2);
-      Math.floor((a[h] - 1) / e2) < F && l.push(""), G(l, o, e2);
+var exec = (string, columns, options = {}) => {
+  if (options.trim !== false && string.trim() === "") {
+    return "";
+  }
+  let returnValue = "";
+  let escapeCode;
+  let escapeUrl;
+  const words = string.split(" ");
+  let rows = [""];
+  let rowLength = 0;
+  for (let index = 0; index < words.length; index++) {
+    const word = words[index];
+    if (options.trim !== false) {
+      const row = rows.at(-1) ?? "";
+      const trimmed = row.trimStart();
+      if (row.length !== trimmed.length) {
+        rows[rows.length - 1] = trimmed;
+        rowLength = dist_default2(trimmed);
+      }
+    }
+    if (index !== 0) {
+      if (rowLength >= columns && (options.wordWrap === false || options.trim === false)) {
+        rows.push("");
+        rowLength = 0;
+      }
+      if (rowLength || options.trim === false) {
+        rows[rows.length - 1] += " ";
+        rowLength++;
+      }
+    }
+    const wordLength = dist_default2(word);
+    if (options.hard && wordLength > columns) {
+      const remainingColumns = columns - rowLength;
+      const breaksStartingThisLine = 1 + Math.floor((wordLength - remainingColumns - 1) / columns);
+      const breaksStartingNextLine = Math.floor((wordLength - 1) / columns);
+      if (breaksStartingNextLine < breaksStartingThisLine) {
+        rows.push("");
+      }
+      wrapWord(rows, word, columns);
+      rowLength = dist_default2(rows.at(-1) ?? "");
       continue;
     }
-    if (p + a[h] > e2 && p > 0 && a[h] > 0) {
-      if (s.wordWrap === false && p < e2) {
-        G(l, o, e2);
+    if (rowLength + wordLength > columns && rowLength && wordLength) {
+      if (options.wordWrap === false && rowLength < columns) {
+        wrapWord(rows, word, columns);
+        rowLength = dist_default2(rows.at(-1) ?? "");
         continue;
       }
-      l.push("");
+      rows.push("");
+      rowLength = 0;
     }
-    if (p + a[h] > e2 && s.wordWrap === false) {
-      G(l, o, e2);
+    if (rowLength + wordLength > columns && options.wordWrap === false) {
+      wrapWord(rows, word, columns);
+      rowLength = dist_default2(rows.at(-1) ?? "");
       continue;
     }
-    l[l.length - 1] += o;
+    rows[rows.length - 1] += word;
+    rowLength += wordLength;
   }
-  s.trim !== false && (l = l.map((h) => vt(h)));
-  const E = l.join(`
-`), g = E[Symbol.iterator]();
-  let m = g.next(), A = g.next(), V2 = 0;
-  for (; !m.done; ) {
-    const h = m.value, o = A.value;
-    if (i += h, h === W || h === Z) {
-      et.lastIndex = V2 + 1;
-      const F = et.exec(E)?.groups;
-      if (F?.code !== void 0) {
-        const d2 = Number.parseFloat(F.code);
-        r = d2 === Ft ? void 0 : d2;
-      } else F?.uri !== void 0 && (n = F.uri.length === 0 ? void 0 : F.uri);
+  if (options.trim !== false) {
+    rows = rows.map((row) => stringVisibleTrimSpacesRight(row));
+  }
+  const preString = rows.join("\n");
+  let inSurrogate = false;
+  for (let i2 = 0; i2 < preString.length; i2++) {
+    const character = preString[i2];
+    returnValue += character;
+    if (!inSurrogate) {
+      inSurrogate = character >= "\uD800" && character <= "\uDBFF";
+      if (inSurrogate) {
+        continue;
+      }
+    } else {
+      inSurrogate = false;
     }
-    const p = r ? mt(r) : void 0;
-    o === `
-` ? (n && (i += it("")), r && p && (i += st(p))) : h === `
-` && (r && p && (i += st(r)), n && (i += it(n))), V2 += h.length, m = A, A = g.next();
+    if (character === ESC || character === CSI) {
+      GROUP_REGEX.lastIndex = i2 + 1;
+      const groupsResult = GROUP_REGEX.exec(preString);
+      const groups = groupsResult?.groups;
+      if (groups?.code !== void 0) {
+        const code = Number.parseFloat(groups.code);
+        escapeCode = code === END_CODE ? void 0 : code;
+      } else if (groups?.uri !== void 0) {
+        escapeUrl = groups.uri.length === 0 ? void 0 : groups.uri;
+      }
+    }
+    if (preString[i2 + 1] === "\n") {
+      if (escapeUrl) {
+        returnValue += wrapAnsiHyperlink("");
+      }
+      const closingCode = escapeCode ? getClosingCode(escapeCode) : void 0;
+      if (escapeCode && closingCode) {
+        returnValue += wrapAnsiCode(closingCode);
+      }
+    } else if (character === "\n") {
+      if (escapeCode && getClosingCode(escapeCode)) {
+        returnValue += wrapAnsiCode(escapeCode);
+      }
+      if (escapeUrl) {
+        returnValue += wrapAnsiHyperlink(escapeUrl);
+      }
+    }
   }
-  return i;
+  return returnValue;
 };
-function K(t, e2, s) {
-  return String(t).normalize().replaceAll(`\r
-`, `
-`).split(`
-`).map((i) => Et(i, e2, s)).join(`
-`);
+var CRLF_OR_LF = /\r?\n/;
+function wrapAnsi(string, columns, options) {
+  return String(string).normalize().split(CRLF_OR_LF).map((line) => exec(line, columns, options)).join("\n");
 }
-var At = ["up", "down", "left", "right", "space", "enter", "cancel"];
-var _ = { actions: new Set(At), aliases: /* @__PURE__ */ new Map([["k", "up"], ["j", "down"], ["h", "left"], ["l", "right"], ["", "cancel"], ["escape", "cancel"]]), messages: { cancel: "Canceled", error: "Something went wrong" }, withGuide: true };
-function H(t, e2) {
-  if (typeof t == "string") return _.aliases.get(t) === e2;
-  for (const s of t) if (s !== void 0 && H(s, e2)) return true;
+
+// node_modules/@clack/core/dist/index.mjs
+var import_sisteransi = __toESM(require_src(), 1);
+import { ReadStream } from "node:tty";
+function findCursor(s, o2, l2) {
+  if (!l2.some((r2) => !r2.disabled))
+    return s;
+  const t2 = s + o2, n2 = Math.max(l2.length - 1, 0), e = t2 < 0 ? n2 : t2 > n2 ? 0 : t2;
+  return l2[e].disabled ? findCursor(e, o2 < 0 ? -1 : 1, l2) : e;
+}
+var a$2 = ["up", "down", "left", "right", "space", "enter", "cancel"];
+var t = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December"
+];
+var settings = {
+  actions: new Set(a$2),
+  aliases: /* @__PURE__ */ new Map([
+    // vim support
+    ["k", "up"],
+    ["j", "down"],
+    ["h", "left"],
+    ["l", "right"],
+    ["", "cancel"],
+    // opinionated defaults!
+    ["escape", "cancel"]
+  ]),
+  messages: {
+    cancel: "Canceled",
+    error: "Something went wrong"
+  },
+  withGuide: true,
+  date: {
+    monthNames: [...t],
+    messages: {
+      required: "Please enter a valid date",
+      invalidMonth: "There are only 12 months in a year",
+      invalidDay: (n2, e) => `There are only ${n2} days in ${e}`,
+      afterMin: (n2) => `Date must be on or after ${n2.toISOString().slice(0, 10)}`,
+      beforeMax: (n2) => `Date must be on or before ${n2.toISOString().slice(0, 10)}`
+    }
+  }
+};
+function isActionKey(n2, e) {
+  if (typeof n2 == "string")
+    return settings.aliases.get(n2) === e;
+  for (const s of n2)
+    if (s !== void 0 && isActionKey(s, e))
+      return true;
   return false;
 }
-function _t(t, e2) {
-  if (t === e2) return;
-  const s = t.split(`
-`), i = e2.split(`
-`), r = Math.max(s.length, i.length), n = [];
-  for (let u = 0; u < r; u++) s[u] !== i[u] && n.push(u);
-  return { lines: n, numLinesBefore: s.length, numLinesAfter: i.length, numLines: r };
+function diffLines(i2, s) {
+  if (i2 === s) return;
+  const e = i2.split(`
+`), t2 = s.split(`
+`), r2 = Math.max(e.length, t2.length), f = [];
+  for (let n2 = 0; n2 < r2; n2++)
+    e[n2] !== t2[n2] && f.push(n2);
+  return {
+    lines: f,
+    numLinesBefore: e.length,
+    numLinesAfter: t2.length,
+    numLines: r2
+  };
 }
-var bt = globalThis.process.platform.startsWith("win");
-var z = Symbol("clack:cancel");
-function Ct(t) {
-  return t === z;
+var R = globalThis.process.platform.startsWith("win");
+var CANCEL_SYMBOL = Symbol("clack:cancel");
+function isCancel(e) {
+  return e === CANCEL_SYMBOL;
 }
-function T(t, e2) {
-  const s = t;
-  s.isTTY && s.setRawMode(e2);
+function setRawMode(e, r2) {
+  const o2 = e;
+  o2.isTTY && o2.setRawMode(r2);
 }
-function Bt({ input: t = q, output: e2 = R, overwrite: s = true, hideCursor: i = true } = {}) {
-  const r = k.createInterface({ input: t, output: e2, prompt: "", tabSize: 1 });
-  k.emitKeypressEvents(t, r), t instanceof J && t.isTTY && t.setRawMode(true);
-  const n = (u, { name: a, sequence: l }) => {
-    const E = String(u);
-    if (H([E, a, l], "cancel")) {
-      i && e2.write(import_sisteransi.cursor.show), process.exit(0);
+function block({
+  input: e = stdin,
+  output: r2 = stdout,
+  overwrite: o2 = true,
+  hideCursor: t2 = true
+} = {}) {
+  const s = l.createInterface({
+    input: e,
+    output: r2,
+    prompt: "",
+    tabSize: 1
+  });
+  l.emitKeypressEvents(e, s), e instanceof ReadStream && e.isTTY && e.setRawMode(true);
+  const n2 = (f, { name: a3, sequence: p }) => {
+    const c2 = String(f);
+    if (isActionKey([c2, a3, p], "cancel")) {
+      t2 && r2.write(import_sisteransi.cursor.show), process.exit(0);
       return;
     }
-    if (!s) return;
-    const g = a === "return" ? 0 : -1, m = a === "return" ? -1 : 0;
-    k.moveCursor(e2, g, m, () => {
-      k.clearLine(e2, 1, () => {
-        t.once("keypress", n);
+    if (!o2) return;
+    const i2 = a3 === "return" ? 0 : -1, m = a3 === "return" ? -1 : 0;
+    l.moveCursor(r2, i2, m, () => {
+      l.clearLine(r2, 1, () => {
+        e.once("keypress", n2);
       });
     });
   };
-  return i && e2.write(import_sisteransi.cursor.hide), t.once("keypress", n), () => {
-    t.off("keypress", n), i && e2.write(import_sisteransi.cursor.show), t instanceof J && t.isTTY && !bt && t.setRawMode(false), r.terminal = false, r.close();
+  return t2 && r2.write(import_sisteransi.cursor.hide), e.once("keypress", n2), () => {
+    e.off("keypress", n2), t2 && r2.write(import_sisteransi.cursor.show), e instanceof ReadStream && e.isTTY && !R && e.setRawMode(false), s.terminal = false, s.close();
   };
 }
-var rt = (t) => "columns" in t && typeof t.columns == "number" ? t.columns : 80;
-var nt = (t) => "rows" in t && typeof t.rows == "number" ? t.rows : 20;
-function xt(t, e2, s, i = s) {
-  const r = rt(t ?? R);
-  return K(e2, r - s.length, { hard: true, trim: false }).split(`
-`).map((n, u) => `${u === 0 ? i : s}${n}`).join(`
+var getColumns = (e) => "columns" in e && typeof e.columns == "number" ? e.columns : 80;
+var getRows = (e) => "rows" in e && typeof e.rows == "number" ? e.rows : 20;
+function wrapTextWithPrefix(e, r2, o2, t2 = o2, s = o2, n2) {
+  const f = getColumns(e ?? stdout);
+  return wrapAnsi(r2, f - o2.length, {
+    hard: true,
+    trim: false
+  }).split(`
+`).map((c2, i2, m) => {
+    const d2 = n2 ? n2(c2, i2) : c2;
+    return i2 === 0 ? `${t2}${d2}` : i2 === m.length - 1 ? `${s}${d2}` : `${o2}${d2}`;
+  }).join(`
 `);
 }
-var x = class {
+function runValidation(e, n2) {
+  if ("~standard" in e) {
+    const a3 = e["~standard"].validate(n2);
+    if (a3 instanceof Promise)
+      throw new TypeError(
+        "Schema validation must be synchronous. Update `validate()` and remove any asynchronous logic."
+      );
+    return a3.issues?.at(0)?.message;
+  }
+  return e(n2);
+}
+var V = class {
   input;
   output;
   _abortSignal;
@@ -399,168 +649,215 @@ var x = class {
   error = "";
   value;
   userInput = "";
-  constructor(e2, s = true) {
-    const { input: i = q, output: r = R, render: n, signal: u, ...a } = e2;
-    this.opts = a, this.onKeypress = this.onKeypress.bind(this), this.close = this.close.bind(this), this.render = this.render.bind(this), this._render = n.bind(this), this._track = s, this._abortSignal = u, this.input = i, this.output = r;
+  constructor(t2, e = true) {
+    const { input: i2 = stdin, output: n2 = stdout, render: s, signal: r2, ...o2 } = t2;
+    this.opts = o2, this.onKeypress = this.onKeypress.bind(this), this.close = this.close.bind(this), this.render = this.render.bind(this), this._render = s.bind(this), this._track = e, this._abortSignal = r2, this.input = i2, this.output = n2;
   }
+  /**
+   * Unsubscribe all listeners
+   */
   unsubscribe() {
     this._subscribers.clear();
   }
-  setSubscriber(e2, s) {
-    const i = this._subscribers.get(e2) ?? [];
-    i.push(s), this._subscribers.set(e2, i);
+  /**
+   * Set a subscriber with opts
+   * @param event - The event name
+   */
+  setSubscriber(t2, e) {
+    const i2 = this._subscribers.get(t2) ?? [];
+    i2.push(e), this._subscribers.set(t2, i2);
   }
-  on(e2, s) {
-    this.setSubscriber(e2, { cb: s });
+  /**
+   * Subscribe to an event
+   * @param event - The event name
+   * @param cb - The callback
+   */
+  on(t2, e) {
+    this.setSubscriber(t2, { cb: e });
   }
-  once(e2, s) {
-    this.setSubscriber(e2, { cb: s, once: true });
+  /**
+   * Subscribe to an event once
+   * @param event - The event name
+   * @param cb - The callback
+   */
+  once(t2, e) {
+    this.setSubscriber(t2, { cb: e, once: true });
   }
-  emit(e2, ...s) {
-    const i = this._subscribers.get(e2) ?? [], r = [];
-    for (const n of i) n.cb(...s), n.once && r.push(() => i.splice(i.indexOf(n), 1));
-    for (const n of r) n();
+  /**
+   * Emit an event with data
+   * @param event - The event name
+   * @param data - The data to pass to the callback
+   */
+  emit(t2, ...e) {
+    const i2 = this._subscribers.get(t2) ?? [], n2 = [];
+    for (const s of i2)
+      s.cb(...e), s.once && n2.push(() => i2.splice(i2.indexOf(s), 1));
+    for (const s of n2)
+      s();
   }
   prompt() {
-    return new Promise((e2) => {
+    return new Promise((t2) => {
       if (this._abortSignal) {
-        if (this._abortSignal.aborted) return this.state = "cancel", this.close(), e2(z);
-        this._abortSignal.addEventListener("abort", () => {
-          this.state = "cancel", this.close();
-        }, { once: true });
+        if (this._abortSignal.aborted)
+          return this.state = "cancel", this.close(), t2(CANCEL_SYMBOL);
+        this._abortSignal.addEventListener(
+          "abort",
+          () => {
+            this.state = "cancel", this.close();
+          },
+          { once: true }
+        );
       }
-      this.rl = ot.createInterface({ input: this.input, tabSize: 2, prompt: "", escapeCodeTimeout: 50, terminal: true }), this.rl.prompt(), this.opts.initialUserInput !== void 0 && this._setUserInput(this.opts.initialUserInput, true), this.input.on("keypress", this.onKeypress), T(this.input, true), this.output.on("resize", this.render), this.render(), this.once("submit", () => {
-        this.output.write(import_sisteransi.cursor.show), this.output.off("resize", this.render), T(this.input, false), e2(this.value);
+      this.rl = l__default.createInterface({
+        input: this.input,
+        tabSize: 2,
+        prompt: "",
+        escapeCodeTimeout: 50,
+        terminal: true
+      }), this.rl.prompt(), this.opts.initialUserInput !== void 0 && this._setUserInput(this.opts.initialUserInput, true), this.input.on("keypress", this.onKeypress), setRawMode(this.input, true), this.output.on("resize", this.render), this.render(), this.once("submit", () => {
+        this.output.write(import_sisteransi.cursor.show), this.output.off("resize", this.render), setRawMode(this.input, false), t2(this.value);
       }), this.once("cancel", () => {
-        this.output.write(import_sisteransi.cursor.show), this.output.off("resize", this.render), T(this.input, false), e2(z);
+        this.output.write(import_sisteransi.cursor.show), this.output.off("resize", this.render), setRawMode(this.input, false), t2(CANCEL_SYMBOL);
       });
     });
   }
-  _isActionKey(e2, s) {
-    return e2 === "	";
+  _isActionKey(t2, e) {
+    return t2 === "	";
   }
-  _setValue(e2) {
-    this.value = e2, this.emit("value", this.value);
+  _shouldSubmit(t2, e) {
+    return true;
   }
-  _setUserInput(e2, s) {
-    this.userInput = e2 ?? "", this.emit("userInput", this.userInput), s && this._track && this.rl && (this.rl.write(this.userInput), this._cursor = this.rl.cursor);
+  _setValue(t2) {
+    this.value = t2, this.emit("value", this.value);
+  }
+  _setUserInput(t2, e) {
+    this.userInput = t2 ?? "", this.emit("userInput", this.userInput), e && this._track && this.rl && (this.rl.write(this.userInput), this._cursor = this.rl.cursor);
   }
   _clearUserInput() {
     this.rl?.write(null, { ctrl: true, name: "u" }), this._setUserInput("");
   }
-  onKeypress(e2, s) {
-    if (this._track && s.name !== "return" && (s.name && this._isActionKey(e2, s) && this.rl?.write(null, { ctrl: true, name: "h" }), this._cursor = this.rl?.cursor ?? 0, this._setUserInput(this.rl?.line)), this.state === "error" && (this.state = "active"), s?.name && (!this._track && _.aliases.has(s.name) && this.emit("cursor", _.aliases.get(s.name)), _.actions.has(s.name) && this.emit("cursor", s.name)), e2 && (e2.toLowerCase() === "y" || e2.toLowerCase() === "n") && this.emit("confirm", e2.toLowerCase() === "y"), this.emit("key", e2?.toLowerCase(), s), s?.name === "return") {
+  onKeypress(t2, e) {
+    if (this._track && e.name !== "return" && (e.name && this._isActionKey(t2, e) && this.rl?.write(null, { ctrl: true, name: "h" }), this._cursor = this.rl?.cursor ?? 0, this._setUserInput(this.rl?.line)), this.state === "error" && (this.state = "active"), e?.name && (!this._track && settings.aliases.has(e.name) && this.emit("cursor", settings.aliases.get(e.name)), settings.actions.has(e.name) && this.emit("cursor", e.name)), t2 && (t2.toLowerCase() === "y" || t2.toLowerCase() === "n") && this.emit("confirm", t2.toLowerCase() === "y"), this.emit("key", t2, e), e?.name === "return" && this._shouldSubmit(t2, e)) {
       if (this.opts.validate) {
-        const i = this.opts.validate(this.value);
-        i && (this.error = i instanceof Error ? i.message : i, this.state = "error", this.rl?.write(this.userInput));
+        const i2 = runValidation(this.opts.validate, this.value);
+        i2 && (this.error = i2 instanceof Error ? i2.message : i2, this.state = "error", this.rl?.write(this.userInput));
       }
       this.state !== "error" && (this.state = "submit");
     }
-    H([e2, s?.name, s?.sequence], "cancel") && (this.state = "cancel"), (this.state === "submit" || this.state === "cancel") && this.emit("finalize"), this.render(), (this.state === "submit" || this.state === "cancel") && this.close();
+    isActionKey([t2, e?.name, e?.sequence], "cancel") && (this.state = "cancel"), (this.state === "submit" || this.state === "cancel") && this.emit("finalize"), this.render(), (this.state === "submit" || this.state === "cancel") && this.close();
   }
   close() {
     this.input.unpipe(), this.input.removeListener("keypress", this.onKeypress), this.output.write(`
-`), T(this.input, false), this.rl?.close(), this.rl = void 0, this.emit(`${this.state}`, this.value), this.unsubscribe();
+`), setRawMode(this.input, false), this.rl?.close(), this.rl = void 0, this.emit(`${this.state}`, this.value), this.unsubscribe();
   }
   restoreCursor() {
-    const e2 = K(this._prevFrame, process.stdout.columns, { hard: true, trim: false }).split(`
+    const t2 = wrapAnsi(this._prevFrame, process.stdout.columns, { hard: true, trim: false }).split(`
 `).length - 1;
-    this.output.write(import_sisteransi.cursor.move(-999, e2 * -1));
+    this.output.write(import_sisteransi.cursor.move(-999, t2 * -1));
   }
   render() {
-    const e2 = K(this._render(this) ?? "", process.stdout.columns, { hard: true, trim: false });
-    if (e2 !== this._prevFrame) {
-      if (this.state === "initial") this.output.write(import_sisteransi.cursor.hide);
+    const t2 = wrapAnsi(this._render(this) ?? "", process.stdout.columns, {
+      hard: true,
+      trim: false
+    });
+    if (t2 !== this._prevFrame) {
+      if (this.state === "initial")
+        this.output.write(import_sisteransi.cursor.hide);
       else {
-        const s = _t(this._prevFrame, e2), i = nt(this.output);
-        if (this.restoreCursor(), s) {
-          const r = Math.max(0, s.numLinesAfter - i), n = Math.max(0, s.numLinesBefore - i);
-          let u = s.lines.find((a) => a >= r);
-          if (u === void 0) {
-            this._prevFrame = e2;
+        const e = diffLines(this._prevFrame, t2), i2 = getRows(this.output);
+        if (this.restoreCursor(), e) {
+          const n2 = Math.max(0, e.numLinesAfter - i2), s = Math.max(0, e.numLinesBefore - i2);
+          let r2 = e.lines.find((o2) => o2 >= n2);
+          if (r2 === void 0) {
+            this._prevFrame = t2;
             return;
           }
-          if (s.lines.length === 1) {
-            this.output.write(import_sisteransi.cursor.move(0, u - n)), this.output.write(import_sisteransi.erase.lines(1));
-            const a = e2.split(`
+          if (e.lines.length === 1) {
+            this.output.write(import_sisteransi.cursor.move(0, r2 - s)), this.output.write(import_sisteransi.erase.lines(1));
+            const o2 = t2.split(`
 `);
-            this.output.write(a[u]), this._prevFrame = e2, this.output.write(import_sisteransi.cursor.move(0, a.length - u - 1));
+            this.output.write(o2[r2]), this._prevFrame = t2, this.output.write(import_sisteransi.cursor.move(0, o2.length - r2 - 1));
             return;
-          } else if (s.lines.length > 1) {
-            if (r < n) u = r;
+          } else if (e.lines.length > 1) {
+            if (n2 < s)
+              r2 = n2;
             else {
-              const l = u - n;
-              l > 0 && this.output.write(import_sisteransi.cursor.move(0, l));
+              const h2 = r2 - s;
+              h2 > 0 && this.output.write(import_sisteransi.cursor.move(0, h2));
             }
             this.output.write(import_sisteransi.erase.down());
-            const a = e2.split(`
-`).slice(u);
-            this.output.write(a.join(`
-`)), this._prevFrame = e2;
+            const f = t2.split(`
+`).slice(r2);
+            this.output.write(f.join(`
+`)), this._prevFrame = t2;
             return;
           }
         }
         this.output.write(import_sisteransi.erase.down());
       }
-      this.output.write(e2), this.state === "initial" && (this.state = "active"), this._prevFrame = e2;
+      this.output.write(t2), this.state === "initial" && (this.state = "active"), this._prevFrame = t2;
     }
   }
 };
-var kt = class extends x {
+var r = class extends V {
   get cursor() {
     return this.value ? 0 : 1;
   }
   get _value() {
     return this.cursor === 0;
   }
-  constructor(e2) {
-    super(e2, false), this.value = !!e2.initialValue, this.on("userInput", () => {
+  constructor(t2) {
+    super(t2, false), this.value = !!t2.initialValue, this.on("userInput", () => {
       this.value = this._value;
-    }), this.on("confirm", (s) => {
-      this.output.write(import_sisteransi.cursor.move(0, -1)), this.value = s, this.state = "submit", this.close();
+    }), this.on("confirm", (i2) => {
+      this.output.write(import_sisteransi.cursor.move(0, -1)), this.value = i2, this.state = "submit", this.close();
     }), this.on("cursor", () => {
       this.value = !this.value;
     });
   }
 };
-var Lt = class extends x {
+var a$1 = class a extends V {
   options;
   cursor = 0;
   get _value() {
     return this.options[this.cursor].value;
   }
   get _enabledOptions() {
-    return this.options.filter((e2) => e2.disabled !== true);
+    return this.options.filter((e) => e.disabled !== true);
   }
   toggleAll() {
-    const e2 = this._enabledOptions, s = this.value !== void 0 && this.value.length === e2.length;
-    this.value = s ? [] : e2.map((i) => i.value);
+    const e = this._enabledOptions, i2 = this.value !== void 0 && this.value.length === e.length;
+    this.value = i2 ? [] : e.map((t2) => t2.value);
   }
   toggleInvert() {
-    const e2 = this.value;
-    if (!e2) return;
-    const s = this._enabledOptions.filter((i) => !e2.includes(i.value));
-    this.value = s.map((i) => i.value);
+    const e = this.value;
+    if (!e)
+      return;
+    const i2 = this._enabledOptions.filter((t2) => !e.includes(t2.value));
+    this.value = i2.map((t2) => t2.value);
   }
   toggleValue() {
     this.value === void 0 && (this.value = []);
-    const e2 = this.value.includes(this._value);
-    this.value = e2 ? this.value.filter((s) => s !== this._value) : [...this.value, this._value];
+    const e = this.value.includes(this._value);
+    this.value = e ? this.value.filter((i2) => i2 !== this._value) : [...this.value, this._value];
   }
-  constructor(e2) {
-    super(e2, false), this.options = e2.options, this.value = [...e2.initialValues ?? []];
-    const s = Math.max(this.options.findIndex(({ value: i }) => i === e2.cursorAt), 0);
-    this.cursor = this.options[s].disabled ? B(s, 1, this.options) : s, this.on("key", (i) => {
-      i === "a" && this.toggleAll(), i === "i" && this.toggleInvert();
-    }), this.on("cursor", (i) => {
-      switch (i) {
+  constructor(e) {
+    super(e, false), this.options = e.options, this.value = [...e.initialValues ?? []];
+    const i2 = Math.max(
+      this.options.findIndex(({ value: t2 }) => t2 === e.cursorAt),
+      0
+    );
+    this.cursor = this.options[i2].disabled ? findCursor(i2, 1, this.options) : i2, this.on("key", (t2, l2) => {
+      l2.name === "a" && this.toggleAll(), l2.name === "i" && this.toggleInvert();
+    }), this.on("cursor", (t2) => {
+      switch (t2) {
         case "left":
         case "up":
-          this.cursor = B(this.cursor, -1, this.options);
+          this.cursor = findCursor(this.cursor, -1, this.options);
           break;
         case "down":
         case "right":
-          this.cursor = B(this.cursor, 1, this.options);
+          this.cursor = findCursor(this.cursor, 1, this.options);
           break;
         case "space":
           this.toggleValue();
@@ -569,7 +866,7 @@ var Lt = class extends x {
     });
   }
 };
-var Mt = class extends x {
+var o = class extends V {
   _mask = "\u2022";
   get cursor() {
     return this._cursor;
@@ -578,22 +875,24 @@ var Mt = class extends x {
     return this.userInput.replaceAll(/./g, this._mask);
   }
   get userInputWithCursor() {
-    if (this.state === "submit" || this.state === "cancel") return this.masked;
-    const e2 = this.userInput;
-    if (this.cursor >= e2.length) return `${this.masked}${import_picocolors.default.inverse(import_picocolors.default.hidden("_"))}`;
-    const s = this.masked, i = s.slice(0, this.cursor), r = s.slice(this.cursor);
-    return `${i}${import_picocolors.default.inverse(r[0])}${r.slice(1)}`;
+    if (this.state === "submit" || this.state === "cancel")
+      return this.masked;
+    const t2 = this.userInput;
+    if (this.cursor >= t2.length)
+      return `${this.masked}${styleText(["inverse", "hidden"], "_")}`;
+    const s = this.masked, r2 = s.slice(0, this.cursor), e = s.slice(this.cursor);
+    return `${r2}${styleText("inverse", e[0])}${e.slice(1)}`;
   }
   clear() {
     this._clearUserInput();
   }
-  constructor({ mask: e2, ...s }) {
-    super(s), this._mask = e2 ?? "\u2022", this.on("userInput", (i) => {
-      this._setValue(i);
+  constructor({ mask: t2, ...s }) {
+    super(s), this._mask = t2 ?? "\u2022", this.on("userInput", (r2) => {
+      this._setValue(r2);
     });
   }
 };
-var Wt = class extends x {
+var a2 = class extends V {
   options;
   cursor = 0;
   get _selectedValue() {
@@ -602,613 +901,659 @@ var Wt = class extends x {
   changeValue() {
     this.value = this._selectedValue.value;
   }
-  constructor(e2) {
-    super(e2, false), this.options = e2.options;
-    const s = this.options.findIndex(({ value: r }) => r === e2.initialValue), i = s === -1 ? 0 : s;
-    this.cursor = this.options[i].disabled ? B(i, 1, this.options) : i, this.changeValue(), this.on("cursor", (r) => {
-      switch (r) {
+  constructor(t2) {
+    super(t2, false), this.options = t2.options;
+    const i2 = this.options.findIndex(({ value: s }) => s === t2.initialValue), e = i2 === -1 ? 0 : i2;
+    this.cursor = this.options[e].disabled ? findCursor(e, 1, this.options) : e, this.changeValue(), this.on("cursor", (s) => {
+      switch (s) {
         case "left":
         case "up":
-          this.cursor = B(this.cursor, -1, this.options);
+          this.cursor = findCursor(this.cursor, -1, this.options);
           break;
         case "down":
         case "right":
-          this.cursor = B(this.cursor, 1, this.options);
+          this.cursor = findCursor(this.cursor, 1, this.options);
           break;
       }
       this.changeValue();
     });
   }
 };
-var $t = class extends x {
+var n = class extends V {
   get userInputWithCursor() {
-    if (this.state === "submit") return this.userInput;
-    const e2 = this.userInput;
-    if (this.cursor >= e2.length) return `${this.userInput}\u2588`;
-    const s = e2.slice(0, this.cursor), [i, ...r] = e2.slice(this.cursor);
-    return `${s}${import_picocolors.default.inverse(i)}${r.join("")}`;
+    if (this.state === "submit")
+      return this.userInput;
+    const t2 = this.userInput;
+    if (this.cursor >= t2.length)
+      return `${this.userInput}\u2588`;
+    const e = t2.slice(0, this.cursor), [s, ...r2] = t2.slice(this.cursor);
+    return `${e}${styleText("inverse", s)}${r2.join("")}`;
   }
   get cursor() {
     return this._cursor;
   }
-  constructor(e2) {
-    super({ ...e2, initialUserInput: e2.initialUserInput ?? e2.initialValue }), this.on("userInput", (s) => {
-      this._setValue(s);
+  constructor(t2) {
+    super({
+      ...t2,
+      initialUserInput: t2.initialUserInput ?? t2.initialValue
+    }), this.on("userInput", (e) => {
+      this._setValue(e);
     }), this.on("finalize", () => {
-      this.value || (this.value = e2.defaultValue), this.value === void 0 && (this.value = "");
+      this.value || (this.value = t2.defaultValue), this.value === void 0 && (this.value = "");
     });
   }
 };
 
 // node_modules/@clack/prompts/dist/index.mjs
-var import_picocolors2 = __toESM(require_picocolors(), 1);
-import N2 from "node:process";
+import { styleText as styleText2, stripVTControlCharacters } from "node:util";
+import process$1 from "node:process";
 var import_sisteransi2 = __toESM(require_src(), 1);
-function me() {
-  return N2.platform !== "win32" ? N2.env.TERM !== "linux" : !!N2.env.CI || !!N2.env.WT_SESSION || !!N2.env.TERMINUS_SUBLIME || N2.env.ConEmuTask === "{cmd::Cmder}" || N2.env.TERM_PROGRAM === "Terminus-Sublime" || N2.env.TERM_PROGRAM === "vscode" || N2.env.TERM === "xterm-256color" || N2.env.TERM === "alacritty" || N2.env.TERMINAL_EMULATOR === "JetBrains-JediTerm";
+function isUnicodeSupported() {
+  if (process$1.platform !== "win32") {
+    return process$1.env.TERM !== "linux";
+  }
+  return Boolean(process$1.env.CI) || Boolean(process$1.env.WT_SESSION) || Boolean(process$1.env.TERMINUS_SUBLIME) || process$1.env.ConEmuTask === "{cmd::Cmder}" || process$1.env.TERM_PROGRAM === "Terminus-Sublime" || process$1.env.TERM_PROGRAM === "vscode" || process$1.env.TERM === "xterm-256color" || process$1.env.TERM === "alacritty" || process$1.env.TERMINAL_EMULATOR === "JetBrains-JediTerm";
 }
-var et2 = me();
-var ct2 = () => process.env.CI === "true";
-var C = (t, r) => et2 ? t : r;
-var Rt = C("\u25C6", "*");
-var dt2 = C("\u25A0", "x");
-var $t2 = C("\u25B2", "x");
-var V = C("\u25C7", "o");
-var ht2 = C("\u250C", "T");
-var d = C("\u2502", "|");
-var x2 = C("\u2514", "\u2014");
-var Ot = C("\u2510", "T");
-var Pt = C("\u2518", "\u2014");
-var Q2 = C("\u25CF", ">");
-var H2 = C("\u25CB", " ");
-var st2 = C("\u25FB", "[\u2022]");
-var U2 = C("\u25FC", "[+]");
-var q2 = C("\u25FB", "[ ]");
-var Nt = C("\u25AA", "\u2022");
-var rt2 = C("\u2500", "-");
-var mt2 = C("\u256E", "+");
-var Wt2 = C("\u251C", "+");
-var pt2 = C("\u256F", "+");
-var gt2 = C("\u2570", "+");
-var Lt2 = C("\u256D", "+");
-var ft2 = C("\u25CF", "\u2022");
-var Ft2 = C("\u25C6", "*");
-var yt2 = C("\u25B2", "!");
-var Et2 = C("\u25A0", "x");
-var W2 = (t) => {
-  switch (t) {
+var unicode = isUnicodeSupported();
+var isCI = () => process.env.CI === "true";
+var unicodeOr = (e, o2) => unicode ? e : o2;
+var S_STEP_ACTIVE = unicodeOr("\u25C6", "*");
+var S_STEP_CANCEL = unicodeOr("\u25A0", "x");
+var S_STEP_ERROR = unicodeOr("\u25B2", "x");
+var S_STEP_SUBMIT = unicodeOr("\u25C7", "o");
+var S_BAR_START = unicodeOr("\u250C", "T");
+var S_BAR = unicodeOr("\u2502", "|");
+var S_BAR_END = unicodeOr("\u2514", "\u2014");
+var S_BAR_START_RIGHT = unicodeOr("\u2510", "T");
+var S_BAR_END_RIGHT = unicodeOr("\u2518", "\u2014");
+var S_RADIO_ACTIVE = unicodeOr("\u25CF", ">");
+var S_RADIO_INACTIVE = unicodeOr("\u25CB", " ");
+var S_CHECKBOX_ACTIVE = unicodeOr("\u25FB", "[\u2022]");
+var S_CHECKBOX_SELECTED = unicodeOr("\u25FC", "[+]");
+var S_CHECKBOX_INACTIVE = unicodeOr("\u25FB", "[ ]");
+var S_PASSWORD_MASK = unicodeOr("\u25AA", "\u2022");
+var S_BAR_H = unicodeOr("\u2500", "-");
+var S_CORNER_TOP_RIGHT = unicodeOr("\u256E", "+");
+var S_CONNECT_LEFT = unicodeOr("\u251C", "+");
+var S_CORNER_BOTTOM_RIGHT = unicodeOr("\u256F", "+");
+var S_CORNER_BOTTOM_LEFT = unicodeOr("\u2570", "+");
+var S_CORNER_TOP_LEFT = unicodeOr("\u256D", "+");
+var S_INFO = unicodeOr("\u25CF", "\u2022");
+var S_SUCCESS = unicodeOr("\u25C6", "*");
+var S_WARN = unicodeOr("\u25B2", "!");
+var S_ERROR = unicodeOr("\u25A0", "x");
+var symbol = (e) => {
+  switch (e) {
     case "initial":
     case "active":
-      return import_picocolors2.default.cyan(Rt);
+      return styleText2("cyan", S_STEP_ACTIVE);
     case "cancel":
-      return import_picocolors2.default.red(dt2);
+      return styleText2("red", S_STEP_CANCEL);
     case "error":
-      return import_picocolors2.default.yellow($t2);
+      return styleText2("yellow", S_STEP_ERROR);
     case "submit":
-      return import_picocolors2.default.green(V);
+      return styleText2("green", S_STEP_SUBMIT);
   }
 };
-var vt2 = (t) => {
-  switch (t) {
+var symbolBar = (e) => {
+  switch (e) {
     case "initial":
     case "active":
-      return import_picocolors2.default.cyan(d);
+      return styleText2("cyan", S_BAR);
     case "cancel":
-      return import_picocolors2.default.red(d);
+      return styleText2("red", S_BAR);
     case "error":
-      return import_picocolors2.default.yellow(d);
+      return styleText2("yellow", S_BAR);
     case "submit":
-      return import_picocolors2.default.green(d);
+      return styleText2("green", S_BAR);
   }
 };
-var pe = (t) => t === 161 || t === 164 || t === 167 || t === 168 || t === 170 || t === 173 || t === 174 || t >= 176 && t <= 180 || t >= 182 && t <= 186 || t >= 188 && t <= 191 || t === 198 || t === 208 || t === 215 || t === 216 || t >= 222 && t <= 225 || t === 230 || t >= 232 && t <= 234 || t === 236 || t === 237 || t === 240 || t === 242 || t === 243 || t >= 247 && t <= 250 || t === 252 || t === 254 || t === 257 || t === 273 || t === 275 || t === 283 || t === 294 || t === 295 || t === 299 || t >= 305 && t <= 307 || t === 312 || t >= 319 && t <= 322 || t === 324 || t >= 328 && t <= 331 || t === 333 || t === 338 || t === 339 || t === 358 || t === 359 || t === 363 || t === 462 || t === 464 || t === 466 || t === 468 || t === 470 || t === 472 || t === 474 || t === 476 || t === 593 || t === 609 || t === 708 || t === 711 || t >= 713 && t <= 715 || t === 717 || t === 720 || t >= 728 && t <= 731 || t === 733 || t === 735 || t >= 768 && t <= 879 || t >= 913 && t <= 929 || t >= 931 && t <= 937 || t >= 945 && t <= 961 || t >= 963 && t <= 969 || t === 1025 || t >= 1040 && t <= 1103 || t === 1105 || t === 8208 || t >= 8211 && t <= 8214 || t === 8216 || t === 8217 || t === 8220 || t === 8221 || t >= 8224 && t <= 8226 || t >= 8228 && t <= 8231 || t === 8240 || t === 8242 || t === 8243 || t === 8245 || t === 8251 || t === 8254 || t === 8308 || t === 8319 || t >= 8321 && t <= 8324 || t === 8364 || t === 8451 || t === 8453 || t === 8457 || t === 8467 || t === 8470 || t === 8481 || t === 8482 || t === 8486 || t === 8491 || t === 8531 || t === 8532 || t >= 8539 && t <= 8542 || t >= 8544 && t <= 8555 || t >= 8560 && t <= 8569 || t === 8585 || t >= 8592 && t <= 8601 || t === 8632 || t === 8633 || t === 8658 || t === 8660 || t === 8679 || t === 8704 || t === 8706 || t === 8707 || t === 8711 || t === 8712 || t === 8715 || t === 8719 || t === 8721 || t === 8725 || t === 8730 || t >= 8733 && t <= 8736 || t === 8739 || t === 8741 || t >= 8743 && t <= 8748 || t === 8750 || t >= 8756 && t <= 8759 || t === 8764 || t === 8765 || t === 8776 || t === 8780 || t === 8786 || t === 8800 || t === 8801 || t >= 8804 && t <= 8807 || t === 8810 || t === 8811 || t === 8814 || t === 8815 || t === 8834 || t === 8835 || t === 8838 || t === 8839 || t === 8853 || t === 8857 || t === 8869 || t === 8895 || t === 8978 || t >= 9312 && t <= 9449 || t >= 9451 && t <= 9547 || t >= 9552 && t <= 9587 || t >= 9600 && t <= 9615 || t >= 9618 && t <= 9621 || t === 9632 || t === 9633 || t >= 9635 && t <= 9641 || t === 9650 || t === 9651 || t === 9654 || t === 9655 || t === 9660 || t === 9661 || t === 9664 || t === 9665 || t >= 9670 && t <= 9672 || t === 9675 || t >= 9678 && t <= 9681 || t >= 9698 && t <= 9701 || t === 9711 || t === 9733 || t === 9734 || t === 9737 || t === 9742 || t === 9743 || t === 9756 || t === 9758 || t === 9792 || t === 9794 || t === 9824 || t === 9825 || t >= 9827 && t <= 9829 || t >= 9831 && t <= 9834 || t === 9836 || t === 9837 || t === 9839 || t === 9886 || t === 9887 || t === 9919 || t >= 9926 && t <= 9933 || t >= 9935 && t <= 9939 || t >= 9941 && t <= 9953 || t === 9955 || t === 9960 || t === 9961 || t >= 9963 && t <= 9969 || t === 9972 || t >= 9974 && t <= 9977 || t === 9979 || t === 9980 || t === 9982 || t === 9983 || t === 10045 || t >= 10102 && t <= 10111 || t >= 11094 && t <= 11097 || t >= 12872 && t <= 12879 || t >= 57344 && t <= 63743 || t >= 65024 && t <= 65039 || t === 65533 || t >= 127232 && t <= 127242 || t >= 127248 && t <= 127277 || t >= 127280 && t <= 127337 || t >= 127344 && t <= 127373 || t === 127375 || t === 127376 || t >= 127387 && t <= 127404 || t >= 917760 && t <= 917999 || t >= 983040 && t <= 1048573 || t >= 1048576 && t <= 1114109;
-var ge = (t) => t === 12288 || t >= 65281 && t <= 65376 || t >= 65504 && t <= 65510;
-var fe = (t) => t >= 4352 && t <= 4447 || t === 8986 || t === 8987 || t === 9001 || t === 9002 || t >= 9193 && t <= 9196 || t === 9200 || t === 9203 || t === 9725 || t === 9726 || t === 9748 || t === 9749 || t >= 9800 && t <= 9811 || t === 9855 || t === 9875 || t === 9889 || t === 9898 || t === 9899 || t === 9917 || t === 9918 || t === 9924 || t === 9925 || t === 9934 || t === 9940 || t === 9962 || t === 9970 || t === 9971 || t === 9973 || t === 9978 || t === 9981 || t === 9989 || t === 9994 || t === 9995 || t === 10024 || t === 10060 || t === 10062 || t >= 10067 && t <= 10069 || t === 10071 || t >= 10133 && t <= 10135 || t === 10160 || t === 10175 || t === 11035 || t === 11036 || t === 11088 || t === 11093 || t >= 11904 && t <= 11929 || t >= 11931 && t <= 12019 || t >= 12032 && t <= 12245 || t >= 12272 && t <= 12287 || t >= 12289 && t <= 12350 || t >= 12353 && t <= 12438 || t >= 12441 && t <= 12543 || t >= 12549 && t <= 12591 || t >= 12593 && t <= 12686 || t >= 12688 && t <= 12771 || t >= 12783 && t <= 12830 || t >= 12832 && t <= 12871 || t >= 12880 && t <= 19903 || t >= 19968 && t <= 42124 || t >= 42128 && t <= 42182 || t >= 43360 && t <= 43388 || t >= 44032 && t <= 55203 || t >= 63744 && t <= 64255 || t >= 65040 && t <= 65049 || t >= 65072 && t <= 65106 || t >= 65108 && t <= 65126 || t >= 65128 && t <= 65131 || t >= 94176 && t <= 94180 || t === 94192 || t === 94193 || t >= 94208 && t <= 100343 || t >= 100352 && t <= 101589 || t >= 101632 && t <= 101640 || t >= 110576 && t <= 110579 || t >= 110581 && t <= 110587 || t === 110589 || t === 110590 || t >= 110592 && t <= 110882 || t === 110898 || t >= 110928 && t <= 110930 || t === 110933 || t >= 110948 && t <= 110951 || t >= 110960 && t <= 111355 || t === 126980 || t === 127183 || t === 127374 || t >= 127377 && t <= 127386 || t >= 127488 && t <= 127490 || t >= 127504 && t <= 127547 || t >= 127552 && t <= 127560 || t === 127568 || t === 127569 || t >= 127584 && t <= 127589 || t >= 127744 && t <= 127776 || t >= 127789 && t <= 127797 || t >= 127799 && t <= 127868 || t >= 127870 && t <= 127891 || t >= 127904 && t <= 127946 || t >= 127951 && t <= 127955 || t >= 127968 && t <= 127984 || t === 127988 || t >= 127992 && t <= 128062 || t === 128064 || t >= 128066 && t <= 128252 || t >= 128255 && t <= 128317 || t >= 128331 && t <= 128334 || t >= 128336 && t <= 128359 || t === 128378 || t === 128405 || t === 128406 || t === 128420 || t >= 128507 && t <= 128591 || t >= 128640 && t <= 128709 || t === 128716 || t >= 128720 && t <= 128722 || t >= 128725 && t <= 128727 || t >= 128732 && t <= 128735 || t === 128747 || t === 128748 || t >= 128756 && t <= 128764 || t >= 128992 && t <= 129003 || t === 129008 || t >= 129292 && t <= 129338 || t >= 129340 && t <= 129349 || t >= 129351 && t <= 129535 || t >= 129648 && t <= 129660 || t >= 129664 && t <= 129672 || t >= 129680 && t <= 129725 || t >= 129727 && t <= 129733 || t >= 129742 && t <= 129755 || t >= 129760 && t <= 129768 || t >= 129776 && t <= 129784 || t >= 131072 && t <= 196605 || t >= 196608 && t <= 262141;
-var At2 = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/y;
-var it2 = /[\x00-\x08\x0A-\x1F\x7F-\x9F]{1,1000}/y;
-var nt2 = /\t{1,1000}/y;
-var wt = new RegExp("[\\u{1F1E6}-\\u{1F1FF}]{2}|\\u{1F3F4}[\\u{E0061}-\\u{E007A}]{2}[\\u{E0030}-\\u{E0039}\\u{E0061}-\\u{E007A}]{1,3}\\u{E007F}|(?:\\p{Emoji}\\uFE0F\\u20E3?|\\p{Emoji_Modifier_Base}\\p{Emoji_Modifier}?|\\p{Emoji_Presentation})(?:\\u200D(?:\\p{Emoji_Modifier_Base}\\p{Emoji_Modifier}?|\\p{Emoji_Presentation}|\\p{Emoji}\\uFE0F\\u20E3?))*", "yu");
-var at2 = /(?:[\x20-\x7E\xA0-\xFF](?!\uFE0F)){1,1000}/y;
-var Fe = new RegExp("\\p{M}+", "gu");
-var ye = { limit: 1 / 0, ellipsis: "" };
-var jt = (t, r = {}, s = {}) => {
-  const i = r.limit ?? 1 / 0, a = r.ellipsis ?? "", o = r?.ellipsisWidth ?? (a ? jt(a, ye, s).width : 0), u = s.ansiWidth ?? 0, l = s.controlWidth ?? 0, n = s.tabWidth ?? 8, c = s.ambiguousWidth ?? 1, g = s.emojiWidth ?? 2, F = s.fullWidthWidth ?? 2, p = s.regularWidth ?? 1, E = s.wideWidth ?? 2;
-  let $ = 0, m = 0, h = t.length, y2 = 0, f = false, v = h, S2 = Math.max(0, i - o), I2 = 0, B2 = 0, A = 0, w = 0;
-  t: for (; ; ) {
-    if (B2 > I2 || m >= h && m > $) {
-      const _2 = t.slice(I2, B2) || t.slice($, m);
-      y2 = 0;
-      for (const D2 of _2.replaceAll(Fe, "")) {
-        const T2 = D2.codePointAt(0) || 0;
-        if (ge(T2) ? w = F : fe(T2) ? w = E : c !== p && pe(T2) ? w = c : w = p, A + w > S2 && (v = Math.min(v, Math.max(I2, $) + y2)), A + w > i) {
-          f = true;
-          break t;
+var E$1 = (l2, o2, g, c2, h2, O = false) => {
+  let r2 = o2, w = 0;
+  if (O)
+    for (let i2 = c2 - 1; i2 >= g && (r2 -= l2[i2].length, w++, !(r2 <= h2)); i2--)
+      ;
+  else
+    for (let i2 = g; i2 < c2 && (r2 -= l2[i2].length, w++, !(r2 <= h2)); i2++)
+      ;
+  return { lineCount: r2, removals: w };
+};
+var limitOptions = ({
+  cursor: l2,
+  options: o2,
+  style: g,
+  output: c2 = process.stdout,
+  maxItems: h2 = Number.POSITIVE_INFINITY,
+  columnPadding: O = 0,
+  rowPadding: r2 = 4
+}) => {
+  const i2 = getColumns(c2) - O, I = getRows(c2), C2 = styleText2("dim", "..."), x = Math.max(I - r2, 0), m = Math.max(Math.min(h2, x), 5);
+  let p = 0;
+  l2 >= m - 3 && (p = Math.max(
+    Math.min(l2 - m + 3, o2.length - m),
+    0
+  ));
+  let f = m < o2.length && p > 0, u3 = m < o2.length && p + m < o2.length;
+  const W2 = Math.min(
+    p + m,
+    o2.length
+  ), e = [];
+  let d2 = 0;
+  f && d2++, u3 && d2++;
+  const v = p + (f ? 1 : 0), P = W2 - (u3 ? 1 : 0);
+  for (let t2 = v; t2 < P; t2++) {
+    const n2 = wrapAnsi(g(o2[t2], t2 === l2), i2, {
+      hard: true,
+      trim: false
+    }).split(`
+`);
+    e.push(n2), d2 += n2.length;
+  }
+  if (d2 > x) {
+    let t2 = 0, n2 = 0, s = d2;
+    const M = l2 - v;
+    let a3 = x;
+    const T = () => E$1(e, s, 0, M, a3), L = () => E$1(
+      e,
+      s,
+      M + 1,
+      e.length,
+      a3,
+      true
+    );
+    f ? ({ lineCount: s, removals: t2 } = T(), s > a3 && (u3 || (a3 -= 1), { lineCount: s, removals: n2 } = L())) : (u3 || (a3 -= 1), { lineCount: s, removals: n2 } = L(), s > a3 && (a3 -= 1, { lineCount: s, removals: t2 } = T())), t2 > 0 && (f = true, e.splice(0, t2)), n2 > 0 && (u3 = true, e.splice(e.length - n2, n2));
+  }
+  const b = [];
+  f && b.push(C2);
+  for (const t2 of e)
+    for (const n2 of t2)
+      b.push(n2);
+  return u3 && b.push(C2), b;
+};
+var confirm = (i2) => {
+  const a3 = i2.active ?? "Yes", s = i2.inactive ?? "No";
+  return new r({
+    active: a3,
+    inactive: s,
+    signal: i2.signal,
+    input: i2.input,
+    output: i2.output,
+    initialValue: i2.initialValue ?? true,
+    render() {
+      const e = i2.withGuide ?? settings.withGuide, u3 = `${symbol(this.state)}  `, l2 = e ? `${styleText2("gray", S_BAR)}  ` : "", f = wrapTextWithPrefix(
+        i2.output,
+        i2.message,
+        l2,
+        u3
+      ), o2 = `${e ? `${styleText2("gray", S_BAR)}
+` : ""}${f}
+`, c2 = this.value ? a3 : s;
+      switch (this.state) {
+        case "submit": {
+          const r2 = e ? `${styleText2("gray", S_BAR)}  ` : "";
+          return `${o2}${r2}${styleText2("dim", c2)}`;
         }
-        y2 += D2.length, A += w;
-      }
-      I2 = B2 = 0;
-    }
-    if (m >= h) break;
-    if (at2.lastIndex = m, at2.test(t)) {
-      if (y2 = at2.lastIndex - m, w = y2 * p, A + w > S2 && (v = Math.min(v, m + Math.floor((S2 - A) / p))), A + w > i) {
-        f = true;
-        break;
-      }
-      A += w, I2 = $, B2 = m, m = $ = at2.lastIndex;
-      continue;
-    }
-    if (At2.lastIndex = m, At2.test(t)) {
-      if (A + u > S2 && (v = Math.min(v, m)), A + u > i) {
-        f = true;
-        break;
-      }
-      A += u, I2 = $, B2 = m, m = $ = At2.lastIndex;
-      continue;
-    }
-    if (it2.lastIndex = m, it2.test(t)) {
-      if (y2 = it2.lastIndex - m, w = y2 * l, A + w > S2 && (v = Math.min(v, m + Math.floor((S2 - A) / l))), A + w > i) {
-        f = true;
-        break;
-      }
-      A += w, I2 = $, B2 = m, m = $ = it2.lastIndex;
-      continue;
-    }
-    if (nt2.lastIndex = m, nt2.test(t)) {
-      if (y2 = nt2.lastIndex - m, w = y2 * n, A + w > S2 && (v = Math.min(v, m + Math.floor((S2 - A) / n))), A + w > i) {
-        f = true;
-        break;
-      }
-      A += w, I2 = $, B2 = m, m = $ = nt2.lastIndex;
-      continue;
-    }
-    if (wt.lastIndex = m, wt.test(t)) {
-      if (A + g > S2 && (v = Math.min(v, m)), A + g > i) {
-        f = true;
-        break;
-      }
-      A += g, I2 = $, B2 = m, m = $ = wt.lastIndex;
-      continue;
-    }
-    m += 1;
-  }
-  return { width: f ? S2 : A, index: f ? v : h, truncated: f, ellipsed: f && i >= o };
-};
-var Ee = { limit: 1 / 0, ellipsis: "", ellipsisWidth: 0 };
-var M2 = (t, r = {}) => jt(t, Ee, r).width;
-var ot2 = "\x1B";
-var Gt = "\x9B";
-var ve = 39;
-var Ct2 = "\x07";
-var kt2 = "[";
-var Ae = "]";
-var Vt2 = "m";
-var St = `${Ae}8;;`;
-var Ht = new RegExp(`(?:\\${kt2}(?<code>\\d+)m|\\${St}(?<uri>.*)${Ct2})`, "y");
-var we = (t) => {
-  if (t >= 30 && t <= 37 || t >= 90 && t <= 97) return 39;
-  if (t >= 40 && t <= 47 || t >= 100 && t <= 107) return 49;
-  if (t === 1 || t === 2) return 22;
-  if (t === 3) return 23;
-  if (t === 4) return 24;
-  if (t === 7) return 27;
-  if (t === 8) return 28;
-  if (t === 9) return 29;
-  if (t === 0) return 0;
-};
-var Ut = (t) => `${ot2}${kt2}${t}${Vt2}`;
-var Kt = (t) => `${ot2}${St}${t}${Ct2}`;
-var Ce = (t) => t.map((r) => M2(r));
-var It2 = (t, r, s) => {
-  const i = r[Symbol.iterator]();
-  let a = false, o = false, u = t.at(-1), l = u === void 0 ? 0 : M2(u), n = i.next(), c = i.next(), g = 0;
-  for (; !n.done; ) {
-    const F = n.value, p = M2(F);
-    l + p <= s ? t[t.length - 1] += F : (t.push(F), l = 0), (F === ot2 || F === Gt) && (a = true, o = r.startsWith(St, g + 1)), a ? o ? F === Ct2 && (a = false, o = false) : F === Vt2 && (a = false) : (l += p, l === s && !c.done && (t.push(""), l = 0)), n = c, c = i.next(), g += F.length;
-  }
-  u = t.at(-1), !l && u !== void 0 && u.length > 0 && t.length > 1 && (t[t.length - 2] += t.pop());
-};
-var Se = (t) => {
-  const r = t.split(" ");
-  let s = r.length;
-  for (; s > 0 && !(M2(r[s - 1]) > 0); ) s--;
-  return s === r.length ? t : r.slice(0, s).join(" ") + r.slice(s).join("");
-};
-var Ie = (t, r, s = {}) => {
-  if (s.trim !== false && t.trim() === "") return "";
-  let i = "", a, o;
-  const u = t.split(" "), l = Ce(u);
-  let n = [""];
-  for (const [$, m] of u.entries()) {
-    s.trim !== false && (n[n.length - 1] = (n.at(-1) ?? "").trimStart());
-    let h = M2(n.at(-1) ?? "");
-    if ($ !== 0 && (h >= r && (s.wordWrap === false || s.trim === false) && (n.push(""), h = 0), (h > 0 || s.trim === false) && (n[n.length - 1] += " ", h++)), s.hard && l[$] > r) {
-      const y2 = r - h, f = 1 + Math.floor((l[$] - y2 - 1) / r);
-      Math.floor((l[$] - 1) / r) < f && n.push(""), It2(n, m, r);
-      continue;
-    }
-    if (h + l[$] > r && h > 0 && l[$] > 0) {
-      if (s.wordWrap === false && h < r) {
-        It2(n, m, r);
-        continue;
-      }
-      n.push("");
-    }
-    if (h + l[$] > r && s.wordWrap === false) {
-      It2(n, m, r);
-      continue;
-    }
-    n[n.length - 1] += m;
-  }
-  s.trim !== false && (n = n.map(($) => Se($)));
-  const c = n.join(`
-`), g = c[Symbol.iterator]();
-  let F = g.next(), p = g.next(), E = 0;
-  for (; !F.done; ) {
-    const $ = F.value, m = p.value;
-    if (i += $, $ === ot2 || $ === Gt) {
-      Ht.lastIndex = E + 1;
-      const f = Ht.exec(c)?.groups;
-      if (f?.code !== void 0) {
-        const v = Number.parseFloat(f.code);
-        a = v === ve ? void 0 : v;
-      } else f?.uri !== void 0 && (o = f.uri.length === 0 ? void 0 : f.uri);
-    }
-    const h = a ? we(a) : void 0;
-    m === `
-` ? (o && (i += Kt("")), a && h && (i += Ut(h))) : $ === `
-` && (a && h && (i += Ut(a)), o && (i += Kt(o))), E += $.length, F = p, p = g.next();
-  }
-  return i;
-};
-function J2(t, r, s) {
-  return String(t).normalize().replaceAll(`\r
-`, `
-`).split(`
-`).map((i) => Ie(i, r, s)).join(`
-`);
-}
-var be = (t, r, s, i, a) => {
-  let o = r, u = 0;
-  for (let l = s; l < i; l++) {
-    const n = t[l];
-    if (o = o - n.length, u++, o <= a) break;
-  }
-  return { lineCount: o, removals: u };
-};
-var X2 = (t) => {
-  const { cursor: r, options: s, style: i } = t, a = t.output ?? process.stdout, o = rt(a), u = t.columnPadding ?? 0, l = t.rowPadding ?? 4, n = o - u, c = nt(a), g = import_picocolors2.default.dim("..."), F = t.maxItems ?? Number.POSITIVE_INFINITY, p = Math.max(c - l, 0), E = Math.max(Math.min(F, p), 5);
-  let $ = 0;
-  r >= E - 3 && ($ = Math.max(Math.min(r - E + 3, s.length - E), 0));
-  let m = E < s.length && $ > 0, h = E < s.length && $ + E < s.length;
-  const y2 = Math.min($ + E, s.length), f = [];
-  let v = 0;
-  m && v++, h && v++;
-  const S2 = $ + (m ? 1 : 0), I2 = y2 - (h ? 1 : 0);
-  for (let A = S2; A < I2; A++) {
-    const w = J2(i(s[A], A === r), n, { hard: true, trim: false }).split(`
-`);
-    f.push(w), v += w.length;
-  }
-  if (v > p) {
-    let A = 0, w = 0, _2 = v;
-    const D2 = r - S2, T2 = (Y, L2) => be(f, _2, Y, L2, p);
-    m ? ({ lineCount: _2, removals: A } = T2(0, D2), _2 > p && ({ lineCount: _2, removals: w } = T2(D2 + 1, f.length))) : ({ lineCount: _2, removals: w } = T2(D2 + 1, f.length), _2 > p && ({ lineCount: _2, removals: A } = T2(0, D2))), A > 0 && (m = true, f.splice(0, A)), w > 0 && (h = true, f.splice(f.length - w, w));
-  }
-  const B2 = [];
-  m && B2.push(g);
-  for (const A of f) for (const w of A) B2.push(w);
-  return h && B2.push(g), B2;
-};
-var Re = (t) => {
-  const r = t.active ?? "Yes", s = t.inactive ?? "No";
-  return new kt({ active: r, inactive: s, signal: t.signal, input: t.input, output: t.output, initialValue: t.initialValue ?? true, render() {
-    const i = t.withGuide ?? _.withGuide, a = `${i ? `${import_picocolors2.default.gray(d)}
-` : ""}${W2(this.state)}  ${t.message}
-`, o = this.value ? r : s;
-    switch (this.state) {
-      case "submit": {
-        const u = i ? `${import_picocolors2.default.gray(d)}  ` : "";
-        return `${a}${u}${import_picocolors2.default.dim(o)}`;
-      }
-      case "cancel": {
-        const u = i ? `${import_picocolors2.default.gray(d)}  ` : "";
-        return `${a}${u}${import_picocolors2.default.strikethrough(import_picocolors2.default.dim(o))}${i ? `
-${import_picocolors2.default.gray(d)}` : ""}`;
-      }
-      default: {
-        const u = i ? `${import_picocolors2.default.cyan(d)}  ` : "", l = i ? import_picocolors2.default.cyan(x2) : "";
-        return `${a}${u}${this.value ? `${import_picocolors2.default.green(Q2)} ${r}` : `${import_picocolors2.default.dim(H2)} ${import_picocolors2.default.dim(r)}`}${t.vertical ? i ? `
-${import_picocolors2.default.cyan(d)}  ` : `
-` : ` ${import_picocolors2.default.dim("/")} `}${this.value ? `${import_picocolors2.default.dim(H2)} ${import_picocolors2.default.dim(s)}` : `${import_picocolors2.default.green(Q2)} ${s}`}
-${l}
+        case "cancel": {
+          const r2 = e ? `${styleText2("gray", S_BAR)}  ` : "";
+          return `${o2}${r2}${styleText2(["strikethrough", "dim"], c2)}${e ? `
+${styleText2("gray", S_BAR)}` : ""}`;
+        }
+        default: {
+          const r2 = e ? `${styleText2("cyan", S_BAR)}  ` : "", g = e ? styleText2("cyan", S_BAR_END) : "";
+          return `${o2}${r2}${this.value ? `${styleText2("green", S_RADIO_ACTIVE)} ${a3}` : `${styleText2("dim", S_RADIO_INACTIVE)} ${styleText2("dim", a3)}`}${i2.vertical ? e ? `
+${styleText2("cyan", S_BAR)}  ` : `
+` : ` ${styleText2("dim", "/")} `}${this.value ? `${styleText2("dim", S_RADIO_INACTIVE)} ${styleText2("dim", s)}` : `${styleText2("green", S_RADIO_ACTIVE)} ${s}`}
+${g}
 `;
+        }
       }
     }
-  } }).prompt();
+  }).prompt();
 };
-var R2 = { message: (t = [], { symbol: r = import_picocolors2.default.gray(d), secondarySymbol: s = import_picocolors2.default.gray(d), output: i = process.stdout, spacing: a = 1, withGuide: o } = {}) => {
-  const u = [], l = o ?? _.withGuide, n = l ? s : "", c = l ? `${r}  ` : "", g = l ? `${s}  ` : "";
-  for (let p = 0; p < a; p++) u.push(n);
-  const F = Array.isArray(t) ? t : t.split(`
+var log = {
+  message: (s = [], {
+    symbol: e = styleText2("gray", S_BAR),
+    secondarySymbol: r2 = styleText2("gray", S_BAR),
+    output: m = process.stdout,
+    spacing: l2 = 1,
+    withGuide: c2
+  } = {}) => {
+    const t2 = [], o2 = c2 ?? settings.withGuide, f = o2 ? r2 : "", O = o2 ? `${e}  ` : "", u3 = o2 ? `${r2}  ` : "";
+    for (let i2 = 0; i2 < l2; i2++)
+      t2.push(f);
+    const g = Array.isArray(s) ? s : s.split(`
 `);
-  if (F.length > 0) {
-    const [p, ...E] = F;
-    p.length > 0 ? u.push(`${c}${p}`) : u.push(l ? r : "");
-    for (const $ of E) $.length > 0 ? u.push(`${g}${$}`) : u.push(l ? s : "");
-  }
-  i.write(`${u.join(`
+    if (g.length > 0) {
+      const [i2, ...y] = g;
+      i2.length > 0 ? t2.push(`${O}${i2}`) : t2.push(o2 ? e : "");
+      for (const p of y)
+        p.length > 0 ? t2.push(`${u3}${p}`) : t2.push(o2 ? r2 : "");
+    }
+    m.write(`${t2.join(`
 `)}
 `);
-}, info: (t, r) => {
-  R2.message(t, { ...r, symbol: import_picocolors2.default.blue(ft2) });
-}, success: (t, r) => {
-  R2.message(t, { ...r, symbol: import_picocolors2.default.green(Ft2) });
-}, step: (t, r) => {
-  R2.message(t, { ...r, symbol: import_picocolors2.default.green(V) });
-}, warn: (t, r) => {
-  R2.message(t, { ...r, symbol: import_picocolors2.default.yellow(yt2) });
-}, warning: (t, r) => {
-  R2.warn(t, r);
-}, error: (t, r) => {
-  R2.message(t, { ...r, symbol: import_picocolors2.default.red(Et2) });
-} };
-var Ne = (t = "", r) => {
-  (r?.output ?? process.stdout).write(`${import_picocolors2.default.gray(x2)}  ${import_picocolors2.default.red(t)}
+  },
+  info: (s, e) => {
+    log.message(s, { ...e, symbol: styleText2("blue", S_INFO) });
+  },
+  success: (s, e) => {
+    log.message(s, { ...e, symbol: styleText2("green", S_SUCCESS) });
+  },
+  step: (s, e) => {
+    log.message(s, { ...e, symbol: styleText2("green", S_STEP_SUBMIT) });
+  },
+  warn: (s, e) => {
+    log.message(s, { ...e, symbol: styleText2("yellow", S_WARN) });
+  },
+  /** alias for `log.warn()`. */
+  warning: (s, e) => {
+    log.warn(s, e);
+  },
+  error: (s, e) => {
+    log.message(s, { ...e, symbol: styleText2("red", S_ERROR) });
+  }
+};
+var cancel = (o2 = "", t2) => {
+  const i2 = t2?.output ?? process.stdout, e = t2?.withGuide ?? settings.withGuide ? `${styleText2("gray", S_BAR_END)}  ` : "";
+  i2.write(`${e}${styleText2("red", o2)}
 
 `);
 };
-var We = (t = "", r) => {
-  (r?.output ?? process.stdout).write(`${import_picocolors2.default.gray(ht2)}  ${t}
+var intro = (o2 = "", t2) => {
+  const i2 = t2?.output ?? process.stdout, e = t2?.withGuide ?? settings.withGuide ? `${styleText2("gray", S_BAR_START)}  ` : "";
+  i2.write(`${e}${o2}
 `);
 };
-var Le = (t = "", r) => {
-  (r?.output ?? process.stdout).write(`${import_picocolors2.default.gray(d)}
-${import_picocolors2.default.gray(x2)}  ${t}
+var outro = (o2 = "", t2) => {
+  const i2 = t2?.output ?? process.stdout, e = t2?.withGuide ?? settings.withGuide ? `${styleText2("gray", S_BAR)}
+${styleText2("gray", S_BAR_END)}  ` : "";
+  i2.write(`${e}${o2}
 
 `);
 };
-var Z2 = (t, r) => t.split(`
-`).map((s) => r(s)).join(`
+var d = (n2, a3) => n2.split(`
+`).map((m) => a3(m)).join(`
 `);
-var je = (t) => {
-  const r = (i, a) => {
-    const o = i.label ?? String(i.value);
-    return a === "disabled" ? `${import_picocolors2.default.gray(q2)} ${Z2(o, (u) => import_picocolors2.default.strikethrough(import_picocolors2.default.gray(u)))}${i.hint ? ` ${import_picocolors2.default.dim(`(${i.hint ?? "disabled"})`)}` : ""}` : a === "active" ? `${import_picocolors2.default.cyan(st2)} ${o}${i.hint ? ` ${import_picocolors2.default.dim(`(${i.hint})`)}` : ""}` : a === "selected" ? `${import_picocolors2.default.green(U2)} ${Z2(o, import_picocolors2.default.dim)}${i.hint ? ` ${import_picocolors2.default.dim(`(${i.hint})`)}` : ""}` : a === "cancelled" ? `${Z2(o, (u) => import_picocolors2.default.strikethrough(import_picocolors2.default.dim(u)))}` : a === "active-selected" ? `${import_picocolors2.default.green(U2)} ${o}${i.hint ? ` ${import_picocolors2.default.dim(`(${i.hint})`)}` : ""}` : a === "submitted" ? `${Z2(o, import_picocolors2.default.dim)}` : `${import_picocolors2.default.dim(q2)} ${Z2(o, import_picocolors2.default.dim)}`;
-  }, s = t.required ?? true;
-  return new Lt({ options: t.options, signal: t.signal, input: t.input, output: t.output, initialValues: t.initialValues, required: s, cursorAt: t.cursorAt, validate(i) {
-    if (s && (i === void 0 || i.length === 0)) return `Please select at least one option.
-${import_picocolors2.default.reset(import_picocolors2.default.dim(`Press ${import_picocolors2.default.gray(import_picocolors2.default.bgWhite(import_picocolors2.default.inverse(" space ")))} to select, ${import_picocolors2.default.gray(import_picocolors2.default.bgWhite(import_picocolors2.default.inverse(" enter ")))} to submit`))}`;
-  }, render() {
-    const i = xt(t.output, t.message, `${vt2(this.state)}  `, `${W2(this.state)}  `), a = `${import_picocolors2.default.gray(d)}
-${i}
-`, o = this.value ?? [], u = (l, n) => {
-      if (l.disabled) return r(l, "disabled");
-      const c = o.includes(l.value);
-      return n && c ? r(l, "active-selected") : c ? r(l, "selected") : r(l, n ? "active" : "inactive");
-    };
-    switch (this.state) {
-      case "submit": {
-        const l = this.options.filter(({ value: c }) => o.includes(c)).map((c) => r(c, "submitted")).join(import_picocolors2.default.dim(", ")) || import_picocolors2.default.dim("none"), n = xt(t.output, l, `${import_picocolors2.default.gray(d)}  `);
-        return `${a}${n}`;
-      }
-      case "cancel": {
-        const l = this.options.filter(({ value: c }) => o.includes(c)).map((c) => r(c, "cancelled")).join(import_picocolors2.default.dim(", "));
-        if (l.trim() === "") return `${a}${import_picocolors2.default.gray(d)}`;
-        const n = xt(t.output, l, `${import_picocolors2.default.gray(d)}  `);
-        return `${a}${n}
-${import_picocolors2.default.gray(d)}`;
-      }
-      case "error": {
-        const l = `${import_picocolors2.default.yellow(d)}  `, n = this.error.split(`
-`).map((F, p) => p === 0 ? `${import_picocolors2.default.yellow(x2)}  ${import_picocolors2.default.yellow(F)}` : `   ${F}`).join(`
-`), c = a.split(`
-`).length, g = n.split(`
+var multiselect = (n2) => {
+  const a3 = (t2, o2) => {
+    const r2 = t2.label ?? String(t2.value);
+    return o2 === "disabled" ? `${styleText2("gray", S_CHECKBOX_INACTIVE)} ${d(r2, (l2) => styleText2(["strikethrough", "gray"], l2))}${t2.hint ? ` ${styleText2("dim", `(${t2.hint ?? "disabled"})`)}` : ""}` : o2 === "active" ? `${styleText2("cyan", S_CHECKBOX_ACTIVE)} ${r2}${t2.hint ? ` ${styleText2("dim", `(${t2.hint})`)}` : ""}` : o2 === "selected" ? `${styleText2("green", S_CHECKBOX_SELECTED)} ${d(r2, (l2) => styleText2("dim", l2))}${t2.hint ? ` ${styleText2("dim", `(${t2.hint})`)}` : ""}` : o2 === "cancelled" ? `${d(r2, (l2) => styleText2(["strikethrough", "dim"], l2))}` : o2 === "active-selected" ? `${styleText2("green", S_CHECKBOX_SELECTED)} ${r2}${t2.hint ? ` ${styleText2("dim", `(${t2.hint})`)}` : ""}` : o2 === "submitted" ? `${d(r2, (l2) => styleText2("dim", l2))}` : `${styleText2("dim", S_CHECKBOX_INACTIVE)} ${d(r2, (l2) => styleText2("dim", l2))}`;
+  }, m = n2.required ?? true;
+  return new a$1({
+    options: n2.options,
+    signal: n2.signal,
+    input: n2.input,
+    output: n2.output,
+    initialValues: n2.initialValues,
+    required: m,
+    cursorAt: n2.cursorAt,
+    validate(t2) {
+      if (m && (t2 === void 0 || t2.length === 0))
+        return `Please select at least one option.
+${styleText2(
+          "reset",
+          styleText2(
+            "dim",
+            `Press ${styleText2(["gray", "bgWhite", "inverse"], " space ")} to select, ${styleText2(
+              "gray",
+              styleText2("bgWhite", styleText2("inverse", " enter "))
+            )} to submit`
+          )
+        )}`;
+    },
+    render() {
+      const t2 = n2.withGuide ?? settings.withGuide, o2 = wrapTextWithPrefix(
+        n2.output,
+        n2.message,
+        t2 ? `${symbolBar(this.state)}  ` : "",
+        `${symbol(this.state)}  `
+      ), r2 = `${t2 ? `${styleText2("gray", S_BAR)}
+` : ""}${o2}
+`, l2 = this.value ?? [], g = (i2, u3) => {
+        if (i2.disabled)
+          return a3(i2, "disabled");
+        const s = l2.includes(i2.value);
+        return u3 && s ? a3(i2, "active-selected") : s ? a3(i2, "selected") : a3(i2, u3 ? "active" : "inactive");
+      };
+      switch (this.state) {
+        case "submit": {
+          const i2 = this.options.filter(({ value: s }) => l2.includes(s)).map((s) => a3(s, "submitted")).join(styleText2("dim", ", ")) || styleText2("dim", "none"), u3 = wrapTextWithPrefix(
+            n2.output,
+            i2,
+            t2 ? `${styleText2("gray", S_BAR)}  ` : ""
+          );
+          return `${r2}${u3}`;
+        }
+        case "cancel": {
+          const i2 = this.options.filter(({ value: s }) => l2.includes(s)).map((s) => a3(s, "cancelled")).join(styleText2("dim", ", "));
+          if (i2.trim() === "")
+            return `${r2}${styleText2("gray", S_BAR)}`;
+          const u3 = wrapTextWithPrefix(
+            n2.output,
+            i2,
+            t2 ? `${styleText2("gray", S_BAR)}  ` : ""
+          );
+          return `${r2}${u3}${t2 ? `
+${styleText2("gray", S_BAR)}` : ""}`;
+        }
+        case "error": {
+          const i2 = t2 ? `${styleText2("yellow", S_BAR)}  ` : "", u3 = this.error.split(`
+`).map(
+            (h2, x) => x === 0 ? `${t2 ? `${styleText2("yellow", S_BAR_END)}  ` : ""}${styleText2("yellow", h2)}` : `   ${h2}`
+          ).join(`
+`), s = r2.split(`
+`).length, v = u3.split(`
 `).length + 1;
-        return `${a}${l}${X2({ output: t.output, options: this.options, cursor: this.cursor, maxItems: t.maxItems, columnPadding: l.length, rowPadding: c + g, style: u }).join(`
-${l}`)}
-${n}
+          return `${r2}${i2}${limitOptions({
+            output: n2.output,
+            options: this.options,
+            cursor: this.cursor,
+            maxItems: n2.maxItems,
+            columnPadding: i2.length,
+            rowPadding: s + v,
+            style: g
+          }).join(`
+${i2}`)}
+${u3}
 `;
+        }
+        default: {
+          const i2 = t2 ? `${styleText2("cyan", S_BAR)}  ` : "", u3 = r2.split(`
+`).length, s = t2 ? 2 : 1;
+          return `${r2}${i2}${limitOptions({
+            output: n2.output,
+            options: this.options,
+            cursor: this.cursor,
+            maxItems: n2.maxItems,
+            columnPadding: i2.length,
+            rowPadding: u3 + s,
+            style: g
+          }).join(`
+${i2}`)}
+${t2 ? styleText2("cyan", S_BAR_END) : ""}
+`;
+        }
       }
-      default: {
-        const l = `${import_picocolors2.default.cyan(d)}  `, n = a.split(`
-`).length;
-        return `${a}${l}${X2({ output: t.output, options: this.options, cursor: this.cursor, maxItems: t.maxItems, columnPadding: l.length, rowPadding: n + 2, style: u }).join(`
-${l}`)}
-${import_picocolors2.default.cyan(x2)}
-`;
-      }
     }
-  } }).prompt();
+  }).prompt();
 };
-var Ge = (t) => import_picocolors2.default.dim(t);
-var ke = (t, r, s) => {
-  const i = { hard: true, trim: false }, a = J2(t, r, i).split(`
-`), o = a.reduce((n, c) => Math.max(M2(c), n), 0), u = a.map(s).reduce((n, c) => Math.max(M2(c), n), 0), l = r - (u - o);
-  return J2(t, l, i);
+var W$1 = (o2) => styleText2("dim", o2);
+var C = (o2, e, s) => {
+  const a3 = {
+    hard: true,
+    trim: false
+  }, i2 = wrapAnsi(o2, e, a3).split(`
+`), c2 = i2.reduce((n2, r2) => Math.max(dist_default2(r2), n2), 0), u3 = i2.map(s).reduce((n2, r2) => Math.max(dist_default2(r2), n2), 0), g = e - (u3 - c2);
+  return wrapAnsi(o2, g, a3);
 };
-var Ve = (t = "", r = "", s) => {
-  const i = s?.output ?? N2.stdout, a = s?.withGuide ?? _.withGuide, o = s?.format ?? Ge, u = ["", ...ke(t, rt(i) - 6, o).split(`
-`).map(o), ""], l = M2(r), n = Math.max(u.reduce((p, E) => {
-    const $ = M2(E);
-    return $ > p ? $ : p;
-  }, 0), l) + 2, c = u.map((p) => `${import_picocolors2.default.gray(d)}  ${p}${" ".repeat(n - M2(p))}${import_picocolors2.default.gray(d)}`).join(`
-`), g = a ? `${import_picocolors2.default.gray(d)}
-` : "", F = a ? Wt2 : gt2;
-  i.write(`${g}${import_picocolors2.default.green(V)}  ${import_picocolors2.default.reset(r)} ${import_picocolors2.default.gray(rt2.repeat(Math.max(n - l - 1, 1)) + mt2)}
-${c}
-${import_picocolors2.default.gray(F + rt2.repeat(n + 2) + pt2)}
-`);
+var note = (o2 = "", e = "", s) => {
+  const a3 = s?.output ?? process$1.stdout, i2 = s?.withGuide ?? settings.withGuide, c2 = s?.format ?? W$1, g = ["", ...C(o2, getColumns(a3) - 6, c2).split(`
+`).map(c2), ""], n2 = dist_default2(e), r2 = Math.max(
+    g.reduce((m, F) => {
+      const O = dist_default2(F);
+      return O > m ? O : m;
+    }, 0),
+    n2
+  ) + 2, h2 = g.map(
+    (m) => `${styleText2("gray", S_BAR)}  ${m}${" ".repeat(r2 - dist_default2(m))}${styleText2("gray", S_BAR)}`
+  ).join(`
+`), T = i2 ? `${styleText2("gray", S_BAR)}
+` : "", l$1 = i2 ? S_CONNECT_LEFT : S_CORNER_BOTTOM_LEFT;
+  a3.write(
+    `${T}${styleText2("green", S_STEP_SUBMIT)}  ${styleText2("reset", e)} ${styleText2(
+      "gray",
+      S_BAR_H.repeat(Math.max(r2 - n2 - 1, 1)) + S_CORNER_TOP_RIGHT
+    )}
+${h2}
+${styleText2("gray", l$1 + S_BAR_H.repeat(r2 + 2) + S_CORNER_BOTTOM_RIGHT)}
+`
+  );
 };
-var He = (t) => new Mt({ validate: t.validate, mask: t.mask ?? Nt, signal: t.signal, input: t.input, output: t.output, render() {
-  const r = t.withGuide ?? _.withGuide, s = `${r ? `${import_picocolors2.default.gray(d)}
-` : ""}${W2(this.state)}  ${t.message}
-`, i = this.userInputWithCursor, a = this.masked;
-  switch (this.state) {
-    case "error": {
-      const o = r ? `${import_picocolors2.default.yellow(d)}  ` : "", u = r ? `${import_picocolors2.default.yellow(x2)}  ` : "", l = a ?? "";
-      return t.clearOnError && this.clear(), `${s.trim()}
-${o}${l}
-${u}${import_picocolors2.default.yellow(this.error)}
-`;
-    }
-    case "submit": {
-      const o = r ? `${import_picocolors2.default.gray(d)}  ` : "", u = a ? import_picocolors2.default.dim(a) : "";
-      return `${s}${o}${u}`;
-    }
-    case "cancel": {
-      const o = r ? `${import_picocolors2.default.gray(d)}  ` : "", u = a ? import_picocolors2.default.strikethrough(import_picocolors2.default.dim(a)) : "";
-      return `${s}${o}${u}${a && r ? `
-${import_picocolors2.default.gray(d)}` : ""}`;
-    }
-    default: {
-      const o = r ? `${import_picocolors2.default.cyan(d)}  ` : "", u = r ? import_picocolors2.default.cyan(x2) : "";
-      return `${s}${o}${i}
-${u}
-`;
-    }
-  }
-} }).prompt();
-var Ke = import_picocolors2.default.magenta;
-var bt2 = ({ indicator: t = "dots", onCancel: r, output: s = process.stdout, cancelMessage: i, errorMessage: a, frames: o = et2 ? ["\u25D2", "\u25D0", "\u25D3", "\u25D1"] : ["\u2022", "o", "O", "0"], delay: u = et2 ? 80 : 120, signal: l, ...n } = {}) => {
-  const c = ct2();
-  let g, F, p = false, E = false, $ = "", m, h = performance.now();
-  const y2 = rt(s), f = n?.styleFrame ?? Ke, v = (b) => {
-    const O2 = b > 1 ? a ?? _.messages.error : i ?? _.messages.cancel;
-    E = b === 1, p && (L2(O2, b), E && typeof r == "function" && r());
-  }, S2 = () => v(2), I2 = () => v(1), B2 = () => {
-    process.on("uncaughtExceptionMonitor", S2), process.on("unhandledRejection", S2), process.on("SIGINT", I2), process.on("SIGTERM", I2), process.on("exit", v), l && l.addEventListener("abort", I2);
-  }, A = () => {
-    process.removeListener("uncaughtExceptionMonitor", S2), process.removeListener("unhandledRejection", S2), process.removeListener("SIGINT", I2), process.removeListener("SIGTERM", I2), process.removeListener("exit", v), l && l.removeEventListener("abort", I2);
-  }, w = () => {
-    if (m === void 0) return;
-    c && s.write(`
-`);
-    const b = J2(m, y2, { hard: true, trim: false }).split(`
-`);
-    b.length > 1 && s.write(import_sisteransi2.cursor.up(b.length - 1)), s.write(import_sisteransi2.cursor.to(0)), s.write(import_sisteransi2.erase.down());
-  }, _2 = (b) => b.replace(/\.+$/, ""), D2 = (b) => {
-    const O2 = (performance.now() - b) / 1e3, j2 = Math.floor(O2 / 60), G2 = Math.floor(O2 % 60);
-    return j2 > 0 ? `[${j2}m ${G2}s]` : `[${G2}s]`;
-  }, T2 = n.withGuide ?? _.withGuide, Y = (b = "") => {
-    p = true, g = Bt({ output: s }), $ = _2(b), h = performance.now(), T2 && s.write(`${import_picocolors2.default.gray(d)}
-`);
-    let O2 = 0, j2 = 0;
-    B2(), F = setInterval(() => {
-      if (c && $ === m) return;
-      w(), m = $;
-      const G2 = f(o[O2]);
-      let tt2;
-      if (c) tt2 = `${G2}  ${$}...`;
-      else if (t === "timer") tt2 = `${G2}  ${$} ${D2(h)}`;
-      else {
-        const te = ".".repeat(Math.floor(j2)).slice(0, 3);
-        tt2 = `${G2}  ${$}${te}`;
-      }
-      const Zt = J2(tt2, y2, { hard: true, trim: false });
-      s.write(Zt), O2 = O2 + 1 < o.length ? O2 + 1 : 0, j2 = j2 < 4 ? j2 + 0.125 : 0;
-    }, u);
-  }, L2 = (b = "", O2 = 0, j2 = false) => {
-    if (!p) return;
-    p = false, clearInterval(F), w();
-    const G2 = O2 === 0 ? import_picocolors2.default.green(V) : O2 === 1 ? import_picocolors2.default.red(dt2) : import_picocolors2.default.red($t2);
-    $ = b ?? $, j2 || (t === "timer" ? s.write(`${G2}  ${$} ${D2(h)}
-`) : s.write(`${G2}  ${$}
-`)), A(), g();
-  };
-  return { start: Y, stop: (b = "") => L2(b, 0), message: (b = "") => {
-    $ = _2(b ?? $);
-  }, cancel: (b = "") => L2(b, 1), error: (b = "") => L2(b, 2), clear: () => L2("", 0, true), get isCancelled() {
-    return E;
-  } };
-};
-var zt = { light: C("\u2500", "-"), heavy: C("\u2501", "="), block: C("\u2588", "#") };
-var lt2 = (t, r) => t.includes(`
-`) ? t.split(`
-`).map((s) => r(s)).join(`
-`) : r(t);
-var Je = (t) => {
-  const r = (s, i) => {
-    const a = s.label ?? String(s.value);
-    switch (i) {
-      case "disabled":
-        return `${import_picocolors2.default.gray(H2)} ${lt2(a, import_picocolors2.default.gray)}${s.hint ? ` ${import_picocolors2.default.dim(`(${s.hint ?? "disabled"})`)}` : ""}`;
-      case "selected":
-        return `${lt2(a, import_picocolors2.default.dim)}`;
-      case "active":
-        return `${import_picocolors2.default.green(Q2)} ${a}${s.hint ? ` ${import_picocolors2.default.dim(`(${s.hint})`)}` : ""}`;
-      case "cancelled":
-        return `${lt2(a, (o) => import_picocolors2.default.strikethrough(import_picocolors2.default.dim(o)))}`;
-      default:
-        return `${import_picocolors2.default.dim(H2)} ${lt2(a, import_picocolors2.default.dim)}`;
-    }
-  };
-  return new Wt({ options: t.options, signal: t.signal, input: t.input, output: t.output, initialValue: t.initialValue, render() {
-    const s = t.withGuide ?? _.withGuide, i = `${W2(this.state)}  `, a = `${vt2(this.state)}  `, o = xt(t.output, t.message, a, i), u = `${s ? `${import_picocolors2.default.gray(d)}
-` : ""}${o}
-`;
+var password = (r2) => new o({
+  validate: r2.validate,
+  mask: r2.mask ?? S_PASSWORD_MASK,
+  signal: r2.signal,
+  input: r2.input,
+  output: r2.output,
+  render() {
+    const e = r2.withGuide ?? settings.withGuide, o2 = `${e ? `${styleText2("gray", S_BAR)}
+` : ""}${symbol(this.state)}  ${r2.message}
+`, c2 = this.userInputWithCursor, i2 = this.masked;
     switch (this.state) {
+      case "error": {
+        const s = e ? `${styleText2("yellow", S_BAR)}  ` : "", n2 = e ? `${styleText2("yellow", S_BAR_END)}  ` : "", l2 = i2 ?? "";
+        return r2.clearOnError && this.clear(), `${o2.trim()}
+${s}${l2}
+${n2}${styleText2("yellow", this.error)}
+`;
+      }
       case "submit": {
-        const l = s ? `${import_picocolors2.default.gray(d)}  ` : "", n = xt(t.output, r(this.options[this.cursor], "selected"), l);
-        return `${u}${n}`;
+        const s = e ? `${styleText2("gray", S_BAR)}  ` : "", n2 = i2 ? styleText2("dim", i2) : "";
+        return `${o2}${s}${n2}`;
       }
       case "cancel": {
-        const l = s ? `${import_picocolors2.default.gray(d)}  ` : "", n = xt(t.output, r(this.options[this.cursor], "cancelled"), l);
-        return `${u}${n}${s ? `
-${import_picocolors2.default.gray(d)}` : ""}`;
+        const s = e ? `${styleText2("gray", S_BAR)}  ` : "", n2 = i2 ? styleText2(["strikethrough", "dim"], i2) : "";
+        return `${o2}${s}${n2}${i2 && e ? `
+${styleText2("gray", S_BAR)}` : ""}`;
       }
       default: {
-        const l = s ? `${import_picocolors2.default.cyan(d)}  ` : "", n = s ? import_picocolors2.default.cyan(x2) : "", c = u.split(`
-`).length, g = s ? 2 : 1;
-        return `${u}${l}${X2({ output: t.output, cursor: this.cursor, options: this.options, maxItems: t.maxItems, columnPadding: l.length, rowPadding: c + g, style: (F, p) => r(F, F.disabled ? "disabled" : p ? "active" : "inactive") }).join(`
-${l}`)}
-${n}
+        const s = e ? `${styleText2("cyan", S_BAR)}  ` : "", n2 = e ? styleText2("cyan", S_BAR_END) : "";
+        return `${o2}${s}${c2}
+${n2}
 `;
       }
     }
-  } }).prompt();
+  }
+}).prompt();
+var W = (l2) => styleText2("magenta", l2);
+var spinner = ({
+  indicator: l2 = "dots",
+  onCancel: h2,
+  output: n2 = process.stdout,
+  cancelMessage: G,
+  errorMessage: O,
+  frames: E = unicode ? ["\u25D2", "\u25D0", "\u25D3", "\u25D1"] : ["\u2022", "o", "O", "0"],
+  delay: F = unicode ? 80 : 120,
+  signal: m,
+  ...I
+} = {}) => {
+  const u3 = isCI();
+  let M, T, d2 = false, S = false, s = "", p, w = performance.now();
+  const x = getColumns(n2), k = I?.styleFrame ?? W, g = (e) => {
+    const r2 = e > 1 ? O ?? settings.messages.error : G ?? settings.messages.cancel;
+    S = e === 1, d2 && (a3(r2, e), S && typeof h2 == "function" && h2());
+  }, f = () => g(2), i2 = () => g(1), A = () => {
+    process.on("uncaughtExceptionMonitor", f), process.on("unhandledRejection", f), process.on("SIGINT", i2), process.on("SIGTERM", i2), process.on("exit", g), m && m.addEventListener("abort", i2);
+  }, H = () => {
+    process.removeListener("uncaughtExceptionMonitor", f), process.removeListener("unhandledRejection", f), process.removeListener("SIGINT", i2), process.removeListener("SIGTERM", i2), process.removeListener("exit", g), m && m.removeEventListener("abort", i2);
+  }, y = () => {
+    if (p === void 0) return;
+    u3 && n2.write(`
+`);
+    const r2 = wrapAnsi(p, x, {
+      hard: true,
+      trim: false
+    }).split(`
+`);
+    r2.length > 1 && n2.write(import_sisteransi2.cursor.up(r2.length - 1)), n2.write(import_sisteransi2.cursor.to(0)), n2.write(import_sisteransi2.erase.down());
+  }, C2 = (e) => e.replace(/\.+$/, ""), _ = (e) => {
+    const r2 = (performance.now() - e) / 1e3, t2 = Math.floor(r2 / 60), o2 = Math.floor(r2 % 60);
+    return t2 > 0 ? `[${t2}m ${o2}s]` : `[${o2}s]`;
+  }, N = I.withGuide ?? settings.withGuide, P = (e = "") => {
+    d2 = true, M = block({ output: n2 }), s = C2(e), w = performance.now(), N && n2.write(`${styleText2("gray", S_BAR)}
+`);
+    let r2 = 0, t2 = 0;
+    A(), T = setInterval(() => {
+      if (u3 && s === p)
+        return;
+      y(), p = s;
+      const o2 = k(E[r2]);
+      let v;
+      if (u3)
+        v = `${o2}  ${s}...`;
+      else if (l2 === "timer")
+        v = `${o2}  ${s} ${_(w)}`;
+      else {
+        const B = ".".repeat(Math.floor(t2)).slice(0, 3);
+        v = `${o2}  ${s}${B}`;
+      }
+      const j = wrapAnsi(v, x, {
+        hard: true,
+        trim: false
+      });
+      n2.write(j), r2 = r2 + 1 < E.length ? r2 + 1 : 0, t2 = t2 < 4 ? t2 + 0.125 : 0;
+    }, F);
+  }, a3 = (e = "", r2 = 0, t2 = false) => {
+    if (!d2) return;
+    d2 = false, clearInterval(T), y();
+    const o2 = r2 === 0 ? styleText2("green", S_STEP_SUBMIT) : r2 === 1 ? styleText2("red", S_STEP_CANCEL) : styleText2("red", S_STEP_ERROR);
+    s = e ?? s, t2 || (l2 === "timer" ? n2.write(`${o2}  ${s} ${_(w)}
+`) : n2.write(`${o2}  ${s}
+`)), H(), M();
+  };
+  return {
+    start: P,
+    stop: (e = "") => a3(e, 0),
+    message: (e = "") => {
+      s = C2(e ?? s);
+    },
+    cancel: (e = "") => a3(e, 1),
+    error: (e = "") => a3(e, 2),
+    clear: () => a3("", 0, true),
+    get isCancelled() {
+      return S;
+    }
+  };
 };
-var Qt = `${import_picocolors2.default.gray(d)}  `;
-var Ye = async (t, r) => {
-  for (const s of t) {
-    if (s.enabled === false) continue;
-    const i = bt2(r);
-    i.start(s.title);
-    const a = await s.task(i.message);
-    i.stop(a || s.title);
+var u2 = {
+  light: unicodeOr("\u2500", "-"),
+  heavy: unicodeOr("\u2501", "="),
+  block: unicodeOr("\u2588", "#")
+};
+var c = (e, a3) => e.includes(`
+`) ? e.split(`
+`).map((t2) => a3(t2)).join(`
+`) : a3(e);
+var select = (e) => {
+  const a3 = (t2, d2) => {
+    const s = t2.label ?? String(t2.value);
+    switch (d2) {
+      case "disabled":
+        return `${styleText2("gray", S_RADIO_INACTIVE)} ${c(s, (n2) => styleText2("gray", n2))}${t2.hint ? ` ${styleText2("dim", `(${t2.hint ?? "disabled"})`)}` : ""}`;
+      case "selected":
+        return `${c(s, (n2) => styleText2("dim", n2))}`;
+      case "active":
+        return `${styleText2("green", S_RADIO_ACTIVE)} ${s}${t2.hint ? ` ${styleText2("dim", `(${t2.hint})`)}` : ""}`;
+      case "cancelled":
+        return `${c(s, (n2) => styleText2(["strikethrough", "dim"], n2))}`;
+      default:
+        return `${styleText2("dim", S_RADIO_INACTIVE)} ${c(s, (n2) => styleText2("dim", n2))}`;
+    }
+  };
+  return new a2({
+    options: e.options,
+    signal: e.signal,
+    input: e.input,
+    output: e.output,
+    initialValue: e.initialValue,
+    render() {
+      const t2 = e.withGuide ?? settings.withGuide, d2 = `${symbol(this.state)}  `, s = `${symbolBar(this.state)}  `, n2 = wrapTextWithPrefix(
+        e.output,
+        e.message,
+        s,
+        d2
+      ), u3 = `${t2 ? `${styleText2("gray", S_BAR)}
+` : ""}${n2}
+`;
+      switch (this.state) {
+        case "submit": {
+          const r2 = t2 ? `${styleText2("gray", S_BAR)}  ` : "", l2 = wrapTextWithPrefix(
+            e.output,
+            a3(this.options[this.cursor], "selected"),
+            r2
+          );
+          return `${u3}${l2}`;
+        }
+        case "cancel": {
+          const r2 = t2 ? `${styleText2("gray", S_BAR)}  ` : "", l2 = wrapTextWithPrefix(
+            e.output,
+            a3(this.options[this.cursor], "cancelled"),
+            r2
+          );
+          return `${u3}${l2}${t2 ? `
+${styleText2("gray", S_BAR)}` : ""}`;
+        }
+        default: {
+          const r2 = t2 ? `${styleText2("cyan", S_BAR)}  ` : "", l2 = t2 ? styleText2("cyan", S_BAR_END) : "", g = u3.split(`
+`).length, h2 = t2 ? 2 : 1;
+          return `${u3}${r2}${limitOptions({
+            output: e.output,
+            cursor: this.cursor,
+            options: this.options,
+            maxItems: e.maxItems,
+            columnPadding: r2.length,
+            rowPadding: g + h2,
+            style: (p, b) => a3(p, p.disabled ? "disabled" : b ? "active" : "inactive")
+          }).join(`
+${r2}`)}
+${l2}
+`;
+        }
+      }
+    }
+  }).prompt();
+};
+var i = `${styleText2("gray", S_BAR)}  `;
+var tasks = async (o2, e) => {
+  for (const t2 of o2) {
+    if (t2.enabled === false) continue;
+    const s = spinner(e);
+    s.start(t2.title);
+    const n2 = await t2.task(s.message);
+    s.stop(n2 || t2.title);
   }
 };
-var Ze = (t) => new $t({ validate: t.validate, placeholder: t.placeholder, defaultValue: t.defaultValue, initialValue: t.initialValue, output: t.output, signal: t.signal, input: t.input, render() {
-  const r = t?.withGuide ?? _.withGuide, s = `${`${r ? `${import_picocolors2.default.gray(d)}
-` : ""}${W2(this.state)}  `}${t.message}
-`, i = t.placeholder ? import_picocolors2.default.inverse(t.placeholder[0]) + import_picocolors2.default.dim(t.placeholder.slice(1)) : import_picocolors2.default.inverse(import_picocolors2.default.hidden("_")), a = this.userInput ? this.userInputWithCursor : i, o = this.value ?? "";
-  switch (this.state) {
-    case "error": {
-      const u = this.error ? `  ${import_picocolors2.default.yellow(this.error)}` : "", l = r ? `${import_picocolors2.default.yellow(d)}  ` : "", n = r ? import_picocolors2.default.yellow(x2) : "";
-      return `${s.trim()}
-${l}${a}
-${n}${u}
+var text = (t2) => new n({
+  validate: t2.validate,
+  placeholder: t2.placeholder,
+  defaultValue: t2.defaultValue,
+  initialValue: t2.initialValue,
+  output: t2.output,
+  signal: t2.signal,
+  input: t2.input,
+  render() {
+    const i2 = t2?.withGuide ?? settings.withGuide, s = `${`${i2 ? `${styleText2("gray", S_BAR)}
+` : ""}${symbol(this.state)}  `}${t2.message}
+`, c2 = t2.placeholder ? styleText2("inverse", t2.placeholder[0]) + styleText2("dim", t2.placeholder.slice(1)) : styleText2(["inverse", "hidden"], "_"), o2 = this.userInput ? this.userInputWithCursor : c2, a3 = this.value ?? "";
+    switch (this.state) {
+      case "error": {
+        const n2 = this.error ? `  ${styleText2("yellow", this.error)}` : "", r2 = i2 ? `${styleText2("yellow", S_BAR)}  ` : "", d2 = i2 ? styleText2("yellow", S_BAR_END) : "";
+        return `${s.trim()}
+${r2}${o2}
+${d2}${n2}
 `;
-    }
-    case "submit": {
-      const u = o ? `  ${import_picocolors2.default.dim(o)}` : "", l = r ? import_picocolors2.default.gray(d) : "";
-      return `${s}${l}${u}`;
-    }
-    case "cancel": {
-      const u = o ? `  ${import_picocolors2.default.strikethrough(import_picocolors2.default.dim(o))}` : "", l = r ? import_picocolors2.default.gray(d) : "";
-      return `${s}${l}${u}${o.trim() ? `
-${l}` : ""}`;
-    }
-    default: {
-      const u = r ? `${import_picocolors2.default.cyan(d)}  ` : "", l = r ? import_picocolors2.default.cyan(x2) : "";
-      return `${s}${u}${a}
-${l}
+      }
+      case "submit": {
+        const n2 = a3 ? `  ${styleText2("dim", a3)}` : "", r2 = i2 ? styleText2("gray", S_BAR) : "";
+        return `${s}${r2}${n2}`;
+      }
+      case "cancel": {
+        const n2 = a3 ? `  ${styleText2(["strikethrough", "dim"], a3)}` : "", r2 = i2 ? styleText2("gray", S_BAR) : "";
+        return `${s}${r2}${n2}${a3.trim() ? `
+${r2}` : ""}`;
+      }
+      default: {
+        const n2 = i2 ? `${styleText2("cyan", S_BAR)}  ` : "", r2 = i2 ? styleText2("cyan", S_BAR_END) : "";
+        return `${s}${n2}${o2}
+${r2}
 `;
+      }
     }
   }
-} }).prompt();
+}).prompt();
 
 // src/steps/welcome.ts
-var import_picocolors3 = __toESM(require_picocolors(), 1);
+var import_picocolors = __toESM(require_picocolors(), 1);
 import { existsSync } from "fs";
 
 // src/utils/system.ts
@@ -1236,8 +1581,8 @@ function commandExists(command) {
 function runCommand(command, args = []) {
   try {
     const fullCommand = [command, ...args].join(" ");
-    const stdout = execSync(fullCommand, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] });
-    return { stdout: stdout.trim(), stderr: "", exitCode: 0 };
+    const stdout2 = execSync(fullCommand, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] });
+    return { stdout: stdout2.trim(), stderr: "", exitCode: 0 };
   } catch (error) {
     return {
       stdout: error.stdout?.toString().trim() ?? "",
@@ -1255,35 +1600,36 @@ function expandHome(filepath) {
 
 // src/steps/welcome.ts
 async function runWelcome() {
-  We(import_picocolors3.default.bgCyan(import_picocolors3.default.black(" claude-mem installer ")));
-  R2.info(`Version: 1.0.0`);
-  R2.info(`Platform: ${process.platform} (${process.arch})`);
+  intro(import_picocolors.default.bgCyan(import_picocolors.default.black(" claude-mem installer ")));
+  log.info(`Version: 1.0.0`);
+  log.info(`Platform: ${process.platform} (${process.arch})`);
   const settingsExist = existsSync(expandHome("~/.claude-mem/settings.json"));
   const pluginExist = existsSync(expandHome("~/.claude/plugins/marketplaces/thedotmack/"));
   const alreadyInstalled = settingsExist && pluginExist;
   if (alreadyInstalled) {
-    R2.warn("Existing claude-mem installation detected.");
+    log.warn("Existing claude-mem installation detected.");
   }
-  const installMode = await Je({
+  const installMode = await select({
     message: "What would you like to do?",
     options: alreadyInstalled ? [
       { value: "upgrade", label: "Upgrade", hint: "update to latest version" },
       { value: "configure", label: "Configure", hint: "change settings only" },
-      { value: "fresh", label: "Fresh Install", hint: "reinstall from scratch" }
+      { value: "fresh", label: "Fresh Install", hint: "reinstall from scratch" },
+      { value: "uninstall", label: "Uninstall", hint: "remove claude-mem" }
     ] : [
       { value: "fresh", label: "Fresh Install", hint: "recommended" },
       { value: "configure", label: "Configure Only", hint: "set up settings without installing" }
     ]
   });
-  if (Ct(installMode)) {
-    Ne("Installation cancelled.");
+  if (isCancel(installMode)) {
+    cancel("Installation cancelled.");
     process.exit(0);
   }
   return installMode;
 }
 
 // src/steps/dependencies.ts
-var import_picocolors4 = __toESM(require_picocolors(), 1);
+var import_picocolors2 = __toESM(require_picocolors(), 1);
 
 // src/utils/dependencies.ts
 import { existsSync as existsSync2 } from "fs";
@@ -1319,11 +1665,11 @@ function parseVersion(output) {
 function compareVersions(current, minimum) {
   const currentParts = current.split(".").map(Number);
   const minimumParts = minimum.split(".").map(Number);
-  for (let i = 0; i < Math.max(currentParts.length, minimumParts.length); i++) {
-    const a = currentParts[i] || 0;
-    const b = minimumParts[i] || 0;
-    if (a > b) return true;
-    if (a < b) return false;
+  for (let i2 = 0; i2 < Math.max(currentParts.length, minimumParts.length); i2++) {
+    const a3 = currentParts[i2] || 0;
+    const b = minimumParts[i2] || 0;
+    if (a3 > b) return true;
+    if (a3 < b) return false;
   }
   return true;
 }
@@ -1356,16 +1702,16 @@ async function runDependencyChecks() {
     bunPath: null,
     uvPath: null
   };
-  await Ye([
+  await tasks([
     {
       title: "Checking Node.js",
       task: async () => {
         const version = process.version.slice(1);
         if (compareVersions(version, "18.0.0")) {
           status.nodeOk = true;
-          return `Node.js ${process.version} ${import_picocolors4.default.green("\u2713")}`;
+          return `Node.js ${process.version} ${import_picocolors2.default.green("\u2713")}`;
         }
-        return `Node.js ${process.version} \u2014 requires >= 18.0.0 ${import_picocolors4.default.red("\u2717")}`;
+        return `Node.js ${process.version} \u2014 requires >= 18.0.0 ${import_picocolors2.default.red("\u2717")}`;
       }
     },
     {
@@ -1374,9 +1720,9 @@ async function runDependencyChecks() {
         const info = findBinary("git");
         if (info.found) {
           status.gitOk = true;
-          return `git ${info.version ?? ""} ${import_picocolors4.default.green("\u2713")}`;
+          return `git ${info.version ?? ""} ${import_picocolors2.default.green("\u2713")}`;
         }
-        return `git not found ${import_picocolors4.default.red("\u2717")}`;
+        return `git not found ${import_picocolors2.default.red("\u2717")}`;
       }
     },
     {
@@ -1386,12 +1732,12 @@ async function runDependencyChecks() {
         if (info.found && info.version && compareVersions(info.version, "1.1.14")) {
           status.bunOk = true;
           status.bunPath = info.path;
-          return `Bun ${info.version} ${import_picocolors4.default.green("\u2713")}`;
+          return `Bun ${info.version} ${import_picocolors2.default.green("\u2713")}`;
         }
         if (info.found && info.version) {
-          return `Bun ${info.version} \u2014 requires >= 1.1.14 ${import_picocolors4.default.yellow("\u26A0")}`;
+          return `Bun ${info.version} \u2014 requires >= 1.1.14 ${import_picocolors2.default.yellow("\u26A0")}`;
         }
-        return `Bun not found ${import_picocolors4.default.yellow("\u26A0")}`;
+        return `Bun not found ${import_picocolors2.default.yellow("\u26A0")}`;
       }
     },
     {
@@ -1401,41 +1747,41 @@ async function runDependencyChecks() {
         if (info.found) {
           status.uvOk = true;
           status.uvPath = info.path;
-          return `uv ${info.version ?? ""} ${import_picocolors4.default.green("\u2713")}`;
+          return `uv ${info.version ?? ""} ${import_picocolors2.default.green("\u2713")}`;
         }
-        return `uv not found ${import_picocolors4.default.yellow("\u26A0")}`;
+        return `uv not found ${import_picocolors2.default.yellow("\u26A0")}`;
       }
     }
   ]);
   if (!status.gitOk) {
     const os = detectOS();
-    R2.error("git is required but not found.");
+    log.error("git is required but not found.");
     if (os === "macos") {
-      R2.info("Install with: xcode-select --install");
+      log.info("Install with: xcode-select --install");
     } else if (os === "linux") {
-      R2.info("Install with: sudo apt install git (or your distro equivalent)");
+      log.info("Install with: sudo apt install git (or your distro equivalent)");
     } else {
-      R2.info("Download from: https://git-scm.com/downloads");
+      log.info("Download from: https://git-scm.com/downloads");
     }
-    Ne("Please install git and try again.");
+    cancel("Please install git and try again.");
     process.exit(1);
   }
   if (!status.nodeOk) {
-    R2.error(`Node.js >= 18.0.0 is required. Current: ${process.version}`);
-    Ne("Please upgrade Node.js and try again.");
+    log.error(`Node.js >= 18.0.0 is required. Current: ${process.version}`);
+    cancel("Please upgrade Node.js and try again.");
     process.exit(1);
   }
   if (!status.bunOk) {
-    const shouldInstall = await Re({
+    const shouldInstall = await confirm({
       message: "Bun is required but not found. Install it now?",
       initialValue: true
     });
-    if (Ct(shouldInstall)) {
-      Ne("Installation cancelled.");
+    if (isCancel(shouldInstall)) {
+      cancel("Installation cancelled.");
       process.exit(0);
     }
     if (shouldInstall) {
-      const s = bt2();
+      const s = spinner();
       s.start("Installing Bun...");
       try {
         installBun();
@@ -1443,7 +1789,7 @@ async function runDependencyChecks() {
         if (recheck.found) {
           status.bunOk = true;
           status.bunPath = recheck.path;
-          s.stop(`Bun installed ${import_picocolors4.default.green("\u2713")}`);
+          s.stop(`Bun installed ${import_picocolors2.default.green("\u2713")}`);
         } else {
           s.stop(`Bun installed but not found in PATH. You may need to restart your shell.`);
         }
@@ -1451,22 +1797,22 @@ async function runDependencyChecks() {
         s.stop(`Bun installation failed. Install manually: curl -fsSL https://bun.sh/install | bash`);
       }
     } else {
-      R2.warn("Bun is required for claude-mem. Install manually: curl -fsSL https://bun.sh/install | bash");
-      Ne("Cannot continue without Bun.");
+      log.warn("Bun is required for claude-mem. Install manually: curl -fsSL https://bun.sh/install | bash");
+      cancel("Cannot continue without Bun.");
       process.exit(1);
     }
   }
   if (!status.uvOk) {
-    const shouldInstall = await Re({
+    const shouldInstall = await confirm({
       message: "uv (Python package manager) is recommended for Chroma. Install it now?",
       initialValue: true
     });
-    if (Ct(shouldInstall)) {
-      Ne("Installation cancelled.");
+    if (isCancel(shouldInstall)) {
+      cancel("Installation cancelled.");
       process.exit(0);
     }
     if (shouldInstall) {
-      const s = bt2();
+      const s = spinner();
       s.start("Installing uv...");
       try {
         installUv();
@@ -1474,7 +1820,7 @@ async function runDependencyChecks() {
         if (recheck.found) {
           status.uvOk = true;
           status.uvPath = recheck.path;
-          s.stop(`uv installed ${import_picocolors4.default.green("\u2713")}`);
+          s.stop(`uv installed ${import_picocolors2.default.green("\u2713")}`);
         } else {
           s.stop("uv installed but not found in PATH. You may need to restart your shell.");
         }
@@ -1482,7 +1828,7 @@ async function runDependencyChecks() {
         s.stop("uv installation failed. Install manually: curl -fsSL https://astral.sh/uv/install.sh | sh");
       }
     } else {
-      R2.warn("Skipping uv \u2014 Chroma vector search will not be available.");
+      log.warn("Skipping uv \u2014 Chroma vector search will not be available.");
     }
   }
   return status;
@@ -1490,7 +1836,7 @@ async function runDependencyChecks() {
 
 // src/steps/ide-selection.ts
 async function runIdeSelection() {
-  const result = await je({
+  const result = await multiselect({
     message: "Which IDEs do you use?",
     options: [
       { value: "claude-code", label: "Claude Code", hint: "recommended" },
@@ -1500,23 +1846,23 @@ async function runIdeSelection() {
     initialValues: ["claude-code"],
     required: true
   });
-  if (Ct(result)) {
-    Ne("Installation cancelled.");
+  if (isCancel(result)) {
+    cancel("Installation cancelled.");
     process.exit(0);
   }
   const selectedIDEs = result;
   if (selectedIDEs.includes("claude-code")) {
-    R2.info("Claude Code: Plugin will be registered via marketplace.");
+    log.info("Claude Code: Plugin will be registered via marketplace.");
   }
   if (selectedIDEs.includes("cursor")) {
-    R2.info("Cursor: Hooks will be configured for your projects.");
+    log.info("Cursor: Hooks will be configured for your projects.");
   }
   return selectedIDEs;
 }
 
 // src/steps/provider.ts
 async function runProviderConfiguration() {
-  const provider = await Je({
+  const provider = await select({
     message: "Which AI provider should claude-mem use for memory compression?",
     options: [
       { value: "claude", label: "Claude", hint: "uses your Claude subscription" },
@@ -1524,52 +1870,52 @@ async function runProviderConfiguration() {
       { value: "openrouter", label: "OpenRouter", hint: "free models available" }
     ]
   });
-  if (Ct(provider)) {
-    Ne("Installation cancelled.");
+  if (isCancel(provider)) {
+    cancel("Installation cancelled.");
     process.exit(0);
   }
   const config = { provider };
   if (provider === "claude") {
-    const authMethod = await Je({
+    const authMethod = await select({
       message: "How should Claude authenticate?",
       options: [
         { value: "cli", label: "CLI (Max Plan subscription)", hint: "no API key needed" },
         { value: "api", label: "API Key", hint: "uses Anthropic API credits" }
       ]
     });
-    if (Ct(authMethod)) {
-      Ne("Installation cancelled.");
+    if (isCancel(authMethod)) {
+      cancel("Installation cancelled.");
       process.exit(0);
     }
     config.claudeAuthMethod = authMethod;
     if (authMethod === "api") {
-      const apiKey = await He({
+      const apiKey = await password({
         message: "Enter your Anthropic API key:",
         validate: (value) => {
           if (!value || value.trim().length === 0) return "API key is required";
           if (!value.startsWith("sk-ant-")) return "Anthropic API keys start with sk-ant-";
         }
       });
-      if (Ct(apiKey)) {
-        Ne("Installation cancelled.");
+      if (isCancel(apiKey)) {
+        cancel("Installation cancelled.");
         process.exit(0);
       }
       config.apiKey = apiKey;
     }
   }
   if (provider === "gemini") {
-    const apiKey = await He({
+    const apiKey = await password({
       message: "Enter your Gemini API key:",
       validate: (value) => {
         if (!value || value.trim().length === 0) return "API key is required";
       }
     });
-    if (Ct(apiKey)) {
-      Ne("Installation cancelled.");
+    if (isCancel(apiKey)) {
+      cancel("Installation cancelled.");
       process.exit(0);
     }
     config.apiKey = apiKey;
-    const model = await Je({
+    const model = await select({
       message: "Which Gemini model?",
       options: [
         { value: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite", hint: "fastest, highest free RPM" },
@@ -1577,40 +1923,40 @@ async function runProviderConfiguration() {
         { value: "gemini-3-flash-preview", label: "Gemini 3 Flash Preview", hint: "latest" }
       ]
     });
-    if (Ct(model)) {
-      Ne("Installation cancelled.");
+    if (isCancel(model)) {
+      cancel("Installation cancelled.");
       process.exit(0);
     }
     config.model = model;
-    const rateLimiting = await Re({
+    const rateLimiting = await confirm({
       message: "Enable rate limiting? (recommended for free tier)",
       initialValue: true
     });
-    if (Ct(rateLimiting)) {
-      Ne("Installation cancelled.");
+    if (isCancel(rateLimiting)) {
+      cancel("Installation cancelled.");
       process.exit(0);
     }
     config.rateLimitingEnabled = rateLimiting;
   }
   if (provider === "openrouter") {
-    const apiKey = await He({
+    const apiKey = await password({
       message: "Enter your OpenRouter API key:",
       validate: (value) => {
         if (!value || value.trim().length === 0) return "API key is required";
       }
     });
-    if (Ct(apiKey)) {
-      Ne("Installation cancelled.");
+    if (isCancel(apiKey)) {
+      cancel("Installation cancelled.");
       process.exit(0);
     }
     config.apiKey = apiKey;
-    const model = await Ze({
+    const model = await text({
       message: "Which OpenRouter model?",
       defaultValue: "xiaomi/mimo-v2-flash:free",
       placeholder: "xiaomi/mimo-v2-flash:free"
     });
-    if (Ct(model)) {
-      Ne("Installation cancelled.");
+    if (isCancel(model)) {
+      cancel("Installation cancelled.");
       process.exit(0);
     }
     config.model = model;
@@ -1619,14 +1965,14 @@ async function runProviderConfiguration() {
 }
 
 // src/steps/settings.ts
-var import_picocolors5 = __toESM(require_picocolors(), 1);
+var import_picocolors3 = __toESM(require_picocolors(), 1);
 async function runSettingsConfiguration() {
-  const useDefaults = await Re({
+  const useDefaults = await confirm({
     message: "Use default settings? (recommended for most users)",
     initialValue: true
   });
-  if (Ct(useDefaults)) {
-    Ne("Installation cancelled.");
+  if (isCancel(useDefaults)) {
+    cancel("Installation cancelled.");
     process.exit(0);
   }
   if (useDefaults) {
@@ -1640,7 +1986,7 @@ async function runSettingsConfiguration() {
       chromaMode: "local"
     };
   }
-  const workerPort = await Ze({
+  const workerPort = await text({
     message: "Worker service port:",
     defaultValue: "37777",
     placeholder: "37777",
@@ -1651,20 +1997,20 @@ async function runSettingsConfiguration() {
       }
     }
   });
-  if (Ct(workerPort)) {
-    Ne("Installation cancelled.");
+  if (isCancel(workerPort)) {
+    cancel("Installation cancelled.");
     process.exit(0);
   }
-  const dataDir = await Ze({
+  const dataDir = await text({
     message: "Data directory:",
     defaultValue: "~/.claude-mem",
     placeholder: "~/.claude-mem"
   });
-  if (Ct(dataDir)) {
-    Ne("Installation cancelled.");
+  if (isCancel(dataDir)) {
+    cancel("Installation cancelled.");
     process.exit(0);
   }
-  const contextObservations = await Ze({
+  const contextObservations = await text({
     message: "Number of context observations per session:",
     defaultValue: "50",
     placeholder: "50",
@@ -1675,11 +2021,11 @@ async function runSettingsConfiguration() {
       }
     }
   });
-  if (Ct(contextObservations)) {
-    Ne("Installation cancelled.");
+  if (isCancel(contextObservations)) {
+    cancel("Installation cancelled.");
     process.exit(0);
   }
-  const logLevel = await Je({
+  const logLevel = await select({
     message: "Log level:",
     options: [
       { value: "DEBUG", label: "DEBUG", hint: "verbose" },
@@ -1689,25 +2035,25 @@ async function runSettingsConfiguration() {
     ],
     initialValue: "INFO"
   });
-  if (Ct(logLevel)) {
-    Ne("Installation cancelled.");
+  if (isCancel(logLevel)) {
+    cancel("Installation cancelled.");
     process.exit(0);
   }
-  const pythonVersion = await Ze({
+  const pythonVersion = await text({
     message: "Python version (for Chroma):",
     defaultValue: "3.13",
     placeholder: "3.13"
   });
-  if (Ct(pythonVersion)) {
-    Ne("Installation cancelled.");
+  if (isCancel(pythonVersion)) {
+    cancel("Installation cancelled.");
     process.exit(0);
   }
-  const chromaEnabled = await Re({
+  const chromaEnabled = await confirm({
     message: "Enable Chroma vector search?",
     initialValue: true
   });
-  if (Ct(chromaEnabled)) {
-    Ne("Installation cancelled.");
+  if (isCancel(chromaEnabled)) {
+    cancel("Installation cancelled.");
     process.exit(0);
   }
   let chromaMode;
@@ -1715,30 +2061,30 @@ async function runSettingsConfiguration() {
   let chromaPort;
   let chromaSsl;
   if (chromaEnabled) {
-    const mode = await Je({
+    const mode = await select({
       message: "Chroma mode:",
       options: [
         { value: "local", label: "Local", hint: "starts local Chroma server" },
         { value: "remote", label: "Remote", hint: "connect to existing server" }
       ]
     });
-    if (Ct(mode)) {
-      Ne("Installation cancelled.");
+    if (isCancel(mode)) {
+      cancel("Installation cancelled.");
       process.exit(0);
     }
     chromaMode = mode;
     if (mode === "remote") {
-      const host = await Ze({
+      const host = await text({
         message: "Chroma host:",
         defaultValue: "127.0.0.1",
         placeholder: "127.0.0.1"
       });
-      if (Ct(host)) {
-        Ne("Installation cancelled.");
+      if (isCancel(host)) {
+        cancel("Installation cancelled.");
         process.exit(0);
       }
       chromaHost = host;
-      const port = await Ze({
+      const port = await text({
         message: "Chroma port:",
         defaultValue: "8000",
         placeholder: "8000",
@@ -1747,17 +2093,17 @@ async function runSettingsConfiguration() {
           if (isNaN(portNum) || portNum < 1 || portNum > 65535) return "Port must be between 1 and 65535";
         }
       });
-      if (Ct(port)) {
-        Ne("Installation cancelled.");
+      if (isCancel(port)) {
+        cancel("Installation cancelled.");
         process.exit(0);
       }
       chromaPort = port;
-      const ssl = await Re({
+      const ssl = await confirm({
         message: "Use SSL for Chroma connection?",
         initialValue: false
       });
-      if (Ct(ssl)) {
-        Ne("Installation cancelled.");
+      if (isCancel(ssl)) {
+        cancel("Installation cancelled.");
         process.exit(0);
       }
       chromaSsl = ssl;
@@ -1776,17 +2122,17 @@ async function runSettingsConfiguration() {
     chromaSsl
   };
   const summaryLines = [
-    `Worker port: ${import_picocolors5.default.cyan(workerPort)}`,
-    `Data directory: ${import_picocolors5.default.cyan(dataDir)}`,
-    `Context observations: ${import_picocolors5.default.cyan(contextObservations)}`,
-    `Log level: ${import_picocolors5.default.cyan(logLevel)}`,
-    `Python version: ${import_picocolors5.default.cyan(pythonVersion)}`,
-    `Chroma: ${chromaEnabled ? import_picocolors5.default.green("enabled") : import_picocolors5.default.dim("disabled")}`
+    `Worker port: ${import_picocolors3.default.cyan(workerPort)}`,
+    `Data directory: ${import_picocolors3.default.cyan(dataDir)}`,
+    `Context observations: ${import_picocolors3.default.cyan(contextObservations)}`,
+    `Log level: ${import_picocolors3.default.cyan(logLevel)}`,
+    `Python version: ${import_picocolors3.default.cyan(pythonVersion)}`,
+    `Chroma: ${chromaEnabled ? import_picocolors3.default.green("enabled") : import_picocolors3.default.dim("disabled")}`
   ];
   if (chromaEnabled && chromaMode) {
-    summaryLines.push(`Chroma mode: ${import_picocolors5.default.cyan(chromaMode)}`);
+    summaryLines.push(`Chroma mode: ${import_picocolors3.default.cyan(chromaMode)}`);
   }
-  Ve(summaryLines.join("\n"), "Settings Summary");
+  note(summaryLines.join("\n"), "Settings Summary");
   return config;
 }
 
@@ -1801,7 +2147,7 @@ function expandDataDir(dataDir) {
   return dataDir;
 }
 function buildSettingsObject(providerConfig, settingsConfig) {
-  const settings = {
+  const settings2 = {
     CLAUDE_MEM_WORKER_PORT: settingsConfig.workerPort,
     CLAUDE_MEM_WORKER_HOST: "127.0.0.1",
     CLAUDE_MEM_DATA_DIR: expandDataDir(settingsConfig.dataDir),
@@ -1811,26 +2157,26 @@ function buildSettingsObject(providerConfig, settingsConfig) {
     CLAUDE_MEM_PROVIDER: providerConfig.provider
   };
   if (providerConfig.provider === "claude") {
-    settings.CLAUDE_MEM_CLAUDE_AUTH_METHOD = providerConfig.claudeAuthMethod ?? "cli";
+    settings2.CLAUDE_MEM_CLAUDE_AUTH_METHOD = providerConfig.claudeAuthMethod ?? "cli";
   }
   if (providerConfig.provider === "gemini") {
-    if (providerConfig.apiKey) settings.CLAUDE_MEM_GEMINI_API_KEY = providerConfig.apiKey;
-    if (providerConfig.model) settings.CLAUDE_MEM_GEMINI_MODEL = providerConfig.model;
-    settings.CLAUDE_MEM_GEMINI_RATE_LIMITING_ENABLED = providerConfig.rateLimitingEnabled !== false ? "true" : "false";
+    if (providerConfig.apiKey) settings2.CLAUDE_MEM_GEMINI_API_KEY = providerConfig.apiKey;
+    if (providerConfig.model) settings2.CLAUDE_MEM_GEMINI_MODEL = providerConfig.model;
+    settings2.CLAUDE_MEM_GEMINI_RATE_LIMITING_ENABLED = providerConfig.rateLimitingEnabled !== false ? "true" : "false";
   }
   if (providerConfig.provider === "openrouter") {
-    if (providerConfig.apiKey) settings.CLAUDE_MEM_OPENROUTER_API_KEY = providerConfig.apiKey;
-    if (providerConfig.model) settings.CLAUDE_MEM_OPENROUTER_MODEL = providerConfig.model;
+    if (providerConfig.apiKey) settings2.CLAUDE_MEM_OPENROUTER_API_KEY = providerConfig.apiKey;
+    if (providerConfig.model) settings2.CLAUDE_MEM_OPENROUTER_MODEL = providerConfig.model;
   }
   if (settingsConfig.chromaEnabled) {
-    settings.CLAUDE_MEM_CHROMA_MODE = settingsConfig.chromaMode ?? "local";
+    settings2.CLAUDE_MEM_CHROMA_MODE = settingsConfig.chromaMode ?? "local";
     if (settingsConfig.chromaMode === "remote") {
-      if (settingsConfig.chromaHost) settings.CLAUDE_MEM_CHROMA_HOST = settingsConfig.chromaHost;
-      if (settingsConfig.chromaPort) settings.CLAUDE_MEM_CHROMA_PORT = settingsConfig.chromaPort;
-      if (settingsConfig.chromaSsl !== void 0) settings.CLAUDE_MEM_CHROMA_SSL = String(settingsConfig.chromaSsl);
+      if (settingsConfig.chromaHost) settings2.CLAUDE_MEM_CHROMA_HOST = settingsConfig.chromaHost;
+      if (settingsConfig.chromaPort) settings2.CLAUDE_MEM_CHROMA_PORT = settingsConfig.chromaPort;
+      if (settingsConfig.chromaSsl !== void 0) settings2.CLAUDE_MEM_CHROMA_SSL = String(settingsConfig.chromaSsl);
     }
   }
-  return settings;
+  return settings2;
 }
 function writeSettings(providerConfig, settingsConfig) {
   const dataDir = expandDataDir(settingsConfig.dataDir);
@@ -1849,7 +2195,7 @@ function writeSettings(providerConfig, settingsConfig) {
 }
 
 // src/steps/install.ts
-var import_picocolors6 = __toESM(require_picocolors(), 1);
+var import_picocolors4 = __toESM(require_picocolors(), 1);
 import { execSync as execSync3 } from "child_process";
 import { existsSync as existsSync4, mkdirSync as mkdirSync2, readFileSync as readFileSync2, writeFileSync as writeFileSync2, cpSync } from "fs";
 import { join as join3 } from "path";
@@ -1909,10 +2255,10 @@ function registerPlugin(version) {
   }
 }
 function enablePluginInClaudeSettings() {
-  const settings = readJsonFile(CLAUDE_SETTINGS_PATH);
-  if (!settings.enabledPlugins) settings.enabledPlugins = {};
-  settings.enabledPlugins["claude-mem@thedotmack"] = true;
-  writeJsonFile(CLAUDE_SETTINGS_PATH, settings);
+  const settings2 = readJsonFile(CLAUDE_SETTINGS_PATH);
+  if (!settings2.enabledPlugins) settings2.enabledPlugins = {};
+  settings2.enabledPlugins["claude-mem@thedotmack"] = true;
+  writeJsonFile(CLAUDE_SETTINGS_PATH, settings2);
 }
 function getPluginVersion() {
   const pluginJsonPath = join3(MARKETPLACE_DIR, "plugin", ".claude-plugin", "plugin.json");
@@ -1924,7 +2270,7 @@ function getPluginVersion() {
 }
 async function runInstallation(selectedIDEs) {
   const tempDir = join3(tmpdir(), `claude-mem-install-${Date.now()}`);
-  await Ye([
+  await tasks([
     {
       title: "Cloning claude-mem repository",
       task: async (message) => {
@@ -1933,7 +2279,7 @@ async function runInstallation(selectedIDEs) {
           `git clone --depth 1 https://github.com/thedotmack/claude-mem.git "${tempDir}"`,
           { stdio: "pipe" }
         );
-        return `Repository cloned ${import_picocolors6.default.green("OK")}`;
+        return `Repository cloned ${import_picocolors4.default.green("OK")}`;
       }
     },
     {
@@ -1941,7 +2287,7 @@ async function runInstallation(selectedIDEs) {
       task: async (message) => {
         message("Running npm install...");
         execSync3("npm install", { cwd: tempDir, stdio: "pipe" });
-        return `Dependencies installed ${import_picocolors6.default.green("OK")}`;
+        return `Dependencies installed ${import_picocolors4.default.green("OK")}`;
       }
     },
     {
@@ -1949,7 +2295,7 @@ async function runInstallation(selectedIDEs) {
       task: async (message) => {
         message("Compiling TypeScript and bundling...");
         execSync3("npm run build", { cwd: tempDir, stdio: "pipe" });
-        return `Plugin built ${import_picocolors6.default.green("OK")}`;
+        return `Plugin built ${import_picocolors4.default.green("OK")}`;
       }
     },
     {
@@ -1970,7 +2316,7 @@ async function runInstallation(selectedIDEs) {
         registerPlugin(version);
         message("Enabling plugin...");
         enablePluginInClaudeSettings();
-        return `Plugin registered (v${getPluginVersion()}) ${import_picocolors6.default.green("OK")}`;
+        return `Plugin registered (v${getPluginVersion()}) ${import_picocolors4.default.green("OK")}`;
       }
     }
   ]);
@@ -1979,13 +2325,13 @@ async function runInstallation(selectedIDEs) {
   } catch {
   }
   if (selectedIDEs.includes("cursor")) {
-    R2.info("Cursor hook configuration will be available after first launch.");
-    R2.info("Run: claude-mem cursor-setup (coming soon)");
+    log.info("Cursor hook configuration will be available after first launch.");
+    log.info("Run: claude-mem cursor-setup (coming soon)");
   }
 }
 
 // src/steps/worker.ts
-var import_picocolors7 = __toESM(require_picocolors(), 1);
+var import_picocolors5 = __toESM(require_picocolors(), 1);
 import { spawn } from "child_process";
 import { join as join4 } from "path";
 import { homedir as homedir4 } from "os";
@@ -2006,14 +2352,14 @@ async function pollHealthEndpoint(port, maxAttempts = HEALTH_CHECK_MAX_ATTEMPTS)
 async function runWorkerStartup(workerPort, dataDir) {
   const bunInfo = findBinary("bun", ["~/.bun/bin/bun", "/usr/local/bin/bun", "/opt/homebrew/bin/bun"]);
   if (!bunInfo.found || !bunInfo.path) {
-    R2.error("Bun is required to start the worker but was not found.");
-    R2.info("Install Bun: curl -fsSL https://bun.sh/install | bash");
+    log.error("Bun is required to start the worker but was not found.");
+    log.info("Install Bun: curl -fsSL https://bun.sh/install | bash");
     return;
   }
   const workerScript = join4(MARKETPLACE_DIR2, "plugin", "scripts", "worker-service.cjs");
   const expandedDataDir = expandHome(dataDir);
   const logPath = join4(expandedDataDir, "logs");
-  const s = bt2();
+  const s = spinner();
   s.start("Starting worker service...");
   const child = spawn(bunInfo.path, [workerScript], {
     cwd: MARKETPLACE_DIR2,
@@ -2028,16 +2374,16 @@ async function runWorkerStartup(workerPort, dataDir) {
   child.unref();
   const workerIsHealthy = await pollHealthEndpoint(workerPort);
   if (workerIsHealthy) {
-    s.stop(`Worker running on port ${import_picocolors7.default.cyan(workerPort)} ${import_picocolors7.default.green("OK")}`);
+    s.stop(`Worker running on port ${import_picocolors5.default.cyan(workerPort)} ${import_picocolors5.default.green("OK")}`);
   } else {
     s.stop(`Worker may still be starting. Check logs at: ${logPath}`);
-    R2.warn("Health check timed out. The worker might need more time to initialize.");
-    R2.info(`Check status: curl http://127.0.0.1:${workerPort}/api/health`);
+    log.warn("Health check timed out. The worker might need more time to initialize.");
+    log.info(`Check status: curl http://127.0.0.1:${workerPort}/api/health`);
   }
 }
 
 // src/steps/complete.ts
-var import_picocolors8 = __toESM(require_picocolors(), 1);
+var import_picocolors6 = __toESM(require_picocolors(), 1);
 function getProviderLabel(config) {
   switch (config.provider) {
     case "claude":
@@ -2060,13 +2406,13 @@ function getIDELabels(ides) {
 }
 function runCompletion(providerConfig, settingsConfig, selectedIDEs) {
   const summaryLines = [
-    `Provider:   ${import_picocolors8.default.cyan(getProviderLabel(providerConfig))}`,
-    `IDEs:       ${import_picocolors8.default.cyan(getIDELabels(selectedIDEs))}`,
-    `Data dir:   ${import_picocolors8.default.cyan(settingsConfig.dataDir)}`,
-    `Port:       ${import_picocolors8.default.cyan(settingsConfig.workerPort)}`,
-    `Chroma:     ${settingsConfig.chromaEnabled ? import_picocolors8.default.green("enabled") : import_picocolors8.default.dim("disabled")}`
+    `Provider:   ${import_picocolors6.default.cyan(getProviderLabel(providerConfig))}`,
+    `IDEs:       ${import_picocolors6.default.cyan(getIDELabels(selectedIDEs))}`,
+    `Data dir:   ${import_picocolors6.default.cyan(settingsConfig.dataDir)}`,
+    `Port:       ${import_picocolors6.default.cyan(settingsConfig.workerPort)}`,
+    `Chroma:     ${settingsConfig.chromaEnabled ? import_picocolors6.default.green("enabled") : import_picocolors6.default.dim("disabled")}`
   ];
-  Ve(summaryLines.join("\n"), "Configuration Summary");
+  note(summaryLines.join("\n"), "Configuration Summary");
   const nextStepsLines = [];
   if (selectedIDEs.includes("claude-code")) {
     nextStepsLines.push("Open Claude Code and start a conversation \u2014 memory is automatic!");
@@ -2074,10 +2420,111 @@ function runCompletion(providerConfig, settingsConfig, selectedIDEs) {
   if (selectedIDEs.includes("cursor")) {
     nextStepsLines.push("Open Cursor \u2014 hooks are active in your projects.");
   }
-  nextStepsLines.push(`View your memories: ${import_picocolors8.default.underline(`http://localhost:${settingsConfig.workerPort}`)}`);
-  nextStepsLines.push(`Search past work: use ${import_picocolors8.default.bold("/mem-search")} in Claude Code`);
-  Ve(nextStepsLines.join("\n"), "Next Steps");
-  Le(import_picocolors8.default.green("claude-mem installed successfully!"));
+  nextStepsLines.push(`View your memories: ${import_picocolors6.default.underline(`http://localhost:${settingsConfig.workerPort}`)}`);
+  nextStepsLines.push(`Search past work: use ${import_picocolors6.default.bold("/mem-search")} in Claude Code`);
+  note(nextStepsLines.join("\n"), "Next Steps");
+  outro(import_picocolors6.default.green("claude-mem installed successfully!"));
+}
+
+// src/steps/uninstall.ts
+var import_picocolors7 = __toESM(require_picocolors(), 1);
+import { execSync as execSync4 } from "child_process";
+import { existsSync as existsSync5, readFileSync as readFileSync3, writeFileSync as writeFileSync3, rmSync } from "fs";
+import { join as join5 } from "path";
+import { homedir as homedir5 } from "os";
+var MARKETPLACE_DIR3 = join5(homedir5(), ".claude", "plugins", "marketplaces", "thedotmack");
+var PLUGINS_DIR2 = join5(homedir5(), ".claude", "plugins");
+var PLUGIN_CACHE_DIR = join5(PLUGINS_DIR2, "cache", "thedotmack");
+var CLAUDE_SETTINGS_PATH2 = join5(homedir5(), ".claude", "settings.json");
+var DATA_DIR = expandHome("~/.claude-mem");
+var BUN_EXTRA_PATHS2 = ["~/.bun/bin/bun", "/usr/local/bin/bun", "/opt/homebrew/bin/bun"];
+function readJsonFile2(filepath) {
+  if (!existsSync5(filepath)) return {};
+  return JSON.parse(readFileSync3(filepath, "utf-8"));
+}
+function writeJsonFile2(filepath, data) {
+  writeFileSync3(filepath, JSON.stringify(data, null, 2) + "\n", "utf-8");
+}
+function stopWorker() {
+  const workerScript = join5(MARKETPLACE_DIR3, "plugin", "scripts", "worker-service.cjs");
+  if (!existsSync5(workerScript)) return;
+  const bunInfo = findBinary("bun", BUN_EXTRA_PATHS2);
+  if (!bunInfo.found || !bunInfo.path) return;
+  try {
+    execSync4(`"${bunInfo.path}" "${workerScript}" stop`, { stdio: "pipe" });
+  } catch {
+  }
+}
+function disablePluginInClaudeSettings() {
+  if (!existsSync5(CLAUDE_SETTINGS_PATH2)) return;
+  const settings2 = readJsonFile2(CLAUDE_SETTINGS_PATH2);
+  if (settings2.enabledPlugins && "claude-mem@thedotmack" in settings2.enabledPlugins) {
+    delete settings2.enabledPlugins["claude-mem@thedotmack"];
+    writeJsonFile2(CLAUDE_SETTINGS_PATH2, settings2);
+  }
+}
+function unregisterPlugin() {
+  const installedPluginsPath = join5(PLUGINS_DIR2, "installed_plugins.json");
+  if (existsSync5(installedPluginsPath)) {
+    const installedPlugins = readJsonFile2(installedPluginsPath);
+    if (installedPlugins.plugins && "claude-mem@thedotmack" in installedPlugins.plugins) {
+      delete installedPlugins.plugins["claude-mem@thedotmack"];
+      writeJsonFile2(installedPluginsPath, installedPlugins);
+    }
+  }
+  const knownMarketplacesPath = join5(PLUGINS_DIR2, "known_marketplaces.json");
+  if (existsSync5(knownMarketplacesPath)) {
+    const knownMarketplaces = readJsonFile2(knownMarketplacesPath);
+    if ("thedotmack" in knownMarketplaces) {
+      delete knownMarketplaces["thedotmack"];
+      writeJsonFile2(knownMarketplacesPath, knownMarketplaces);
+    }
+  }
+}
+function removeDir(dir) {
+  if (existsSync5(dir)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+async function runUninstall() {
+  const confirmed = await confirm({
+    message: "This will remove the claude-mem plugin from Claude Code. Continue?",
+    initialValue: false
+  });
+  if (isCancel(confirmed) || !confirmed) {
+    cancel("Uninstall cancelled.");
+    process.exit(0);
+  }
+  let deleteData = false;
+  if (existsSync5(DATA_DIR)) {
+    const answer = await confirm({
+      message: `Also delete all stored memories and settings at ${import_picocolors7.default.dim(DATA_DIR)}? This cannot be undone.`,
+      initialValue: false
+    });
+    if (isCancel(answer)) {
+      cancel("Uninstall cancelled.");
+      process.exit(0);
+    }
+    deleteData = answer;
+  }
+  const s = spinner();
+  s.start("Stopping worker service...");
+  stopWorker();
+  s.stop(`Worker stopped ${import_picocolors7.default.green("OK")}`);
+  s.start("Removing plugin from Claude Code...");
+  disablePluginInClaudeSettings();
+  unregisterPlugin();
+  removeDir(MARKETPLACE_DIR3);
+  removeDir(PLUGIN_CACHE_DIR);
+  s.stop(`Plugin removed ${import_picocolors7.default.green("OK")}`);
+  if (deleteData) {
+    s.start("Deleting stored memories...");
+    removeDir(DATA_DIR);
+    s.stop(`Memories deleted ${import_picocolors7.default.green("OK")}`);
+  } else {
+    log.info(`Stored memories kept at ${import_picocolors7.default.dim(DATA_DIR)}`);
+  }
+  outro(import_picocolors7.default.green("claude-mem has been uninstalled. Restart Claude Code to finish."));
 }
 
 // src/index.ts
@@ -2088,12 +2535,16 @@ async function runInstaller() {
     process.exit(1);
   }
   const installMode = await runWelcome();
+  if (installMode === "uninstall") {
+    await runUninstall();
+    return;
+  }
   await runDependencyChecks();
   const selectedIDEs = await runIdeSelection();
   const providerConfig = await runProviderConfiguration();
   const settingsConfig = await runSettingsConfiguration();
   writeSettings(providerConfig, settingsConfig);
-  R2.success("Settings saved.");
+  log.success("Settings saved.");
   if (installMode !== "configure") {
     await runInstallation(selectedIDEs);
     await runWorkerStartup(settingsConfig.workerPort, settingsConfig.dataDir);
@@ -2101,7 +2552,7 @@ async function runInstaller() {
   runCompletion(providerConfig, settingsConfig, selectedIDEs);
 }
 runInstaller().catch((error) => {
-  Ne("Installation failed.");
+  cancel("Installation failed.");
   console.error(error);
   process.exit(1);
 });

--- a/installer/src/index.ts
+++ b/installer/src/index.ts
@@ -8,6 +8,7 @@ import { writeSettings } from './utils/settings-writer.js';
 import { runInstallation } from './steps/install.js';
 import { runWorkerStartup } from './steps/worker.js';
 import { runCompletion } from './steps/complete.js';
+import { runUninstall } from './steps/uninstall.js';
 
 async function runInstaller(): Promise<void> {
   if (!process.stdin.isTTY) {
@@ -17,6 +18,12 @@ async function runInstaller(): Promise<void> {
   }
 
   const installMode = await runWelcome();
+
+  // Uninstall is a self-contained flow — skip dependency checks and config.
+  if (installMode === 'uninstall') {
+    await runUninstall();
+    return;
+  }
 
   // Dependency checks (all modes)
   await runDependencyChecks();

--- a/installer/src/steps/uninstall.ts
+++ b/installer/src/steps/uninstall.ts
@@ -1,0 +1,134 @@
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import { execSync } from 'child_process';
+import { existsSync, readFileSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { expandHome } from '../utils/system.js';
+import { findBinary } from '../utils/dependencies.js';
+
+const MARKETPLACE_DIR = join(homedir(), '.claude', 'plugins', 'marketplaces', 'thedotmack');
+const PLUGINS_DIR = join(homedir(), '.claude', 'plugins');
+const PLUGIN_CACHE_DIR = join(PLUGINS_DIR, 'cache', 'thedotmack');
+const CLAUDE_SETTINGS_PATH = join(homedir(), '.claude', 'settings.json');
+const DATA_DIR = expandHome('~/.claude-mem');
+
+const BUN_EXTRA_PATHS = ['~/.bun/bin/bun', '/usr/local/bin/bun', '/opt/homebrew/bin/bun'];
+
+function readJsonFile(filepath: string): any {
+  if (!existsSync(filepath)) return {};
+  return JSON.parse(readFileSync(filepath, 'utf-8'));
+}
+
+function writeJsonFile(filepath: string, data: any): void {
+  writeFileSync(filepath, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+}
+
+/**
+ * Stop the running worker so file handles (and the port) are released before
+ * we delete the plugin directory. Best-effort — failures are non-fatal.
+ */
+function stopWorker(): void {
+  const workerScript = join(MARKETPLACE_DIR, 'plugin', 'scripts', 'worker-service.cjs');
+  if (!existsSync(workerScript)) return;
+
+  const bunInfo = findBinary('bun', BUN_EXTRA_PATHS);
+  if (!bunInfo.found || !bunInfo.path) return;
+
+  try {
+    execSync(`"${bunInfo.path}" "${workerScript}" stop`, { stdio: 'pipe' });
+  } catch {
+    // Worker may already be stopped — ignore.
+  }
+}
+
+/**
+ * Remove the plugin entry from ~/.claude/settings.json enabledPlugins.
+ */
+function disablePluginInClaudeSettings(): void {
+  if (!existsSync(CLAUDE_SETTINGS_PATH)) return;
+  const settings = readJsonFile(CLAUDE_SETTINGS_PATH);
+  if (settings.enabledPlugins && 'claude-mem@thedotmack' in settings.enabledPlugins) {
+    delete settings.enabledPlugins['claude-mem@thedotmack'];
+    writeJsonFile(CLAUDE_SETTINGS_PATH, settings);
+  }
+}
+
+/**
+ * Unregister the plugin and marketplace from Claude Code's registries.
+ */
+function unregisterPlugin(): void {
+  const installedPluginsPath = join(PLUGINS_DIR, 'installed_plugins.json');
+  if (existsSync(installedPluginsPath)) {
+    const installedPlugins = readJsonFile(installedPluginsPath);
+    if (installedPlugins.plugins && 'claude-mem@thedotmack' in installedPlugins.plugins) {
+      delete installedPlugins.plugins['claude-mem@thedotmack'];
+      writeJsonFile(installedPluginsPath, installedPlugins);
+    }
+  }
+
+  const knownMarketplacesPath = join(PLUGINS_DIR, 'known_marketplaces.json');
+  if (existsSync(knownMarketplacesPath)) {
+    const knownMarketplaces = readJsonFile(knownMarketplacesPath);
+    if ('thedotmack' in knownMarketplaces) {
+      delete knownMarketplaces['thedotmack'];
+      writeJsonFile(knownMarketplacesPath, knownMarketplaces);
+    }
+  }
+}
+
+function removeDir(dir: string): void {
+  if (existsSync(dir)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+export async function runUninstall(): Promise<void> {
+  const confirmed = await p.confirm({
+    message: 'This will remove the claude-mem plugin from Claude Code. Continue?',
+    initialValue: false,
+  });
+
+  if (p.isCancel(confirmed) || !confirmed) {
+    p.cancel('Uninstall cancelled.');
+    process.exit(0);
+  }
+
+  // Ask up front whether to also delete stored memories, so the whole run is
+  // unattended after this point.
+  let deleteData = false;
+  if (existsSync(DATA_DIR)) {
+    const answer = await p.confirm({
+      message: `Also delete all stored memories and settings at ${pc.dim(DATA_DIR)}? This cannot be undone.`,
+      initialValue: false,
+    });
+    if (p.isCancel(answer)) {
+      p.cancel('Uninstall cancelled.');
+      process.exit(0);
+    }
+    deleteData = answer;
+  }
+
+  const s = p.spinner();
+
+  s.start('Stopping worker service...');
+  stopWorker();
+  s.stop(`Worker stopped ${pc.green('OK')}`);
+
+  s.start('Removing plugin from Claude Code...');
+  disablePluginInClaudeSettings();
+  unregisterPlugin();
+  removeDir(MARKETPLACE_DIR);
+  removeDir(PLUGIN_CACHE_DIR);
+  s.stop(`Plugin removed ${pc.green('OK')}`);
+
+  if (deleteData) {
+    s.start('Deleting stored memories...');
+    removeDir(DATA_DIR);
+    s.stop(`Memories deleted ${pc.green('OK')}`);
+  } else {
+    p.log.info(`Stored memories kept at ${pc.dim(DATA_DIR)}`);
+  }
+
+  p.outro(pc.green('claude-mem has been uninstalled. Restart Claude Code to finish.'));
+}

--- a/installer/src/steps/welcome.ts
+++ b/installer/src/steps/welcome.ts
@@ -3,7 +3,7 @@ import pc from 'picocolors';
 import { existsSync } from 'fs';
 import { expandHome } from '../utils/system.js';
 
-export type InstallMode = 'fresh' | 'upgrade' | 'configure';
+export type InstallMode = 'fresh' | 'upgrade' | 'configure' | 'uninstall';
 
 export async function runWelcome(): Promise<InstallMode> {
   p.intro(pc.bgCyan(pc.black(' claude-mem installer ')));
@@ -27,6 +27,7 @@ export async function runWelcome(): Promise<InstallMode> {
           { value: 'upgrade' as const, label: 'Upgrade', hint: 'update to latest version' },
           { value: 'configure' as const, label: 'Configure', hint: 'change settings only' },
           { value: 'fresh' as const, label: 'Fresh Install', hint: 'reinstall from scratch' },
+          { value: 'uninstall' as const, label: 'Uninstall', hint: 'remove claude-mem' },
         ]
       : [
           { value: 'fresh' as const, label: 'Fresh Install', hint: 'recommended' },


### PR DESCRIPTION
## Summary
Installer-only changes (split out from #2923).

- **`build.mjs`** now sets the execute bit on `dist/index.js`, so the shebang'd bin works via `npx`/direct invocation (esbuild does not set it). This was the likely cause of the installer "not launching".
- Added an **Uninstall** option to the welcome menu (shown when claude-mem is already installed).
- New **uninstall step** (`src/steps/uninstall.ts`): stops the worker, removes the plugin from Claude Code's `settings.json` / `installed_plugins.json` / `known_marketplaces.json`, deletes the marketplace + cache directories, and optionally deletes `~/.claude-mem` memories (opt-in, defaults to keeping them).

## Verification
- Installer typechecks and builds; `dist/index.js` is now `-rwxr-xr-x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)