### PR TITLE
fix(bun-runner): bound hook invocations so a wedged worker can't block the prompt

### DIFF
--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -93,6 +93,28 @@ if (args.length === 0) {
 
 args[0] = fixBrokenScriptPath(args[0]);
 
+// Lifecycle commands manage the long-lived worker daemon; every other invocation
+// is a hook payload whose runtime blocks the Claude Code event that spawned it
+// (UserPromptSubmit, PostToolUse, ...). A wedged worker on one of those must never
+// hang the user's prompt — see the watchdog below.
+const LIFECYCLE_COMMANDS = ['start', 'stop', 'restart', 'status'];
+const isLifecycle = LIFECYCLE_COMMANDS.some(cmd => args.includes(cmd));
+
+// Kill the child and everything it spawned. On Windows the child is a cmd.exe
+// wrapper (shell:true), so child.kill() leaves the real `bun` grandchild running
+// — the orphan pileup that stacks up one hung worker per prompt. taskkill /T /F
+// tears down the whole tree.
+function killChildTree(child) {
+  if (!child || child.killed) return;
+  if (IS_WINDOWS && child.pid) {
+    try {
+      spawnSync('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore' });
+      return;
+    } catch {}
+  }
+  try { child.kill(); } catch {}
+}
+
 const bunPath = findBun();
 
 if (!bunPath) {
@@ -145,6 +167,32 @@ if (IS_WINDOWS) {
 
 const child = spawn(spawnCmd, spawnArgs, spawnOptions);
 
+// Watchdog: a hook payload invocation must never block its Claude Code event for
+// longer than this. If the worker wedges (e.g. a stuck daemon connection on
+// Windows), kill the process tree and exit 0 — honoring the exit-0 strategy, with
+// the runner-errors log as the durable signal. Lifecycle commands are exempt: the
+// daemon they start is meant to outlive this launcher.
+let watchdog = null;
+if (!isLifecycle) {
+  const timeoutMs = Number(process.env.CLAUDE_MEM_HOOK_TIMEOUT_MS) || 8000;
+  watchdog = setTimeout(() => {
+    try {
+      const dataDir = process.env.CLAUDE_MEM_DATA_DIR || join(homedir(), '.claude-mem');
+      const logsDir = join(dataDir, 'logs');
+      mkdirSync(logsDir, { recursive: true });
+      appendFileSync(
+        join(logsDir, 'runner-errors.log'),
+        `[bun-runner] worker hook exceeded ${timeoutMs}ms — killed to unblock prompt\n` +
+        `  script: ${args[0]}\n` +
+        `  timestamp: ${new Date().toISOString()}\n\n`
+      );
+    } catch {}
+    killChildTree(child);
+    process.exit(0);
+  }, timeoutMs);
+  if (watchdog.unref) watchdog.unref();
+}
+
 if (child.stdin) {
   if (stdinData && stdinData.length > 0) {
     child.stdin.write(stdinData);
@@ -154,9 +202,6 @@ if (child.stdin) {
     // they manage the worker daemon, not hook payloads.  Killing the child here
     // prevents the daemon from starting/stopping on platforms where Claude Code
     // doesn't pipe a payload for SessionStart (e.g. Windows CC ≤ 2.1.145).
-    const lifecycleCommands = ['start', 'stop', 'restart', 'status'];
-    const isLifecycle = lifecycleCommands.some(cmd => args.includes(cmd));
-
     if (isLifecycle) {
       // Lifecycle commands don't need stdin — close pipe and let child run.
       try { child.stdin.end(); } catch {}
@@ -231,6 +276,7 @@ child.on('error', (err) => {
 });
 
 child.on('close', (code, signal) => {
+  if (watchdog) clearTimeout(watchdog);
   if ((signal || code > 128) && args.includes('start')) {
     process.exit(0);
   }

--- a/tests/bun-runner.test.ts
+++ b/tests/bun-runner.test.ts
@@ -23,3 +23,23 @@ describe('bun-runner.js findBun: DEP0190 regression guard (#1503)', () => {
     expect(source).toContain("spawnSync('which', ['bun']");
   });
 });
+
+describe('bun-runner.js hook watchdog: a wedged worker must not block the prompt', () => {
+  it('arms a timeout for non-lifecycle (hook payload) invocations', () => {
+    expect(source).toContain('watchdog = setTimeout(');
+    expect(source).toContain('CLAUDE_MEM_HOOK_TIMEOUT_MS');
+  });
+
+  it('exempts lifecycle commands from the watchdog', () => {
+    expect(source).toContain('if (!isLifecycle)');
+  });
+
+  it('clears the watchdog when the child closes', () => {
+    expect(source).toContain('if (watchdog) clearTimeout(watchdog)');
+  });
+
+  it('tree-kills the child on Windows so no orphan worker survives', () => {
+    expect(source).toContain('taskkill');
+    expect(source).toContain("'/T'");
+  });
+});


### PR DESCRIPTION
## Problem

On Windows, every prompt began hanging: slash commands and normal input appeared frozen. Root cause is the `UserPromptSubmit` → `session-init` hook. A hook payload invocation inherits the bun worker's runtime and blocks the Claude Code event that spawned it. When the worker wedges (observed as a stuck daemon connection after an auto-update), the prompt blocks on `bun-runner.js` until the host's 60s hook timeout fires — unusable.

Because the Windows child is a `cmd.exe` wrapper (`shell:true`), `child.kill()` only kills the wrapper, leaving the real `bun` grandchild alive. These orphans stacked up **one per prompt** (observed ~8 wedged `worker-service.cjs hook` processes).

## Fix

Add a watchdog around **non-lifecycle** (hook payload) invocations in `bun-runner.js`:

- If the worker doesn't exit within `CLAUDE_MEM_HOOK_TIMEOUT_MS` (default `8000`), tree-kill it and `exit 0`, appending a line to `runner-errors.log` as the durable signal (consistent with the existing exit-0 / marker-file IO discipline).
- On Windows the kill uses `taskkill /pid <pid> /T /F` so the whole tree dies (not just the `cmd.exe` wrapper) — this also stops the orphan pileup.
- Lifecycle commands (`start`/`stop`/`restart`/`status`) are **exempt** — the daemon they manage is meant to outlive the launcher.

The launcher parser-compat constraint (#2791, no `?.`/`??`) and the `fixBrokenScriptPath` safety net are preserved.

## Tests

Added source-pattern assertions to `tests/bun-runner.test.ts` (matching the file's existing test style). `bun test tests/bun-runner.test.ts` → 7 pass. `node --check` passes; no `?.`/`??` introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)