### PR TITLE
test(settings): isolate loadFromFile tests from all ambient default env keys

### DIFF
--- a/tests/shared/settings-defaults-manager.test.ts
+++ b/tests/shared/settings-defaults-manager.test.ts
@@ -8,27 +8,35 @@ import { SettingsDefaultsManager } from '../../src/shared/SettingsDefaultsManage
 describe('SettingsDefaultsManager', () => {
   let tempDir: string;
   let settingsPath: string;
-  let prevDataDirEnv: string | undefined;
+  let savedDefaultKeyEnv: Record<string, string | undefined>;
 
   beforeEach(() => {
     tempDir = join(tmpdir(), `settings-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
     mkdirSync(tempDir, { recursive: true });
     settingsPath = join(tempDir, 'settings.json');
 
-    // The preload tripwire (tests/preload.ts) pins CLAUDE_MEM_DATA_DIR for
-    // the whole run, and loadFromFile applies env overrides on top of file
-    // values — which would make every loadFromFile result diverge from
-    // getAllDefaults()'s hardcoded ~/.claude-mem default. These tests are
-    // about file > defaults behavior on an EXPLICIT settingsPath (no real
-    // data-dir I/O happens here), so drop the env override for their
-    // duration and restore it after.
-    prevDataDirEnv = process.env.CLAUDE_MEM_DATA_DIR;
-    delete process.env.CLAUDE_MEM_DATA_DIR;
+    // loadFromFile applies env overrides on top of file/defaults, so ANY
+    // settings-default key present in process.env makes its result diverge
+    // from getAllDefaults(). On a dev machine this is not just the
+    // CLAUDE_MEM_DATA_DIR pinned by the preload tripwire (tests/preload.ts) —
+    // a running claude-mem install also exports e.g. CLAUDE_MEM_API_TIMEOUT_MS,
+    // which silently broke these tests on contributor boxes while passing in a
+    // clean CI env. These tests cover file > defaults behavior on an EXPLICIT
+    // settingsPath (no real data-dir I/O), so strip EVERY default key from the
+    // env for their duration and restore after — robust to whichever
+    // CLAUDE_MEM_* vars the host happens to export.
+    savedDefaultKeyEnv = {};
+    for (const key of Object.keys(SettingsDefaultsManager.getAllDefaults())) {
+      savedDefaultKeyEnv[key] = process.env[key];
+      delete process.env[key];
+    }
   });
 
   afterEach(() => {
-    if (prevDataDirEnv === undefined) delete process.env.CLAUDE_MEM_DATA_DIR;
-    else process.env.CLAUDE_MEM_DATA_DIR = prevDataDirEnv;
+    for (const [key, value] of Object.entries(savedDefaultKeyEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
     try {
       rmSync(tempDir, { recursive: true, force: true });
     } catch {


### PR DESCRIPTION
## What

Generalize the env isolation in `tests/shared/settings-defaults-manager.test.ts`: snapshot and delete **every** `getAllDefaults()` key from `process.env` in `beforeEach`, restore in `afterEach`.

Closes #3056

## Why

The `loadFromFile` edge-case tests assert `loadFromFile(<empty|corrupt file>)` deep-equals `getAllDefaults()`. But `loadFromFile` applies `process.env` overrides on top of file/defaults, while `getAllDefaults()` returns pure defaults — so any settings-default key present in the environment makes the two diverge.

The suite already stripped `CLAUDE_MEM_DATA_DIR` for this reason, but only that one key. On a contributor machine running a claude-mem install, other keys are exported too (e.g. `CLAUDE_MEM_API_TIMEOUT_MS=120000`), which silently failed 9 of these tests locally while CI — a clean env — stayed green.

```bash
bun test tests/shared/settings-defaults-manager.test.ts            # 9 fail on a dev box
env -u CLAUDE_MEM_API_TIMEOUT_MS bun test tests/shared/settings-defaults-manager.test.ts  # 35 pass
```

## Scope

**Test-only.** No production code changes — `loadFromFile`'s env-override behavior is correct and is already covered by the `environment variable overrides` describe block. The generalized strip is robust to whichever `CLAUDE_MEM_*` vars the host exports and subsumes the existing `CLAUDE_MEM_DATA_DIR` special-case. As a bonus it also de-flakes the `get`/`getInt`/`getBool` tests, which read `process.env` directly.

## Verification

Full suite before (on a dev box exporting `CLAUDE_MEM_*`): **2159 pass / 9 fail**.
After: **2159 pass / 0 fail**. `tsc --noEmit` clean.