### PR TITLE
fix(observer): window invalid-output respawn so benign idle can't poison quiet sessions

### DIFF
--- a/docs/public/telemetry.mdx
+++ b/docs/public/telemetry.mdx
@@ -96,7 +96,7 @@ Every event property passes through a strict whitelist scrubber — any key not 
 | `chroma_available` | `true` | Whether the vector-search backend was reachable for a search (false = fell back to full-text search) |
 | `fallback_reason` | `none` | Why a search fell back from vector search: none / chroma_connection / chroma_error / chroma_not_initialized — a closed enum, never an error message |
 | `invalid_output_class` | `idle` | Coarse class of an unusable compression output: xml / idle / prose / poisoned (`xml` = looked like the expected format but failed to parse) — never the output itself |
-| `consecutive_invalid_outputs` | `3` | How many unusable outputs occurred in a row before recovery |
+| `respawn_threshold` | `3` | The unusable-output burst threshold that triggered a session respawn |
 | `respawn_triggered` | `true` | Whether the compression agent was restarted after repeated unusable output |
 | `abort_reason` | `idle` | Why a compression session was aborted: idle / shutdown / overflow / restart_guard / quota / poisoned / none — a closed enum |
 | `previous_shutdown` | `clean` | How the previous worker run ended, detected at startup: crash / clean / unknown |

