### PR TITLE
fix(worker): surface missing-credentials warning at session start for marketplace installs

### DIFF
--- a/src/services/worker/http/routes/SearchRoutes.ts
+++ b/src/services/worker/http/routes/SearchRoutes.ts
@@ -423,7 +423,10 @@ export class SearchRoutes extends BaseRouteHandler {
         // this warning briefly can ignore it — it self-clears as soon as the
         // first observation lands.
         const credEnv = loadClaudeMemEnv();
-        const hasCreds = credEnv.ANTHROPIC_API_KEY || credEnv.ANTHROPIC_AUTH_TOKEN;
+        const hasCreds = credEnv.ANTHROPIC_API_KEY
+          || credEnv.ANTHROPIC_AUTH_TOKEN
+          || credEnv.GEMINI_API_KEY
+          || credEnv.OPENROUTER_API_KEY;
         if (!hasCreds) {
           const credWarning = [
             '⚠️  claude-mem credentials not configured — observations cannot be generated.',

--- a/src/services/worker/http/routes/SearchRoutes.ts
+++ b/src/services/worker/http/routes/SearchRoutes.ts
@@ -11,6 +11,7 @@ import { logger } from '../../../../utils/logger.js';
 import { groupByDate } from '../../../../shared/timeline-formatting.js';
 import { countObservationsByProjects } from '../../../context/ObservationCompiler.js';
 import { SettingsDefaultsManager } from '../../../../shared/SettingsDefaultsManager.js';
+import { loadClaudeMemEnv } from '../../../../shared/EnvManager.js';
 import { USER_SETTINGS_PATH } from '../../../../shared/paths.js';
 import type { ObservationSearchResult, SessionSummarySearchResult } from '../../../sqlite/types.js';
 import { captureEvent } from '../../../telemetry/telemetry.js';
@@ -406,7 +407,42 @@ export class SearchRoutes extends BaseRouteHandler {
       if (!this.projectsHaveObservations(sessionStore, projects)) {
         const port = process.env.CLAUDE_MEM_WORKER_PORT ?? settings.CLAUDE_MEM_WORKER_PORT;
         const viewerUrl = `http://localhost:${port}`;
-        const hintBody = WELCOME_HINT_TEMPLATE.replace('{viewer_url}', viewerUrl);
+        let hintBody = WELCOME_HINT_TEMPLATE.replace('{viewer_url}', viewerUrl);
+
+        // Surface missing credentials at session start (#3027).
+        //
+        // Marketplace installs never create ~/.claude-mem/.env, so non-OAuth
+        // users (DeepSeek, OpenRouter, custom gateways) get silent failures
+        // — the SDK subprocess has no credentials, every observation attempt
+        // returns "Not logged in", and 0 observations are ever stored.
+        //
+        // We intentionally do NOT try to detect Anthropic OAuth here: the
+        // OAuth token lives in the platform keychain and is only read at SDK
+        // spawn time (buildIsolatedEnvWithFreshOAuth, async). There is no
+        // reliable sync signal in the worker process. OAuth users who see
+        // this warning briefly can ignore it — it self-clears as soon as the
+        // first observation lands.
+        const credEnv = loadClaudeMemEnv();
+        const hasCreds = credEnv.ANTHROPIC_API_KEY || credEnv.ANTHROPIC_AUTH_TOKEN;
+        if (!hasCreds) {
+          const credWarning = [
+            '⚠️  claude-mem credentials not configured — observations cannot be generated.',
+            'Anthropic OAuth users can ignore this message.',
+            '',
+            'Create ~/.claude-mem/.env with your API credentials:',
+            '```',
+            '# For custom gateways (DeepSeek, BigModel, etc.):',
+            'ANTHROPIC_AUTH_TOKEN=your-token',
+            'ANTHROPIC_BASE_URL=https://your-api-endpoint',
+            '',
+            '# Or for direct Anthropic API:',
+            'ANTHROPIC_API_KEY=your-key',
+            '```',
+            'Then restart Claude Code. See https://docs.claude-mem.ai/configuration',
+          ].join('\n');
+          hintBody = credWarning + '\n\n' + hintBody;
+        }
+
         res.setHeader('Content-Type', 'text/plain; charset=utf-8');
         res.send(hintBody);
         return;

--- a/tests/worker/http/routes/search-routes-welcome-hint.test.ts
+++ b/tests/worker/http/routes/search-routes-welcome-hint.test.ts
@@ -287,4 +287,40 @@ describe('SearchRoutes Welcome Hint', () => {
     expect(body).not.toContain('⚠️');
     expect(body).not.toContain('credentials not configured');
   });
+
+  it('omits credential warning when .env has GEMINI_API_KEY', async () => {
+    mockClaudeMemEnv = { GEMINI_API_KEY: 'test-gemini-key' };
+
+    const routes = new SearchRoutes(mockSearchManager);
+    const handler = captureContextInjectHandler(routes);
+
+    const res = createMockRes();
+    const req = { query: { projects: '/path/to/empty-project' } } as unknown as Request;
+
+    handler(req, res as unknown as Response);
+    await new Promise(resolve => setImmediate(resolve));
+
+    const body = (res.send as any).mock.calls[0][0] as string;
+    expect(body).toContain('# claude-mem status');
+    expect(body).not.toContain('⚠️');
+    expect(body).not.toContain('credentials not configured');
+  });
+
+  it('omits credential warning when .env has OPENROUTER_API_KEY', async () => {
+    mockClaudeMemEnv = { OPENROUTER_API_KEY: 'test-openrouter-key' };
+
+    const routes = new SearchRoutes(mockSearchManager);
+    const handler = captureContextInjectHandler(routes);
+
+    const res = createMockRes();
+    const req = { query: { projects: '/path/to/empty-project' } } as unknown as Request;
+
+    handler(req, res as unknown as Response);
+    await new Promise(resolve => setImmediate(resolve));
+
+    const body = (res.send as any).mock.calls[0][0] as string;
+    expect(body).toContain('# claude-mem status');
+    expect(body).not.toContain('⚠️');
+    expect(body).not.toContain('credentials not configured');
+  });
 });

--- a/tests/worker/http/routes/search-routes-welcome-hint.test.ts
+++ b/tests/worker/http/routes/search-routes-welcome-hint.test.ts
@@ -18,6 +18,12 @@ mock.module('../../../../src/shared/paths.js', () => ({
   paths: realPaths.paths,
 }));
 
+// Mutable reference so individual tests can control loadClaudeMemEnv's return value.
+let mockClaudeMemEnv: Record<string, string | undefined> = {};
+mock.module('../../../../src/shared/EnvManager.js', () => ({
+  loadClaudeMemEnv: () => mockClaudeMemEnv,
+}));
+
 import { SearchRoutes } from '../../../../src/services/worker/http/routes/SearchRoutes.js';
 
 let loggerSpies: ReturnType<typeof spyOn>[] = [];
@@ -81,6 +87,7 @@ describe('SearchRoutes Welcome Hint', () => {
     };
 
     generateContextStub.mockClear();
+    mockClaudeMemEnv = {};
     delete process.env.CLAUDE_MEM_WELCOME_HINT_ENABLED;
   });
 
@@ -218,5 +225,66 @@ describe('SearchRoutes Welcome Hint', () => {
 
     const body = (res.send as any).mock.calls[0][0] as string;
     expect(body).toContain('http://localhost:43210');
+  });
+
+  // ── Credential warning ──────────────────────────────────────────
+
+  it('prepends credential warning when .env has no credentials', async () => {
+    const routes = new SearchRoutes(mockSearchManager);
+    const handler = captureContextInjectHandler(routes);
+
+    const res = createMockRes();
+    const req = { query: { projects: '/path/to/empty-project' } } as unknown as Request;
+
+    handler(req, res as unknown as Response);
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(res.send).toHaveBeenCalledTimes(1);
+    const body = (res.send as any).mock.calls[0][0] as string;
+    expect(body).toContain('⚠️  claude-mem credentials not configured');
+    expect(body).toContain('Anthropic OAuth users can ignore this message.');
+    expect(body).toContain('Create ~/.claude-mem/.env with your API credentials');
+    expect(body).toContain('ANTHROPIC_AUTH_TOKEN=your-token');
+    expect(body).toContain('ANTHROPIC_API_KEY=your-key');
+    expect(body).toContain('# claude-mem status');
+    expect(body).toContain('/learn-codebase');
+    // Warning must appear before the welcome hint
+    expect(body.indexOf('⚠️')).toBeLessThan(body.indexOf('# claude-mem status'));
+  });
+
+  it('omits credential warning when .env has ANTHROPIC_AUTH_TOKEN', async () => {
+    mockClaudeMemEnv = { ANTHROPIC_AUTH_TOKEN: 'test-token' };
+
+    const routes = new SearchRoutes(mockSearchManager);
+    const handler = captureContextInjectHandler(routes);
+
+    const res = createMockRes();
+    const req = { query: { projects: '/path/to/empty-project' } } as unknown as Request;
+
+    handler(req, res as unknown as Response);
+    await new Promise(resolve => setImmediate(resolve));
+
+    const body = (res.send as any).mock.calls[0][0] as string;
+    expect(body).toContain('# claude-mem status');
+    expect(body).not.toContain('⚠️');
+    expect(body).not.toContain('credentials not configured');
+  });
+
+  it('omits credential warning when .env has ANTHROPIC_API_KEY', async () => {
+    mockClaudeMemEnv = { ANTHROPIC_API_KEY: 'test-key' };
+
+    const routes = new SearchRoutes(mockSearchManager);
+    const handler = captureContextInjectHandler(routes);
+
+    const res = createMockRes();
+    const req = { query: { projects: '/path/to/empty-project' } } as unknown as Request;
+
+    handler(req, res as unknown as Response);
+    await new Promise(resolve => setImmediate(resolve));
+
+    const body = (res.send as any).mock.calls[0][0] as string;
+    expect(body).toContain('# claude-mem status');
+    expect(body).not.toContain('⚠️');
+    expect(body).not.toContain('credentials not configured');
   });
 });


