### PR TITLE
fix: install Windows Claude Code hooks without bash

### DIFF
--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -238,11 +238,12 @@ child.on('error', (err) => {
 });
 
 child.on('close', (code, signal) => {
-  if (shouldEmitHookContinueJson && !signal && (code ?? 0) === 0) {
+  const exitCode = typeof code === 'number' ? code : 0;
+  if (shouldEmitHookContinueJson && !signal && exitCode === 0) {
     process.stdout.write('{"continue":true,"suppressOutput":true}\n');
   }
   if ((signal || code > 128) && args.includes('start')) {
     process.exit(0);
   }
-  process.exit(code || 0);
+  process.exit(exitCode);
 });

--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -135,7 +135,7 @@ function collectStdin() {
 const stdinData = await collectStdin();
 
 const spawnOptions = {
-  stdio: ['pipe', 'inherit', 'inherit'],
+  stdio: ['pipe', shouldEmitHookContinueJson ? 'ignore' : 'inherit', 'inherit'],
   windowsHide: true,
   env: process.env
 };

--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -25,6 +25,7 @@ function findBun() {
     ? spawnSync('where bun', {
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
         shell: true
       })
     : spawnSync('which', ['bun'], {
@@ -85,6 +86,12 @@ if (isPluginDisabledInClaudeSettings()) {
 }
 
 const args = process.argv.slice(2);
+
+let shouldEmitHookContinueJson = false;
+if (args[0] === '--hook-continue-json') {
+  shouldEmitHookContinueJson = true;
+  args.shift();
+}
 
 if (args.length === 0) {
   console.error('Usage: node bun-runner.js <script> [args...]');
@@ -231,6 +238,9 @@ child.on('error', (err) => {
 });
 
 child.on('close', (code, signal) => {
+  if (shouldEmitHookContinueJson && !signal && (code ?? 0) === 0) {
+    process.stdout.write('{"continue":true,"suppressOutput":true}\n');
+  }
   if ((signal || code > 128) && args.includes('start')) {
     process.exit(0);
   }

--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'crypto';
 import { spawnSync } from 'child_process';
 import { loadTelemetryConfig, saveTelemetryConfig } from '../../services/telemetry/consent.js';
 import { captureCliEvent } from '../../services/telemetry/cli-telemetry.js';
+import { rewriteInstalledClaudeCodeHooksForWindows } from '../../services/integrations/ClaudeCodeHooksInstaller.js';
 import { spawnHidden } from '../../shared/spawn.js';
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
@@ -669,6 +670,10 @@ function copyPluginToMarketplace(): void {
       force: true,
     });
   }
+
+  if (IS_WINDOWS) {
+    rewriteInstalledClaudeCodeHooksForWindows(join(marketplaceDir, 'plugin'));
+  }
 }
 
 function copyPluginToCache(version: string): void {
@@ -678,6 +683,10 @@ function copyPluginToCache(version: string): void {
   rmSync(cachePath, { recursive: true, force: true });
   ensureDirectoryExists(cachePath);
   cpSync(sourcePluginDirectory, cachePath, { recursive: true, force: true });
+
+  if (IS_WINDOWS) {
+    rewriteInstalledClaudeCodeHooksForWindows(cachePath);
+  }
 }
 
 /**

--- a/src/services/integrations/ClaudeCodeHooksInstaller.ts
+++ b/src/services/integrations/ClaudeCodeHooksInstaller.ts
@@ -1,0 +1,61 @@
+import { readFileSync, writeFileSync } from 'fs';
+import path from 'path';
+
+interface ClaudeCodeHookCommand {
+  type: 'command';
+  command: string;
+  args?: string[];
+  shell?: string;
+  timeout?: number;
+}
+
+interface ClaudeCodeHookGroup {
+  matcher?: string;
+  hooks: ClaudeCodeHookCommand[];
+}
+
+interface ClaudeCodeHooksJson {
+  description: string;
+  hooks: Record<string, ClaudeCodeHookGroup[]>;
+}
+
+type HookTarget = {
+  event: string;
+  groupIndex: number;
+  hookIndex: number;
+  args: string[];
+};
+
+const WINDOWS_CLAUDE_CODE_HOOKS: HookTarget[] = [
+  { event: 'Setup', groupIndex: 0, hookIndex: 0, args: ['version-check.js'] },
+  { event: 'SessionStart', groupIndex: 0, hookIndex: 0, args: ['bun-runner.js', '--hook-continue-json', 'worker-service.cjs', 'start'] },
+  { event: 'SessionStart', groupIndex: 0, hookIndex: 1, args: ['bun-runner.js', 'worker-service.cjs', 'hook', 'claude-code', 'context'] },
+  { event: 'UserPromptSubmit', groupIndex: 0, hookIndex: 0, args: ['bun-runner.js', 'worker-service.cjs', 'hook', 'claude-code', 'session-init'] },
+  { event: 'PostToolUse', groupIndex: 0, hookIndex: 0, args: ['bun-runner.js', 'worker-service.cjs', 'hook', 'claude-code', 'observation'] },
+  { event: 'PreToolUse', groupIndex: 0, hookIndex: 0, args: ['bun-runner.js', 'worker-service.cjs', 'hook', 'claude-code', 'file-context'] },
+  { event: 'Stop', groupIndex: 0, hookIndex: 0, args: ['bun-runner.js', 'worker-service.cjs', 'hook', 'claude-code', 'summarize'] },
+];
+
+function resolveScriptArgs(pluginRoot: string, relativeArgs: string[]): string[] {
+  return relativeArgs.map((arg) => {
+    if (!arg.endsWith('.js') && !arg.endsWith('.cjs')) return arg;
+    return path.join(pluginRoot, 'scripts', arg);
+  });
+}
+
+export function rewriteInstalledClaudeCodeHooksForWindows(pluginRoot: string, nodePath: string = process.execPath): void {
+  const hooksPath = path.join(pluginRoot, 'hooks', 'hooks.json');
+  const parsed = JSON.parse(readFileSync(hooksPath, 'utf-8')) as ClaudeCodeHooksJson;
+
+  for (const target of WINDOWS_CLAUDE_CODE_HOOKS) {
+    const hook = parsed.hooks?.[target.event]?.[target.groupIndex]?.hooks?.[target.hookIndex];
+    if (!hook) {
+      throw new Error(`Claude Code hook ${target.event}.${target.groupIndex}.${target.hookIndex} missing in ${hooksPath}`);
+    }
+    hook.command = nodePath;
+    hook.args = resolveScriptArgs(pluginRoot, target.args);
+    delete hook.shell;
+  }
+
+  writeFileSync(hooksPath, JSON.stringify(parsed, null, 2) + '\n');
+}

--- a/tests/bun-runner.test.ts
+++ b/tests/bun-runner.test.ts
@@ -15,11 +15,20 @@ describe('bun-runner.js findBun: DEP0190 regression guard (#1503)', () => {
     expect(source).toContain("spawnSync('where bun'");
   });
 
+  it('hides the Windows where-bun probe window', () => {
+    expect(source).toContain('windowsHide: true');
+  });
+
   it('uses no shell option for Unix which-bun lookup', () => {
     const unixCallMatch = source.match(/spawnSync\('which',\s*\['bun'\],\s*\{([^}]+)\}/)
     if (unixCallMatch) {
       expect(unixCallMatch[1]).not.toContain('shell');
     }
     expect(source).toContain("spawnSync('which', ['bun']");
+  });
+
+  it('supports emitting SessionStart continue JSON without a shell wrapper', () => {
+    expect(source).toContain("'--hook-continue-json'");
+    expect(source).toContain("process.stdout.write('{\"continue\":true,\"suppressOutput\":true}\\n')");
   });
 });

--- a/tests/bun-runner.test.ts
+++ b/tests/bun-runner.test.ts
@@ -31,4 +31,8 @@ describe('bun-runner.js findBun: DEP0190 regression guard (#1503)', () => {
     expect(source).toContain("'--hook-continue-json'");
     expect(source).toContain("process.stdout.write('{\"continue\":true,\"suppressOutput\":true}\\n')");
   });
+
+  it('suppresses child stdout when emitting SessionStart continue JSON', () => {
+    expect(source).toContain("stdio: ['pipe', shouldEmitHookContinueJson ? 'ignore' : 'inherit', 'inherit']");
+  });
 });

--- a/tests/claude-code-windows-hooks.test.ts
+++ b/tests/claude-code-windows-hooks.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'bun:test';
+import { cpSync, mkdtempSync, mkdirSync, readFileSync, rmSync } from 'fs';
+import path from 'path';
+import { tmpdir } from 'os';
+import { rewriteInstalledClaudeCodeHooksForWindows } from '../src/services/integrations/ClaudeCodeHooksInstaller.js';
+
+function readHooks(filePath: string) {
+  return JSON.parse(readFileSync(filePath, 'utf-8')) as {
+    hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string; args?: string[]; shell?: string; timeout?: number }> }>>;
+  };
+}
+
+describe('rewriteInstalledClaudeCodeHooksForWindows', () => {
+  it('rewrites the seven Claude Code hooks to exec form while preserving matchers and timeouts', () => {
+    const tempRoot = mkdtempSync(path.join(tmpdir(), 'cm-win-hooks-'));
+    const pluginRoot = path.join(tempRoot, 'plugin');
+    mkdirSync(path.join(pluginRoot, 'hooks'), { recursive: true });
+    cpSync(
+      path.join(import.meta.dir, '..', 'plugin', 'hooks', 'hooks.json'),
+      path.join(pluginRoot, 'hooks', 'hooks.json'),
+    );
+
+    try {
+      rewriteInstalledClaudeCodeHooksForWindows(pluginRoot, 'C:\\Program Files\\nodejs\\node.exe');
+      const hooks = readHooks(path.join(pluginRoot, 'hooks', 'hooks.json')).hooks;
+
+      const setup = hooks.Setup[0].hooks[0];
+      const sessionStartStart = hooks.SessionStart[0].hooks[0];
+      const sessionStartContext = hooks.SessionStart[0].hooks[1];
+      const promptSubmit = hooks.UserPromptSubmit[0].hooks[0];
+      const postToolUse = hooks.PostToolUse[0].hooks[0];
+      const preToolUse = hooks.PreToolUse[0].hooks[0];
+      const stop = hooks.Stop[0].hooks[0];
+
+      expect(hooks.Setup[0].matcher).toBe('*');
+      expect(hooks.SessionStart[0].matcher).toBe('startup|clear|compact');
+      expect(hooks.PostToolUse[0].matcher).toBe('*');
+      expect(hooks.PreToolUse[0].matcher).toBe('Read');
+
+      expect(setup.timeout).toBe(300);
+      expect(sessionStartStart.timeout).toBe(60);
+      expect(postToolUse.timeout).toBe(120);
+      expect(stop.timeout).toBe(120);
+
+      for (const hook of [setup, sessionStartStart, sessionStartContext, promptSubmit, postToolUse, preToolUse, stop]) {
+        expect(hook.command).toBe('C:\\Program Files\\nodejs\\node.exe');
+        expect(hook.shell).toBeUndefined();
+        expect(Array.isArray(hook.args)).toBe(true);
+      }
+
+      expect(setup.args).toEqual([
+        path.join(pluginRoot, 'scripts', 'version-check.js'),
+      ]);
+      expect(sessionStartStart.args).toEqual([
+        path.join(pluginRoot, 'scripts', 'bun-runner.js'),
+        '--hook-continue-json',
+        path.join(pluginRoot, 'scripts', 'worker-service.cjs'),
+        'start',
+      ]);
+      expect(sessionStartContext.args).toEqual([
+        path.join(pluginRoot, 'scripts', 'bun-runner.js'),
+        path.join(pluginRoot, 'scripts', 'worker-service.cjs'),
+        'hook',
+        'claude-code',
+        'context',
+      ]);
+      expect(promptSubmit.args).toEqual([
+        path.join(pluginRoot, 'scripts', 'bun-runner.js'),
+        path.join(pluginRoot, 'scripts', 'worker-service.cjs'),
+        'hook',
+        'claude-code',
+        'session-init',
+      ]);
+      expect(postToolUse.args?.slice(-2)).toEqual(['claude-code', 'observation']);
+      expect(preToolUse.args?.slice(-2)).toEqual(['claude-code', 'file-context']);
+      expect(stop.args?.slice(-2)).toEqual(['claude-code', 'summarize']);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('is wired into both marketplace and cache install roots', () => {
+    const installSource = readFileSync(
+      path.join(import.meta.dir, '..', 'src', 'npx-cli', 'commands', 'install.ts'),
+      'utf-8',
+    );
+
+    expect(installSource).toContain("rewriteInstalledClaudeCodeHooksForWindows(join(marketplaceDir, 'plugin'))");
+    expect(installSource).toContain('rewriteInstalledClaudeCodeHooksForWindows(cachePath)');
+  });
+});


### PR DESCRIPTION
## Summary
- rewrite installed Windows Claude Code hooks to exec form with absolute Node/script paths instead of copying the shell-form bash bundle onto Windows unchanged
- preserve the checked-in Unix/macOS artifact while covering both installed Windows plugin roots: the marketplace copy and the versioned cache copy used by repair and upgrade flows
- hide the Windows where bun probe and reuse bun-runner.js --hook-continue-json so the first SessionStart hook still emits Claude's continue and suppressOutput payload without a shell wrapper

## Verification
- bun test tests/bun-runner.test.ts tests/claude-code-windows-hooks.test.ts
- npm run build could not complete locally in this clean worktree because root dependencies are not installed (scripts/build-hooks.js failed immediately on missing esbuild)

Closes #2869