### PR TITLE
fix(build): align root tree-sitter override with bundled plugin manifest (closes #3035)

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "zod-to-json-schema": "^3.25.2"
   },
   "overrides": {
+    "tree-sitter": "^0.25.0",
     "tmp": "^0.2.7"
   },
   "devDependencies": {

--- a/tests/infrastructure/tree-sitter-manifest-consistency.test.ts
+++ b/tests/infrastructure/tree-sitter-manifest-consistency.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(__dirname, '../..');
+
+function readJson(relativePath: string): any {
+  return JSON.parse(readFileSync(path.join(projectRoot, relativePath), 'utf-8'));
+}
+
+describe('Tree-sitter manifest consistency', () => {
+  it('keeps the root tree-sitter override aligned with the bundled plugin manifest', () => {
+    const rootPackageJson = readJson('package.json');
+    const pluginPackageJson = readJson('plugin/package.json');
+
+    expect(rootPackageJson.overrides?.['tree-sitter']).toBeDefined();
+    expect(pluginPackageJson.overrides?.['tree-sitter']).toBeDefined();
+    expect(rootPackageJson.overrides['tree-sitter']).toBe(
+      pluginPackageJson.overrides['tree-sitter'],
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Strict `npm install` on the root manifest still trips a `tree-sitter` peer-resolution failure because the root package is missing the `tree-sitter` override that the bundled plugin manifest already carries. This change mirrors that override into the root manifest and adds a focused infrastructure test that keeps the root and plugin override values aligned.

Closes #3035

## Why

The bundled runtime manifest in `plugin/package.json` already pins `overrides.tree-sitter` to `^0.25.0`, and a clean temp-copy install succeeds there. The root manifest still only overrides `tmp`, so strict npm resolution is left to reconcile `@derekstride/tree-sitter-sql` and `@tree-sitter-grammars/tree-sitter-lua` on its own, which reproduces the current `ERESOLVE` failure.

Related background: https://github.com/thedotmack/claude-mem/pull/2300 and https://github.com/thedotmack/claude-mem/pull/2305 fixed the earlier marketplace install path; this PR only closes the remaining root-manifest parity gap.

## Scope

This PR only fixes the root manifest parity gap and adds a regression guard for that exact drift. It does not reshuffle tree-sitter dependencies, change installer fallback behavior, or touch the bundled plugin runtime manifest beyond using it as the source of truth.

## Verification

- [x] `bun test tests/infrastructure/tree-sitter-manifest-consistency.test.ts`
- [x] `npm run build`
- [x] `npm run lint:hook-io`
- [x] `npm run lint:spawn-env`
- [ ] `npm run strip-comments:check` — repo baseline remains `Changed: 329 (check mode, no writes)`
- [x] Manual: temp-copy root `package.json` strict `npm install --ignore-scripts` fails on base and succeeds on head

Closes #3035
