### PR TITLE
feat(server): data deletion — forget a memory or purge a project

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -20,6 +20,8 @@ Available beta endpoints:
 - `PATCH /v1/memories/:id`
 - `POST /v1/search`
 - `POST /v1/context`
+- `DELETE /v1/memories/:id`
+- `DELETE /v1/projects/:projectId/memory`
 - `GET /v1/audit?projectId=<id>`
 
 When `CLAUDE_MEM_AUTH_MODE=api-key`, send `Authorization: Bearer <key>`. Read endpoints require `memories:read`; write endpoints require `memories:write`.
@@ -38,3 +40,11 @@ always populated (or `null` only when generation was explicitly disabled).
 The actual provider call happens in a separate BullMQ worker process
 (`claude-mem server worker start`); the HTTP path never blocks on a
 provider response.
+
+## Data deletion (forget)
+
+Right-to-erasure. Both require **write** scope and are scoped to the caller's team.
+
+- `DELETE /v1/memories/:id` — delete a single observation (its sources cascade). `404` if it doesn't exist for the team.
+- `DELETE /v1/projects/:projectId/memory` — purge ALL captured content for a project (observations, agent events, sessions, generation jobs); keeps the project shell. Returns per-table `counts`. Both are audited (`observation.deleted` / `project.memory_purged`).
+

--- a/src/server/routes/v1/ServerV1PostgresRoutes.ts
+++ b/src/server/routes/v1/ServerV1PostgresRoutes.ts
@@ -19,6 +19,7 @@ import { PostgresAuthRepository } from '../../../storage/postgres/auth.js';
 import { PostgresObservationRepository } from '../../../storage/postgres/observations.js';
 import { logger } from '../../../utils/logger.js';
 import { requirePostgresServerAuth } from '../../middleware/postgres-auth.js';
+import { PostgresDataDeletionRepository } from '../../../storage/postgres/data-deletion.js';
 import { requestIdMiddleware } from '../../middleware/request-id.js';
 import type { ActiveServerBetaQueueManager } from '../../runtime/ActiveServerBetaQueueManager.js';
 import type { ServerBetaQueueManager } from '../../runtime/types.js';
@@ -926,6 +927,54 @@ export class ServerV1PostgresRoutes implements RouteHandler {
         }
       },
     ));
