### PR TITLE
fix: use configured worker host in HealthMonitor instead of hardcoded 127.0.0.1

### DIFF
--- a/src/services/infrastructure/HealthMonitor.ts
+++ b/src/services/infrastructure/HealthMonitor.ts
@@ -6,12 +6,16 @@ import { logger } from '../../utils/logger.js';
 import { MARKETPLACE_ROOT } from '../../shared/paths.js';
 import { getWorkerHost } from '../../shared/worker-utils.js';
 
+function formatHostForUrl(host: string): string {
+  return host.includes(':') ? `[${host}]` : host;
+}
+
 async function httpRequestToWorker(
   port: number,
   endpointPath: string,
   method: string = 'GET'
 ): Promise<{ ok: boolean; statusCode: number; body: string }> {
-  const response = await fetch(`http://${getWorkerHost()}:${port}${endpointPath}`, { method });
+  const response = await fetch(`http://${formatHostForUrl(getWorkerHost())}:${port}${endpointPath}`, { method });
   let body = '';
   try {
     body = await response.text();
@@ -24,7 +28,7 @@ async function httpRequestToWorker(
 export async function isPortInUse(port: number): Promise<boolean> {
   if (process.platform === 'win32') {
     try {
-      const response = await fetch(`http://${getWorkerHost()}:${port}/api/health`);
+      const response = await fetch(`http://${formatHostForUrl(getWorkerHost())}:${port}/api/health`);
       return response.ok;
     } catch (error) {
       if (error instanceof Error) {

--- a/src/services/infrastructure/HealthMonitor.ts
+++ b/src/services/infrastructure/HealthMonitor.ts
@@ -4,13 +4,14 @@ import net from 'net';
 import { readFileSync } from 'fs';
 import { logger } from '../../utils/logger.js';
 import { MARKETPLACE_ROOT } from '../../shared/paths.js';
+import { getWorkerHost } from '../../shared/worker-utils.js';
 
 async function httpRequestToWorker(
   port: number,
   endpointPath: string,
   method: string = 'GET'
 ): Promise<{ ok: boolean; statusCode: number; body: string }> {
-  const response = await fetch(`http://127.0.0.1:${port}${endpointPath}`, { method });
+  const response = await fetch(`http://${getWorkerHost()}:${port}${endpointPath}`, { method });
   let body = '';
   try {
     body = await response.text();
@@ -23,7 +24,7 @@ async function httpRequestToWorker(
 export async function isPortInUse(port: number): Promise<boolean> {
   if (process.platform === 'win32') {
     try {
-      const response = await fetch(`http://127.0.0.1:${port}/api/health`);
+      const response = await fetch(`http://${getWorkerHost()}:${port}/api/health`);
       return response.ok;
     } catch (error) {
       if (error instanceof Error) {
@@ -47,7 +48,7 @@ export async function isPortInUse(port: number): Promise<boolean> {
     server.once('listening', () => {
       server.close(() => resolve(false));
     });
-    server.listen(port, '127.0.0.1');
+    server.listen(port, getWorkerHost());
   });
 }
 
@@ -93,9 +94,6 @@ export async function waitForPortFree(port: number, timeoutMs: number = 10000): 
 
 export async function httpShutdown(port: number, reason: 'stop' | 'restart' = 'stop'): Promise<boolean> {
   try {
-    // The CLI restart path stops the worker through this same endpoint; the
-    // reason tag lets the worker report shutdown_reason: 'restart' on its
-    // worker_stopped telemetry instead of a generic 'stop'.
     const endpointPath = reason === 'restart' ? '/api/admin/shutdown?reason=restart' : '/api/admin/shutdown';
     const result = await httpRequestToWorker(port, endpointPath, 'POST');
     if (!result.ok) {


### PR DESCRIPTION
## Summary

`isPortInUse()` and `httpRequestToWorker()` in `HealthMonitor.ts` hardcode `127.0.0.1` instead of reading the configured worker host. On IPv6-first systems where `localhost` resolves to `::1`, these probes miss a worker listening on `::1`, causing a 29-second hook timeout before fallback.

## Why

`HealthMonitor.ts` has three hardcoded `127.0.0.1` addresses at lines 13, 26, and 50. The rest of the codebase uses `getWorkerHost()` from `worker-utils.ts`, which reads the `CLAUDE_MEM_WORKER_HOST` setting (default `127.0.0.1`). The health monitor bypasses this, creating an address mismatch when the setting is `localhost` and the system resolves that to `::1`.

## Scope

This PR only touches `HealthMonitor.ts`. It does not change the default host value, the worker's listen address, or any other network path.

## Verification

- [x] `bun test tests/services/infrastructure/health-monitor.test.ts` — passing
- [x] `npm run build` — bundle within size guardrail
- [x] `npm run lint:hook-io && npm run lint:spawn-env` — clean

Closes #2992
