### PR TITLE
fix: stop double-encoding tool payloads in observation prompts

### DIFF
--- a/src/sdk/prompts.ts
+++ b/src/sdk/prompts.ts
@@ -7,8 +7,9 @@ export const SUMMARY_MODE_MARKER = 'MODE SWITCH: PROGRESS SUMMARY';
 export interface Observation {
   id: number;
   tool_name: string;
-  tool_input: string;
-  tool_output: string;
+  /** JSON text as stored by ingest (string), or a raw value from other producers. */
+  tool_input: unknown;
+  tool_output: unknown;
   created_at_epoch: number;
   cwd?: string;
 }
@@ -105,10 +106,17 @@ const OBS_PROMPT_FIELD_HEAD_RATIO = 0.6;
 const OBS_PROMPT_FIELD_TAIL_RATIO = 0.3;
 
 function truncateObservationField(value: unknown, maxChars: number = OBS_PROMPT_FIELD_MAX_CHARS): string {
-  // JSON.stringify returns undefined for undefined / functions / symbols;
-  // fall back to empty string so the call sites (template literal output)
-  // and the length check below stay well-defined.
-  const raw = JSON.stringify(value, null, 2) ?? '';
+  // Strings embed as-is: at this point a string is either plain tool output
+  // or JSON text that failed to parse in buildObservationPrompt. Running it
+  // through JSON.stringify again would escape every quote, newline, and
+  // backslash (`"` -> `\"`, LF -> `\n`), which inflates the prompt's token
+  // count, spends the maxChars budget on escape characters instead of
+  // content, and hands the observer model escaped soup instead of readable
+  // text. Non-strings serialize once, pretty-printed. JSON.stringify returns
+  // undefined for undefined / functions / symbols; fall back to empty string
+  // so the call sites (template literal output) and the length check below
+  // stay well-defined.
+  const raw = typeof value === 'string' ? value : JSON.stringify(value, null, 2) ?? '';
   if (raw.length <= maxChars) return raw;
   const headChars = Math.max(0, Math.floor(maxChars * OBS_PROMPT_FIELD_HEAD_RATIO));
   const tailChars = Math.max(0, Math.floor(maxChars * OBS_PROMPT_FIELD_TAIL_RATIO));

--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -498,8 +498,11 @@ export class ClaudeProvider {
         const obsPrompt = buildObservationPrompt({
           id: 0, // Not used in prompt
           tool_name: message.tool_name!,
-          tool_input: JSON.stringify(message.tool_input),
-          tool_output: JSON.stringify(message.tool_response),
+          // Already JSON text from ingestObservation — wrapping it in another
+          // JSON.stringify double-encodes the payload, so the prompt carried
+          // `{\"file_path\":...}` escape soup instead of readable JSON.
+          tool_input: message.tool_input,
+          tool_output: message.tool_response,
           created_at_epoch: Date.now(),
           cwd: message.cwd
         });

--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -199,8 +199,11 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     const obsPrompt = buildObservationPrompt({
       id: 0,
       tool_name: message.tool_name!,
-      tool_input: JSON.stringify(message.tool_input),
-      tool_output: JSON.stringify(message.tool_response),
+      // Already JSON text from ingestObservation — wrapping it in another
+      // JSON.stringify double-encodes the payload, so the prompt carried
+      // `{\"file_path\":...}` escape soup instead of readable JSON.
+      tool_input: message.tool_input,
+      tool_output: message.tool_response,
       created_at_epoch: originalTimestamp ?? Date.now(),
       cwd: message.cwd
     });

--- a/tests/sdk/prompts.test.ts
+++ b/tests/sdk/prompts.test.ts
@@ -19,6 +19,61 @@ describe('buildObservationPrompt', () => {
   });
 });
 
