### PR TITLE
fix: force reinstall on missing .install-version marker instead of nagging (#3092)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 **Setup hook always printed "runtime not yet set up" for marketplace-only installs (#3092).**
 
-`.install-version` is only ever written by `npx claude-mem@latest install`. Installs made purely through the Claude Code plugin marketplace never run that installer, so the marker never existed and `version-check.js` printed the same misleading "runtime not yet set up - run: npx claude-mem@latest install" hint on every Setup hook — even though `ensurePluginDependencies()` earlier in the same script had already materialized the real runtime deps for that exact install. Worse, `npx claude-mem@latest` resolves to a stale, version-mismatched npm release, so the suggested fix didn't even work.
+`.install-version` is only ever written by `npx claude-mem@latest install`. Installs made purely through the Claude Code plugin marketplace never run that installer, so the marker never existed and `version-check.js` printed the same misleading "runtime not yet set up - run: npx claude-mem@latest install" hint on every Setup hook. Worse, `npx claude-mem@latest` resolves to a stale, version-mismatched npm release, so the suggested fix didn't even work.
 
-`version-check.js` now self-heals a missing marker by stamping it with the currently-installed version instead of emitting that hint, since by the time this code runs the runtime genuinely is set up.
+A missing marker isn't always a fresh install, though: `ContextBuilder.ts` deliberately deletes it after an `ERR_DLOPEN_FAILED` to signal "native module needs rebuilding." `ensurePluginDependencies()` only reinstalled when `node_modules` was entirely missing, so that signal never actually triggered a reinstall of an already-present-but-broken `node_modules` — the marker just kept nagging until the user manually reinstalled.
+
+`version-check.js` now checks marker presence before calling `ensurePluginDependencies()`, and forces a real reinstall (clearing `node_modules` first) whenever the marker is missing, regardless of whether `node_modules` already exists. The marker is only self-healed with the current version if that reinstall actually succeeds — otherwise the original hint stays, so a genuinely broken install still has a visible, actionable signal.
 
 ### Added
-- Two cases in `tests/plugin-version-check.test.ts` covering the missing-marker self-heal and the no-renag-on-next-run behavior
+- Three cases in `tests/plugin-version-check-ensure-deps.test.ts` covering the forced reinstall (clearing stale `node_modules`), the marker self-heal on success, and no self-heal on failure
 
 ## [13.9.2] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+## Bug Fix
+
+**Setup hook always printed "runtime not yet set up" for marketplace-only installs (#3092).**
+
+`.install-version` is only ever written by `npx claude-mem@latest install`. Installs made purely through the Claude Code plugin marketplace never run that installer, so the marker never existed and `version-check.js` printed the same misleading "runtime not yet set up - run: npx claude-mem@latest install" hint on every Setup hook — even though `ensurePluginDependencies()` earlier in the same script had already materialized the real runtime deps for that exact install. Worse, `npx claude-mem@latest` resolves to a stale, version-mismatched npm release, so the suggested fix didn't even work.
+
+`version-check.js` now self-heals a missing marker by stamping it with the currently-installed version instead of emitting that hint, since by the time this code runs the runtime genuinely is set up.
+
+### Added
+- Two cases in `tests/plugin-version-check.test.ts` covering the missing-marker self-heal and the no-renag-on-next-run behavior
+
 ## [13.9.2] - 2026-07-01
 
 ## Bug Fix

--- a/plugin/scripts/version-check.js
+++ b/plugin/scripts/version-check.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from 'child_process';
-import { existsSync, readFileSync, rmSync } from 'fs';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -178,7 +178,19 @@ try {
   const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8'));
   const markerPath = join(ROOT, '.install-version');
   if (!existsSync(markerPath)) {
-    emitUpgradeHint('claude-mem: runtime not yet set up - run: npx claude-mem@latest install');
+    // Marketplace-only installs never invoke the npx CLI installer that
+    // writes this marker (only `npx claude-mem@latest install` does), so
+    // this branch fired the "runtime not yet set up" hint on every single
+    // Setup run — even though ensurePluginDependencies() above already
+    // materialized the real runtime deps for this exact install. Self-heal
+    // instead of nagging with advice that can't be acted on for these
+    // installs: stamp the marker with the version that's actually running,
+    // since executing this script IS that version's setup (#3092).
+    try {
+      writeFileSync(markerPath, JSON.stringify({ version: pkg.version }));
+    } catch {
+      emitUpgradeHint('claude-mem: runtime not yet set up - run: npx claude-mem@latest install');
+    }
     process.exit(0);
   }
   const markerVersion = readInstallMarkerVersion(markerPath);

--- a/plugin/scripts/version-check.js
+++ b/plugin/scripts/version-check.js
@@ -55,21 +55,44 @@ function findBun() {
 // has a 300s timeout (vs 60s for SessionStart), runs once per Claude
 // Code launch, and is the only standalone hook script — the natural
 // place to materialise plugin runtime state.
-function ensurePluginDependencies(pluginRoot) {
-  if (!existsSync(join(pluginRoot, 'package.json'))) return;
+//
+// Returns one of: 'no-package-json' | 'already-installed' | 'bun-not-found'
+// | 'install-error' | 'install-failed' | 'installed'. Callers use this to
+// decide whether it's safe to treat the runtime as verified (#3092).
+function ensurePluginDependencies(pluginRoot, { force = false } = {}) {
+  if (!existsSync(join(pluginRoot, 'package.json'))) return 'no-package-json';
+
+  const nodeModulesPath = join(pluginRoot, NODE_MODULES_DIRNAME);
 
   // Guard on node_modules (package-manager marker) rather than a specific
   // package, so the check stays correct if dependencies are later renamed.
-  if (existsSync(join(pluginRoot, NODE_MODULES_DIRNAME))) return;
+  // `force` bypasses this guard and clears any existing node_modules first
+  // instead of trusting it — used when the .install-version marker is
+  // missing. A missing marker can mean a fresh marketplace-only install
+  // (node_modules is missing too, so this is a no-op either way) OR
+  // ContextBuilder.ts deliberately deleting the marker after an
+  // ERR_DLOPEN_FAILED to signal a native module needs rebuilding — in that
+  // case node_modules exists but is broken, and the non-forced guard below
+  // would wrongly treat it as fine and skip reinstalling it (#3092).
+  if (force) {
+    try {
+      rmSync(nodeModulesPath, { recursive: true, force: true });
+    } catch (rmErr) {
+      const rmReason = rmErr && rmErr.message ? rmErr.message : String(rmErr);
+      console.error(`${VERSION_CHECK_LOG_PREFIX} failed to clear node_modules before forced reinstall (${rmReason})`);
+    }
+  } else if (existsSync(nodeModulesPath)) {
+    return 'already-installed';
+  }
 
   const bunPath = findBun();
   if (!bunPath) {
     console.error(`${VERSION_CHECK_LOG_PREFIX} bun not found on PATH; cannot auto-install plugin dependencies`);
-    return;
+    return 'bun-not-found';
   }
 
   // Progress diagnostic so users understand the (one-time) Setup hang.
-  console.error(`${VERSION_CHECK_LOG_PREFIX} installing plugin dependencies (first run, one-time)...`);
+  console.error(`${VERSION_CHECK_LOG_PREFIX} installing plugin dependencies (${force ? 'forced reinstall' : 'first run, one-time'})...`);
 
   let result;
   try {
@@ -83,7 +106,7 @@ function ensurePluginDependencies(pluginRoot) {
   } catch (err) {
     const reason = err && err.message ? err.message : String(err);
     console.error(`${VERSION_CHECK_LOG_PREFIX} bun install threw (${reason}); worker may crash with missing module errors`);
-    return;
+    return 'install-error';
   }
 
   // spawnSync does NOT throw on a failed child. Three distinct failure
@@ -112,17 +135,19 @@ function ensurePluginDependencies(pluginRoot) {
     // partial dir so the next Setup invocation can retry automatically
     // (gh #2650 review).
     try {
-      rmSync(join(pluginRoot, NODE_MODULES_DIRNAME), { recursive: true, force: true });
+      rmSync(nodeModulesPath, { recursive: true, force: true });
     } catch (rmErr) {
       const rmReason = rmErr && rmErr.message ? rmErr.message : String(rmErr);
       console.error(`${VERSION_CHECK_LOG_PREFIX} failed to clean up partial node_modules (${rmReason}); next Setup run may skip retry`);
     }
-  } else {
-    // Close the diagnostic loop: a Setup hook that can block for up to
-    // 120s needs an explicit completion line so users can distinguish a
-    // hung install from one that finished silently (gh #2650 review).
-    console.error(`${VERSION_CHECK_LOG_PREFIX} plugin dependencies installed successfully`);
+    return 'install-failed';
   }
+
+  // Close the diagnostic loop: a Setup hook that can block for up to
+  // 120s needs an explicit completion line so users can distinguish a
+  // hung install from one that finished silently (gh #2650 review).
+  console.error(`${VERSION_CHECK_LOG_PREFIX} plugin dependencies installed successfully`);
+  return 'installed';
 }
 
 function resolveRoot() {
@@ -141,7 +166,12 @@ function resolveRoot() {
 const ROOT = resolveRoot();
 if (!ROOT) process.exit(0);
 
-ensurePluginDependencies(ROOT);
+// Check marker presence BEFORE ensurePluginDependencies() so a missing
+// marker can force a real reinstall (bypassing the node_modules-exists
+// guard) rather than just being cosmetically re-stamped afterward (#3092).
+const MARKER_PATH = join(ROOT, '.install-version');
+const markerExistedBeforeInstall = existsSync(MARKER_PATH);
+const installOutcome = ensurePluginDependencies(ROOT, { force: !markerExistedBeforeInstall });
 
 function emitUpgradeHint(message) {
   if (process.env.CLAUDE_MEM_CODEX_HOOK === '1') {
@@ -176,19 +206,26 @@ function readInstallMarkerVersion(markerPath) {
 
 try {
   const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8'));
-  const markerPath = join(ROOT, '.install-version');
-  if (!existsSync(markerPath)) {
+  const markerPath = MARKER_PATH;
+  if (!markerExistedBeforeInstall) {
     // Marketplace-only installs never invoke the npx CLI installer that
     // writes this marker (only `npx claude-mem@latest install` does), so
     // this branch fired the "runtime not yet set up" hint on every single
-    // Setup run — even though ensurePluginDependencies() above already
-    // materialized the real runtime deps for this exact install. Self-heal
-    // instead of nagging with advice that can't be acted on for these
-    // installs: stamp the marker with the version that's actually running,
-    // since executing this script IS that version's setup (#3092).
-    try {
-      writeFileSync(markerPath, JSON.stringify({ version: pkg.version }));
-    } catch {
+    // Setup run for those installs. But a missing marker can also mean
+    // ContextBuilder.ts deliberately deleted it after an ERR_DLOPEN_FAILED
+    // to force a native-module rebuild — silently re-stamping the marker
+    // without actually fixing anything would erase that signal while the
+    // plugin stays broken. ensurePluginDependencies() above was called with
+    // force:true specifically to tell them apart: only self-heal the marker
+    // when that forced (re)install actually succeeded; otherwise keep the
+    // nag so the user still has a visible, actionable signal (#3092).
+    if (installOutcome === 'installed') {
+      try {
+        writeFileSync(markerPath, JSON.stringify({ version: pkg.version }));
+      } catch {
+        emitUpgradeHint('claude-mem: runtime not yet set up - run: npx claude-mem@latest install');
+      }
+    } else {
       emitUpgradeHint('claude-mem: runtime not yet set up - run: npx claude-mem@latest install');
     }
     process.exit(0);

--- a/tests/plugin-version-check-ensure-deps.test.ts
+++ b/tests/plugin-version-check-ensure-deps.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { spawn } from 'child_process';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, resolve } from 'path';
 
@@ -62,7 +62,11 @@ function runVersionCheck(pluginRoot: string, fakeBinDir: string): Promise<{ stde
 
 type BunBehavior = 'success' | 'partial-then-fail';
 
-function makeFreshPlugin(name: string, bunBehavior: BunBehavior = 'success'): { pluginRoot: string; fakeBinDir: string } {
+function makeFreshPlugin(
+  name: string,
+  bunBehavior: BunBehavior = 'success',
+  { writeMarker = true } = {},
+): { pluginRoot: string; fakeBinDir: string } {
   const pluginRoot = join(tmpRoot, name);
   mkdirSync(pluginRoot, { recursive: true });
   writeFileSync(join(pluginRoot, 'package.json'), JSON.stringify({
@@ -70,7 +74,9 @@ function makeFreshPlugin(name: string, bunBehavior: BunBehavior = 'success'): { 
     version: '0.0.0',
     dependencies: { zod: '^3.0.0' },
   }));
-  writeFileSync(join(pluginRoot, '.install-version'), JSON.stringify({ version: '0.0.0' }));
+  if (writeMarker) {
+    writeFileSync(join(pluginRoot, '.install-version'), JSON.stringify({ version: '0.0.0' }));
+  }
 
   const fakeBinDir = join(pluginRoot, '.bin');
   mkdirSync(fakeBinDir, { recursive: true });
@@ -168,4 +174,58 @@ describe.skipIf(SKIP_NON_UNIX)('version-check Setup-phase ensurePluginDependenci
     // absence proves the install path was not taken.
     expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(false);
   });
+});
+
+describe.skipIf(SKIP_NON_UNIX)('version-check missing-marker forced reinstall (#3092)', () => {
+  // ContextBuilder.ts deletes .install-version after an ERR_DLOPEN_FAILED to
+  // signal "native module needs rebuilding" — node_modules exists but is
+  // broken. A missing marker must NOT be treated as "already installed";
+  // ensurePluginDependencies() must clear node_modules and reinstall for
+  // real, and the marker should only be self-healed if that succeeds.
+
+  test('forces a reinstall (clearing existing node_modules) when the marker is missing', async () => {
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-missing-marker-force', 'success', { writeMarker: false });
+    // Simulate a broken-but-present node_modules from a prior install whose
+    // native module now fails to load (the ContextBuilder.ts scenario) —
+    // a stale file the fake "success" bun script does not itself create.
+    mkdirSync(join(pluginRoot, 'node_modules', 'zod', 'v3'), { recursive: true });
+    writeFileSync(join(pluginRoot, 'node_modules', 'zod', 'v3', 'stale-broken-binary'), 'stale');
+    expect(existsSync(join(pluginRoot, '.install-version'))).toBe(false);
+
+    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
+    // The forced path must actually invoke bun, not skip because
+    // node_modules already existed.
+    expect(stderr).toContain(INSTALL_DIAGNOSTIC);
+    expect(stderr).toContain(INSTALL_SUCCESS_DIAGNOSTIC);
+    expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(true);
+    // The stale pre-existing file must be gone — proof node_modules was
+    // actually cleared before reinstalling, not left in place.
+    expect(existsSync(join(pluginRoot, 'node_modules', 'zod', 'v3', 'stale-broken-binary'))).toBe(false);
+  }, SPAWN_TIMEOUT_MS + 5000);
+
+  test('self-heals the marker with the current version after a successful forced reinstall', async () => {
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-missing-marker-self-heal', 'success', { writeMarker: false });
+    mkdirSync(join(pluginRoot, 'node_modules'), { recursive: true });
+
+    const { code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
+    const markerPath = join(pluginRoot, '.install-version');
+    expect(existsSync(markerPath)).toBe(true);
+    expect(JSON.parse(readFileSync(markerPath, 'utf-8'))).toEqual({ version: '0.0.0' });
+  }, SPAWN_TIMEOUT_MS + 5000);
+
+  test('does not self-heal the marker (and keeps the actionable hint) if the forced reinstall fails', async () => {
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-missing-marker-force-fail', 'partial-then-fail', { writeMarker: false });
+    mkdirSync(join(pluginRoot, 'node_modules'), { recursive: true });
+
+    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
+    expect(stderr).toContain(INSTALL_FAILURE_DIAGNOSTIC);
+    expect(stderr).toContain('claude-mem: runtime not yet set up - run: npx claude-mem@latest install');
+    expect(existsSync(join(pluginRoot, '.install-version'))).toBe(false);
+  }, SPAWN_TIMEOUT_MS + 5000);
 });

--- a/tests/plugin-version-check.test.ts
+++ b/tests/plugin-version-check.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'fs';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { spawnSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -66,30 +66,11 @@ describe('plugin/scripts/version-check.js install marker compatibility', () => {
       'claude-mem: upgraded to v12.4.4 - run: npx claude-mem@latest install',
     );
   });
-
-  // Marketplace-only installs never invoke the npx CLI installer that writes
-  // .install-version, so a missing marker used to permanently emit "runtime
-  // not yet set up" on every Setup run — even though ensurePluginDependencies()
-  // already materialized the real deps for this exact install (#3092).
-  it('self-heals a missing install marker instead of emitting an unresolvable hint', () => {
-    const markerPath = join(tempDir, '.install-version');
-    expect(existsSync(markerPath)).toBe(false);
-
-    const result = runVersionCheck(tempDir);
-
-    expect(result.status).toBe(0);
-    expect(result.stderr).toBe('');
-    expect(existsSync(markerPath)).toBe(true);
-    expect(JSON.parse(readFileSync(markerPath, 'utf-8'))).toEqual({ version: '12.4.4' });
-  });
-
-  it('does not re-nag on the run immediately after self-healing a missing marker', () => {
-    runVersionCheck(tempDir);
-
-    const result = runVersionCheck(tempDir);
-
-    expect(result.status).toBe(0);
-    expect(result.stdout).toBe('');
-    expect(result.stderr).toBe('');
-  });
 });
+
+// The missing-marker self-heal path (#3092) forces ensurePluginDependencies()
+// to bypass its node_modules-exists guard (see plugin/scripts/version-check.js),
+// so it needs a real or faked `bun` on PATH to exercise deterministically.
+// That coverage lives in tests/plugin-version-check-ensure-deps.test.ts,
+// which already has fake-bun infrastructure for this — this file stays
+// scoped to marker-format compatibility with dependencies pre-verified.

--- a/tests/plugin-version-check.test.ts
+++ b/tests/plugin-version-check.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'fs';
 import { spawnSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -65,5 +65,31 @@ describe('plugin/scripts/version-check.js install marker compatibility', () => {
     expect(result.stderr).toContain(
       'claude-mem: upgraded to v12.4.4 - run: npx claude-mem@latest install',
     );
+  });
+
+  // Marketplace-only installs never invoke the npx CLI installer that writes
+  // .install-version, so a missing marker used to permanently emit "runtime
+  // not yet set up" on every Setup run — even though ensurePluginDependencies()
+  // already materialized the real deps for this exact install (#3092).
+  it('self-heals a missing install marker instead of emitting an unresolvable hint', () => {
+    const markerPath = join(tempDir, '.install-version');
+    expect(existsSync(markerPath)).toBe(false);
+
+    const result = runVersionCheck(tempDir);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(existsSync(markerPath)).toBe(true);
+    expect(JSON.parse(readFileSync(markerPath, 'utf-8'))).toEqual({ version: '12.4.4' });
+  });
+
+  it('does not re-nag on the run immediately after self-healing a missing marker', () => {
+    runVersionCheck(tempDir);
+
+    const result = runVersionCheck(tempDir);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('');
   });
 });


### PR DESCRIPTION
## Summary

Fixes Bug 2 from #3092: the Setup hook printed "runtime not yet set up - run: npx claude-mem@latest install" on every single Setup run for installs made purely through the Claude Code plugin marketplace, since `.install-version` is only ever written by the npx CLI installer, which those installs never invoke. The suggested fix didn't even work — `npx claude-mem@latest` resolves to a stale, version-mismatched npm release.

This PR went through two rounds of review. The first (committed as [9607a33](https://github.com/thedotmack/claude-mem/commit/9607a33)) simply self-healed the marker by writing it whenever missing. Review caught a real regression: `ContextBuilder.ts` deliberately deletes `.install-version` after an `ERR_DLOPEN_FAILED` to signal "native module needs rebuilding" — but `ensurePluginDependencies()` only ever reinstalled when `node_modules` was entirely missing, never when it existed but contained a broken native binary. The naive self-heal would have silently erased that recovery signal on the very next Setup run without actually fixing anything.

The corrected fix (this PR's current state):

- `version-check.js` now checks marker presence **before** calling `ensurePluginDependencies()`, and passes `force: true` when the marker is missing.
- `ensurePluginDependencies(pluginRoot, { force })` now clears any existing `node_modules` first and always reinstalls when forced — instead of trusting `node_modules`'s mere existence — and returns an outcome string instead of void.
- The marker is only self-healed with the current version when that reinstall actually reports `'installed'`. Any other outcome (bun not found, install failed) falls through to the original hint, so a genuinely broken install still has a visible, actionable signal.

This preserves the `ContextBuilder.ts` native-rebuild recovery path while fixing the false nag for the common marketplace-only-install case.

## Test plan

- [x] Three new cases in `tests/plugin-version-check-ensure-deps.test.ts` (reusing the file's existing fake-`bun` infrastructure): forces a reinstall and clears stale `node_modules` when the marker is missing, self-heals the marker after a successful forced reinstall, does not self-heal (keeps the hint) if the forced reinstall fails
- [x] Reverted two tests from an earlier commit in `tests/plugin-version-check.test.ts` — that file's `beforeEach` pre-seeds `node_modules` specifically to keep dependency-install logic out of scope for marker-format tests, which no longer holds once a missing marker can trigger `force:true`; real coverage now lives in the ensure-deps file instead
- [x] Confirmed via `git stash` on just `plugin/scripts/version-check.js` that the new tests correctly fail against the old code (empty stderr where an install diagnostic was expected)
- [x] `npm run typecheck` passes
- [ ] Full `npm run build` and complete `bun test` suite — not run locally (relying on this repo's CI, same as #3102)