### PR TITLE
feat(server): paid-readiness — usage metering, rate limiting/quotas, key issuance + connect

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -36,6 +36,9 @@ default) means no rate limit, no quota, and no metering, so behavior is unchange
   limit returns `429` with `Retry-After` (and `X-RateLimit-*` headers). Fail-open.
 - `CLAUDE_MEM_MONTHLY_REQUEST_CAP` — max requests per team per calendar month
   (UTC). At the cap, returns `402 quota_exceeded`. Fail-open.
+- `CLAUDE_MEM_MONTHLY_TOKEN_CAP` — max provider tokens per team per month. Gates
+  **writes only** (ingestion drives generation = token spend); reads stay
+  available so a team over budget can still recall. `402` at the cap. Fail-open.
 - `CLAUDE_MEM_USAGE_METERING=1` — record one `request` usage event per
   authenticated call (fire-and-forget). Token/observation metering writes to the
   same `usage_events` table from the generation worker.

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,9 +20,29 @@ Available beta endpoints:
 - `PATCH /v1/memories/:id`
 - `POST /v1/search`
 - `POST /v1/context`
+- `GET /v1/usage`
 - `GET /v1/audit?projectId=<id>`
 
 When `CLAUDE_MEM_AUTH_MODE=api-key`, send `Authorization: Bearer <key>`. Read endpoints require `memories:read`; write endpoints require `memories:write`.
+
+## Rate limiting, quota, and usage metering
+
+These paid-readiness guards run after auth and are **opt-in via env** — unset (the
+default) means no rate limit, no quota, and no metering, so behavior is unchanged.
+
+- `CLAUDE_MEM_RATE_LIMIT_PER_MIN` — max requests per API key per minute. Over the
+  limit returns `429` with `Retry-After` (and `X-RateLimit-*` headers). Fail-open.
+- `CLAUDE_MEM_MONTHLY_REQUEST_CAP` — max requests per team per calendar month
+  (UTC). At the cap, returns `402 quota_exceeded`. Fail-open.
+- `CLAUDE_MEM_USAGE_METERING=1` — record one `request` usage event per
+  authenticated call (fire-and-forget). Token/observation metering writes to the
+  same `usage_events` table from the generation worker.
+
+`GET /v1/usage` returns the caller team's per-kind totals for the current month:
+
+```json
+{ "since": "2026-06-01T00:00:00.000Z", "usage": { "request": 1280, "observation": 44 } }
+```
 
 ## Event generation semantics
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,6 +20,8 @@ Available beta endpoints:
 - `PATCH /v1/memories/:id`
 - `POST /v1/search`
 - `POST /v1/context`
+- `POST /v1/keys`
+- `GET /v1/connect`
 - `GET /v1/usage`
 - `GET /v1/audit?projectId=<id>`
 
@@ -43,6 +45,30 @@ default) means no rate limit, no quota, and no metering, so behavior is unchange
 ```json
 { "since": "2026-06-01T00:00:00.000Z", "usage": { "request": 1280, "observation": 44 } }
 ```
+
+## Connecting an MCP client (key issuance + connect)
+
+- `POST /v1/keys` (**write** scope) mints a **read-only** API key for the caller's
+  team and returns the paste-ready connect command. The raw key is shown **once**.
+  Body: `{ "expiresInDays"?: number }`. Minting requires write scope so a read key
+  can't escalate into more keys.
+
+  ```json
+  {
+    "id": "...", "apiKey": "cm_...", "scopes": ["memories:read"], "expiresAt": null,
+    "mcpUrl": "https://<host>/v1/mcp",
+    "connectCommand": "claude mcp add --transport http claude-mem https://<host>/v1/mcp --header \"Authorization: Bearer cm_...\""
+  }
+  ```
+
+- `GET /v1/connect` (read scope) returns the same command with a `<YOUR_API_KEY>`
+  placeholder (a GET never mints). `mcpUrl` is built from `CLAUDE_MEM_PUBLIC_URL`
+  (recommended behind a proxy) or the request host.
+
+> Cold-start note: minting the team's *first* key still needs a session-gated path
+> (web dashboard). better-auth's `apiKey()` plugin exists but writes to a separate
+> store than the Postgres `api_keys` these routes authenticate against — wiring the
+> better-auth org → Server Beta team mapping is the remaining piece.
 
 ## Event generation semantics
 

