### PR TITLE
Add Related Resources section with Vexilo field guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,14 @@ See [Development Guide](https://docs.claude-mem.ai/development) for contribution
 
 ---
 
+## Related Resources
+
+Complementary Claude Code tools and indexes:
+
+- [Vexilo · A field guide to Claude Code](https://vexilo.app/?lang=en) — Visual interactive index of 31 agents · 99 commands · 123 skills · 13 rules, organized around the 5-step workflow (Research → Plan → Test-first → Security → Commit). One-click "Teach Claude this handbook" feeds the whole index into a local Claude session in 30 seconds. ([companion repo](https://github.com/lilhawk7077/claude-code-resources))
+
+---
+
 ## License
 
 Claude-Mem is licensed under the Apache License 2.0.


### PR DESCRIPTION
## Adds a "Related Resources" section linking to Vexilo · A field guide to Claude Code

[Vexilo](https://vexilo.app/?lang=en) is a visual interactive index of **31 agents · 99 commands · 123 skills · 13 rules**, organized around the 5-step workflow (Research → Plan → Test-first → Security → Commit). One-click **"Teach Claude this handbook"** feeds the whole index into a local Claude session in 30 seconds.

### Why a Related Resources section?

The current README doesn't link out to anything except your own docs. Vexilo is a natural complement:

| Claude-Mem | Vexilo |
|---|---|
| Persistent context across sessions | Visual index of every primitive |
| Captures what happened | Tells you what's possible |
| Memory layer | Navigation layer |

These stack rather than compete — a user can install Claude-Mem for memory and use Vexilo to discover the agents / commands / skills Claude-Mem is capturing context from.

### Where
New section "## Related Resources" added right before "## License" so it doesn't disrupt the current flow.

### Checklist
- [x] Open and free
- [x] Actively maintained (v1.1.9, weekly updates)
- [x] Directly relevant to Claude Code
- [x] Companion repo MIT-licensed
- [x] Doesn't duplicate anything in your README