### PR TITLE
fix(windows): hide cmd window in `where bun` spawnSync (findBun)

### DIFF
--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -25,7 +25,8 @@ function findBun() {
     ? spawnSync('where bun', {
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
-        shell: true
+        shell: true,
+        windowsHide: true
       })
     : spawnSync('which', ['bun'], {
         encoding: 'utf-8',

--- a/plugin/scripts/version-check.js
+++ b/plugin/scripts/version-check.js
@@ -13,7 +13,7 @@ const NODE_MODULES_DIRNAME = 'node_modules';
 
 function findBun() {
   const pathCheck = IS_WINDOWS
-    ? spawnSync('where bun', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], shell: true })
+    ? spawnSync('where bun', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], shell: true, windowsHide: true })
     : spawnSync('which', ['bun'], { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
 
   if (pathCheck.status === 0 && pathCheck.stdout.trim()) {


### PR DESCRIPTION
## Problem

On Windows, `findBun()` in both `plugin/scripts/bun-runner.js` and `plugin/scripts/version-check.js` resolves Bun with:

```js
spawnSync('where bun', { encoding: 'utf-8', stdio: ['pipe','pipe','pipe'], shell: true })
```

With `shell: true` and no `windowsHide`, Node launches `cmd.exe /c where bun`, which **flashes a visible console window**. Because `bun-runner.js` runs on every hook event (SessionStart, UserPromptSubmit, PostToolUse on Write/Edit, Stop), users see constant window blinking during normal Claude Code use.

This is the same class of issue tracked around #2708 / the Windows spawn surfaces — this PR fixes the two `where bun` lookups specifically.

## Fix

Add `windowsHide: true` to both `where bun` `spawnSync` calls.

- The main `spawn` in `bun-runner.js` and `codexSpawn` in `CodexCliInstaller.ts` already pass `windowsHide: true` — these two lookups were the remaining surfaces that escaped it.
- POSIX `which` path is untouched (no shell, no window).

## Test

`tests/bun-runner.test.ts` asserts `source.toContain("spawnSync('where bun'")` — still satisfied (the call signature is unchanged apart from the added option).

🤖 Generated with [Claude Code](https://claude.com/claude-code)