### PR TITLE
Add support for projectName override via .claude-mem.json

### DIFF
--- a/docs/public/configuration.mdx
+++ b/docs/public/configuration.mdx
@@ -219,6 +219,26 @@ Claude-mem can automatically generate `CLAUDE.md` files in your project folders 
 
 See [Folder Context Files](usage/folder-context) for full documentation on how this feature works, configuration options, and git integration recommendations.
 
+## Per-Project Configuration (`.claude-mem.json`)
+
+You can drop a `.claude-mem.json` file in a project to override per-project behavior. It is read from the project (walking up from the working directory to your home directory), so committing it travels with the repo.
+
+### Pinning the project name
+
+By default the project name is the git repo root's folder name (or the working-directory basename when not in a repo). Set `projectName` to pin it explicitly:
+
+```json
+{
+  "projectName": "my-app"
+}
+```
+
+This is useful when you keep several independent copies or clones of the same project in differently-named folders (e.g. `my-app`, `my-app-2`, `my-app-3`). Give each a `.claude-mem.json` with the same `projectName` and they all share one memory/project instead of being split by folder name.
+
+- The configured name takes precedence over both the git-repo-root and basename derivation.
+- It also applies inside git worktrees, collapsing the usual `parent/worktree` composite to the single configured name.
+- `project_name` (snake_case) is accepted as an alias. An empty or non-string value is ignored and the default derivation is used.
+
 ## Context Injection Configuration
 
 Claude-Mem injects past observations into each new session, giving Claude awareness of recent work. You can configure exactly what gets injected using the **Context Settings Modal**.

--- a/src/utils/project-name.ts
+++ b/src/utils/project-name.ts
@@ -1,14 +1,67 @@
 import { homedir } from 'os'
 import path from 'path';
+import { readFileSync } from 'fs';
 import { execFileSync } from 'child_process';
 import { logger } from './logger.js';
 import { detectWorktree } from './worktree.js';
