### PR TITLE
feat: bound observer conversation history for OpenAI-compatible providers

### DIFF
--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -2,6 +2,7 @@ import { DatabaseManager } from './DatabaseManager.js';
 import { SessionManager } from './SessionManager.js';
 import { logger } from '../../utils/logger.js';
 import { buildInitPrompt, buildObservationPrompt, buildSummaryPrompt, buildContinuationPrompt } from '../../sdk/prompts.js';
+import { pruneProcessedObservationPayloads } from './history-pruning.js';
 import type { ActiveSession, ConversationMessage } from '../worker-types.js';
 import { ModeManager } from '../domain/ModeManager.js';
 import type { ModeConfig } from '../domain/types.js';
@@ -206,6 +207,12 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     });
 
     session.conversationHistory.push({ role: 'user', content: obsPrompt });
+
+    // Stub out payloads already converted to stored observations so the
+    // request below stays bounded instead of re-sending every prior tool
+    // dump (see history-pruning.ts).
+    pruneProcessedObservationPayloads(session.conversationHistory);
+
     session.lastPromptSentAt = Date.now();
     session.lastGeneratorSource = 'ingest';
     const obsResponse = await this.query(session.conversationHistory, config);
@@ -255,6 +262,11 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     }, mode);
 
     session.conversationHistory.push({ role: 'user', content: summaryPrompt });
+
+    // Same bounding as the observation path: the summary reads the assistant
+    // observations for its narrative, not the raw tool payloads behind them.
+    pruneProcessedObservationPayloads(session.conversationHistory);
+
     session.lastPromptSentAt = Date.now();
     session.lastGeneratorSource = 'summarize';
     const summaryResponse = await this.query(session.conversationHistory, config);

