### PR TITLE
fix(chroma): pin chroma-mcp via uvx canonical `tool@version` form (#2939)

### DIFF
--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -23,6 +23,17 @@ const CHROMA_SUPERVISOR_ID = 'chroma-mcp';
 
 const CHROMA_MCP_PINNED_VERSION = '0.2.6';
 
+// chroma-mcp is pinned via uvx's canonical `tool@version` exact-pin form.
+// NOT `chroma-mcp==<ver>`: `==` in the uvx command position is undocumented
+// (uv's docs only teach `command@<version>`) and was reported to fail on a
+// Windows/uvx 0.11.19 setup with "Not a valid package or extra name" (#2939) —
+// killing the MCP connection and degrading semantic search to FTS5. `@` is the
+// documented, exact-only pin and works across every uvx version tested. Range
+// and extra specs still ride on `--with` (see CHROMA_MCP_DEP_OVERRIDES below).
+// Single source of truth: both the remote and local buildCommandArgs() branches
+// reference this constant so the pin syntax can never drift between call sites.
+const CHROMA_MCP_TOOL_SPEC = `chroma-mcp@${CHROMA_MCP_PINNED_VERSION}` as const;
+
 // Override transitive dep resolutions for chroma-mcp 0.2.6 (issue #2371).
 //
 // Why onnxruntime>=1.20: the shipped all-MiniLM-L6-v2 model has pytorch-2.0
@@ -215,7 +226,7 @@ export class ChromaMcpManager {
       const args = [
         '--python', pythonVersion,
         ...depOverrideFlags,
-        `chroma-mcp==${CHROMA_MCP_PINNED_VERSION}`,
+        CHROMA_MCP_TOOL_SPEC,
         '--client-type', 'http',
         '--host', chromaHost,
         '--port', chromaPort
@@ -241,7 +252,7 @@ export class ChromaMcpManager {
     return [
       '--python', pythonVersion,
       ...depOverrideFlags,
-      `chroma-mcp==${CHROMA_MCP_PINNED_VERSION}`,
+      CHROMA_MCP_TOOL_SPEC,
       '--client-type', 'persistent',
       '--data-dir', DEFAULT_CHROMA_DATA_DIR.replace(/\\/g, '/')
     ];

--- a/tests/services/sync/chroma-mcp-manager-uvx-version-syntax.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-uvx-version-syntax.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterAll, mock } from 'bun:test';
+
+// Regression tests for #2939: chroma-mcp must be pinned with uvx's canonical
+// `tool@version` exact-pin form, NOT `tool==version`. `==` in the uvx command
+// position is undocumented and was reported to fail on Windows/uvx 0.11.19 with
+// "Not a valid package or extra name", killing the MCP connection and degrading
+// semantic search to FTS5. `@` is the documented, exact-only form.
+//
+// These assert the spawned uvx args (captured from the fake transport), i.e.
+// the observable behavior of buildCommandArgs() — not any private constant —
+// so they survive refactors of how the spec string is composed.
+
+// Capture real exports before mock.module mutates the live namespace, then
+// re-register the snapshots in afterAll so these mocks do not leak into later
+// test files (bun's mock.module is process-global; mock.restore() does NOT undo it).
+import * as realSettingsDefaultsManager from '../../../src/shared/SettingsDefaultsManager.js';
+import * as realPaths from '../../../src/shared/paths.js';
+import * as realLogger from '../../../src/utils/logger.js';
+const realSettingsSnapshot = { ...realSettingsDefaultsManager };
+const realPathsSnapshot = { ...realPaths };
+const realLoggerSnapshot = { ...realLogger };
+
+let currentSettings: Record<string, string> = {};
+
+let capturedTransportOpts: { command: string; args: string[] } | null = null;
+
+mock.module('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+  StdioClientTransport: class FakeTransport {
+    onclose: (() => void) | null = null;
+    constructor(opts: { command: string; args: string[] }) {
+      capturedTransportOpts = { command: opts.command, args: opts.args };
+    }
+    async close() {}
+  },
+}));
+
+mock.module('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: class FakeClient {
+    constructor() {}
+    async connect() {}
+    async callTool() {
+      return { content: [{ type: 'text', text: '{}' }] };
+    }
+    async close() {}
+  },
+}));
+
+mock.module('../../../src/shared/SettingsDefaultsManager.js', () => ({
+  SettingsDefaultsManager: {
+    get: (key: string) => currentSettings[key] ?? '',
+    getInt: () => 0,
+    loadFromFile: () => currentSettings,
+  },
+}));
+
+mock.module('../../../src/shared/paths.js', () => ({
+  USER_SETTINGS_PATH: '/tmp/fake-settings.json',
+}));
+
+mock.module('../../../src/utils/logger.js', () => ({
+  logger: {
+    info: () => {},
+    debug: () => {},
+    warn: () => {},
+    error: () => {},
+    failure: () => {},
+  },
+}));
+
+import { ChromaMcpManager } from '../../../src/services/sync/ChromaMcpManager.js';
+
+afterAll(() => {
+  mock.module('../../../src/shared/SettingsDefaultsManager.js', () => realSettingsSnapshot);
+  mock.module('../../../src/shared/paths.js', () => realPathsSnapshot);
+  mock.module('../../../src/utils/logger.js', () => realLoggerSnapshot);
+});
+
+// The chroma-mcp dist name == its entry-point name, and 0.2.6 is an exact pin,
+// so the canonical uvx form is `chroma-mcp@0.2.6`. This must match the pinned
+// version constant in ChromaMcpManager.ts (CHROMA_MCP_PINNED_VERSION = '0.2.6').
+const EXPECTED_TOOL_SPEC = 'chroma-mcp@0.2.6';
+
+let mgr: ChromaMcpManager;
+
+async function captureArgs(mode: 'local' | 'remote'): Promise<string[]> {
+  currentSettings = { CLAUDE_MEM_CHROMA_MODE: mode };
+  await mgr.callTool('chroma_list_collections', {});
+  expect(capturedTransportOpts).not.toBeNull();
+  return capturedTransportOpts!.args;
+}
+
+describe('ChromaMcpManager uvx version-pin syntax (#2939)', () => {
+  beforeEach(async () => {
+    await ChromaMcpManager.reset();
+    capturedTransportOpts = null;
+    currentSettings = {};
+    mgr = ChromaMcpManager.getInstance();
+  });
+
+  for (const mode of ['local', 'remote'] as const) {
+    // Negative: the exact bug — `chroma-mcp==0.2.6` must never be emitted.
+    it(`[${mode}] does not emit the pip-style chroma-mcp==<version> spec`, async () => {
+      const args = await captureArgs(mode);
+      expect(args).not.toContain('chroma-mcp==0.2.6');
+    });
+
+    // Negative (broader guard): no arg in the command line may use `==` pinning
+    // for chroma-mcp, regardless of the version value.
+    it(`[${mode}] no argument pins chroma-mcp with == syntax`, async () => {
+      const args = await captureArgs(mode);
+      expect(args.some(a => a.startsWith('chroma-mcp=='))).toBe(false);
+    });
+
+    // Positive: the canonical `@` exact-pin spec is emitted...
+    it(`[${mode}] emits the canonical chroma-mcp@<version> spec`, async () => {
+      const args = await captureArgs(mode);
+      expect(args).toContain(EXPECTED_TOOL_SPEC);
+    });
+
+    // Positive: ...in the uvx command position (immediately before the
+    // --client-type flag that follows it in both modes).
+    it(`[${mode}] places the chroma-mcp@<version> spec in the command position`, async () => {
+      const args = await captureArgs(mode);
+      const clientTypeIdx = args.indexOf('--client-type');
+      expect(clientTypeIdx).toBeGreaterThan(0);
+      expect(args[clientTypeIdx - 1]).toBe(EXPECTED_TOOL_SPEC);
+    });
+  }
+
+  // Positive: the pin is still exact (version unchanged) — `@` is exact-only,
+  // so this is semantically identical to the prior `==0.2.6`.
+  it('preserves the exact 0.2.6 pin via the @ form', async () => {
+    const args = await captureArgs('local');
+    const spec = args.find(a => a.startsWith('chroma-mcp@'));
+    expect(spec).toBe('chroma-mcp@0.2.6');
+  });
+});


