### PR TITLE
feat(openrouter): add CLAUDE_MEM_OPENROUTER_EXTRA_BODY for provider-specific request parameters

### DIFF
--- a/src/services/worker/OpenRouterProvider.ts
+++ b/src/services/worker/OpenRouterProvider.ts
@@ -198,7 +198,7 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
   }
 
   protected async query(history: ConversationMessage[], config: OpenRouterConfig): Promise<ProviderQueryResult> {
-    return this.queryOpenRouterMultiTurn(history, config.apiKey, config.model, config.apiUrl, config.siteUrl, config.appName);
+    return this.queryOpenRouterMultiTurn(history, config.apiKey, config.model, config.apiUrl, config.siteUrl, config.appName, config.extraBody);
   }
 
   private async queryOpenRouterMultiTurn(
@@ -207,7 +207,8 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
     model: string,
     apiUrl: string,
     siteUrl?: string,
-    appName?: string
+    appName?: string,
+    extraBody?: Record<string, unknown>,
   ): Promise<ProviderQueryResult> {
     const truncatedHistory = this.truncateHistoryForOpenRouter(history);
     const messages = this.conversationToOpenAIMessages(truncatedHistory);
@@ -246,7 +247,7 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
             // User-defined extra body parameters merged last so they can
             // override any of the above. Used for provider-specific params
             // like thinking control (e.g. {"thinking":{"type":"disabled"}}).
-            ...(config.extraBody ?? {}),
+            ...(extraBody ?? {}),
           }),
           signal: attemptSignal,
         });

--- a/src/services/worker/OpenRouterProvider.ts
+++ b/src/services/worker/OpenRouterProvider.ts
@@ -136,6 +136,7 @@ interface OpenRouterConfig {
   apiUrl: string;
   siteUrl?: string;
   appName?: string;
+  extraBody?: Record<string, unknown>;
 }
 
 export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfig> {
@@ -242,6 +243,10 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
             // Only sent to openrouter.ai — strict custom gateways may reject
             // unknown body fields.
             ...(apiUrl.includes('openrouter.ai') ? { usage: { include: true } } : {}),
+            // User-defined extra body parameters merged last so they can
+            // override any of the above. Used for provider-specific params
+            // like thinking control (e.g. {"thinking":{"type":"disabled"}}).
+            ...(config.extraBody ?? {}),
           }),
           signal: attemptSignal,
         });
@@ -350,7 +355,25 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
     const siteUrl = settings.CLAUDE_MEM_OPENROUTER_SITE_URL || '';
     const appName = settings.CLAUDE_MEM_OPENROUTER_APP_NAME || 'claude-mem';
 
-    return { apiKey, model, apiUrl, siteUrl, appName };
+    // Parse optional extra body parameters (JSON string). Merged into the
+    // request body last so users can override defaults or add provider-specific
+    // fields like thinking control: {"thinking":{"type":"disabled"}}.
+    let extraBody: Record<string, unknown> | undefined;
+    const extraBodyRaw = settings.CLAUDE_MEM_OPENROUTER_EXTRA_BODY;
+    if (extraBodyRaw) {
+      try {
+        const parsed = JSON.parse(extraBodyRaw);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          extraBody = parsed as Record<string, unknown>;
+        } else {
+          logger.warn('SDK', 'CLAUDE_MEM_OPENROUTER_EXTRA_BODY must be a JSON object, ignoring');
+        }
+      } catch {
+        logger.warn('SDK', 'CLAUDE_MEM_OPENROUTER_EXTRA_BODY is not valid JSON, ignoring');
+      }
+    }
+
+    return { apiKey, model, apiUrl, siteUrl, appName, extraBody };
   }
 }
 

