### PR TITLE
Fix empty folder CLAUDE.md and Chroma observation sync

### DIFF
--- a/src/services/sync/ChromaSync.ts
+++ b/src/services/sync/ChromaSync.ts
@@ -2,18 +2,18 @@
 import { ChromaMcpManager } from './ChromaMcpManager.js';
 import { ChromaSyncState, ProjectWatermarks } from './ChromaSyncState.js';
 import { ParsedObservation, ParsedSummary } from '../../sdk/parser.js';
-// cmem-sdk: keep SessionStore + parseFileList off the SDK's import graph.
-// Both come from the SQLite layer (`bun:sqlite`). The SDK only uses the
-// constructor + ensureCollectionExists + close() surface of ChromaSync,
-// so a TYPE-ONLY import is sufficient — value-level uses (`new
-// SessionStore()` / parseFileList(...)) are loaded lazily inside the
-// SQLite-only methods that need them. Plan §3 anti-pattern: do NOT add
-// `bun:sqlite` to the SDK bundle externals — fix the import chain.
+// cmem-sdk: keep SessionStore off the SDK's import graph. It comes from the
+// SQLite layer (`bun:sqlite`). The SDK only uses the constructor +
+// ensureCollectionExists + close() surface of ChromaSync, so a TYPE-ONLY
+// import is sufficient — the value-level use (`new SessionStore()`) is loaded
+// lazily inside the SQLite-only backfill methods that need it. Plan §3
+// anti-pattern: do NOT add `bun:sqlite` to the SDK bundle externals — fix the
+// import chain.
 import type { SessionStore as SessionStoreType } from '../sqlite/SessionStore.js';
 import { logger } from '../../utils/logger.js';
 import { ChromaUnavailableError } from '../worker/search/errors.js';
 import { normalizePlatformSource } from '../../shared/platform-source.js';
-import type * as SqliteFilesModule from '../sqlite/observations/files.js';
+import { parseFileList } from '../sqlite/observations/files.js';
 
 type SessionStore = SessionStoreType;
 type SessionStoreCtor = new () => SessionStoreType;
@@ -38,14 +38,6 @@ function loadSessionStoreCtor(): SessionStoreCtor {
   return _sessionStoreCtor;
 }
 
-let _filesHelper: typeof SqliteFilesModule | undefined;
-function loadFilesHelper(): typeof SqliteFilesModule {
-  if (!_filesHelper) {
-    const req = lazyCreateRequire();
-    _filesHelper = req('../sqlite/observations/files.js') as typeof SqliteFilesModule;
-  }
-  return _filesHelper;
-}
 
 // Exported for cmem-sdk Phase 6: the SDK builds ChromaDocument values from
 // Postgres observations (UUID id, content string, metadata bag) and calls