### PR DESCRIPTION
## What

`ChromaMcpManager.buildCommandArgs()` emitted the chroma-mcp tool spec as `chroma-mcp==<version>` in the **uvx command (tool-name) position**. This PR switches it to uvx's canonical `chroma-mcp@<version>` exact-pin form and collapses the previously-duplicated literal into a single `CHROMA_MCP_TOOL_SPEC` constant.

Closes #2939

## Why

`==` in the uvx command position:
- is **undocumented** — uv's docs only teach `command@<version>`;
- was reported to fail on **Windows / uvx 0.11.19** with `error: "Not a valid package or extra name: chroma-mcp==0.2.6"`, killing the MCP stdio connection (`MCP error -32000: Connection closed`) and silently degrading semantic search to FTS5.

`command@<version>` is uv's documented, canonical exact-pin form ("the `@` syntax cannot be used for anything other than an exact version") and is accepted across every uvx version tested. `0.2.6` is an exact pin, so semantics are unchanged. The range specs (`onnxruntime>=1.20`, `protobuf<7`) correctly stay behind `--with` (PEP 508's documented home), and are untouched.

Verified locally on uvx 0.11.24: both `chroma-mcp==0.2.6` and `chroma-mcp@0.2.6` resolve to exactly 0.2.6; the `@` form additionally works where `==` failed.

## Durability

The `chroma-mcp==<version>` literal was duplicated across the remote and local branches of `buildCommandArgs()`. Collapsing it into one `CHROMA_MCP_TOOL_SPEC` constant means the pin syntax can never drift between the two call sites again.

## Tests

New `tests/services/sync/chroma-mcp-manager-uvx-version-syntax.test.ts` (mirrors the existing `chroma-mcp-manager-ssl.test.ts` mock harness), written failing-first against the `==` code. Asserts the spawned uvx args — for both local and remote modes — emit `chroma-mcp@0.2.6` in the command position and never `chroma-mcp==`. 9 tests, all green; `tsc --noEmit` clean.

> Note: the bundled `plugin/scripts/worker-service.cjs` is a generated artifact and is intentionally not included in this diff; it regenerates on `npm run build-and-sync`.