### PR TITLE
fix(hooks): never exit 2 from the summarize/Stop hook on worker failure

### DIFF
--- a/src/cli/adapters/claude-code.ts
+++ b/src/cli/adapters/claude-code.ts
@@ -20,6 +20,9 @@ export const claudeCodeAdapter: PlatformAdapter = {
       toolInput: r.tool_input,
       toolResponse: r.tool_response,
       transcriptPath: r.transcript_path,
+      // #3161: feeds summarize.ts's re-entry loop breaker (codex.ts already
+      // maps this; without it the breaker never fires on Claude Code).
+      stopHookActive: typeof r.stop_hook_active === 'boolean' ? r.stop_hook_active : undefined,
       agentId: pickAgentField(r.agent_id),
       agentType: pickAgentField(r.agent_type),
     };

--- a/src/cli/handlers/summarize.ts
+++ b/src/cli/handlers/summarize.ts
@@ -57,7 +57,7 @@ export const summarizeHandler: EventHandler = {
     }
 
     if (input.stopHookActive === true) {
-      logger.debug('HOOK', 'Skipping summary: Codex Stop hook re-entry detected', {
+      logger.debug('HOOK', 'Skipping summary: Stop hook re-entry detected (stop_hook_active)', {
         sessionId: input.sessionId,
       });
       return { continue: true, suppressOutput: true, exitCode: HOOK_EXIT_CODES.SUCCESS };

--- a/src/cli/handlers/summarize.ts
+++ b/src/cli/handlers/summarize.ts
@@ -145,6 +145,18 @@ export const summarizeHandler: EventHandler = {
       },
     );
     if (isWorkerFallback(queueResult)) {
+      // #3161: this handler never exits 2 (neverBlock) and exit-0 stderr is
+      // verbose-only, so a tripped fail-loud streak surfaces as a USER_HINT —
+      // the Stop hook fires at the end of every turn, exactly when the user
+      // is watching the terminal.
+      if (queueResult.consecutiveFailures !== undefined) {
+        return {
+          continue: true,
+          suppressOutput: true,
+          exitCode: HOOK_EXIT_CODES.SUCCESS,
+          systemMessage: `claude-mem worker unreachable for ${queueResult.consecutiveFailures} consecutive hooks — memory capture is paused. Run \`npx claude-mem restart\` to recover.`,
+        };
+      }
       return { continue: true, suppressOutput: true, exitCode: HOOK_EXIT_CODES.SUCCESS };
     }
 

--- a/src/cli/hook-command.ts
+++ b/src/cli/hook-command.ts
@@ -8,6 +8,7 @@ import {
   installHookStderrBuffer,
   emitModelContext,
   emitBlockingError,
+  emitDiagnostic,
   exitGraceful,
   resetHookIoState,
 } from '../shared/hook-io.js';
@@ -141,10 +142,11 @@ export async function hookCommand(platform: string, event: string, options: Hook
       // EXIT_SIGNAL per CLAUDE.md: transient worker errors exit 0 to avoid
       // Windows Terminal tab accumulation. The fail-loud counter (worker-utils
       // recordWorkerUnreachable) handles the surface-after-N-failures path and
-      // emits the threshold-gated hook_failed telemetry internally. Awaited:
+      // emits the threshold-gated hook_failed telemetry internally; the
+      // summarize handler is exempt from its exit-2 path (#3161). Awaited:
       // when the count JUST reaches the threshold it sends the event and then
       // exits 2; exitGraceful below would kill a pending POST mid-flight.
-      await recordWorkerUnreachable();
+      await recordWorkerUnreachable(options);
       exitGraceful(options);
       return HOOK_EXIT_CODES.SUCCESS;
     }
@@ -161,6 +163,17 @@ export async function hookCommand(platform: string, event: string, options: Hook
         error_mode: 'blocking_error',
         threshold_tripped: false,
       });
+    }
+    // #3161: mirror the fail-loud exemption in recordWorkerUnreachable for the
+    // non-transport error class. A deterministic throw here (adapter/stdin/
+    // handler) would otherwise exit 2 on Stop and loop every session end.
+    if (event === 'summarize') {
+      emitDiagnostic(
+        `claude-mem hook error (summarize, not blocking): ${error instanceof Error ? error.message : String(error)}\n`
+      );
+      emitModelContext(adapter, buildNoOpResult(event));
+      exitGraceful(options);
+      return HOOK_EXIT_CODES.SUCCESS;
     }
     // BLOCKING_FEEDBACK: flush the buffered logger.error line to stderr and
     // exit 2 so the model receives it per Claude Code's hook contract.

--- a/src/cli/hook-command.ts
+++ b/src/cli/hook-command.ts
@@ -8,7 +8,6 @@ import {
   installHookStderrBuffer,
   emitModelContext,
   emitBlockingError,
-  emitDiagnostic,
   exitGraceful,
   resetHookIoState,
 } from '../shared/hook-io.js';
@@ -164,23 +163,25 @@ export async function hookCommand(platform: string, event: string, options: Hook
         threshold_tripped: false,
       });
     }
