### PR TITLE
feat(worker): add CLAUDE_MEM_WORKER_SCRIPT_PATH to pin the worker bundle

### DIFF
--- a/docs/public/configuration.mdx
+++ b/docs/public/configuration.mdx
@@ -20,6 +20,7 @@ Settings are managed in `~/.claude-mem/settings.json`. The file is auto-created 
 | `CLAUDE_MEM_CONTEXT_OBSERVATIONS` | `50`                        | Number of observations to inject      |
 | `CLAUDE_MEM_WORKER_PORT`      | `37700 + (uid % 100)`           | Worker service port (per-user default; override for fixed port) |
 | `CLAUDE_MEM_WORKER_HOST`      | `127.0.0.1`                     | Worker service host address           |
+| `CLAUDE_MEM_WORKER_SCRIPT_PATH` | —                               | Absolute path to a specific `worker-service.cjs` for the daemon to spawn/respawn. Overrides the installed-plugin and cwd resolution. Opt-in; for local-build testing and bundle pinning. |
 | `CLAUDE_MEM_DATA_DIR`         | `~/.claude-mem`                 | Data root — every other path (database, chroma, logs, settings.json, worker.pid) derives from this |
 | `CLAUDE_MEM_SKIP_TOOLS`       | `ListMcpResourcesTool,SlashCommand,Skill,TodoWrite,AskUserQuestion` | Comma-separated tools to exclude from observations |
 

