### PR TITLE
fix(worker): stop respawning sessions on benign "nothing to record" output

### DIFF
--- a/src/sdk/output-classifier.ts
+++ b/src/sdk/output-classifier.ts
@@ -31,6 +31,21 @@ const POISONED_MARKERS: string[] = [
   'this session has ended',
 ];
 
+// Benign "nothing to record" phrases the SDK emits as plain prose instead of
+// <skip_summary/>. They mean the batch had no memory-worthy content — a healthy
+// outcome — so they must be treated as idle, never as a wedge that accumulates
+// toward a respawn. Kept lowercase; matched case-insensitively against the raw
+// output.
+const BENIGN_SKIP_MARKERS: string[] = [
+  'no observations to record',
+  'nothing to record',
+  'no observations to make',
+  'nothing to summarize',
+  'no summary needed',
+  'nothing worth recording',
+  'no memory-worthy',
+];
+
 /**
  * Returns a short, single-line preview of raw output for diagnostics/logging so
  * a dropped batch is visible instead of silent.
@@ -52,7 +67,8 @@ export function previewOutput(raw: unknown, maxLength: number = PREVIEW_LENGTH):
  * - `xml`      — contains a parseable `<observation>`/`<summary>`/`<skip_summary/>`
  *                root tag. (Whether it ultimately yields rows is parseAgentXml's
  *                job; this is the structural gate.)
- * - `idle`     — empty / whitespace-only. Benign: the SDK had nothing to say.
+ * - `idle`     — empty / whitespace-only, or a plain-prose "nothing to record"
+ *                skip. Benign: the SDK had nothing memory-worthy to say.
  * - `poisoned` — a known "session exhausted"/closure string. Recover by killing
  *                and respawning the SDK session.
  * - `prose`    — any other non-XML text. Conversational output; not persisted.
@@ -74,6 +90,14 @@ export function classifyObserverOutput(raw: unknown): ObserverOutputClass {
 
   if (/<(observation|summary)\b/i.test(raw) || /<skip_summary\b/i.test(raw)) {
     return 'xml';
+  }
+
+  // A "nothing to record" answer in plain prose is a benign skip, not a wedge:
+  // classify it as idle so it never counts toward the respawn threshold.
+  for (const marker of BENIGN_SKIP_MARKERS) {
+    if (lower.includes(marker)) {
+      return 'idle';
+    }
   }
 
   return 'prose';

--- a/src/services/worker/agents/ResponseProcessor.ts
+++ b/src/services/worker/agents/ResponseProcessor.ts
@@ -19,8 +19,9 @@ import { captureEvent } from '../../telemetry/telemetry.js';
 
 /**
  * Consecutive non-XML observer outputs tolerated before we kill and respawn the
- * SDK session (plan-11, #2485). Idle and prose both count; poisoned triggers an
- * immediate respawn regardless of the count.
+ * SDK session (plan-11, #2485). Only prose counts toward the threshold; idle is
+ * benign ("nothing to record") and never counts; poisoned triggers an immediate
+ * respawn regardless of the count.
  */
 export const INVALID_OUTPUT_RESPAWN_THRESHOLD = 3;
 
