### PR TITLE
fix(opencode-plugin): add platformSource identifier to all observations

### DIFF
--- a/src/integrations/opencode-plugin/index.ts
+++ b/src/integrations/opencode-plugin/index.ts
@@ -197,6 +197,7 @@ export const ClaudeMemPlugin = async (ctx: OpenCodePluginContext) => {
       const contentSessionId = ensureSessionInitialized(input.sessionID, projectName);
       workerPostFireAndForget("/api/sessions/observations", {
         contentSessionId,
+        platformSource: 'opencode',
         tool_name: input.tool,
         tool_input: output.args || {},
         tool_response: truncate(output.output || ""),
@@ -222,6 +223,7 @@ export const ClaudeMemPlugin = async (ctx: OpenCodePluginContext) => {
 
       workerPostFireAndForget("/api/sessions/observations", {
         contentSessionId,
+        platformSource: 'opencode',
         tool_name: "assistant_message",
         tool_input: {},
         tool_response: truncate(messageText),
@@ -237,6 +239,7 @@ export const ClaudeMemPlugin = async (ctx: OpenCodePluginContext) => {
       const contentSessionId = ensureSessionInitialized(input.sessionID, projectName);
       workerPostFireAndForget("/api/sessions/summarize", {
         contentSessionId,
+        platformSource: 'opencode',
         last_assistant_message: "",
       });
     },
@@ -254,6 +257,7 @@ export const ClaudeMemPlugin = async (ctx: OpenCodePluginContext) => {
           const contentSessionId = ensureSessionInitialized(sessionID, projectName);
           workerPostFireAndForget("/api/sessions/summarize", {
             contentSessionId,
+            platformSource: 'opencode',
             last_assistant_message: "",
           });
           break;


### PR DESCRIPTION
OpenCode observations were being captured but marked as 'claude' by default, making them invisible in the viewer when selecting 'opencode' as the platform source. Add platformSource: 'opencode' to all observation and summary POSTs.

Fixes:
- tool.execute.after observations now tagged with platformSource
- chat.message observations now tagged with platformSource
- experimental.session.compacting summaries now tagged with platformSource
- session.idle summaries now tagged with platformSource

Result: OpenCode observations now visible in web viewer and properly filtered by platform source.

Test:
- Capture observation in OpenCode
- View in http://localhost:37777
- Select 'opencode' in platform source dropdown
- Observation should be visible