--- a/docs/public/development.mdx
+++ b/docs/public/development.mdx
@@ -112,6 +112,34 @@ npm run worker:logs
 echo '{"session_id":"test-123","cwd":"'$(pwd)'","source":"startup"}' | node plugin/scripts/context-hook.js
 ```
 
+#### Run the worker from a local build (without syncing to the marketplace)
+
+`CLAUDE_MEM_WORKER_SCRIPT_PATH` pins the worker bundle the daemon spawns/respawns,
+so you can test a local build in isolation without overwriting your installed
+plugin:
+
+```bash
+npm run build   # bundles src → plugin/scripts/worker-service.cjs
+CLAUDE_MEM_WORKER_SCRIPT_PATH="$PWD/plugin/scripts/worker-service.cjs" \
+  CLAUDE_MEM_DATA_DIR=/tmp/cm-dev \
+  CLAUDE_MEM_WORKER_PORT=37999 \
+  bun plugin/scripts/worker-service.cjs start
+```
+
+This supersedes the implicit `cwd` fallback (which only applies when the worker
+happens to be launched from the repo root and the marketplace path is absent).
+Unset the variable to return to the installed-plugin resolution.
+
+<Note>
+If the pinned bundle's version differs from your **installed** plugin's version,
+the installed hooks may try to recycle the worker to match the plugin version and
+fight the pin (a restart loop) once Claude Code sessions start firing hooks
+against it. For a clean isolated run, either pin a bundle matching your installed
+plugin version, or drive the worker directly (as above) without an active session
+hammering it. Use a dedicated `CLAUDE_MEM_DATA_DIR` + `CLAUDE_MEM_WORKER_PORT` to
+keep it off your real install.
+</Note>
+
 ### 5. Iterate
 
 Repeat steps 1-4 until your changes work as expected.

--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -211,18 +211,20 @@ async function isWorkerReady(): Promise<boolean> {
 }
 
 /**
- * Canonical worker-script resolver: the marketplace install first, then the
- * dev-tree copy under cwd. Exported so other launchers (e.g. the MCP server)
- * prefer the same marketplace copy instead of spawning a stale cache-dir
- * bundle.
+ * Canonical worker-script resolver: an explicit `CLAUDE_MEM_WORKER_SCRIPT_PATH`
+ * override first (opt-in; for pinning a local-build bundle), then the marketplace
+ * install, then the dev-tree copy under cwd. Exported so other launchers (e.g.
+ * the MCP server) prefer the same bundle instead of spawning a stale cache-dir
+ * one. Unset override → identical to the prior marketplace-then-cwd behavior.
  */
 export function resolveWorkerScriptPath(): string | null {
   const candidates = [
+    process.env.CLAUDE_MEM_WORKER_SCRIPT_PATH,                            // explicit override, checked first (opt-in)
     path.join(MARKETPLACE_ROOT, 'plugin', 'scripts', 'worker-service.cjs'),
     path.join(process.cwd(), 'plugin', 'scripts', 'worker-service.cjs'),
   ];
   for (const candidate of candidates) {
-    if (existsSync(candidate)) return candidate;
+    if (candidate && existsSync(candidate)) return candidate;
   }
   return null;
 }

--- a/tests/shared/worker-script-path.test.ts
+++ b/tests/shared/worker-script-path.test.ts
@@ -1,0 +1,45 @@
+// tests/shared/worker-script-path.test.ts
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { resolveWorkerScriptPath } from '../../src/shared/worker-utils.js';
+
+describe('resolveWorkerScriptPath — CLAUDE_MEM_WORKER_SCRIPT_PATH override', () => {
+  let tempDir: string;
+  let existingScript: string;
+  const orig = process.env.CLAUDE_MEM_WORKER_SCRIPT_PATH;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'wsp-'));
+    existingScript = join(tempDir, 'worker-service.cjs');
+    writeFileSync(existingScript, '// stub', 'utf-8');
+    delete process.env.CLAUDE_MEM_WORKER_SCRIPT_PATH;
+  });
+
+  afterEach(() => {
+    if (orig === undefined) delete process.env.CLAUDE_MEM_WORKER_SCRIPT_PATH;
+    else process.env.CLAUDE_MEM_WORKER_SCRIPT_PATH = orig;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns the override path when set and existing (wins over defaults)', () => {
+    process.env.CLAUDE_MEM_WORKER_SCRIPT_PATH = existingScript;
+    expect(resolveWorkerScriptPath()).toBe(existingScript);
+  });
+
+  it('ignores a set-but-nonexistent override (identical to unset)', () => {
+    // baseline = whatever default resolution produces on this host (marketplace
+    // path locally, null in CI). We assert relative behavior, not an absolute.
+    const unsetResult = resolveWorkerScriptPath(); // env unset in beforeEach
+    process.env.CLAUDE_MEM_WORKER_SCRIPT_PATH = join(tempDir, 'does-not-exist.cjs');
+    expect(resolveWorkerScriptPath()).toBe(unsetResult);
+  });
+
+  it('ignores an empty-string override (identical to unset)', () => {
+    // baseline = host-dependent default resolution (see above); relative assert.
+    const unsetResult = resolveWorkerScriptPath();
+    process.env.CLAUDE_MEM_WORKER_SCRIPT_PATH = '';
+    expect(resolveWorkerScriptPath()).toBe(unsetResult);
+  });
+});


### PR DESCRIPTION
Closes #3054.

## Problem
`resolveWorkerScriptPath()` (`src/shared/worker-utils.ts`) resolves the `worker-service.cjs` the daemon spawns/respawns from two hardcoded candidates — the installed marketplace path, then cwd — with no override. The installed path is checked first and almost always exists, so **every respawn resolves to the installed bundle**, even when the worker was launched from a local build. There's no documented way to run/test the worker against a local branch build without overwriting the install via `sync-marketplace`.

## Change
Add an **opt-in** env var `CLAUDE_MEM_WORKER_SCRIPT_PATH`, checked first in `resolveWorkerScriptPath()` (guarded by `existsSync`):

```ts
const candidates = [
  process.env.CLAUDE_MEM_WORKER_SCRIPT_PATH,   // opt-in override, first
  path.join(MARKETPLACE_ROOT, 'plugin', 'scripts', 'worker-service.cjs'),
  path.join(process.cwd(), 'plugin', 'scripts', 'worker-service.cjs'),
];
for (const candidate of candidates) {
  if (candidate && existsSync(candidate)) return candidate;
}
```

- **One site, all daemon spawn paths inherit it** — `worker-utils.ts` lazy-spawn, `worker-service.ts` restart + restart-handoff successor, `mcp-server.ts`. (The `npx` CLI wrapper and hook shell templates intentionally keep resolving the installed bundle as thin entry-clients; they delegate to the daemon, which honors the override.)
- **Opt-in / zero-risk** — unset, empty, or set-but-nonexistent → byte-identical prior behavior. The `candidate &&` guard is also required for the type to compile (`process.env.X` is `string | undefined`).
- **Env-only** — this is a bootstrap resolution (which worker to spawn, before settings load), so it deliberately gets no `SettingsDefaults` entry, mirroring how `MARKETPLACE_ROOT`/`CLAUDE_CONFIG_DIR` are env-derived.
- **Naming** follows the project conventions: `CLAUDE_MEM_WORKER_*` scope (cf. `WORKER_PORT`/`WORKER_HOST`) + `_PATH` suffix (cf. `CLAUDE_MEM_CHROMA_UVX_PATH`).

## Tests
New `tests/shared/worker-script-path.test.ts` (first coverage for this resolver): override-set-and-existing wins; set-but-nonexistent ignored (== unset); empty-string ignored (== unset). Env/temp-file isolated. `npm run typecheck` clean; full suite shows no new failures.

## Docs
`configuration.mdx` (env table) + `development.mdx` (Manual Testing: local-build recipe, with a note that pinning a *different*-version bundle than the installed plugin can trigger the existing version-recycle restart behavior once sessions fire hooks).