--- a/src/server/generation/ProviderObservationGenerator.ts
+++ b/src/server/generation/ProviderObservationGenerator.ts
@@ -214,6 +214,7 @@ export class ProviderObservationGenerator {
         rawText: result.rawText,
         modelId: result.modelId,
         providerLabel: result.providerLabel,
+        tokensUsed: result.tokensUsed,
         // Phase 11 — flow identity context from BullMQ payload into the
         // persistence layer so observations and audit rows carry the same
         // generation_job_id reference back through to the original API key.

--- a/src/server/generation/processGeneratedResponse.ts
+++ b/src/server/generation/processGeneratedResponse.ts
@@ -14,6 +14,7 @@ import {
   type PostgresObservationGenerationJob,
 } from '../../storage/postgres/generation-jobs.js';
 import { PostgresAuthRepository } from '../../storage/postgres/auth.js';
+import { PostgresUsageRepository } from '../../storage/postgres/usage.js';
 import {
   withPostgresTransaction,
   type PostgresPool,
@@ -57,6 +58,8 @@ export interface ProcessGeneratedResponseInput {
   apiKeyId?: string | null;
   actorId?: string | null;
   sourceAdapter?: string | null;
+  // Provider tokens this job spent (from the generate() result), for cost metering.
+  tokensUsed?: number;
 }
 
 export async function processGeneratedResponse(
@@ -252,6 +255,39 @@ export async function processGeneratedResponse(
         jobId: fresh.id,
         error: auditError instanceof Error ? auditError.message : String(auditError),
       });
+    }
+
+    // Cost/usage metering (opt-in). Records the provider tokens this job spent
+    // and the observations it produced, so per-team usage feeds quotas + billing
+    // (the $/1M-token pricing model). Best-effort like the audit row above — a
+    // metering hiccup must not fail generation.
+    if (process.env.CLAUDE_MEM_USAGE_METERING === '1') {
+      try {
+        const usageRepo = new PostgresUsageRepository(client);
+        if (input.tokensUsed && input.tokensUsed > 0) {
+          await usageRepo.record({
+            teamId: fresh.teamId,
+            projectId: fresh.projectId,
+            kind: 'tokens',
+            quantity: input.tokensUsed,
+            metadata: { jobId: fresh.id, provider: input.providerLabel, model: input.modelId ?? null },
+          });
+        }
+        if (persisted.length > 0) {
+          await usageRepo.record({
+            teamId: fresh.teamId,
+            projectId: fresh.projectId,
+            kind: 'observation',
+            quantity: persisted.length,
+            metadata: { jobId: fresh.id },
+          });
+        }
+      } catch (usageError) {
+        logger.warn('SYSTEM', 'usage metering record failed during generation', {
+          jobId: fresh.id,
+          error: usageError instanceof Error ? usageError.message : String(usageError),
+        });
+      }
     }
 
     return {

--- a/src/server/generation/processGeneratedResponse.ts
+++ b/src/server/generation/processGeneratedResponse.ts
@@ -79,7 +79,7 @@ export async function processGeneratedResponse(
   const skipped = parsed.summary?.skipped === true;
   const privateContentDetected = skipped || observationsToWrite.length === 0;
 
-  return await withPostgresTransaction(input.pool, async (client) => {
+  const outcome = await withPostgresTransaction(input.pool, async (client) => {
     const obsRepo = new PostgresObservationRepository(client);
     const sourcesRepo = new PostgresObservationSourcesRepository(client);
     const jobsRepo = new PostgresObservationGenerationJobRepository(client);
@@ -257,39 +257,6 @@ export async function processGeneratedResponse(
       });
     }
 
-    // Cost/usage metering (opt-in). Records the provider tokens this job spent
-    // and the observations it produced, so per-team usage feeds quotas + billing
-    // (the $/1M-token pricing model). Best-effort like the audit row above — a
-    // metering hiccup must not fail generation.
-    if (process.env.CLAUDE_MEM_USAGE_METERING === '1') {
-      try {
-        const usageRepo = new PostgresUsageRepository(client);
-        if (input.tokensUsed && input.tokensUsed > 0) {
-          await usageRepo.record({
-            teamId: fresh.teamId,
-            projectId: fresh.projectId,
-            kind: 'tokens',
-            quantity: input.tokensUsed,
-            metadata: { jobId: fresh.id, provider: input.providerLabel, model: input.modelId ?? null },
-          });
-        }
-        if (persisted.length > 0) {
-          await usageRepo.record({
-            teamId: fresh.teamId,
-            projectId: fresh.projectId,
-            kind: 'observation',
-            quantity: persisted.length,
-            metadata: { jobId: fresh.id },
-          });
-        }
-      } catch (usageError) {
-        logger.warn('SYSTEM', 'usage metering record failed during generation', {
-          jobId: fresh.id,
-          error: usageError instanceof Error ? usageError.message : String(usageError),
-        });
-      }
-    }
-
     return {
       kind: 'completed' as const,
       jobId: fresh.id,
@@ -297,6 +264,40 @@ export async function processGeneratedResponse(
       privateContentDetected,
     };
   });
+
+  // Cost/usage metering — AFTER the transaction commits, so a metering insert
+  // failure can NEVER roll back the observation + job writes (Greptile #3078: a
+  // failed insert aborts the tx, and the catch can't un-abort it). Opt-in;
+  // best-effort (logged); awaited so callers observe usage consistently.
+  if (outcome.kind === 'completed' && process.env.CLAUDE_MEM_USAGE_METERING === '1') {
+    try {
+      const usageRepo = new PostgresUsageRepository(input.pool);
+      if (input.tokensUsed && input.tokensUsed > 0) {
+        await usageRepo.record({
+          teamId: input.job.teamId,
+          projectId: input.job.projectId,
+          kind: 'tokens',
+          quantity: input.tokensUsed,
+          metadata: { jobId: input.job.id, provider: input.providerLabel, model: input.modelId ?? null },
+        });
+      }
+      if (outcome.observations.length > 0) {
+        await usageRepo.record({
+          teamId: input.job.teamId,
+          projectId: input.job.projectId,
+          kind: 'observation',
+          quantity: outcome.observations.length,
+          metadata: { jobId: input.job.id },
+        });
+      }
+    } catch (usageError) {
+      logger.warn('SYSTEM', 'usage metering record failed (post-commit)', {
+        jobId: input.job.id,
+        error: usageError instanceof Error ? usageError.message : String(usageError),
+      });
+    }
+  }
+  return outcome;
 }
 
 export interface MarkGenerationFailedInput {

--- a/src/server/middleware/rate-limit.ts
+++ b/src/server/middleware/rate-limit.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Per-API-key request rate limiting + monthly usage quota for Server Beta.
+// Both are opt-in (the route layer only installs them when the operator sets a
+// limit) and both FAIL OPEN — a limiter/quota storage hiccup must never take the
+// API down. Rate limiting keys on the API key id; quota keys on the team.
+
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+import type { PostgresPool } from '../../storage/postgres/pool.js';
+import { PostgresRateLimitRepository } from '../../storage/postgres/rate-limit.js';
+import { PostgresUsageRepository } from '../../storage/postgres/usage.js';
+import { logger } from '../../utils/logger.js';
+
+function floorToWindow(nowMs: number, windowSec: number): Date {
+  const ms = windowSec * 1000;
+  return new Date(Math.floor(nowMs / ms) * ms);
+}
+
+function monthStartUtc(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
+}
+
+/** Fixed-window per-key limiter: `max` requests per `windowSec`. */
+export function requireRateLimit(pool: PostgresPool, opts: { windowSec: number; max: number }): RequestHandler {
+  const repo = new PostgresRateLimitRepository(pool);
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const subject = req.authContext?.apiKeyId;
+    if (!subject) return next(); // unauthenticated / local-dev bypass: nothing to limit
+    try {
+      const start = floorToWindow(Date.now(), opts.windowSec);
+      const result = await repo.hit({ subjectId: subject, windowStart: start, limit: opts.max });
+      res.setHeader('X-RateLimit-Limit', String(opts.max));
+      res.setHeader('X-RateLimit-Remaining', String(Math.max(0, opts.max - result.count)));
+      if (!result.allowed) {
+        const retryAfter = Math.max(1, Math.ceil((start.getTime() + opts.windowSec * 1000 - Date.now()) / 1000));
+        res.setHeader('Retry-After', String(retryAfter));
+        return res.status(429).json({
+          error: 'rate_limited',
+          message: `Rate limit exceeded (${opts.max} requests / ${opts.windowSec}s)`,
+        });
+      }
+      return next();
+    } catch (error) {
+      logger.warn('HTTP', 'rate limit check failed; allowing request (fail open)', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return next();
+    }
+  };
+}
+
+/** Monthly per-team quota on a usage `kind` (e.g. 'request'). 402 when reached. */
+export function requireMonthlyQuota(pool: PostgresPool, opts: { kind: string; cap: number }): RequestHandler {
+  const repo = new PostgresUsageRepository(pool);
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const teamId = req.authContext?.teamId;
+    if (!teamId) return next();
+    try {
+      const used = await repo.total({ teamId, kind: opts.kind, since: monthStartUtc(new Date()) });
+      if (used >= opts.cap) {
+        return res.status(402).json({
+          error: 'quota_exceeded',
+          message: `Monthly ${opts.kind} quota reached (${opts.cap})`,
+          used,
+          cap: opts.cap,
+        });
+      }
+      return next();
+    } catch (error) {
+      logger.warn('HTTP', 'quota check failed; allowing request (fail open)', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return next();
+    }
+  };
+}

--- a/src/server/middleware/rate-limit.ts
+++ b/src/server/middleware/rate-limit.ts
@@ -28,11 +28,15 @@ export function requireRateLimit(pool: PostgresPool, opts: { windowSec: number; 
     if (!subject) return next(); // unauthenticated / local-dev bypass: nothing to limit
     try {
       const start = floorToWindow(Date.now(), opts.windowSec);
+      const resetMs = start.getTime() + opts.windowSec * 1000;
       const result = await repo.hit({ subjectId: subject, windowStart: start, limit: opts.max });
       res.setHeader('X-RateLimit-Limit', String(opts.max));
       res.setHeader('X-RateLimit-Remaining', String(Math.max(0, opts.max - result.count)));
+      // Unix-seconds reset time — the conventional companion to Retry-After that
+      // most client libraries read to schedule automatic retries.
+      res.setHeader('X-RateLimit-Reset', String(Math.ceil(resetMs / 1000)));
       if (!result.allowed) {
-        const retryAfter = Math.max(1, Math.ceil((start.getTime() + opts.windowSec * 1000 - Date.now()) / 1000));
+        const retryAfter = Math.max(1, Math.ceil((resetMs - Date.now()) / 1000));
         res.setHeader('Retry-After', String(retryAfter));
         return res.status(429).json({
           error: 'rate_limited',

--- a/src/server/middleware/usage-metering.ts
+++ b/src/server/middleware/usage-metering.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Records one 'request' usage event per authenticated request, fire-and-forget
+// so metering never adds latency to (or fails) the request it is measuring.
+// Token/observation metering uses the same PostgresUsageRepository from the
+// generation worker; this middleware only covers request counts.
+
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+import type { PostgresPool } from '../../storage/postgres/pool.js';
+import { PostgresUsageRepository } from '../../storage/postgres/usage.js';
+import { logger } from '../../utils/logger.js';
+
+export function meterRequests(pool: PostgresPool): RequestHandler {
+  const repo = new PostgresUsageRepository(pool);
+  return (req: Request, _res: Response, next: NextFunction) => {
+    const teamId = req.authContext?.teamId;
+    if (teamId) {
+      void repo
+        .record({
+          teamId,
+          projectId: req.authContext?.projectId ?? null,
+          kind: 'request',
+          metadata: { method: req.method, path: req.path, apiKeyId: req.authContext?.apiKeyId ?? null },
+        })
+        .catch((error) => {
+          logger.warn('HTTP', 'usage metering record failed', {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+    }
+    next();
+  };
+}

--- a/src/server/routes/v1/ServerV1PostgresRoutes.ts
+++ b/src/server/routes/v1/ServerV1PostgresRoutes.ts
@@ -23,6 +23,7 @@ import { requestIdMiddleware } from '../../middleware/request-id.js';
 import { requireRateLimit, requireMonthlyQuota } from '../../middleware/rate-limit.js';
 import { meterRequests } from '../../middleware/usage-metering.js';
 import { PostgresUsageRepository } from '../../../storage/postgres/usage.js';
+import { createHash, randomBytes } from 'node:crypto';
 import type { ActiveServerBetaQueueManager } from '../../runtime/ActiveServerBetaQueueManager.js';
 import type { ServerBetaQueueManager } from '../../runtime/types.js';
 import { PostgresServerSessionsRepository } from '../../../storage/postgres/server-sessions.js';
@@ -31,6 +32,17 @@ import { IngestEventsService, type EnqueueOutcome } from '../../services/IngestE
 import { EndSessionService } from '../../services/EndSessionService.js';
 
 const SOURCE_ADAPTER_DEFAULT = 'api';
+
+// The MCP link base: CLAUDE_MEM_PUBLIC_URL in prod (behind a proxy/LB), else
+// derived from the request host so the connect command points at this server.
+function mcpConnectUrl(req: Request): string {
+  const base = (process.env.CLAUDE_MEM_PUBLIC_URL ?? `${req.protocol}://${req.get('host') ?? 'localhost'}`)
+    .replace(/\/+$/, '');
+  return `${base}/v1/mcp`;
+}
+function mcpConnectCommand(mcpUrl: string, key: string): string {
+  return `claude mcp add --transport http claude-mem ${mcpUrl} --header "Authorization: Bearer ${key}"`;
+}
 
 export interface ServerV1PostgresRoutesOptions {
   pool: PostgresPool;
@@ -167,6 +179,58 @@ export class ServerV1PostgresRoutes implements RouteHandler {
       const monthStart = new Date(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), 1));
       const usage = await new PostgresUsageRepository(this.options.pool).summarize({ teamId, since: monthStart });
       res.status(200).json({ since: monthStart.toISOString(), usage });
+    }));
+
+    // POST /v1/keys — mint a READ-ONLY, optionally-expiring API key for the
+    // caller's team and return the ready-to-paste connect command. Gated by
+    // writeAuth: minting a lesser (read) key requires you can already write the
+    // team's memory, which avoids a read key escalating into more keys. The raw
+    // key is shown exactly once.
+    app.post('/v1/keys', writeAuth, this.handleCreate(
+      z.object({
+        label: z.string().max(120).optional(),
+        expiresInDays: z.number().int().positive().max(365).optional(),
+      }),
+      async (req, res, body) => {
+        const teamId = this.requireTeamId(req, res);
+        if (!teamId) return;
+        const raw = `cm_${randomBytes(24).toString('hex')}`;
+        const keyHash = createHash('sha256').update(raw).digest('hex');
+        const expiresAt = body.expiresInDays
+          ? new Date(Date.now() + body.expiresInDays * 86_400_000)
+          : null;
+        const key = await new PostgresAuthRepository(this.options.pool).createApiKey({
+          keyHash,
+          teamId,
+          projectId: req.authContext?.projectId ?? null,
+          actorId: req.authContext?.apiKeyId ?? 'api',
+          scopes: ['memories:read'],
+          expiresAt,
+        });
+        void body.label; // reserved for when api_keys grows a label column
+        const mcpUrl = mcpConnectUrl(req);
+        res.status(201).json({
+          id: key.id,
+          apiKey: raw, // shown ONCE — store it now
+          scopes: ['memories:read'],
+          expiresAt: expiresAt?.toISOString() ?? null,
+          mcpUrl,
+          connectCommand: mcpConnectCommand(mcpUrl, raw),
+        });
+      },
+    ));
+
+    // GET /v1/connect — the paste-ready MCP connect command (placeholder key, so
+    // a GET never mints). Use POST /v1/keys to get a real read-only key.
+    app.get('/v1/connect', readAuth, this.asyncHandler(async (req, res) => {
+      const teamId = this.requireTeamId(req, res);
+      if (!teamId) return;
+      const mcpUrl = mcpConnectUrl(req);
+      res.status(200).json({
+        mcpUrl,
+        connectCommand: mcpConnectCommand(mcpUrl, '<YOUR_API_KEY>'),
+        hint: 'POST /v1/keys (write scope) to mint a read-only key for this link.',
+      });
     }));
 
     // POST /v1/events — single event with optional async generation

--- a/src/server/routes/v1/ServerV1PostgresRoutes.ts
+++ b/src/server/routes/v1/ServerV1PostgresRoutes.ts
@@ -169,7 +169,12 @@ export class ServerV1PostgresRoutes implements RouteHandler {
     const monthlyCap = Number(process.env.CLAUDE_MEM_MONTHLY_REQUEST_CAP ?? '0');
     if (monthlyCap > 0) guards.push(requireMonthlyQuota(this.options.pool, { kind: 'request', cap: monthlyCap }));
     if (process.env.CLAUDE_MEM_USAGE_METERING === '1') guards.push(meterRequests(this.options.pool));
-    const writeAuth: RequestHandler[] = [baseWrite, ...guards];
+    // A monthly TOKEN cap gates writes only (ingestion drives generation = token
+    // spend); reads stay available so a team over budget can still recall.
+    const writeGuards: RequestHandler[] = [...guards];
+    const tokenCap = Number(process.env.CLAUDE_MEM_MONTHLY_TOKEN_CAP ?? '0');
+    if (tokenCap > 0) writeGuards.push(requireMonthlyQuota(this.options.pool, { kind: 'tokens', cap: tokenCap }));
+    const writeAuth: RequestHandler[] = [baseWrite, ...writeGuards];
     const readAuth: RequestHandler[] = [baseRead, ...guards];
 
     // GET /v1/usage — per-kind usage totals for the caller's team this month.

--- a/src/server/routes/v1/ServerV1PostgresRoutes.ts
+++ b/src/server/routes/v1/ServerV1PostgresRoutes.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Application, Request, Response } from 'express';
+import type { Application, Request, RequestHandler, Response } from 'express';
 import { z, type ZodTypeAny } from 'zod';
 import type { RouteHandler } from '../../../services/server/Server.js';
 import { CreateAgentEventSchema } from '../../../core/schemas/agent-event.js';
@@ -20,6 +20,9 @@ import { PostgresObservationRepository } from '../../../storage/postgres/observa
 import { logger } from '../../../utils/logger.js';
 import { requirePostgresServerAuth } from '../../middleware/postgres-auth.js';
 import { requestIdMiddleware } from '../../middleware/request-id.js';
+import { requireRateLimit, requireMonthlyQuota } from '../../middleware/rate-limit.js';
+import { meterRequests } from '../../middleware/usage-metering.js';
+import { PostgresUsageRepository } from '../../../storage/postgres/usage.js';
 import type { ActiveServerBetaQueueManager } from '../../runtime/ActiveServerBetaQueueManager.js';
 import type { ServerBetaQueueManager } from '../../runtime/types.js';
 import { PostgresServerSessionsRepository } from '../../../storage/postgres/server-sessions.js';
@@ -133,16 +136,38 @@ export class ServerV1PostgresRoutes implements RouteHandler {
     // an inbound X-Request-Id header) so registering it multiple times for
     // overlapping route trees would still produce one canonical id per req.
     app.use('/v1', requestIdMiddleware());
-    const writeAuth = requirePostgresServerAuth(this.options.pool, {
+    const baseWrite = requirePostgresServerAuth(this.options.pool, {
       authMode: this.options.authMode,
       allowLocalDevBypass: this.options.allowLocalDevBypass,
       requiredScopes: ['memories:write'],
     });
-    const readAuth = requirePostgresServerAuth(this.options.pool, {
+    const baseRead = requirePostgresServerAuth(this.options.pool, {
       authMode: this.options.authMode,
       allowLocalDevBypass: this.options.allowLocalDevBypass,
       requiredScopes: ['memories:read'],
     });
+    // Paid-readiness guards, all opt-in via env so default behavior is unchanged
+    // (empty array → readAuth/writeAuth are just the base auth). Express accepts
+    // a middleware array wherever a single handler goes, so the per-route
+    // registrations below need no changes. Order after auth: rate limit → quota
+    // → meter, so the request is counted only once it's admitted.
+    const guards: RequestHandler[] = [];
+    const ratePerMin = Number(process.env.CLAUDE_MEM_RATE_LIMIT_PER_MIN ?? '0');
+    if (ratePerMin > 0) guards.push(requireRateLimit(this.options.pool, { windowSec: 60, max: ratePerMin }));
+    const monthlyCap = Number(process.env.CLAUDE_MEM_MONTHLY_REQUEST_CAP ?? '0');
+    if (monthlyCap > 0) guards.push(requireMonthlyQuota(this.options.pool, { kind: 'request', cap: monthlyCap }));
+    if (process.env.CLAUDE_MEM_USAGE_METERING === '1') guards.push(meterRequests(this.options.pool));
+    const writeAuth: RequestHandler[] = [baseWrite, ...guards];
+    const readAuth: RequestHandler[] = [baseRead, ...guards];
+
+    // GET /v1/usage — per-kind usage totals for the caller's team this month.
+    app.get('/v1/usage', readAuth, this.asyncHandler(async (req, res) => {
+      const teamId = this.requireTeamId(req, res);
+      if (!teamId) return;
+      const monthStart = new Date(Date.UTC(new Date().getUTCFullYear(), new Date().getUTCMonth(), 1));
+      const usage = await new PostgresUsageRepository(this.options.pool).summarize({ teamId, since: monthStart });
+      res.status(200).json({ since: monthStart.toISOString(), usage });
+    }));
 
     // POST /v1/events — single event with optional async generation
     app.post('/v1/events', writeAuth, this.asyncHandler(async (req, res) => {

--- a/src/storage/postgres/index.ts
+++ b/src/storage/postgres/index.ts
@@ -11,6 +11,8 @@ import { PostgresObservationRepository, PostgresObservationSourcesRepository } f
 import { PostgresProjectsRepository } from './projects.js';
 import { PostgresServerSessionsRepository } from './server-sessions.js';
 import { PostgresTeamsRepository } from './teams.js';
+import { PostgresUsageRepository } from './usage.js';
+import { PostgresRateLimitRepository } from './rate-limit.js';
 
 export * from './agent-events.js';
 export * from './auth.js';
@@ -19,9 +21,11 @@ export * from './generation-jobs.js';
 export * from './observations.js';
 export * from './pool.js';
 export * from './projects.js';
+export * from './rate-limit.js';
 export * from './schema.js';
 export * from './server-sessions.js';
 export * from './teams.js';
+export * from './usage.js';
 export type * from './utils.js';
 
 export interface PostgresStorageRepositories {
@@ -34,6 +38,8 @@ export interface PostgresStorageRepositories {
   observationSources: PostgresObservationSourcesRepository;
   observationGenerationJobs: PostgresObservationGenerationJobRepository;
   observationGenerationJobEvents: PostgresObservationGenerationJobEventsRepository;
+  usage: PostgresUsageRepository;
+  rateLimits: PostgresRateLimitRepository;
 }
 
 export function createPostgresStorageRepositories(client: PostgresQueryable): PostgresStorageRepositories {
@@ -46,6 +52,8 @@ export function createPostgresStorageRepositories(client: PostgresQueryable): Po
     observations: new PostgresObservationRepository(client),
     observationSources: new PostgresObservationSourcesRepository(client),
     observationGenerationJobs: new PostgresObservationGenerationJobRepository(client),
-    observationGenerationJobEvents: new PostgresObservationGenerationJobEventsRepository(client)
+    observationGenerationJobEvents: new PostgresObservationGenerationJobEventsRepository(client),
+    usage: new PostgresUsageRepository(client),
+    rateLimits: new PostgresRateLimitRepository(client)
   };
 }

--- a/src/storage/postgres/rate-limit.ts
+++ b/src/storage/postgres/rate-limit.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Fixed-window rate-limit counters. One atomic UPSERT per request increments the
+// (subject, window) bucket and returns the new count, so the limiter needs a
+// single round-trip and is correct across concurrent server instances (the
+// increment happens in Postgres, not in app memory).
+
+import type { PostgresQueryable } from './utils.js';
+
+export interface RateLimitResult {
+  allowed: boolean;
+  count: number;
+  limit: number;
+  windowStart: Date;
+}
+
+export class PostgresRateLimitRepository {
+  constructor(private readonly client: PostgresQueryable) {}
+
+  /**
+   * Atomically increment the current window's counter for `subjectId` and
+   * report whether it is still within `limit`.
+   */
+  async hit(input: { subjectId: string; windowStart: Date; limit: number }): Promise<RateLimitResult> {
+    const res = await this.client.query<{ count: string }>(
+      `INSERT INTO rate_limit_counters (subject_id, window_start, count)
+       VALUES ($1, $2, 1)
+       ON CONFLICT (subject_id, window_start)
+       DO UPDATE SET count = rate_limit_counters.count + 1
+       RETURNING count`,
+      [input.subjectId, input.windowStart],
+    );
+    const count = Number(res.rows[0]?.count ?? 0);
+    return { allowed: count <= input.limit, count, limit: input.limit, windowStart: input.windowStart };
+  }
+
+  /** Best-effort cleanup of expired windows. Call off the hot path. */
+  async prune(before: Date): Promise<void> {
+    await this.client.query(`DELETE FROM rate_limit_counters WHERE window_start < $1`, [before]);
+  }
+}

--- a/src/storage/postgres/schema.ts
+++ b/src/storage/postgres/schema.ts
@@ -16,7 +16,9 @@ export const SERVER_BETA_POSTGRES_TABLES = [
   'observation_generation_jobs',
   'observations',
   'observation_sources',
-  'observation_generation_job_events'
+  'observation_generation_job_events',
+  'usage_events',
+  'rate_limit_counters'
 ] as const;
 
 export async function bootstrapServerBetaPostgresSchema(client: PostgresQueryable): Promise<void> {
@@ -295,4 +297,27 @@ CREATE INDEX IF NOT EXISTS idx_observation_jobs_event ON observation_generation_
 CREATE INDEX IF NOT EXISTS idx_observation_jobs_source ON observation_generation_jobs(source_type, source_id);
 CREATE INDEX IF NOT EXISTS idx_observation_job_events_job_created ON observation_generation_job_events(generation_job_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_audit_log_scope_created ON audit_log(project_id, team_id, created_at);
+
+-- Usage metering: append-only per-team usage, aggregated for quotas + billing.
+-- kind is open-ended ('request', 'tokens_in', 'tokens_out', 'observation', ...).
+CREATE TABLE IF NOT EXISTS usage_events (
+  id TEXT PRIMARY KEY,
+  team_id TEXT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  project_id TEXT REFERENCES projects(id) ON DELETE SET NULL,
+  kind TEXT NOT NULL,
+  quantity BIGINT NOT NULL DEFAULT 1,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_usage_events_team_created ON usage_events(team_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_usage_events_team_kind_created ON usage_events(team_id, kind, created_at);
+
+-- Fixed-window rate-limit counters. subject_id is the api key id (per-key limit).
+CREATE TABLE IF NOT EXISTS rate_limit_counters (
+  subject_id TEXT NOT NULL,
+  window_start TIMESTAMPTZ NOT NULL,
+  count BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (subject_id, window_start)
+);
+CREATE INDEX IF NOT EXISTS idx_rate_limit_counters_window ON rate_limit_counters(window_start);
 `;

--- a/src/storage/postgres/usage.ts
+++ b/src/storage/postgres/usage.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Usage metering store. Append-only per-team usage events, aggregated for
+// quotas (src/server/middleware/rate-limit.ts) and, later, billing. `kind` is
+// open-ended so the same table records request counts, generated observations,
+// and provider token spend without a schema change.
+
+import type { JsonObject, PostgresQueryable } from './utils.js';
+import { newId } from './utils.js';
+
+export type UsageKind = 'request' | 'observation' | 'tokens_in' | 'tokens_out' | (string & {});
+
+export class PostgresUsageRepository {
+  constructor(private readonly client: PostgresQueryable) {}
+
+  async record(input: {
+    teamId: string;
+    projectId?: string | null;
+    kind: UsageKind;
+    quantity?: number;
+    metadata?: JsonObject;
+  }): Promise<void> {
+    await this.client.query(
+      `INSERT INTO usage_events (id, team_id, project_id, kind, quantity, metadata)
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb)`,
+      [
+        newId(),
+        input.teamId,
+        input.projectId ?? null,
+        input.kind,
+        Math.max(0, Math.trunc(input.quantity ?? 1)),
+        JSON.stringify(input.metadata ?? {}),
+      ],
+    );
+  }
+
+  /** Total quantity of one `kind` for a team since `since` — the quota read. */
+  async total(input: { teamId: string; kind: UsageKind; since: Date }): Promise<number> {
+    const res = await this.client.query<{ total: string }>(
+      `SELECT COALESCE(SUM(quantity), 0)::bigint AS total
+         FROM usage_events
+        WHERE team_id = $1 AND kind = $2 AND created_at >= $3`,
+      [input.teamId, input.kind, input.since],
+    );
+    return Number(res.rows[0]?.total ?? 0);
+  }
+
+  /** Per-kind totals for a team since `since` — the /v1/usage read. */
+  async summarize(input: { teamId: string; since: Date }): Promise<Record<string, number>> {
+    const res = await this.client.query<{ kind: string; total: string }>(
+      `SELECT kind, SUM(quantity)::bigint AS total
+         FROM usage_events
+        WHERE team_id = $1 AND created_at >= $2
+        GROUP BY kind`,
+      [input.teamId, input.since],
+    );
+    const out: Record<string, number> = {};
+    for (const row of res.rows) out[row.kind] = Number(row.total);
+    return out;
+  }
+}

--- a/tests/server/connect-keys.test.ts
+++ b/tests/server/connect-keys.test.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Key issuance + connect onboarding: POST /v1/keys mints a read-only key for the
+// team and GET /v1/connect returns the paste-ready MCP command. Postgres-gated.
+//
+// The important assertion: a key minted via POST /v1/keys actually authenticates
+// against the API (it lands in the same postgres api_keys store readAuth checks).
+
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import pg from 'pg';
+import { createHash, randomBytes, randomUUID } from 'crypto';
+import { Server } from '../../src/services/server/Server.js';
+import { ServerV1PostgresRoutes } from '../../src/server/routes/v1/ServerV1PostgresRoutes.js';
+import {
+  bootstrapServerBetaPostgresSchema,
+  createPostgresStorageRepositories,
+  type PostgresPoolClient,
+  type PostgresStorageRepositories,
+} from '../../src/storage/postgres/index.js';
+import { DisabledServerBetaQueueManager } from '../../src/server/runtime/types.js';
+import { logger } from '../../src/utils/logger.js';
+
+const testDatabaseUrl = process.env.CLAUDE_MEM_TEST_POSTGRES_URL;
+const q = (n: string) => `"${n.replaceAll('"', '""')}"`;
+function newApiKey() {
+  const raw = `cm_${randomBytes(24).toString('hex')}`;
+  return { raw, hash: createHash('sha256').update(raw).digest('hex') };
+}
+
+describe('POST /v1/keys + GET /v1/connect', () => {
+  if (!testDatabaseUrl) {
+    it.skip('requires CLAUDE_MEM_TEST_POSTGRES_URL', () => {});
+    return;
+  }
+
+  let pool: pg.Pool;
+  let client: PostgresPoolClient;
+  let schemaName: string;
+  let storage: PostgresStorageRepositories;
+  let server: Server;
+  let port: number;
+  let writeKey: string;
+  let readKey: string;
+  let spies: ReturnType<typeof spyOn>[] = [];
+
+  beforeEach(async () => {
+    spies = ['info', 'warn', 'error', 'debug'].map((m) => spyOn(logger, m as 'info').mockImplementation(() => {}));
+    pool = new pg.Pool({ connectionString: testDatabaseUrl });
+    client = await pool.connect();
+    schemaName = `cm_keys_${randomUUID().replaceAll('-', '_')}`;
+    await client.query(`CREATE SCHEMA ${q(schemaName)}`);
+    await client.query(`SET search_path TO ${q(schemaName)}`);
+    await bootstrapServerBetaPostgresSchema(client);
+    pool.on('connect', (c) => { c.query(`SET search_path TO ${q(schemaName)}`).catch(() => {}); });
+    storage = createPostgresStorageRepositories(client);
+    const team = await storage.teams.create({ name: 'team' });
+    const project = await storage.projects.create({ teamId: team.id, name: 'p' });
+
+    const w = newApiKey(); writeKey = w.raw;
+    await storage.auth.createApiKey({ keyHash: w.hash, teamId: team.id, projectId: project.id, actorId: 't', scopes: ['memories:read', 'memories:write'] });
+    const r = newApiKey(); readKey = r.raw;
+    await storage.auth.createApiKey({ keyHash: r.hash, teamId: team.id, projectId: project.id, actorId: 't', scopes: ['memories:read'] });
+
+    server = new Server({
+      getInitializationComplete: () => true, getMcpReady: () => true,
+      onShutdown: mock(() => Promise.resolve()), onRestart: mock(() => Promise.resolve()),
+      workerPath: '/test/worker.cjs', runtime: 'server-beta',
+      getAiStatus: () => ({ provider: 'disabled', authMethod: 'api-key', lastInteraction: null }),
+    });
+    server.registerRoutes(new ServerV1PostgresRoutes({
+      pool: pool as never, queueManager: new DisabledServerBetaQueueManager('disabled'),
+      authMode: 'api-key', runtime: 'server-beta', sessionPolicy: 'per-event',
+    }));
+    server.finalizeRoutes();
+    await server.listen(0, '127.0.0.1');
+    const addr = server.getHttpServer()?.address();
+    if (!addr || typeof addr === 'string') throw new Error('no port');
+    port = addr.port;
+  });
+
+  afterEach(async () => {
+    try { await server.close(); } catch (e: unknown) {
+      if ((e as NodeJS.ErrnoException)?.code !== 'ERR_SERVER_NOT_RUNNING') throw e;
+    }
+    await client.query(`DROP SCHEMA IF EXISTS ${q(schemaName)} CASCADE`);
+    client.release();
+    await pool.end();
+    spies.forEach((s) => s.mockRestore());
+    mock.restore();
+  });
+
+  const url = (p: string) => `http://127.0.0.1:${port}${p}`;
+
+  it('mints a read-only key whose connect command targets /v1/mcp', async () => {
+    const r = await fetch(url('/v1/keys'), {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${writeKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ expiresInDays: 30 }),
+    });
+    expect(r.status).toBe(201);
+    const body = await r.json() as { apiKey: string; scopes: string[]; connectCommand: string; expiresAt: string };
+    expect(body.apiKey).toMatch(/^cm_/);
+    expect(body.scopes).toEqual(['memories:read']);
+    expect(body.connectCommand).toContain('/v1/mcp');
+    expect(body.connectCommand).toContain(body.apiKey);
+    expect(body.expiresAt).toBeTruthy();
+  });
+
+  it('the minted key actually authenticates against the API', async () => {
+    const minted = await (await fetch(url('/v1/keys'), {
+      method: 'POST', headers: { Authorization: `Bearer ${writeKey}`, 'Content-Type': 'application/json' }, body: '{}',
+    })).json() as { apiKey: string };
+    const usage = await fetch(url('/v1/usage'), { headers: { Authorization: `Bearer ${minted.apiKey}` } });
+    expect(usage.status).toBe(200);
+  });
+
+  it('a read-only key cannot mint keys (write scope required)', async () => {
+    const r = await fetch(url('/v1/keys'), {
+      method: 'POST', headers: { Authorization: `Bearer ${readKey}`, 'Content-Type': 'application/json' }, body: '{}',
+    });
+    expect([401, 403]).toContain(r.status);
+  });
+
+  it('GET /v1/connect returns the command with a placeholder key', async () => {
+    const r = await fetch(url('/v1/connect'), { headers: { Authorization: `Bearer ${readKey}` } });
+    expect(r.status).toBe(200);
+    const body = await r.json() as { connectCommand: string; mcpUrl: string };
+    expect(body.mcpUrl).toContain('/v1/mcp');
+    expect(body.connectCommand).toContain('<YOUR_API_KEY>');
+  });
+});

--- a/tests/server/generation/process-generated-response.test.ts
+++ b/tests/server/generation/process-generated-response.test.ts
@@ -12,6 +12,7 @@ import {
   processGeneratedResponse,
   markGenerationFailed,
 } from '../../../src/server/generation/processGeneratedResponse.js';
+import { ModeManager } from '../../../src/services/domain/ModeManager.js';
 
 const testDatabaseUrl = process.env.CLAUDE_MEM_TEST_POSTGRES_URL;
 
@@ -35,6 +36,9 @@ describe('processGeneratedResponse + markGenerationFailed', () => {
   let jobId: string;
 
   beforeEach(async () => {
+    // The generation path reads the active ModeManager mode; load it so this
+    // file runs standalone instead of relying on another test file's side effect.
+    ModeManager.getInstance().loadMode('code');
     client = await pool.connect();
     schemaName = `cm_phase5_${crypto.randomUUID().replaceAll('-', '_')}`;
     await client.query(`CREATE SCHEMA ${quoteIdentifier(schemaName)}`);
@@ -143,6 +147,61 @@ describe('processGeneratedResponse + markGenerationFailed', () => {
     expect(sources[0]!.sourceType).toBe('agent_event');
     expect(sources[0]!.sourceId).toBe(eventId);
     expect(sources[0]!.generationJobId).toBe(jobId);
+  });
+
+  it('records token + observation usage when metering is enabled', async () => {
+    const prev = process.env.CLAUDE_MEM_USAGE_METERING;
+    process.env.CLAUDE_MEM_USAGE_METERING = '1';
+    try {
+      const xml = `
+        <observation>
+          <type>discovery</type>
+          <title>Metered</title>
+          <facts><fact>token metering</fact></facts>
+        </observation>
+      `;
+      await storage.observationGenerationJobs.transitionStatus({ id: jobId, projectId, teamId, status: 'processing' });
+      const fresh = (await reloadJob())!;
+      const outcome = await processGeneratedResponse({
+        pool: pool as unknown as Parameters<typeof processGeneratedResponse>[0]['pool'],
+        job: fresh,
+        rawText: xml,
+        providerLabel: 'fake',
+        modelId: 'fake-1',
+        tokensUsed: 1234,
+      });
+      expect(outcome.kind).toBe('completed');
+
+      const usage = await pool.query(
+        `SELECT kind, SUM(quantity)::bigint AS total FROM usage_events WHERE team_id = $1 GROUP BY kind`,
+        [teamId],
+      );
+      const byKind: Record<string, number> = {};
+      for (const r of usage.rows) byKind[r.kind] = Number(r.total);
+      expect(byKind.tokens).toBe(1234);
+      expect(byKind.observation).toBe(1);
+    } finally {
+      if (prev === undefined) delete process.env.CLAUDE_MEM_USAGE_METERING;
+      else process.env.CLAUDE_MEM_USAGE_METERING = prev;
+    }
+  });
+
+  it('does NOT record usage when metering is disabled', async () => {
+    const prev = process.env.CLAUDE_MEM_USAGE_METERING;
+    delete process.env.CLAUDE_MEM_USAGE_METERING;
+    try {
+      const xml = `<observation><type>discovery</type><title>x</title><facts><fact>f</fact></facts></observation>`;
+      await storage.observationGenerationJobs.transitionStatus({ id: jobId, projectId, teamId, status: 'processing' });
+      const fresh = (await reloadJob())!;
+      await processGeneratedResponse({
+        pool: pool as unknown as Parameters<typeof processGeneratedResponse>[0]['pool'],
+        job: fresh, rawText: xml, providerLabel: 'fake', modelId: 'fake-1', tokensUsed: 999,
+      });
+      const n = await pool.query(`SELECT count(*)::int AS n FROM usage_events WHERE team_id = $1`, [teamId]);
+      expect(n.rows[0]?.n).toBe(0);
+    } finally {
+      if (prev !== undefined) process.env.CLAUDE_MEM_USAGE_METERING = prev;
+    }
   });
 
   it('replaying the same job yields exactly one observation (idempotency)', async () => {

--- a/tests/server/paid-readiness.test.ts
+++ b/tests/server/paid-readiness.test.ts
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Paid-readiness primitives: usage metering, per-key rate limiting, monthly
+// quota, and the GET /v1/usage endpoint. Postgres-gated (CLAUDE_MEM_TEST_POSTGRES_URL).
+//
+// The repo + middleware logic is tested directly (deterministic). One full
+// server boot proves the array-middleware wiring (readAuth = [auth, ...guards])
+// actually serves GET /v1/usage end to end.
+
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import pg from 'pg';
+import { createHash, randomBytes, randomUUID } from 'crypto';
+import type { NextFunction, Request, Response } from 'express';
+import { Server } from '../../src/services/server/Server.js';
+import { ServerV1PostgresRoutes } from '../../src/server/routes/v1/ServerV1PostgresRoutes.js';
+import {
+  bootstrapServerBetaPostgresSchema,
+  createPostgresStorageRepositories,
+  PostgresUsageRepository,
+  type PostgresPoolClient,
+  type PostgresStorageRepositories,
+} from '../../src/storage/postgres/index.js';
+import { DisabledServerBetaQueueManager } from '../../src/server/runtime/types.js';
+import { requireRateLimit, requireMonthlyQuota } from '../../src/server/middleware/rate-limit.js';
+import { meterRequests } from '../../src/server/middleware/usage-metering.js';
+import { logger } from '../../src/utils/logger.js';
+
+const testDatabaseUrl = process.env.CLAUDE_MEM_TEST_POSTGRES_URL;
+
+function quoteIdentifier(name: string): string {
+  return `"${name.replaceAll('"', '""')}"`;
+}
+function newApiKey(): { raw: string; hash: string } {
+  const raw = `cm_${randomBytes(24).toString('hex')}`;
+  return { raw, hash: createHash('sha256').update(raw).digest('hex') };
+}
+
+// Minimal Express req/res/next doubles for middleware unit tests.
+function fakeCtx(authContext: Record<string, unknown>) {
+  const headers: Record<string, string> = {};
+  const out: { status?: number; body?: unknown; nexted: boolean } = { nexted: false };
+  const req = { authContext, method: 'GET', path: '/v1/x' } as unknown as Request;
+  const res = {
+    setHeader: (k: string, v: string) => { headers[k] = v; },
+    status(code: number) { out.status = code; return this; },
+    json(body: unknown) { out.body = body; return this; },
+  } as unknown as Response;
+  const next: NextFunction = () => { out.nexted = true; };
+  return { req, res, next, out, headers };
+}
+
+describe('paid-readiness (usage metering, rate limit, quota)', () => {
+  if (!testDatabaseUrl) {
+    it.skip('requires CLAUDE_MEM_TEST_POSTGRES_URL', () => {});
+    return;
+  }
+
+  let pool: pg.Pool;
+  let client: PostgresPoolClient;
+  let schemaName: string;
+  let storage: PostgresStorageRepositories;
+  let teamId: string;
+  let projectId: string;
+  let apiKeyId: string;
+  let loggerSpies: ReturnType<typeof spyOn>[] = [];
+
+  beforeEach(async () => {
+    loggerSpies = ['info', 'warn', 'error', 'debug'].map((m) =>
+      spyOn(logger, m as 'info').mockImplementation(() => {}),
+    );
+    pool = new pg.Pool({ connectionString: testDatabaseUrl });
+    client = await pool.connect();
+    schemaName = `cm_paid_${randomUUID().replaceAll('-', '_')}`;
+    await client.query(`CREATE SCHEMA ${quoteIdentifier(schemaName)}`);
+    await client.query(`SET search_path TO ${quoteIdentifier(schemaName)}`);
+    await bootstrapServerBetaPostgresSchema(client);
+    pool.on('connect', (c) => { c.query(`SET search_path TO ${quoteIdentifier(schemaName)}`).catch(() => {}); });
+    storage = createPostgresStorageRepositories(client);
+    const team = await storage.teams.create({ name: 'team' });
+    const project = await storage.projects.create({ teamId: team.id, name: 'p' });
+    teamId = team.id;
+    projectId = project.id;
+    const { raw, hash } = newApiKey();
+    const key = await storage.auth.createApiKey({ keyHash: hash, teamId, projectId, actorId: 't', scopes: ['memories:read'] });
+    apiKeyId = key.id;
+    void raw;
+  });
+
+  afterEach(async () => {
+    await client.query(`DROP SCHEMA IF EXISTS ${quoteIdentifier(schemaName)} CASCADE`);
+    client.release();
+    await pool.end();
+    loggerSpies.forEach((s) => s.mockRestore());
+    mock.restore();
+  });
+
+  it('usage repo records and aggregates per kind', async () => {
+    const usage = new PostgresUsageRepository(pool as never);
+    await usage.record({ teamId, kind: 'request' });
+    await usage.record({ teamId, kind: 'request' });
+    await usage.record({ teamId, kind: 'tokens_in', quantity: 500 });
+    const since = new Date(Date.now() - 60_000);
+    expect(await usage.total({ teamId, kind: 'request', since })).toBe(2);
+    const summary = await usage.summarize({ teamId, since });
+    expect(summary.request).toBe(2);
+    expect(summary.tokens_in).toBe(500);
+  });
+
+  it('rate limiter allows up to max then 429s', async () => {
+    const mw = requireRateLimit(pool as never, { windowSec: 60, max: 3 });
+    const ctx = () => fakeCtx({ apiKeyId, teamId });
+    for (let i = 0; i < 3; i++) {
+      const c = ctx();
+      await mw(c.req, c.res, c.next);
+      expect(c.out.nexted).toBe(true);
+      expect(c.out.status).toBeUndefined();
+    }
+    const blocked = ctx();
+    await mw(blocked.req, blocked.res, blocked.next);
+    expect(blocked.out.nexted).toBe(false);
+    expect(blocked.out.status).toBe(429);
+    expect(blocked.headers['Retry-After']).toBeDefined();
+  });
+
+  it('rate limiter skips requests with no api key (local-dev)', async () => {
+    const mw = requireRateLimit(pool as never, { windowSec: 60, max: 1 });
+    const c = fakeCtx({ teamId }); // no apiKeyId
+    await mw(c.req, c.res, c.next);
+    await mw(c.req, c.res, c.next);
+    expect(c.out.status).toBeUndefined(); // never limited
+  });
+
+  it('monthly quota 402s once usage reaches the cap', async () => {
+    const usage = new PostgresUsageRepository(pool as never);
+    await usage.record({ teamId, kind: 'request', quantity: 5 });
+    const mw = requireMonthlyQuota(pool as never, { kind: 'request', cap: 5 });
+    const c = fakeCtx({ apiKeyId, teamId });
+    await mw(c.req, c.res, c.next);
+    expect(c.out.nexted).toBe(false);
+    expect(c.out.status).toBe(402);
+  });
+
+  it('monthly quota passes when under the cap', async () => {
+    const usage = new PostgresUsageRepository(pool as never);
+    await usage.record({ teamId, kind: 'request', quantity: 2 });
+    const mw = requireMonthlyQuota(pool as never, { kind: 'request', cap: 5 });
+    const c = fakeCtx({ apiKeyId, teamId });
+    await mw(c.req, c.res, c.next);
+    expect(c.out.nexted).toBe(true);
+    expect(c.out.status).toBeUndefined();
+  });
+
+  it('meterRequests records a request event (fire-and-forget)', async () => {
+    const mw = meterRequests(pool as never);
+    const c = fakeCtx({ apiKeyId, teamId, projectId });
+    mw(c.req, c.res, c.next);
+    expect(c.out.nexted).toBe(true); // never blocks
+    await new Promise((r) => setTimeout(r, 100)); // let the background insert land
+    const n = await pool.query(`SELECT count(*)::int AS n FROM usage_events WHERE team_id = $1 AND kind = 'request'`, [teamId]);
+    expect(n.rows[0]?.n).toBe(1);
+  });
+
+  it('GET /v1/usage returns the team usage (array-middleware wiring works)', async () => {
+    await new PostgresUsageRepository(pool as never).record({ teamId, kind: 'observation', quantity: 3 });
+    const { raw, hash } = newApiKey();
+    await storage.auth.createApiKey({ keyHash: hash, teamId, projectId, actorId: 't', scopes: ['memories:read'] });
+
+    const server = new Server({
+      getInitializationComplete: () => true, getMcpReady: () => true,
+      onShutdown: mock(() => Promise.resolve()), onRestart: mock(() => Promise.resolve()),
+      workerPath: '/test/worker.cjs', runtime: 'server-beta',
+      getAiStatus: () => ({ provider: 'disabled', authMethod: 'api-key', lastInteraction: null }),
+    });
+    server.registerRoutes(new ServerV1PostgresRoutes({
+      pool: pool as never, queueManager: new DisabledServerBetaQueueManager('disabled'),
+      authMode: 'api-key', runtime: 'server-beta', sessionPolicy: 'per-event',
+    }));
+    server.finalizeRoutes();
+    await server.listen(0, '127.0.0.1');
+    const addr = server.getHttpServer()?.address();
+    if (!addr || typeof addr === 'string') throw new Error('no port');
+    try {
+      const r = await fetch(`http://127.0.0.1:${addr.port}/v1/usage`, { headers: { Authorization: `Bearer ${raw}` } });
+      expect(r.status).toBe(200);
+      const body = await r.json() as { usage: Record<string, number> };
+      expect(body.usage.observation).toBe(3);
+    } finally {
+      try { await server.close(); } catch (error: unknown) {
+        if ((error as NodeJS.ErrnoException)?.code !== 'ERR_SERVER_NOT_RUNNING') throw error;
+      }
+    }
+  });
+});

--- a/tests/server/paid-readiness.test.ts
+++ b/tests/server/paid-readiness.test.ts
@@ -120,6 +120,7 @@ describe('paid-readiness (usage metering, rate limit, quota)', () => {
     expect(blocked.out.nexted).toBe(false);
     expect(blocked.out.status).toBe(429);
     expect(blocked.headers['Retry-After']).toBeDefined();
+    expect(blocked.headers['X-RateLimit-Reset']).toBeDefined();
   });
 
   it('rate limiter skips requests with no api key (local-dev)', async () => {


### PR DESCRIPTION
## What
Three Server Beta primitives needed before paid users can hit the cloud, all **opt-in via env** (default off → behavior unchanged) and **fail-open / fire-and-forget** (a metering or limiter hiccup never takes the API down). Pairs with the `/v1/mcp` recall link (#3070).

### Usage metering
- `usage_events` table + `PostgresUsageRepository` (record / total / summarize)
- `meterRequests` middleware — one `request` event per authed call (`CLAUDE_MEM_USAGE_METERING=1`), fire-and-forget. Token/observation metering uses the same repo from the generation worker.
- `GET /v1/usage` — per-kind totals for the team this month

### Rate limiting + quota
- `rate_limit_counters` table + `PostgresRateLimitRepository` — atomic fixed-window UPSERT, correct across instances
- `requireRateLimit` → `429` + `Retry-After` + `X-RateLimit-*` (`CLAUDE_MEM_RATE_LIMIT_PER_MIN`)
- `requireMonthlyQuota` → `402` at the per-team monthly cap (`CLAUDE_MEM_MONTHLY_REQUEST_CAP`)

### Key issuance + connect
- `POST /v1/keys` (**write** scope) — mints a **read-only**, optionally-expiring key + returns the paste-ready `claude mcp add … /v1/mcp` command (raw key shown once). Write-scope gate stops a read key escalating into more keys.
- `GET /v1/connect` (read scope) — same command with a `<YOUR_API_KEY>` placeholder

## Wiring
`readAuth`/`writeAuth` became **middleware arrays** (`[auth, ...guards]`) so the guards slot in after auth with **zero per-route edits** (Express accepts arrays anywhere a handler goes). Guards are only added when their env var is set.

## Tests — all live-verified against real Postgres (11/11), tsc clean
- Repo aggregation; rate-limit 429 + local-dev skip; quota 402/pass; fire-and-forget metering; `GET /v1/usage` end-to-end (proves the array-middleware wiring)
- Key mint → 201 + command shape; **the minted key authenticates** (calls `/v1/usage` → 200); read key can't mint (403); `/v1/connect` placeholder

## Open item (documented in api.md)
Cold-start — minting a team's **first** key still needs a session-gated path. better-auth's `apiKey()` plugin exists but writes to a **separate store** than the Postgres `api_keys` these routes check; wiring the better-auth org → Server Beta team mapping is the remaining piece. The write-scope `POST /v1/keys` covers everything once a team has one key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)