### PR TITLE
fix: worker-service missing sqlite/SessionStore.js + observations/files.js (#3092)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+## Bug Fix
+
+**Worker's Chroma backfill failed on every startup — `sqlite/SessionStore.js` and `sqlite/observations/files.js` missing from the bundle (#3092).**
+
+`ChromaSync.ts` loads `SessionStore` and `parseFileList` through a runtime `createRequire(import.meta.url)(...)` call instead of a static `import`, so the cmem-sdk (tsup) build doesn't follow them and drag `bun:sqlite` into SDK consumers. But the worker's esbuild bundle doesn't follow that same indirection either, so `worker-service.cjs` shipped without these two modules — every worker startup logged `Backfill failed (non-blocking)` from a `Cannot find module '../sqlite/SessionStore.js'` error, and Chroma vector-search backfill silently never ran.
+
+`scripts/build-hooks.js` now emits both modules as loose files next to the worker bundle (`plugin/sqlite/SessionStore.js`, `plugin/sqlite/observations/files.js`), and `plugin/sqlite` is added to the npm `files` whitelist so the published package actually ships them.
+
+### Added
+- `tests/worker-service-lazy-sqlite-modules.test.ts` — regression test asserting both modules are emitted and resolve the same way `ChromaSync.ts` requires them at runtime
+
 ## [13.9.2] - 2026-07-01
 
 ## Bug Fix

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "plugin/modes",
     "plugin/scripts/*.js",
     "plugin/scripts/*.cjs",
+    "plugin/sqlite",
     "plugin/skills",
     "plugin/ui",
     "openclaw"

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -349,6 +349,34 @@ async function buildHooks() {
       );
     }
 
