### PR TITLE
fix(codex): remove unsupported hooks description

### DIFF
--- a/plugin/hooks/codex-hooks.json
+++ b/plugin/hooks/codex-hooks.json
@@ -1,5 +1,4 @@
 {
-  "description": "claude-mem Codex CLI hook integration",
   "hooks": {
     "SessionStart": [
       {

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -629,6 +629,12 @@ async function buildHooks() {
       }
     }
     const codexHooks = JSON.parse(fs.readFileSync('plugin/hooks/codex-hooks.json', 'utf-8'));
+    const validCodexHookRootKeys = new Set(['hooks']);
+    for (const rootKey of Object.keys(codexHooks)) {
+      if (!validCodexHookRootKeys.has(rootKey)) {
+        throw new Error(`plugin/hooks/codex-hooks.json contains unknown Codex hook root field: ${rootKey}`);
+      }
+    }
     for (const eventName of Object.keys(codexHooks.hooks ?? {})) {
       if (!validCodexHookEvents.has(eventName)) {
         throw new Error(`plugin/hooks/codex-hooks.json contains unknown Codex hook event: ${eventName}`);


### PR DESCRIPTION
## Summary
- remove the unsupported root-level `description` field from `plugin/hooks/codex-hooks.json`
- add build-time validation so future unsupported Codex hook root fields fail before release

Fixes #2947

## Tests
- `bun test tests/infrastructure/plugin-distribution.test.ts`
- `npm run build`