### PR TITLE
fix(context): guard against NaN config values that silently truncate output

### DIFF
--- a/src/services/context/ContextConfigLoader.ts
+++ b/src/services/context/ContextConfigLoader.ts
@@ -4,6 +4,27 @@ import { paths } from '../../shared/paths.js';
 import { ModeManager } from '../domain/ModeManager.js';
 import type { ContextConfig } from './types.js';
 
+// Mirrors SettingsDefaultsManager.DEFAULTS for the three numeric context
+// fields. Kept here as the last-line-of-defense default so a corrupted
+// settings.json (manual edits writing null / "" / non-numeric strings) can't
+// surface NaN downstream — see asInt below for why that matters.
+const FALLBACK_TOTAL_OBSERVATION_COUNT = 50;
+const FALLBACK_FULL_OBSERVATION_COUNT = 0;
+const FALLBACK_SESSION_COUNT = 10;
+
+// parseInt('', 10) and parseInt(undefined as any, 10) both return NaN.
+// SettingsDefaultsManager.loadFromFile guarantees these keys exist under
+// the happy path, but a settings.json edited by hand or written by a
+// pre-migration tool can carry null / "" / non-numeric values; the spread
+// in SettingsDefaultsManager that overlays user values then copies the
+// bad type over the string default. NaN flows from here into SQL LIMIT
+// bindings and Array.prototype.slice indices, which Postgres rejects and
+// JS silently coerces to empty results — a silent context truncation.
+function asInt(value: unknown, fallback: number): number {
+  const parsed = parseInt(String(value ?? ''), 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
 export function loadContextConfig(): ContextConfig {
   const settingsPath = paths.settings();
   const settings = SettingsDefaultsManager.loadFromFile(settingsPath);
@@ -13,9 +34,15 @@ export function loadContextConfig(): ContextConfig {
   const observationConcepts = new Set(mode.observation_concepts.map(c => c.id));
 
   return {
-    totalObservationCount: parseInt(settings.CLAUDE_MEM_CONTEXT_OBSERVATIONS, 10),
-    fullObservationCount: parseInt(settings.CLAUDE_MEM_CONTEXT_FULL_COUNT, 10),
-    sessionCount: parseInt(settings.CLAUDE_MEM_CONTEXT_SESSION_COUNT, 10),
+    totalObservationCount: asInt(
+      settings.CLAUDE_MEM_CONTEXT_OBSERVATIONS,
+      FALLBACK_TOTAL_OBSERVATION_COUNT,
+    ),
+    fullObservationCount: asInt(
+      settings.CLAUDE_MEM_CONTEXT_FULL_COUNT,
+      FALLBACK_FULL_OBSERVATION_COUNT,
+    ),
+    sessionCount: asInt(settings.CLAUDE_MEM_CONTEXT_SESSION_COUNT, FALLBACK_SESSION_COUNT),
     showReadTokens: settings.CLAUDE_MEM_CONTEXT_SHOW_READ_TOKENS === 'true',
     showWorkTokens: settings.CLAUDE_MEM_CONTEXT_SHOW_WORK_TOKENS === 'true',
     showSavingsAmount: settings.CLAUDE_MEM_CONTEXT_SHOW_SAVINGS_AMOUNT === 'true',


### PR DESCRIPTION
## Bug

`loadContextConfig` calls `parseInt` directly on settings values and flows the result into `ContextConfig` with no validation. `parseInt('', 10)` and `parseInt(undefined as any, 10)` both return `NaN`. NaN then propagates downstream:

- **SQL** — `LIMIT NaN` is rejected by Postgres (`error: invalid input syntax`). Some drivers coerce silently and return zero rows.
- **JS** — `Array.prototype.slice(0, NaN)` returns `[]`. The context renderer silently produces an empty payload with no error or log.

## Why this can happen even with defaults

`SettingsDefaultsManager` does guarantee these keys exist on the happy path, but a `settings.json` edited by hand, written by a pre-migration tool, or left from an old install can carry `null` / `""` / non-numeric values. The spread in `SettingsDefaultsManager.loadFromFile` (around line 236-240) overlays user values onto string defaults using `result[key] = ...`, which is type-unaware — so a `null` in the file overrides the `'50'` default.

End-user-visible symptom: context payload silently truncates to nothing. No log, no error, just an empty context.

## Fix

Add a small `asInt(value, fallback)` helper that returns the fallback on NaN or negative numbers, and use it for the three numeric context fields. Fallback constants mirror `SettingsDefaultsManager.DEFAULTS` so behavior is unchanged on the happy path.

## How this was found

AntFleet two-model review on `bench-claude-mem` — Claude Opus 4.7 and GPT-5 unanimously flagged this:
- https://github.com/AntFleet/bench-claude-mem/pull/4#issuecomment-4700599745

## Test plan

- [ ] Hand-test: write `~/.claude-mem/settings.json` with `{"CLAUDE_MEM_CONTEXT_OBSERVATIONS": null}`, call `loadContextConfig`, confirm `totalObservationCount === 50` (the fallback) instead of `NaN`
- [ ] Existing tests pass (no behavior change on the happy path)
