### PR TITLE
refactor(settings): route SettingsDefaults diagnostics through emitDiagnostic

### DIFF
--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -3,6 +3,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { HOOK_TIMEOUTS, getTimeout } from './hook-constants.js';
+import { emitDiagnostic } from './hook-io.js';
 
 export interface SettingsDefaults {
   CLAUDE_MEM_MODEL: string;
@@ -205,10 +206,12 @@ export class SettingsDefaultsManager {
           writeFileSync(settingsPath, JSON.stringify(defaults, null, 2), 'utf-8');
           // stderr, never stdout: this fires on the first boot in a fresh data
           // dir, and CLI commands like `start` promise machine-readable JSON
-          // on stdout to the hook framework.
-          console.warn('[SETTINGS] Created settings file with defaults:', settingsPath);
+          // on stdout to the hook framework. emitDiagnostic routes through the
+          // same channel logger uses so the line survives the Phase 2 hook
+          // stderr buffer (#2292) instead of being swallowed by raw console.
+          emitDiagnostic(`[SETTINGS] Created settings file with defaults: ${settingsPath}\n`);
         } catch (error: unknown) {
-          console.warn('[SETTINGS] Failed to create settings file, using in-memory defaults:', settingsPath, error instanceof Error ? error.message : String(error));
+          emitDiagnostic(`[SETTINGS] Failed to create settings file, using in-memory defaults: ${settingsPath} ${error instanceof Error ? error.message : String(error)}\n`);
         }
         return applyEnvOverrides ? this.applyEnvOverrides(defaults) : defaults;
       }
@@ -226,9 +229,9 @@ export class SettingsDefaultsManager {
         try {
           writeFileSync(settingsPath, JSON.stringify(flatSettings, null, 2), 'utf-8');
           // stderr, never stdout — same JSON-on-stdout contract as above.
-          console.warn('[SETTINGS] Migrated settings file from nested to flat schema:', settingsPath);
+          emitDiagnostic(`[SETTINGS] Migrated settings file from nested to flat schema: ${settingsPath}\n`);
         } catch (error: unknown) {
-          console.warn('[SETTINGS] Failed to auto-migrate settings file:', settingsPath, error instanceof Error ? error.message : String(error));
+          emitDiagnostic(`[SETTINGS] Failed to auto-migrate settings file: ${settingsPath} ${error instanceof Error ? error.message : String(error)}\n`);
           // Continue with in-memory migration even if write fails
         }
       }
@@ -242,7 +245,7 @@ export class SettingsDefaultsManager {
 
       return applyEnvOverrides ? this.applyEnvOverrides(result) : result;
     } catch (error: unknown) {
-      console.warn('[SETTINGS] Failed to load settings, using defaults:', settingsPath, error instanceof Error ? error.message : String(error));
+      emitDiagnostic(`[SETTINGS] Failed to load settings, using defaults: ${settingsPath} ${error instanceof Error ? error.message : String(error)}\n`);
       const defaults = this.getAllDefaults();
       return applyEnvOverrides ? this.applyEnvOverrides(defaults) : defaults;
     }


### PR DESCRIPTION
## Summary

`SettingsDefaultsManager` is a base-layer library module (runs under the worker daemon and hooks) that emitted its `[SETTINGS]` diagnostics via raw `console.warn`. Those lines can be swallowed by the Phase 2 hook stderr buffer (#2292).

Replace the 5 `console.warn` calls with `emitDiagnostic` (from `hook-io`):

- **Survives the Phase 2 hook stderr buffer (#2292)** — the same channel `logger` itself uses, instead of being swallowed by raw console.
- **Preserves the deliberate stderr-not-stdout behavior** that protects the machine-readable JSON contract on stdout (CLI commands like `start` promise JSON on stdout to the hook framework).

## Why `emitDiagnostic`, not `logger`

`logger` transitively depends on this module (`logger → shared/paths → SettingsDefaultsManager`). Importing `logger` here would **invert the layering and risk a circular dependency at bootstrap**. `hook-io` is a leaf module (type-only import), so there is no cycle.

## Scope note

This was scoped deliberately. Of 546 `console.*` calls in `src/`, the vast majority are correct and intentionally left as-is:

- `worker-service.ts` / `ServerBetaService.ts` — CLI entrypoints; `console.log(JSON.stringify(...))` is the program's stdout output contract. Routing to the file logger would silence the CLI.
- `npx-cli/**`, `*Installer.ts`, `bin/**` — user-facing CLI / install-time output.
- `ui/viewer/**` — browser React code; the Node file-based logger cannot run there.
- `utils/logger.ts`, `shared/hook-io.ts` — the logger's own stderr fallback.

## Verification

- `tsc --noEmit` clean
- `npm run build` green
- `bun test` — 39 pass / 0 fail (incl. `settings-defaults-manager.test.ts` and `logger-usage-standards.test.ts`)
- `[SETTINGS]` diagnostics confirmed still printing to stderr in test output