### PR TITLE
feat(integrations): add Antigravity CLI hooks support

### DIFF
--- a/src/cli/adapters/antigravity-cli.ts
+++ b/src/cli/adapters/antigravity-cli.ts
@@ -1,0 +1,97 @@
+import type { PlatformAdapter } from '../types.js';
+import { AdapterRejectedInput, isValidCwd } from './errors.js';
+
+/**
+ * Antigravity CLI adapter.
+ *
+ * Antigravity replaces Gemini CLI (Gemini CLI stops serving 2026-06-18). Its
+ * declarative hooks live in ~/.gemini/config/hooks.json and the stdin payload
+ * is shaped differently from Gemini CLI:
+ *
+ *   {
+ *     "conversationId": "...",            // → sessionId
+ *     "artifactDirectoryPath": "...",
+ *     "stepIdx": 50,
+ *     "toolCall": { "name": "run_command", "args": { "CommandLine": ..., "Cwd": ... } },
+ *     "transcriptPath": "...",
+ *     "workspacePaths": ["..."],          // → cwd (first entry)
+ *     "error": ""                         // PostToolUse only
+ *   }
+ *
+ * Unlike Gemini CLI, the payload carries NO `hook_event_name`. The event is
+ * known only from the CLI argument (`hook antigravity-cli <event>`), so this
+ * adapter never infers the event from stdin — it only normalizes the data.
+ *
+ * The above shape for PreToolUse/PostToolUse was confirmed by live probing
+ * agy 1.0.9 in both headless and interactive sessions. Those are the ONLY two
+ * events the CLI hook runner fires today — session/turn lifecycle events
+ * (SessionStart, Stop, Compaction, …) exist in the Python SDK but are not yet
+ * surfaced by the CLI. See AntigravityCliHooksInstaller for details.
+ */
+export const antigravityCliAdapter: PlatformAdapter = {
+  normalizeInput(raw) {
+    const r = (raw ?? {}) as any;
+
+    const toolCall = (r.toolCall ?? {}) as Record<string, unknown>;
+    const toolArgs = (toolCall.args ?? {}) as Record<string, unknown>;
+
+    const cwd = r.cwd
+      ?? (Array.isArray(r.workspacePaths) ? r.workspacePaths[0] : undefined)
+      ?? (typeof toolArgs.Cwd === 'string' ? toolArgs.Cwd : undefined)
+      ?? process.env.GEMINI_CWD
+      ?? process.env.GEMINI_PROJECT_DIR
+      ?? process.env.CLAUDE_PROJECT_DIR
+      ?? process.cwd();
+    if (!isValidCwd(cwd)) {
+      throw new AdapterRejectedInput('invalid_cwd');
+    }
+
+    const sessionId = r.conversationId
+      ?? r.session_id
+      ?? process.env.GEMINI_SESSION_ID
+      ?? undefined;
+
+    const toolName = typeof toolCall.name === 'string' ? toolCall.name : undefined;
+    const toolInput = toolCall.args !== undefined ? toolCall.args : undefined;
+
+    // PostToolUse carries an `error` field; PreToolUse has no result yet.
+    let toolResponse: unknown;
+    if ('error' in r) {
+      toolResponse = { error: r.error };
+    } else if (toolName) {
+      toolResponse = { _preExecution: true };
+    }
+
+    const metadata: Record<string, unknown> = {};
+    if (r.conversationId) metadata.conversationId = r.conversationId;
+    if (r.artifactDirectoryPath) metadata.artifactDirectoryPath = r.artifactDirectoryPath;
+    if (r.stepIdx !== undefined) metadata.stepIdx = r.stepIdx;
+
+    return {
+      sessionId,
+      cwd,
+      prompt: r.prompt,
+      toolName,
+      toolInput,
+      toolResponse,
+      transcriptPath: r.transcriptPath,
+      metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+    };
+  },
+
+  formatOutput(result) {
+    // Antigravity hooks read a JSON object on stdout with a `decision` key
+    // (allow | deny | ask). claude-mem is a passive observer — it captures
+    // memory and never blocks the agent — so it always allows. Context is
+    // injected via GEMINI.md (still parsed by Antigravity), not stdout.
+    const decision = result.decision === 'block' ? 'deny' : 'allow';
+
+    const output: Record<string, unknown> = { decision };
+
+    if (result.reason) {
+      output.reason = result.reason;
+    }
+
+    return output;
+  }
+};

