### PR TITLE
fix(windows): add windowsHide to git rev-parse in findGitRepoRoot (#2900)

### DIFF
--- a/src/utils/project-name.ts
+++ b/src/utils/project-name.ts
@@ -24,6 +24,9 @@ function findGitRepoRoot(dir: string): string | null {
       cwd: dir,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
+      // Without this, a console-less worker daemon spawning git opens a visible
+      // terminal window per call on Windows (#2900).
+      windowsHide: true,
     }).trim();
     return root || null;
   } catch (error: unknown) {


### PR DESCRIPTION
## Problem

`getProjectName()` -> `findGitRepoRoot()` in `src/utils/project-name.ts` runs `git rev-parse --show-toplevel` on effectively every observation the worker processes. The `execFileSync` call is missing `windowsHide: true`, so on Windows the console-less worker daemon opens a **visible terminal window per call**. In my trace this was the single highest-frequency flash source from #2900.

This site is **not covered by #2921** (which fixes `ProcessManager.ts`, `WorktreeAdoption.ts`, the MCP launcher, and daemon spawns). One-line complementary fix.

## Verification

Windows 11, claude-mem 13.10.1, bun 1.3.14, Windows Terminal as default host:

- Ran a process-creation monitor (200 ms polling, Win32_Process) for 75 s while sessions were active.
- **Before**: 5 visible console windows (`OpenConsole.exe` spawns), each within ~50 ms of a `git.exe` child of the bun worker daemon (`git rev-parse --show-toplevel` and the two `git -C` helpers).
- **After** patching only the git call sites (this one + the two in #2921) in the bundled `worker-service.cjs`: **0 visible windows** in 75 s; the daemon still ran its git calls with unchanged output.

Notably, the worker's PowerShell spawns (which already pass `windowsHide: true`) never flashed — Bun honors the flag when present, so carrying it through the remaining git sites is sufficient for this flash source.

Fixes the remaining call site of #2900, complements #2921.

🤖 Generated with [Claude Code](https://claude.com/claude-code)