### PR TITLE
fix(installer): drop shell:IS_WINDOWS from version-probe spawns to silence DEP0190 on Node 22 (closes #2941)

### DIFF
--- a/src/npx-cli/commands/doctor.ts
+++ b/src/npx-cli/commands/doctor.ts
@@ -26,7 +26,7 @@ interface CheckResult {
 function probeVersion(bin: string): string | null {
   try {
     const [probeExe, probeArgs] = IS_WINDOWS
-      ? (['cmd.exe', ['/c', bin, '--version']] as const)
+      ? (['cmd.exe', ['/d', '/c', bin, '--version']] as const)
       : ([bin, ['--version']] as const);
     const result = spawnSync(probeExe, probeArgs, {
       encoding: 'utf-8',

--- a/src/npx-cli/commands/doctor.ts
+++ b/src/npx-cli/commands/doctor.ts
@@ -25,8 +25,10 @@ interface CheckResult {
 
 function probeVersion(bin: string): string | null {
   try {
-    const resolved = IS_WINDOWS ? `${bin}.cmd` : bin;
-    const result = spawnSync(resolved, ['--version'], {
+    const [probeExe, probeArgs] = IS_WINDOWS
+      ? (['cmd.exe', ['/c', bin, '--version']] as const)
+      : ([bin, ['--version']] as const);
+    const result = spawnSync(probeExe, probeArgs, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });

--- a/src/npx-cli/commands/doctor.ts
+++ b/src/npx-cli/commands/doctor.ts
@@ -25,10 +25,10 @@ interface CheckResult {
 
 function probeVersion(bin: string): string | null {
   try {
-    const result = spawnSync(bin, ['--version'], {
+    const resolved = IS_WINDOWS ? `${bin}.cmd` : bin;
+    const result = spawnSync(resolved, ['--version'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
-      shell: IS_WINDOWS,
     });
     return result.status === 0 ? result.stdout.trim() : null;
   } catch {

--- a/src/npx-cli/install/npm-install-helper.ts
+++ b/src/npx-cli/install/npm-install-helper.ts
@@ -54,10 +54,9 @@ export function extractEresolveBlock(stderr: string): string {
 // the spinner mid-frame and the install looks stalled.
 export function runNpmStrict(cwd: string, flags: string[], isFirstRun = true): Promise<NpmResult> {
   return new Promise((resolve) => {
-    const child = spawn('npm', flags, {
+    const child = spawn(IS_WINDOWS ? 'npm.cmd' : 'npm', flags, {
       cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
-      ...(IS_WINDOWS ? { shell: process.env.ComSpec ?? 'cmd.exe' } : {}),
     });
 
     let stdout = '';

--- a/src/npx-cli/install/npm-install-helper.ts
+++ b/src/npx-cli/install/npm-install-helper.ts
@@ -54,7 +54,10 @@ export function extractEresolveBlock(stderr: string): string {
 // the spinner mid-frame and the install looks stalled.
 export function runNpmStrict(cwd: string, flags: string[], isFirstRun = true): Promise<NpmResult> {
   return new Promise((resolve) => {
-    const child = spawn(IS_WINDOWS ? 'npm.cmd' : 'npm', flags, {
+    const [npmExe, npmFlags] = IS_WINDOWS
+      ? (['cmd.exe', ['/c', 'npm', ...flags]] as const)
+      : (['npm', flags] as const);
+    const child = spawn(npmExe, npmFlags, {
       cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
     });

--- a/src/npx-cli/install/npm-install-helper.ts
+++ b/src/npx-cli/install/npm-install-helper.ts
@@ -55,7 +55,7 @@ export function extractEresolveBlock(stderr: string): string {
 export function runNpmStrict(cwd: string, flags: string[], isFirstRun = true): Promise<NpmResult> {
   return new Promise((resolve) => {
     const [npmExe, npmFlags] = IS_WINDOWS
-      ? (['cmd.exe', ['/c', 'npm', ...flags]] as const)
+      ? (['cmd.exe', ['/d', '/c', 'npm', ...flags]] as const)
       : (['npm', flags] as const);
     const child = spawn(npmExe, npmFlags, {
       cwd,

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -72,12 +72,11 @@ function markerPath(targetDir: string): string {
 
 function getBunPath(): string | null {
   try {
-    const result = spawnSync('bun', ['--version'], {
+    const result = spawnSync(IS_WINDOWS ? 'bun.cmd' : 'bun', ['--version'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
-      shell: IS_WINDOWS,
     });
-    if (result.status === 0) return 'bun';
+    if (result.status === 0) return IS_WINDOWS ? 'bun.cmd' : 'bun';
   } catch {
     // Not in PATH
   }
@@ -97,7 +96,6 @@ function getBunVersion(): string | null {
     const result = spawnSync(bunPath, ['--version'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
-      shell: IS_WINDOWS,
     });
     return result.status === 0 ? result.stdout.trim() : null;
   } catch {
@@ -107,12 +105,11 @@ function getBunVersion(): string | null {
 
 function getUvPath(): string | null {
   try {
-    const result = spawnSync('uv', ['--version'], {
+    const result = spawnSync(IS_WINDOWS ? 'uv.cmd' : 'uv', ['--version'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
-      shell: IS_WINDOWS,
     });
-    if (result.status === 0) return 'uv';
+    if (result.status === 0) return IS_WINDOWS ? 'uv.cmd' : 'uv';
   } catch {
     // Not in PATH
   }
@@ -132,7 +129,6 @@ function getUvVersion(): string | null {
     const result = spawnSync(uvPath, ['--version'], {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
-      shell: IS_WINDOWS,
     });
     return result.status === 0 ? result.stdout.trim() : null;
   } catch {

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -73,7 +73,7 @@ function markerPath(targetDir: string): string {
 function getBunPath(): string | null {
   try {
     const [bunExe, bunVersionArgs] = IS_WINDOWS
-      ? (['cmd.exe', ['/c', 'bun', '--version']] as const)
+      ? (['cmd.exe', ['/d', '/c', 'bun', '--version']] as const)
       : (['bun', ['--version']] as const);
     const result = spawnSync(bunExe, bunVersionArgs, {
       encoding: 'utf-8',
@@ -97,7 +97,7 @@ function getBunVersion(): string | null {
 
   try {
     const [bvExe, bvArgs] = IS_WINDOWS
-      ? (['cmd.exe', ['/c', bunPath, '--version']] as const)
+      ? (['cmd.exe', ['/d', '/c', bunPath, '--version']] as const)
       : ([bunPath, ['--version']] as const);
     const result = spawnSync(bvExe, bvArgs, {
       encoding: 'utf-8',
@@ -112,7 +112,7 @@ function getBunVersion(): string | null {
 function getUvPath(): string | null {
   try {
     const [uvExe, uvVersionArgs] = IS_WINDOWS
-      ? (['cmd.exe', ['/c', 'uv', '--version']] as const)
+      ? (['cmd.exe', ['/d', '/c', 'uv', '--version']] as const)
       : (['uv', ['--version']] as const);
     const result = spawnSync(uvExe, uvVersionArgs, {
       encoding: 'utf-8',
@@ -136,7 +136,7 @@ function getUvVersion(): string | null {
 
   try {
     const [uvExe, uvVersionArgs] = IS_WINDOWS
-      ? (['cmd.exe', ['/c', uvPath, '--version']] as const)
+      ? (['cmd.exe', ['/d', '/c', uvPath, '--version']] as const)
       : ([uvPath, ['--version']] as const);
     const result = spawnSync(uvExe, uvVersionArgs, {
       encoding: 'utf-8',

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -72,11 +72,14 @@ function markerPath(targetDir: string): string {
 
 function getBunPath(): string | null {
   try {
-    const result = spawnSync(IS_WINDOWS ? 'bun.cmd' : 'bun', ['--version'], {
+    const [bunExe, bunVersionArgs] = IS_WINDOWS
+      ? (['cmd.exe', ['/c', 'bun', '--version']] as const)
+      : (['bun', ['--version']] as const);
+    const result = spawnSync(bunExe, bunVersionArgs, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });
-    if (result.status === 0) return IS_WINDOWS ? 'bun.cmd' : 'bun';
+    if (result.status === 0) return 'bun';
   } catch {
     // Not in PATH
   }
@@ -93,7 +96,10 @@ function getBunVersion(): string | null {
   if (!bunPath) return null;
 
   try {
-    const result = spawnSync(bunPath, ['--version'], {
+    const [bvExe, bvArgs] = IS_WINDOWS
+      ? (['cmd.exe', ['/c', bunPath, '--version']] as const)
+      : ([bunPath, ['--version']] as const);
+    const result = spawnSync(bvExe, bvArgs, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });
@@ -105,11 +111,14 @@ function getBunVersion(): string | null {
 
 function getUvPath(): string | null {
   try {
-    const result = spawnSync(IS_WINDOWS ? 'uv.cmd' : 'uv', ['--version'], {
+    const [uvExe, uvVersionArgs] = IS_WINDOWS
+      ? (['cmd.exe', ['/c', 'uv', '--version']] as const)
+      : (['uv', ['--version']] as const);
+    const result = spawnSync(uvExe, uvVersionArgs, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });
-    if (result.status === 0) return IS_WINDOWS ? 'uv.cmd' : 'uv';
+    if (result.status === 0) return 'uv';
   } catch {
     // Not in PATH
   }
@@ -126,7 +135,10 @@ function getUvVersion(): string | null {
   if (!uvPath) return null;
 
   try {
-    const result = spawnSync(uvPath, ['--version'], {
+    const [uvExe, uvVersionArgs] = IS_WINDOWS
+      ? (['cmd.exe', ['/c', uvPath, '--version']] as const)
+      : ([uvPath, ['--version']] as const);
+    const result = spawnSync(uvExe, uvVersionArgs, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     });

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { exec, execSync, spawnSync } from 'child_process';
 import { createRequire } from 'module';
-import { join } from 'path';
+import { isAbsolute, join } from 'path';
 import { homedir } from 'os';
 import { ErrorSeverity } from './error-taxonomy.js';
 import { installerError, type InstallSummary } from './error-reporter.js';
@@ -96,7 +96,10 @@ function getBunVersion(): string | null {
   if (!bunPath) return null;
 
   try {
-    const [bvExe, bvArgs] = IS_WINDOWS
+    // Absolute paths bypass cmd.exe to avoid metacharacter splitting
+    // (e.g. & in C:\Users\A&B\.bun\bin\bun.exe). Short name 'bun' still
+    // needs cmd.exe /d /c for PATH resolution without shell:true (DEP0190).
+    const [bvExe, bvArgs] = IS_WINDOWS && !isAbsolute(bunPath)
       ? (['cmd.exe', ['/d', '/c', bunPath, '--version']] as const)
       : ([bunPath, ['--version']] as const);
     const result = spawnSync(bvExe, bvArgs, {
@@ -135,7 +138,7 @@ function getUvVersion(): string | null {
   if (!uvPath) return null;
 
   try {
-    const [uvExe, uvVersionArgs] = IS_WINDOWS
+    const [uvExe, uvVersionArgs] = IS_WINDOWS && !isAbsolute(uvPath)
       ? (['cmd.exe', ['/d', '/c', uvPath, '--version']] as const)
       : ([uvPath, ['--version']] as const);
     const result = spawnSync(uvExe, uvVersionArgs, {

--- a/src/npx-cli/utils/bun-resolver.ts
+++ b/src/npx-cli/utils/bun-resolver.ts
@@ -21,11 +21,10 @@ function bunCandidatePaths(): string[] {
 }
 
 export function resolveBunBinaryPath(): string | null {
-  const whichCommand = IS_WINDOWS ? 'where' : 'which';
+  const whichCommand = IS_WINDOWS ? 'where.exe' : 'which';
   const pathCheck = spawnSync(whichCommand, ['bun'], {
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'pipe'],
-    shell: IS_WINDOWS,
   });
 
   if (pathCheck.status === 0 && pathCheck.stdout.trim()) {


### PR DESCRIPTION
## Summary

Every `npx claude-mem` command on Windows with Node ≥ 22 prints `[DEP0190] DeprecationWarning` because seven `spawnSync`/`spawn` call sites in the npx-cli source pass both a truthy `shell` option and a separate `args` array. Node 22 made this a named deprecation. This PR removes the `shell` option from each call site by invoking `cmd.exe /c` explicitly on Windows for commands that require shell dispatch (bun, uv, npm, and arbitrary bin names in the doctor probe) and `where.exe` (a native binary) for the PATH-lookup probe.

Closes #2941

## Why

`src/npx-cli/utils/bun-resolver.ts:25`, `setup-runtime.ts:76,98,111,133`, `npm-install-helper.ts:59`, and `doctor.ts:30` all pass `shell: IS_WINDOWS` plus an args array. Node 22+ warns on this pattern (DEP0190) because args are concatenated into the shell command string without escaping, which can lead to injection. PR #1677 fixed `scripts/bun-runner.js` but the same pattern persisted in the npx-cli source bundle.

The fix: use `spawnSync('cmd.exe', ['/c', executable, ...args])` on Windows instead of the `shell:` option. This lets `cmd.exe` handle `.cmd` shims and `.exe` binaries alike — without passing the `shell` option to Node's spawn, so DEP0190 is not triggered. For the `where`/`which` probe in `bun-resolver.ts`, `where.exe` is a native binary (`C:\Windows\System32\where.exe`) that spawns directly without any shell.

## Scope

This PR covers the seven `shell:` + args sites in the npx-cli source. It does not address:

- `installBun()` / `installUv()` `execSync` calls: they run shell pipelines (`irm ... | iex`, `curl ... | bash`) which are inherently shell constructs with no separate args array — not DEP0190 triggers.
- `installPluginDependencies()` `execSync` call: same — command-string form, no args array.
- Hook shell scripts or the `dist/` bundle: `npm run build` regenerates the bundle from the fixed source.

## Verification

- [ ] `npm run build` — bundle within size guardrail; TypeScript compiles clean
- [ ] `npm run lint:spawn-env` — all spawn sites pass discipline check
- [ ] `npm run lint:hook-io && npm run strip-comments:check` — clean
- [ ] Manual on Windows Node 22: `NODE_OPTIONS=--trace-deprecation npx claude-mem doctor` — no DEP0190 lines

Closes #2941