@@ -152,12 +144,8 @@ export class ChromaSync {
 
     const facts = obs.facts ? JSON.parse(obs.facts) : [];
     const concepts = obs.concepts ? JSON.parse(obs.concepts) : [];
-    // parseFileList is SQLite-shaped (`bun:sqlite` in the import chain) —
-    // resolve it through the deferred loader so this method stays out of
-    // the SDK bundle's import graph. Plan §3.
-    const filesHelper = loadFilesHelper();
-    const files_read = filesHelper.parseFileList(obs.files_read);
-    const files_modified = filesHelper.parseFileList(obs.files_modified);
+    const files_read = parseFileList(obs.files_read);
+    const files_modified = parseFileList(obs.files_modified);
 
     const baseMetadata: Record<string, string | number | null> = {
       sqlite_id: obs.id,
@@ -625,8 +613,7 @@ export class ChromaSync {
 
     const watermarks = ChromaSyncState.get(backfillProject);
 
-    const SessionStoreCtor = loadSessionStoreCtor();
-    const db = storeOverride ?? new SessionStoreCtor();
+    const db = storeOverride ?? new (loadSessionStoreCtor())();
 
     try {
       await this.runBackfillPipeline(db, backfillProject, watermarks);
@@ -1048,8 +1035,7 @@ export class ChromaSync {
     let db: SessionStore | undefined;
     let sync: ChromaSync | undefined;
     try {
-      const SessionStoreCtor = loadSessionStoreCtor();
-      db = storeOverride ?? new SessionStoreCtor();
+      db = storeOverride ?? new (loadSessionStoreCtor())();
       sync = new ChromaSync('claude-mem');
     } catch (error) {
       logger.error('CHROMA_SYNC', 'Failed to initialize backfill resources',

--- a/src/services/worker/search/strategies/HybridSearchStrategy.ts
+++ b/src/services/worker/search/strategies/HybridSearchStrategy.ts
@@ -76,8 +76,8 @@ export class HybridSearchStrategy {
     sessions: SessionSummarySearchResult[];
     usedChroma: boolean;
   }> {
-    const { limit = SEARCH_CONSTANTS.DEFAULT_LIMIT, project, platformSource, dateRange, orderBy } = options;
-    const filterOptions = { limit, project, platformSource, dateRange, orderBy };
+    const { limit = SEARCH_CONSTANTS.DEFAULT_LIMIT, project, platformSource, dateRange, orderBy, isFolder } = options;
+    const filterOptions = { limit, project, platformSource, dateRange, orderBy, isFolder };
 
     logger.debug('SEARCH', 'HybridSearchStrategy: findByFile', { filePath });
 
@@ -154,6 +154,12 @@ export class HybridSearchStrategy {
     const rankedIds = this.intersectWithRanking(metadataIds, chromaResults.ids);
 
     if (rankedIds.length > 0) {
+      for (const id of metadataIds) {
+        if (!rankedIds.includes(id)) {
+          rankedIds.push(id);
+        }
+      }
+
       const observations = this.sessionStore.getObservationsByIds(rankedIds, {
         orderBy: 'relevance',
         limit: options.limit,
@@ -165,15 +171,11 @@ export class HybridSearchStrategy {
       return { observations, sessions, usedChroma: true };
     }
 
-    if (options.platformSource) {
-      return {
-        observations: this.sortMetadataFallback(fallbackObservations, options.limit, options.orderBy),
-        sessions,
-        usedChroma: false
-      };
-    }
-
-    return { observations: [], sessions, usedChroma: false };
+    return {
+      observations: this.sortMetadataFallback(fallbackObservations, options.limit, options.orderBy),
+      sessions,
+      usedChroma: false
+    };
   }
 
   private sortMetadataFallback(

--- a/src/utils/claude-md-utils.ts
+++ b/src/utils/claude-md-utils.ts
@@ -318,10 +318,11 @@ export async function updateFolderClaudeMdFiles(
   });
 
   for (const folderPath of folderPaths) {
+    const queryPath = projectRoot ? path.relative(projectRoot, folderPath) : folderPath;
     let response: Response;
     try {
       response = await workerHttpRequest(
-        `/api/search/by-file?filePath=${encodeURIComponent(folderPath)}&limit=${limit}&project=${encodeURIComponent(project)}&isFolder=true`
+        `/api/search/by-file?filePath=${encodeURIComponent(queryPath)}&limit=${limit}&project=${encodeURIComponent(project)}&isFolder=true`
       );
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);

--- a/src/utils/claude-md-utils.ts
+++ b/src/utils/claude-md-utils.ts
@@ -348,10 +348,8 @@ export async function updateFolderClaudeMdFiles(
 
     const formatted = formatTimelineForClaudeMd(result.content[0].text);
 
-    const claudeMdPath = path.join(folderPath, targetFilename);
     const hasNoActivity = formatted.includes('*No recent activity*');
     const isEmptyOrSkeleton = formatted.trim() === '' || hasNoActivity;
-    const fileExists = existsSync(claudeMdPath);
 
     // #2400 — when the generated content is empty/skeleton AND the folder
     // matches the user's deny-list, never inject (skip even if the file exists,
@@ -361,7 +359,7 @@ export async function updateFolderClaudeMdFiles(
       continue;
     }
 
-    if (hasNoActivity && !fileExists) {
+    if (isEmptyOrSkeleton) {
       logger.debug('FOLDER_INDEX', 'Skipping empty context file creation', { folderPath, targetFilename });
       continue;
     }

--- a/tests/utils/claude-md-utils.test.ts
+++ b/tests/utils/claude-md-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, mock, afterEach, afterAll, beforeEach } from 'bun:test';
 import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
-import path, { join } from 'path';
+import path, { join, relative } from 'path';
 import { tmpdir } from 'os';
 
 // Snapshot the real modules BEFORE mock.module mutates the live namespace, then
@@ -397,7 +397,7 @@ describe('updateFolderClaudeMdFiles', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const callUrl = (fetchMock.mock.calls[0] as unknown[])[0] as string;
-    expect(callUrl).toContain(encodeURIComponent('/home/user/my-project/src/utils'));
+    expect(callUrl).toContain(encodeURIComponent('src/utils'));
   });
 
   it('should accept absolute paths within projectRoot and use them directly', async () => {
@@ -420,12 +420,12 @@ describe('updateFolderClaudeMdFiles', () => {
       [filePath],  // absolute path within tempDir
       'test-project',
       37777,
-      tempDir  
+      tempDir
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const callUrl = (fetchMock.mock.calls[0] as unknown[])[0] as string;
-    expect(callUrl).toContain(encodeURIComponent(folderPath));
+    expect(callUrl).toContain(encodeURIComponent(relative(tempDir, folderPath)));
   });
 
   it('should work without projectRoot for backward compatibility', async () => {
@@ -478,7 +478,7 @@ describe('updateFolderClaudeMdFiles', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const callUrl = (fetchMock.mock.calls[0] as unknown[])[0] as string;
-    expect(callUrl).toContain(encodeURIComponent('/home/user/my-project/src/utils'));
+    expect(callUrl).toContain(encodeURIComponent('src/utils'));
     expect(callUrl.replace('http://', '')).not.toContain('//');
   });
 
@@ -534,7 +534,7 @@ describe('updateFolderClaudeMdFiles', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const callUrl = (fetchMock.mock.calls[0] as unknown[])[0] as string;
-    expect(callUrl).toContain(encodeURIComponent('/home/user/project/src/utils'));
+    expect(callUrl).toContain(encodeURIComponent('src/utils'));
   });
 
   it('should handle empty string paths gracefully with projectRoot', async () => {
@@ -556,7 +556,7 @@ describe('updateFolderClaudeMdFiles', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const callUrl = (fetchMock.mock.calls[0] as unknown[])[0] as string;
-    expect(callUrl).toContain(encodeURIComponent('/home/user/project/src'));
+    expect(callUrl).toContain(encodeURIComponent('src'));
   });
 });
 
@@ -809,8 +809,8 @@ describe('issue #859 - skip folders with active CLAUDE.md', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const callUrl = (fetchMock.mock.calls[0] as unknown[])[0] as string;
-    expect(callUrl).toContain(encodeURIComponent('/project/src/services'));
-    expect(callUrl).not.toContain(encodeURIComponent('/project/src/utils'));
+    expect(callUrl).toContain(encodeURIComponent('src/services'));
+    expect(callUrl).not.toContain(encodeURIComponent('src/utils'));
   });
 
   it('should handle relative CLAUDE.md paths with projectRoot', async () => {
@@ -850,7 +850,7 @@ describe('issue #859 - skip folders with active CLAUDE.md', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const callUrl = (fetchMock.mock.calls[0] as unknown[])[0] as string;
-    expect(callUrl).toContain(encodeURIComponent('/project/src/c'));
+    expect(callUrl).toContain(encodeURIComponent('src/c'));
   });
 
   it('should still exclude project root even when CLAUDE.md filter would allow it', async () => {
@@ -1082,9 +1082,9 @@ describe('CLAUDE.local.md support', () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const callUrl = (fetchMock.mock.calls[0] as unknown[])[0] as string;
-    expect(callUrl).toContain(encodeURIComponent('/project/src/c'));
-    expect(callUrl).not.toContain(encodeURIComponent('/project/src/a'));
-    expect(callUrl).not.toContain(encodeURIComponent('/project/src/b'));
+    expect(callUrl).toContain(encodeURIComponent('src/c'));
+    expect(callUrl).not.toContain(encodeURIComponent('src/a'));
+    expect(callUrl).not.toContain(encodeURIComponent('src/b'));
   });
 });
 

--- a/tests/utils/claude-md-utils.test.ts
+++ b/tests/utils/claude-md-utils.test.ts
@@ -1152,7 +1152,7 @@ describe('skeleton CLAUDE.md deny-list (#2400)', () => {
     expect(readFileSync(claudeMdPath, 'utf-8')).toContain('#123');
   });
 
-  it('default (unset deny-list) preserves prior behavior — existing file gets the empty section rewritten', async () => {
+  it('empty/skeleton content never touches an existing file, even with no deny-list', async () => {
     delete process.env[ENV_KEY];
 
     const folderPath = join(tempDir, 'no-denylist');
@@ -1168,10 +1168,29 @@ describe('skeleton CLAUDE.md deny-list (#2400)', () => {
 
     await updateFolderClaudeMdFiles([filePath], 'test-project', 37777, tempDir);
 
-    // With no deny-list, the existing file is still processed (the new guard is
-    // a no-op), so the tagged context section is appended to the existing file.
+    // When the timeline parses to no observations, `formatted` is '' — the guard
+    // now skips unconditionally, so we neither inject an empty wrapper nor wipe
+    // the existing file down to a 43-byte skeleton. The file is left untouched.
     const content = readFileSync(claudeMdPath, 'utf-8');
-    expect(content).toContain('PRE-EXISTING');
-    expect(content).toContain('<claude-mem-context>');
+    expect(content).toBe('PRE-EXISTING');
+    expect(content).not.toContain('<claude-mem-context>');
+  });
+
+  it('does not create an empty skeleton CLAUDE.md in a folder with no observations', async () => {
+    delete process.env[ENV_KEY];
+
+    const folderPath = join(tempDir, 'no-obs');
+    mkdirSync(folderPath, { recursive: true });
+    const claudeMdPath = join(folderPath, 'CLAUDE.md');
+    const filePath = join(folderPath, 'file.ts');
+
+    global.fetch = mock(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(emptySkeletonResponse),
+    } as Response));
+
+    await updateFolderClaudeMdFiles([filePath], 'test-project', 37777, tempDir);
+
+    expect(existsSync(claudeMdPath)).toBe(false);
   });
 });


### PR DESCRIPTION
## Symptoms

Two user-visible failures this fixes:

1. Generated folder CLAUDE.md files always contained an empty
   `<claude-mem-context>` wrapper (or no useful content).
2. Every observation vector sync logged and failed:

   ```
   [🔮 CHROMA ] SDK chroma sync failed, continuing without vector search {obsId=1526, type=discovery, title=...} {}
   ```

## Root causes

**Empty folder CLAUDE.md** — `updateFolderClaudeMdFiles` queried the by-file
search with the *absolute* folder path, but observations persist
*project-relative* file paths. The SQL `LIKE %path%` never matched, so every
folder returned zero results and produced empty/skeleton content. Two
follow-on bugs compounded it: `isFolder` was dropped before reaching
`SessionSearch` (folder queries degraded to exact-file lookups), and the
metadata fallback was gated on `platformSource`, so a by-file/folder lookup
returned nothing whenever Chroma was empty, stale, or mid-backfill.

**Chroma sync failures** — `syncObservation` loaded `parseFileList` via a lazy
`createRequire(import.meta.url)('../sqlite/observations/files.js')`. In the
esbuild worker bundle `import.meta.url` is the bundle path, so the relative
require resolved to a nonexistent location and threw "Cannot find module"
before any sync ran. `parseFileList` is pure (imports only `logger`, no
`bun:sqlite`), so it is now a static import — inlined into the worker bundle,
still absent from the SDK bundle. The backfill path had the same shape: it
called `loadSessionStoreCtor()` unconditionally even when a store was
injected, so it now only falls back to the lazy require when none is given.

## Changes

- Query folder observations by project-relative path (commit 1).
- Forward `isFolder` through `HybridSearchStrategy.findByFile`.
- Return the complete metadata set on file/folder lookups regardless of
  Chroma state (Chroma only reorders, never drops exact matches).
- Static `parseFileList` import; conditional `SessionStore` lazy load.
- Never write an empty/skeleton folder CLAUDE.md (commit 2).

## Verification

- `build:sdk` + `check:sdk-bundle` green — SDK bundle still free of
  `bun:sqlite` and other shell-only deps.
- `tests/utils/claude-md-utils.test.ts`: 69 pass, added regression coverage
  for no-observation folders and empty-content-leaves-file-untouched.
