### PR TITLE
fix(windows): strip UTF-8 BOM in all settings.json readers (#3013)

### DIFF
--- a/src/npx-cli/commands/server.ts
+++ b/src/npx-cli/commands/server.ts
@@ -11,6 +11,7 @@ import {
   runStatusCommand,
   runStopCommand,
 } from './runtime.js';
+import { stripBom } from '../../utils/json-utils.js';
 
 const UNSUPPORTED_SERVER_COMMANDS = new Set([
   'logs',
@@ -148,7 +149,7 @@ async function runServerBetaKeysRotateCommand(): Promise<void> {
   let previousApiKeyId: string | null = null;
   if (existsSync(settingsPath)) {
     try {
-      const raw = JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>;
+      const raw = JSON.parse(stripBom(readFileSync(settingsPath, 'utf-8'))) as Record<string, unknown>;
       const flat = (raw.env && typeof raw.env === 'object' ? raw.env : raw) as Record<string, unknown>;
       const previousKey = flat.CLAUDE_MEM_SERVER_BETA_API_KEY;
       if (typeof previousKey === 'string' && previousKey.length > 0) {

--- a/src/services/hooks/server-beta-bootstrap.ts
+++ b/src/services/hooks/server-beta-bootstrap.ts
@@ -23,6 +23,7 @@
 import { createHash, randomBytes } from 'crypto';
 import { chmodSync, existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { dirname } from 'path';
+import { stripBom } from '../../utils/json-utils.js';
 import { createPostgresPool, type PostgresPool } from '../../storage/postgres/pool.js';
 import { parsePostgresConfig } from '../../storage/postgres/config.js';
 import { PostgresAuthRepository } from '../../storage/postgres/auth.js';
@@ -133,7 +134,7 @@ export function persistServerBetaSettings(
   let existing: Record<string, unknown> = {};
   if (existsSync(settingsPath)) {
     try {
-      existing = JSON.parse(readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>;
+      existing = JSON.parse(stripBom(readFileSync(settingsPath, 'utf-8'))) as Record<string, unknown>;
     } catch {
       existing = {};
     }

--- a/src/services/worker/http/routes/SettingsRoutes.ts
+++ b/src/services/worker/http/routes/SettingsRoutes.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { readFileSync, writeFileSync, existsSync, renameSync, mkdirSync } from 'fs';
 import { getPackageRoot, paths } from '../../../../shared/paths.js';
 import { logger } from '../../../../utils/logger.js';
+import { stripBom } from '../../../../utils/json-utils.js';
 import { SettingsManager } from '../../SettingsManager.js';
 import { getBranchInfo, switchBranch, pullUpdates } from '../../BranchManager.js';
 import { ModeManager } from '../../../domain/ModeManager.js';
@@ -65,7 +66,7 @@ export class SettingsRoutes extends BaseRouteHandler {
     if (existsSync(settingsPath)) {
       const settingsData = readFileSync(settingsPath, 'utf-8');
       try {
-        settings = JSON.parse(settingsData);
+        settings = JSON.parse(stripBom(settingsData));
       } catch (parseError) {
         const normalizedParseError = parseError instanceof Error ? parseError : new Error(String(parseError));
         logger.error('HTTP', 'Failed to parse settings file', { settingsPath }, normalizedParseError);

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -3,6 +3,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { HOOK_TIMEOUTS, getTimeout } from './hook-constants.js';
+import { stripBom } from '../utils/json-utils.js';
 
 export interface SettingsDefaults {
   CLAUDE_MEM_MODEL: string;
@@ -214,10 +215,8 @@ export class SettingsDefaultsManager {
       }
 
       const settingsData = readFileSync(settingsPath, 'utf-8');
-      // Strip UTF-8 BOM if present — Windows tools (editors, formatters, CLI
-      // hooks) may prepend U+FEFF which Bun's JSON.parse rejects silently,
-      // causing a full fallback to defaults and breaking server-beta routing.
-      const settings = JSON.parse(settingsData.replace(/^\uFEFF/, ''));
+      // BOM-tolerant: Windows tooling may prepend U+FEFF (see stripBom).
+      const settings = JSON.parse(stripBom(settingsData));
 
       let flatSettings = settings;
       if (settings.env && typeof settings.env === 'object') {

--- a/src/shared/paths.ts
+++ b/src/shared/paths.ts
@@ -5,6 +5,7 @@ import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { SettingsDefaultsManager } from './SettingsDefaultsManager.js';
 import { logger } from '../utils/logger.js';
+import { stripBom } from '../utils/json-utils.js';
 
 function getDirname(): string {
   if (typeof __dirname !== 'undefined') {
@@ -24,7 +25,7 @@ export function resolveDataDir(): string {
   const settingsPath = join(defaultDataDir, 'settings.json');
   try {
     if (existsSync(settingsPath)) {
-      const raw = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+      const raw = JSON.parse(stripBom(readFileSync(settingsPath, 'utf-8')));
       const settings = raw.env ?? raw; 
       if (settings.CLAUDE_MEM_DATA_DIR) {
         return settings.CLAUDE_MEM_DATA_DIR;

--- a/src/shared/plugin-state.ts
+++ b/src/shared/plugin-state.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { logger } from '../utils/logger.js';
+import { stripBom } from '../utils/json-utils.js';
 
 const PLUGIN_SETTINGS_KEY = 'claude-mem@thedotmack';
 
@@ -12,7 +13,7 @@ export function isPluginDisabledInClaudeSettings(): boolean {
     const settingsPath = join(claudeConfigDir, 'settings.json');
     if (!existsSync(settingsPath)) return false;
     const raw = readFileSync(settingsPath, 'utf-8');
-    const settings = JSON.parse(raw);
+    const settings = JSON.parse(stripBom(raw));
     return settings?.enabledPlugins?.[PLUGIN_SETTINGS_KEY] === false;
   } catch (error: unknown) {
     logger.error('CONFIG', 'Failed to read Claude settings', { error: error instanceof Error ? error.message : String(error) });

--- a/src/utils/json-utils.ts
+++ b/src/utils/json-utils.ts
@@ -1,11 +1,23 @@
 
 import { existsSync, readFileSync } from 'fs';
-import { logger } from './logger.js';
+
+/**
+ * Strip a leading UTF-8 BOM (U+FEFF) from a string.
+ *
+ * Windows tooling — PowerShell 5.1, some editors and formatters — prepends a
+ * BOM (EF BB BF) when it rewrites a file. Node/Bun decode it to U+FEFF at
+ * position 0 on `utf-8` read, and JSON.parse rejects it as an unexpected token.
+ * Our own writes never add a BOM, so any BOM on disk came from external
+ * tooling; readers must tolerate it. See issue #3013.
+ */
+export function stripBom(text: string): string {
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+}
 
 export function readJsonSafe<T>(filePath: string, defaultValue: T): T {
   if (!existsSync(filePath)) return defaultValue;
   try {
-    return JSON.parse(readFileSync(filePath, 'utf-8'));
+    return JSON.parse(stripBom(readFileSync(filePath, 'utf-8')));
   } catch (error: unknown) {
     throw new Error(`Corrupt JSON file, refusing to overwrite: ${filePath}: ${error instanceof Error ? error.message : String(error)}`);
   }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -3,6 +3,7 @@ import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { paths } from '../shared/paths.js';
 import { emitDiagnostic } from '../shared/hook-io.js';
+import { stripBom } from './json-utils.js';
 
 export enum LogLevel {
   DEBUG = 0,
@@ -107,7 +108,7 @@ class Logger {
         const settingsPath = paths.settings();
         if (existsSync(settingsPath)) {
           const settingsData = readFileSync(settingsPath, 'utf-8');
-          const settings = JSON.parse(settingsData);
+          const settings = JSON.parse(stripBom(settingsData));
           const envLevel = (settings.CLAUDE_MEM_LOG_LEVEL || 'INFO').toUpperCase();
           this.level = LogLevel[envLevel as keyof typeof LogLevel] ?? LogLevel.INFO;
         } else {

--- a/tests/utils/json-utils.test.ts
+++ b/tests/utils/json-utils.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { readJsonSafe, stripBom } from '../../src/utils/json-utils.js';
+
+const BOM = '﻿';
+
+describe('stripBom', () => {
+  it('removes a leading UTF-8 BOM', () => {
+    expect(stripBom(BOM + '{"a":1}')).toBe('{"a":1}');
+  });
+
+  it('leaves BOM-free strings untouched', () => {
+    expect(stripBom('{"a":1}')).toBe('{"a":1}');
+  });
+
+  it('only strips a BOM at position 0', () => {
+    expect(stripBom('{}' + BOM)).toBe('{}' + BOM);
+  });
+});
+
+describe('readJsonSafe with a BOM-prefixed file', () => {
+  let tempDir: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `json-utils-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tempDir, { recursive: true });
+    filePath = join(tempDir, 'settings.json');
+  });
+
+  afterEach(() => {
+    try { rmSync(tempDir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  // Reproduces issue #3013: PowerShell-written settings.json carries a UTF-8 BOM
+  // that Bun's JSON.parse rejects, breaking every settings reader on Windows.
+  it('parses JSON that PowerShell wrote with a UTF-8 BOM', () => {
+    writeFileSync(filePath, BOM + JSON.stringify({ CLAUDE_MEM_LOG_LEVEL: 'DEBUG' }), 'utf-8');
+    const result = readJsonSafe<Record<string, unknown>>(filePath, {});
+    expect(result.CLAUDE_MEM_LOG_LEVEL).toBe('DEBUG');
+  });
+});


### PR DESCRIPTION
Fixes #3013.

**Problem.** On Windows, external tooling (PowerShell 5.1, some editors/formatters) rewrites `~/.claude-mem/settings.json` with a UTF-8 BOM (`EF BB BF`). Node/Bun decode it to `U+FEFF` at offset 0 on `utf-8` read, and `JSON.parse` rejects it — so the worker fails to load config on **every** hook, eventually tripping `CAPTURE_BROKEN` and disabling capture entirely.

**Root cause.** BOM stripping was added to exactly **one** of seven settings readers (`SettingsDefaultsManager`). The other six still parsed raw and threw — including `logger.getLevel()`, which is the source of the `Failed to load log level from settings` error in the report.

**Why read-side, not write-side.** Our own writes use `writeFileSync(..., 'utf-8')`, which never emits a BOM — so a write-side fix is a no-op and wouldn't repair the already-BOM'd files sitting on users' disks. The fix has to be read-side resilience.

**Changes**
- Add shared `stripBom()` to `utils/json-utils` and route `readJsonSafe` through it
- Strip BOM in the six remaining `settings.json` readers (`logger`, `paths`, `plugin-state`, npx `server`, `server-beta-bootstrap`, `SettingsRoutes`)
- Collapse `SettingsDefaultsManager`'s inline BOM regex onto the shared helper
- Drop a dead `logger` import so `json-utils` stays an import-cycle-free leaf
- Test: `readJsonSafe` parses a BOM-prefixed `settings.json`

**Verification:** `bun test` 39/39 pass · `tsc --noEmit` clean.