### PR TITLE
fix(security): add Skill/Workflow/SlashCommand/ExitPlanMode to Observer deny-list

### DIFF
--- a/src/sdk/hardened-options.ts
+++ b/src/sdk/hardened-options.ts
@@ -59,7 +59,11 @@ export const OBSERVER_DISALLOWED_TOOLS = [
   'Task',           // No spawning sub-agents
   'NotebookEdit',   // No notebook editing
   'AskUserQuestion',// No asking questions
-  'TodoWrite',
+  'TodoWrite',      // No todo writing
+  'Skill',          // No skill invocation
+  'Workflow',       // No workflow orchestration
+  'SlashCommand',   // No slash-command execution
+  'ExitPlanMode',   // No plan-mode exit
 ] as const;
 
 export interface HardenedSdkOptionsInput {

--- a/tests/security/observer-tool-enforcement.test.ts
+++ b/tests/security/observer-tool-enforcement.test.ts
@@ -41,14 +41,24 @@ describe('Observer/KnowledgeAgent SDK tool enforcement (hardened-options)', () =
       expect(opts.allowedTools).toHaveLength(0);
     });
 
-    it('keeps the full disallowedTools deny-list (12 tools)', () => {
+    it('keeps the full disallowedTools deny-list (16 tools)', () => {
       const opts = buildHardenedSdkOptions({ ...BASE_INPUT });
       const denied = opts.disallowedTools ?? [];
       for (const tool of OBSERVER_DISALLOWED_TOOLS) {
         expect(denied).toContain(tool);
       }
+      // Explicit membership: the deny-list MUST name each of these tools by hand.
+      // A count-only assertion would pass even if a required tool were swapped for
+      // an arbitrary string, so pin the exact security contract here.
+      for (const required of [
+        'Bash', 'Read', 'Write', 'Edit', 'Grep', 'Glob', 'WebFetch', 'WebSearch',
+        'Task', 'NotebookEdit', 'AskUserQuestion', 'TodoWrite',
+        'Skill', 'Workflow', 'SlashCommand', 'ExitPlanMode',
+      ]) {
+        expect(denied).toContain(required);
+      }
       expect(denied).toHaveLength(OBSERVER_DISALLOWED_TOOLS.length);
-      expect(OBSERVER_DISALLOWED_TOOLS).toHaveLength(12);
+      expect(OBSERVER_DISALLOWED_TOOLS).toHaveLength(16);
     });
 
     it("uses the most restrictive non-interactive permissionMode ('dontAsk')", () => {
@@ -121,8 +131,13 @@ describe('Observer/KnowledgeAgent SDK tool enforcement (hardened-options)', () =
       expect(lines[0].project).toBe('demo');
     });
 
-    it('denies Bash, Edit, Read, and Task — all tool names denied', async () => {
-      for (const tool of ['Bash', 'Edit', 'Read', 'Task', 'SomeFutureUnknownTool']) {
+    it('denies Bash, Edit, Read, Task, the plan/skill tools, and unknown tools — all denied', async () => {
+      const attempted = [
+        'Bash', 'Edit', 'Read', 'Task',
+        'Skill', 'Workflow', 'SlashCommand', 'ExitPlanMode',
+        'SomeFutureUnknownTool',
+      ];
+      for (const tool of attempted) {
         const result = await callCanUseTool({ ...BASE_INPUT }, tool, { x: 1 });
         expect(result.behavior).toBe('deny');
         if (result.behavior === 'deny') {
@@ -131,7 +146,7 @@ describe('Observer/KnowledgeAgent SDK tool enforcement (hardened-options)', () =
         }
       }
       const lines = readAuditLines();
-      expect(lines).toHaveLength(5);
+      expect(lines).toHaveLength(attempted.length);
       expect(lines.every((l) => l.result === 'denied')).toBe(true);
     });
 


### PR DESCRIPTION
## What

Add four newer built-in tools — `Skill`, `Workflow`, `SlashCommand`, `ExitPlanMode` — to
`OBSERVER_DISALLOWED_TOOLS` in `src/sdk/hardened-options.ts`, and update the security test to
match (count `12` → `16`, plus stronger assertions).

## Why

The Observer / KnowledgeAgent background sessions are locked down to **zero tool access** via the
defense-in-depth stack in `hardened-options.ts` (`tools: []`, `allowedTools: []`,
`disallowedTools`, `permissionMode: 'dontAsk'`, and the `canUseTool` backstop). The explicit
`disallowedTools` "suspenders" layer named 12 tools but was missing these four, which have since
become built-ins.

In a headless, tool-less Observer context these four tools are non-functional, and leaving them
off the **explicitly named** deny-list means the SDK does not short-circuit them at the
`disallowedTools` layer — the attempts fall through to the `canUseTool` backstop, wasting model
round-trips (and tokens) on tool calls that can never succeed. Naming them:

- lets the SDK's own `disallowedTools` layer reject them earlier, cutting the wasted attempts, and
- keeps `OBSERVER_DISALLOWED_TOOLS` an accurate, self-documenting record of what the lockdown
  intends to block.

This is **not a security-posture change**: `tools: []` and the `canUseTool` backstop already deny
*every* tool (including unknown ones — see the existing `SomeFutureUnknownTool` test). This only
extends the explicit named layer + docs, consistent with the existing 12 entries.

Downstream, users have been hand-patching the built `plugin/scripts/worker-service.cjs` after each
upgrade to get this effect; that patch is lost on every version bump. Fixing it at the source makes
it durable.

## Scope

Two files only:

- `src/sdk/hardened-options.ts` — the four tools appended to `OBSERVER_DISALLOWED_TOOLS`.
- `tests/security/observer-tool-enforcement.test.ts` —
  - deny-list count `12` → `16`;
  - **explicit per-tool membership assertions** so the count test can no longer pass if a required
    tool name is silently swapped for an arbitrary string;
  - the `canUseTool` denial test extended to cover the four new names (audit-line count derived
    from the list length rather than hardcoded).

The built bundle `plugin/scripts/worker-service.cjs` is intentionally **not** touched here — it is
regenerated from source by `scripts/build-hooks.js` during the release build.

## Testing

```
bun test tests/security/observer-tool-enforcement.test.ts
# 13 pass, 0 fail, 89 expect() calls
```

## Notes for the maintainer

- I did not touch the stale SDK-version comment in `hardened-options.ts` (`verified against …
  v0.2.141`, while the package now depends on a newer `@anthropic-ai/claude-agent-sdk`) — it is
  pre-existing and out of scope for this change; happy to refresh it in a follow-up if you'd like.
- I'm not claiming a measured token number here — the concrete win is eliminating the wasted
  retry round-trips for these four names and keeping the deny-list durable across upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
