### PR TITLE
fix(sqlite): skip empty-title observations at capture

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -1890,6 +1890,13 @@ export class SessionStore {
     overrideTimestampEpoch?: number,
     generatedByModel?: string
   ): { id: number; createdAtEpoch: number } {
+    // storeObservations skips empty-title rows, which would leave no id to return here.
+    // This wrapper stores exactly one observation, so require a title up front rather than
+    // returning an undefined id.
+    if (!observation.title || observation.title.trim() === '') {
+      throw new Error('storeObservation requires a non-empty title');
+    }
+
     const result = this.storeObservations(
       memorySessionId,
       project,
@@ -1999,6 +2006,13 @@ export class SessionStore {
       );
 
       for (const observation of observations) {
+        // Skip observations with an empty title. They're malformed, low-signal rows that
+        // just take up space in the recency-based recall window without adding any facts.
+        if (!observation.title || observation.title.trim() === '') {
+          logger.debug('DB', 'Skipping observation with empty title');
+          continue;
+        }
+
         const contentHash = computeObservationContentHash(memorySessionId, observation.title, observation.narrative);
         const inserted = obsStmt.get(
           memorySessionId,

--- a/src/services/worker/http/routes/MemoryRoutes.ts
+++ b/src/services/worker/http/routes/MemoryRoutes.ts
@@ -42,7 +42,9 @@ export class MemoryRoutes extends BaseRouteHandler {
 
     const observation = {
       type: 'discovery',  // Use existing valid type
-      title: title || text.substring(0, 60).trim() + (text.length > 60 ? '...' : ''),
+      // A whitespace-only title is truthy but blank once trimmed; fall back to the text so we
+      // never hand storeObservation an empty title.
+      title: title?.trim() || text.substring(0, 60).trim() + (text.length > 60 ? '...' : ''),
       subtitle: 'Manual memory',
       facts: [] as string[],
       narrative: text,

--- a/tests/sqlite/session-store-empty-title.test.ts
+++ b/tests/sqlite/session-store-empty-title.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { SessionStore } from '../../src/services/sqlite/SessionStore.js';
+
+function obs(overrides: Partial<Parameters<SessionStore['storeObservation']>[2]> = {}) {
+  return {
+    type: 'discovery',
+    title: 'A Real Observation',
+    subtitle: null,
+    facts: [] as string[],
+    narrative: 'Some narrative content',
+    concepts: [] as string[],
+    files_read: [] as string[],
+    files_modified: [] as string[],
+    ...overrides,
+  };
+}
+
+describe('SessionStore.storeObservations empty-title handling', () => {
+  let store: SessionStore;
+
+  beforeEach(() => {
+    store = new SessionStore(':memory:');
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  // observations.memory_session_id is an enforced FK to sdk_sessions; register it first.
+  function session(memorySessionId: string): string {
+    const id = store.createSDKSession(`content-${memorySessionId}`, 'project', 'prompt');
+    store.updateMemorySessionId(id, memorySessionId);
+    return memorySessionId;
+  }
+
+  it('skips observations with empty, whitespace-only, or null titles', () => {
+    const mem = session('mem-empty-title');
+
+    const result = store.storeObservations(
+      mem,
+      'project',
+      [
+        obs({ title: 'A Real Observation' }),
+        obs({ title: '' }),
+        obs({ title: '   ' }),
+        obs({ title: null }),
+      ],
+      null,
+      1,
+      0,
+    );
+
+    expect(result.observationIds.length).toBe(1);
+
+    const stored = store.getObservationsForSession(mem);
+    expect(stored.length).toBe(1);
+    expect(stored[0].title).toBe('A Real Observation');
+  });
+
+  it('stores every observation when all titles are present', () => {
+    const mem = session('mem-all-titled');
+
+    const result = store.storeObservations(
+      mem,
+      'project',
+      [obs({ title: 'First' }), obs({ title: 'Second' })],
+      null,
+      1,
+      0,
+    );
+
+    expect(result.observationIds.length).toBe(2);
+    expect(store.getObservationsForSession(mem).length).toBe(2);
+  });
+
+  it('storeObservation (single) throws on an empty title instead of returning an undefined id', () => {
+    const mem = session('mem-single-empty');
+    expect(() => store.storeObservation(mem, 'project', obs({ title: '' }))).toThrow(/non-empty title/);
+    expect(() => store.storeObservation(mem, 'project', obs({ title: null }))).toThrow(/non-empty title/);
+  });
+
+  it('storeObservation (single) stores and returns a real id for a titled observation', () => {
+    const mem = session('mem-single-ok');
+    const result = store.storeObservation(mem, 'project', obs({ title: 'Kept' }));
+    expect(result.id).toBeGreaterThan(0);
+  });
+});

--- a/tests/worker/http/routes/memory-routes.test.ts
+++ b/tests/worker/http/routes/memory-routes.test.ts
@@ -174,4 +174,22 @@ describe('MemoryRoutes — POST /api/memory/save (#2116)', () => {
     expect(statusSpy).toHaveBeenCalledWith(400);
     expect(mockStoreObservation).not.toHaveBeenCalled();
   });
+
+  it('falls back to a text-derived title when the title is whitespace-only', () => {
+    const handler = buildHandler();
+    const { req, res } = createMockReqRes({ text: 'the memory body text', title: '   ' });
+    handler(req as Request, res as Response);
+
+    expect(mockStoreObservation).toHaveBeenCalledTimes(1);
+    // A whitespace-only title must not reach storeObservation (it would throw); use the text.
+    expect(storeObservationCalls[0][2].title).toBe('the memory body text');
+  });
+
+  it('uses the provided title (trimmed) when it has content', () => {
+    const handler = buildHandler();
+    const { req, res } = createMockReqRes({ text: 'body', title: '  My Title  ' });
+    handler(req as Request, res as Response);
+
+    expect(storeObservationCalls[0][2].title).toBe('My Title');
+  });
 });


### PR DESCRIPTION
## What & why

`content_hash` dedup only catches byte-identical observations, so it can't stop malformed rows from piling up. #3163 measured 212 empty-title observations in a real ~45k-row DB. They're pure noise that still take slots in the recency-ordered recall window injected at session start.

This is the smallest, no-ambiguity slice of #3163: stop empty-title observations at capture.

## Change

- `SessionStore.storeObservations` (the live capture path the summarizer uses) skips any observation whose title is null, empty, or whitespace-only, so the row is never written.
- The single-observation `storeObservation` wrapper requires a non-empty title (throws rather than returning an undefined id), keeping its `{ id: number }` contract.
- Its one caller, `POST /api/memory/save` (`MemoryRoutes`), now falls back to the text-derived title for empty **and** whitespace-only titles. Previously `title || fallback` let a whitespace-only title through, which would have hit the guard; `text` is validated non-empty, so the fallback is always valid.
- `importObservation` is untouched, so restoring an existing DB preserves historical rows.

## Testing

- `tests/sqlite/session-store-empty-title.test.ts`: batch skips empty/whitespace/null titles; the single-observation wrapper throws on an empty title and stores a titled one.
- `tests/worker/http/routes/memory-routes.test.ts`: a whitespace-only title falls back to the text-derived title, and a provided title is used (trimmed).
- SQLite suite: 72 pass. Route suite: 9 pass. `tsc --noEmit`: clean.

## Follow-ups

The bigger part of #3163 (coalescing repeated `(project, title)` boilerplate onto a counter) has real design choices: exact vs fuzzy title match, which types to coalesce, and the coalesce semantics. I left it out to keep this bounded. Happy to do it next if you let me know how you'd want the dedup to behave.

Refs #3163