### PR DESCRIPTION
## Problem

When claude-mem is installed via the Claude Code plugin marketplace (`/plugin marketplace add thedotmack/claude-mem` + `/plugin install claude-mem`), the `~/.claude-mem/.env` file is never created. The `npx claude-mem install` path handles this via interactive prompts, but the marketplace path has no equivalent onboarding.

Without `~/.claude-mem/.env`, non-OAuth users (DeepSeek, OpenRouter, custom gateways) experience a **completely silent failure**: the worker's SDK subprocess receives "Not logged in · Please run /login" on every observation attempt. The session gets poisoned, re-spawned, and eventually killed — all without the user ever knowing.

The user sees "This project has no memory yet…" forever, with zero indication that credential configuration is the blocker.

## Fix

In `SearchRoutes.handleContextInject`, before returning the welcome hint when a project has no observations, check whether credentials are available via `loadClaudeMemEnv()`. If `~/.claude-mem/.env` has no credentials configured, prepend a warning with setup instructions.

**Security**: only reads from `~/.claude-mem/.env` via `loadClaudeMemEnv()` — respects the existing `BLOCKED_ENV_VARS` boundary. Never reads credentials from `process.env`.

**OAuth users**: intentionally not detected (OAuth token lives in platform keychain, only readable asynchronously at SDK spawn time). OAuth users who briefly see this warning can ignore it — it self-clears once the first observation lands.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Marketplace + no .env | "no memory yet" (silent failure) | ⚠️ Warning + setup instructions + welcome hint |
| Marketplace + .env configured | Welcome hint | Welcome hint (unchanged) |
| npm install + .env configured | Welcome hint | Welcome hint (unchanged) |

## Changes

- **`src/services/worker/http/routes/SearchRoutes.ts`**: added `loadClaudeMemEnv` import and credential check in welcome-hint branch
- **`tests/worker/http/routes/search-routes-welcome-hint.test.ts`**: 3 new test cases covering empty .env, ANTHROPIC_AUTH_TOKEN, and ANTHROPIC_API_KEY scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)