### PR TITLE
feat(server): remote authenticated MCP recall endpoint (POST /v1/mcp)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -20,6 +20,7 @@ Available beta endpoints:
 - `PATCH /v1/memories/:id`
 - `POST /v1/search`
 - `POST /v1/context`
+- `ALL /v1/mcp` (remote MCP recall — see below)
 - `GET /v1/audit?projectId=<id>`
 
 When `CLAUDE_MEM_AUTH_MODE=api-key`, send `Authorization: Bearer <key>`. Read endpoints require `memories:read`; write endpoints require `memories:write`.
@@ -38,3 +39,30 @@ always populated (or `null` only when generation was explicitly disabled).
 The actual provider call happens in a separate BullMQ worker process
 (`claude-mem server worker start`); the HTTP path never blocks on a
 provider response.
+
+## Remote MCP endpoint
+
+`/v1/mcp` is a streamable-HTTP [MCP](https://modelcontextprotocol.io) server —
+the secure, authenticated link a user pastes into Claude Code (or any MCP
+client) to recall their cloud memory. It is read-only and authenticated by the
+same API key as the REST routes (`memories:read`); the key's team (and project,
+if the key is project-scoped) bound every read.
+
+Connect:
+
+```bash
+claude mcp add --transport http claude-mem <server-base>/v1/mcp \
+  --header "Authorization: Bearer cm_..."
+```
+
+Tools:
+
+- `search` — `{ projectId, query, limit? }` → matching observations (FTS, same
+  path as `POST /v1/search`).
+- `context` — `{ projectId, query, limit? }` → observations plus a concatenated
+  `context` string ready for prompt injection (same path as `POST /v1/context`).
+- `recent` — `{ projectId, limit? }` → the newest observations for a project.
+
+The transport is stateless: one MCP server + transport per request, so it needs
+no session affinity behind a load balancer. Mutating tools are intentionally
+absent — a pasted recall link cannot write.

