### PR TITLE
Observe silent worker failures: log disabled-refusal + wire dead ai.lastInteraction field

### DIFF
--- a/src/sdk/output-classifier.ts
+++ b/src/sdk/output-classifier.ts
@@ -70,3 +70,30 @@ export function isQuotaLimitedObserverOutput(raw: unknown): boolean {
     /\b(rate limit|quota)\b.*\b(subscription|weekly|claude usage)\b.*\b(reached|exceeded|exhausted|reset|resets|try again)\b/.test(text)
   );
 }
+
+/**
+ * Detect authentication-failure prose returned as an assistant message instead of
+ * a structured error — e.g. the Claude CLI's "Not logged in · Please run /login"
+ * or an API "401 / Invalid authentication credentials". Distinct from a benign
+ * `idle` "nothing to observe": auth prose means the extraction silently produced
+ * NOTHING and will keep doing so until re-auth, so the pipeline should record a
+ * durable signal (see ResponseProcessor) rather than drop it indistinguishably.
+ * Kept intentionally narrow so ordinary prose about auth/HTTP does not trip it.
+ */
+export function isAuthFailureObserverOutput(raw: unknown): boolean {
+  if (typeof raw !== 'string' || raw.trim() === '') {
+    return false;
+  }
+
+  const text = raw.toLowerCase().replace(/\s+/g, ' ').trim();
+
+  return (
+    /\bnot logged in\b/.test(text) ||
+    /\brun\b[^.]{0,30}\/login\b/.test(text) ||
+    /invalid authentication/.test(text) ||
+    /authentication (failed|error|credentials)/.test(text) ||
+    /\bunauthenticated\b/.test(text) ||
+    /\bapi error:?\s*401\b/.test(text) ||
+    /\b401\b[^0-9]{0,40}(unauthor|authenticat|credential|token|login)/.test(text)
+  );
+}

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -787,6 +787,18 @@ export class WorkerService implements WorkerRef {
       });
     })();
   }
+
+  recordAiInteraction(result: { success: boolean; error?: string }): void {
+    let provider = 'claude';
+    if (isOpenRouterSelected() && isOpenRouterAvailable()) provider = 'openrouter';
+    else if (isGeminiSelected() && isGeminiAvailable()) provider = 'gemini';
+    this.lastAiInteraction = {
+      timestamp: Date.now(),
+      success: result.success,
+      provider,
+      ...(result.error ? { error: result.error } : {}),
+    };
+  }
 }
 
 export async function ensureWorkerStarted(port: number): Promise<WorkerStartResult> {
@@ -992,6 +1004,15 @@ async function main() {
 
   const hookInitiatedCommands = ['start', 'hook', 'restart', '--daemon'];
   if ((command === undefined || hookInitiatedCommands.includes(command)) && isPluginDisabledInClaudeSettings()) {
+    // Log the reason instead of exiting silently. Without this line, a disabled
+    // plugin makes the worker refuse every start/hook/--daemon with a bare
+    // exit(0) and no trace — indistinguishable from a crash, and only
+    // discoverable by reverse-engineering the bundle. One INFO line turns
+    // "memory mysteriously stopped" into an obvious cause.
+    logger.info('SYSTEM', 'Worker not starting: claude-mem is disabled in Claude settings (enabledPlugins["claude-mem@thedotmack"] === false). Re-enable the plugin to resume memory capture.', {
+      command: command ?? '(none)',
+      configDir: process.env.CLAUDE_CONFIG_DIR || '~/.claude',
+    });
     process.exit(0);
   }
 

--- a/src/services/worker/agents/ResponseProcessor.ts
+++ b/src/services/worker/agents/ResponseProcessor.ts
@@ -4,6 +4,7 @@ import { parseAgentXml, type ParsedObservation, type ParsedSummary } from '../..
 import {
   classifyObserverOutput,
   isQuotaLimitedObserverOutput,
+  isAuthFailureObserverOutput,
   previewOutput,
 } from '../../../sdk/output-classifier.js';
 import { updateCursorContextForProject } from '../../integrations/CursorHooksInstaller.js';
@@ -82,6 +83,12 @@ export async function processAgentResponse(
       consecutiveInvalidOutputs: session.consecutiveInvalidOutputs,
     });
 
+    // Auth-failure prose means extraction produced nothing and will keep doing
+    // so until re-auth — record a durable failure signal before dropping.
+    if (isAuthFailureObserverOutput(text)) {
+      worker?.recordAiInteraction?.({ success: false, error: 'unauthenticated' });
+    }
+
     // Plain-text skip responses are intentionally ignored. Re-queueing them
     // creates an observer loop where the same low-signal batch is retried.
     await sessionManager.confirmClaimedMessages(session.sessionDbId);
@@ -142,6 +149,8 @@ export async function processAgentResponse(
     sessionId: session.sessionDbId,
     memorySessionId: session.memorySessionId
   });
