### PR TITLE
fix(search): honor date_from/date_to in worker searches (#3189)

### DIFF
--- a/src/services/worker/SearchManager.ts
+++ b/src/services/worker/SearchManager.ts
@@ -274,14 +274,20 @@ export class SearchManager {
       normalized.type = normalized.type.split(',').map((s: string) => s.trim()).filter(Boolean);
     }
 
-    if (normalized.dateStart || normalized.dateEnd) {
+    const dateStart = normalized.dateStart ?? normalized.date_start ?? normalized.date_from;
+    const dateEnd = normalized.dateEnd ?? normalized.date_end ?? normalized.date_to;
+    if (dateStart || dateEnd) {
       normalized.dateRange = {
-        start: normalized.dateStart,
-        end: normalized.dateEnd
+        start: dateStart,
+        end: dateEnd
       };
-      delete normalized.dateStart;
-      delete normalized.dateEnd;
     }
+    delete normalized.dateStart;
+    delete normalized.dateEnd;
+    delete normalized.date_start;
+    delete normalized.date_end;
+    delete normalized.date_from;
+    delete normalized.date_to;
 
     if (normalized.isFolder === 'true') {
       normalized.isFolder = true;

--- a/src/services/worker/search/SearchOrchestrator.ts
+++ b/src/services/worker/search/SearchOrchestrator.ts
@@ -128,14 +128,20 @@ export class SearchOrchestrator {
       }
     }
 
-    if (normalized.dateStart || normalized.dateEnd) {
+    const dateStart = normalized.dateStart ?? normalized.date_start ?? normalized.date_from;
+    const dateEnd = normalized.dateEnd ?? normalized.date_end ?? normalized.date_to;
+    if (dateStart || dateEnd) {
       normalized.dateRange = {
-        start: normalized.dateStart,
-        end: normalized.dateEnd
+        start: dateStart,
+        end: dateEnd
       };
-      delete normalized.dateStart;
-      delete normalized.dateEnd;
     }
+    delete normalized.dateStart;
+    delete normalized.dateEnd;
+    delete normalized.date_start;
+    delete normalized.date_end;
+    delete normalized.date_from;
+    delete normalized.date_to;
 
     const rawPlatformSource = normalized.platformSource ?? normalized.platform_source;
     if (typeof rawPlatformSource === 'string' && rawPlatformSource.trim()) {

--- a/tests/worker/search-manager.test.ts
+++ b/tests/worker/search-manager.test.ts
@@ -2,6 +2,35 @@ import { describe, it, expect, mock } from 'bun:test';
 import { SearchManager } from '../../src/services/worker/SearchManager.js';
 
 describe('SearchManager platform-scoped Chroma hydration', () => {
+  it('normalizes date_from/date_to filters into dateRange for worker search', async () => {
+    const searchObservations = mock(() => []);
+    const manager = new SearchManager(
+      {
+        searchObservations,
+        searchSessions: mock(() => []),
+        searchUserPrompts: mock(() => []),
+      } as any,
+      {} as any,
+      null,
+      {} as any,
+      {} as any,
+    );
+
+    await manager.search({
+      type: 'observations',
+      date_from: '2025-01-01',
+      date_to: '2025-01-31',
+      format: 'json',
+    });
+
+    expect(searchObservations).toHaveBeenCalledWith(undefined, expect.objectContaining({
+      dateRange: {
+        start: '2025-01-01',
+        end: '2025-01-31',
+      },
+    }));
+  });
+
   it('passes platformSource into Chroma observation where filter and SQLite hydration', async () => {
     const observation = {
       id: 5,

--- a/tests/worker/search/search-orchestrator.test.ts
+++ b/tests/worker/search/search-orchestrator.test.ts
@@ -21,6 +21,35 @@ const observation = {
 };
 
 describe('SearchOrchestrator platform-scoped Chroma zero fallback', () => {
+  it('normalizes date_from/date_to filters into dateRange for SQLite search', async () => {
+    const searchObservations = mock(() => [observation]);
+    const orchestrator = new SearchOrchestrator(
+      {
+        searchObservations,
+        searchSessions: mock(() => []),
+        searchUserPrompts: mock(() => []),
+      } as any,
+      {} as any,
+      null,
+    );
+
+    const result = await orchestrator.search({
+      searchType: 'observations',
+      date_from: '2025-01-01',
+      date_to: '2025-01-31',
+    });
+
+    expect(searchObservations).toHaveBeenCalledWith(undefined, expect.objectContaining({
+      dateRange: {
+        start: '2025-01-01',
+        end: '2025-01-31',
+      },
+    }));
+    expect(result.usedChroma).toBe(false);
+    expect(result.strategy).toBe('sqlite');
+    expect(result.results.observations).toEqual([observation]);
+  });
+
   it('falls back to SQLiteStrategy when platform-scoped Chroma search returns no rows', async () => {
     const queryChroma = mock(() => Promise.resolve({ ids: [], distances: [], metadatas: [] }));
     const searchObservations = mock(() => [observation]);


### PR DESCRIPTION
## Summary

Worker and subagent `search` calls can send `date_from` and `date_to`, but the worker search normalizers only mapped `dateStart` and `date_start` into `dateRange`. This change teaches both worker-side normalizers to accept `date_from` and `date_to` too, so date-scoped searches reach the existing `dateRange` path in both the manager and the SQLite fallback orchestrator.

## Why

The interactive MCP schema documents `dateStart` and `dateEnd`, but the reporter's worker-mode reproduction used `date_from` and `date_to`. In current source, `SearchManager.normalizeSearchArgs()` and `SearchOrchestrator.normalizeParams()` only lift camelCase and `_start` / `_end` variants into `dateRange`, so worker-mode calls can silently drop the filter before the search strategies ever see it.

## Scope

This is parameter normalization only. It does not change search ranking, timeline behavior, date parsing, Chroma filtering semantics, or the interactive API surface.

## Risk

The change is narrow because all accepted aliases still collapse into the same existing `dateRange` structure. Existing `dateStart`, `dateEnd`, `date_start`, and `date_end` behavior stays intact.

## Verification

- [x] `bun test tests/worker/search-manager.test.ts` — 7 passing
- [x] `bun test tests/worker/search/search-orchestrator.test.ts` — 3 passing
- [x] `npm run build` — all build targets compiled successfully
- [x] `npm run lint:hook-io` — clean
- [x] `npm run lint:spawn-env` — clean
- [ ] `npm run strip-comments:check` — local check flagged 308 files in check mode

Closes #3189
