### PR TITLE
docs: release-branch strategy (main/core-dev/community-edge) + run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,11 @@ Contributions are welcome! Please:
 4. Update documentation
 5. Submit a Pull Request
 
+Claude-Mem ships from three branches: `main` (stable), `core-dev`, and
+`community-edge`. Only `main` is published to npm; the others are run from source.
+See [Release Branches](https://docs.claude-mem.ai/branches) for the strategy and
+how to run the non-stable lines locally.
+
 See [Development Guide](https://docs.claude-mem.ai/development) for contribution workflow.
 
 ---

--- a/docs/public/branches.mdx
+++ b/docs/public/branches.mdx
@@ -15,18 +15,22 @@ Claude-Mem ships from three long-lived branches. Only one is published to npm.
 
 ## How changes flow
 
-Low ceremony, solo-maintainer friendly:
+Work is **promoted upward** toward stable. Nothing lands on `main` directly.
 
-- `main` (stable) is the trunk. Releases happen **only** from `main`.
-- `main` merges **forward** into `core-dev` and `community-edge` to keep them current.
-- Validated fixes on the edge lines are promoted **back down** to `main` via normal pull requests.
+- **New work enters as a PR to `core-dev` or `community-edge`** — never to `main`.
+- `community-edge → core-dev`: promote validated bleeding-edge work up (merge, or
+  open a PR straight to `core-dev`).
+- **`core-dev → main` is the only way `main` advances.** Stable is whatever
+  `core-dev` has hardened. `main` never takes a merge from anywhere else.
 
 ```
-main ──► core-dev ──► community-edge     (forward merges keep edges current)
-main ◄── PR ◄──────── validated fixes    (promote hardened work back to stable)
+community-edge ──► core-dev ──► main
+  (new PRs, or       (new PRs land      (only ever advances
+   promote up)        here too)          by merging core-dev)
 ```
 
-There are no required gates or reviewers on the edge lines — merge at your discretion.
+Releases happen **only** from `main`. There are no required gates or reviewers on
+the edge lines — merge at your discretion.
 
 ## Which one should I use?
 

--- a/docs/public/branches.mdx
+++ b/docs/public/branches.mdx
@@ -1,0 +1,66 @@
+---
+title: "Release Branches"
+description: "The three branches Claude-Mem ships from, and how to run the non-stable lines locally"
+---
+
+# Release Branches
+
+Claude-Mem ships from three long-lived branches. Only one is published to npm.
+
+| Line               | Branch           | Who it's for                                         | Published to npm? |
+|--------------------|------------------|------------------------------------------------------|-------------------|
+| **Stable**         | `main`           | Everyone. This is the `npx claude-mem` install.      | **Yes** — the only published line |
+| **Core Dev**       | `core-dev`       | Maintainer + testers who want root-cause reliability fixes early | No — run from source |
+| **Community Edge** | `community-edge` | Bleeding edge with integrated community PRs          | No — run from source |
+
+## How changes flow
+
+Low ceremony, solo-maintainer friendly:
+
+- `main` (stable) is the trunk. Releases happen **only** from `main`.
+- `main` merges **forward** into `core-dev` and `community-edge` to keep them current.
+- Validated fixes on the edge lines are promoted **back down** to `main` via normal pull requests.
+
+```
+main ──► core-dev ──► community-edge     (forward merges keep edges current)
+main ◄── PR ◄──────── validated fixes    (promote hardened work back to stable)
+```
+
+There are no required gates or reviewers on the edge lines — merge at your discretion.
+
+## Which one should I use?
+
+- **Just want memory that works?** Use **stable**. `npx claude-mem@latest` is always `main`.
+- **Want to test root-cause worker/runtime reliability fixes before they land?** Use **core-dev**.
+- **Want the newest community integrations and don't mind rough edges?** Use **community-edge** (least stable).
+
+## Run a non-stable line locally
+
+Only `main` is published to npm, so `core-dev` and `community-edge` are run from source:
+
+```bash
+git clone https://github.com/thedotmack/claude-mem.git
+cd claude-mem
+git checkout core-dev          # or: community-edge
+npm install
+npm run build-and-sync         # builds, syncs to your local marketplace, restarts the worker
+```
+
+`build-and-sync` installs the checked-out branch into your local Claude Code
+plugin marketplace and restarts the worker, so the running plugin reflects that
+branch.
+
+### Go back to stable
+
+```bash
+git checkout main
+npm run build-and-sync
+```
+
+Or reinstall the published build with `npx claude-mem@latest`.
+
+## Releasing (maintainer)
+
+Releases (`npm run release`, `release:patch` / `release:minor` / `release:major`,
+git tags, npm publish) happen from **`main` only**. The edge lines are source-run
+and are never published to npm.

--- a/docs/public/docs.json
+++ b/docs/public/docs.json
@@ -85,6 +85,7 @@
           "modes",
           "telemetry",
           "development",
+          "branches",
           "troubleshooting",
           "platform-integration",
           "openclaw-integration"

--- a/plans/2026-07-05-three-release-branches.md
+++ b/plans/2026-07-05-three-release-branches.md
@@ -1,0 +1,106 @@
+# Plan: Three Long-Lived Release Branches (stable / core-dev / community-edge)
+
+Owner: solo maintainer (thedotmack). Repo: github.com/thedotmack/claude-mem.
+Goal: turn the three plan PRs into three permanent release lines, document the
+strategy in one place, and give clone/run instructions for the non-stable lines.
+
+## The three lines (source of truth)
+
+| Line            | Branch           | For                                          | Published to npm? |
+|-----------------|------------------|----------------------------------------------|-------------------|
+| Stable          | `main`           | Everyone. The `npx claude-mem` install.      | Yes (only line)   |
+| Core Dev        | `core-dev`       | Maintainer + testers wanting root-cause fixes | No — run from source |
+| Community Edge  | `community-edge` | Bleeding edge, integrated community PRs       | No — run from source |
+
+Flow (simplest, low-ceremony): all three start from `main`. `main` merges
+**forward** into `core-dev` and `community-edge` to keep them current. Validated
+fixes are promoted **back down** toward `main` via normal PRs. No gates, no
+required reviewers — solo maintainer discretion.
+
+## Facts (verified 2026-07-05)
+
+- PR #3141 `plan/stable-working-build` @ `f6c7f51` — base `main`. STABLE landing.
+- PR #3143 `plan/root-cause-holistic-fixes` @ `c81acee` — becomes `core-dev`.
+- PR #3142 `plan/community-bleeding-edge` @ `a20d1ac` — becomes `community-edge`.
+- No `core-dev` / `community-edge` branches exist on origin yet.
+- Docs: `docs/public/*.mdx`, nav in `docs/public/docs.json` ("Configuration & Development" group at line 79).
+- README contributing section: README.md ~line 374.
+- Non-stable run path = clone + `git checkout <branch>` + `npm install` + `npm run build-and-sync`.
+
+## Decision needed before execution (Phase 1)
+
+The two source PRs #3143 and #3142 exist to merge their content into `main`. But
+we are NOT merging them into `main` — their content becomes the permanent
+`core-dev` / `community-edge` branches instead. So after the branches are pushed,
+those two PRs are redundant.
+
+**Recommended:** create the branches from the PR heads, then **close #3143 and
+#3142** with a comment: "Promoted to long-lived branch `core-dev` /
+`community-edge`; this is now a permanent release line, not a merge-to-main."
+Keep #3141 open (or merge it) as the stable landing.
+
+Confirm before Phase 1 runs the close.
+
+---
+
+## Phase 1 — Create & publish the branches
+
+1. Create `core-dev` from PR #3143 head:
+   `git branch core-dev c81acee39a771848bd30ee26e3c52ec26d713cd1`
+   `git push origin core-dev`
+2. Create `community-edge` from PR #3142 head:
+   `git branch community-edge a20d1ac44144d4749acfd68faceda2794f3187f0`
+   `git push origin community-edge`
+3. (Per decision above) close #3143 and #3142 with the redirect comment.
+
+**Verify:** `git ls-remote --heads origin | grep -E 'core-dev|community-edge'`
+shows both refs at the expected SHAs.
+
+## Phase 2 — Author the branch-strategy doc
+
+Create `docs/public/branches.mdx`. Contents (copy this structure, don't invent):
+
+- Frontmatter: `title: "Release Branches"`, description one-liner.
+- Section "The three lines": the table above (stable/core-dev/community-edge, who
+  it's for, npm-published yes/no).
+- Section "How changes flow": `main` forward-merges into the two edge lines to
+  stay current; validated fixes promote back to `main` via PR. One diagram/line,
+  no policy ceremony.
+- Section "Which one should I use?": Stable for normal use; core-dev to test
+  root-cause reliability fixes early; community-edge for the newest community
+  integrations (least stable).
+- Section "Run a non-stable line locally":
+  ```bash
+  git clone https://github.com/thedotmack/claude-mem.git
+  cd claude-mem
+  git checkout core-dev          # or: community-edge
+  npm install
+  npm run build-and-sync         # builds + syncs to local marketplace + restarts worker
+  ```
+  Note: only `main` is published to npm, so `npx claude-mem@latest` always = stable.
+  To go back to stable: `git checkout main && npm run build-and-sync`.
+- Section "Releasing" (maintainer): releases (`npm run release`, tags, publish)
+  happen from `main` only. Edge lines are source-run and never published.
+
+**Verify:** file exists, frontmatter valid, no invented npm scripts (only real
+ones: `build-and-sync`, `release`, `release:patch|minor|major`).
+
+## Phase 3 — Wire up nav + README
+
+1. `docs/public/docs.json`: add `"branches"` to the "Configuration & Development"
+   group pages array (after `"development"`). Keep JSON valid.
+2. `README.md` contributing section (~line 374): add a short line pointing to the
+   Release Branches doc — "claude-mem ships from three branches: `main` (stable),
+   `core-dev`, `community-edge`. See [Release Branches](https://docs.claude-mem.ai/branches)."
+
+**Verify:** `node -e "JSON.parse(require('fs').readFileSync('docs/public/docs.json','utf8'))"`
+exits clean. README renders the link.
+
+## Phase 4 — Final verification
+
+- Both branches pushed at correct SHAs (`git ls-remote`).
+- `docs.json` parses.
+- `branches.mdx` present and in nav.
+- README updated.
+- (If decided) #3143 and #3142 closed with redirect comments; #3141 status unchanged.
+- Do NOT edit CHANGELOG (auto-generated).


### PR DESCRIPTION
Documents the three release lines and how to run the non-stable ones locally.

- New `docs/public/branches.mdx`: the three lines (main=stable, core-dev, community-edge), promotion flow (community-edge → core-dev → main), "which one should I use", and clone/`build-and-sync` instructions for the non-published branches.
- Adds `branches` to the docs nav.
- README contributing section points to the Release Branches doc.

This is the page the recently-closed community-PR comments link to (docs.claude-mem.ai/branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)