### PR TITLE
docs(version-bump): hand off npm publishing to the human

### DIFF
--- a/plugin/skills/version-bump/SKILL.md
+++ b/plugin/skills/version-bump/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: claude-code-plugin-release
-description: Automated semantic versioning and release workflow for Claude Code plugins. Handles version increments across package.json, marketplace.json, plugin.json manifests, npm publishing (so `npx claude-mem@X.Y.Z` resolves), build verification, git tagging, GitHub releases, and changelog generation.
+description: Automated semantic versioning and release workflow for Claude Code plugins. Handles version increments across package.json, marketplace.json, plugin.json manifests, build verification, git tagging, GitHub releases, and changelog generation. NPM publishing (so `npx claude-mem@X.Y.Z` resolves) is handed off to the human maintainer, who raised npm security.
 ---
 
 # Version Bump & Release Workflow
@@ -32,15 +32,20 @@ description: Automated semantic versioning and release workflow for Claude Code 
 4.  **Commit**: `git add -A && git commit -m "chore: bump version to X.Y.Z"`.
 5.  **Tag**: `git tag -a vX.Y.Z -m "Version X.Y.Z"`.
 6.  **Push**: `git push origin main && git push origin vX.Y.Z`.
-7.  **Publish to npm** (this is what makes `npx claude-mem@X.Y.Z` work):
+7.  **Publish to npm — HAND OFF TO HUMAN.** The human maintainer raised npm
+    security, so publishing now requires credentials/2FA only they can provide.
+    The agent MUST NOT run `npm publish` (or `np` / `npm run release:*`, which
+    also publish) itself. **Hand off NPM publishing to the human now:** stop and
+    tell them the version is committed, tagged, and pushed, and that they must
+    publish to npm to make `npx claude-mem@X.Y.Z` resolve. Give them the command:
     ```bash
-    npm publish
+    npm publish   # run by the HUMAN — the prepublishOnly script rebuilds the package
     ```
-    The `prepublishOnly` script re-runs the package build automatically. After publish, run `npm run build-and-sync` again if the publish build touched local artifacts. Confirm publish succeeded:
+    Wait for the human to confirm they published, then verify it landed:
     ```bash
     npm view claude-mem@X.Y.Z version   # should print X.Y.Z
     ```
-    Alternative: `npm run release:patch` / `release:minor` / `release:major` invokes `np` and handles tag+push+publish in one shot — use ONLY if you skipped steps 4–6, otherwise `np` will error on the existing tag.
+    If the publish build touched local artifacts, run `npm run build-and-sync` again afterward.
 8.  **GitHub release**: `gh release create vX.Y.Z --title "vX.Y.Z" --notes "RELEASE_NOTES"`.
 9.  **Changelog**: Regenerate via the project's changelog script:
     ```bash
@@ -61,7 +66,7 @@ description: Automated semantic versioning and release workflow for Claude Code 
 - [ ] `git grep` for old version returns zero hits
 - [ ] `npm run build-and-sync` succeeded
 - [ ] Git tag created and pushed
-- [ ] **`npm publish` succeeded and `npm view claude-mem@X.Y.Z version` confirms it** (so `npx claude-mem@X.Y.Z` resolves)
+- [ ] **NPM publishing handed off to the human** (agent does NOT run `npm publish` — human raised security); once they publish, `npm view claude-mem@X.Y.Z version` confirms it (so `npx claude-mem@X.Y.Z` resolves)
 - [ ] GitHub release created with notes
 - [ ] `CHANGELOG.md` updated and pushed
 - [ ] Discord notification run from `~/Scripts/claude-mem/`

--- a/plugin/skills/version-bump/SKILL.md
+++ b/plugin/skills/version-bump/SKILL.md
@@ -20,14 +20,15 @@ description: Automated semantic versioning and release workflow for Claude Code 
     - `.claude-plugin/plugin.json` — top-level Claude-plugin manifest
     - `plugin/.claude-plugin/plugin.json` — bundled Claude-plugin manifest
     - `.codex-plugin/plugin.json` — Codex-plugin manifest
+    - `plugin/.codex-plugin/plugin.json` — bundled Codex-plugin manifest
     - `openclaw/openclaw.plugin.json` — OpenClaw plugin manifest
 
-    Verify coverage before editing: `git grep -l "\"version\": \"<OLD>\""` should list all seven. If a new manifest has been added since this doc was last updated, update this list.
+    Verify coverage before editing: `git grep -l "\"version\": \"<OLD>\""` should list all eight. If a new manifest has been added since this doc was last updated, update this list.
 
 ## Workflow
 
 1.  **Update**: Increment the version string in every path above. Do NOT touch `CHANGELOG.md` — it's regenerated.
-2.  **Verify**: `git grep -n "\"version\": \"<NEW>\""` — confirm all seven files match. `git grep -n "\"version\": \"<OLD>\""` — should return zero hits.
+2.  **Verify**: `git grep -n "\"version\": \"<NEW>\""` — confirm all eight files match. `git grep -n "\"version\": \"<OLD>\""` — should return zero hits.
 3.  **Build and sync**: `npm run build-and-sync` to regenerate artifacts, sync the local marketplace copy, restart the worker, and clear the queue. Do not use plain `npm run build` for release validation because it can leave the local marketplace/worker out of sync.
 4.  **Commit**: `git add -A && git commit -m "chore: bump version to X.Y.Z"`.
 5.  **Tag**: `git tag -a vX.Y.Z -m "Version X.Y.Z"`.
@@ -62,7 +63,7 @@ description: Automated semantic versioning and release workflow for Claude Code 
 
 ## Checklist
 
-- [ ] All seven config files have matching versions
+- [ ] All eight config files have matching versions
 - [ ] `git grep` for old version returns zero hits
 - [ ] `npm run build-and-sync` succeeded
 - [ ] Git tag created and pushed


### PR DESCRIPTION
## What

Updates the **version-bump** skill (`plugin/skills/version-bump/SKILL.md`) so the agent no longer runs `npm publish` itself — it hands NPM publishing off to the human maintainer.

## Why

The maintainer raised npm security (2FA / restricted tokens), so `npm publish` can no longer run non-interactively from an agent. During the v13.6.2 release, the agent's `npm publish` failed with `E401 Unauthorized` / `E404` — the publish must be done by the human.

## Changes

- **Step 7** rewritten to **HAND OFF TO HUMAN**: the agent stops after commit/tag/push, tells the human the release is ready, and instructs them to run `npm publish`. Explicitly covers `np` / `npm run release:*` (which also publish) as forbidden for the agent. Verification via `npm view claude-mem@X.Y.Z version` happens after the human confirms.
- **Checklist** item updated to reflect the hand-off.
- **Skill description** updated to note npm publishing is human-driven.

Docs/skill-content only — no code or build-artifact changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)