--- a/src/server/mcp/recall-mcp-server.ts
+++ b/src/server/mcp/recall-mcp-server.ts
@@ -24,7 +24,10 @@ import {
 export interface RecallBackend {
   // Returns serialized observations (already shaped by serializeObservation),
   // scoped to the caller's team. Throws if `projectId` is outside the key's scope.
+  // `search` and `context` query identically; they are separate methods so the
+  // route can audit each tool under its own mode (search vs context).
   search(args: { projectId: string; query: string; limit: number }): Promise<unknown[]>;
+  context(args: { projectId: string; query: string; limit: number }): Promise<unknown[]>;
   recent(args: { projectId: string; limit: number }): Promise<unknown[]>;
 }
 
@@ -117,7 +120,7 @@ export function createRecallMcpServer(backend: RecallBackend, version: string): 
         return jsonResult({ observations });
       }
       if (name === 'context') {
-        const observations = await backend.search({
+        const observations = await backend.context({
           projectId: requireString(args, 'projectId'),
           query: requireString(args, 'query'),
           limit: clampLimit(args.limit, CONTEXT_LIMIT),

--- a/src/server/mcp/recall-mcp-server.ts
+++ b/src/server/mcp/recall-mcp-server.ts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Remote-recall MCP server factory.
+//
+// Builds a low-level MCP `Server` exposing the read tools (`search`, `context`,
+// `recent`) over an injected `RecallBackend`. The backend is the only seam to
+// storage, so this factory is pure and unit-testable without Postgres — the
+// route layer (ServerV1PostgresRoutes) supplies a backend already scoped to the
+// authenticated API key's team (and honoring any project scope).
+//
+// This is the same recall surface the stdio MCP server exposes via
+// ServerBetaClient (`/v1/search`, `/v1/context`), so a hosted MCP link and the
+// local CLI read identical data. The mutating tools are intentionally absent:
+// a pasted recall link is read-only.
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type CallToolResult,
+  type Tool,
+} from '@modelcontextprotocol/sdk/types.js';
+
+export interface RecallBackend {
+  // Returns serialized observations (already shaped by serializeObservation),
+  // scoped to the caller's team. Throws if `projectId` is outside the key's scope.
+  search(args: { projectId: string; query: string; limit: number }): Promise<unknown[]>;
+  recent(args: { projectId: string; limit: number }): Promise<unknown[]>;
+}
+
+const SEARCH_LIMIT = { default: 20, max: 100 };
+const CONTEXT_LIMIT = { default: 10, max: 50 };
+const RECENT_LIMIT = { default: 20, max: 100 };
+
+const TOOLS: Tool[] = [
+  {
+    name: 'search',
+    description:
+      'Full-text search your claude-mem memory for a project. Returns matching observations (most relevant first).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectId: { type: 'string', description: 'Project to search within.' },
+        query: { type: 'string', description: 'Search query.' },
+        limit: { type: 'integer', minimum: 1, maximum: SEARCH_LIMIT.max },
+      },
+      required: ['projectId', 'query'],
+    },
+  },
+  {
+    name: 'context',
+    description:
+      'Like search, but also returns a concatenated context string ready to inject into a prompt.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectId: { type: 'string', description: 'Project to search within.' },
+        query: { type: 'string', description: 'Search query.' },
+        limit: { type: 'integer', minimum: 1, maximum: CONTEXT_LIMIT.max },
+      },
+      required: ['projectId', 'query'],
+    },
+  },
+  {
+    name: 'recent',
+    description: 'List the most recent observations for a project (newest first).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectId: { type: 'string', description: 'Project to list.' },
+        limit: { type: 'integer', minimum: 1, maximum: RECENT_LIMIT.max },
+      },
+      required: ['projectId'],
+    },
+  },
+];
+
+function clampLimit(raw: unknown, spec: { default: number; max: number }): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return spec.default;
+  return Math.min(Math.max(1, Math.trunc(raw)), spec.max);
+}
+
+function requireString(args: Record<string, unknown>, key: string): string {
+  const value = args[key];
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`"${key}" is required`);
+  }
+  return value;
+}
+
+function jsonResult(payload: unknown): CallToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }] };
+}
+
+/**
+ * Build a read-only recall MCP server bound to `backend`. The caller owns the
+ * transport (stdio in the CLI, streamable-HTTP in Server Beta).
+ */
+export function createRecallMcpServer(backend: RecallBackend, version: string): Server {
+  const server = new Server(
+    { name: 'claude-mem', version },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request): Promise<CallToolResult> => {
+    const name = request.params.name;
+    const args = (request.params.arguments ?? {}) as Record<string, unknown>;
+    try {
+      if (name === 'search') {
+        const observations = await backend.search({
+          projectId: requireString(args, 'projectId'),
+          query: requireString(args, 'query'),
+          limit: clampLimit(args.limit, SEARCH_LIMIT),
+        });
+        return jsonResult({ observations });
+      }
+      if (name === 'context') {
+        const observations = await backend.search({
+          projectId: requireString(args, 'projectId'),
+          query: requireString(args, 'query'),
+          limit: clampLimit(args.limit, CONTEXT_LIMIT),
+        });
+        const context = observations
+          .map((o) => (o as { content?: unknown }).content)
+          .filter((t): t is string => typeof t === 'string' && t.length > 0)
+          .join('\n\n');
+        return jsonResult({ observations, context });
+      }
+      if (name === 'recent') {
+        const observations = await backend.recent({
+          projectId: requireString(args, 'projectId'),
+          limit: clampLimit(args.limit, RECENT_LIMIT),
+        });
+        return jsonResult({ observations });
+      }
+      throw new Error(`Unknown tool: ${name}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { isError: true, content: [{ type: 'text', text: message }] };
+    }
+  });
+
+  return server;
+}
+
+export const RECALL_MCP_TOOLS = TOOLS;

--- a/src/server/routes/v1/ServerV1PostgresRoutes.ts
+++ b/src/server/routes/v1/ServerV1PostgresRoutes.ts
@@ -20,6 +20,8 @@ import { PostgresObservationRepository } from '../../../storage/postgres/observa
 import { logger } from '../../../utils/logger.js';
 import { requirePostgresServerAuth } from '../../middleware/postgres-auth.js';
 import { requestIdMiddleware } from '../../middleware/request-id.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { createRecallMcpServer, type RecallBackend } from '../../mcp/recall-mcp-server.js';
 import type { ActiveServerBetaQueueManager } from '../../runtime/ActiveServerBetaQueueManager.js';
 import type { ServerBetaQueueManager } from '../../runtime/types.js';
 import { PostgresServerSessionsRepository } from '../../../storage/postgres/server-sessions.js';
@@ -28,6 +30,10 @@ import { IngestEventsService, type EnqueueOutcome } from '../../services/IngestE
 import { EndSessionService } from '../../services/EndSessionService.js';
 
 const SOURCE_ADAPTER_DEFAULT = 'api';
+
+declare const __DEFAULT_PACKAGE_VERSION__: string;
+const MCP_SERVER_VERSION =
+  typeof __DEFAULT_PACKAGE_VERSION__ !== 'undefined' ? __DEFAULT_PACKAGE_VERSION__ : '0.0.0-dev';
 
 export interface ServerV1PostgresRoutesOptions {
   pool: PostgresPool;
@@ -926,6 +932,45 @@ export class ServerV1PostgresRoutes implements RouteHandler {
         }
       },
     ));
+
+    // Remote authenticated MCP endpoint. The "secure MCP link" a user pastes
+    // into Claude Code (or any MCP client) to recall their cloud memory:
+    //   claude mcp add --transport http claude-mem <base>/v1/mcp \
+    //     --header "Authorization: Bearer cm_..."
+    // Same readAuth (memories:read) + team/project scoping as /v1/search, so it
+    // reads identical data through identical guards. Stateless streamable-HTTP:
+    // one transport + server per request, bound to this key's team.
+    app.all('/v1/mcp', readAuth, this.asyncHandler(async (req, res) => {
+      const teamId = this.requireTeamId(req, res);
+      if (!teamId) return;
+      const projectScope = req.authContext?.projectId ?? null;
+      const repo = new PostgresObservationRepository(this.options.pool);
+      const assertProjectAllowed = (projectId: string): void => {
+        if (projectScope && projectScope !== projectId) {
+          throw new Error('API key is scoped to a different project');
+        }
+      };
+      const backend: RecallBackend = {
+        search: async ({ projectId, query, limit }) => {
+          assertProjectAllowed(projectId);
+          const rows = await repo.search({ projectId, teamId, query, limit });
+          return rows.map(serializeObservation);
+        },
+        recent: async ({ projectId, limit }) => {
+          assertProjectAllowed(projectId);
+          const rows = await repo.listByProject({ projectId, teamId, limit });
+          return rows.map(serializeObservation);
+        },
+      };
+      const server = createRecallMcpServer(backend, MCP_SERVER_VERSION);
+      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+      res.on('close', () => {
+        void transport.close();
+        void server.close();
+      });
+      await server.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+    }));
   }
 
   private async auditRead(

--- a/src/server/routes/v1/ServerV1PostgresRoutes.ts
+++ b/src/server/routes/v1/ServerV1PostgresRoutes.ts
@@ -937,10 +937,10 @@ export class ServerV1PostgresRoutes implements RouteHandler {
     // into Claude Code (or any MCP client) to recall their cloud memory:
     //   claude mcp add --transport http claude-mem <base>/v1/mcp \
     //     --header "Authorization: Bearer cm_..."
-    // Same readAuth (memories:read) + team/project scoping as /v1/search, so it
-    // reads identical data through identical guards. Stateless streamable-HTTP:
-    // one transport + server per request, bound to this key's team.
-    app.all('/v1/mcp', readAuth, this.asyncHandler(async (req, res) => {
+    // Same readAuth (memories:read) + team/project scoping + audit trail as
+    // /v1/search, so it reads identical data through identical guards. Stateless
+    // streamable-HTTP: one transport + server per request, bound to this key's team.
+    const mcpHandler = this.asyncHandler(async (req, res) => {
       const teamId = this.requireTeamId(req, res);
       if (!teamId) return;
       const projectScope = req.authContext?.projectId ?? null;
@@ -954,11 +954,20 @@ export class ServerV1PostgresRoutes implements RouteHandler {
         search: async ({ projectId, query, limit }) => {
           assertProjectAllowed(projectId);
           const rows = await repo.search({ projectId, teamId, query, limit });
+          // Audit the read, same as POST /v1/search — the MCP path is no exception.
+          await this.auditRead(req, 'observation.read', null, projectId, {
+            mode: 'search', via: 'mcp', query, limit,
+            resultCount: rows.length, observationIds: rows.map(o => o.id),
+          });
           return rows.map(serializeObservation);
         },
         recent: async ({ projectId, limit }) => {
           assertProjectAllowed(projectId);
           const rows = await repo.listByProject({ projectId, teamId, limit });
+          await this.auditRead(req, 'observation.read', null, projectId, {
+            mode: 'recent', via: 'mcp', limit,
+            resultCount: rows.length, observationIds: rows.map(o => o.id),
+          });
           return rows.map(serializeObservation);
         },
       };
@@ -970,7 +979,12 @@ export class ServerV1PostgresRoutes implements RouteHandler {
       });
       await server.connect(transport);
       await transport.handleRequest(req, res, req.body);
-    }));
+    });
+    // MCP streamable-HTTP only uses POST (JSON-RPC) and GET (SSE). Scope the
+    // route to those instead of app.all, so DELETE/PUT/PATCH/OPTIONS don't run
+    // auth + transport only to be rejected.
+    app.post('/v1/mcp', readAuth, mcpHandler);
+    app.get('/v1/mcp', readAuth, mcpHandler);
   }
 
   private async auditRead(

--- a/src/server/routes/v1/ServerV1PostgresRoutes.ts
+++ b/src/server/routes/v1/ServerV1PostgresRoutes.ts
@@ -961,6 +961,15 @@ export class ServerV1PostgresRoutes implements RouteHandler {
           });
           return rows.map(serializeObservation);
         },
+        context: async ({ projectId, query, limit }) => {
+          assertProjectAllowed(projectId);
+          const rows = await repo.search({ projectId, teamId, query, limit });
+          await this.auditRead(req, 'observation.read', null, projectId, {
+            mode: 'context', via: 'mcp', query, limit,
+            resultCount: rows.length, observationIds: rows.map(o => o.id),
+          });
+          return rows.map(serializeObservation);
+        },
         recent: async ({ projectId, limit }) => {
           assertProjectAllowed(projectId);
           const rows = await repo.listByProject({ projectId, teamId, limit });

--- a/tests/server/mcp/recall-mcp-server.test.ts
+++ b/tests/server/mcp/recall-mcp-server.test.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Unit tests for the remote-recall MCP server factory. The factory is pure
+// (storage is injected as a RecallBackend), so these run with no Postgres —
+// they drive a real MCP Client over an in-memory transport, exactly how a
+// hosted client would, and assert tool listing, arg forwarding/clamping,
+// context packing, and that backend failures surface as tool errors (not
+// transport throws).
+
+import { describe, it, expect } from 'bun:test';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createRecallMcpServer, type RecallBackend } from '../../../src/server/mcp/recall-mcp-server.js';
+
+interface Recorded {
+  search: Array<{ projectId: string; query: string; limit: number }>;
+  recent: Array<{ projectId: string; limit: number }>;
+}
+
+function makeBackend(overrides: Partial<RecallBackend> = {}): { backend: RecallBackend; calls: Recorded } {
+  const calls: Recorded = { search: [], recent: [] };
+  const backend: RecallBackend = {
+    search: async (args) => {
+      calls.search.push(args);
+      return [
+        { id: 'o1', content: 'alpha' },
+        { id: 'o2', content: 'beta' },
+      ];
+    },
+    recent: async (args) => {
+      calls.recent.push(args);
+      return [{ id: 'r1', content: 'recent-one' }];
+    },
+    ...overrides,
+  };
+  return { backend, calls };
+}
+
+async function connectClient(backend: RecallBackend): Promise<Client> {
+  const server = createRecallMcpServer(backend, '9.9.9');
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test-client', version: '0' }, { capabilities: {} });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return client;
+}
+
+function textOf(result: { content: unknown }): string {
+  const first = (result.content as Array<{ type: string; text?: string }>)[0];
+  return first?.text ?? '';
+}
+
+describe('createRecallMcpServer', () => {
+  it('lists exactly the read-only recall tools', async () => {
+    const client = await connectClient(makeBackend().backend);
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name).sort()).toEqual(['context', 'recent', 'search']);
+    await client.close();
+  });
+
+  it('search forwards args, clamps the limit, and returns observations', async () => {
+    const { backend, calls } = makeBackend();
+    const client = await connectClient(backend);
+    const res = await client.callTool({
+      name: 'search',
+      arguments: { projectId: 'p1', query: 'hello', limit: 9999 },
+    });
+    expect(calls.search[0]).toEqual({ projectId: 'p1', query: 'hello', limit: 100 });
+    expect(JSON.parse(textOf(res)).observations).toHaveLength(2);
+    await client.close();
+  });
+
+  it('context packs the observation contents into a joined string', async () => {
+    const client = await connectClient(makeBackend().backend);
+    const res = await client.callTool({ name: 'context', arguments: { projectId: 'p1', query: 'hi' } });
+    expect(JSON.parse(textOf(res)).context).toBe('alpha\n\nbeta');
+    await client.close();
+  });
+
+  it('recent calls the recent backend with the default limit', async () => {
+    const { backend, calls } = makeBackend();
+    const client = await connectClient(backend);
+    await client.callTool({ name: 'recent', arguments: { projectId: 'p2' } });
+    expect(calls.recent[0]).toEqual({ projectId: 'p2', limit: 20 });
+    await client.close();
+  });
+
+  it('a missing required arg is a tool error, not a transport throw', async () => {
+    const client = await connectClient(makeBackend().backend);
+    const res = await client.callTool({ name: 'search', arguments: { projectId: 'p1' } });
+    expect(res.isError).toBe(true);
+    await client.close();
+  });
+
+  it('a backend project-scope rejection surfaces as a tool error', async () => {
+    const { backend } = makeBackend({
+      search: async () => {
+        throw new Error('API key is scoped to a different project');
+      },
+    });
+    const client = await connectClient(backend);
+    const res = await client.callTool({ name: 'search', arguments: { projectId: 'other', query: 'x' } });
+    expect(res.isError).toBe(true);
+    expect(textOf(res)).toContain('different project');
+    await client.close();
+  });
+
+  it('an unknown tool is a tool error', async () => {
+    const client = await connectClient(makeBackend().backend);
+    const res = await client.callTool({ name: 'nope', arguments: {} });
+    expect(res.isError).toBe(true);
+    await client.close();
+  });
+});

--- a/tests/server/mcp/recall-mcp-server.test.ts
+++ b/tests/server/mcp/recall-mcp-server.test.ts
@@ -14,18 +14,24 @@ import { createRecallMcpServer, type RecallBackend } from '../../../src/server/m
 
 interface Recorded {
   search: Array<{ projectId: string; query: string; limit: number }>;
+  context: Array<{ projectId: string; query: string; limit: number }>;
   recent: Array<{ projectId: string; limit: number }>;
 }
 
 function makeBackend(overrides: Partial<RecallBackend> = {}): { backend: RecallBackend; calls: Recorded } {
-  const calls: Recorded = { search: [], recent: [] };
+  const calls: Recorded = { search: [], context: [], recent: [] };
+  const observations = [
+    { id: 'o1', content: 'alpha' },
+    { id: 'o2', content: 'beta' },
+  ];
   const backend: RecallBackend = {
     search: async (args) => {
       calls.search.push(args);
-      return [
-        { id: 'o1', content: 'alpha' },
-        { id: 'o2', content: 'beta' },
-      ];
+      return observations;
+    },
+    context: async (args) => {
+      calls.context.push(args);
+      return observations;
     },
     recent: async (args) => {
       calls.recent.push(args);
@@ -69,9 +75,12 @@ describe('createRecallMcpServer', () => {
     await client.close();
   });
 
-  it('context packs the observation contents into a joined string', async () => {
-    const client = await connectClient(makeBackend().backend);
+  it('context routes through backend.context and packs a joined string', async () => {
+    const { backend, calls } = makeBackend();
+    const client = await connectClient(backend);
     const res = await client.callTool({ name: 'context', arguments: { projectId: 'p1', query: 'hi' } });
+    expect(calls.context).toHaveLength(1);
+    expect(calls.search).toHaveLength(0);
     expect(JSON.parse(textOf(res)).context).toBe('alpha\n\nbeta');
     await client.close();
   });

--- a/tests/server/runtime/server-mcp-http-routes.test.ts
+++ b/tests/server/runtime/server-mcp-http-routes.test.ts
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Integration test for the remote authenticated MCP endpoint (POST /v1/mcp).
+//
+// The unit test (tests/server/mcp/recall-mcp-server.test.ts) covers tool logic
+// over an in-memory transport. THIS test covers the part the unit test can't:
+// the real streamable-HTTP wiring through Express 5 + readAuth + Postgres. It
+// boots the actual server, inserts observations, then drives /v1/mcp with a
+// genuine MCP HTTP client carrying an `Authorization: Bearer cm_...` header —
+// the exact path a user's Claude Code takes.
+//
+// Postgres-gated, like server-mcp-routes.test.ts: requires CLAUDE_MEM_TEST_POSTGRES_URL.
+
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import pg from 'pg';
+import { createHash, randomBytes, randomUUID } from 'crypto';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { Server } from '../../../src/services/server/Server.js';
+import { ServerV1PostgresRoutes } from '../../../src/server/routes/v1/ServerV1PostgresRoutes.js';
+import {
+  bootstrapServerBetaPostgresSchema,
+  createPostgresStorageRepositories,
+  type PostgresPoolClient,
+  type PostgresStorageRepositories,
+} from '../../../src/storage/postgres/index.js';
+import { DisabledServerBetaQueueManager } from '../../../src/server/runtime/types.js';
+import { logger } from '../../../src/utils/logger.js';
+
+const testDatabaseUrl = process.env.CLAUDE_MEM_TEST_POSTGRES_URL;
+
+function quoteIdentifier(name: string): string {
+  return `"${name.replaceAll('"', '""')}"`;
+}
+
+function newApiKey(): { raw: string; hash: string } {
+  const raw = `cm_${randomBytes(24).toString('hex')}`;
+  const hash = createHash('sha256').update(raw).digest('hex');
+  return { raw, hash };
+}
+
+describe('POST /v1/mcp — remote authenticated MCP recall (streamable HTTP)', () => {
+  if (!testDatabaseUrl) {
+    it.skip('requires CLAUDE_MEM_TEST_POSTGRES_URL', () => {});
+    return;
+  }
+
+  let pool: pg.Pool;
+  let client: PostgresPoolClient;
+  let schemaName: string;
+  let storage: PostgresStorageRepositories;
+  let server: Server;
+  let port: number;
+  let teamId: string;
+  let projectId: string;
+  let apiKeyRaw: string;
+  let loggerSpies: ReturnType<typeof spyOn>[] = [];
+
+  beforeEach(async () => {
+    loggerSpies = [
+      spyOn(logger, 'info').mockImplementation(() => {}),
+      spyOn(logger, 'warn').mockImplementation(() => {}),
+      spyOn(logger, 'error').mockImplementation(() => {}),
+      spyOn(logger, 'debug').mockImplementation(() => {}),
+    ];
+    pool = new pg.Pool({ connectionString: testDatabaseUrl });
+    client = await pool.connect();
+    schemaName = `cm_mcp_http_${randomUUID().replaceAll('-', '_')}`;
+    await client.query(`CREATE SCHEMA ${quoteIdentifier(schemaName)}`);
+    await client.query(`SET search_path TO ${quoteIdentifier(schemaName)}`);
+    await bootstrapServerBetaPostgresSchema(client);
+    pool.on('connect', (poolClient) => {
+      poolClient.query(`SET search_path TO ${quoteIdentifier(schemaName)}`).catch(() => {});
+    });
+    storage = createPostgresStorageRepositories(client);
+
+    const team = await storage.teams.create({ name: 'team' });
+    const project = await storage.projects.create({ teamId: team.id, name: 'p' });
+    teamId = team.id;
+    projectId = project.id;
+
+    // The MCP endpoint is read-only, so a read-scoped key must be sufficient.
+    const { raw, hash } = newApiKey();
+    apiKeyRaw = raw;
+    await storage.auth.createApiKey({
+      keyHash: hash,
+      teamId,
+      projectId,
+      actorId: 'test',
+      scopes: ['memories:read'],
+    });
+
+    // Seed memory directly (bypassing auth) so recall has something to find.
+    await storage.observations.create({
+      projectId, teamId, kind: 'manual',
+      content: 'The login bug was a stale CSRF cookie on the callback.',
+    });
+    await storage.observations.create({
+      projectId, teamId, kind: 'manual',
+      content: 'We chose per-user namespaces for the shared cloud instance.',
+    });
+
+    server = new Server({
+      getInitializationComplete: () => true,
+      getMcpReady: () => true,
+      onShutdown: mock(() => Promise.resolve()),
+      onRestart: mock(() => Promise.resolve()),
+      workerPath: '/test/worker.cjs',
+      runtime: 'server-beta',
+      getAiStatus: () => ({ provider: 'disabled', authMethod: 'api-key', lastInteraction: null }),
+    });
+    server.registerRoutes(new ServerV1PostgresRoutes({
+      pool: pool as never,
+      queueManager: new DisabledServerBetaQueueManager('disabled in tests'),
+      authMode: 'api-key',
+      runtime: 'server-beta',
+      sessionPolicy: 'per-event',
+    }));
+    server.finalizeRoutes();
+    await server.listen(0, '127.0.0.1');
+    const address = server.getHttpServer()?.address();
+    if (!address || typeof address === 'string') throw new Error('no port');
+    port = address.port;
+  });
+
+  afterEach(async () => {
+    try { await server.close(); } catch (error: unknown) {
+      const code = (error as NodeJS.ErrnoException | undefined)?.code;
+      if (code !== 'ERR_SERVER_NOT_RUNNING') throw error;
+    }
+    await client.query(`DROP SCHEMA IF EXISTS ${quoteIdentifier(schemaName)} CASCADE`);
+    client.release();
+    await pool.end();
+    loggerSpies.forEach(spy => spy.mockRestore());
+    mock.restore();
+  });
+
+  function connectMcp(key: string): Promise<Client> {
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${port}/v1/mcp`),
+      { requestInit: { headers: { Authorization: `Bearer ${key}` } } },
+    );
+    const mcp = new Client({ name: 'integration-test', version: '0' }, { capabilities: {} });
+    return mcp.connect(transport).then(() => mcp);
+  }
+
+  function textOf(result: { content: unknown }): string {
+    return (result.content as Array<{ type: string; text?: string }>)[0]?.text ?? '';
+  }
+
+  it('lists the recall tools over HTTP with a valid key', async () => {
+    const mcp = await connectMcp(apiKeyRaw);
+    const { tools } = await mcp.listTools();
+    expect(tools.map(t => t.name).sort()).toEqual(['context', 'recent', 'search']);
+    await mcp.close();
+  });
+
+  it('recent returns the team-scoped observations', async () => {
+    const mcp = await connectMcp(apiKeyRaw);
+    const res = await mcp.callTool({ name: 'recent', arguments: { projectId, limit: 10 } });
+    const { observations } = JSON.parse(textOf(res));
+    expect(observations.length).toBe(2);
+    const contents = observations.map((o: { content: string }) => o.content).join(' ');
+    expect(contents).toContain('CSRF cookie');
+    await mcp.close();
+  });
+
+  it('search finds an observation by content', async () => {
+    const mcp = await connectMcp(apiKeyRaw);
+    const res = await mcp.callTool({ name: 'search', arguments: { projectId, query: 'login bug' } });
+    const { observations } = JSON.parse(textOf(res));
+    expect(observations.some((o: { content: string }) => o.content.includes('login bug'))).toBe(true);
+    await mcp.close();
+  });
+
+  it('rejects an unauthenticated connection (no key → 401)', async () => {
+    const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/v1/mcp`));
+    const mcp = new Client({ name: 'noauth', version: '0' }, { capabilities: {} });
+    await expect(mcp.connect(transport)).rejects.toThrow();
+  });
+});

