### PR TITLE
fix: reap children leaked by non-graceful worker deaths at boot

### DIFF
--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -17,7 +17,7 @@ import { logger } from '../utils/logger.js';
 import { ChromaMcpManager } from './sync/ChromaMcpManager.js';
 import { ChromaSync } from './sync/ChromaSync.js';
 import { openConfiguredSqliteDatabase } from './sqlite/connection.js';
-import { configureSupervisorSignalHandlers, getSupervisor, startSupervisor } from '../supervisor/index.js';
+import { configureSupervisorSignalHandlers, getSupervisor, reapLeakedProcesses, startSupervisor } from '../supervisor/index.js';
 import { sanitizeEnv } from '../supervisor/env-sanitizer.js';
 
 import { ensureWorkerStarted as ensureWorkerStartedShared, type WorkerStartResult } from './worker-spawner.js';
@@ -412,6 +412,24 @@ export class WorkerService implements WorkerRef {
     this.detectPreviousShutdown();
 
     await startSupervisor();
+
+    // Reap children leaked by a previous run that died outside the graceful-
+    // shutdown path (crash, SIGKILL, or shutdown-deadline expiry). Must run
+    // before server.listen: with no hook traffic yet this run has registered
+    // nothing, so every live registry record except our own pid is a leak
+    // from a dead predecessor (issue #3175).
+    try {
+      const reaped = await reapLeakedProcesses(getSupervisor().getRegistry());
+      if (reaped > 0) {
+        logger.info('SYSTEM', 'Reaped processes leaked by previous worker run', { reaped });
+      }
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        logger.warn('SYSTEM', 'Leaked-process reap failed (non-blocking)', {}, error);
+      } else {
+        logger.warn('SYSTEM', 'Leaked-process reap failed (non-blocking, non-Error)', { error: String(error) });
+      }
+    }
 
     await this.server.listen(port, host);
 

--- a/src/supervisor/index.ts
+++ b/src/supervisor/index.ts
@@ -8,6 +8,7 @@ import {
   type ProcessRegistry
 } from './process-registry.js';
 import { runShutdownCascade } from './shutdown.js';
+export { reapLeakedProcesses } from './shutdown.js';
 import { startHealthChecker, stopHealthChecker } from './health-checker.js';
 import { paths } from '../shared/paths.js';
 

--- a/src/supervisor/shutdown.ts
+++ b/src/supervisor/shutdown.ts
@@ -148,6 +148,135 @@ export function removeOwnedPidFile(pidFilePath: string, currentPid: number | nul
   }
 }
 