+describe('buildObservationPrompt payload encoding', () => {
+  it('renders stored JSON text as readable pretty-printed JSON, not escaped soup', () => {
+    // ingestObservation stores tool payloads as JSON text (a single
+    // JSON.stringify). The providers must pass that text through untouched;
+    // a second JSON.stringify at the call site used to double-encode it and
+    // the prompt carried `{\"file_path\":...}` instead of readable JSON.
+    const prompt = buildObservationPrompt({
+      id: 1,
+      tool_name: 'Read',
+      tool_input: JSON.stringify({ file_path: '/repo/src/app.ts' }),
+      tool_output: JSON.stringify({ content: 'line one\nline "two"' }),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(prompt).toContain('"file_path": "/repo/src/app.ts"');
+    expect(prompt).not.toContain('\\"file_path\\"');
+    // Content strings keep single-level JSON escapes, never double (`\\n`, `\\\"`).
+    expect(prompt).toContain('"content": "line one\\nline \\"two\\""');
+    expect(prompt).not.toContain('\\\\n');
+  });
+
+  it('survives a double-encoded payload without re-escaping it', () => {
+    // Defense in depth: if a caller does double-encode, the first parse
+    // yields the inner JSON text (a string), which must embed raw rather
+    // than being JSON-escaped a second time.
+    const stored = JSON.stringify({ command: 'echo "hi"' });
+    const prompt = buildObservationPrompt({
+      id: 2,
+      tool_name: 'Bash',
+      tool_input: JSON.stringify(stored),
+      tool_output: JSON.stringify(JSON.stringify({ stdout: 'hi' })),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(prompt).toContain(stored);
+    expect(prompt).not.toContain('\\\\\"');
+  });
+
+  it('embeds plain-text (non-JSON) tool output raw', () => {
+    const prompt = buildObservationPrompt({
+      id: 3,
+      tool_name: 'Bash',
+      tool_input: JSON.stringify({ command: 'ls' }),
+      tool_output: 'total 8\ndrwxr-xr-x  2 user  staff',
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(prompt).toContain('total 8\ndrwxr-xr-x  2 user  staff');
+    expect(prompt).not.toContain('total 8\\n');
+  });
+});
+
 describe('buildObservationPrompt oversized field truncation (#2468)', () => {
   it('truncates an oversized outcome field with an elided marker, keeping head and tail', () => {
     const huge = 'HEAD_SENTINEL' + 'A'.repeat(60_000) + 'TAIL_SENTINEL';
@@ -37,6 +92,23 @@ describe('buildObservationPrompt oversized field truncation (#2468)', () => {
     expect(prompt).toContain('HEAD_SENTINEL');
     expect(prompt).toContain('TAIL_SENTINEL');
     // the oversized field is actually shrunk well below its raw 60k size
+    expect(prompt.length).toBeLessThan(40_000);
+  });
+
+  it('truncates an oversized plain-string field with an elided marker', () => {
+    const huge = 'HEAD_SENTINEL' + 'B'.repeat(60_000) + 'TAIL_SENTINEL';
+    const prompt = buildObservationPrompt({
+      id: 3,
+      tool_name: 'Bash',
+      tool_input: JSON.stringify({ command: 'cat big.log' }),
+      tool_output: huge,
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(prompt).toContain('reason="oversize"');
+    expect(prompt).toContain('HEAD_SENTINEL');
+    expect(prompt).toContain('TAIL_SENTINEL');
     expect(prompt.length).toBeLessThan(40_000);
   });
 


### PR DESCRIPTION
## What

Observer prompts were carrying tool payloads double-JSON-encoded. `ingestObservation` stores `tool_input` / `tool_response` as JSON text (one `JSON.stringify`), but `ClaudeProvider` and `OpenAICompatibleProvider` wrapped them in a second `JSON.stringify` before `buildObservationPrompt`. The parse inside `buildObservationPrompt` then unwrapped only one level, leaving a string, and `truncateObservationField` re-escaped that string. Every `<parameters>` and `<outcome>` block ended up as a single-line escaped blob:

```
<parameters>"{\"file_path\":\"/Users/x/project/src/greet.ts\"}"</parameters>
<outcome>"{\"type\":\"text\",\"file\":{\"content\":\"import { logger } from './logger.js';\\n\\nexport function greet(\\\"...\\\")...
```

instead of the pretty-printed JSON the function's own tests exercise:

```
<parameters>{
  "file_path": "/Users/x/project/src/greet.ts"
}</parameters>
```

## Why it matters

Measured with cl100k on realistic payloads (Read of a 7KB source file, Bash output, Grep matches), the escaped form costs 5-11% more tokens for identical content, on every observation, on every provider. Three knock-on effects:

1. The 16k-char truncation budget from #2468 is partly spent on `\"` and `\\n` escape characters, so less real content survives for oversized payloads.
2. Longer prompts reach the context ceiling sooner; context overflow is classified unrecoverable and kills the session.
3. The observer model reads escape soup, which is strictly harder to extract facts and file paths from.

## Fix

- Providers pass the stored JSON text through untouched (removes the second `JSON.stringify`).
- `truncateObservationField` embeds string values raw instead of re-escaping them. This also makes the prompt builder safe against double-encoded or plain-text payloads from any other producer: parsed objects pretty-print exactly as before, strings can no longer gain an extra escape level.

No schema, storage, or API changes. `GeminiProvider` inherits the fix via `OpenAICompatibleProvider`.

## Tests

- New: stored JSON text renders as readable JSON with no double escapes; a deliberately double-encoded payload survives without re-escaping; plain-text (non-JSON) output embeds raw; oversized plain-string fields still get the #2468 elision marker.
- Full suite: 2205 pass / 0 fail, `typecheck:root` clean.

## Note on the reverted observer-context work (066826a5)

The reverted `stringifyObserverPayload` from #3143 touched these same call sites, but bundled the encoding fix with payload sanitization and history capping, which is why it went out with the revert. This PR is only the encoding correction: same call sites, no sanitization, no truncation-policy change, no history management. The #2468 elision behavior is untouched and covered by the existing tests plus a new one for plain-string fields.
