### PR TITLE
feat(mcp): add memory_save tool for worker-runtime manual writes

### DIFF
--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -643,6 +643,55 @@ NEVER fetch full details without filtering first. 10x token savings.`,
       return handleObservationAdd(merged);
     },
   },
+  // Worker-runtime manual write. Unlike observation_add/memory_add (which are
+  // gated to server-beta and call /v1/memories), this talks to the worker's
+  // ungated POST /api/memory/save — writing straight to SQLite + Chroma. It is
+  // the only manual-write path available on the default `worker` runtime, where
+  // no server-beta server, API key, or project id is configured. Uses the same
+  // workerHttpRequest plumbing as search/timeline, so it shares the worker the
+  // MCP server already auto-starts in worker mode. No Bun-only imports.
+  {
+    name: 'memory_save',
+    description:
+      'Save a manual memory to the local worker (SQLite + Chroma) via POST /api/memory/save. ' +
+      'Worker-runtime path — does NOT require server-beta. Use this on the default worker runtime. ' +
+      'Params: text (required), title, project, metadata.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        text: { type: 'string', description: 'The memory content to store' },
+        title: { type: 'string', description: 'Optional short title; auto-derived from text if omitted' },
+        project: { type: 'string', description: 'Project bucket; defaults to the worker default project if omitted' },
+        metadata: { type: 'object', additionalProperties: true },
+      },
+      required: ['text'],
+      additionalProperties: false,
+    },
+    handler: async (args: any) => {
+      try {
+        if (typeof args?.text !== 'string' || args.text.trim().length === 0) {
+          throw new Error('memory_save: "text" is required');
+        }
+        const body: Record<string, unknown> = { text: args.text };
+        if (typeof args.title === 'string' && args.title.trim()) body.title = args.title;
+        if (typeof args.project === 'string' && args.project.trim()) body.project = args.project;
+        if (args.metadata && typeof args.metadata === 'object') body.metadata = args.metadata;
+
+        const response = await workerHttpRequest('/api/memory/save', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        if (!response.ok) {
+          const detail = await response.text().catch(() => '');
+          throw new Error(`worker /api/memory/save returned ${response.status}${detail ? `: ${detail}` : ''}`);
+        }
+        return formatJsonResult(await response.json());
+      } catch (error) {
+        return formatToolError(error);
+      }
+    },
+  },
   {
     name: 'memory_search',
     description: 'Compatibility alias for observation_search. Same FTS path; same /v1/search REST endpoint.',

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -669,6 +669,18 @@ NEVER fetch full details without filtering first. 10x token savings.`,
     },
     handler: async (args: any) => {
       try {
+        // Worker-only: this tool writes to the local worker's SQLite + Chroma.
+        // In server-beta mode main() skips worker auto-start, so posting here
+        // would either fail with a connection error or land the memory in a
+        // stray local worker instead of the selected server-beta backend —
+        // splitting manual memories across stores. Fail clearly and point the
+        // caller at the server-beta-backed tools instead.
+        if (selectRuntime() === 'server-beta') {
+          throw new Error(
+            'memory_save targets the worker runtime (POST /api/memory/save) and is unavailable when ' +
+            'CLAUDE_MEM_RUNTIME=server-beta. Use observation_add / memory_add, which write to the server-beta backend.'
+          );
+        }
         if (typeof args?.text !== 'string' || args.text.trim().length === 0) {
           throw new Error('memory_save: "text" is required');
         }


### PR DESCRIPTION
## Problem

The `observation_add` / `memory_add` MCP tools are gated to the **server-beta** runtime — they call the `/v1` REST core and throw `requires CLAUDE_MEM_RUNTIME=server-beta` on the default `worker` runtime. That leaves **worker-runtime users with no agent-facing manual-write tool at all**, even though the worker already exposes an ungated `POST /api/memory/save` endpoint (`MemoryRoutes.ts`) that writes straight to SQLite + Chroma.

So an agent told to "save this to memory" on a stock worker install hits a hard error, despite the backend fully supporting the write.

## Change

Adds a `memory_save` MCP tool that proxies `POST /api/memory/save` via the existing `workerHttpRequest` helper — the same plumbing `search` / `timeline` / `get_observations` already use. It:

- works on the **default `worker` runtime** (no server-beta, Postgres, or Docker required);
- introduces **no new imports** and **no Bun-only code** (stays within the MCP bundle's Node constraint and the 600 KB budget — built bundle is ~333 KB);
- mirrors the shape of the existing `memory_*` alias tools.

```
Params: text (required), title?, project?, metadata?
Returns: { success, id, title, project, message }
```

## Test

Built via `scripts/build-hooks.js` and exercised over a real MCP stdio handshake against a running worker:

- `tools/list` includes `memory_save` (required: `["text"]`)
- `tools/call memory_save` → `{ "success": true, "id": <n>, "project": "...", "message": "Memory saved as observation #<n>" }`, verified persisted to SQLite and synced to Chroma.

## Why not just use server-beta?

server-beta requires standing up Docker + Postgres + an API key. For users who deliberately stay on the lightweight worker runtime, this exposes the manual-write capability the worker already has, with zero added infrastructure.