--- a/tests/server/runtime/server-mcp-http-routes.test.ts
+++ b/tests/server/runtime/server-mcp-http-routes.test.ts
@@ -173,6 +173,18 @@ describe('POST /v1/mcp — remote authenticated MCP recall (streamable HTTP)', (
     await mcp.close();
   });
 
+  it('writes an audit_log row for an MCP read (parity with /v1/search)', async () => {
+    const mcp = await connectMcp(apiKeyRaw);
+    await mcp.callTool({ name: 'recent', arguments: { projectId, limit: 5 } });
+    await mcp.close();
+    const audit = await pool.query(
+      `SELECT details FROM audit_log WHERE team_id = $1 AND action = 'observation.read'`,
+      [teamId],
+    );
+    expect(audit.rows.length).toBeGreaterThan(0);
+    expect(audit.rows.some((r: { details: { via?: string } }) => r.details?.via === 'mcp')).toBe(true);
+  });
+
   it('rejects an unauthenticated connection (no key → 401)', async () => {
     const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/v1/mcp`));
     const mcp = new Client({ name: 'noauth', version: '0' }, { capabilities: {} });

--- a/tests/server/runtime/server-mcp-http-routes.test.ts
+++ b/tests/server/runtime/server-mcp-http-routes.test.ts
@@ -173,16 +173,20 @@ describe('POST /v1/mcp — remote authenticated MCP recall (streamable HTTP)', (
     await mcp.close();
   });
 
-  it('writes an audit_log row for an MCP read (parity with /v1/search)', async () => {
+  it('writes audit_log rows for MCP reads, with the right mode per tool', async () => {
     const mcp = await connectMcp(apiKeyRaw);
     await mcp.callTool({ name: 'recent', arguments: { projectId, limit: 5 } });
+    await mcp.callTool({ name: 'context', arguments: { projectId, query: 'login bug' } });
     await mcp.close();
     const audit = await pool.query(
       `SELECT details FROM audit_log WHERE team_id = $1 AND action = 'observation.read'`,
       [teamId],
     );
-    expect(audit.rows.length).toBeGreaterThan(0);
-    expect(audit.rows.some((r: { details: { via?: string } }) => r.details?.via === 'mcp')).toBe(true);
+    const modes = audit.rows.map((r: { details: { via?: string; mode?: string } }) =>
+      r.details?.via === 'mcp' ? r.details?.mode : null,
+    ).filter(Boolean);
+    expect(modes).toContain('recent');
+    expect(modes).toContain('context');
   });
 
   it('rejects an unauthenticated connection (no key → 401)', async () => {


### PR DESCRIPTION
## What
The **secure authenticated MCP link** a user pastes into Claude Code (or Cursor / Codex / any MCP client) to recall their cloud memory from Server Beta:

```
claude mcp add --transport http claude-mem <server-beta-base>/v1/mcp \
  --header "Authorization: Bearer cm_..."
```

Closes the one gap: the MCP server today is **stdio-only** (local worker). Server Beta already has the cloud recall data + API-key auth + REST recall — it just had no remote MCP transport. This adds it.

## Design — reuse, not rebuild
- **Auth:** the existing `readAuth` (`requirePostgresServerAuth`, scope `memories:read`). No new auth — the `cm_` key's team (and project scope) bound every read, same as `/v1/search`.
- **Storage:** the existing `PostgresObservationRepository.search` / `.listByProject` — the same code path as `/v1/search` and `/v1/context`. Identical data, identical guards.
- **Transport:** MCP streamable-HTTP (SDK 1.29), **stateless** — one transport + server per request, so it slots into Express 5 with no session state.

`src/server/mcp/recall-mcp-server.ts` is a pure factory (storage injected as a `RecallBackend`) exposing read-only tools **`search` / `context` / `recent`**. The route in `ServerV1PostgresRoutes` supplies a team-scoped backend. Mutating tools are intentionally omitted — a pasted recall link is read-only.

## Tests
`tests/server/mcp/recall-mcp-server.test.ts` drives a real MCP client over an in-memory transport (no Postgres): tool listing, arg forwarding + limit clamping, context packing, and backend failures surfacing as tool errors. **7/7 pass; full `tsc --noEmit` clean.**

## Before merge — one live check
Per the "verify against the live server" lesson: worth one integration pass hitting `/v1/mcp` on a real Server Beta with a `cm_` key from an MCP client, to confirm the streamable-HTTP + Express 5 wiring end-to-end (the unit test covers the tool logic, not the HTTP transport handshake).

## Open question
Where is Server Beta deployed (the host the link points at), and is `POST /v1/keys` the intended way for a user to mint a `cm_` key? Happy to add a key-issuance route + a Connect snippet in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)