-    // #3161: mirror the fail-loud exemption in recordWorkerUnreachable for the
-    // non-transport error class. A deterministic throw here (adapter/stdin/
-    // handler) would otherwise exit 2 on Stop and loop every session end.
-    if (event === 'summarize') {
-      emitDiagnostic(
-        `claude-mem hook error (summarize, not blocking): ${error instanceof Error ? error.message : String(error)}\n`
-      );
+    // #3161: summarize (Stop) must never see exit 2 — a deterministic throw
+    // here (adapter/stdin/handler) would otherwise loop every session end.
+    // emitBlockingError's neverBlock downgrades the exit code only; the model
+    // still needs a valid stdout envelope, which buildNoOpResult supplies.
+    const neverBlock = event === 'summarize';
+    if (neverBlock) {
       emitModelContext(adapter, buildNoOpResult(event));
+    }
+    // BLOCKING_FEEDBACK: flush the buffered logger.error line to stderr and
+    // exit 2 so the model receives it per Claude Code's hook contract (unless
+    // neverBlock vetoes the exit).
+    emitBlockingError(
+      `Hook error: ${error instanceof Error ? error.message : String(error)}`,
+      { ...options, neverBlock },
+    );
+    if (neverBlock) {
       exitGraceful(options);
       return HOOK_EXIT_CODES.SUCCESS;
     }
-    // BLOCKING_FEEDBACK: flush the buffered logger.error line to stderr and
-    // exit 2 so the model receives it per Claude Code's hook contract.
-    emitBlockingError(
-      `Hook error: ${error instanceof Error ? error.message : String(error)}`,
-      options,
-    );
     return HOOK_EXIT_CODES.BLOCKING_ERROR;
   } finally {
     stderrBuffer.restore();

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -128,7 +128,7 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_TRANSCRIPTS_CONFIG_PATH: join(homedir(), '.claude-mem', 'transcript-watch.json'),
     CLAUDE_MEM_CODEX_TRANSCRIPT_INGESTION: 'false',
     CLAUDE_MEM_MAX_CONCURRENT_AGENTS: '2',  // Max concurrent Claude SDK agent subprocesses
-    CLAUDE_MEM_HOOK_FAIL_LOUD_THRESHOLD: '3',  // Plan 05 Phase 8 — escalate to exit code 2 after N consecutive worker-unreachable hook invocations
+    CLAUDE_MEM_HOOK_FAIL_LOUD_THRESHOLD: '3',  // Plan 05 Phase 8 — escalate to exit code 2 after N consecutive worker-unreachable hook invocations (#3161: summarize/Stop hooks never escalate — diagnostic + exit 0)
     CLAUDE_MEM_EXCLUDED_PROJECTS: '',  // Comma-separated glob patterns for excluded project paths
     CLAUDE_MEM_FOLDER_MD_EXCLUDE: '[]',  // JSON array of folder paths to exclude from CLAUDE.md generation
     CLAUDE_MEM_FOLDER_MD_SKELETON_DENYLIST: '[]',  // #2400 — JSON array of glob patterns; when a folder matches AND its generated CLAUDE.md would be empty/skeleton, skip injection (avoids polluting non-content dirs with empty skeletons). Default [] preserves existing behavior.

--- a/src/shared/hook-io.ts
+++ b/src/shared/hook-io.ts
@@ -127,21 +127,29 @@ let moduleHasEmitted = false;
 
 export interface ExitOptions {
   skipExit?: boolean;
+  /** Veto exit 2 in emitBlockingError; irrelevant to exitGraceful (already exit 0). */
+  neverBlock?: boolean;
 }
 
 /**
- * BLOCKING_FEEDBACK: flush buffered stderr (so preceding diagnostics reach the
- * operator/model), write `msg` to real stderr, then exit 2 so the model
- * receives it per Claude Code's hook contract. `skipExit` is the test seam
- * that mirrors HookCommandOptions.skipExit.
+ * BLOCKING_FEEDBACK: flush buffered stderr, write `msg` to real stderr, then
+ * exit 2 so the model receives it per Claude Code's hook contract. `skipExit`
+ * is the test seam that mirrors HookCommandOptions.skipExit.
+ *
+ * `neverBlock` vetoes both the flush and the exit — #3161: exit 2 from a Stop
+ * hook means "don't stop", not "show the model an error", so blocking on a
+ * worker outage re-wakes the agent every time it tries to end the session, an
+ * endless loop while the worker stays down. Callers compute neverBlock from
+ * the active hook event so every call site inherits the rule without
+ * repeating the check.
  */
 export function emitBlockingError(msg: string, options: ExitOptions = {}): void {
   if (bufferedChunks && bufferedChunks.length > 0) {
-    bypassWrite(bufferedChunks.join(''));
+    if (!options.neverBlock) bypassWrite(bufferedChunks.join(''));
     bufferedChunks = [];
   }
   bypassWrite(msg.endsWith('\n') ? msg : `${msg}\n`);
-  if (!options.skipExit) {
+  if (!options.skipExit && !options.neverBlock) {
     process.exit(2);
   }
 }

--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -684,9 +684,18 @@ function resetWorkerFailureCounter(): void {
 
 const WORKER_FALLBACK_BRAND: unique symbol = Symbol.for('claude-mem/worker-fallback');
 
-export type WorkerFallback =
-  | { continue: true; [WORKER_FALLBACK_BRAND]: true }
-  | { continue: true; reason: string; [WORKER_FALLBACK_BRAND]: true };
+export type WorkerFallback = {
+  continue: true;
+  reason?: string;
+  /**
+   * Present when the fail-loud streak is at/past threshold. The summarize/Stop
+   * handler surfaces it as a USER_HINT (HookResult.systemMessage) — its exit
+   * code can never carry the fail-loud signal (#3161 neverBlock), and exit-0
+   * stderr is verbose-only, so this is the only user-visible channel left.
+   */
+  consecutiveFailures?: number;
+  [WORKER_FALLBACK_BRAND]: true;
+};
 
 export type WorkerCallResult<T> = T | WorkerFallback;
 
@@ -700,6 +709,22 @@ export interface WorkerFallbackOptions {
   timeoutMs?: number;
 }
 
+/**
+ * Record the unreachable failure and build the branded fallback for it,
+ * tagging `consecutiveFailures` once the fail-loud streak is at/past
+ * threshold (repeats every failure past it, matching the stderr warning).
+ * Exported for the isolated-state verification harness; production callers
+ * are the two unreachable branches in executeWithWorkerFallback.
+ */
+export async function buildWorkerUnreachableFallback(reason: string): Promise<WorkerFallback> {
+  const failures = await recordWorkerUnreachable();
+  const fallback: WorkerFallback = { continue: true, reason, [WORKER_FALLBACK_BRAND]: true };
+  if (failures >= getFailLoudThreshold()) {
+    fallback.consecutiveFailures = failures;
+  }
+  return fallback;
+}
+
 export async function executeWithWorkerFallback<T = unknown>(
   url: string,
   method: 'GET' | 'POST' | 'PUT' | 'DELETE',
@@ -708,8 +733,7 @@ export async function executeWithWorkerFallback<T = unknown>(
 ): Promise<WorkerCallResult<T>> {
   const alive = await ensureWorkerAliveOnce();
   if (!alive) {
-    await recordWorkerUnreachable();
-    return { continue: true, reason: 'worker_unreachable', [WORKER_FALLBACK_BRAND]: true };
+    return buildWorkerUnreachableFallback('worker_unreachable');
   }
 
   const init: { method: string; headers?: Record<string, string>; body?: string; timeoutMs?: number } = { method };
@@ -751,8 +775,7 @@ export async function executeWithWorkerFallback<T = unknown>(
   try {
     text = await response.text();
   } catch {
-    await recordWorkerUnreachable();
-    return { continue: true, reason: 'worker_body_read_failed', [WORKER_FALLBACK_BRAND]: true };
+    return buildWorkerUnreachableFallback('worker_body_read_failed');
   }
 
   // Body read succeeded → the worker is genuinely reachable; now safe to reset.

--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -7,7 +7,7 @@ import { SettingsDefaultsManager, type SettingsDefaults } from "./SettingsDefaul
 import { MARKETPLACE_ROOT, DATA_DIR } from "./paths.js";
 import { loadFromFileOnce } from "./hook-settings.js";
 import { validateWorkerPidFile } from "../supervisor/index.js";
-import { emitBlockingError } from "./hook-io.js";
+import { emitBlockingError, emitDiagnostic, type ExitOptions } from "./hook-io.js";
 import { captureCliEvent } from "../services/telemetry/cli-telemetry.js";
 import { checkVersionMatch } from "../services/infrastructure/index.js";
 // Imported from ProcessManager.js directly (not the infrastructure barrel):
@@ -631,7 +631,10 @@ export function getActiveHookType(): TelemetryHookType | null {
   return activeHookType;
 }
 
-export async function recordWorkerUnreachable(): Promise<number> {
+export async function recordWorkerUnreachable(options: ExitOptions = {}): Promise<number> {
+  // Snapshot before the awaited telemetry POST so the exemption can't read a
+  // hook type mutated by a concurrent invocation.
+  const hookType = activeHookType;
   const state = readHookFailureState();
   const next: HookFailureState = {
     consecutiveFailures: state.consecutiveFailures + 1,
@@ -652,18 +655,33 @@ export async function recordWorkerUnreachable(): Promise<number> {
     // API (the defining failure here IS "worker unreachable").
     if (next.consecutiveFailures === threshold) {
       await captureCliEvent('hook_failed', {
-        ...(activeHookType !== null ? { hook_type: activeHookType } : {}),
+        ...(hookType !== null ? { hook_type: hookType } : {}),
         error_mode: 'worker_unavailable',
         consecutive_failures: next.consecutiveFailures,
         threshold_tripped: true,
       });
     }
+    // #3161: the summarize handler must NEVER exit 2. Exit 2 from a Stop hook
+    // blocks the stop and re-wakes the agent; while the worker stays down every
+    // Stop retrips this, an endless wake/stop loop. Keep the counter + streak
+    // telemetry (it still surfaces as BLOCKING_FEEDBACK at the next non-summarize
+    // hook, where blocking can't re-wake a stopping session) but downgrade to a
+    // diagnostic. Keyed on the handler name, so every event mapped to summarize
+    // is exempt (Stop across platforms, Antigravity PreCompress).
+    if (hookType === 'summarize') {
+      emitDiagnostic(
+        `claude-mem worker unreachable for ${next.consecutiveFailures} consecutive hooks (summarize hook: not blocking).\n`
+      );
+      return next.consecutiveFailures;
+    }
     // #2292 fix: BLOCKING_FEEDBACK. emitBlockingError flushes the Phase 2
-    // stderr buffer (so preceding logger.warn lines also surface) and writes
-    // via the bypass channel + exits 2. Previously this raw process.stderr.write
-    // was swallowed by hookCommand's blanket no-op, so the user/model never saw it.
+    // stderr buffer (so preceding buffered third-party stderr noise also
+    // surfaces) and writes via the bypass channel + exits 2. Previously this
+    // raw process.stderr.write was swallowed by hookCommand's blanket no-op,
+    // so the user/model never saw it.
     emitBlockingError(
-      `claude-mem worker unreachable for ${next.consecutiveFailures} consecutive hooks.`
+      `claude-mem worker unreachable for ${next.consecutiveFailures} consecutive hooks.`,
+      options,
     );
   }
   return next.consecutiveFailures;
@@ -734,8 +752,22 @@ export async function executeWithWorkerFallback<T = unknown>(
     return parsed as T;
   }
 
+  // #3161: a worker dying mid-body rejects text() with an ECONNRESET whose
+  // message matches no transport pattern in isWorkerUnavailableError, so an
+  // unguarded throw would escape into hookCommand's catch-all (exit 2 on Stop).
+  // Treat it as the unreachable case it is — record the failure and return the
+  // branded fallback — rather than swallowing it into a false empty-body
+  // "success" (which would also wrongly reset the streak below).
+  let text: string;
+  try {
+    text = await response.text();
+  } catch {
+    await recordWorkerUnreachable();
+    return { continue: true, reason: 'worker_body_read_failed', [WORKER_FALLBACK_BRAND]: true };
+  }
+
+  // Body read succeeded → the worker is genuinely reachable; now safe to reset.
   resetWorkerFailureCounter();
-  const text = await response.text();
   if (text.length === 0) return undefined as unknown as T;
   try {
     return JSON.parse(text) as T;

--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -7,7 +7,7 @@ import { SettingsDefaultsManager, type SettingsDefaults } from "./SettingsDefaul
 import { MARKETPLACE_ROOT, DATA_DIR } from "./paths.js";
 import { loadFromFileOnce } from "./hook-settings.js";
 import { validateWorkerPidFile } from "../supervisor/index.js";
-import { emitBlockingError, emitDiagnostic, type ExitOptions } from "./hook-io.js";
+import { emitBlockingError, type ExitOptions } from "./hook-io.js";
 import { captureCliEvent } from "../services/telemetry/cli-telemetry.js";
 import { checkVersionMatch } from "../services/infrastructure/index.js";
 // Imported from ProcessManager.js directly (not the infrastructure barrel):
@@ -661,27 +661,16 @@ export async function recordWorkerUnreachable(options: ExitOptions = {}): Promis
         threshold_tripped: true,
       });
     }
-    // #3161: the summarize handler must NEVER exit 2. Exit 2 from a Stop hook
-    // blocks the stop and re-wakes the agent; while the worker stays down every
-    // Stop retrips this, an endless wake/stop loop. Keep the counter + streak
-    // telemetry (it still surfaces as BLOCKING_FEEDBACK at the next non-summarize
-    // hook, where blocking can't re-wake a stopping session) but downgrade to a
-    // diagnostic. Keyed on the handler name, so every event mapped to summarize
-    // is exempt (Stop across platforms, Antigravity PreCompress).
-    if (hookType === 'summarize') {
-      emitDiagnostic(
-        `claude-mem worker unreachable for ${next.consecutiveFailures} consecutive hooks (summarize hook: not blocking).\n`
-      );
-      return next.consecutiveFailures;
-    }
     // #2292 fix: BLOCKING_FEEDBACK. emitBlockingError flushes the Phase 2
     // stderr buffer (so preceding buffered third-party stderr noise also
     // surfaces) and writes via the bypass channel + exits 2. Previously this
     // raw process.stderr.write was swallowed by hookCommand's blanket no-op,
-    // so the user/model never saw it.
+    // so the user/model never saw it. #3161: neverBlock vetoes the exit-2 step
+    // for the summarize/Stop handler (see emitBlockingError) — the message and
+    // counter/telemetry above are unaffected, only the exit code changes.
     emitBlockingError(
       `claude-mem worker unreachable for ${next.consecutiveFailures} consecutive hooks.`,
-      options,
+      { ...options, neverBlock: hookType === 'summarize' },
     );
   }
   return next.consecutiveFailures;

--- a/tests/cli/handlers/summarize-worker-unreachable-hint.test.ts
+++ b/tests/cli/handlers/summarize-worker-unreachable-hint.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, spyOn, mock } from 'bun:test';
+
+// Capture real exports before mock.module mutates the live namespace, then
+// re-register the snapshots in afterAll so these mocks do not leak into later
+// test files (bun's mock.module is process-global; mock.restore() does NOT undo it).
+import * as realHookSettings from '../../../src/shared/hook-settings.js';
+import * as realWorkerUtils from '../../../src/shared/worker-utils.js';
+const realHookSettingsSnapshot = { ...realHookSettings };
+const realWorkerUtilsSnapshot = { ...realWorkerUtils };
+
+mock.module('../../../src/shared/hook-settings.js', () => ({
+  loadFromFileOnce: () => ({ CLAUDE_MEM_EXCLUDED_PROJECTS: '' }),
+}));
+
+const WORKER_FALLBACK_BRAND = Symbol.for('claude-mem/worker-fallback');
+// Per-test control of what executeWithWorkerFallback resolves to.
+let nextFallback: Record<string | symbol, unknown> | null = null;
+
+mock.module('../../../src/shared/worker-utils.js', () => ({
+  ...realWorkerUtilsSnapshot,
+  executeWithWorkerFallback: () => Promise.resolve(nextFallback),
+}));
+
+import { logger } from '../../../src/utils/logger.js';
+import { summarizeHandler } from '../../../src/cli/handlers/summarize.js';
+
+let loggerSpies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(() => {
+  nextFallback = null;
+  loggerSpies = [
+    spyOn(logger, 'info').mockImplementation(() => {}),
+    spyOn(logger, 'debug').mockImplementation(() => {}),
+    spyOn(logger, 'warn').mockImplementation(() => {}),
+    spyOn(logger, 'error').mockImplementation(() => {}),
+    spyOn(logger, 'failure').mockImplementation(() => {}),
+    spyOn(logger, 'dataIn').mockImplementation(() => {}),
+  ];
+});
+
+afterEach(() => {
+  loggerSpies.forEach(s => s.mockRestore());
+});
+
+afterAll(() => {
+  mock.module('../../../src/shared/hook-settings.js', () => realHookSettingsSnapshot);
+  mock.module('../../../src/shared/worker-utils.js', () => realWorkerUtilsSnapshot);
+});
+
+const baseInput = {
+  sessionId: 'test-session',
+  cwd: '/tmp/summarize-hint-test',
+  lastAssistantMessage: 'final answer',
+  platform: 'claude-code',
+};
+
+describe('#3161 — tripped fail-loud streak surfaces as a USER_HINT on the Stop hook', () => {
+  it('attaches systemMessage when the worker fallback carries consecutiveFailures', async () => {
+    nextFallback = {
+      continue: true,
+      reason: 'worker_unreachable',
+      consecutiveFailures: 3,
+      [WORKER_FALLBACK_BRAND]: true,
+    };
+    const result = await summarizeHandler.execute({ ...baseInput });
+    expect(result.systemMessage).toContain('unreachable for 3 consecutive hooks');
+    expect(result.systemMessage).toContain('npx claude-mem restart');
+    // The hint must never change the non-blocking contract.
+    expect(result.continue).toBe(true);
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('stays silent below the fail-loud threshold (fallback without consecutiveFailures)', async () => {
+    nextFallback = {
+      continue: true,
+      reason: 'worker_unreachable',
+      [WORKER_FALLBACK_BRAND]: true,
+    };
+    const result = await summarizeHandler.execute({ ...baseInput });
+    expect(result.systemMessage).toBeUndefined();
+    expect(result.continue).toBe(true);
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/tests/cli/hook-stream-discipline.test.ts
+++ b/tests/cli/hook-stream-discipline.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'bun:test';
+import { describe, it, expect, afterEach, spyOn } from 'bun:test';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import {
@@ -67,43 +67,91 @@ describe('#2292 — fail-loud diagnostic is no longer swallowed', () => {
 });
 
 describe('#3161 — Stop hook never exits 2 on worker-unreachable', () => {
-  it('worker-utils fail-loud branch exempts summarize BEFORE the emitBlockingError exit-2 path (source contract)', () => {
+  it('emitBlockingError veto: neverBlock downgrades exit 2 to a diagnostic-only write (behavioral)', () => {
+    // Single source of truth: emitBlockingError itself owns the exit-2 veto,
+    // so every call site (recordWorkerUnreachable, hookCommand's catch-all)
+    // inherits it by passing neverBlock instead of repeating a guard.
+    const real = captureRealStderr();
+    const buffer = installHookStderrBuffer();
+    // Spy (not skipExit) so the veto itself is under test: a neverBlock
+    // regression fails this assertion cleanly instead of exit-2-killing the
+    // test runner.
+    const exitSpy = spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+    try {
+      emitBlockingError('worker unreachable for 3 consecutive hooks.', { neverBlock: true });
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(real.chunks.join('')).toContain('worker unreachable for 3 consecutive hooks.');
+    } finally {
+      exitSpy.mockRestore();
+      buffer.restore();
+      real.restore();
+    }
+  });
+
+  it('emitBlockingError veto: neverBlock drops (not flushes) buffered third-party noise, matching the pre-#3161-refactor short-circuit', () => {
+    // Before centralizing the veto in emitBlockingError, the summarize branch
+    // called emitDiagnostic (which never touches bufferedChunks) and returned
+    // BEFORE reaching emitBlockingError's flush — so buffered noise stayed
+    // silently buffered until hookCommand's finally{} discarded it. Routing
+    // the summarize path through emitBlockingError unconditionally would leak
+    // that noise unless neverBlock also suppresses the flush, not just exit.
+    const real = captureRealStderr();
+    const buffer = installHookStderrBuffer();
+    try {
+      process.stderr.write('third-party noise that must stay silent on the neverBlock path\n');
+      emitBlockingError('worker unreachable for 3 consecutive hooks.', { neverBlock: true, skipExit: true });
+      const surfaced = real.chunks.join('');
+      expect(surfaced).not.toContain('third-party noise');
+      expect(surfaced).toContain('worker unreachable for 3 consecutive hooks.');
+    } finally {
+      buffer.restore();
+      real.restore();
+    }
+  });
+
+  it('emitBlockingError still flushes buffered noise on the normal (non-neverBlock) blocking path (regression guard)', () => {
+    const real = captureRealStderr();
+    const buffer = installHookStderrBuffer();
+    try {
+      process.stderr.write('buffered noise that SHOULD surface on a real blocking error\n');
+      emitBlockingError('blocking message', { skipExit: true });
+      const surfaced = real.chunks.join('');
+      expect(surfaced).toContain('buffered noise');
+      expect(surfaced).toContain('blocking message');
+    } finally {
+      buffer.restore();
+      real.restore();
+    }
+  });
+
+  it('worker-utils recordWorkerUnreachable computes neverBlock from the summarize hook type (source contract)', () => {
     const src = readFileSync(join(REPO_ROOT, 'src', 'shared', 'worker-utils.ts'), 'utf-8');
     const fnStart = src.indexOf('export async function recordWorkerUnreachable');
     expect(fnStart).toBeGreaterThan(-1);
-    // Guard the anchor itself: a missing column-0 close brace would make
-    // slice(fnStart, -1) silently widen the window to the whole file tail.
     const fnEnd = src.indexOf('\n}', fnStart);
     expect(fnEnd).toBeGreaterThan(fnStart);
     const fnBody = src.slice(fnStart, fnEnd);
-    const guardIdx = fnBody.indexOf("hookType === 'summarize'");
-    const blockIdx = fnBody.indexOf('emitBlockingError(');
-    // The summarize exemption must exist and short-circuit before exit 2.
-    expect(guardIdx).toBeGreaterThan(-1);
-    expect(blockIdx).toBeGreaterThan(-1);
-    expect(guardIdx).toBeLessThan(blockIdx);
-    // The exemption must actually SHORT-CIRCUIT: without a `return` between
-    // the guard and emitBlockingError, the summarize branch would emit the
-    // diagnostic and still fall through to exit 2 (mutation caught here).
-    expect(fnBody.slice(guardIdx, blockIdx)).toContain('return');
-    // The exempt path stays loud for the operator (diagnostic, not silence).
-    expect(fnBody).toContain('emitDiagnostic(');
+    // No local exit-2 short-circuit for summarize — the veto is delegated to
+    // emitBlockingError via the neverBlock option, not duplicated here.
+    expect(fnBody).toContain("neverBlock: hookType === 'summarize'");
+    expect(fnBody).toContain('emitBlockingError(');
   });
 
-  it('hookCommand catch-all exempts summarize from the exit-2 path too (source contract)', () => {
+  it('hookCommand catch-all delegates the summarize exemption to emitBlockingError via neverBlock (source contract)', () => {
     // The fail-loud exemption alone is not enough: non-transport errors
     // (adapter/stdin/handler throws, or a worker dying mid-response-body)
-    // escape to the catch-all, which must also never exit 2 for summarize.
+    // escape to the catch-all, which must also never exit 2 for summarize —
+    // via the same neverBlock option, not a second copy of the guard.
     const src = readFileSync(join(REPO_ROOT, 'src', 'cli', 'hook-command.ts'), 'utf-8');
     const catchIdx = src.indexOf('} catch (error) {');
     expect(catchIdx).toBeGreaterThan(-1);
     const tail = src.slice(catchIdx);
-    const exemptIdx = tail.indexOf("event === 'summarize'");
+    const neverBlockIdx = tail.indexOf("const neverBlock = event === 'summarize'");
     const blockIdx = tail.indexOf('emitBlockingError(');
-    expect(exemptIdx).toBeGreaterThan(-1);
+    expect(neverBlockIdx).toBeGreaterThan(-1);
     expect(blockIdx).toBeGreaterThan(-1);
-    expect(exemptIdx).toBeLessThan(blockIdx);
-    expect(tail.slice(exemptIdx, blockIdx)).toContain('exitGraceful');
+    expect(neverBlockIdx).toBeLessThan(blockIdx);
+    expect(tail.slice(blockIdx, blockIdx + 200)).toContain('neverBlock');
   });
 
   it('executeWithWorkerFallback handles a mid-body text() rejection as unreachable, not empty-body success (source contract)', () => {

--- a/tests/cli/hook-stream-discipline.test.ts
+++ b/tests/cli/hook-stream-discipline.test.ts
@@ -66,6 +66,80 @@ describe('#2292 — fail-loud diagnostic is no longer swallowed', () => {
   });
 });
 
+describe('#3161 — Stop hook never exits 2 on worker-unreachable', () => {
+  it('worker-utils fail-loud branch exempts summarize BEFORE the emitBlockingError exit-2 path (source contract)', () => {
+    const src = readFileSync(join(REPO_ROOT, 'src', 'shared', 'worker-utils.ts'), 'utf-8');
+    const fnStart = src.indexOf('export async function recordWorkerUnreachable');
+    expect(fnStart).toBeGreaterThan(-1);
+    // Guard the anchor itself: a missing column-0 close brace would make
+    // slice(fnStart, -1) silently widen the window to the whole file tail.
+    const fnEnd = src.indexOf('\n}', fnStart);
+    expect(fnEnd).toBeGreaterThan(fnStart);
+    const fnBody = src.slice(fnStart, fnEnd);
+    const guardIdx = fnBody.indexOf("hookType === 'summarize'");
+    const blockIdx = fnBody.indexOf('emitBlockingError(');
+    // The summarize exemption must exist and short-circuit before exit 2.
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(blockIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeLessThan(blockIdx);
+    // The exemption must actually SHORT-CIRCUIT: without a `return` between
+    // the guard and emitBlockingError, the summarize branch would emit the
+    // diagnostic and still fall through to exit 2 (mutation caught here).
+    expect(fnBody.slice(guardIdx, blockIdx)).toContain('return');
+    // The exempt path stays loud for the operator (diagnostic, not silence).
+    expect(fnBody).toContain('emitDiagnostic(');
+  });
+
+  it('hookCommand catch-all exempts summarize from the exit-2 path too (source contract)', () => {
+    // The fail-loud exemption alone is not enough: non-transport errors
+    // (adapter/stdin/handler throws, or a worker dying mid-response-body)
+    // escape to the catch-all, which must also never exit 2 for summarize.
+    const src = readFileSync(join(REPO_ROOT, 'src', 'cli', 'hook-command.ts'), 'utf-8');
+    const catchIdx = src.indexOf('} catch (error) {');
+    expect(catchIdx).toBeGreaterThan(-1);
+    const tail = src.slice(catchIdx);
+    const exemptIdx = tail.indexOf("event === 'summarize'");
+    const blockIdx = tail.indexOf('emitBlockingError(');
+    expect(exemptIdx).toBeGreaterThan(-1);
+    expect(blockIdx).toBeGreaterThan(-1);
+    expect(exemptIdx).toBeLessThan(blockIdx);
+    expect(tail.slice(exemptIdx, blockIdx)).toContain('exitGraceful');
+  });
+
+  it('executeWithWorkerFallback handles a mid-body text() rejection as unreachable, not empty-body success (source contract)', () => {
+    // A worker dying mid-body rejects text() with a plain Error whose message
+    // matches no transport pattern — unguarded it escapes to the catch-all
+    // (exit 2 on Stop). The success branch must catch it, record the failure,
+    // and return the branded fallback — NOT swallow it into an empty-body
+    // undefined "success" after resetWorkerFailureCounter has run.
+    const src = readFileSync(join(REPO_ROOT, 'src', 'shared', 'worker-utils.ts'), 'utf-8');
+    const fnStart = src.indexOf('export async function executeWithWorkerFallback');
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnBody = src.slice(fnStart);
+    // The success-branch read is wrapped so a rejection routes to the fallback.
+    const readIdx = fnBody.indexOf('text = await response.text();');
+    expect(readIdx).toBeGreaterThan(-1);
+    const catchIdx = fnBody.indexOf('recordWorkerUnreachable()', readIdx);
+    const resetIdx = fnBody.indexOf('resetWorkerFailureCounter();', readIdx);
+    // recordWorkerUnreachable + branded fallback come from the read's catch,
+    // BEFORE the success-path reset (which must only run once the body is read).
+    expect(catchIdx).toBeGreaterThan(readIdx);
+    expect(resetIdx).toBeGreaterThan(catchIdx);
+    expect(fnBody.slice(catchIdx, resetIdx)).toContain('WORKER_FALLBACK_BRAND');
+    // No bare unguarded read remains in the success path.
+    expect(fnBody.includes('await response.text();\n  if (text.length')).toBe(false);
+  });
+
+  it('claude-code adapter maps stop_hook_active so the summarize re-entry loop breaker can fire', () => {
+    const base = { session_id: 's1', cwd: process.cwd() };
+    expect(claudeCodeAdapter.normalizeInput({ ...base, stop_hook_active: true }).stopHookActive).toBe(true);
+    expect(claudeCodeAdapter.normalizeInput({ ...base, stop_hook_active: false }).stopHookActive).toBe(false);
+    expect(claudeCodeAdapter.normalizeInput(base).stopHookActive).toBeUndefined();
+    // Non-boolean junk never coerces (the handler checks `=== true`).
+    expect(claudeCodeAdapter.normalizeInput({ ...base, stop_hook_active: 'yes' }).stopHookActive).toBeUndefined();
+  });
+});
+
 describe('worker-unavailable transient path stays quiet (exit 0)', () => {
   it('exitGraceful drops buffered stderr so transient failures never leak', () => {
     const real = captureRealStderr();

--- a/tests/cli/hook-stream-discipline.test.ts
+++ b/tests/cli/hook-stream-discipline.test.ts
@@ -167,13 +167,21 @@ describe('#3161 — Stop hook never exits 2 on worker-unreachable', () => {
     // The success-branch read is wrapped so a rejection routes to the fallback.
     const readIdx = fnBody.indexOf('text = await response.text();');
     expect(readIdx).toBeGreaterThan(-1);
-    const catchIdx = fnBody.indexOf('recordWorkerUnreachable()', readIdx);
+    const catchIdx = fnBody.indexOf("buildWorkerUnreachableFallback('worker_body_read_failed')", readIdx);
     const resetIdx = fnBody.indexOf('resetWorkerFailureCounter();', readIdx);
-    // recordWorkerUnreachable + branded fallback come from the read's catch,
-    // BEFORE the success-path reset (which must only run once the body is read).
+    // The read's catch routes through the unreachable-fallback builder (which
+    // records the failure and returns the branded fallback) BEFORE the
+    // success-path reset (which must only run once the body is read).
     expect(catchIdx).toBeGreaterThan(readIdx);
     expect(resetIdx).toBeGreaterThan(catchIdx);
-    expect(fnBody.slice(catchIdx, resetIdx)).toContain('WORKER_FALLBACK_BRAND');
+    // The builder itself owns record + brand + the tripped-streak tag that
+    // feeds the summarize USER_HINT.
+    const helperStart = src.indexOf('export async function buildWorkerUnreachableFallback');
+    expect(helperStart).toBeGreaterThan(-1);
+    const helperBody = src.slice(helperStart, src.indexOf('\n}', helperStart));
+    expect(helperBody).toContain('recordWorkerUnreachable()');
+    expect(helperBody).toContain('WORKER_FALLBACK_BRAND');
+    expect(helperBody).toContain('consecutiveFailures');
     // No bare unguarded read remains in the success path.
     expect(fnBody.includes('await response.text();\n  if (text.length')).toBe(false);
   });


### PR DESCRIPTION
While the worker is down, ending a session can become impossible: the fail-loud counter (#2292) exits 2 once the worker is unreachable for N consecutive hooks, and **exit 2 from a Stop hook means "block the stop"** — Claude Code re-wakes the agent, the next Stop trips the same branch, and the session loops until the worker recovers (#3161).

## Design

One invariant, enforced at one point: **the summarize handler never exits 2.** The hook path's only `process.exit(2)` lives in `emitBlockingError`, which gains a `neverBlock` veto; both callers (the fail-loud counter, `hookCommand`'s catch-all) compute it from the active hook type. Keying on the handler name rather than the platform event makes every event mapped to summarize (Stop on Claude Code/Codex, PreCompress on Antigravity) inherit the exemption.

That single veto closes all three loop vectors:

1. **Fail-loud threshold** — counter, streak telemetry, and stderr warning unchanged; only the exit code drops to 0. The streak still blocks loudly at the next non-Stop hook, where a human or the model can act.
2. **Catch-all** — a deterministic throw (stdin/adapter/handler) exits 0 with a valid stdout envelope instead of escaping to exit 2 on every session end.
3. **Mid-body ECONNRESET** — a worker dying mid-response-body is recorded as unreachable and returns the branded fallback, instead of escaping to the catch-all or collapsing into a false empty-body success that resets the streak.

Since exit-0 stderr is verbose-only, the issue's "exit 0 with a logged warning" needs a real channel: at/past threshold the worker fallback carries `consecutiveFailures`, and the summarize handler surfaces it as `systemMessage` — *"worker unreachable for N consecutive hooks — memory capture is paused. Run `npx claude-mem restart` to recover."* Stop fires at the end of every turn, so the warning lands while the user is watching. The 429/5xx fallback is deliberately untagged: a reachable worker is a different failure mode. The claude-code adapter also maps `stop_hook_active` so the summarize re-entry breaker can fire (second line of defense).

**If you review one thing:** the `neverBlock` gate in `src/shared/hook-io.ts` and its two call sites.

## Verification

- `tsc --noEmit` clean; full suite 2254 pass / 0 fail.
- Behavioral tests: a `process.exit` spy proves the veto suppresses exit 2; buffered stderr noise is dropped on the veto path and still flushed on the normal blocking path; the handler attaches the hint at threshold and stays silent below it.
- Isolated-state replay of the repro: threshold crossed across three consecutive Stop invocations → zero exits, warning emitted, counter persisted; the same streak on `observation` still exits 2. Malformed stdin through the real `hookCommand`: summarize → exit 0 + valid envelope, observation → exit 2.

## Out of scope

- A persistently-5xx worker resets the streak each failure, so fail-loud never trips in that mode — pre-existing, different failure mode (reachable but broken), separate issue.
- The same unmapped-field / event-routing gaps on the `raw` and Antigravity adapters.

Fixes #3161