+
+/** Per-project config file that may carry an explicit `projectName` override. */
+const CONFIG_FILENAME = '.claude-mem.json';
 
 function expandTilde(p: string): string {
   if (p === '~' || p.startsWith('~/')) {
     return p.replace(/^~/, homedir())
   }
   return p
+}
+
+/** Read a non-empty `projectName` (or `project_name`) string from a config file. */
+function readProjectNameField(configPath: string): string | null {
+  let raw: Record<string, unknown>;
+  try {
+    raw = JSON.parse(readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+  } catch {
+    // Missing file or invalid JSON — nothing to override with.
+    return null;
+  }
+  const value = raw.projectName ?? raw.project_name;
+  if (typeof value === 'string' && value.trim() !== '') {
+    return value.trim();
+  }
+  return null;
+}
+
+/**
+ * Read an explicit project-name override from a `.claude-mem.json` config file.
+ * Walks up from `startDir` (through the repo and up to the home directory) and
+ * returns the first `projectName` string it finds, or null when none is set.
+ *
+ * This lets independent copies of a project (e.g. my-app, my-app-2, …) share
+ * one memory: commit a `.claude-mem.json` with `{ "projectName": "my-app" }` and
+ * every copy/worktree resolves to that name regardless of its folder name —
+ * rather than the default git-repo-root / cwd basename.
+ */
+export function getConfiguredProjectName(startDir: string): string | null {
+  const home = homedir();
+  let dir = path.resolve(startDir);
+
+  while (true) {
+    const name = readProjectNameField(path.join(dir, CONFIG_FILENAME));
+    if (name) {
+      logger.info('PROJECT_NAME', 'Using project name from .claude-mem.json', {
+        configDir: dir,
+        projectName: name,
+      });
+      return name;
+    }
+
+    const parent = path.dirname(dir);
+    // Stop after checking the home directory, or once we reach the FS root.
+    if (dir === home || parent === dir) break;
+    dir = parent;
+  }
+
+  return null;
 }
 
 /**
@@ -39,6 +92,12 @@ export function getProjectName(cwd: string | null | undefined): string {
   }
 
   const expanded = expandTilde(cwd)
+
+  // An explicit `.claude-mem.json` { projectName } override wins over the
+  // git-root / basename derivation, so independent copies of a project can be
+  // pinned to one shared memory regardless of their folder names.
+  const configured = getConfiguredProjectName(expanded);
+  if (configured) return configured;
 
   // #2663 — derive the project name from the git repo root when inside a repo so
   // the name is stable across subdirectories/worktrees. Fall back to the cwd
@@ -81,6 +140,13 @@ export function getProjectContext(cwd: string | null | undefined): ProjectContex
   }
 
   const expandedCwd = expandTilde(cwd);
+
+  // An explicit `.claude-mem.json` name is authoritative: skip worktree
+  // compositing so every copy/worktree collapses to the one configured project.
+  if (getConfiguredProjectName(expandedCwd)) {
+    return { primary: cwdProjectName, parent: null, isWorktree: false, allProjects: [cwdProjectName] };
+  }
+
   const worktreeInfo = detectWorktree(expandedCwd);
 
   if (worktreeInfo.isWorktree && worktreeInfo.parentProjectName) {

--- a/tests/utils/project-name.test.ts
+++ b/tests/utils/project-name.test.ts
@@ -94,6 +94,70 @@ describe('getProjectName', () => {
     });
   });
 
+  describe('.claude-mem.json projectName override', () => {
+    let tmp: string;
+    let repoRoot: string;
+    let nestedDir: string;
+
+    beforeAll(async () => {
+      const { mkdtempSync, mkdirSync, writeFileSync, realpathSync } = await import('fs');
+      const { execFileSync } = await import('child_process');
+      const { join } = await import('path');
+      const { tmpdir } = await import('os');
+
+      tmp = realpathSync(mkdtempSync(join(tmpdir(), 'cm-cfgname-')));
+      repoRoot = join(tmp, 'my-app-2');
+      nestedDir = join(repoRoot, 'packages', 'core');
+      mkdirSync(nestedDir, { recursive: true });
+      execFileSync('git', ['init', '-q'], { cwd: repoRoot });
+      writeFileSync(
+        join(repoRoot, '.claude-mem.json'),
+        JSON.stringify({ projectName: 'my-app' })
+      );
+    });
+
+    afterAll(async () => {
+      const { rmSync } = await import('fs');
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    it('overrides the repo-root name at the project root', () => {
+      expect(getProjectName(repoRoot)).toBe('my-app');
+    });
+
+    it('is inherited by nested subdirectories (walks up to the config)', () => {
+      expect(getProjectName(nestedDir)).toBe('my-app');
+    });
+
+    it('getProjectContext reports the configured name with no worktree composite', () => {
+      const ctx = getProjectContext(repoRoot);
+      expect(ctx.primary).toBe('my-app');
+      expect(ctx.parent).toBeNull();
+      expect(ctx.isWorktree).toBe(false);
+      expect(ctx.allProjects).toEqual(['my-app']);
+    });
+
+    it('also accepts the snake_case project_name key', async () => {
+      const { mkdtempSync, writeFileSync, rmSync, realpathSync } = await import('fs');
+      const { join } = await import('path');
+      const { tmpdir } = await import('os');
+      const dir = realpathSync(mkdtempSync(join(tmpdir(), 'cm-cfgsnake-')));
+      writeFileSync(join(dir, '.claude-mem.json'), JSON.stringify({ project_name: 'Shared' }));
+      expect(getProjectName(dir)).toBe('Shared');
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('ignores an empty or non-string projectName and falls back to basename', async () => {
+      const { mkdtempSync, writeFileSync, rmSync, realpathSync } = await import('fs');
+      const { join, basename } = await import('path');
+      const { tmpdir } = await import('os');
+      const dir = realpathSync(mkdtempSync(join(tmpdir(), 'cm-cfgempty-')));
+      writeFileSync(join(dir, '.claude-mem.json'), JSON.stringify({ projectName: '   ' }));
+      expect(getProjectName(dir)).toBe(basename(dir));
+      rmSync(dir, { recursive: true, force: true });
+    });
+  });
+
   describe('realistic scenarios from #1478', () => {
     it('handles ~ the same as full home path', () => {
       const home = homedir();


### PR DESCRIPTION
## Info
Project names are derived from the git repo root (or cwd basename), which splits independent copies/clones of the same project into separate memories just because their folders are named differently.

## How?
Add an explicit override: a `.claude-mem.json` with `{ "projectName": "..." }` (read by walking up from cwd to the home dir) pins the project name regardless of folder name. It takes precedence over the git-root/basename derivation and collapses worktree composites to the single configured name, so sibling copies can share one memory. Accepts `project_name` as a snake_case alias; empty or non-string values are ignored.