### PR TITLE
fix(mcp): make the `search` tool work in server-beta runtime (route to /v1/search)

### DIFF
--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -485,11 +485,23 @@ NEVER fetch full details without filtering first. 10x token savings.`,
       // the Chroma-backed SearchOrchestrator. When the install runs server-beta (where
       // generated observations live in Postgres, not local SQLite) and Chroma is not
       // configured, observation text queries return empty — so `search` silently yields
-      // 0 observations even though the data is in PG. Route text queries to the PG-backed
-      // /v1/search (same path as observation_search) when server-beta is available; fall
-      // back to the worker for worker-mode or filter-only (no text) queries.
+      // 0 observations even though the data is in PG.
+      //
+      // Route to the PG-backed /v1/search (same path as observation_search) ONLY when it
+      // can serve the request faithfully: server-beta is available, there is a text query,
+      // the result type is observations (or unspecified), and no filter /v1/search cannot
+      // honor is set. /v1/search is observations-only and takes only { projectId, query,
+      // limit } — so prompt/session-typed queries and platformSource/project/obs_type/date/
+      // offset/orderBy filters must keep the worker path (which applies them), otherwise we
+      // would silently drop the filter or mis-route the query.
       const sb = resolveServerBetaToolContext();
-      if (sb && sb.available && typeof args?.query === 'string' && args.query.trim().length > 0) {
+      const hasText = typeof args?.query === 'string' && args.query.trim().length > 0;
+      const typeIsObservations = args?.type === undefined || args?.type === 'observations';
+      const hasUnsupportedFilter =
+        args?.platformSource !== undefined || args?.project !== undefined ||
+        args?.obs_type !== undefined || args?.dateStart !== undefined ||
+        args?.dateEnd !== undefined || args?.offset !== undefined || args?.orderBy !== undefined;
+      if (sb && sb.available && hasText && typeIsObservations && !hasUnsupportedFilter) {
         const request: ServerBetaSearchObservationsRequest = {
           projectId: sb.projectId,
           query: args.query,

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -481,6 +481,22 @@ NEVER fetch full details without filtering first. 10x token savings.`,
       additionalProperties: true
     },
     handler: async (args: any) => {
+      // In server-beta runtime the local worker /api/search reads the local SQLite via
+      // the Chroma-backed SearchOrchestrator. When the install runs server-beta (where
+      // generated observations live in Postgres, not local SQLite) and Chroma is not
+      // configured, observation text queries return empty — so `search` silently yields
+      // 0 observations even though the data is in PG. Route text queries to the PG-backed
+      // /v1/search (same path as observation_search) when server-beta is available; fall
+      // back to the worker for worker-mode or filter-only (no text) queries.
+      const sb = resolveServerBetaToolContext();
+      if (sb && sb.available && typeof args?.query === 'string' && args.query.trim().length > 0) {
+        const request: ServerBetaSearchObservationsRequest = {
+          projectId: sb.projectId,
+          query: args.query,
+          ...(args.limit !== undefined ? { limit: args.limit } : {}),
+        };
+        return formatJsonResult(await sb.client.searchObservations(request));
+      }
       const endpoint = TOOL_ENDPOINT_MAP['search'];
       return await callWorkerAPI(endpoint, args);
     }


### PR DESCRIPTION
## Problem

In **server-beta** runtime the `search` MCP tool returns prompts but **0 observations**, even though the observations exist in Postgres. `observation_search` (which calls `/v1/search`) returns them fine, so the data and the server are healthy — only `search` is blind.

## Root cause

The `search` handler always routes to the local worker `/api/search`, which reads the local SQLite via the Chroma-backed `SearchOrchestrator`. In server-beta installs the local SQLite is **frozen** (generated observations live in PG, not SQLite) and, when Chroma isn't configured, observation **text** queries return empty — so `search` silently yields 0 observations. Prompts still return via a separate FTS path, which is why it looks like *"prompts work, observations don't."*

This is the server-beta-side mirror of #3064 (server-beta-only tools advertised under `worker` runtime): the tool surface isn't runtime-aware.

## Fix

When the runtime is server-beta **and** the query has text, route to the PG-backed `/v1/search` (the same path `observation_search` uses); otherwise fall back to the worker `/api/search` for worker-mode or filter-only (no text) queries. Reuses existing helpers (`resolveServerBetaToolContext`, `formatJsonResult`, `ServerBetaSearchObservationsRequest`).

`timeline` and `get_observations` are intentionally left unchanged — they're the SQLite-era numeric-id workflow and don't map to server-beta's UUID-keyed observations.

## Testing

- `tsc --noEmit` passes.
- Built the MCP server, spawned it with `CLAUDE_MEM_RUNTIME=server-beta`, and called `tools/call search` → returned Postgres observations (previously 0).

Related: #3064

🤖 Generated with [Claude Code](https://claude.com/claude-code)
