### PR TITLE
fix: use @ instead of == for chroma-mcp version pinning with uvx

### DIFF
--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -1,4 +1,3 @@
-
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { execFile, execSync, type ChildProcess } from 'child_process';
@@ -215,7 +214,7 @@ export class ChromaMcpManager {
       const args = [
         '--python', pythonVersion,
         ...depOverrideFlags,
-        `chroma-mcp==${CHROMA_MCP_PINNED_VERSION}`,
+        `chroma-mcp@${CHROMA_MCP_PINNED_VERSION}`,
         '--client-type', 'http',
         '--host', chromaHost,
         '--port', chromaPort
@@ -241,7 +240,7 @@ export class ChromaMcpManager {
     return [
       '--python', pythonVersion,
       ...depOverrideFlags,
-      `chroma-mcp==${CHROMA_MCP_PINNED_VERSION}`,
+      `chroma-mcp@${CHROMA_MCP_PINNED_VERSION}`,
       '--client-type', 'persistent',
       '--data-dir', DEFAULT_CHROMA_DATA_DIR.replace(/\\/g, '/')
     ];


### PR DESCRIPTION
uvx (uv's script runner) only supports @ syntax for version pinning (e.g. chroma-mcp@0.2.6), not pip-style ==. The == characters are parsed as part of the package name, causing uvx to reject the command with "Not a valid package or extra name", which results in MCP error -32000, 10s backoff, and permanent fallback to FTS5 keyword search.

Fixes #2939