--- a/src/cli/adapters/index.ts
+++ b/src/cli/adapters/index.ts
@@ -1,4 +1,5 @@
 import type { PlatformAdapter } from '../types.js';
+import { antigravityCliAdapter } from './antigravity-cli.js';
 import { claudeCodeAdapter } from './claude-code.js';
 import { codexAdapter } from './codex.js';
 import { cursorAdapter } from './cursor.js';
@@ -13,10 +14,12 @@ export function getPlatformAdapter(platform: string): PlatformAdapter {
     case 'cursor': return cursorAdapter;
     case 'gemini':
     case 'gemini-cli': return geminiCliAdapter;
+    case 'antigravity':
+    case 'antigravity-cli': return antigravityCliAdapter;
     case 'windsurf': return windsurfAdapter;
     case 'raw': return rawAdapter;
     default: return rawAdapter;
   }
 }
 
-export { claudeCodeAdapter, codexAdapter, cursorAdapter, geminiCliAdapter, rawAdapter, windsurfAdapter };
+export { antigravityCliAdapter, claudeCodeAdapter, codexAdapter, cursorAdapter, geminiCliAdapter, rawAdapter, windsurfAdapter };

--- a/src/cli/handlers/context.ts
+++ b/src/cli/handlers/context.ts
@@ -70,7 +70,7 @@ export const contextHandler: EventHandler = {
 
     const platform = input.platform;
 
-    const displayContent = coloredTimeline || (platform === 'gemini-cli' || platform === 'gemini' ? additionalContext : '');
+    const displayContent = coloredTimeline || (platform === 'gemini-cli' || platform === 'gemini' || platform === 'antigravity-cli' || platform === 'antigravity' ? additionalContext : '');
 
     const systemMessage = showTerminalOutput && displayContent
       ? `${displayContent}\n\nView Observations Live @ http://localhost:${port}`

--- a/src/npx-cli/commands/ide-detection.ts
+++ b/src/npx-cli/commands/ide-detection.ts
@@ -104,6 +104,14 @@ export function detectInstalledIDEs(): IDEInfo[] {
       hint: 'MCP-based integration',
     },
     {
+      id: 'antigravity-cli',
+      label: 'Antigravity CLI',
+      detected:
+        existsSync(join(home, '.gemini', 'antigravity-cli')) || isCommandInPath('agy'),
+      supported: true,
+      hint: 'hooks + context injection',
+    },
+    {
       id: 'goose',
       label: 'Goose',
       detected:

--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -330,6 +330,23 @@ function makeIDETask(ideId: string, summary: InstallSummary): TaskDescriptor | n
       };
     }
 
