### PR TITLE
fix(observer): treat correct-empty observer prose as idle (#3193)

### DIFF
--- a/src/sdk/output-classifier.ts
+++ b/src/sdk/output-classifier.ts
@@ -34,7 +34,8 @@ export function previewOutput(raw: unknown, maxLength: number = PREVIEW_LENGTH):
  * - `xml`      — contains a parseable `<observation>`/`<summary>`/`<skip_summary/>`
  *                root tag. (Whether it ultimately yields rows is parseAgentXml's
  *                job; this is the structural gate.)
- * - `idle`     — empty / whitespace-only. Benign: the SDK had nothing to say.
+ * - `idle`     — empty / whitespace-only, or polite ready/no-work prose.
+ *                Benign: the SDK had nothing substantive to say.
  * - `prose`    — any other non-XML text. Conversational output; not persisted.
  */
 export function classifyObserverOutput(raw: unknown): ObserverOutputClass {
@@ -44,6 +45,16 @@ export function classifyObserverOutput(raw: unknown): ObserverOutputClass {
 
   if (/<(observation|summary)\b/i.test(raw) || /<skip_summary\b/i.test(raw)) {
     return 'xml';
+  }
+
+  const text = raw.toLowerCase().replace(/\s+/g, ' ').trim();
+  if (
+    /\bno observations to record\b/.test(text)
+    || /\bnothing (?:to|new to) (?:record|observe|report|do)\b/.test(text)
+    || /\b(?:ready|waiting) to observe and record\b/.test(text)
+    || /\bi do(?:n't| not) see any tool executions, file changes,? or technical work\b/.test(text)
+  ) {
+    return 'idle';
   }
 
   return 'prose';

--- a/src/sdk/output-classifier.ts
+++ b/src/sdk/output-classifier.ts
@@ -49,10 +49,10 @@ export function classifyObserverOutput(raw: unknown): ObserverOutputClass {
 
   const text = raw.toLowerCase().replace(/\s+/g, ' ').trim();
   if (
-    /\bno observations to record\b/.test(text)
-    || /\bnothing (?:to|new to) (?:record|observe|report|do)\b/.test(text)
-    || /\b(?:ready|waiting) to observe and record\b/.test(text)
-    || /\bi do(?:n't| not) see any tool executions, file changes,? or technical work\b/.test(text)
+    /^no observations to record[.!]?$/i.test(text)
+    || /^nothing (?:to|new to) (?:record|observe|report|do)[.!]?$/i.test(text)
+    || /^(?:i['’]m |i am )?(?:ready|waiting) to observe and record,? but i do(?:n't| not) see any tool executions, file changes,? or technical work[.!]?$/i.test(text)
+    || /^i do(?:n't| not) see any tool executions, file changes,? or technical work[.!]?$/i.test(text)
   ) {
     return 'idle';
   }

--- a/tests/sdk/output-classifier.test.ts
+++ b/tests/sdk/output-classifier.test.ts
@@ -47,6 +47,12 @@ describe('classifyObserverOutput (plan-11 #2485)', () => {
     ).toBe('idle');
   });
 
+  it('keeps mixed ready-plus-failure prose in the prose bucket', () => {
+    expect(
+      classifyObserverOutput('Ready to observe and record, but the prior batch failed to parse.'),
+    ).toBe('prose');
+  });
+
   it('classifies former poison marker strings as ordinary prose', () => {
     expect(classifyObserverOutput('This session has been exhausted, I cannot continue.')).toBe('prose');
     expect(classifyObserverOutput('Error: prompt is too long for this model.')).toBe('prose');

--- a/tests/sdk/output-classifier.test.ts
+++ b/tests/sdk/output-classifier.test.ts
@@ -39,6 +39,14 @@ describe('classifyObserverOutput (plan-11 #2485)', () => {
     expect(classifyObserverOutput('Skipping — repeated log scan with no new findings.')).toBe('prose');
   });
 
+  it('classifies polite ready/no-work prose as idle', () => {
+    expect(
+      classifyObserverOutput(
+        `I'm ready to observe and record, but I don't see any tool executions, file changes, or technical work.`,
+      ),
+    ).toBe('idle');
+  });
+
   it('classifies former poison marker strings as ordinary prose', () => {
     expect(classifyObserverOutput('This session has been exhausted, I cannot continue.')).toBe('prose');
     expect(classifyObserverOutput('Error: prompt is too long for this model.')).toBe('prose');

--- a/tests/worker/agents/response-processor.test.ts
+++ b/tests/worker/agents/response-processor.test.ts
@@ -236,6 +236,42 @@ describe('ResponseProcessor', () => {
       expect(session.earliestPendingTimestamp).toBeNull();
       expect(mockStoreObservations).not.toHaveBeenCalled();
     });
+
+    it('treats polite ready/no-work prose as idle and keeps the invalid-output counter at zero', async () => {
+      const confirmClaimedMessages = mock(() => Promise.resolve(0));
+      mockSessionManager = {
+        getMessageIterator: async function* () { yield* []; },
+        getPendingMessageStore: () => ({ confirmProcessed: mock(() => {}) }),
+        confirmClaimedMessages,
+      } as unknown as SessionManager;
+
+      const session = createMockSession({
+        consecutiveInvalidOutputs: 2,
+      });
+      const responseText =
+        `I'm ready to observe and record, but I don't see any tool executions, file changes, or technical work.`;
+
+      await processAgentResponse(
+        responseText,
+        session,
+        mockDbManager,
+        mockSessionManager,
+        mockWorker,
+        100,
+        null,
+        'TestAgent'
+      );
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'PARSER',
+        expect.stringMatching(/^TestAgent returned non-XML idle response/),
+        expect.objectContaining({ sessionId: 1, outputClass: 'idle', consecutiveInvalidOutputs: 0 })
+      );
+      expect(confirmClaimedMessages).toHaveBeenCalledWith(1);
+      expect(session.consecutiveInvalidOutputs).toBe(0);
+      expect(session.earliestPendingTimestamp).toBeNull();
+      expect(mockStoreObservations).not.toHaveBeenCalled();
+    });
   });
 
   describe('parsing summary from XML response', () => {

--- a/tests/worker/poison-respawn.test.ts
+++ b/tests/worker/poison-respawn.test.ts
@@ -93,7 +93,7 @@ describe('observer invalid-output handling (Phase 3 recovery)', () => {
     expect(session.abortReason ?? null).toBeNull();
   });
 
-  it('repeated "No observations to record" acknowledgements confirm and never build respawn debt', async () => {
+  it('repeated polite ready/no-work acknowledgements confirm and never build respawn debt', async () => {
     const sm = new SessionManager(makeDbManager());
     const session = sm.initializeSession(2, 'do the thing', 1);
     session.memorySessionId = 'mem-2';
@@ -104,7 +104,7 @@ describe('observer invalid-output handling (Phase 3 recovery)', () => {
 
     for (let i = 0; i < 5; i++) {
       await processAgentResponse(
-        'No observations to record.',
+        `I'm ready to observe and record, but I don't see any tool executions, file changes, or technical work.`,
         session,
         makeDbManager(),
         sm,


### PR DESCRIPTION
## Summary

The observer's correct-empty "ready/no-work" replies were being classified as ordinary prose, which meant each quiet poll counted as an invalid output strike. This change classifies specific ready/no-work observer replies as `idle`, so the existing response processor path confirms the claimed batch without building respawn debt.

## Why

`classifyObserverOutput()` is the shared structural gate for non-XML observer replies after XML detection. The issue's reporter-shaped reply, "I'm ready to observe and record, but I don't see any tool executions, file changes, or technical work.", currently falls through to `prose`, so `processAgentResponse()` increments `consecutiveInvalidOutputs` until the session is poisoned and respawned. Classifying the known no-work shapes as `idle` fixes the root path once, while preserving the existing handling for quota prose, context-window prose, and genuinely broken replies.

## Scope

This only changes output classification for specific no-work observer prose and adds regression coverage around the idle path. It does not change XML parsing, quota detection, authentication failures, session respawn rules for malformed output, or generator scheduling.

## Risk

The behavior change is narrow because the new idle rules are phrase-based and run only after the XML check. Ordinary prose and the former poisoned marker strings still classify as `prose`, so broken-session signals remain visible.

## Verification

- [x] `bun test tests/sdk/output-classifier.test.ts` — 17 passing
- [x] `bun test tests/worker/agents/response-processor.test.ts` — 17 passing
- [x] `bun test tests/worker/poison-respawn.test.ts` — 5 passing
- [x] `npm run build` — all build targets compiled successfully
- [x] `npm run lint:hook-io` — clean
- [x] `npm run lint:spawn-env` — clean
- [ ] `npm run strip-comments:check` — local check flagged 308 files in check mode

Closes #3193