@@ -58,7 +59,14 @@ export async function processAgentResponse(
     const outputClass = classifyObserverOutput(text);
     const preview = previewOutput(text);
 
-    session.consecutiveInvalidOutputs = (session.consecutiveInvalidOutputs ?? 0) + 1;
+    // Idle is benign (empty / "nothing to record"): a healthy session with no
+    // memory-worthy content must NOT accumulate toward a kill/respawn. Only
+    // prose (a possible wedge) increments; poisoned respawns immediately below.
+    if (outputClass === 'idle') {
+      session.consecutiveInvalidOutputs = session.consecutiveInvalidOutputs ?? 0;
+    } else {
+      session.consecutiveInvalidOutputs = (session.consecutiveInvalidOutputs ?? 0) + 1;
+    }
 
     logger.warn('PARSER', `${agentName} returned non-XML ${outputClass} response — ignoring queued batch`, {
       sessionId: session.sessionDbId,

--- a/tests/sdk/output-classifier.test.ts
+++ b/tests/sdk/output-classifier.test.ts
@@ -35,6 +35,12 @@ describe('classifyObserverOutput (plan-11 #2485)', () => {
     expect(classifyObserverOutput('Skipping — repeated log scan with no new findings.')).toBe('prose');
   });
 
+  it('classifies a plain-prose "nothing to record" skip as idle (benign)', () => {
+    expect(classifyObserverOutput('No observations to record.')).toBe('idle');
+    expect(classifyObserverOutput('Nothing to record for this batch.')).toBe('idle');
+    expect(classifyObserverOutput('No summary needed.')).toBe('idle');
+  });
+
   it('classifies "session exhausted" closure string as poisoned', () => {
     expect(classifyObserverOutput('This session has been exhausted, I cannot continue.')).toBe('poisoned');
   });

--- a/tests/worker/poison-respawn.test.ts
+++ b/tests/worker/poison-respawn.test.ts
@@ -140,6 +140,29 @@ describe('poison respawn (plan-11 #2485)', () => {
     expect(respawnSpy).toHaveBeenCalledWith(2);
   });
 
+  it('never respawns on benign idle / "nothing to record" outputs, no matter how many', async () => {
+    const sm = new SessionManager(makeDbManager());
+    const session = sm.initializeSession(4, 'do the thing', 1);
+    session.memorySessionId = 'mem-4';
+    await sm.queueObservation(4, {
+      tool_name: 'Read', tool_input: {}, tool_response: {}, prompt_number: 1, toolUseId: 'tu-b',
+    });
+
+    const respawnSpy = spyOn(sm, 'respawnPoisonedSession');
+
+    // Far more than the threshold: a healthy session with nothing memory-worthy
+    // must keep returning benign skips without ever being killed/respawned.
+    for (let i = 0; i < INVALID_OUTPUT_RESPAWN_THRESHOLD + 3; i++) {
+      await processAgentResponse(
+        i % 2 === 0 ? 'No observations to record.' : '',
+        session, makeDbManager(), sm, mockWorker, 0, null, 'TestAgent'
+      );
+    }
+
+    expect(respawnSpy).not.toHaveBeenCalled();
+    expect(session.consecutiveInvalidOutputs).toBe(0);
+  });
+
   it('respawnPoisonedSession preserves the buffer and resets context', async () => {
     const sm = new SessionManager(makeDbManager());
     const session = sm.initializeSession(3, 'do the thing', 1);


### PR DESCRIPTION
## Problem

A healthy observer session that legitimately has **no memory-worthy content** answers with empty/idle output or plain prose such as `No observations to record.`

In `ResponseProcessor.processAgentResponse`, *every* non-XML output — `idle` **and** `prose` alike — incremented `consecutiveInvalidOutputs`. After 3 such benign responses the session was classified as `poisoned`, killed and respawned. On a session that keeps having nothing to record this becomes a kill/respawn loop that saturates the worker and surfaces to hooks as repeated **"worker unreachable"**.

Observed in the wild:
```
[PARSER] SDK returned non-XML idle  ... consecutiveInvalidOutputs=1
[PARSER] SDK returned non-XML prose ... consecutiveInvalidOutputs=2   preview="No observations to record."
[SESSION] SDK session poisoned — killing and respawning ... threshold=3
[SDK_SPAWN] child emitted error event ... AbortError
```

This contradicts the classifier's own documented intent (plan-11 #2485): *"avoid respawn churn on benign idle output, and trigger recovery on a poisoned session."*

## Fix

- **`output-classifier.ts`** — recognize plain-prose "nothing to record" skips (`no observations to record`, `nothing to summarize`, `no summary needed`, …) as the existing benign `idle` class instead of `prose`. The SDK sometimes answers in prose instead of emitting `<skip_summary/>`.
- **`ResponseProcessor.ts`** — `idle` no longer counts toward the respawn threshold. Only `prose` (a possible wedge) accumulates; `poisoned` still respawns immediately. This realigns the code with the classifier's documented intent.

Genuine conversational prose and real `poisoned` closure strings are unaffected — the wedge protection is preserved.

## Tests

- `tests/sdk/output-classifier.test.ts` — benign-skip prose classifies as `idle`.
- `tests/worker/poison-respawn.test.ts` — repeated idle / "nothing to record" outputs never trigger a respawn, regardless of count.

Both suites pass (`bun test` — 18/18 on the two affected files).

> Note: only source + tests are included; rebuilt `plugin/scripts/*.cjs` bundles are intentionally omitted (esbuild reorders the bundle, producing hundreds of lines of unrelated churn).