+
+    // DELETE /v1/memories/:id — forget a single observation (sources cascade).
+    app.delete('/v1/memories/:id', writeAuth, this.asyncHandler(async (req, res) => {
+      const teamId = this.requireTeamId(req, res);
+      if (!teamId) return;
+      const id = String(req.params.id);
+      const projectScope = req.authContext?.projectId ?? null;
+      try {
+        const deletion = new PostgresDataDeletionRepository(this.options.pool);
+        // Project-scoped key deletes within its project; a team-scoped key
+        // matches by id + team across the team's projects.
+        let deleted: boolean;
+        if (projectScope) {
+          deleted = await deletion.deleteObservation({ id, projectId: projectScope, teamId });
+        } else {
+          const byTeam = await this.options.pool.query(
+            `DELETE FROM observations WHERE id = $1 AND team_id = $2`,
+            [id, teamId],
+          );
+          deleted = (byTeam.rowCount ?? 0) > 0;
+        }
+        if (!deleted) {
+          res.status(404).json({ error: 'not_found' });
+          return;
+        }
+        await this.auditWrite(req, 'observation.deleted', id, projectScope, { via: 'api' });
+        res.status(200).json({ deleted: true, id });
+      } catch (error) {
+        this.handleDbError(error, res, 'observation.delete');
+      }
+    }));
+
+    // DELETE /v1/projects/:projectId/memory — forget EVERYTHING captured for a
+    // project (observations, raw events, sessions, jobs). Keeps the project shell.
+    app.delete('/v1/projects/:projectId/memory', writeAuth, this.asyncHandler(async (req, res) => {
+      const teamId = this.requireTeamId(req, res);
+      if (!teamId) return;
+      const projectId = String(req.params.projectId);
+      if (!this.ensureProjectAllowed(req, res, projectId)) return;
+      try {
+        const counts = await new PostgresDataDeletionRepository(this.options.pool)
+          .purgeProjectMemory({ projectId, teamId });
+        await this.auditWrite(req, 'project.memory_purged', projectId, projectId, { ...counts, via: 'api' });
+        res.status(200).json({ purged: true, projectId, counts });
+      } catch (error) {
+        this.handleDbError(error, res, 'project.purge');
+      }
+    }));
   }
 
   private async auditRead(

--- a/src/storage/postgres/data-deletion.ts
+++ b/src/storage/postgres/data-deletion.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Data deletion ("forget") for Server Beta — the right-to-erasure path a paid
+// cloud must have. Everything is scoped by (project_id, team_id) so a key can
+// only ever delete its own team's data. observation_sources cascade from both
+// observations and agent_events, so deleting those rows removes their links too.
+
+import type { PostgresPool } from './pool.js';
+import { withPostgresTransaction } from './pool.js';
+
+export interface PurgeCounts {
+  observations: number;
+  agentEvents: number;
+  sessions: number;
+  jobs: number;
+}
+
+export class PostgresDataDeletionRepository {
+  constructor(private readonly pool: PostgresPool) {}
+
+  /** Delete a single observation (and its sources, via cascade). Returns true if a row was removed. */
+  async deleteObservation(input: { id: string; projectId: string; teamId: string }): Promise<boolean> {
+    const res = await this.pool.query(
+      `DELETE FROM observations WHERE id = $1 AND project_id = $2 AND team_id = $3`,
+      [input.id, input.projectId, input.teamId],
+    );
+    return (res.rowCount ?? 0) > 0;
+  }
+
+  /**
+   * Purge ALL of a project's captured content — observations, raw agent events,
+   * sessions, and generation jobs — in one transaction. Keeps the project shell
+   * (config/membership) so the team can keep using it. Returns per-table counts.
+   */
+  async purgeProjectMemory(input: { projectId: string; teamId: string }): Promise<PurgeCounts> {
+    const { projectId, teamId } = input;
+    return withPostgresTransaction(this.pool, async (client) => {
+      const del = async (table: string): Promise<number> => {
+        const res = await client.query(
+          `DELETE FROM ${table} WHERE project_id = $1 AND team_id = $2`,
+          [projectId, teamId],
+        );
+        return res.rowCount ?? 0;
+      };
+      // Observations first (their sources cascade). Jobs/events next — deleting
+      // agent_events cascades its jobs + sources, so the job count is a floor.
+      const observations = await del('observations');
+      const jobs = await del('observation_generation_jobs');
+      const agentEvents = await del('agent_events');
+      const sessions = await del('server_sessions');
+      return { observations, agentEvents, sessions, jobs };
+    });
+  }
+}

--- a/src/storage/postgres/index.ts
+++ b/src/storage/postgres/index.ts
@@ -15,6 +15,7 @@ import { PostgresTeamsRepository } from './teams.js';
 export * from './agent-events.js';
 export * from './auth.js';
 export * from './config.js';
+export * from './data-deletion.js';
 export * from './generation-jobs.js';
 export * from './observations.js';
 export * from './pool.js';

--- a/tests/server/data-deletion.test.ts
+++ b/tests/server/data-deletion.test.ts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Data deletion ("forget"): DELETE /v1/memories/:id and
+// DELETE /v1/projects/:projectId/memory. Postgres-gated. Asserts the purge is
+// scoped to the team (another team's project is untouched).
+
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import pg from 'pg';
+import { createHash, randomBytes, randomUUID } from 'crypto';
+import { Server } from '../../src/services/server/Server.js';
+import { ServerV1PostgresRoutes } from '../../src/server/routes/v1/ServerV1PostgresRoutes.js';
+import {
+  bootstrapServerBetaPostgresSchema,
+  createPostgresStorageRepositories,
+  type PostgresPoolClient,
+  type PostgresStorageRepositories,
+} from '../../src/storage/postgres/index.js';
+import { DisabledServerBetaQueueManager } from '../../src/server/runtime/types.js';
+import { logger } from '../../src/utils/logger.js';
+
+const testDatabaseUrl = process.env.CLAUDE_MEM_TEST_POSTGRES_URL;
+const q = (n: string) => `"${n.replaceAll('"', '""')}"`;
+function newApiKey() {
+  const raw = `cm_${randomBytes(24).toString('hex')}`;
+  return { raw, hash: createHash('sha256').update(raw).digest('hex') };
+}
+
+describe('data deletion (forget)', () => {
+  if (!testDatabaseUrl) {
+    it.skip('requires CLAUDE_MEM_TEST_POSTGRES_URL', () => {});
+    return;
+  }
+
+  let pool: pg.Pool;
+  let client: PostgresPoolClient;
+  let schemaName: string;
+  let storage: PostgresStorageRepositories;
+  let server: Server;
+  let port: number;
+  let writeKey: string;
+  let teamId: string;
+  let projectA: string;
+  let projectB: string;
+  let otherTeamProject: string;
+  let spies: ReturnType<typeof spyOn>[] = [];
+
+  beforeEach(async () => {
+    spies = ['info', 'warn', 'error', 'debug'].map((m) => spyOn(logger, m as 'info').mockImplementation(() => {}));
+    // Create the schema first, then give the pool a connection-level search_path
+    // (via `options`) so EVERY connection lands in it — no on-connect race, which
+    // otherwise makes the auth query miss api_keys and 403.
+    schemaName = `cm_del_${randomUUID().replaceAll('-', '_')}`;
+    const admin = new pg.Client({ connectionString: testDatabaseUrl });
+    await admin.connect();
+    await admin.query(`CREATE SCHEMA ${q(schemaName)}`);
+    await admin.end();
+    pool = new pg.Pool({ connectionString: testDatabaseUrl, options: `-c search_path=${schemaName}` });
+    client = await pool.connect();
+    await bootstrapServerBetaPostgresSchema(client);
+    storage = createPostgresStorageRepositories(client);
+
+    const team = await storage.teams.create({ name: 'team' });
+    teamId = team.id;
+    const a = await storage.projects.create({ teamId, name: 'A' });
+    const b = await storage.projects.create({ teamId, name: 'B' });
+    projectA = a.id; projectB = b.id;
+    for (const projectId of [projectA, projectB]) {
+      await storage.observations.create({ projectId, teamId, kind: 'manual', content: `mem ${projectId} 1` });
+      await storage.observations.create({ projectId, teamId, kind: 'manual', content: `mem ${projectId} 2` });
+    }
+    await storage.agentEvents.create({ projectId: projectA, teamId, sourceAdapter: 'api', eventType: 'tool_use', payload: { t: 'ls' }, occurredAt: new Date() });
+
+    // A different team + project — must survive a team-A purge.
+    const other = await storage.teams.create({ name: 'other' });
+    const op = await storage.projects.create({ teamId: other.id, name: 'O' });
+    otherTeamProject = op.id;
+    await storage.observations.create({ projectId: op.id, teamId: other.id, kind: 'manual', content: 'other secret' });
+
+    const w = newApiKey(); writeKey = w.raw;
+    await storage.auth.createApiKey({ keyHash: w.hash, teamId, projectId: null, actorId: 't', scopes: ['memories:read', 'memories:write'] });
+
+    server = new Server({
+      getInitializationComplete: () => true, getMcpReady: () => true,
+      onShutdown: mock(() => Promise.resolve()), onRestart: mock(() => Promise.resolve()),
+      workerPath: '/test/worker.cjs', runtime: 'server-beta',
+      getAiStatus: () => ({ provider: 'disabled', authMethod: 'api-key', lastInteraction: null }),
+    });
+    server.registerRoutes(new ServerV1PostgresRoutes({
+      pool: pool as never, queueManager: new DisabledServerBetaQueueManager('disabled'),
+      authMode: 'api-key', runtime: 'server-beta', sessionPolicy: 'per-event',
+    }));
+    server.finalizeRoutes();
+    await server.listen(0, '127.0.0.1');
+    const addr = server.getHttpServer()?.address();
+    if (!addr || typeof addr === 'string') throw new Error('no port');
+    port = addr.port;
+  });
+
+  afterEach(async () => {
+    try { await server.close(); } catch (e: unknown) {
+      if ((e as NodeJS.ErrnoException)?.code !== 'ERR_SERVER_NOT_RUNNING') throw e;
+    }
+    await client.query(`DROP SCHEMA IF EXISTS ${q(schemaName)} CASCADE`);
+    client.release();
+    await pool.end();
+    spies.forEach((s) => s.mockRestore());
+    mock.restore();
+  });
+
+  const url = (p: string) => `http://127.0.0.1:${port}${p}`;
+  // A function, not a constant: writeKey is only set in beforeEach, so a
+  // describe-level constant would capture `undefined`.
+  const auth = () => ({ Authorization: `Bearer ${writeKey}` });
+  const countObs = async (projectId: string) =>
+    Number((await pool.query(`SELECT count(*)::int n FROM observations WHERE project_id=$1`, [projectId])).rows[0].n);
+
+  it('purges a project\'s memory and leaves other projects + teams intact', async () => {
+    const r = await fetch(url(`/v1/projects/${projectA}/memory`), { method: 'DELETE', headers: auth() });
+    expect(r.status).toBe(200);
+    const body = await r.json() as { counts: { observations: number; agentEvents: number } };
+    expect(body.counts.observations).toBe(2);
+    expect(body.counts.agentEvents).toBe(1);
+    expect(await countObs(projectA)).toBe(0);
+    expect(await countObs(projectB)).toBe(2);         // sibling project untouched
+    expect(await countObs(otherTeamProject)).toBe(1); // other team untouched
+  });
+
+  it('a team-A key cannot purge another team\'s project (deletes nothing)', async () => {
+    const r = await fetch(url(`/v1/projects/${otherTeamProject}/memory`), { method: 'DELETE', headers: auth() });
+    expect(r.status).toBe(200);
+    const body = await r.json() as { counts: { observations: number } };
+    expect(body.counts.observations).toBe(0);
+    expect(await countObs(otherTeamProject)).toBe(1); // still there
+  });
+
+  it('deletes a single observation, then 404s on repeat', async () => {
+    const id = (await pool.query(`SELECT id FROM observations WHERE project_id=$1 LIMIT 1`, [projectA])).rows[0].id;
+    const r1 = await fetch(url(`/v1/memories/${id}`), { method: 'DELETE', headers: auth() });
+    expect(r1.status).toBe(200);
+    expect(await countObs(projectA)).toBe(1);
+    const r2 = await fetch(url(`/v1/memories/${id}`), { method: 'DELETE', headers: auth() });
+    expect(r2.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## What
The right-to-erasure path a paid memory cloud needs (GDPR / trust / offboarding). Item #5 on the launch roadmap.

- **`DELETE /v1/memories/:id`** — forget a single observation (its `observation_sources` cascade). `404` if it doesn't exist for the team.
- **`DELETE /v1/projects/:projectId/memory`** — purge **everything captured** for a project (observations + agent events + sessions + generation jobs), keeping the project shell so the team keeps using it. Returns per-table `counts`.

Both require **write** scope, are scoped by `(project_id, team_id)`, and are audited (`observation.deleted` / `project.memory_purged`).

## Implementation
New `PostgresDataDeletionRepository` (`deleteObservation`, `purgeProjectMemory` — the purge runs in one transaction). No new tables; uses the existing cascade FKs.

## Tests — postgres-gated, verified live (3/3)
- Purge a project → its memory gone; **sibling projects and other teams untouched**
- A team-A key purging **another team's** project deletes nothing (team isolation)
- Single delete → gone; repeat → `404`

`tsc --noEmit` clean.

> Part of the cloud paid-readiness line alongside #3070 (MCP link) and #3078 (metering/quotas/keys).
🤖 Generated with [Claude Code](https://claude.com/claude-code)