### PR TITLE
fix(chroma): static-import parseFileList so worker backfill stops crashing on missing sqlite/observations/files.js (#3126, #3107)

### DIFF
--- a/src/services/sync/ChromaSync.ts
+++ b/src/services/sync/ChromaSync.ts
@@ -2,38 +2,23 @@
 import { ChromaMcpManager } from './ChromaMcpManager.js';
 import { ChromaSyncState, ProjectWatermarks } from './ChromaSyncState.js';
 import { ParsedObservation, ParsedSummary } from '../../sdk/parser.js';
-// cmem-sdk: keep SessionStore + parseFileList off the SDK's import graph.
-// Both come from the SQLite layer (`bun:sqlite`). The SDK never calls the
-// SQLite-only methods of ChromaSync, so a TYPE-ONLY import is sufficient —
-// the value-level use (parseFileList(...)) is loaded lazily inside the
-// methods that need it. Plan §3 anti-pattern: do NOT add `bun:sqlite` to
-// the SDK bundle externals — fix the import chain.
+// cmem-sdk: SessionStore stays a TYPE-ONLY import — it pulls in `bun:sqlite`
+// and the SDK never calls the SQLite-only methods of ChromaSync.
 import type { SessionStore as SessionStoreType } from '../sqlite/SessionStore.js';
 import { logger } from '../../utils/logger.js';
 import { ChromaUnavailableError } from '../worker/search/errors.js';
 import { normalizePlatformSource } from '../../shared/platform-source.js';
-import type * as SqliteFilesModule from '../sqlite/observations/files.js';
+// parseFileList is a pure helper (JSON.parse over a text column) — its import
+// chain (files.ts -> logger -> paths/hook-io) is `bun:sqlite`-free, so a plain
+// static import is safe for BOTH bundles. It was previously loaded via a lazy
+// createRequire('../sqlite/observations/files.js') on the mistaken assumption
+// that files.ts was SQLite-coupled; esbuild does not follow that dynamic
+// require, so the worker build emitted neither the inlined helper nor the
+// sidecar file, and the backfill path crashed at runtime with
+// `Cannot find module '../sqlite/observations/files.js'`. See #3126 / #3107.
+import { parseFileList } from '../sqlite/observations/files.js';
 
 type SessionStore = SessionStoreType;
-
-// Lazy CJS require so tsup (used by the cmem-sdk build) does not follow
-// these SQLite-coupled modules into the SDK bundle. Worker/Bun runtime
-// reaches them at first call; the SDK never calls the methods that
-// trigger these loads, so they never load in SDK consumers.
-const lazyCreateRequire = (): ((id: string) => unknown) => {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const mod = require('module') as typeof import('module');
-  return mod.createRequire(import.meta.url);
-};
-
-let _filesHelper: typeof SqliteFilesModule | undefined;
-function loadFilesHelper(): typeof SqliteFilesModule {
-  if (!_filesHelper) {
-    const req = lazyCreateRequire();
-    _filesHelper = req('../sqlite/observations/files.js') as typeof SqliteFilesModule;
-  }
-  return _filesHelper;
-}
 
 // Exported for cmem-sdk Phase 6: the SDK builds ChromaDocument values from
 // Postgres observations (UUID id, content string, metadata bag) and calls
@@ -140,12 +125,8 @@ export class ChromaSync {
 
     const facts = obs.facts ? JSON.parse(obs.facts) : [];
     const concepts = obs.concepts ? JSON.parse(obs.concepts) : [];
-    // parseFileList is SQLite-shaped (`bun:sqlite` in the import chain) —
-    // resolve it through the deferred loader so this method stays out of
-    // the SDK bundle's import graph. Plan §3.
-    const filesHelper = loadFilesHelper();
-    const files_read = filesHelper.parseFileList(obs.files_read);
-    const files_modified = filesHelper.parseFileList(obs.files_modified);
+    const files_read = parseFileList(obs.files_read);
+    const files_modified = parseFileList(obs.files_modified);
 
     const baseMetadata: Record<string, string | number | null> = {
       sqlite_id: obs.id,


### PR DESCRIPTION
## Summary

Fixes the Chroma **backfill crash** reported in #3126 (Bug 1) and the packaging gap diagnosed in #3107: at runtime the worker throws

```
[CHROMA_SYNC] Backfill failed: Cannot find module '../sqlite/observations/files.js'
  from '.../scripts/worker-service.cjs'
[CHROMA] SDK chroma sync failed, continuing without vector search
```

Observations keep landing in SQLite, but never reach Chroma — semantic/vector search is silently dead for any project with a watermark gap.

## Root cause

`ChromaSync` loaded `parseFileList` through a lazy `createRequire('../sqlite/observations/files.js')`:

```ts
import type * as SqliteFilesModule from '../sqlite/observations/files.js'; // type-only, erased at build
...
_filesHelper = req('../sqlite/observations/files.js'); // dynamic createRequire
```

esbuild (which builds `worker-service.cjs`) **does not follow dynamic `createRequire` calls**. Since the only value-level reference was that dynamic require, esbuild emitted **neither** an inlined copy of the helper **nor** a sidecar `scripts/sqlite/observations/files.js` file. The published bundle ships `worker-service.cjs` with a `require('../sqlite/observations/files.js')` in the backfill path but no `sqlite/` directory anywhere in the package — exactly as #3126/#3107 observed.

The lazy require was justified by a comment stating `files.ts` is SQLite-coupled (*"`bun:sqlite` in the import chain"*). That's not accurate: `files.ts` only imports `logger`, and its full transitive chain (`files.ts → logger → paths/hook-io`) is **`bun:sqlite`-free**. So the dynamic require protected against a coupling that doesn't exist.

## Fix

Replace the type-only import + lazy `createRequire` loader with a **plain static import**:

```ts
import { parseFileList } from '../sqlite/observations/files.js';
```

Because the chain is `bun:sqlite`-free, this is safe for **both** bundles — the worker (esbuild) and the SDK (tsup) — and lets esbuild inline the helper directly into `worker-service.cjs`. `SessionStore` stays a type-only import (it genuinely pulls in `bun:sqlite`).

Net: **−32 / +13**, one file.

## Verification

Bundled `ChromaSync.ts` with the worker build's exact esbuild options (`--bundle --platform=node --format=cjs --target=node18` + the same externals as `scripts/build-hooks.js`) and inspected the output:

- ✅ **No** `require()` of `sqlite/observations/files` remains (only esbuild's inlined-module header comment).
- ✅ `createRequire` shim: gone.
- ✅ `parseFileList` body inlined into the bundle (the `File list is not JSON` branch is present).
- ✅ esbuild build succeeds (the `import.meta` warning is the same benign one the official build already suppresses via `logLevel: 'error'`).

## Not covered here

This PR fixes **only Bug 1** (backfill crash / missing module). The two other items in #3126 are out of scope and left for follow-ups:

1. The `[CHROMA]` real-time error logging serializing `Error` to `{}` (should log `message`/`stack`).
2. Bug 2 — the `search` MCP tool ignoring its `query` parameter.