+    case 'antigravity-cli': {
+      return {
+        title: 'Antigravity CLI: installing hooks',
+        task: async (message) => {
+          message('Loading Antigravity CLI installer…');
+          const { installAntigravityCliHooks } = await import('../../services/integrations/AntigravityCliHooksInstaller.js');
+          message('Installing Antigravity CLI hooks…');
+          const { result, output } = await bufferConsole(() => installAntigravityCliHooks());
+          if (result !== 0) {
+            recordFailure('Antigravity CLI: hook installation failed', output);
+            return `Antigravity CLI: hook installation failed ${pc.red('FAIL')}`;
+          }
+          return `Antigravity CLI: hooks installed ${pc.green('OK')}`;
+        },
+      };
+    }
+
     case 'opencode': {
       return {
         title: 'OpenCode: installing plugin',

--- a/src/npx-cli/commands/uninstall.ts
+++ b/src/npx-cli/commands/uninstall.ts
@@ -361,6 +361,10 @@ export async function runUninstallCommand(): Promise<void> {
       const { uninstallGeminiCliHooks } = await import('../../services/integrations/GeminiCliHooksInstaller.js');
       return uninstallGeminiCliHooks();
     }},
+    { label: 'Antigravity CLI hooks', fn: async () => {
+      const { uninstallAntigravityCliHooks } = await import('../../services/integrations/AntigravityCliHooksInstaller.js');
+      return uninstallAntigravityCliHooks();
+    }},
     { label: 'Windsurf hooks', fn: async () => {
       const { uninstallWindsurfHooks } = await import('../../services/integrations/WindsurfHooksInstaller.js');
       return uninstallWindsurfHooks();

--- a/src/npx-cli/index.ts
+++ b/src/npx-cli/index.ts
@@ -59,8 +59,8 @@ ${pc.bold('Runtime Commands')} (requires Bun, delegates to installed plugin):
 
 ${pc.bold('IDE Identifiers')}:
   claude-code, cursor, gemini-cli, opencode, openclaw,
-  windsurf, codex-cli, copilot-cli, antigravity, goose,
-  roo-code, warp
+  windsurf, codex-cli, copilot-cli, antigravity, antigravity-cli,
+  goose, roo-code, warp
 `);
 }
 

--- a/src/services/integrations/AntigravityCliHooksInstaller.ts
+++ b/src/services/integrations/AntigravityCliHooksInstaller.ts
@@ -1,0 +1,347 @@
+
+import path from 'path';
+import { homedir } from 'os';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { logger } from '../../utils/logger.js';
+import { getWorkerServiceAbsolutePath as findWorkerServicePath, getBunAbsolutePath as findBunPath } from './install-paths.js';
+
+/**
+ * Antigravity CLI hooks installer.
+ *
+ * Antigravity replaces Gemini CLI (which stops serving 2026-06-18). Key
+ * differences from GeminiCliHooksInstaller:
+ *
+ *  - Hooks live in a dedicated file ~/.gemini/config/hooks.json (NOT inside
+ *    settings.json). A known early-CLI bug wrote them to
+ *    ~/.gemini/antigravity-cli/hooks.json — that path is deliberately avoided.
+ *  - The hooks.json shape is inverted: the top level is keyed by a hook NAME,
+ *    and each hook name maps event names to matcher/command groups.
+ *  - The `timeout` field is in SECONDS, not milliseconds.
+ *  - Hooks receive JSON on stdin and return `{ "decision": "allow" }` on
+ *    stdout (see antigravity-cli adapter); claude-mem always allows.
+ *  - Context injection still flows through ~/.gemini/GEMINI.md, which
+ *    Antigravity continues to parse.
+ *
+ * Event-name confidence (from live probing agy 1.0.9 + official SDK docs):
+ *   - PreToolUse / PostToolUse  → confirmed by probe (name + payload)
+ *   - SessionStart              → official SDK (on_session_start); high
+ *   - PreInvocation / Stop /
+ *     Compaction / Notification → from SDK lifecycle + web; NOT yet observed
+ *                                 in headless print mode. Verify against an
+ *                                 interactive agy session before relying on
+ *                                 memory capture for those events.
+ */
+
+interface AntigravityHookEntry {
+  type: 'command';
+  command: string;
+  timeout: number;
+}
+
+interface AntigravityHookGroup {
+  matcher: string;
+  hooks: AntigravityHookEntry[];
+}
+
+// hooks.json shape: { [hookName]: { [eventName]: AntigravityHookGroup[] } }
+interface AntigravityHookEventMap {
+  [eventName: string]: AntigravityHookGroup[];
+}
+
+interface AntigravityHooksConfig {
+  [hookName: string]: AntigravityHookEventMap;
+}
+
+const GEMINI_CONFIG_DIR = path.join(homedir(), '.gemini');
+const HOOKS_DIR = path.join(GEMINI_CONFIG_DIR, 'config');
+const HOOKS_PATH = path.join(HOOKS_DIR, 'hooks.json');
+const GEMINI_MD_PATH = path.join(GEMINI_CONFIG_DIR, 'GEMINI.md');
+
+const HOOK_NAME = 'claude-mem';
+const HOOK_TIMEOUT_SEC = 10;
+
+// Antigravity CLI event name -> claude-mem internal event.
+//
+// Only the two tool-level events are registered: live probing of agy 1.0.9
+// (both headless --print AND a full interactive session) confirmed that the
+// CLI declarative hooks.json fires ONLY PreToolUse / PostToolUse. A 12-event
+// probe (SessionStart, SessionEnd, PreInvocation, PostInvocation, PreTurn,
+// PostTurn, Stop, Compaction, Notification, ToolError, …) saw none of the
+// lifecycle events fire — they exist in the Python SDK (on_session_start,
+// on_compaction, …) but are not yet surfaced by the CLI hook runner.
+//
+// Consequence: observation capture works via PostToolUse; memory context is
+// injected through ~/.gemini/GEMINI.md (read by Antigravity at startup), which
+// does not depend on a SessionStart hook. Session-boundary and summarize
+// triggers are unavailable until agy exposes those events.
+//
+// To re-enable when agy adds them: add the event here and re-run the probe to
+// confirm the name + payload before relying on it.
+const ANTIGRAVITY_EVENT_TO_INTERNAL_EVENT: Record<string, string> = {
+  'PreToolUse': 'observation',     // confirmed: agy 1.0.9 probe
+  'PostToolUse': 'observation',    // confirmed: agy 1.0.9 probe
+};
+
+function buildHookCommand(
+  bunPath: string,
+  workerServicePath: string,
+  antigravityEventName: string,
+): string {
+  const internalEvent = ANTIGRAVITY_EVENT_TO_INTERNAL_EVENT[antigravityEventName];
+  if (!internalEvent) {
+    throw new Error(`Unknown Antigravity CLI event: ${antigravityEventName}`);
+  }
+
+  const escapedBunPath = bunPath.replace(/\\/g, '\\\\');
+  const escapedWorkerPath = workerServicePath.replace(/\\/g, '\\\\');
+
+  return `"${escapedBunPath}" "${escapedWorkerPath}" hook antigravity-cli ${internalEvent}`;
+}
+
+function createHookGroup(hookCommand: string): AntigravityHookGroup {
+  return {
+    matcher: '*',
+    hooks: [{
+      type: 'command',
+      command: hookCommand,
+      timeout: HOOK_TIMEOUT_SEC,
+    }],
+  };
+}
+
+function readHooksConfig(): AntigravityHooksConfig {
+  if (!existsSync(HOOKS_PATH)) {
+    return {};
+  }
+
+  const content = readFileSync(HOOKS_PATH, 'utf-8');
+  try {
+    return JSON.parse(content) as AntigravityHooksConfig;
+  } catch (error) {
+    const wrapped = error instanceof Error ? error : new Error(String(error));
+    logger.error('WORKER', 'Corrupt JSON in Antigravity hooks', { path: HOOKS_PATH }, wrapped);
+    throw new Error(`Corrupt JSON in ${HOOKS_PATH}, refusing to overwrite user hooks`);
+  }
+}
+
+function writeHooksConfig(config: AntigravityHooksConfig): void {
+  mkdirSync(HOOKS_DIR, { recursive: true });
+  writeFileSync(HOOKS_PATH, JSON.stringify(config, null, 2) + '\n');
+}
+
+function buildClaudeMemEventMap(
+  bunPath: string,
+  workerServicePath: string,
+): AntigravityHookEventMap {
+  const eventMap: AntigravityHookEventMap = {};
+  for (const antigravityEvent of Object.keys(ANTIGRAVITY_EVENT_TO_INTERNAL_EVENT)) {
+    const command = buildHookCommand(bunPath, workerServicePath, antigravityEvent);
+    eventMap[antigravityEvent] = [createHookGroup(command)];
+  }
+  return eventMap;
+}
+
+function setupGeminiMdContextSection(): void {
+  const contextTag = '<claude-mem-context>';
+  const contextEndTag = '</claude-mem-context>';
+  const placeholder = `${contextTag}
+# Memory Context from Past Sessions
+
+*No context yet. Complete your first session and context will appear here.*
+${contextEndTag}`;
+
+  let content = '';
+  if (existsSync(GEMINI_MD_PATH)) {
+    content = readFileSync(GEMINI_MD_PATH, 'utf-8');
+  }
+
+  if (content.includes(contextTag)) {
+    return;
+  }
+
+  const separator = content.length > 0 && !content.endsWith('\n') ? '\n\n' : content.length > 0 ? '\n' : '';
+  const newContent = content + separator + placeholder + '\n';
+
+  mkdirSync(GEMINI_CONFIG_DIR, { recursive: true });
+  writeFileSync(GEMINI_MD_PATH, newContent);
+}
+
+export async function installAntigravityCliHooks(): Promise<number> {
+  console.log('\nInstalling Claude-Mem Antigravity CLI hooks...\n');
+
+  const workerServicePath = findWorkerServicePath();
+  if (!workerServicePath) {
+    console.error('Could not find worker-service.cjs');
+    console.error('   Expected at: ~/.claude/plugins/marketplaces/thedotmack/plugin/scripts/worker-service.cjs');
+    return 1;
+  }
+
+  const bunPath = findBunPath();
+  console.log(`  Using Bun runtime: ${bunPath}`);
+  console.log(`  Worker service: ${workerServicePath}`);
+
+  try {
+    const existingConfig = readHooksConfig();
+    const mergedConfig: AntigravityHooksConfig = { ...existingConfig };
+    mergedConfig[HOOK_NAME] = buildClaudeMemEventMap(bunPath, workerServicePath);
+
+    writeHooksConfig(mergedConfig);
+    console.log(`  Wrote hooks into ${HOOKS_PATH}`);
+
+    setupGeminiMdContextSection();
+    console.log(`  Setup context injection in ${GEMINI_MD_PATH}`);
+
+    const eventNames = Object.keys(ANTIGRAVITY_EVENT_TO_INTERNAL_EVENT);
+    console.log(`  Registered ${eventNames.length} hook events:`);
+    for (const event of eventNames) {
+      console.log(`    ${event} → ${ANTIGRAVITY_EVENT_TO_INTERNAL_EVENT[event]}`);
+    }
+
+    console.log(`
+Installation complete!
+
+Hooks installed to: ${HOOKS_PATH}
+Using unified CLI: bun worker-service.cjs hook antigravity-cli <event>
+
+Next steps:
+  1. Start claude-mem worker: claude-mem start
+  2. Restart Antigravity CLI to load the hooks
+  3. Memory will be captured automatically during sessions
+
+Context Injection:
+  Context from past sessions is injected via ~/.gemini/GEMINI.md
+  and automatically included in Antigravity CLI conversations.
+`);
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`\nInstallation failed: ${message}`);
+    return 1;
+  }
+}
+
+export function uninstallAntigravityCliHooks(): number {
+  console.log('\nUninstalling Claude-Mem Antigravity CLI hooks...\n');
+
+  if (!existsSync(HOOKS_PATH)) {
+    console.log('  No Antigravity CLI hooks file found — nothing to uninstall.');
+    return 0;
+  }
+
+  try {
+    const config = readHooksConfig();
+    if (!config[HOOK_NAME]) {
+      console.log('  No claude-mem hooks found — nothing to uninstall.');
+      return 0;
+    }
+
+    const removedEvents = Object.keys(config[HOOK_NAME]).length;
+    delete config[HOOK_NAME];
+
+    writeHooksConfig(config);
+    console.log(`  Removed claude-mem hooks (${removedEvents} events) from ${HOOKS_PATH}`);
+
+    if (existsSync(GEMINI_MD_PATH)) {
+      let mdContent = readFileSync(GEMINI_MD_PATH, 'utf-8');
+      const contextRegex = /\n?<claude-mem-context>[\s\S]*?<\/claude-mem-context>\n?/;
+      if (contextRegex.test(mdContent)) {
+        mdContent = mdContent.replace(contextRegex, '');
+        writeFileSync(GEMINI_MD_PATH, mdContent);
+        console.log(`  Removed context section from ${GEMINI_MD_PATH}`);
+      }
+    }
+
+    console.log('\nUninstallation complete!\n');
+    console.log('Restart Antigravity CLI to apply changes.');
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`\nUninstallation failed: ${message}`);
+    return 1;
+  }
+}
+
+export function checkAntigravityCliHooksStatus(): number {
+  console.log('\nClaude-Mem Antigravity CLI Hooks Status\n');
+
+  if (!existsSync(HOOKS_PATH)) {
+    console.log('Antigravity CLI hooks: Not found');
+    console.log(`  Expected at: ${HOOKS_PATH}\n`);
+    console.log('No hooks installed. Run: claude-mem install --ide antigravity-cli\n');
+    return 0;
+  }
+
+  let config: AntigravityHooksConfig;
+  try {
+    config = readHooksConfig();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const wrapped = error instanceof Error ? error : new Error(String(error));
+    logger.error('WORKER', 'Failed to read Antigravity CLI hooks', { path: HOOKS_PATH }, wrapped);
+    console.log(`Antigravity CLI hooks: ${message}\n`);
+    return 0;
+  }
+
+  const claudeMemHooks = config[HOOK_NAME];
+  if (!claudeMemHooks) {
+    console.log('Antigravity CLI hooks: Found, but no claude-mem hooks\n');
+    console.log('Run: claude-mem install --ide antigravity-cli\n');
+    return 0;
+  }
+
+  const installedEvents = Object.keys(claudeMemHooks);
+  console.log(`Hooks file: ${HOOKS_PATH}`);
+  console.log(`Mode: Unified CLI (bun worker-service.cjs hook antigravity-cli)`);
+  console.log(`Events: ${installedEvents.length} of ${Object.keys(ANTIGRAVITY_EVENT_TO_INTERNAL_EVENT).length} mapped`);
+  for (const event of installedEvents) {
+    const internalEvent = ANTIGRAVITY_EVENT_TO_INTERNAL_EVENT[event] ?? 'unknown';
+    console.log(`  ${event} → ${internalEvent}`);
+  }
+
+  if (existsSync(GEMINI_MD_PATH)) {
+    const mdContent = readFileSync(GEMINI_MD_PATH, 'utf-8');
+    if (mdContent.includes('<claude-mem-context>')) {
+      console.log(`Context: Active (${GEMINI_MD_PATH})`);
+    } else {
+      console.log('Context: GEMINI.md exists but missing claude-mem section');
+    }
+  } else {
+    console.log('Context: No GEMINI.md found');
+  }
+
+  console.log('');
+  return 0;
+}
+
+export async function handleAntigravityCliCommand(subcommand: string, _args: string[]): Promise<number> {
+  switch (subcommand) {
+    case 'install':
+      return installAntigravityCliHooks();
+
+    case 'uninstall':
+      return uninstallAntigravityCliHooks();
+
+    case 'status':
+      return checkAntigravityCliHooksStatus();
+
+    default:
+      console.log(`
+Claude-Mem Antigravity CLI Integration
+
+Usage: claude-mem antigravity-cli <command>
+
+Commands:
+  install             Install hooks into ~/.gemini/config/hooks.json
+  uninstall           Remove claude-mem hooks (preserves other hooks)
+  status              Check installation status
+
+Examples:
+  claude-mem antigravity-cli install     # Install hooks
+  claude-mem antigravity-cli status      # Check if installed
+  claude-mem antigravity-cli uninstall   # Remove hooks
+
+For more info: https://docs.claude-mem.ai/usage/gemini-provider
+      `);
+      return 0;
+  }
+}

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -72,6 +72,9 @@ import {
 import {
   handleGeminiCliCommand
 } from './integrations/GeminiCliHooksInstaller.js';
+import {
+  handleAntigravityCliCommand
+} from './integrations/AntigravityCliHooksInstaller.js';
 
 import { DatabaseManager } from './worker/DatabaseManager.js';
 import { SessionManager } from './worker/SessionManager.js';
@@ -1210,6 +1213,13 @@ async function main() {
       break;
     }
 
+    case 'antigravity-cli': {
+      const antigravitySubcommand = process.argv[3];
+      const antigravityResult = await handleAntigravityCliCommand(antigravitySubcommand, process.argv.slice(4));
+      process.exit(antigravityResult);
+      break;
+    }
+
     case 'hook': {
       // IO discipline: this case is the entry point to the hook execution path.
       // Once hookCommand is invoked, src/shared/hook-io.ts owns all
@@ -1220,7 +1230,7 @@ async function main() {
       const event = process.argv[4];
       if (!platform || !event) {
         console.error('Usage: claude-mem hook <platform> <event>');
-        console.error('Platforms: claude-code, codex, cursor, gemini-cli, raw');
+        console.error('Platforms: claude-code, codex, cursor, gemini-cli, antigravity-cli, raw');
         console.error('Events: context, session-init, observation, summarize, user-message');
         process.exit(1);
       }

--- a/tests/antigravity-cli-compat.test.ts
+++ b/tests/antigravity-cli-compat.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+
+// Real cwd that passes isValidCwd (repo root at test runtime).
+const CWD = process.cwd();
+
+const basePost = () => ({
+  conversationId: 'conv-abc-123',
+  artifactDirectoryPath: '/some/brain',
+  error: '',
+  stepIdx: 7,
+  toolCall: {
+    name: 'run_command',
+    args: { CommandLine: 'echo hi', Cwd: CWD },
+  },
+  transcriptPath: '/some/transcript.jsonl',
+  workspacePaths: [CWD],
+});
+
+describe('antigravityCliAdapter.normalizeInput - real agy 1.0.9 payload', () => {
+  it('maps conversationId -> sessionId', async () => {
+    const { antigravityCliAdapter } = await import('../src/cli/adapters/antigravity-cli.js');
+    const r = antigravityCliAdapter.normalizeInput(basePost());
+    expect(r.sessionId).toBe('conv-abc-123');
+  });
+
+  it('maps workspacePaths[0] -> cwd', async () => {
+    const { antigravityCliAdapter } = await import('../src/cli/adapters/antigravity-cli.js');
+    const r = antigravityCliAdapter.normalizeInput(basePost());
+    expect(r.cwd).toBe(CWD);
+  });
+
+  it('falls back to toolCall.args.Cwd when workspacePaths missing', async () => {
+    const { antigravityCliAdapter } = await import('../src/cli/adapters/antigravity-cli.js');
+    const payload = basePost();
+    delete (payload as { workspacePaths?: unknown }).workspacePaths;
+    const r = antigravityCliAdapter.normalizeInput(payload);
+    expect(r.cwd).toBe(CWD);
+  });
+
+  it('maps toolCall.name -> toolName and toolCall.args -> toolInput', async () => {
+    const { antigravityCliAdapter } = await import('../src/cli/adapters/antigravity-cli.js');
+    const r = antigravityCliAdapter.normalizeInput(basePost());
+    expect(r.toolName).toBe('run_command');
+    expect((r.toolInput as { CommandLine?: string }).CommandLine).toBe('echo hi');
+  });
+
+  it('PostToolUse (has error field) -> toolResponse carries error', async () => {
+    const { antigravityCliAdapter } = await import('../src/cli/adapters/antigravity-cli.js');
+    const r = antigravityCliAdapter.normalizeInput(basePost());
+    expect(r.toolResponse).toEqual({ error: '' });
+  });
+
+  it('PreToolUse (no error field) -> toolResponse marks pre-execution', async () => {
+    const { antigravityCliAdapter } = await import('../src/cli/adapters/antigravity-cli.js');
+    const payload = basePost();
+    delete (payload as { error?: unknown }).error;
+    const r = antigravityCliAdapter.normalizeInput(payload);
+    expect(r.toolResponse).toEqual({ _preExecution: true });
+  });
+
+  it('preserves transcriptPath and antigravity metadata', async () => {
+    const { antigravityCliAdapter } = await import('../src/cli/adapters/antigravity-cli.js');
+    const r = antigravityCliAdapter.normalizeInput(basePost());
+    expect(r.transcriptPath).toBe('/some/transcript.jsonl');
+    expect(r.metadata?.conversationId).toBe('conv-abc-123');
+    expect(r.metadata?.stepIdx).toBe(7);
+  });
+});
+
+describe('antigravityCliAdapter.formatOutput - allow/deny contract', () => {
+  it('defaults to decision allow', async () => {
+    const { antigravityCliAdapter } = await import('../src/cli/adapters/antigravity-cli.js');
+    expect(antigravityCliAdapter.formatOutput({ continue: true })).toEqual({ decision: 'allow' });
+  });
+
+  it('maps block decision to deny and passes reason', async () => {
+    const { antigravityCliAdapter } = await import('../src/cli/adapters/antigravity-cli.js');
+    const out = antigravityCliAdapter.formatOutput({ decision: 'block', reason: 'nope' }) as {
+      decision: string;
+      reason?: string;
+    };
+    expect(out.decision).toBe('deny');
+    expect(out.reason).toBe('nope');
+  });
+});
+
+describe('antigravityCliAdapter - registry wiring', () => {
+  it('resolves for both antigravity and antigravity-cli platform ids', async () => {
+    const { getPlatformAdapter } = await import('../src/cli/adapters/index.js');
+    const { antigravityCliAdapter } = await import('../src/cli/adapters/antigravity-cli.js');
+    expect(getPlatformAdapter('antigravity')).toBe(antigravityCliAdapter);
+    expect(getPlatformAdapter('antigravity-cli')).toBe(antigravityCliAdapter);
+  });
+});
+
+describe('AntigravityCliHooksInstaller - event mapping (probe-confirmed)', () => {
+  const src = () =>
+    readFileSync('src/services/integrations/AntigravityCliHooksInstaller.ts', 'utf-8');
+
+  it('maps only the two tool events confirmed by agy 1.0.9 probing', () => {
+    const s = src();
+    expect(s).toContain("'PreToolUse': 'observation'");
+    expect(s).toContain("'PostToolUse': 'observation'");
+  });
+
+  it('does NOT register unverified lifecycle events', () => {
+    const s = src();
+    // These exist in the Python SDK but the CLI hook runner never fired them.
+    // They must stay out of the active map until re-probed (see installer comment).
+    expect(s).not.toContain("'SessionStart':");
+    expect(s).not.toContain("'Stop':");
+    expect(s).not.toContain("'Compaction':");
+    expect(s).not.toContain("'Notification':");
+    expect(s).not.toContain("'PreInvocation':");
+  });
+
+  it('writes hooks to ~/.gemini/config/hooks.json (not settings.json, not antigravity-cli dir)', () => {
+    const s = src();
+    expect(s).toContain("path.join(GEMINI_CONFIG_DIR, 'config')");
+    expect(s).toContain("'hooks.json'");
+    expect(s).not.toContain("antigravity-cli', 'hooks.json'");
+  });
+
+  it('uses seconds (not ms) for the hook timeout', () => {
+    const s = src();
+    expect(s).toContain('HOOK_TIMEOUT_SEC = 10');
+  });
+
+  it('dispatches via the antigravity-cli platform', () => {
+    const s = src();
+    expect(s).toContain('hook antigravity-cli');
+  });
+});


### PR DESCRIPTION
Antigravity CLI (agy) replaces Gemini CLI, which stops serving on 2026-06-18. Add a parallel `antigravity-cli` integration alongside the existing MCP-only `antigravity` identifier (IDE vs terminal CLI are distinct hosts).

- New adapter (antigravity-cli.ts) normalizes the agy hook payload (conversationId -> sessionId, toolCall.name/args, workspacePaths[0] -> cwd) and emits the {decision: allow} stdout contract; claude-mem is a passive observer and never blocks the agent.
- New AntigravityCliHooksInstaller writes ~/.gemini/config/hooks.json (top-level claude-mem key, timeout in seconds); context injection reuses ~/.gemini/GEMINI.md, which Antigravity still parses.
- Wire install/uninstall/status, IDE detection, help text, worker hook dispatch, and the platform adapter registry.
- Register only PreToolUse/PostToolUse: live probing of agy 1.0.9 (headless and interactive) confirmed these are the only events the CLI hook runner currently fires. Lifecycle events (SessionStart, Stop, Compaction, ...) exist in the Python SDK but are not yet surfaced by the CLI; the installer comment documents how to restore them once available.
- Add tests/antigravity-cli-compat.test.ts: adapter payload parsing plus installer event-mapping regression guards.