### PR TITLE
test(worker): guard in-memory buffer reclaim

### DIFF
--- a/tests/services/worker/session-message-buffer.test.ts
+++ b/tests/services/worker/session-message-buffer.test.ts
@@ -72,6 +72,36 @@ describe('SessionMessageBuffer (in-RAM observation buffer)', () => {
     expect(second.map(m => m.tool_name)).toEqual(['Write']);
   });
 
+  test('resetClaimed re-yields an in-flight message without a durable processing row', async () => {
+    const buffer = new SessionMessageBuffer();
+    const controller = new AbortController();
+    const iterator = buffer.drain({
+      sessionDbId: 1,
+      signal: controller.signal,
+      idleTimeoutMs: 10_000,
+    });
+
+    const messageId = buffer.enqueue(1, obs('Read', 'tool-1'));
+
+    const first = await iterator.next();
+    expect(first.done).toBe(false);
+    expect(first.value._persistentId).toBe(messageId);
+    expect(first.value.toolUseId).toBe('tool-1');
+    expect(buffer.getPendingCount(1)).toBe(1);
+
+    expect(buffer.resetClaimed(1)).toBe(1);
+
+    const second = await iterator.next();
+    expect(second.done).toBe(false);
+    expect(second.value._persistentId).toBe(messageId);
+    expect(second.value.toolUseId).toBe('tool-1');
+
+    expect(buffer.confirm(messageId)).toBe(1);
+    expect(buffer.getPendingCount(1)).toBe(0);
+
+    controller.abort();
+  });
+
   test('clear empties a session; dispose forgets it', () => {
     const buffer = new SessionMessageBuffer();
     buffer.enqueue(1, obs('Read', 'a'));


### PR DESCRIPTION
## Summary

- Add regression coverage for `SessionMessageBuffer.resetClaimed()` re-yielding an in-flight message without requiring a durable `pending_messages.status='processing'` row.
- This guards the worker queue failure class observed in Liberty [LIB-284](/LIB/issues/LIB-284): orphaned durable processing rows wedging the drain.

## Context

The live Liberty box is running claude-mem plugin `v10.6.2`, where the installed generated worker bundle still has the durable pending queue behavior. Upstream `main` (`v13.6.1`) has already moved the worker to the in-memory `SessionMessageBuffer` path, which removes the cross-process orphaned `processing` row failure mode. This PR keeps that behavior reviewable and locked down with a focused test instead of proposing a stale patch against the old generated bundle.

## Verification

- `/Users/alex/.bun/bin/bun test tests/services/worker/session-message-buffer.test.ts`
- `git diff --check`

## Not done

- Did not apply or restart the live Liberty claude-mem worker.
- Did not mutate the live sqlite queue.
- Did not merge this PR.
