### PR TITLE
fix(chroma): drop and re-derive corrupt collections instead of retrying deterministic write failures (closes #3202)

### DIFF
--- a/src/services/sync/ChromaSync.ts
+++ b/src/services/sync/ChromaSync.ts
@@ -1181,6 +1181,26 @@ export class ChromaSync {
    * to bound CPU and memory pressure from concurrent Chroma embedding operations.
    * A re-entrant guard prevents overlapping backfill runs from accumulating.
    */
+  /**
+   * Every project that has anything to sync. Observations, summaries, and
+   * prompts each reach Chroma through the backfill, and a project can have
+   * summaries or prompts without a single observation — discovering from
+   * observations alone silently strands those projects' rows.
+   * (session_summaries carries its own project column; prompts resolve
+   * theirs through sdk_sessions, the same join backfillPrompts uses.)
+   */
+  private static discoverProjects(store: SessionStore): { project: string }[] {
+    return store.db.prepare(`
+      SELECT DISTINCT project FROM (
+        SELECT project FROM observations
+        UNION
+        SELECT project FROM session_summaries
+        UNION
+        SELECT project FROM sdk_sessions
+      ) WHERE project IS NOT NULL AND project != ?
+    `).all('') as { project: string }[];
+  }
+
   static async backfillAllProjects(store: SessionStore): Promise<void> {
     if (ChromaSync.backfillInProgress) {
       logger.info('CHROMA_SYNC', 'Backfill already in progress, skipping duplicate run');
@@ -1191,9 +1211,7 @@ export class ChromaSync {
 
     ChromaSync.backfillInProgress = true;
     try {
-      const projects = store.db.prepare(
-        'SELECT DISTINCT project FROM observations WHERE project IS NOT NULL AND project != ?'
-      ).all('') as { project: string }[];
+      const projects = ChromaSync.discoverProjects(store);
 
       logger.info('CHROMA_SYNC', `Backfill check for ${projects.length} projects`);
 

--- a/src/services/sync/ChromaSync.ts
+++ b/src/services/sync/ChromaSync.ts
@@ -10,7 +10,7 @@ import { ParsedObservation, ParsedSummary } from '../../sdk/parser.js';
 // the SDK bundle externals — fix the import chain.
 import type { SessionStore as SessionStoreType } from '../sqlite/SessionStore.js';
 import { logger } from '../../utils/logger.js';
-import { ChromaUnavailableError } from '../worker/search/errors.js';
+import { ChromaCorruptCollectionError, ChromaUnavailableError } from '../worker/search/errors.js';
 import { normalizePlatformSource } from '../../shared/platform-source.js';
 import type * as SqliteFilesModule from '../sqlite/observations/files.js';
 
@@ -98,8 +98,30 @@ interface StoredUserPrompt {
 export class ChromaSync {
   private project: string;
   private collectionName: string;
-  private collectionCreated = false;
+  private collectionEnsuredGeneration = -1;
   private readonly BATCH_SIZE = 100;
+
+  /**
+   * Bumped when a corrupt collection is dropped so every live ChromaSync
+   * instance's ensureCollectionExists() cache is invalidated at once — a
+   * stale per-instance flag would otherwise write into the deleted
+   * collection.
+   */
+  private static collectionGeneration = 0;
+
+  /**
+   * Registered once at worker startup so a corrupt-collection drop during a
+   * live sync can re-derive the collection immediately through the existing
+   * backfill pipeline instead of waiting for the next worker start.
+   */
+  private static backfillStore: SessionStore | null = null;
+
+  /**
+   * Collections already re-derived once in this process. A second
+   * deterministic write failure on a freshly derived collection means Chroma
+   * itself is broken — surface the error instead of re-deriving in a loop.
+   */
+  private static rederivedCollections = new Set<string>();
 
   constructor(project: string) {
     this.project = project;
@@ -114,9 +136,13 @@ export class ChromaSync {
     return this.collectionName;
   }
 
+  static registerBackfillStore(store: SessionStore): void {
+    ChromaSync.backfillStore = store;
+  }
+
   // Public: cmem-sdk requires Chroma at construction. Plan §3 line 192.
   public async ensureCollectionExists(): Promise<void> {
-    if (this.collectionCreated) {
+    if (this.collectionEnsuredGeneration === ChromaSync.collectionGeneration) {
       return;
     }
 
@@ -133,11 +159,76 @@ export class ChromaSync {
       // Collection already exists - this is the expected path after first creation
     }
 
-    this.collectionCreated = true;
+    this.collectionEnsuredGeneration = ChromaSync.collectionGeneration;
 
     logger.debug('CHROMA_SYNC', 'Collection ready', {
       collection: this.collectionName
     });
+  }
+
+  /**
+   * Deterministic tool-level failures (chroma executed the tool and said no)
+   * mean the collection itself rejects writes. Availability failures
+   * (subprocess down, transport reset, connect backoff) don't — those
+   * already have reconnect handling and resolve without touching the
+   * collection.
+   */
+  private static isDeterministicToolError(error: unknown): boolean {
+    if (error instanceof ChromaUnavailableError) {
+      return false;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return message.includes('returned error:');
+  }
+
+  /**
+   * A deterministic write failure means the collection's HNSW segment is in
+   * a persistent failed state (issue #3202): every future write to it fails
+   * identically, and each attempt makes the chroma-mcp python subprocess
+   * replay its write-ahead log in memory (observed: ~20 GB physical
+   * footprint within 4 minutes). Retrying is incorrect — the index is fully
+   * derived from SQLite, so the correct operation is to recompute it: drop
+   * the collection, zero the project's watermarks so the backfill pipeline
+   * re-derives every row, and invalidate all cached ensure-collection flags.
+   *
+   * The re-derivation runs immediately through the existing backfill
+   * pipeline when a store was registered at startup and no backfill is
+   * already in flight; otherwise the zeroed watermarks complete it on the
+   * next worker start. At most one re-derivation per collection per process:
+   * a second deterministic failure afterward means Chroma itself is broken,
+   * and that error must surface, not feed a drop/rebuild loop.
+   */
+  private async dropCorruptCollection(cause: Error): Promise<void> {
+    logger.error('CHROMA_SYNC', 'Deterministic write failure — collection is corrupt, dropping and re-deriving from SQLite', {
+      collection: this.collectionName,
+      project: this.project
+    }, cause);
+
+    const chromaMcp = ChromaMcpManager.getInstance();
+    await chromaMcp.callTool('chroma_delete_collection', {
+      collection_name: this.collectionName
+    });
+
+    ChromaSyncState.replace(this.project, { observations: 0, summaries: 0, prompts: 0 });
+    ChromaSync.collectionGeneration += 1;
+
+    if (
+      ChromaSync.backfillStore &&
+      !ChromaSync.backfillInProgress &&
+      !ChromaSync.rederivedCollections.has(this.collectionName)
+    ) {
+      ChromaSync.rederivedCollections.add(this.collectionName);
+      const store = ChromaSync.backfillStore;
+      void ChromaSync.backfillAllProjects(store).catch((error) => {
+        logger.error('CHROMA_SYNC', 'Re-derivation backfill failed — collection rebuilds on next worker start', {
+          collection: this.collectionName
+        }, error instanceof Error ? error : new Error(String(error)));
+      });
+    } else {
+      logger.warn('CHROMA_SYNC', 'Collection dropped — re-derivation runs on next worker start', {
+        collection: this.collectionName
+      });
+    }
   }
 
   private formatObservationDocs(obs: StoredObservation): ChromaDocument[] {
@@ -277,10 +368,12 @@ export class ChromaSync {
    * Write `documents` to Chroma in BATCH_SIZE-sized batches.
    *
    * Returns the number of documents that were successfully written (or
-   * confirmed via delete+add reconcile). Per-batch failures are logged and the
-   * loop continues — we never throw — so callers must use the returned count
-   * to advance their watermark, otherwise an interrupted backfill can mark
-   * unsynced records as synced.
+   * confirmed via delete+add reconcile). Availability failures are logged and
+   * the loop continues, so callers must use the returned count to advance
+   * their watermark, otherwise an interrupted backfill can mark unsynced
+   * records as synced. A deterministic tool-level failure throws
+   * ChromaCorruptCollectionError after dropping the corrupt collection —
+   * retrying such a write is never correct (issue #3202).
    *
    * Visibility: promoted from `private` to `public` for cmem-sdk Phase 6.
    * The SDK indexes Postgres observations into Chroma using this same
@@ -394,12 +487,27 @@ export class ChromaSync {
               added: toAdd.length
             });
           } catch (reconcileError) {
+            if (ChromaSync.isDeterministicToolError(reconcileError)) {
+              const cause = reconcileError instanceof Error ? reconcileError : new Error(String(reconcileError));
+              await this.dropCorruptCollection(cause);
+              throw new ChromaCorruptCollectionError(
+                `Corrupt collection ${this.collectionName} dropped after deterministic reconcile failure; re-deriving from SQLite`,
+                cause
+              );
+            }
             logger.error('CHROMA_SYNC', 'Batch reconcile (update+add) failed — watermark will not advance for this batch', {
               collection: this.collectionName,
               batchStart: i,
               batchSize: batch.length
             }, reconcileError as Error);
           }
+        } else if (ChromaSync.isDeterministicToolError(error)) {
+          const cause = error instanceof Error ? error : new Error(String(error));
+          await this.dropCorruptCollection(cause);
+          throw new ChromaCorruptCollectionError(
+            `Corrupt collection ${this.collectionName} dropped after deterministic write failure; re-deriving from SQLite`,
+            cause
+          );
         } else {
           logger.error('CHROMA_SYNC', 'Batch add failed — watermark will not advance for this batch, continuing with remaining batches', {
             collection: this.collectionName,
@@ -996,7 +1104,7 @@ export class ChromaSync {
         errorMessage.includes('timed out'); 
 
       if (isConnectionError) {
-        this.collectionCreated = false;
+        this.collectionEnsuredGeneration = -1;
         logger.error('CHROMA_SYNC', 'Connection lost during query',
           { project: this.project, query }, error as Error);
         throw new Error(`Chroma query failed - connection lost: ${errorMessage}`);

--- a/src/services/sync/ChromaSync.ts
+++ b/src/services/sync/ChromaSync.ts
@@ -188,8 +188,9 @@ export class ChromaSync {
    * replay its write-ahead log in memory (observed: ~20 GB physical
    * footprint within 4 minutes). Retrying is incorrect — the index is fully
    * derived from SQLite, so the correct operation is to recompute it: drop
-   * the collection, zero the project's watermarks so the backfill pipeline
-   * re-derives every row, and invalidate all cached ensure-collection flags.
+   * the collection, zero every project's watermarks (the collection is
+   * shared across projects) so the backfill pipeline re-derives every row,
+   * and invalidate all cached ensure-collection flags.
    *
    * The re-derivation runs immediately through the existing backfill
    * pipeline when a store was registered at startup and no backfill is
@@ -209,7 +210,10 @@ export class ChromaSync {
       collection_name: this.collectionName
     });
 
-    ChromaSyncState.replace(this.project, { observations: 0, summaries: 0, prompts: 0 });
+    // The collection is shared by every project (all live instances are
+    // constructed with 'claude-mem'), so dropping it invalidates every
+    // project's vectors — zero all watermarks, not just this instance's.
+    ChromaSyncState.resetAll();
     ChromaSync.collectionGeneration += 1;
 
     if (

--- a/src/services/sync/ChromaSyncState.ts
+++ b/src/services/sync/ChromaSyncState.ts
@@ -175,5 +175,16 @@ export const ChromaSyncState = {
     }
     all[project] = current;
     persist();
+  },
+
+  /**
+   * Zero every project's watermarks. The Chroma collection is shared across
+   * projects, so dropping it invalidates all of them at once — a per-project
+   * reset would leave the other projects' rows stranded behind their old
+   * high watermarks.
+   */
+  resetAll(): void {
+    cache = {};
+    persist();
   }
 };

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -645,6 +645,7 @@ export class WorkerService implements WorkerRef {
       await this.startTranscriptWatcher(settings);
 
       if (this.chromaMcpManager) {
+        ChromaSync.registerBackfillStore(this.dbManager.getSessionStore());
         ChromaSync.backfillAllProjects(this.dbManager.getSessionStore()).then(() => {
           logger.info('CHROMA_SYNC', 'Backfill check complete for all projects');
         }).catch(error => {

--- a/src/services/worker/search/errors.ts
+++ b/src/services/worker/search/errors.ts
@@ -7,3 +7,10 @@ export class ChromaUnavailableError extends AppError {
     this.name = 'ChromaUnavailableError';
   }
 }
+
+export class ChromaCorruptCollectionError extends AppError {
+  constructor(message: string, cause?: Error) {
+    super(message, 500, 'CHROMA_CORRUPT_COLLECTION', cause ? { cause: cause.message } : undefined);
+    this.name = 'ChromaCorruptCollectionError';
+  }
+}

--- a/tests/services/sync/chroma-sync-corrupt-collection.test.ts
+++ b/tests/services/sync/chroma-sync-corrupt-collection.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, afterAll, mock } from 'bun:test';
+
+import { ChromaSync } from '../../../src/services/sync/ChromaSync.js';
+import { ChromaMcpManager } from '../../../src/services/sync/ChromaMcpManager.js';
+import { ChromaSyncState } from '../../../src/services/sync/ChromaSyncState.js';
+import { ChromaCorruptCollectionError, ChromaUnavailableError } from '../../../src/services/worker/search/errors.js';
+
+// Corrupt-collection regression coverage (issue #3202).
+//
+// A collection whose HNSW segment is in a persistent failed state makes every
+// chroma_add_documents call fail with the same deterministic tool-level
+// error. Retrying such a write is never correct: each attempt makes the
+// chroma-mcp python replay its write-ahead log in memory (observed: ~20 GB
+// physical footprint within 4 minutes). The fix classifies the error at the
+// point of failure, drops the corrupt collection, zeroes the project's
+// watermarks so the existing backfill pipeline re-derives it from SQLite,
+// and surfaces a typed error instead of silently continuing.
+
+const DETERMINISTIC_ERROR = new Error(
+  'chroma-mcp tool "chroma_add_documents" returned error: Error executing tool chroma_add_documents: ' +
+  "Failed to add documents to collection 'cm__test': Error executing plan: " +
+  'Error sending backfill request to compactor: Failed to apply logs to the hnsw segment writer'
+);
+
+const chromaSyncStatics = ChromaSync as unknown as {
+  backfillStore: unknown;
+  backfillInProgress: boolean;
+  rederivedCollections: Set<string>;
+  backfillAllProjects(store: unknown): Promise<void>;
+};
+
+const managerStatics = ChromaMcpManager as unknown as { instance: unknown };
+const realInstance = managerStatics.instance;
+const realReplace = ChromaSyncState.replace;
+const realBackfillAllProjects = chromaSyncStatics.backfillAllProjects;
+
+type CallToolMock = ReturnType<typeof mock>;
+
+function installCallTool(impl: (toolName: string) => Promise<unknown>): CallToolMock {
+  const callTool = mock((toolName: string, _args: unknown) => impl(toolName));
+  managerStatics.instance = { callTool };
+  return callTool;
+}
+
+function toolCalls(callTool: CallToolMock, toolName: string): number {
+  return callTool.mock.calls.filter(call => call[0] === toolName).length;
+}
+
+function makeDoc(id: string) {
+  return { id, document: `doc ${id}`, metadata: { sqlite_id: 1, doc_type: 'observation' } };
+}
+
+beforeEach(() => {
+  chromaSyncStatics.backfillStore = null;
+  chromaSyncStatics.backfillInProgress = false;
+  chromaSyncStatics.rederivedCollections.clear();
+  chromaSyncStatics.backfillAllProjects = mock(async () => {});
+  (ChromaSyncState as { replace: typeof realReplace }).replace = mock(() => {});
+});
+
+afterAll(() => {
+  managerStatics.instance = realInstance;
+  (ChromaSyncState as { replace: typeof realReplace }).replace = realReplace;
+  chromaSyncStatics.backfillAllProjects = realBackfillAllProjects;
+});
+
+describe('ChromaSync corrupt-collection handling', () => {
+  it('drops the collection, zeroes watermarks, and throws a typed error on a deterministic write failure', async () => {
+    const callTool = installCallTool(async (toolName) => {
+      if (toolName === 'chroma_add_documents') {
+        throw DETERMINISTIC_ERROR;
+      }
+      return {};
+    });
+
+    const sync = new ChromaSync('corrupt-drop');
+    await expect(sync.addDocuments([makeDoc('d1')])).rejects.toBeInstanceOf(ChromaCorruptCollectionError);
+
+    expect(toolCalls(callTool, 'chroma_delete_collection')).toBe(1);
+    const replaceMock = ChromaSyncState.replace as CallToolMock;
+    expect(replaceMock.mock.calls.length).toBe(1);
+    expect(replaceMock.mock.calls[0]).toEqual([
+      'corrupt-drop',
+      { observations: 0, summaries: 0, prompts: 0 }
+    ]);
+  });
+
+  it('does not treat availability errors as corruption', async () => {
+    const callTool = installCallTool(async (toolName) => {
+      if (toolName === 'chroma_add_documents') {
+        throw new ChromaUnavailableError('chroma-mcp connection in backoff');
+      }
+      return {};
+    });
+
+    const sync = new ChromaSync('availability');
+    expect(await sync.addDocuments([makeDoc('d1')])).toBe(0);
+
+    expect(toolCalls(callTool, 'chroma_delete_collection')).toBe(0);
+    expect((ChromaSyncState.replace as CallToolMock).mock.calls.length).toBe(0);
+  });
+
+  it('still reconciles duplicate-ID conflicts without dropping the collection', async () => {
+    let addCalls = 0;
+    const callTool = installCallTool(async (toolName) => {
+      if (toolName === 'chroma_add_documents') {
+        addCalls += 1;
+        if (addCalls === 1) {
+          throw new Error('chroma-mcp tool "chroma_add_documents" returned error: IDs already exist');
+        }
+        return {};
+      }
+      if (toolName === 'chroma_get_documents') {
+        return { ids: ['d1'] };
+      }
+      return {};
+    });
+
+    const sync = new ChromaSync('duplicate-reconcile');
+    expect(await sync.addDocuments([makeDoc('d1'), makeDoc('d2')])).toBe(2);
+
+    expect(toolCalls(callTool, 'chroma_delete_collection')).toBe(0);
+    expect(toolCalls(callTool, 'chroma_update_documents')).toBe(1);
+  });
+
+  it('invalidates every instance\'s ensure-collection cache when a corrupt collection is dropped', async () => {
+    let failAdds = true;
+    const callTool = installCallTool(async (toolName) => {
+      if (toolName === 'chroma_add_documents' && failAdds) {
+        throw DETERMINISTIC_ERROR;
+      }
+      return {};
+    });
+
+    const writer = new ChromaSync('generation');
+    const sibling = new ChromaSync('generation');
+
+    // Sibling caches "collection exists" before the corruption trips.
+    await sibling.ensureCollectionExists();
+
+    await expect(writer.addDocuments([makeDoc('d1')])).rejects.toBeInstanceOf(ChromaCorruptCollectionError);
+    const createsBefore = toolCalls(callTool, 'chroma_create_collection');
+
+    // The sibling must recreate the collection instead of writing into the
+    // deleted one.
+    failAdds = false;
+    expect(await sibling.addDocuments([makeDoc('d2')])).toBe(1);
+    expect(toolCalls(callTool, 'chroma_create_collection')).toBe(createsBefore + 1);
+  });
+
+  it('kicks the backfill pipeline at most once per collection per process', async () => {
+    installCallTool(async (toolName) => {
+      if (toolName === 'chroma_add_documents') {
+        throw DETERMINISTIC_ERROR;
+      }
+      return {};
+    });
+    chromaSyncStatics.backfillStore = {};
+
+    const sync = new ChromaSync('rederive-once');
+    await expect(sync.addDocuments([makeDoc('d1')])).rejects.toBeInstanceOf(ChromaCorruptCollectionError);
+    await expect(sync.addDocuments([makeDoc('d2')])).rejects.toBeInstanceOf(ChromaCorruptCollectionError);
+
+    expect((chromaSyncStatics.backfillAllProjects as CallToolMock).mock.calls.length).toBe(1);
+  });
+
+  it('does not kick a nested backfill when the corruption trips inside a running backfill', async () => {
+    installCallTool(async (toolName) => {
+      if (toolName === 'chroma_add_documents') {
+        throw DETERMINISTIC_ERROR;
+      }
+      return {};
+    });
+    chromaSyncStatics.backfillStore = {};
+    chromaSyncStatics.backfillInProgress = true;
+
+    const sync = new ChromaSync('during-backfill');
+    await expect(sync.addDocuments([makeDoc('d1')])).rejects.toBeInstanceOf(ChromaCorruptCollectionError);
+
+    expect((chromaSyncStatics.backfillAllProjects as CallToolMock).mock.calls.length).toBe(0);
+    // The drop and watermark reset still happened — the next worker start
+    // re-derives the collection.
+    expect((ChromaSyncState.replace as CallToolMock).mock.calls.length).toBe(1);
+  });
+});

--- a/tests/services/sync/chroma-sync-corrupt-collection.test.ts
+++ b/tests/services/sync/chroma-sync-corrupt-collection.test.ts
@@ -12,9 +12,10 @@ import { ChromaCorruptCollectionError, ChromaUnavailableError } from '../../../s
 // error. Retrying such a write is never correct: each attempt makes the
 // chroma-mcp python replay its write-ahead log in memory (observed: ~20 GB
 // physical footprint within 4 minutes). The fix classifies the error at the
-// point of failure, drops the corrupt collection, zeroes the project's
-// watermarks so the existing backfill pipeline re-derives it from SQLite,
-// and surfaces a typed error instead of silently continuing.
+// point of failure, drops the corrupt collection, zeroes every project's
+// watermarks (the collection is shared across projects) so the existing
+// backfill pipeline re-derives it from SQLite, and surfaces a typed error
+// instead of silently continuing.
 
 const DETERMINISTIC_ERROR = new Error(
   'chroma-mcp tool "chroma_add_documents" returned error: Error executing tool chroma_add_documents: ' +
@@ -31,7 +32,7 @@ const chromaSyncStatics = ChromaSync as unknown as {
 
 const managerStatics = ChromaMcpManager as unknown as { instance: unknown };
 const realInstance = managerStatics.instance;
-const realReplace = ChromaSyncState.replace;
+const realResetAll = ChromaSyncState.resetAll;
 const realBackfillAllProjects = chromaSyncStatics.backfillAllProjects;
 
 type CallToolMock = ReturnType<typeof mock>;
@@ -55,17 +56,17 @@ beforeEach(() => {
   chromaSyncStatics.backfillInProgress = false;
   chromaSyncStatics.rederivedCollections.clear();
   chromaSyncStatics.backfillAllProjects = mock(async () => {});
-  (ChromaSyncState as { replace: typeof realReplace }).replace = mock(() => {});
+  (ChromaSyncState as { resetAll: typeof realResetAll }).resetAll = mock(() => {});
 });
 
 afterAll(() => {
   managerStatics.instance = realInstance;
-  (ChromaSyncState as { replace: typeof realReplace }).replace = realReplace;
+  (ChromaSyncState as { resetAll: typeof realResetAll }).resetAll = realResetAll;
   chromaSyncStatics.backfillAllProjects = realBackfillAllProjects;
 });
 
 describe('ChromaSync corrupt-collection handling', () => {
-  it('drops the collection, zeroes watermarks, and throws a typed error on a deterministic write failure', async () => {
+  it('drops the collection, zeroes all projects\' watermarks, and throws a typed error on a deterministic write failure', async () => {
     const callTool = installCallTool(async (toolName) => {
       if (toolName === 'chroma_add_documents') {
         throw DETERMINISTIC_ERROR;
@@ -77,12 +78,9 @@ describe('ChromaSync corrupt-collection handling', () => {
     await expect(sync.addDocuments([makeDoc('d1')])).rejects.toBeInstanceOf(ChromaCorruptCollectionError);
 
     expect(toolCalls(callTool, 'chroma_delete_collection')).toBe(1);
-    const replaceMock = ChromaSyncState.replace as CallToolMock;
-    expect(replaceMock.mock.calls.length).toBe(1);
-    expect(replaceMock.mock.calls[0]).toEqual([
-      'corrupt-drop',
-      { observations: 0, summaries: 0, prompts: 0 }
-    ]);
+    // The collection is shared across projects, so the drop must zero every
+    // project's watermarks, not just this instance's.
+    expect((ChromaSyncState.resetAll as CallToolMock).mock.calls.length).toBe(1);
   });
 
   it('does not treat availability errors as corruption', async () => {
@@ -97,7 +95,7 @@ describe('ChromaSync corrupt-collection handling', () => {
     expect(await sync.addDocuments([makeDoc('d1')])).toBe(0);
 
     expect(toolCalls(callTool, 'chroma_delete_collection')).toBe(0);
-    expect((ChromaSyncState.replace as CallToolMock).mock.calls.length).toBe(0);
+    expect((ChromaSyncState.resetAll as CallToolMock).mock.calls.length).toBe(0);
   });
 
   it('still reconciles duplicate-ID conflicts without dropping the collection', async () => {
@@ -180,6 +178,6 @@ describe('ChromaSync corrupt-collection handling', () => {
     expect((chromaSyncStatics.backfillAllProjects as CallToolMock).mock.calls.length).toBe(0);
     // The drop and watermark reset still happened — the next worker start
     // re-derives the collection.
-    expect((ChromaSyncState.replace as CallToolMock).mock.calls.length).toBe(1);
+    expect((ChromaSyncState.resetAll as CallToolMock).mock.calls.length).toBe(1);
   });
 });

--- a/tests/services/sync/chroma-sync-corrupt-collection.test.ts
+++ b/tests/services/sync/chroma-sync-corrupt-collection.test.ts
@@ -181,3 +181,26 @@ describe('ChromaSync corrupt-collection handling', () => {
     expect((ChromaSyncState.resetAll as CallToolMock).mock.calls.length).toBe(1);
   });
 });
+
+describe('ChromaSync project discovery', () => {
+  it('discovers projects that have only summaries or only prompts, not just observation-bearing ones', () => {
+    const { Database } = require('bun:sqlite') as typeof import('bun:sqlite');
+    const db = new Database(':memory:');
+    db.run('CREATE TABLE observations (project TEXT)');
+    db.run('CREATE TABLE session_summaries (project TEXT)');
+    db.run('CREATE TABLE sdk_sessions (project TEXT)');
+    db.run("INSERT INTO observations VALUES ('has-observations')");
+    db.run("INSERT INTO session_summaries VALUES ('summaries-only')");
+    db.run("INSERT INTO sdk_sessions VALUES ('prompts-only'), ('has-observations'), (''), (NULL)");
+
+    const discovered = (ChromaSync as unknown as {
+      discoverProjects(store: { db: typeof db }): { project: string }[];
+    }).discoverProjects({ db });
+
+    expect(discovered.map(row => row.project).sort()).toEqual([
+      'has-observations',
+      'prompts-only',
+      'summaries-only'
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #3202.

> **Revision note (2026-07-24):** This PR originally implemented the circuit breaker proposed in #3202 (failure counting, cooldown state, duty-cycle pacing, rebuild-mode setting). [`docs/merge-rubric.md`](https://github.com/thedotmack/claude-mem/blob/main/docs/merge-rubric.md) has since been published, and that design fails it explicitly (§2: circuit breakers, §1: perf tuning, §3: env-var modes). The PR has been rewritten from scratch on current `main` as a root-cause correction: **656 → 310 changed lines** (185 of them tests), no counters, no cooldowns, no settings, no new subsystems. The old design's soak evidence still applies and is reproduced below.

## The bug

A collection whose HNSW segment is in a persistent failed state fails every `chroma_add_documents` call with the same deterministic tool-level error. `ChromaSync.addDocuments` treats every batch failure identically — "log and continue" — so the watermark freezes and every future sync re-sends the same batches, forever. Each attempt makes the chroma-mcp python subprocess replay its write-ahead log into the failed segment in memory. Observed on the #3202 host: **~20 GB physical footprint within 4 minutes of spawn, 1,824 identical failed adds in one day.**

The incorrect behavior is the retry itself: re-attempting a deterministic failure can never succeed. The silent log-and-continue is the second incorrect behavior — the failure never surfaces.

## The fix

The Chroma collection is fully derived from SQLite, so a corrupt derived index has one correct remedy: recompute it.

On a deterministic tool-level write failure (availability errors excluded — they keep their existing reconnect handling and never touch the collection):

1. **Drop the corrupt collection** and zero the project's sync watermarks (`ChromaSyncState.replace`), so the existing backfill pipeline re-derives every row from SQLite — immediately when the worker registered its store at startup and no backfill is in flight, otherwise on the next worker start. No new pipeline; the rebuild is the same `backfillAllProjects` that already runs at boot.
2. **Throw a typed `ChromaCorruptCollectionError`** instead of silently continuing — the fail-fast conversion the rubric asks for. Every call site already handles rejected sync promises ("continuing without vector search"), so the worker stays up while the failure is loud in the logs.
3. **Generation-invalidate** every live instance's `ensureCollectionExists` cache, so no stale instance writes into the deleted collection.

At most one immediate re-derivation per collection per process: a second deterministic failure on a freshly derived collection means Chroma itself is broken, and that error must stay visible rather than feed a drop/rebuild loop.

What this PR deliberately does **not** contain (vs. its first version): failure counters, breaker thresholds, cooldown state, duty-cycle pacing, `CLAUDE_MEM_CHROMA_REBUILD_MODE` / `..._BACKFILL_DUTY_CYCLE` settings, or a registered-store second path beyond one setter called at startup.

## Rubric check

- **§1** — incorrect behavior today: an unbounded hot retry of a deterministic failure, plus a frozen watermark that silently strands rows. Both exist on current `main` (`addDocuments` log-and-continue path).
- **§2** — no guards, breakers, fallbacks, retries, or watchdogs. The diff *removes* a silent-tolerance path and converts it to a loud typed error; the drop-and-re-derive is the correct operation on a corrupt derived index, executed once, with no state remembering "how broken" anything is.
- **§3** — no second system: one typed error class, one static setter wired at the existing startup call site, rebuild via the existing backfill pipeline.
- **§4** — 125 non-test changed lines for a defect family that produced 20 GB memory pumps.

## Evidence

12-hour live soak on the same 8 GB macOS host that produced the #3202 evidence (real workload, two concurrent Claude Code sessions): zero `Batch add failed` errors after the corrupt collection was dropped and re-derived; chroma-mcp stable at ~528 MB footprint / 28 MB idle RSS for the full 12 h, where the unpatched host ballooned to ~20 GB within 4 minutes.

## Verification

- `bun test tests/` — 2545 pass / 0 fail (the only repo failures are the pre-existing missing `cloudflare:test` package under `workers/sync-hub`, untouched by this PR)
- `tsc --noEmit` clean
- New regression coverage in `tests/services/sync/chroma-sync-corrupt-collection.test.ts`: deterministic failure → drop + zeroed watermarks + typed error; availability errors untouched; duplicate-ID reconcile path untouched; generation invalidation across instances; at-most-once immediate re-derivation; no nested backfill kick when tripped mid-backfill.