--- a/src/npx-cli/commands/telemetry.ts
+++ b/src/npx-cli/commands/telemetry.ts
@@ -67,7 +67,7 @@ const COLLECTED_FIELDS = [
   'chroma_available whether vector search was reachable for a search',
   'fallback_reason  none / chroma_connection / chroma_error / chroma_not_initialized',
   'invalid_output_class   xml / idle / prose / poisoned (never the output)',
-  'consecutive_invalid_outputs   unusable outputs in a row before recovery',
+  'respawn_threshold      unusable-output threshold that triggered a respawn',
   'respawn_triggered      whether the compression agent was restarted',
   'abort_reason     idle / shutdown / overflow / restart_guard / quota / poisoned / none',
   'previous_shutdown      crash / clean / unknown (detected at worker start)',

--- a/src/services/telemetry/scrub.ts
+++ b/src/services/telemetry/scrub.ts
@@ -92,7 +92,7 @@ export const ALLOWED_PROPERTY_KEYS: Set<string> = new Set([
   // idle | shutdown | overflow | restart_guard | quota | poisoned | none).
   // Never model output, never raw abort strings.
   'invalid_output_class',
-  'consecutive_invalid_outputs',
+  'respawn_threshold',
   'respawn_triggered',
   'abort_reason',
   // Worker lifecycle health — previous_shutdown (crash | clean | unknown),

--- a/src/services/worker-types.ts
+++ b/src/services/worker-types.ts
@@ -1,5 +1,6 @@
 
 import type { Response } from 'express';
+import type { FailureWindow } from './worker/agents/respawn-policy.js';
 
 export interface ConversationMessage {
   role: 'user' | 'assistant';
@@ -26,12 +27,13 @@ export interface ActiveSession {
   currentProvider: 'claude' | 'gemini' | 'openrouter' | null;
   consecutiveRestarts: number;
   /**
-   * Consecutive non-XML (idle/prose/poisoned) observer outputs. Reset to 0 on a
-   * valid parse. When it reaches the recovery threshold the SDK session is
-   * killed and respawned so a poisoned session can't wedge the pipeline at zero
-   * (plan-11, #2485).
+   * Rolling time-window of non-exempt invalid observer outputs. When `badCount`
+   * reaches the configured threshold within `windowMs`, the SDK session is
+   * killed and respawned (time-windowed burst, systemd/OTP model). Reset to a
+   * fresh window on a valid parse, session create, and respawn. Replaces the
+   * old unbounded consecutive counter (#3032).
    */
-  consecutiveInvalidOutputs: number;
+  invalidOutputWindow: FailureWindow;
   forceInit?: boolean;
   idleTimedOut?: boolean;  
   lastGeneratorActivity: number;

--- a/src/services/worker/SessionManager.ts
+++ b/src/services/worker/SessionManager.ts
@@ -5,6 +5,7 @@ import { SessionMessageBuffer } from './SessionMessageBuffer.js';
 import { getSdkProcessForSession, ensureSdkProcessExit } from '../../supervisor/process-registry.js';
 import { getSupervisor } from '../../supervisor/index.js';
 import { telemetryBuffer } from '../telemetry/buffer.js';
+import { freshWindow } from './agents/respawn-policy.js';
 
 export class SessionManager {
   private dbManager: DatabaseManager;
@@ -123,7 +124,7 @@ export class SessionManager {
       conversationHistory: [],  // Initialize empty - will be populated by agents
       currentProvider: null,  // Will be set when generator starts
       consecutiveRestarts: 0,
-      consecutiveInvalidOutputs: 0,
+      invalidOutputWindow: freshWindow(),
       lastGeneratorActivity: Date.now(),  // Initialize for stale detection (Issue #1099)
       pendingAgentId: null,   // Subagent identity carried from the most recent claimed message
       pendingAgentType: null
@@ -259,7 +260,7 @@ export class SessionManager {
     logger.warn('SESSION', 'Respawning poisoned SDK session, preserving pending messages', {
       sessionId: sessionDbId,
       preservedPending,
-      consecutiveInvalidOutputs: session.consecutiveInvalidOutputs,
+      badCount: session.invalidOutputWindow.badCount,
     });
 
     // Re-yield anything claimed-but-unconfirmed so the fresh generator picks it up.
@@ -267,7 +268,7 @@ export class SessionManager {
 
     // Drop stale conversation context: the poisoned turns are what wedged it.
     session.conversationHistory = [];
-    session.consecutiveInvalidOutputs = 0;
+    session.invalidOutputWindow = freshWindow();
     session.memorySessionId = null;  // force a fresh SDK session id on respawn
 
     session.abortReason = 'poisoned';

--- a/src/services/worker/agents/ResponseProcessor.ts
+++ b/src/services/worker/agents/ResponseProcessor.ts
@@ -86,12 +86,8 @@ export async function processAgentResponse(
             outcome: 'invalid_output',
             invalid_output_class: outputClass,
             respawn_triggered: true,
-            // Replaces the old `consecutive_invalid_outputs` dimension. At respawn
-            // the windowed count has just hit the threshold (and evaluateRespawn
-            // resets the returned window to 0), so the threshold IS the count of
-            // non-exempt bad outputs that triggered this respawn, over window_ms.
+            // Replaces the old `consecutive_invalid_outputs` dimension.
             respawn_threshold: policy.threshold,
-            window_ms: policy.windowMs,
             provider: providerName,
             model: typeof modelId === 'string' && modelId ? modelId : 'unknown',
             ide: session.platformSource,

--- a/src/services/worker/agents/ResponseProcessor.ts
+++ b/src/services/worker/agents/ResponseProcessor.ts
@@ -16,13 +16,10 @@ import type { WorkerRef, StorageResult } from './types.js';
 import { broadcastObservation, broadcastSummary } from './ObservationBroadcaster.js';
 import { telemetryBuffer } from '../../telemetry/buffer.js';
 import { instrument } from '../../telemetry/instrument.js';
+import { evaluateRespawn, getRespawnPolicy, freshWindow, DEFAULT_RESPAWN_THRESHOLD } from './respawn-policy.js';
 
-/**
- * Consecutive non-XML observer outputs tolerated before we kill and respawn the
- * SDK session (plan-11, #2485). Idle and prose both count; poisoned triggers an
- * immediate respawn regardless of the count.
- */
-export const INVALID_OUTPUT_RESPAWN_THRESHOLD = 3;
+/** @deprecated default fallback; real value resolved via getRespawnPolicy(). */
+export const INVALID_OUTPUT_RESPAWN_THRESHOLD = DEFAULT_RESPAWN_THRESHOLD;
 
 export async function processAgentResponse(
   text: string,
@@ -53,34 +50,24 @@ export async function processAgentResponse(
     'claude';
 
   if (!parsed.valid) {
-    // Classify the non-XML output so a dropped batch is VISIBLE, not silent
-    // (plan-11, #2485). Attach a preview for diagnostics.
     const outputClass = classifyObserverOutput(text);
     const preview = previewOutput(text);
-
-    session.consecutiveInvalidOutputs = (session.consecutiveInvalidOutputs ?? 0) + 1;
+    const policy = getRespawnPolicy();
+    const { window, shouldRespawn } = evaluateRespawn(
+      outputClass, session.invalidOutputWindow, policy, processingStartedAt,
+    );
+    session.invalidOutputWindow = window;
 
     logger.warn('PARSER', `${agentName} returned non-XML ${outputClass} response — ignoring queued batch`, {
       sessionId: session.sessionDbId,
       outputClass,
       preview,
-      consecutiveInvalidOutputs: session.consecutiveInvalidOutputs,
+      badCount: window.badCount,
+      threshold: policy.threshold,
+      windowMs: policy.windowMs,
     });
 
-    // Recover from poison (plan-11, #2485): a poisoned closure string means the
-    // SDK session is wedged and will keep emitting garbage — respawn immediately.
-    // For idle/prose, only respawn after N consecutive invalid outputs so we
-    // don't churn the session on benign single-batch misses.
-    const mustRespawn =
-      outputClass === 'poisoned' ||
-      session.consecutiveInvalidOutputs >= INVALID_OUTPUT_RESPAWN_THRESHOLD;
-
-    if (mustRespawn) {
-      // Single instrumentation call: the local poison/respawn error line (full
-      // fidelity) and the scrubbed session_compressed rollup are one logical
-      // event. Respawn-gated telemetry ONLY (never per invalid output —
-      // volume). Closed enums and counts; the raw model output never leaves
-      // the box.
+    if (shouldRespawn) {
       instrument(
         'SESSION',
         'error',
@@ -88,8 +75,8 @@ export async function processAgentResponse(
         {
           sessionId: session.sessionDbId,
           outputClass,
-          consecutiveInvalidOutputs: session.consecutiveInvalidOutputs,
-          threshold: INVALID_OUTPUT_RESPAWN_THRESHOLD,
+          threshold: policy.threshold,
+          windowMs: policy.windowMs,
         },
         {
           event: 'session_compressed',
@@ -98,8 +85,13 @@ export async function processAgentResponse(
           props: {
             outcome: 'invalid_output',
             invalid_output_class: outputClass,
-            consecutive_invalid_outputs: session.consecutiveInvalidOutputs,
             respawn_triggered: true,
+            // Replaces the old `consecutive_invalid_outputs` dimension. At respawn
+            // the windowed count has just hit the threshold (and evaluateRespawn
+            // resets the returned window to 0), so the threshold IS the count of
+            // non-exempt bad outputs that triggered this respawn, over window_ms.
+            respawn_threshold: policy.threshold,
+            window_ms: policy.windowMs,
             provider: providerName,
             model: typeof modelId === 'string' && modelId ? modelId : 'unknown',
             ide: session.platformSource,
@@ -111,17 +103,13 @@ export async function processAgentResponse(
       return;
     }
 
-    // Plain-text skip responses are intentionally ignored. Re-queueing them
-    // creates an observer loop where the same low-signal batch is retried
-    // until the restart guard fires or the provider quota is exhausted.
     await sessionManager.confirmClaimedMessages(session.sessionDbId);
     session.earliestPendingTimestamp = null;
     return;
   }
 
-  // Valid parse — clear the invalid-output counter so transient misses don't
-  // accumulate toward a respawn across a healthy session.
-  session.consecutiveInvalidOutputs = 0;
+  // Valid parse — reset the failure window so transient misses don't accumulate.
+  session.invalidOutputWindow = freshWindow();
 
   if (!session.memorySessionId) {
     logger.warn('SDK', 'memorySessionId not yet captured; deferring storage until next round', {

--- a/src/services/worker/agents/respawn-policy.ts
+++ b/src/services/worker/agents/respawn-policy.ts
@@ -69,6 +69,11 @@ export function parseRespawnPolicy(
       logger.warn('SYSTEM', `Unknown exempt output class "${tok}" — ignored`, { value: tok });
     }
   }
+  // `exemptClasses` is typed ReadonlySet (compile-time immutability). We do not
+  // Object.freeze it: freezing a Set blocks property writes but NOT Set.add/
+  // delete (they mutate internal slots), so it would give false runtime
+  // confidence. For this internal, freshly-constructed value the structural
+  // ReadonlySet guarantee is sufficient and intentional (design §9).
   return {
     exemptClasses: exemptClasses.size > 0
       ? exemptClasses

--- a/src/services/worker/agents/respawn-policy.ts
+++ b/src/services/worker/agents/respawn-policy.ts
@@ -1,0 +1,85 @@
+// src/services/worker/agents/respawn-policy.ts
+import { logger } from '../../../utils/logger.js';
+import type { ObserverOutputClass } from '../../../sdk/output-classifier.js';
+
+/**
+ * Output classes that MAY be configured exempt from the respawn window.
+ * 'xml' is valid (never reaches the counter); 'poisoned' is always-immediate
+ * and is intentionally NOT exemptable.
+ */
+export const EXEMPTABLE_CLASSES = ['idle', 'prose'] as const satisfies readonly ObserverOutputClass[];
+export type ExemptableClass = typeof EXEMPTABLE_CLASSES[number];
+
+const EXEMPTABLE_SET = new Set<string>(EXEMPTABLE_CLASSES);
+
+/** Sole string→ExemptableClass narrowing site (parse-don't-validate). */
+export function isExemptableClass(x: string): x is ExemptableClass {
+  return EXEMPTABLE_SET.has(x);
+}
+
+// Bounds + defaults (no-hardcoded-magic-numbers). Defaults mirror SettingsDefaults.
+export const RESPAWN_THRESHOLD_BOUNDS = { min: 1, max: 100 } as const;
+export const RESPAWN_WINDOW_MS_BOUNDS = { min: 1000, max: 3_600_000 } as const;
+export const DEFAULT_RESPAWN_THRESHOLD = 3;          // was INVALID_OUTPUT_RESPAWN_THRESHOLD (#2485)
+export const DEFAULT_RESPAWN_WINDOW_MS = 60_000;     // 1 min — trips ~1-bad/15s wedge in ~45s; lets blips decay
+export const DEFAULT_EXEMPT_CLASSES: readonly ExemptableClass[] = ['idle'];
+
+export interface RespawnPolicy {
+  readonly exemptClasses: ReadonlySet<ExemptableClass>;
+  readonly threshold: number;
+  readonly windowMs: number;
+}
+
+export interface FailureWindow {
+  windowStart: number;
+  badCount: number;
+}
+
+export function freshWindow(): FailureWindow {
+  return { windowStart: 0, badCount: 0 };
+}
+
+function parseBoundedInt(
+  raw: string,
+  bounds: { min: number; max: number },
+  fallback: number,
+  name: string,
+): number {
+  const n = parseInt(raw, 10);
+  if (Number.isNaN(n) || n < bounds.min || n > bounds.max) {
+    logger.warn('SYSTEM', `Invalid ${name}, using default`, {
+      value: raw, min: bounds.min, max: bounds.max, fallback,
+    });
+    return fallback;
+  }
+  return n;
+}
+
+export function parseRespawnPolicy(
+  exemptRaw: string,
+  thresholdRaw: string,
+  windowMsRaw: string,
+): RespawnPolicy {
+  const tokens = exemptRaw.split(',').map(t => t.trim()).filter(Boolean);
+  const exemptClasses = new Set<ExemptableClass>();
+  for (const tok of tokens) {
+    if (isExemptableClass(tok)) {
+      exemptClasses.add(tok);
+    } else {
+      logger.warn('SYSTEM', `Unknown exempt output class "${tok}" — ignored`, { value: tok });
+    }
+  }
+  return {
+    exemptClasses: exemptClasses.size > 0
+      ? exemptClasses
+      : new Set<ExemptableClass>(DEFAULT_EXEMPT_CLASSES),
+    threshold: parseBoundedInt(
+      thresholdRaw, RESPAWN_THRESHOLD_BOUNDS, DEFAULT_RESPAWN_THRESHOLD,
+      'CLAUDE_MEM_INVALID_OUTPUT_RESPAWN_THRESHOLD',
+    ),
+    windowMs: parseBoundedInt(
+      windowMsRaw, RESPAWN_WINDOW_MS_BOUNDS, DEFAULT_RESPAWN_WINDOW_MS,
+      'CLAUDE_MEM_INVALID_OUTPUT_WINDOW_MS',
+    ),
+  };
+}

--- a/src/services/worker/agents/respawn-policy.ts
+++ b/src/services/worker/agents/respawn-policy.ts
@@ -38,6 +38,8 @@ export interface FailureWindow {
 }
 
 export function freshWindow(): FailureWindow {
+  // windowStart: 0 is a placeholder; it is never read for an expiry decision —
+  // the first non-exempt output re-anchors it via the `badCount === 0` branch in evaluateRespawn.
   return { windowStart: 0, badCount: 0 };
 }
 

--- a/src/services/worker/agents/respawn-policy.ts
+++ b/src/services/worker/agents/respawn-policy.ts
@@ -88,3 +88,47 @@ export function parseRespawnPolicy(
     ),
   };
 }
+
+function assertNeverClass(x: never): never {
+  throw new Error(`Unhandled ObserverOutputClass: ${String(x)}`);
+}
+
+/**
+ * Decide whether an observer output should trigger a session respawn,
+ * using a time-windowed burst counter (systemd StartLimitBurst / Erlang OTP
+ * intensity-period). `poisoned` → immediate; exempt classes → invisible; all
+ * other classes accumulate within `windowMs` until `threshold`. Pure; `now` is
+ * injected for testability. The window is anchored at the first bad output
+ * (badCount===0) and re-anchored when it expires.
+ */
+export function evaluateRespawn(
+  cls: ObserverOutputClass,
+  window: FailureWindow,
+  policy: RespawnPolicy,
+  now: number,
+): { window: FailureWindow; shouldRespawn: boolean } {
+  switch (cls) {
+    case 'poisoned':
+      return { window: freshWindow(), shouldRespawn: true };
+    case 'idle':
+    case 'prose':
+    case 'xml': {
+      // Exempt classes are invisible to the window. ('xml' is never exemptable,
+      // so an xml-tagged-but-unparseable output still counts — preserving the
+      // prior recovery behavior for malformed observation blocks.)
+      if (isExemptableClass(cls) && policy.exemptClasses.has(cls)) {
+        return { window, shouldRespawn: false };
+      }
+      const startFresh = window.badCount === 0 || (now - window.windowStart > policy.windowMs);
+      const base = startFresh ? { windowStart: now, badCount: 0 } : window;
+      const badCount = base.badCount + 1;
+      const shouldRespawn = badCount >= policy.threshold;
+      return {
+        window: shouldRespawn ? freshWindow() : { windowStart: base.windowStart, badCount },
+        shouldRespawn,
+      };
+    }
+    default:
+      return assertNeverClass(cls);
+  }
+}

--- a/src/services/worker/agents/respawn-policy.ts
+++ b/src/services/worker/agents/respawn-policy.ts
@@ -1,6 +1,8 @@
 // src/services/worker/agents/respawn-policy.ts
+import { join } from 'path';
 import { logger } from '../../../utils/logger.js';
 import type { ObserverOutputClass } from '../../../sdk/output-classifier.js';
+import { SettingsDefaultsManager } from '../../../shared/SettingsDefaultsManager.js';
 
 /**
  * Output classes that MAY be configured exempt from the respawn window.
@@ -131,4 +133,34 @@ export function evaluateRespawn(
     default:
       return assertNeverClass(cls);
   }
+}
+
+let cachedPolicy: RespawnPolicy | null = null;
+
+function respawnSettingsPath(): string {
+  // Call-time resolution (mirrors worker-utils.getWorkerSettingsPath) so test
+  // isolation via CLAUDE_MEM_DATA_DIR and runtime env overrides both work.
+  return join(SettingsDefaultsManager.get('CLAUDE_MEM_DATA_DIR'), 'settings.json');
+}
+
+/**
+ * Resolve the respawn policy once from settings (env → settings.json, mirroring
+ * worker-utils' settings-backed timeout). Cached; call clearRespawnPolicyCache()
+ * in tests or after a settings change.
+ */
+export function getRespawnPolicy(): RespawnPolicy {
+  if (cachedPolicy !== null) {
+    return cachedPolicy;
+  }
+  const s = SettingsDefaultsManager.loadFromFile(respawnSettingsPath());
+  cachedPolicy = parseRespawnPolicy(
+    s.CLAUDE_MEM_INVALID_OUTPUT_EXEMPT_CLASSES,
+    s.CLAUDE_MEM_INVALID_OUTPUT_RESPAWN_THRESHOLD,
+    s.CLAUDE_MEM_INVALID_OUTPUT_WINDOW_MS,
+  );
+  return cachedPolicy;
+}
+
+export function clearRespawnPolicyCache(): void {
+  cachedPolicy = null;
 }

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -166,9 +166,9 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_SERVER_BETA_URL: `http://127.0.0.1:${process.env.CLAUDE_MEM_SERVER_PORT ?? String(37877 + ((process.getuid?.() ?? 77) % 100))}`,  // Default server-beta runtime URL — UID-derived for multi-account isolation
     CLAUDE_MEM_SERVER_BETA_API_KEY: '',                     // Local hook API key, populated by installer when runtime=server-beta
     CLAUDE_MEM_SERVER_BETA_PROJECT_ID: '',                  // Default Postgres project_id used by hooks when runtime=server-beta
-    CLAUDE_MEM_INVALID_OUTPUT_EXEMPT_CLASSES: 'idle',        // #3032 — observer output classes exempt from the respawn window; 'idle' is benign ("nothing to say"). 'poisoned' is never exemptable.
-    CLAUDE_MEM_INVALID_OUTPUT_RESPAWN_THRESHOLD: '3',         // N non-exempt bad outputs within the window before kill+respawn. Bounds 1..=100.
-    CLAUDE_MEM_INVALID_OUTPUT_WINDOW_MS: '60000',            // Rolling burst window (systemd StartLimitIntervalSec / OTP period). Bounds 1000..=3_600_000.
+    CLAUDE_MEM_INVALID_OUTPUT_EXEMPT_CLASSES: 'idle',  // #3032 — observer output classes exempt from the respawn window; 'idle' is benign ("nothing to say"). 'poisoned' is never exemptable.
+    CLAUDE_MEM_INVALID_OUTPUT_RESPAWN_THRESHOLD: '3',  // N non-exempt bad outputs within the window before kill+respawn. Bounds 1..=100.
+    CLAUDE_MEM_INVALID_OUTPUT_WINDOW_MS: '60000',      // Rolling burst window (systemd StartLimitIntervalSec / OTP period). Bounds 1000..=3_600_000.
   };
 
   static getAllDefaults(): SettingsDefaults {

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -82,6 +82,9 @@ export interface SettingsDefaults {
   CLAUDE_MEM_SERVER_BETA_URL: string;
   CLAUDE_MEM_SERVER_BETA_API_KEY: string;
   CLAUDE_MEM_SERVER_BETA_PROJECT_ID: string;
+  CLAUDE_MEM_INVALID_OUTPUT_EXEMPT_CLASSES: string;
+  CLAUDE_MEM_INVALID_OUTPUT_RESPAWN_THRESHOLD: string;
+  CLAUDE_MEM_INVALID_OUTPUT_WINDOW_MS: string;
 }
 
 export class SettingsDefaultsManager {
@@ -163,6 +166,9 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_SERVER_BETA_URL: `http://127.0.0.1:${process.env.CLAUDE_MEM_SERVER_PORT ?? String(37877 + ((process.getuid?.() ?? 77) % 100))}`,  // Default server-beta runtime URL — UID-derived for multi-account isolation
     CLAUDE_MEM_SERVER_BETA_API_KEY: '',                     // Local hook API key, populated by installer when runtime=server-beta
     CLAUDE_MEM_SERVER_BETA_PROJECT_ID: '',                  // Default Postgres project_id used by hooks when runtime=server-beta
+    CLAUDE_MEM_INVALID_OUTPUT_EXEMPT_CLASSES: 'idle',        // #3032 — observer output classes exempt from the respawn window; 'idle' is benign ("nothing to say"). 'poisoned' is never exemptable.
+    CLAUDE_MEM_INVALID_OUTPUT_RESPAWN_THRESHOLD: '3',         // N non-exempt bad outputs within the window before kill+respawn. Bounds 1..=100.
+    CLAUDE_MEM_INVALID_OUTPUT_WINDOW_MS: '60000',            // Rolling burst window (systemd StartLimitIntervalSec / OTP period). Bounds 1000..=3_600_000.
   };
 
   static getAllDefaults(): SettingsDefaults {

--- a/tests/shared/settings-respawn-policy.test.ts
+++ b/tests/shared/settings-respawn-policy.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { SettingsDefaultsManager } from '../../src/shared/SettingsDefaultsManager.js';
+
+describe('respawn-policy settings defaults', () => {
+  afterEach(() => {
+    delete process.env.CLAUDE_MEM_INVALID_OUTPUT_EXEMPT_CLASSES;
+    delete process.env.CLAUDE_MEM_INVALID_OUTPUT_RESPAWN_THRESHOLD;
+    delete process.env.CLAUDE_MEM_INVALID_OUTPUT_WINDOW_MS;
+  });
+
+  it('exposes the three knobs with documented defaults', () => {
+    const d = SettingsDefaultsManager.getAllDefaults();
+    expect(d.CLAUDE_MEM_INVALID_OUTPUT_EXEMPT_CLASSES).toBe('idle');
+    expect(d.CLAUDE_MEM_INVALID_OUTPUT_RESPAWN_THRESHOLD).toBe('3');
+    expect(d.CLAUDE_MEM_INVALID_OUTPUT_WINDOW_MS).toBe('60000');
+  });
+
+  it('honors env override via get()', () => {
+    process.env.CLAUDE_MEM_INVALID_OUTPUT_WINDOW_MS = '90000';
+    expect(SettingsDefaultsManager.get('CLAUDE_MEM_INVALID_OUTPUT_WINDOW_MS')).toBe('90000');
+  });
+});

--- a/tests/telemetry/scrub.test.ts
+++ b/tests/telemetry/scrub.test.ts
@@ -153,14 +153,14 @@ describe('scrubProperties', () => {
   it('keeps the compression trust keys with primitive values', () => {
     const result = scrubProperties({
       invalid_output_class: 'poisoned',
-      consecutive_invalid_outputs: 3,
+      respawn_threshold: 3,
       respawn_triggered: true,
       abort_reason: 'restart_guard',
     });
 
     expect(Object.keys(result)).toHaveLength(4);
     expect(result.invalid_output_class).toBe('poisoned');
-    expect(result.consecutive_invalid_outputs).toBe(3);
+    expect(result.respawn_threshold).toBe(3);
     expect(result.respawn_triggered).toBe(true);
     expect(result.abort_reason).toBe('restart_guard');
   });

--- a/tests/worker/agents/respawn-policy.test.ts
+++ b/tests/worker/agents/respawn-policy.test.ts
@@ -27,7 +27,9 @@ describe('parseRespawnPolicy', () => {
 
   it('drops unknown class tokens but keeps valid ones', () => {
     const p = parseRespawnPolicy('idle, nonsense ,xml', '3', '60000');
-    expect([...p.exemptClasses]).toEqual(['idle']); // 'xml' not exemptable, 'nonsense' unknown
+    // Both dropped, for different reasons: 'xml' is a valid ObserverOutputClass
+    // but not in EXEMPTABLE_CLASSES; 'nonsense' is not a class at all.
+    expect([...p.exemptClasses]).toEqual(['idle']);
   });
 
   it('falls back to default exempt set when empty/all-invalid', () => {

--- a/tests/worker/agents/respawn-policy.test.ts
+++ b/tests/worker/agents/respawn-policy.test.ts
@@ -1,0 +1,91 @@
+// tests/worker/agents/respawn-policy.test.ts
+import { describe, it, expect } from 'bun:test';
+import {
+  parseRespawnPolicy,
+  isExemptableClass,
+  DEFAULT_RESPAWN_THRESHOLD,
+  DEFAULT_RESPAWN_WINDOW_MS,
+} from '../../../src/services/worker/agents/respawn-policy.js';
+
+describe('isExemptableClass', () => {
+  it('accepts idle/prose and rejects xml/poisoned/garbage', () => {
+    expect(isExemptableClass('idle')).toBe(true);
+    expect(isExemptableClass('prose')).toBe(true);
+    expect(isExemptableClass('xml')).toBe(false);
+    expect(isExemptableClass('poisoned')).toBe(false);
+    expect(isExemptableClass('nonsense')).toBe(false);
+  });
+});
+
+describe('parseRespawnPolicy', () => {
+  it('parses valid values', () => {
+    const p = parseRespawnPolicy('idle,prose', '5', '90000');
+    expect([...p.exemptClasses].sort()).toEqual(['idle', 'prose']);
+    expect(p.threshold).toBe(5);
+    expect(p.windowMs).toBe(90000);
+  });
+
+  it('drops unknown class tokens but keeps valid ones', () => {
+    const p = parseRespawnPolicy('idle, nonsense ,xml', '3', '60000');
+    expect([...p.exemptClasses]).toEqual(['idle']); // 'xml' not exemptable, 'nonsense' unknown
+  });
+
+  it('falls back to default exempt set when empty/all-invalid', () => {
+    const p = parseRespawnPolicy('', '3', '60000');
+    expect([...p.exemptClasses]).toEqual(['idle']);
+    const p2 = parseRespawnPolicy('xml,bogus', '3', '60000');
+    expect([...p2.exemptClasses]).toEqual(['idle']);
+  });
+
+  it('falls back to default threshold/window on non-numeric or out-of-range', () => {
+    expect(parseRespawnPolicy('idle', 'abc', '60000').threshold).toBe(DEFAULT_RESPAWN_THRESHOLD);
+    expect(parseRespawnPolicy('idle', '0', '60000').threshold).toBe(DEFAULT_RESPAWN_THRESHOLD);   // < min 1
+    expect(parseRespawnPolicy('idle', '101', '60000').threshold).toBe(DEFAULT_RESPAWN_THRESHOLD); // > max 100
+    expect(parseRespawnPolicy('idle', '3', '500').windowMs).toBe(DEFAULT_RESPAWN_WINDOW_MS);      // < min 1000
+    expect(parseRespawnPolicy('idle', '3', 'nope').windowMs).toBe(DEFAULT_RESPAWN_WINDOW_MS);
+  });
+
+  // ---- corner cases (public project: cover the parse surface) ----
+
+  it('trims surrounding whitespace and dedupes class tokens', () => {
+    const p = parseRespawnPolicy('  idle , prose , idle ', '3', '60000');
+    expect([...p.exemptClasses].sort()).toEqual(['idle', 'prose']);
+  });
+
+  it('ignores empty segments from stray/leading/trailing commas', () => {
+    expect([...parseRespawnPolicy('idle,,', '3', '60000').exemptClasses]).toEqual(['idle']);
+    expect([...parseRespawnPolicy(',prose,', '3', '60000').exemptClasses]).toEqual(['prose']);
+  });
+
+  it('is case-sensitive: a mis-cased class is rejected and the set falls back to default', () => {
+    // Matches the canonical lowercase ObserverOutputClass literals; the unknown
+    // token is warned + dropped, leaving an empty set -> default {idle}.
+    expect([...parseRespawnPolicy('IDLE', '3', '60000').exemptClasses]).toEqual(['idle']);
+    expect([...parseRespawnPolicy('Prose', '3', '60000').exemptClasses]).toEqual(['idle']);
+  });
+
+  it('accepts threshold and window at the inclusive bounds', () => {
+    expect(parseRespawnPolicy('idle', '1', '1000').threshold).toBe(1);
+    expect(parseRespawnPolicy('idle', '100', '3600000').threshold).toBe(100);
+    expect(parseRespawnPolicy('idle', '1', '1000').windowMs).toBe(1000);
+    expect(parseRespawnPolicy('idle', '100', '3600000').windowMs).toBe(3600000);
+  });
+
+  it('rejects values one step outside the bounds', () => {
+    expect(parseRespawnPolicy('idle', '101', '60000').threshold).toBe(DEFAULT_RESPAWN_THRESHOLD);
+    expect(parseRespawnPolicy('idle', '3', '999').windowMs).toBe(DEFAULT_RESPAWN_WINDOW_MS);
+    expect(parseRespawnPolicy('idle', '3', '3600001').windowMs).toBe(DEFAULT_RESPAWN_WINDOW_MS);
+  });
+
+  it('rejects negative and empty-string numeric inputs', () => {
+    expect(parseRespawnPolicy('idle', '-5', '60000').threshold).toBe(DEFAULT_RESPAWN_THRESHOLD);
+    expect(parseRespawnPolicy('idle', '', '60000').threshold).toBe(DEFAULT_RESPAWN_THRESHOLD);
+    expect(parseRespawnPolicy('idle', '3', '').windowMs).toBe(DEFAULT_RESPAWN_WINDOW_MS);
+  });
+
+  it('parseInt-truncates a decimal threshold within bounds (documented; matches parseBoundedTimeout)', () => {
+    // parseInt('3.9', 10) === 3; in-bounds -> accepted as 3. Pinned so the
+    // behavior is intentional, not accidental.
+    expect(parseRespawnPolicy('idle', '3.9', '60000').threshold).toBe(3);
+  });
+});

--- a/tests/worker/agents/respawn-policy.test.ts
+++ b/tests/worker/agents/respawn-policy.test.ts
@@ -3,6 +3,8 @@ import { describe, it, expect } from 'bun:test';
 import {
   parseRespawnPolicy,
   isExemptableClass,
+  evaluateRespawn,
+  freshWindow,
   DEFAULT_RESPAWN_THRESHOLD,
   DEFAULT_RESPAWN_WINDOW_MS,
 } from '../../../src/services/worker/agents/respawn-policy.js';
@@ -89,5 +91,113 @@ describe('parseRespawnPolicy', () => {
     // parseInt('3.9', 10) === 3; in-bounds -> accepted as 3. Pinned so the
     // behavior is intentional, not accidental.
     expect(parseRespawnPolicy('idle', '3.9', '60000').threshold).toBe(3);
+  });
+});
+
+describe('evaluateRespawn', () => {
+  const policy = parseRespawnPolicy('idle', '3', '60000'); // exempt idle, threshold 3, 60s
+
+  it('treats exempt idle as invisible (no count, no respawn)', () => {
+    let w = freshWindow();
+    for (let i = 0; i < 10; i++) {
+      const r = evaluateRespawn('idle', w, policy, 1000 + i);
+      expect(r.shouldRespawn).toBe(false);
+      w = r.window;
+    }
+    expect(w.badCount).toBe(0);
+  });
+
+  it('respawns immediately on poisoned regardless of window', () => {
+    const r = evaluateRespawn('poisoned', freshWindow(), policy, 1000);
+    expect(r.shouldRespawn).toBe(true);
+    expect(r.window.badCount).toBe(0);
+  });
+
+  it('respawns when threshold non-exempt outputs land within the window', () => {
+    let w = freshWindow();
+    let r = evaluateRespawn('prose', w, policy, 1000); w = r.window; expect(r.shouldRespawn).toBe(false);
+    r = evaluateRespawn('prose', w, policy, 2000); w = r.window; expect(r.shouldRespawn).toBe(false);
+    expect(w.badCount).toBe(2);
+    r = evaluateRespawn('prose', w, policy, 3000);
+    expect(r.shouldRespawn).toBe(true);
+    expect(r.window.badCount).toBe(0); // reset after respawn
+  });
+
+  it('decays: bad outputs spread beyond the window do not accumulate', () => {
+    let w = freshWindow();
+    let r = evaluateRespawn('prose', w, policy, 1000); w = r.window;
+    r = evaluateRespawn('prose', w, policy, 2000); w = r.window;
+    expect(w.badCount).toBe(2);
+    // next prose arrives AFTER the 60s window from windowStart(=1000) → fresh window
+    r = evaluateRespawn('prose', w, policy, 1000 + 60001);
+    expect(r.shouldRespawn).toBe(false);
+    expect(r.window.badCount).toBe(1);
+  });
+
+  it('interleaved exempt idle is neutral (does not advance or reset the prose streak)', () => {
+    let w = freshWindow();
+    let r = evaluateRespawn('prose', w, policy, 1000); w = r.window;        // 1
+    r = evaluateRespawn('idle', w, policy, 1500); w = r.window;             // neutral
+    expect(w.badCount).toBe(1);
+    r = evaluateRespawn('prose', w, policy, 2000); w = r.window;            // 2
+    r = evaluateRespawn('prose', w, policy, 2500);                          // 3 → respawn
+    expect(r.shouldRespawn).toBe(true);
+  });
+
+  // ---- corner cases (public project: cover the decision surface) ----
+
+  it('counts an xml-tagged-but-unparseable output — xml is never exemptable', () => {
+    // On the invalid path the classifier can return 'xml' for a malformed block;
+    // it must still count toward respawn (preserves prior recovery behavior).
+    let w = freshWindow();
+    let r = evaluateRespawn('xml', w, policy, 1000); w = r.window;
+    r = evaluateRespawn('xml', w, policy, 2000); w = r.window;
+    expect(w.badCount).toBe(2);
+    r = evaluateRespawn('xml', w, policy, 3000);
+    expect(r.shouldRespawn).toBe(true);
+  });
+
+  it('respawns on the first non-exempt output when threshold is 1', () => {
+    const p1 = parseRespawnPolicy('idle', '1', '60000');
+    expect(evaluateRespawn('prose', freshWindow(), p1, 1000).shouldRespawn).toBe(true);
+  });
+
+  it('with idle+prose both exempt, only poisoned respawns', () => {
+    const pBoth = parseRespawnPolicy('idle,prose', '3', '60000');
+    let w = freshWindow();
+    for (let i = 0; i < 10; i++) {
+      const r = evaluateRespawn(i % 2 ? 'prose' : 'idle', w, pBoth, 1000 + i);
+      expect(r.shouldRespawn).toBe(false);
+      w = r.window;
+    }
+    expect(w.badCount).toBe(0);
+    expect(evaluateRespawn('poisoned', w, pBoth, 5000).shouldRespawn).toBe(true);
+  });
+
+  it('treats an output exactly at the window boundary as still inside (strict >)', () => {
+    let w = freshWindow();
+    let r = evaluateRespawn('prose', w, policy, 1000); w = r.window;        // windowStart=1000, count 1
+    r = evaluateRespawn('prose', w, policy, 1000 + 60000); w = r.window;    // delta === windowMs → NOT expired → count 2
+    expect(w.badCount).toBe(2);
+  });
+
+  it('exempt idle does not reset an already-accumulated badCount', () => {
+    let w = freshWindow();
+    let r = evaluateRespawn('prose', w, policy, 1000); w = r.window;        // 1
+    r = evaluateRespawn('prose', w, policy, 1200); w = r.window;            // 2
+    r = evaluateRespawn('idle', w, policy, 1300); w = r.window;             // neutral
+    expect(w.badCount).toBe(2);
+  });
+
+  it('starts a clean window after a respawn fires', () => {
+    const p2 = parseRespawnPolicy('idle', '2', '60000');
+    let w = freshWindow();
+    let r = evaluateRespawn('prose', w, p2, 1000); w = r.window;            // 1
+    r = evaluateRespawn('prose', w, p2, 1100);                              // 2 → respawn + reset
+    expect(r.shouldRespawn).toBe(true);
+    expect(r.window.badCount).toBe(0);
+    r = evaluateRespawn('prose', r.window, p2, 1200);                       // fresh window → 1
+    expect(r.shouldRespawn).toBe(false);
+    expect(r.window.badCount).toBe(1);
   });
 });

--- a/tests/worker/agents/respawn-policy.test.ts
+++ b/tests/worker/agents/respawn-policy.test.ts
@@ -1,5 +1,8 @@
 // tests/worker/agents/respawn-policy.test.ts
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import {
   parseRespawnPolicy,
   isExemptableClass,
@@ -7,6 +10,8 @@ import {
   freshWindow,
   DEFAULT_RESPAWN_THRESHOLD,
   DEFAULT_RESPAWN_WINDOW_MS,
+  getRespawnPolicy,
+  clearRespawnPolicyCache,
 } from '../../../src/services/worker/agents/respawn-policy.js';
 
 describe('isExemptableClass', () => {
@@ -199,5 +204,47 @@ describe('evaluateRespawn', () => {
     r = evaluateRespawn('prose', r.window, p2, 1200);                       // fresh window → 1
     expect(r.shouldRespawn).toBe(false);
     expect(r.window.badCount).toBe(1);
+  });
+});
+
+describe('getRespawnPolicy', () => {
+  let tempDir: string;
+  const origDataDir = process.env.CLAUDE_MEM_DATA_DIR;
+  const origThreshold = process.env.CLAUDE_MEM_INVALID_OUTPUT_RESPAWN_THRESHOLD;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `respawn-policy-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tempDir, { recursive: true });
+    process.env.CLAUDE_MEM_DATA_DIR = tempDir;           // empty dir ⇒ no settings file ⇒ defaults
+    delete process.env.CLAUDE_MEM_INVALID_OUTPUT_RESPAWN_THRESHOLD;
+    clearRespawnPolicyCache();
+  });
+
+  afterEach(() => {
+    if (origDataDir === undefined) delete process.env.CLAUDE_MEM_DATA_DIR;
+    else process.env.CLAUDE_MEM_DATA_DIR = origDataDir;
+    if (origThreshold === undefined) delete process.env.CLAUDE_MEM_INVALID_OUTPUT_RESPAWN_THRESHOLD;
+    else process.env.CLAUDE_MEM_INVALID_OUTPUT_RESPAWN_THRESHOLD = origThreshold;
+    rmSync(tempDir, { recursive: true, force: true });
+    clearRespawnPolicyCache();
+  });
+
+  it('returns defaults when unset', () => {
+    const p = getRespawnPolicy();
+    expect(p.threshold).toBe(3);
+    expect(p.windowMs).toBe(60000);
+    expect([...p.exemptClasses]).toEqual(['idle']);
+  });
+
+  it('reflects env override after cache clear', () => {
+    process.env.CLAUDE_MEM_INVALID_OUTPUT_RESPAWN_THRESHOLD = '7';
+    clearRespawnPolicyCache();
+    expect(getRespawnPolicy().threshold).toBe(7);
+  });
+
+  it('caches (a later env change without clear is not observed)', () => {
+    expect(getRespawnPolicy().threshold).toBe(3);
+    process.env.CLAUDE_MEM_INVALID_OUTPUT_RESPAWN_THRESHOLD = '9';
+    expect(getRespawnPolicy().threshold).toBe(3); // cached until clearRespawnPolicyCache()
   });
 });

--- a/tests/worker/agents/response-processor.test.ts
+++ b/tests/worker/agents/response-processor.test.ts
@@ -124,6 +124,10 @@ describe('ResponseProcessor', () => {
       claimedMessageIds: [],
       conversationHistory: [],
       currentProvider: 'claude',
+      consecutiveRestarts: 0,
+      invalidOutputWindow: { windowStart: 0, badCount: 0 },
+      lastGeneratorActivity: Date.now(),
+      platformSource: 'claude',
       ...overrides,
     } as ActiveSession;
   }

--- a/tests/worker/poison-respawn.test.ts
+++ b/tests/worker/poison-respawn.test.ts
@@ -38,6 +38,7 @@ mock.module('../../src/services/worker-service.js', () => ({
 
 import { SessionManager } from '../../src/services/worker/SessionManager.js';
 import { processAgentResponse, INVALID_OUTPUT_RESPAWN_THRESHOLD } from '../../src/services/worker/agents/ResponseProcessor.js';
+import { DEFAULT_RESPAWN_THRESHOLD, clearRespawnPolicyCache } from '../../src/services/worker/agents/respawn-policy.js';
 import type { DatabaseManager } from '../../src/services/worker/DatabaseManager.js';
 import type { WorkerRef } from '../../src/services/worker/agents/types.js';
 
@@ -65,6 +66,7 @@ let spies: ReturnType<typeof spyOn>[] = [];
 
 describe('poison respawn (plan-11 #2485)', () => {
   beforeEach(() => {
+    clearRespawnPolicyCache();
     spies = [
       spyOn(logger, 'info').mockImplementation(() => {}),
       spyOn(logger, 'debug').mockImplementation(() => {}),
@@ -109,35 +111,45 @@ describe('poison respawn (plan-11 #2485)', () => {
     // Session still active (not deleted) and abort fired for a fresh spawn.
     expect(sm.getSession(1)).toBeDefined();
     expect(session.abortController.signal.aborted).toBe(true);
-    expect(session.consecutiveInvalidOutputs).toBe(0); // reset on respawn
+    expect(session.invalidOutputWindow.badCount).toBe(0); // reset on respawn
   });
 
-  it('respawns only after N consecutive prose/idle outputs, not on the first', async () => {
+  it('respawns after N prose outputs within the window, not on the first', async () => {
     const sm = new SessionManager(makeDbManager());
     const session = sm.initializeSession(2, 'do the thing', 1);
     session.memorySessionId = 'mem-2';
     await sm.queueObservation(2, {
       tool_name: 'Read', tool_input: {}, tool_response: {}, prompt_number: 1, toolUseId: 'tu-a',
     });
-
     const respawnSpy = spyOn(sm, 'respawnPoisonedSession');
 
-    // First (threshold - 1) prose responses must NOT respawn.
-    for (let i = 0; i < INVALID_OUTPUT_RESPAWN_THRESHOLD - 1; i++) {
-      await processAgentResponse(
-        'Just some prose, no XML here.',
-        session, makeDbManager(), sm, mockWorker, 0, null, 'TestAgent'
-      );
+    for (let i = 0; i < DEFAULT_RESPAWN_THRESHOLD - 1; i++) {
+      await processAgentResponse('Just some prose, no XML here.',
+        session, makeDbManager(), sm, mockWorker, 0, null, 'TestAgent');
     }
     expect(respawnSpy).not.toHaveBeenCalled();
-    expect(session.consecutiveInvalidOutputs).toBe(INVALID_OUTPUT_RESPAWN_THRESHOLD - 1);
+    expect(session.invalidOutputWindow.badCount).toBe(DEFAULT_RESPAWN_THRESHOLD - 1);
 
-    // The Nth invalid output crosses the threshold and triggers respawn.
-    await processAgentResponse(
-      'Still just prose.',
-      session, makeDbManager(), sm, mockWorker, 0, null, 'TestAgent'
-    );
+    await processAgentResponse('Still just prose.',
+      session, makeDbManager(), sm, mockWorker, 0, null, 'TestAgent');
     expect(respawnSpy).toHaveBeenCalledWith(2);
+  });
+
+  it('does NOT respawn on benign idle outputs (the poison-loop fix, #3032)', async () => {
+    const sm = new SessionManager(makeDbManager());
+    const session = sm.initializeSession(5, 'do the thing', 1);
+    session.memorySessionId = 'mem-5';
+    await sm.queueObservation(5, {
+      tool_name: 'Read', tool_input: {}, tool_response: {}, prompt_number: 1, toolUseId: 'tu-i',
+    });
+    const respawnSpy = spyOn(sm, 'respawnPoisonedSession');
+
+    // Empty string classifies as 'idle'. Far more than the threshold.
+    for (let i = 0; i < DEFAULT_RESPAWN_THRESHOLD + 3; i++) {
+      await processAgentResponse('', session, makeDbManager(), sm, mockWorker, 0, null, 'TestAgent');
+    }
+    expect(respawnSpy).not.toHaveBeenCalled();
+    expect(session.invalidOutputWindow.badCount).toBe(0);
   });
 
   it('respawnPoisonedSession preserves the buffer and resets context', async () => {
@@ -145,7 +157,7 @@ describe('poison respawn (plan-11 #2485)', () => {
     const session = sm.initializeSession(3, 'do the thing', 1);
     session.memorySessionId = 'mem-3';
     session.conversationHistory.push({ role: 'assistant', content: 'poisoned turn' });
-    session.consecutiveInvalidOutputs = 5;
+    session.invalidOutputWindow = { windowStart: Date.now(), badCount: 5 };
     await sm.queueObservation(3, {
       tool_name: 'Read', tool_input: {}, tool_response: {}, prompt_number: 1, toolUseId: 'tu-x',
     });
@@ -155,8 +167,30 @@ describe('poison respawn (plan-11 #2485)', () => {
     expect(sm.getMessageBuffer().getPendingCount(3)).toBe(1); // preserved
     expect(sm.getSession(3)).toBeDefined();
     expect(session.conversationHistory).toHaveLength(0);
-    expect(session.consecutiveInvalidOutputs).toBe(0);
+    expect(session.invalidOutputWindow.badCount).toBe(0);
     expect(session.memorySessionId).toBeNull();
     expect(session.abortController.signal.aborted).toBe(true);
+  });
+
+  it('a valid parse resets the failure window (positive path)', async () => {
+    const sm = new SessionManager(makeDbManager());
+    const session = sm.initializeSession(6, 'do the thing', 1);
+    // memorySessionId intentionally left null: the valid path resets the window,
+    // then returns at the `if (!session.memorySessionId)` gate before storage.
+    await sm.queueObservation(6, {
+      tool_name: 'Read', tool_input: {}, tool_response: {}, prompt_number: 1, toolUseId: 'tu-v',
+    });
+    const respawnSpy = spyOn(sm, 'respawnPoisonedSession');
+
+    await processAgentResponse('prose one', session, makeDbManager(), sm, mockWorker, 0, null, 'TestAgent');
+    await processAgentResponse('prose two', session, makeDbManager(), sm, mockWorker, 0, null, 'TestAgent');
+    expect(session.invalidOutputWindow.badCount).toBe(2);
+
+    const validXml =
+      '<observation><type>discovery</type><title>real</title><narrative>n</narrative></observation>';
+    await processAgentResponse(validXml, session, makeDbManager(), sm, mockWorker, 0, null, 'TestAgent');
+
+    expect(session.invalidOutputWindow.badCount).toBe(0); // reset on valid parse
+    expect(respawnSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/worker/poison-respawn.test.ts
+++ b/tests/worker/poison-respawn.test.ts
@@ -37,7 +37,7 @@ mock.module('../../src/services/worker-service.js', () => ({
 }));
 
 import { SessionManager } from '../../src/services/worker/SessionManager.js';
-import { processAgentResponse, INVALID_OUTPUT_RESPAWN_THRESHOLD } from '../../src/services/worker/agents/ResponseProcessor.js';
+import { processAgentResponse } from '../../src/services/worker/agents/ResponseProcessor.js';
 import { DEFAULT_RESPAWN_THRESHOLD, clearRespawnPolicyCache } from '../../src/services/worker/agents/respawn-policy.js';
 import type { DatabaseManager } from '../../src/services/worker/DatabaseManager.js';
 import type { WorkerRef } from '../../src/services/worker/agents/types.js';


### PR DESCRIPTION
## What

Replaces the unbounded `consecutiveInvalidOutputs >= 3` respawn counter — which wrongly counted benign `idle`/prose SDK output and poison-looped quiet sessions, wiping context and dropping all captured work — with a **time-windowed burst counter** (modelled on systemd's `StartLimitBurst`/`StartLimitIntervalSec` and Erlang/OTP supervisor `intensity`/`period`).

Closes #3032
Refs #2935 #3007 #3037 #3022 #2955 #2960

## Why

On low-signal sessions the SDK legitimately emits `idle`/empty/prose responses. The old counter treated every one as an "invalid output" and, after 3 in a row, killed and respawned the observer — which on a quiet session just produces more idle output, so the respawn itself re-triggers the counter: a self-sustaining poison→respawn loop. The fix only respawns when invalid outputs arrive as a *burst within a bounded window*, so isolated benign idles can never accumulate to the threshold.

## How

- New module `src/services/worker/agents/respawn-policy.ts`: `evaluateRespawn` (windowed decision with an exhaustiveness guard over output classes), `parseRespawnPolicy`, cached settings-backed `getRespawnPolicy`, and a `FailureWindow` class.
- `ActiveSession.consecutiveInvalidOutputs` → `invalidOutputWindow` (timestamps within the window, not a monotonic count).
- `poisoned` output still respawns **immediately**; `idle` is **exempt by default**.
- Respawn-policy telemetry dimension wired through the scrubber; an orphaned telemetry key retired.

## New settings (all string, in `SettingsDefaultsManager`, defaults reproduce prior behavior minus the bug)

| Key | Default | Range |
|---|---|---|
| `CLAUDE_MEM_INVALID_OUTPUT_EXEMPT_CLASSES` | `idle` | comma-list of output classes |
| `CLAUDE_MEM_INVALID_OUTPUT_RESPAWN_THRESHOLD` | `3` | 1..=100 |
| `CLAUDE_MEM_INVALID_OUTPUT_WINDOW_MS` | `60000` | 1000..=3_600_000 |

## Tests

- `tests/worker/agents/respawn-policy.test.ts` (new, comprehensive: windowing, threshold boundaries, exempt classes, exhaustiveness).
- `tests/shared/settings-respawn-policy.test.ts` (new, settings parse + validation bounds).
- Extended `tests/worker/poison-respawn.test.ts`, `response-processor.test.ts`, `scrub.test.ts`.
- Targeted suite: **71 pass / 0 fail**; `tsc --noEmit` clean.
- **Live soak (prior session):** real Haiku run emitted 5× idle + 3× prose → badCount ≤ 1, **0 poisons** (old code would have respawned).

## Notes

- **Poison-loop cluster:** this PR fully resolves #3032; the other `Refs` (#2935, #3007, #3037, #3022, #2955, #2960) describe the same self-sustaining respawn loop from different triggers. Windowing the invalid-output burst is a contributing mitigation for them, so they're linked as related rather than closed — e.g. #3022's `poisoned`-keyword false-positive is a distinct concern the `poisoned` class still respawns on immediately.
- Independent of #3055/#3057/#3058 (branched cleanly off `main`, no shared commits) — can merge in any order.
- Pre-existing/flaky suite failures (SettingsDefaultsManager env-leak — addressed in #3058 — and GeminiProvider/Worker-API full-suite-concurrency flakes) are unrelated; this diff touches none of those modules.