+// Cmdline markers used by reapLeakedProcesses to confirm a persisted registry
+// entry still refers to the process it was recorded for. The registry file
+// survives crashes AND system reboots, so a recorded pid may have been
+// recycled by an unrelated process — signaling it blindly could kill an
+// innocent bystander. Entries whose type has no marker are signaled as-is
+// (same trust level as the shutdown cascade).
+const REAP_CMDLINE_MARKERS: Record<string, string> = {
+  chroma: 'chroma-mcp'
+};
+
+async function processCommandLine(pid: number): Promise<string | null> {
+  if (process.platform === 'win32') return null;
+  try {
+    const { stdout } = await execFileAsync('ps', ['-p', String(pid), '-o', 'args=']);
+    return stdout.trim() || null;
+  } catch {
+    // Process exited between checks, or ps is unavailable — caller treats
+    // null as "cannot verify" and falls back to signaling.
+    return null;
+  }
+}
+
+/**
+ * Reap children leaked by a previous worker run that died outside the
+ * graceful-shutdown path (SIGKILL, OOM, crash, or the runShutdownSequence
+ * hard deadline expiring before chroma teardown). ProcessRegistry persists
+ * across runs and initialize() only prunes DEAD entries, so anything still
+ * alive in the registry at boot belongs to a dead predecessor: this run's
+ * first register() under the same id would silently overwrite the entry and
+ * orphan the process forever (issue #3175 — chroma-mcp spawn chains
+ * accumulating for weeks, one tree per non-graceful worker death).
+ *
+ * Must run after startSupervisor() and BEFORE the HTTP server starts
+ * listening: with no hook traffic yet this run has registered nothing, so
+ * every live record except our own pid is a leak. Unlike runShutdownCascade
+ * this never touches the PID file — the boot path owns it.
+ */
+export async function reapLeakedProcesses(registry: ProcessRegistry): Promise<number> {
+  const leaked: ManagedProcessRecord[] = [];
+
+  for (const record of registry.getAll()) {
+    if (record.pid === process.pid) continue;
+    if (!isPidAlive(record.pid)) {
+      registry.unregister(record.id);
+      continue;
+    }
+
+    const marker = REAP_CMDLINE_MARKERS[record.type];
+    if (marker) {
+      const cmdline = await processCommandLine(record.pid);
+      if (cmdline !== null && !cmdline.includes(marker)) {
+        // The pid now belongs to an unrelated process (recycled, e.g. after
+        // a reboot) — drop the entry without signaling anyone.
+        logger.warn('SYSTEM', 'Registry entry pid recycled by an unrelated process, dropping without kill', {
+          id: record.id,
+          pid: record.pid,
+          type: record.type,
+          startedAt: record.startedAt
+        });
+        registry.unregister(record.id);
+        continue;
+      }
+    }
+
+    leaked.push(record);
+  }
+
+  if (leaked.length === 0) return 0;
+
+  for (const record of leaked) {
+    logger.warn('SYSTEM', 'Reaping process leaked by a previous worker run', {
+      id: record.id,
+      pid: record.pid,
+      pgid: record.pgid,
+      type: record.type,
+      startedAt: record.startedAt
+    });
+    try {
+      await signalProcess(record, 'SIGTERM');
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        logger.debug('SYSTEM', 'Failed to SIGTERM leaked process', {
+          pid: record.pid,
+          pgid: record.pgid,
+          type: record.type
+        }, error);
+      } else {
+        logger.warn('SYSTEM', 'Failed to SIGTERM leaked process (non-Error)', {
+          pid: record.pid,
+          pgid: record.pgid,
+          type: record.type,
+          error: String(error)
+        });
+      }
+    }
+  }
+
+  await waitForExit(leaked, 5000);
+
+  const survivors = leaked.filter(record => isPidAlive(record.pid));
+  for (const record of survivors) {
+    try {
+      await signalProcess(record, 'SIGKILL');
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        logger.debug('SYSTEM', 'Failed to SIGKILL leaked process', {
+          pid: record.pid,
+          pgid: record.pgid,
+          type: record.type
+        }, error);
+      } else {
+        logger.warn('SYSTEM', 'Failed to SIGKILL leaked process (non-Error)', {
+          pid: record.pid,
+          pgid: record.pgid,
+          type: record.type,
+          error: String(error)
+        });
+      }
+    }
+  }
+  await waitForExit(survivors, 1000);
+
+  for (const record of leaked) {
+    registry.unregister(record.id);
+  }
+
+  return leaked.length;
+}
+
 async function signalProcess(record: ManagedProcessRecord, signal: 'SIGTERM' | 'SIGKILL'): Promise<void> {
   const { pid, pgid } = record;
 

--- a/tests/supervisor/shutdown.test.ts
+++ b/tests/supervisor/shutdown.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, it } from 'bun:test';
+import { spawn } from 'child_process';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import { createProcessRegistry } from '../../src/supervisor/process-registry.js';
-import { removeOwnedPidFile, runShutdownCascade } from '../../src/supervisor/shutdown.js';
+import { reapLeakedProcesses, removeOwnedPidFile, runShutdownCascade } from '../../src/supervisor/shutdown.js';
 
 function makeTempDir(): string {
   return path.join(tmpdir(), `claude-mem-shutdown-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -216,6 +217,110 @@ describe('supervisor shutdown cascade', () => {
     });
 
     expect(registry.getAll()).toHaveLength(0);
+  });
+});
+
+// Issue #3175: children leaked by a worker that died outside the graceful-
+// shutdown path stay alive in the persisted registry; the successor's first
+// register() under the same id would silently overwrite them. Boot-time reap
+// terminates them instead.
+describe('reapLeakedProcesses (issue #3175)', () => {
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  function makeRegistry() {
+    const tempDir = makeTempDir();
+    tempDirs.push(tempDir);
+    mkdirSync(tempDir, { recursive: true });
+    return createProcessRegistry(path.join(tempDir, 'supervisor.json'));
+  }
+
+  it('prunes dead entries without signaling and reaps live leaked ones', async () => {
+    const registry = makeRegistry();
+    registry.register('dead-child', {
+      pid: 2147483641,
+      type: 'mcp',
+      startedAt: '2026-03-15T00:00:00.000Z'
+    });
+    registry.register('leaked-child', {
+      pid: 41010,
+      type: 'mcp',
+      startedAt: '2026-03-15T00:00:01.000Z'
+    });
+
+    const originalKill = process.kill;
+    const alive = new Set([41010]);
+    const calls: Array<{ pid: number; signal: NodeJS.Signals | number }> = [];
+
+    process.kill = ((pid: number, signal?: NodeJS.Signals | number) => {
+      const normalizedSignal = signal ?? 'SIGTERM';
+      if (normalizedSignal === 0) {
+        if (!alive.has(pid)) {
+          const error = new Error(`kill ESRCH ${pid}`) as NodeJS.ErrnoException;
+          error.code = 'ESRCH';
+          throw error;
+        }
+        return true;
+      }
+      calls.push({ pid, signal: normalizedSignal });
+      alive.delete(pid);
+      return true;
+    }) as typeof process.kill;
+
+    let reaped: number;
+    try {
+      reaped = await reapLeakedProcesses(registry);
+    } finally {
+      process.kill = originalKill;
+    }
+
+    expect(reaped).toBe(1);
+    expect(calls).toEqual([{ pid: 41010, signal: 'SIGTERM' }]);
+    expect(registry.getAll()).toHaveLength(0);
+  });
+
+  it('never touches the current process entry', async () => {
+    const registry = makeRegistry();
+    registry.register('worker', {
+      pid: process.pid,
+      type: 'worker',
+      startedAt: '2026-03-15T00:00:00.000Z'
+    });
+
+    const reaped = await reapLeakedProcesses(registry);
+
+    expect(reaped).toBe(0);
+    expect(registry.getAll()).toHaveLength(1);
+  });
+
+  // The registry file survives system reboots, so a recorded pid may have
+  // been recycled by an unrelated process. A marker-typed entry whose live
+  // cmdline does not match must be dropped WITHOUT being signaled.
+  it.skipIf(process.platform === 'win32')('drops a recycled pid without killing it (cmdline mismatch)', async () => {
+    const bystander = spawn('sleep', ['60'], { stdio: 'ignore' });
+    try {
+      const registry = makeRegistry();
+      registry.register('chroma-mcp', {
+        pid: bystander.pid!,
+        type: 'chroma',
+        startedAt: '2026-03-15T00:00:00.000Z'
+      });
+
+      const reaped = await reapLeakedProcesses(registry);
+
+      expect(reaped).toBe(0);
+      expect(registry.getAll()).toHaveLength(0);
+      // The bystander must still be alive: signal 0 probes without killing.
+      expect(() => process.kill(bystander.pid!, 0)).not.toThrow();
+    } finally {
+      bystander.kill('SIGKILL');
+    }
   });
 });
 


### PR DESCRIPTION
## Problem

Fixes #3175 — orphaned `chroma-mcp` process trees accumulating indefinitely.

Field data from two Linux hosts (v13.x, worker runtime):

- Host A: 15 leaked `uvx chroma-mcp` + python pairs, oldest 21 days, ~4.2 GB RSS combined, one pair per day of use.
- Host B: 31 leaked pairs at the moment of cleanup.
- Each leaked tree also holds `~/.cache/uv/.lock`, which blocks `uv cache prune` (the cache-bloat side effect reported in the issue).

## Root cause (not the missing SessionEnd hook)

`chroma-mcp` is spawned by the **worker** (`ChromaMcpManager` singleton), not per Claude session, so a `SessionEnd` hook would not help. The graceful path already tears the tree down correctly (`performGracefulShutdown` → `chromaMcpManager.stop()` → tree-kill).

The leak happens when a worker dies **outside** the graceful path — SIGKILL, OOM, crash, or the `runShutdownSequence` hard deadline expiring before chroma teardown:

1. `ProcessRegistry` persists to `supervisor.json` across runs.
2. On the next boot, `initialize()` calls `pruneDeadEntries()`, which removes only entries whose pid is **dead**. The predecessor's still-alive chroma entry survives the prune.
3. The successor's first `registerProcess('chroma-mcp', ...)` overwrites that entry — the old pid is forgotten while the process keeps running. Permanent orphan, one tree per non-graceful death.

## Fix

New `reapLeakedProcesses(registry)` in `src/supervisor/shutdown.ts`, called from worker `start()` after `startSupervisor()` and **before** `server.listen`:

- At that point this run has registered nothing (no hook traffic yet), so every live registry record other than our own pid is a leak from a dead predecessor.
- Reuses the existing `signalProcess` / `waitForExit` primitives: SIGTERM → wait 5 s → SIGKILL → unregister. pgid-based group signaling reaches the re-parented `uv → python → chroma-mcp` grandchildren, same as the shutdown cascade.
- **PID-recycling guard**: the registry file survives system reboots, so a recorded pid may now belong to an unrelated process. Marker-typed entries (`chroma` → `chroma-mcp`) are verified against the live process cmdline first; on mismatch the entry is dropped **without** signaling anyone.
- Unlike `runShutdownCascade`, this never touches the PID file — the boot path owns it.
- Best-effort: failures log a warning and never block worker boot.

## Tests

Three new cases in `tests/supervisor/shutdown.test.ts`:

- prunes dead entries without signaling and reaps live leaked ones
- never touches the current process entry
- drops a recycled pid without killing it (real `sleep` bystander, cmdline mismatch)

`bun test tests/supervisor tests/services/worker-shutdown-sequence.test.ts tests/infrastructure/graceful-shutdown.test.ts`: 79 pass, 0 fail. `tsc --noEmit` clean.