+
+  worker?.recordAiInteraction?.({ success: true });
 
   session.lastSummaryStored = result.summaryId !== null;
 

--- a/src/services/worker/agents/types.ts
+++ b/src/services/worker/agents/types.ts
@@ -4,6 +4,7 @@ export interface WorkerRef {
     broadcast(event: SSEEventPayload): void;
   };
   broadcastProcessingStatus?: () => void;
+  recordAiInteraction?: (result: { success: boolean; error?: string }) => void;
 }
 
 export interface ObservationSSEPayload {

--- a/tests/sdk/output-classifier.test.ts
+++ b/tests/sdk/output-classifier.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'bun:test';
 import {
   classifyObserverOutput,
   isQuotaLimitedObserverOutput,
+  isAuthFailureObserverOutput,
   previewOutput,
 } from '../../src/sdk/output-classifier.js';
 
@@ -71,6 +72,43 @@ describe('isQuotaLimitedObserverOutput', () => {
 
   it('does not treat ordinary observer prose as quota prose', () => {
     expect(isQuotaLimitedObserverOutput('No observations to record.')).toBe(false);
+  });
+});
+
+describe('isAuthFailureObserverOutput', () => {
+  it('detects "Not logged in · Please run /login" prose', () => {
+    expect(isAuthFailureObserverOutput('Not logged in · Please run /login')).toBe(true);
+  });
+
+  it('detects a 401 invalid-credentials API error', () => {
+    expect(
+      isAuthFailureObserverOutput('API Error: 401 Invalid authentication credentials'),
+    ).toBe(true);
+  });
+
+  it('detects "Unauthenticated request" prose', () => {
+    expect(isAuthFailureObserverOutput('Unauthenticated request')).toBe(true);
+  });
+
+  it('returns false for empty / non-string input (fail-safe)', () => {
+    expect(isAuthFailureObserverOutput('')).toBe(false);
+    expect(isAuthFailureObserverOutput('   ')).toBe(false);
+    expect(isAuthFailureObserverOutput(undefined)).toBe(false);
+    expect(isAuthFailureObserverOutput(null)).toBe(false);
+  });
+
+  it('does not treat ordinary observer prose as auth failure', () => {
+    expect(isAuthFailureObserverOutput('I observe no tool executions to record.')).toBe(false);
+  });
+
+  it('does not treat valid observation XML as auth failure', () => {
+    expect(
+      isAuthFailureObserverOutput('<observation><type>discovery</type><title>x</title></observation>'),
+    ).toBe(false);
+  });
+
+  it('does not trip on the number 401 in a non-auth sentence', () => {
+    expect(isAuthFailureObserverOutput('We processed 401 records without error.')).toBe(false);
   });
 });
 

--- a/tests/worker/agents/response-processor.test.ts
+++ b/tests/worker/agents/response-processor.test.ts
@@ -40,6 +40,7 @@ describe('ResponseProcessor', () => {
   let mockChromaSyncSummary: ReturnType<typeof mock>;
   let mockBroadcast: ReturnType<typeof mock>;
   let mockBroadcastProcessingStatus: ReturnType<typeof mock>;
+  let mockRecordAiInteraction: ReturnType<typeof mock>;
   let mockDbManager: DatabaseManager;
   let mockSessionManager: SessionManager;
   let mockWorker: WorkerRef;
@@ -89,12 +90,14 @@ describe('ResponseProcessor', () => {
 
     mockBroadcast = mock(() => {});
     mockBroadcastProcessingStatus = mock(() => {});
+    mockRecordAiInteraction = mock(() => {});
 
     mockWorker = {
       sseBroadcaster: {
         broadcast: mockBroadcast,
       },
       broadcastProcessingStatus: mockBroadcastProcessingStatus,
+      recordAiInteraction: mockRecordAiInteraction,
     };
   });
 
@@ -235,6 +238,54 @@ describe('ResponseProcessor', () => {
       expect(confirmClaimedMessages).toHaveBeenCalledWith(1);
       expect(session.earliestPendingTimestamp).toBeNull();
       expect(mockStoreObservations).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('AI interaction health signal', () => {
+    it('records a failed interaction when the observer returns auth-failure prose', async () => {
+      const session = createMockSession();
+      const responseText = 'API Error: 401 Invalid authentication credentials';
+
+      await processAgentResponse(
+        responseText, session, mockDbManager, mockSessionManager, mockWorker,
+        100, null, 'TestAgent'
+      );
+
+      expect(mockRecordAiInteraction).toHaveBeenCalledWith({ success: false, error: 'unauthenticated' });
+      expect(mockStoreObservations).not.toHaveBeenCalled();
+    });
+
+    it('does NOT record an interaction for ordinary non-auth prose', async () => {
+      const session = createMockSession();
+      const responseText = 'Skipping — repeated log scan with no new findings.';
+
+      await processAgentResponse(
+        responseText, session, mockDbManager, mockSessionManager, mockWorker,
+        100, null, 'TestAgent'
+      );
+
+      expect(mockRecordAiInteraction).not.toHaveBeenCalled();
+    });
+
+    it('records a successful interaction when observations store', async () => {
+      const session = createMockSession();
+      const responseText = `
+        <observation>
+          <type>discovery</type>
+          <title>Test</title>
+          <facts></facts>
+          <concepts></concepts>
+          <files_read></files_read>
+          <files_modified></files_modified>
+        </observation>
+      `;
+
+      await processAgentResponse(
+        responseText, session, mockDbManager, mockSessionManager, mockWorker,
+        100, null, 'TestAgent'
+      );
+
+      expect(mockRecordAiInteraction).toHaveBeenCalledWith({ success: true });
     });
   });
 


### PR DESCRIPTION
## Problem

Two silent failure modes make "memory mysteriously stopped recording" effectively undiagnosable:

**1. A disabled plugin exits silently.** When `enabledPlugins["claude-mem@thedotmack"] === false`, `worker-service.ts` `main()` refuses every `start` / `hook` / `restart` / `--daemon` with a bare `process.exit(0)` and no log line — indistinguishable from a crash. The only way to find the cause today is to reverse-engineer the shipped bundle.

**2. Auth-failure prose is dropped indistinguishably, and `ai.lastInteraction` is a dead field.** When the SDK is not authenticated it returns assistant prose ("Not logged in · Please run /login", or a `401 / Invalid authentication credentials`). `classifyObserverOutput` labels that `'prose'`, and `ResponseProcessor` confirms-and-drops it exactly like a benign `idle` ("nothing to observe"). Meanwhile `/api/health` → `ai.lastInteraction` is declared (worker-service.ts) but **never assigned anywhere in `src/`**, so it is always `null`. Net effect: observations silently stop landing while `/api/health` keeps returning `status: ok` and `ai.lastInteraction: null` — no signal that memory has stopped recording.

## Changes (source-only; no drop-semantics or HTTP-status change)

- **`worker-service.ts`** — one `logger.info` before the disabled-plugin `exit(0)`, naming the cause and the fix.
- **`sdk/output-classifier.ts`** — `isAuthFailureObserverOutput()`: a deliberately narrow predicate (mirrors the existing `isQuotaLimitedObserverOutput`) that recognizes auth-failure prose, distinct from benign `idle`.
- **`worker-service.ts`** — implement `recordAiInteraction()`, wiring the previously-dead `lastAiInteraction` field (deriving `provider` the same way `getAiStatus` already does).
- **`worker/agents/ResponseProcessor.ts`** — record `{ success: false, error: 'unauthenticated' }` when auth-failure prose is dropped, and `{ success: true }` after a successful store. `WorkerRef` gains an optional `recordAiInteraction?`.

Result: `/api/health` → `ai.lastInteraction` now reflects whether the SDK is actually authenticating (and when the last successful extraction happened), and recovers automatically on the next success. HTTP status codes and the existing drop behavior are unchanged.

## Tests

- `tests/sdk/output-classifier.test.ts` — `isAuthFailureObserverOutput` is true for the auth strings; false for empty/whitespace/non-string, benign observer prose, a real `<observation>` string, and a non-auth sentence containing "401".
- `tests/worker/agents/response-processor.test.ts` — records failure on auth-failure prose, nothing on ordinary prose, success on a valid store.
- `bun run typecheck:root` is clean; `bun test` on the touched files → **49 pass / 0 fail**.
