### PR TITLE
fix: avoid top-level await in bun-runner so hooks load on Node < 14.8

### DIFF
--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -125,6 +125,12 @@ function collectStdin() {
   });
 }
 
+// Wrapped in an async IIFE: top-level `await` is unsupported in the ESM loader
+// of Node < 14.8, which some Claude Code installs invoke hooks with (e.g. the
+// Node 12 shipped by Ubuntu 22.04 / many WSL setups). There it throws
+// "SyntaxError: Unexpected reserved word" at module load, breaking the hook.
+// Same oldest-Node compatibility reason as the optional-chaining note above.
+(async () => {
 const stdinData = await collectStdin();
 
 const spawnOptions = {
@@ -236,3 +242,4 @@ child.on('close', (code, signal) => {
   }
   process.exit(code || 0);
 });
+})();


### PR DESCRIPTION
## Problem

`plugin/scripts/bun-runner.js` is an ES module that uses a **top-level `await`**:

```js
const stdinData = await collectStdin();
```

Top-level await is unsupported by the ESM loader of **Node < 14.8**. On hosts where Claude Code invokes hooks with an older Node — e.g. the **Node 12** that ships with Ubuntu 22.04 and many WSL setups — the module fails to load before running anything:

```
file:///.../claude-mem/.../scripts/bun-runner.js:128
const stdinData = await collectStdin();
                  ^^^^^
SyntaxError: Unexpected reserved word
    at Loader.moduleStrategy (internal/modules/esm/translators.js:133:18)
```

This breaks **every** claude-mem hook (e.g. the `Stop` hook surfaces it as a hook error) for those users.

## Fix

Wrap the body after `collectStdin()` in an async IIFE so `await` is no longer at module scope. No behavior change on modern Node.

This is the same oldest-Node compatibility concern the file already handles deliberately for optional chaining — see the `?.` note above `isPluginDisabledInClaudeSettings()`.

## Repro / verification

```bash
# Under Node 12:
node --check plugin/scripts/bun-runner.js
```

- **Before:** `SyntaxError: Unexpected reserved word`
- **After:** parses OK (verified on v12.22.9)