--- a/src/services/worker/http/routes/SettingsRoutes.ts
+++ b/src/services/worker/http/routes/SettingsRoutes.ts
@@ -95,6 +95,7 @@ export class SettingsRoutes extends BaseRouteHandler {
       'CLAUDE_MEM_OPENROUTER_APP_NAME',
       'CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES',
       'CLAUDE_MEM_OPENROUTER_MAX_TOKENS',
+      'CLAUDE_MEM_OPENROUTER_EXTRA_BODY',
       'CLAUDE_MEM_DATA_DIR',
       'CLAUDE_MEM_LOG_LEVEL',
       'CLAUDE_MEM_PYTHON_VERSION',
@@ -310,6 +311,17 @@ export class SettingsRoutes extends BaseRouteHandler {
       } catch (error) {
         logger.debug('SETTINGS', 'Invalid URL format', { url: settings.CLAUDE_MEM_OPENROUTER_SITE_URL, error: error instanceof Error ? error.message : String(error) });
         return { valid: false, error: 'CLAUDE_MEM_OPENROUTER_SITE_URL must be a valid URL' };
+      }
+    }
+
+    if (settings.CLAUDE_MEM_OPENROUTER_EXTRA_BODY) {
+      try {
+        const parsed = JSON.parse(settings.CLAUDE_MEM_OPENROUTER_EXTRA_BODY);
+        if (parsed && (typeof parsed !== 'object' || Array.isArray(parsed))) {
+          return { valid: false, error: 'CLAUDE_MEM_OPENROUTER_EXTRA_BODY must be a JSON object (e.g. {"thinking":{"type":"disabled"}})' };
+        }
+      } catch {
+        return { valid: false, error: 'CLAUDE_MEM_OPENROUTER_EXTRA_BODY is not valid JSON' };
       }
     }
 

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -25,6 +25,7 @@ export interface SettingsDefaults {
   CLAUDE_MEM_OPENROUTER_APP_NAME: string;
   CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES: string;
   CLAUDE_MEM_OPENROUTER_MAX_TOKENS: string;
+  CLAUDE_MEM_OPENROUTER_EXTRA_BODY: string;
   CLAUDE_MEM_DATA_DIR: string;
   CLAUDE_MEM_LOG_LEVEL: string;
   CLAUDE_MEM_PYTHON_VERSION: string;
@@ -106,6 +107,7 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_OPENROUTER_APP_NAME: 'claude-mem',  // App name for OpenRouter analytics
     CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES: '20',  // Max messages in context window
     CLAUDE_MEM_OPENROUTER_MAX_TOKENS: '100000',  // Max estimated tokens (~100k safety limit)
+    CLAUDE_MEM_OPENROUTER_EXTRA_BODY: '',  // JSON object merged into request body (e.g. {"thinking":{"type":"disabled"}})
     CLAUDE_MEM_DATA_DIR: join(homedir(), '.claude-mem'),
     CLAUDE_MEM_LOG_LEVEL: 'INFO',
     CLAUDE_MEM_PYTHON_VERSION: '3.13',


### PR DESCRIPTION
## Motivation

Users connecting through OpenAI-compatible endpoints (DeepSeek, MiniMax, local models, etc.) sometimes need to pass provider-specific parameters in the chat completion request body — for example, `{"thinking":{"type":"disabled"}}` to disable reasoning on models that would otherwise consume the output token budget with chain-of-thought.

Currently there is no way to inject custom body fields without patching the source.

## Changes

Adds a new optional setting `CLAUDE_MEM_OPENROUTER_EXTRA_BODY` that accepts a JSON object string. The parsed object is spread **last** into the request body, so it can add or override any field:

```json
{
  "CLAUDE_MEM_OPENROUTER_EXTRA_BODY": "{\"thinking\":{\"type\":\"disabled\"}}"
}
```

**Implementation** (2 files, +26/-1):

- `SettingsDefaultsManager.ts`: new field in the interface + default (`""`)
- `OpenRouterProvider.ts`:
  - `extraBody?: Record<string, unknown>` added to `OpenRouterConfig`
  - `getOpenRouterConfig()` parses the JSON, validates it's an object, logs a warning if invalid
  - `extraBody` spread into the request body after `usage.include` so it's always last

**Error handling**:
- Missing setting: no extra fields spread (unchanged behavior)
- Invalid JSON: logged warning, no extra fields spread
- Valid JSON that is not an object (e.g. array, string, number): logged warning, ignored

## Backward compatibility

Fully compatible — empty/missing setting means no extra fields are spread. All existing requests are unchanged.

## Usage examples

Disable thinking on reasoning models:
```json
{ "CLAUDE_MEM_OPENROUTER_EXTRA_BODY": "{\"thinking\":{\"type\":\"disabled\"}}" }
```

Lower reasoning effort (for providers that support `reasoning_effort`):
```json
{ "CLAUDE_MEM_OPENROUTER_EXTRA_BODY": "{\"reasoning_effort\":\"low\"}" }
```