--- a/src/services/worker/history-pruning.ts
+++ b/src/services/worker/history-pruning.ts
@@ -1,0 +1,95 @@
+import type { ConversationMessage } from '../worker-types.js';
+import { SUMMARY_MODE_MARKER } from '../../sdk/prompts.js';
+import { logger } from '../../utils/logger.js';
+
+// Bounded observer history for the OpenAI-compatible providers.
+//
+// Those providers own `session.conversationHistory` and re-send the whole
+// array on every query() call. Each observation turn appends a user message
+// carrying the full tool payload (up to ~32k chars of <parameters> +
+// <outcome>), so a session with N tool uses re-transmits every prior payload
+// on every subsequent turn: O(N^2) input tokens on per-token billing, and the
+// request eventually crosses the model's context window, which the error
+// classifiers treat as unrecoverable.
+//
+// The raw payload is only needed for the single turn that converts it into
+// <observation> blocks. After processAgentResponse() persists those blocks to
+// SQLite, the payload is dead weight: the assistant messages already in the
+// history ARE the compressed record of that work, and the Claude Code
+// transcript remains the durable source of truth for replay. So once an
+// exchange falls out of the recent window we replace the payload body with a
+// small stub that preserves the message's role, position, tool name, and
+// timestamp — chronology and role alternation stay intact, the observer keeps
+// reading its own observations for continuity, and per-request input becomes
+// bounded instead of growing without limit.
+
+/** Marker attribute distinguishing a stub from a live payload message. */
+const PRUNED_ATTRIBUTE = 'pruned="true"';
+
+/** Payload messages open with this tag (see buildObservationPrompt). */
+const OBSERVATION_OPEN_TAG = '<observed_from_primary_session>';
+
+/**
+ * Number of trailing messages never pruned (~4 user/assistant exchanges).
+ * Keeps enough verbatim context for the observer to batch related tool uses
+ * and dedupe against what it just recorded.
+ */
+export const KEEP_RECENT_MESSAGES = 8;
+
+/**
+ * Messages at or below this size are left alone — a stub would not be
+ * meaningfully smaller than the original.
+ */
+export const MIN_PRUNABLE_CHARS = 600;
+
+function extractTag(content: string, tag: string): string | null {
+  const match = content.match(new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`));
+  return match ? match[1] : null;
+}
+
+function buildStub(content: string): string {
+  const toolName = extractTag(content, 'what_happened') ?? 'unknown';
+  const occurredAt = extractTag(content, 'occurred_at') ?? '';
+  return `<observed_from_primary_session ${PRUNED_ATTRIBUTE}>
+  <what_happened>${toolName}</what_happened>${occurredAt ? `\n  <occurred_at>${occurredAt}</occurred_at>` : ''}
+  <note>Tool payload removed after it was recorded as observations. Do not re-describe this event.</note>
+</observed_from_primary_session>`;
+}
+
+/**
+ * Replace already-processed observation payloads outside the recent window
+ * with compact stubs, in place. Returns the number of messages stubbed.
+ *
+ * Only user messages that carry a live observation payload are touched. The
+ * first message (init/continuation prompt with the observer's role and output
+ * format), summary-mode prompts, assistant messages, small messages, and the
+ * trailing `keepRecent` messages are always preserved verbatim.
+ */
+export function pruneProcessedObservationPayloads(
+  history: ConversationMessage[],
+  keepRecent: number = KEEP_RECENT_MESSAGES,
+  minPrunableChars: number = MIN_PRUNABLE_CHARS,
+): number {
+  const end = history.length - keepRecent;
+  let pruned = 0;
+
+  for (let i = 1; i < end; i++) {
+    const message = history[i];
+    if (message.role !== 'user') continue;
+    if (message.content.length <= minPrunableChars) continue;
+    if (!message.content.includes(OBSERVATION_OPEN_TAG)) continue;
+    if (message.content.includes(SUMMARY_MODE_MARKER)) continue;
+
+    message.content = buildStub(message.content);
+    pruned++;
+  }
+
+  if (pruned > 0) {
+    logger.debug('SDK', 'Pruned processed observation payloads from history', {
+      prunedCount: pruned,
+      historyLength: history.length,
+    });
+  }
+
+  return pruned;
+}

--- a/tests/history-pruning.test.ts
+++ b/tests/history-pruning.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  pruneProcessedObservationPayloads,
+  KEEP_RECENT_MESSAGES,
+  MIN_PRUNABLE_CHARS,
+} from '../src/services/worker/history-pruning.js';
+import { buildObservationPrompt, SUMMARY_MODE_MARKER } from '../src/sdk/prompts.js';
+import type { ConversationMessage } from '../src/services/worker-types.js';
+
+const INIT_PROMPT = 'You are an observer.\n<observed_from_primary_session>\n  <user_request>build the thing</user_request>\n</observed_from_primary_session>\n' + 'x'.repeat(2000);
+
+function observationMessage(tool: string, filler: string): ConversationMessage {
+  return {
+    role: 'user',
+    content: buildObservationPrompt({
+      id: 0,
+      tool_name: tool,
+      tool_input: JSON.stringify({ file_path: `/repo/${tool}.ts` }),
+      tool_output: JSON.stringify({ content: filler }),
+      created_at_epoch: 1700000000000,
+      cwd: '/repo',
+    }),
+  };
+}
+
+function assistantMessage(): ConversationMessage {
+  return { role: 'assistant', content: '<observation><type>discovery</type><title>Found it</title></observation>' };
+}
+
+function buildHistory(exchanges: number): ConversationMessage[] {
+  const history: ConversationMessage[] = [{ role: 'user', content: INIT_PROMPT }];
+  for (let i = 0; i < exchanges; i++) {
+    history.push(observationMessage('Read', `payload ${i} ` + 'y'.repeat(5000)));
+    history.push(assistantMessage());
+  }
+  return history;
+}
+
+describe('pruneProcessedObservationPayloads', () => {
+  it('stubs old observation payloads and keeps role, tool name, and timestamp', () => {
+    const history = buildHistory(10); // 21 messages, indices 1..12 outside keep window
+    const pruned = pruneProcessedObservationPayloads(history);
+
+    expect(pruned).toBeGreaterThan(0);
+    const stub = history[1];
+    expect(stub.role).toBe('user');
+    expect(stub.content).toContain('pruned="true"');
+    expect(stub.content).toContain('<what_happened>Read</what_happened>');
+    expect(stub.content).toContain('2023-11-14'); // from created_at_epoch
+    expect(stub.content).not.toContain('yyyy');
+    expect(stub.content.length).toBeLessThan(MIN_PRUNABLE_CHARS);
+  });
+
+  it('never touches the init prompt, assistant messages, or the recent window', () => {
+    const history = buildHistory(10);
+    const before = history.map(m => m.content);
+    pruneProcessedObservationPayloads(history);
+
+    // init prompt intact
+    expect(history[0].content).toBe(before[0]);
+    // assistant messages intact everywhere
+    for (let i = 0; i < history.length; i++) {
+      if (history[i].role === 'assistant') {
+        expect(history[i].content).toBe(before[i]);
+      }
+    }
+    // trailing window intact
+    for (let i = history.length - KEEP_RECENT_MESSAGES; i < history.length; i++) {
+      expect(history[i].content).toBe(before[i]);
+    }
+  });
+
+  it('skips summary prompts and small messages', () => {
+    const history = buildHistory(8);
+    const summary: ConversationMessage = {
+      role: 'user',
+      content: `--- ${SUMMARY_MODE_MARKER} ---\n<observed_from_primary_session>\n` + 'z'.repeat(2000),
+    };
+    const small: ConversationMessage = { role: 'user', content: '<observed_from_primary_session>tiny</observed_from_primary_session>' };
+    history.splice(3, 0, summary, small);
+
+    pruneProcessedObservationPayloads(history);
+
+    expect(history[3].content).toContain(SUMMARY_MODE_MARKER);
+    expect(history[3].content).toContain('zzz');
+    expect(history[4].content).toBe(small.content);
+  });
+
+  it('is idempotent: a second pass prunes nothing', () => {
+    const history = buildHistory(10);
+    const first = pruneProcessedObservationPayloads(history);
+    const second = pruneProcessedObservationPayloads(history);
+
+    expect(first).toBeGreaterThan(0);
+    expect(second).toBe(0);
+  });
+
+  it('bounds total history size as exchanges grow', () => {
+    const history = buildHistory(40); // 81 messages, ~5k chars per payload
+    const beforeChars = history.reduce((sum, m) => sum + m.content.length, 0);
+    pruneProcessedObservationPayloads(history);
+    const afterChars = history.reduce((sum, m) => sum + m.content.length, 0);
+
+    // Everything outside init + recent window collapses to stubs.
+    expect(afterChars).toBeLessThan(beforeChars / 5);
+    // Chronology and count preserved: nothing is removed, only shrunk.
+    expect(history.length).toBe(81);
+  });
+
+  it('does nothing on short histories that fit the recent window', () => {
+    const history = buildHistory(3); // 7 messages <= 1 + KEEP_RECENT_MESSAGES
+    const pruned = pruneProcessedObservationPayloads(history);
+    expect(pruned).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

`OpenAICompatibleProvider` (and `GeminiProvider` through it) re-sends the whole `session.conversationHistory` on every `query()`. Each observation turn appends a user message carrying the full tool payload, up to ~32k chars of `<parameters>` + `<outcome>`. Nothing is ever trimmed, so a session with N tool uses re-transmits every prior payload on every later turn:

- O(N^2) input tokens on per-token billing (OpenRouter, Gemini, custom gateways). A 50-observation burst at ~3k tokens per payload re-sends roughly 4M input tokens where ~1M would do.
- Requests grow until they cross the model's context window. `classifyGeminiError` / OpenRouter classification treat that as unrecoverable, so the memory session dies mid-workflow.

## Why pruning is safe

A raw payload is only needed for the single turn that converts it into `<observation>` blocks. After `processAgentResponse()` persists those to SQLite, the payload is dead weight: the assistant messages already in the history are the compressed record of that work, and the Claude Code transcript remains the durable source of truth for replay (same reasoning as the SessionMessageBuffer design note).

## Change

New `pruneProcessedObservationPayloads()` runs before each observation and summary query. It replaces observation payloads outside the recent window with a compact stub that preserves role, position, tool name, and timestamp:

```
<observed_from_primary_session pruned="true">
  <what_happened>Read</what_happened>
  <occurred_at>2026-07-06T...</occurred_at>
  <note>Tool payload removed after it was recorded as observations. Do not re-describe this event.</note>
</observed_from_primary_session>
```

Never touched: the init/continuation prompt (observer instructions), summary-mode prompts, all assistant responses, messages at or under 600 chars, and the trailing 8 messages (~4 exchanges, enough verbatim context for batching and dedup). Role alternation and chronology are preserved because messages are shrunk in place, never removed. The function is idempotent; stubs are skipped on later passes.

Per-request input becomes bounded (init + stubs + recent window + current payload) instead of growing without limit, so long sessions keep working instead of hitting the context ceiling.

`ClaudeProvider` is untouched: its history lives inside the SDK subprocess, so this array is only bookkeeping there.

## Tests

`tests/history-pruning.test.ts`: stubbing preserves tool name/timestamp/role; init prompt, assistant messages, and recent window are never modified; summary prompts and small messages are skipped; idempotent second pass; 40-exchange history shrinks by >5x with message count and order unchanged; short histories untouched.

Full suite: 2208 pass / 0 fail, `typecheck:root` clean. Logger standards satisfied (debug log on prune).

## Relationship to #3096 and the core-dev revert (066826a5)

I am aware client-side context management has history here: #3096 removed `truncateHistory()` because a hardcoded 20-message cap dropped messages at 12k tokens and mislabeled it as cost prevention, and the later `boundObserverHistory` attempt from #3143 was reverted on core-dev as a regression of #3096 (it reintroduced a hardcoded 12-message cap plus content sanitization of live payloads).

This change shares neither mechanism:

- No message is ever dropped or reordered. Count, chronology, and role alternation are preserved; messages are shrunk in place.
- No size heuristic, token estimate, or message-count cap decides anything. The only trigger is a state transition: the payload was already converted into observations and persisted by `processAgentResponse()`. Until that happens, a payload is never touched (the recent window covers in-flight exchanges).
- Nothing the model still needs is removed. The assistant messages that summarize each payload stay verbatim, the observations live in SQLite, and the transcript remains the durable source, which is the same recovery contract `SessionMessageBuffer` already documents.
- The init prompt with the observer's instructions is never modified.

The failure #3096 fixed was "a second system guessing at the model's context window". This is not a guess about capacity; it is removing redundant copies of data that the system has, by its own design, already compressed and stored.