+    // worker-service reaches SessionStore + parseFileList through a runtime
+    // `createRequire(import.meta.url)(...)` call (see ChromaSync.ts), not a
+    // static `import` — intentionally, so tsup's cmem-sdk build doesn't
+    // follow them and drag `bun:sqlite` into SDK consumers. But that same
+    // indirection means esbuild's worker-service bundle above does NOT
+    // statically resolve — and therefore does not inline — these modules.
+    // They must be emitted as loose files next to the bundle so the
+    // runtime `require('../sqlite/...')` calls actually resolve (#3092).
+    console.log(`\n🔧 Building lazy-loaded SQLite modules for worker-service...`);
+    const LAZY_SQLITE_MODULES = [
+      { source: 'src/services/sqlite/SessionStore.ts', outfile: `${hooksDir}/../sqlite/SessionStore.js` },
+      { source: 'src/services/sqlite/observations/files.ts', outfile: `${hooksDir}/../sqlite/observations/files.js` },
+    ];
+    for (const mod of LAZY_SQLITE_MODULES) {
+      await build({
+        entryPoints: [mod.source],
+        bundle: true,
+        platform: 'node',
+        target: 'node18',
+        format: 'cjs',
+        outfile: mod.outfile,
+        minify: true,
+        logLevel: 'error',
+        external: ['bun:sqlite'],
+      });
+    }
+    console.log(`✓ Lazy SQLite modules built (${LAZY_SQLITE_MODULES.map((m) => path.relative(hooksDir, m.outfile)).join(', ')})`);
+
     console.log(`\n🔧 Building server beta service...`);
     await build({
       entryPoints: [SERVER_SERVICE.source],

--- a/tests/worker-service-lazy-sqlite-modules.test.ts
+++ b/tests/worker-service-lazy-sqlite-modules.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'bun:test';
+import { existsSync } from 'fs';
+import { createRequire } from 'module';
+import { join } from 'path';
+
+const PLUGIN_DIR = join(import.meta.dir, '..', 'plugin');
+const WORKER_SCRIPTS_DIR = join(PLUGIN_DIR, 'scripts');
+const SESSION_STORE_PATH = join(PLUGIN_DIR, 'sqlite', 'SessionStore.js');
+const OBSERVATIONS_FILES_PATH = join(PLUGIN_DIR, 'sqlite', 'observations', 'files.js');
+
+const require = createRequire(import.meta.url);
+
+// ChromaSync.ts (bundled into worker-service.cjs) reaches these two modules
+// via createRequire(import.meta.url)('../sqlite/....js') at runtime, not a
+// static `import` — intentionally, so tsup's cmem-sdk build doesn't follow
+// them and drag `bun:sqlite` into SDK consumers. esbuild's worker-service
+// bundle does not statically resolve that indirection either, so unless the
+// build also emits these as loose files next to the bundle, the runtime
+// require throws `Cannot find module '../sqlite/SessionStore.js'` on every
+// worker startup and the Chroma backfill pipeline is silently skipped (#3092).
+describe('worker-service.cjs lazy-loaded SQLite modules (#3092)', () => {
+  it('emits sqlite/SessionStore.js next to the worker bundle', () => {
+    expect(existsSync(SESSION_STORE_PATH)).toBe(true);
+  });
+
+  it('emits sqlite/observations/files.js next to the worker bundle', () => {
+    expect(existsSync(OBSERVATIONS_FILES_PATH)).toBe(true);
+  });
+
+  it('resolves sqlite/SessionStore.js the same way ChromaSync.ts requires it at runtime', () => {
+    const { SessionStore } = require(join(WORKER_SCRIPTS_DIR, '../sqlite/SessionStore.js'));
+    expect(typeof SessionStore).toBe('function');
+  });
+
+  it('resolves sqlite/observations/files.js with a working parseFileList export', () => {
+    const { parseFileList } = require(join(WORKER_SCRIPTS_DIR, '../sqlite/observations/files.js'));
+    expect(parseFileList('["a.ts","b.ts"]')).toEqual(['a.ts', 'b.ts']);
+    expect(parseFileList(null)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes Bug 1 from #3092: the Chroma backfill pipeline failed on every worker startup with `Cannot find module '../sqlite/SessionStore.js'`.

`ChromaSync.ts` loads `SessionStore` and `parseFileList` through a runtime `createRequire(import.meta.url)(...)` call instead of a static `import`, intentionally, so the cmem-sdk (tsup) build doesn't follow them and drag `bun:sqlite` into SDK consumers. But esbuild's worker-service bundle in `scripts/build-hooks.js` doesn't follow that same indirection either — it only inlines modules reached through a literal `require(...)` call, not one made via a locally-created `require` reference — so `worker-service.cjs` shipped without either module. Every worker startup logged `Backfill failed (non-blocking)` from the resulting `Cannot find module` error, and Chroma vector-search backfill silently never ran.

- `scripts/build-hooks.js`: after the existing `worker-service.cjs` build step, add a build pass that emits both modules as loose files next to the bundle (`plugin/sqlite/SessionStore.js`, `plugin/sqlite/observations/files.js`), matching the relative path `ChromaSync.ts`'s lazy `require()` expects at runtime.
- `package.json`: add `plugin/sqlite` to the npm `files` whitelist — without this the fix builds and tests clean locally but the published package still wouldn't ship the emitted files.
- `tests/worker-service-lazy-sqlite-modules.test.ts`: regression test that resolves both modules the same way `ChromaSync.ts` does at runtime. Verified locally that it reproduces the exact `#3092` error when the fix is reverted, and passes with it applied.
- `CHANGELOG.md`: `[Unreleased]` entry per the contribution guidelines in `docs/public/development.mdx`.

Out of scope: Bug 2 from #3092 (the `.install-version` marker / "runtime not yet set up" message) is a separate, architecturally distinct issue — it's about the Claude Code marketplace install path never invoking the npx installer that writes that marker, not a build-pipeline gap. Left for a follow-up so this PR stays scoped to one concern.

## Test plan

- [x] `bun test tests/worker-service-lazy-sqlite-modules.test.ts` — 4/4 pass with the fix applied
- [x] Confirmed the test fails with the exact `#3092` error text when `plugin/sqlite/` is removed (proves it's a real regression guard, not a tautology)
- [x] Verified via isolated `npm pack --dry-run --json` that the new `plugin/sqlite` `files` entry recursively packs the nested `plugin/sqlite/observations/files.js`
- [ ] Full `npm run build && npm run typecheck && bun test` — not run locally (heavy toolchain: tree-sitter-cli, onnxruntime-node, Chroma); relying on this repo's own CI (`.github/workflows/ci.yml`) to run these on the PR