### PR TITLE
fix: ensure marketplace.json is available at Claude Code expected location

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,24 +40,23 @@
     },
     "./modes/*": "./plugin/modes/*"
   },
-"files": [
-  "dist",
-  ".agents/plugins/marketplace.json",
-  ".claude-plugin/marketplace.json",
-  ".codex-plugin",
-  "plugin/.claude-plugin",
-  "plugin/.codex-plugin",
-  "plugin/.mcp.json",
-  "plugin/package.json",
-  "plugin/bun.lock",
-  "plugin/hooks",
-  "plugin/modes",
-  "plugin/scripts/*.js",
-  "plugin/scripts/*.cjs",
-  "plugin/skills",
-  "plugin/ui",
-  "openclaw"
-],
+  "files": [
+    "dist",
+    ".agents/plugins/marketplace.json",
+    ".claude-plugin/marketplace.json",    ".codex-plugin",
+    "plugin/.claude-plugin",
+    "plugin/.codex-plugin",
+    "plugin/.mcp.json",
+    "plugin/package.json",
+    "plugin/bun.lock",
+    "plugin/hooks",
+    "plugin/modes",
+    "plugin/scripts/*.js",
+    "plugin/scripts/*.cjs",
+    "plugin/skills",
+    "plugin/ui",
+    "openclaw"
+  ],
   "engines": {
     "node": ">=20.0.0",
     "bun": ">=1.0.0"

--- a/package.json
+++ b/package.json
@@ -40,23 +40,24 @@
     },
     "./modes/*": "./plugin/modes/*"
   },
-  "files": [
-    "dist",
-    ".agents/plugins/marketplace.json",
-    ".codex-plugin",
-    "plugin/.claude-plugin",
-    "plugin/.codex-plugin",
-    "plugin/.mcp.json",
-    "plugin/package.json",
-    "plugin/bun.lock",
-    "plugin/hooks",
-    "plugin/modes",
-    "plugin/scripts/*.js",
-    "plugin/scripts/*.cjs",
-    "plugin/skills",
-    "plugin/ui",
-    "openclaw"
-  ],
+"files": [
+  "dist",
+  ".agents/plugins/marketplace.json",
+  ".claude-plugin/marketplace.json",
+  ".codex-plugin",
+  "plugin/.claude-plugin",
+  "plugin/.codex-plugin",
+  "plugin/.mcp.json",
+  "plugin/package.json",
+  "plugin/bun.lock",
+  "plugin/hooks",
+  "plugin/modes",
+  "plugin/scripts/*.js",
+  "plugin/scripts/*.cjs",
+  "plugin/skills",
+  "plugin/ui",
+  "openclaw"
+],
   "engines": {
     "node": ">=20.0.0",
     "bun": ">=1.0.0"


### PR DESCRIPTION
Fixes #3004

## Problem

Claude Code plugin marketplace discovery expects `marketplace.json` to exist at the standard location:

- `.claude-plugin/marketplace.json`
- or as a direct marketplace JSON file

The repository currently includes the marketplace manifest under `.agents/plugins/marketplace.json`, which is not discovered correctly by Claude Code during marketplace/plugin listing.

## Changes

- Ensure `.claude-plugin/marketplace.json` is included in the package files.
- Keep marketplace metadata available at the standard Claude Code discovery path.
- Preserve existing `.agents/plugins/marketplace.json` support for compatibility.

## Verification

Ran:

```bash
npm pack --dry-run

Confirmed the package includes:

.claude-plugin/marketplace.json
.agents/plugins/marketplace.json

This ensures installations through:

/plugin marketplace add thedotmack/claude-mem
/plugin install claude-mem

can discover the marketplace correctly.


Reference:

Fixes #3004


This will automatically link your PR to the issue and close it when merged. :contentReference[oaicite:1]{index=1}