### PR TITLE
fix(codex): install local plugin cache during setup

### DIFF
--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -1599,6 +1599,7 @@ async function runInstallCommandInner(options: InstallOptions, summary: InstallS
             }
             writeInstallMarker(cacheDir, version, bunVersion, uvVersion);
           }
+          writeInstallMarker(join(marketplaceDirectory(), 'plugin'), version, bunVersion, uvVersion);
           return `Runtime ready (Bun ${bunVersion}, uv ${uvVersion}) ${pc.green('OK')}`;
         },
       },

--- a/src/services/integrations/CodexCliInstaller.ts
+++ b/src/services/integrations/CodexCliInstaller.ts
@@ -126,18 +126,6 @@ function runCodex(args: string[]): void {
   }
 }
 
-function runCodexBestEffort(args: string[], successMessage: string, failureMessage: string): boolean {
-  try {
-    runCodex(args);
-    console.log(`  ${successMessage}`);
-    return true;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(`  ${failureMessage}: ${message}`);
-    return false;
-  }
-}
-
 function isMarketplaceDifferentSourceError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return message.includes(`marketplace '${MARKETPLACE_NAME}' is already added from a different source`)
@@ -419,11 +407,8 @@ export async function installCodexCli(marketplaceRootOverride?: string): Promise
     console.log(`  Registering Codex plugin marketplace: ${marketplaceRoot}`);
     registerCodexMarketplace(marketplaceRoot);
     enableCodexPluginConfig();
-    runCodexBestEffort(
-      ['plugin', 'add', CODEX_PLUGIN_ID],
-      'Installed Codex plugin cache.',
-      `Could not install Codex plugin cache; run: codex plugin add ${CODEX_PLUGIN_ID}`,
-    );
+    runCodex(['plugin', 'add', CODEX_PLUGIN_ID]);
+    console.log('  Installed Codex plugin cache.');
     if (!cleanupLegacyCodexAgentsMdContext()) {
       console.warn(`  Native Codex hooks registered, but failed to remove legacy AGENTS.md context from ${CODEX_AGENTS_MD_PATH}.`);
     }

--- a/src/services/integrations/CodexCliInstaller.ts
+++ b/src/services/integrations/CodexCliInstaller.ts
@@ -420,9 +420,9 @@ export async function installCodexCli(marketplaceRootOverride?: string): Promise
     registerCodexMarketplace(marketplaceRoot);
     enableCodexPluginConfig();
     runCodexBestEffort(
-      ['plugin', 'marketplace', 'upgrade', MARKETPLACE_NAME],
-      'Refreshed Codex marketplace and installed plugin cache.',
-      'Could not refresh Codex marketplace cache; reinstall or upgrade claude-mem from /plugins if Codex still uses old MCP config',
+      ['plugin', 'add', CODEX_PLUGIN_ID],
+      'Installed Codex plugin cache.',
+      `Could not install Codex plugin cache; run: codex plugin add ${CODEX_PLUGIN_ID}`,
     );
     if (!cleanupLegacyCodexAgentsMdContext()) {
       console.warn(`  Native Codex hooks registered, but failed to remove legacy AGENTS.md context from ${CODEX_AGENTS_MD_PATH}.`);

--- a/tests/install-non-tty.test.ts
+++ b/tests/install-non-tty.test.ts
@@ -152,7 +152,9 @@ describe('Install Non-TTY Support', () => {
         codexInstallerSource.indexOf('export async function installCodexCli'),
         codexInstallerSource.indexOf('export function uninstallCodexCli'),
       );
-      expect(installRegion).toContain("['plugin', 'add', CODEX_PLUGIN_ID]");
+      expect(installRegion).toContain("runCodex(['plugin', 'add', CODEX_PLUGIN_ID])");
+      expect(installRegion).toContain('Installed Codex plugin cache.');
+      expect(installRegion).not.toContain('runCodexBestEffort(');
       expect(installRegion).not.toContain("['plugin', 'marketplace', 'upgrade', MARKETPLACE_NAME]");
     });
 

--- a/tests/install-non-tty.test.ts
+++ b/tests/install-non-tty.test.ts
@@ -147,13 +147,21 @@ describe('Install Non-TTY Support', () => {
       expect(installSource).toContain('installCodexCli(marketplaceDirectory())');
     });
 
-    it('refreshes Codex marketplace cache after registration', () => {
+    it('installs the Codex plugin cache after local marketplace registration', () => {
       const installRegion = codexInstallerSource.slice(
         codexInstallerSource.indexOf('export async function installCodexCli'),
         codexInstallerSource.indexOf('export function uninstallCodexCli'),
       );
-      expect(installRegion).toContain("['plugin', 'marketplace', 'upgrade', MARKETPLACE_NAME]");
-      expect(installRegion).toContain('installed plugin cache');
+      expect(installRegion).toContain("['plugin', 'add', CODEX_PLUGIN_ID]");
+      expect(installRegion).not.toContain("['plugin', 'marketplace', 'upgrade', MARKETPLACE_NAME]");
+    });
+
+    it('copies the install marker into the bundled marketplace plugin before Codex installs it', () => {
+      const runtimeSetupRegion = installSource.slice(
+        installSource.indexOf("title: 'Setting up runtime"),
+        installSource.indexOf("return `Runtime ready"),
+      );
+      expect(runtimeSetupRegion).toContain("writeInstallMarker(join(marketplaceDirectory(), 'plugin'), version, bunVersion, uvVersion)");
     });
 
     it('replaces stale Codex marketplace registrations from a different source', () => {


### PR DESCRIPTION
## Summary
- install the Codex plugin cache with `codex plugin add claude-mem@claude-mem-local` after registering the local marketplace
- copy `.install-version` into the bundled marketplace plugin root before Codex installs from it
- update the non-TTY install contract tests so local marketplace registration is not treated as a completed Codex install

## Root cause
On current Codex CLI, `codex plugin marketplace upgrade claude-mem-local` is only valid for Git marketplaces. For a local marketplace it fails with:

```text
marketplace `claude-mem-local` is not configured as a Git marketplace
```

The installer ran that command best-effort, so installs could still report Codex marketplace registration success while `codex plugin list` showed `claude-mem@claude-mem-local` as `not installed` and no active Codex plugin cache existed.

A second related gap is that Codex installs by copying from the bundled marketplace plugin root. That root did not receive `.install-version`, so a freshly installed Codex cache could inherit a missing marker and hit the `runtime not yet set up` SessionStart path even though runtime setup had completed elsewhere.

Related older report: #2361.

## Verification
- Reproduced locally on Codex CLI 0.142.2: worker readiness was healthy, marketplace was registered, but `codex plugin list` still showed `not installed` until `codex plugin add claude-mem@claude-mem-local` was run.
- Verified local repair: `codex plugin list` shows `installed, enabled`; worker readiness returns ready; direct Codex hook replay returns accepted JSON for `SessionStart`, `PreToolUse`, and `PostToolUse` with no `suppressOutput` on tool hooks.
- `bun test tests/install-non-tty.test.ts tests/integration/codex-cli-installer.test.ts tests/setup-runtime.test.ts tests/services/integrations/spawn-contract-windows.test.ts`
- `npm run typecheck:root`
- `npm run build`