### PR TITLE
fix(windows): outer-wrap + verbatim cmd.exe shim payload (fixes codex.cmd install on Windows)

### DIFF
--- a/src/shared/spawn.ts
+++ b/src/shared/spawn.ts
@@ -70,10 +70,16 @@ export function buildSpawnSyncInvocation(
   };
 
   if (platform === 'win32' && WINDOWS_CMD_EXTENSIONS.has(extname(command).toLowerCase())) {
+    const commandLine = [command, ...args].map(quoteWindowsCmdArgument).join(' ');
     return {
       command: process.env.ComSpec ?? 'cmd.exe',
-      args: ['/d', '/s', '/c', [command, ...args].map(quoteWindowsCmdArgument).join(' ')],
-      options: invocationOptions,
+      // Wrap the per-arg-quoted command line in ONE outer quote pair: `cmd /s /c`
+      // strips the outermost quotes and leaves the inner per-arg quoting intact,
+      // so a shim path (or any arg) containing spaces survives. Pairs with
+      // windowsVerbatimArguments below, which stops Node re-escaping this payload
+      // (without it the leading `"` becomes `\"` and cmd.exe rejects the command).
+      args: ['/d', '/s', '/c', `"${commandLine}"`],
+      options: { ...invocationOptions, windowsVerbatimArguments: true },
     };
   }
 

--- a/tests/services/integrations/spawn-contract-windows.test.ts
+++ b/tests/services/integrations/spawn-contract-windows.test.ts
@@ -57,9 +57,10 @@ describe('Windows #2695 - codex spawn resolves the .cmd shim without a shell', (
       '/d',
       '/s',
       '/c',
-      '"C:\\Tools\\bin\\tool.cmd" "run" "C:\\Path With Spaces"',
+      '""C:\\Tools\\bin\\tool.cmd" "run" "C:\\Path With Spaces""',
     ]);
     expect(invocation.options.windowsHide).toBe(true);
+    expect(invocation.options.windowsVerbatimArguments).toBe(true);
     expect('shell' in invocation.options).toBe(false);
   });
 
@@ -84,9 +85,10 @@ describe('Windows #2695 - codex spawn resolves the .cmd shim without a shell', (
       '/d',
       '/s',
       '/c',
-      '"C:\\Program Files\\nodejs\\codex.cmd" "plugin" "marketplace" "add" "C:\\Users\\tester\\Market Place"',
+      '""C:\\Program Files\\nodejs\\codex.cmd" "plugin" "marketplace" "add" "C:\\Users\\tester\\Market Place""',
     ]);
     expect(invocation.options.windowsHide).toBe(true);
+    expect(invocation.options.windowsVerbatimArguments).toBe(true);
     expect('shell' in invocation.options).toBe(false);
   });
 
@@ -94,7 +96,8 @@ describe('Windows #2695 - codex spawn resolves the .cmd shim without a shell', (
     const invocation = resolveCodexSpawnInvocation(['--version'], 'win32', () => null);
 
     expect(invocation.command).toBe('cmd.exe');
-    expect(invocation.args).toEqual(['/d', '/s', '/c', '"codex.cmd" "--version"']);
+    expect(invocation.args).toEqual(['/d', '/s', '/c', '""codex.cmd" "--version""']);
+    expect(invocation.options.windowsVerbatimArguments).toBe(true);
     expect('shell' in invocation.options).toBe(false);
   });
 

--- a/tests/shared/spawn-cmd-verbatim.test.ts
+++ b/tests/shared/spawn-cmd-verbatim.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'bun:test';
+import { buildSpawnSyncInvocation } from '../../src/shared/spawn.js';
+
+// Regression for the Windows codex.cmd spawn failure (issue #2695 follow-up):
+// buildSpawnSyncInvocation builds ONE pre-quoted `cmd.exe /d /s /c "<shim>" ...`
+// payload string. Two invariants keep that payload intact end-to-end:
+//   1. windowsVerbatimArguments — without it Node re-applies its own argv
+//      escaping, turning the leading `"` into `\"`, so cmd.exe tries to run a
+//      program literally named `\"C:\...\codex.cmd\"` and dies.
+//   2. an outer quote pair around the whole command line — `cmd /s /c` strips
+//      the outermost quotes, so without the wrap it eats the real per-arg quotes
+//      and mangles the command line (breaking any arg that contains spaces).
+// This file only imports src/shared/spawn.ts (no heavy deps), so it runs even in
+// a minimal checkout, unlike tests/services/integrations/spawn-contract-windows.
+
+describe('buildSpawnSyncInvocation Windows cmd.exe verbatim contract', () => {
+  it('outer-wraps the pre-quoted cmd.exe payload and marks it verbatim', () => {
+    const invocation = buildSpawnSyncInvocation(
+      'C:\\Users\\tester\\AppData\\Local\\Programs\\nodejs\\codex.cmd',
+      ['--version'],
+      { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] },
+      'win32',
+    );
+
+    // command is process.env.ComSpec ?? 'cmd.exe' — a full path on a real box.
+    expect(invocation.command.toLowerCase().endsWith('cmd.exe')).toBe(true);
+    expect(invocation.args).toEqual([
+      '/d',
+      '/s',
+      '/c',
+      '""C:\\Users\\tester\\AppData\\Local\\Programs\\nodejs\\codex.cmd" "--version""',
+    ]);
+    expect(invocation.options.windowsVerbatimArguments).toBe(true);
+  });
+
+  it('does NOT force verbatim args for directly-spawned native executables', () => {
+    // .exe is spawned directly with its own arg array; forcing verbatim here
+    // would break normal Node quoting for args that contain spaces.
+    const invocation = buildSpawnSyncInvocation(
+      'C:\\Tools\\codex.exe',
+      ['run', 'C:\\Path With Spaces'],
+      { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] },
+      'win32',
+    );
+
+    expect(invocation.command).toBe('C:\\Tools\\codex.exe');
+    expect(invocation.args).toEqual(['run', 'C:\\Path With Spaces']);
+    expect(invocation.options.windowsVerbatimArguments).not.toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

On Windows, `buildSpawnSyncInvocation` (`src/shared/spawn.ts`) wraps `.cmd`/`.bat` shims in a hand-built `cmd.exe /d /s /c <payload>` call. The payload is quoted per-argument but is **never outer-wrapped**, and the spawn options **never set `windowsVerbatimArguments`**. As a result every shim invocation — most visibly the Codex CLI installer spawning `codex.cmd` — fails with:

```
'"C:\...\codex.cmd" "--version' is not recognized as an internal or external command,
operable program or batch file.
```

This makes the **Codex CLI integration step of `npx claude-mem install` fail on Windows** (`codex plugin marketplace add …` and `codex --version` never run; install finishes "Partial" with `codex-cli FAIL`).

Follow-up to #2695, which fixed the original `ENOENT` by resolving the `.cmd` shim and routing it through `cmd.exe`. The routing was correct; the quoting of the resulting command line was not.

## Root cause

The cmd.exe branch builds this command line:

```
cmd.exe /d /s /c "<shim>" "<arg1>" "<arg2>" …
```

Two independent defects corrupt it:

1. **No outer quote pair.** `cmd /s /c` strips the *first and last* quote character of the command string. With the payload above it strips the opening quote of `<shim>` and the closing quote of the final argument, mangling the command line.
2. **Missing `windowsVerbatimArguments`.** The wrapper deliberately calls `spawnSync` *without* the `shell` option, so Node applies its own argv→command-line escaping to the already-quoted payload, turning each `"` into `\"`. cmd.exe then sees `\"<shim>\"` and rejects it — the exact error above.

Either defect alone breaks the call.

## Evidence

Tested empirically against a real `codex.cmd` and a controlled `echoargs.cmd` shim invoked with a space-containing argument, all with `windowsVerbatimArguments: true`:

| payload passed to `cmd /d /s /c` | `codex --version` | spaced arg preserved |
|---|:---:|:---:|
| `"<shim>" "--version"` — per-arg quoted, no outer wrap *(current)* | ❌ not recognized | ❌ dropped |
| `<shim> --version` — bare args | ✅ | ❌ corrupted on spaces |
| `""<shim>" "--version""` — per-arg quoted **+ outer wrap** | ✅ | ✅ intact |

The winning form (outer-wrap **+** `windowsVerbatimArguments`) is exactly the command line Node's own `{ shell: true }` path constructs internally. The spaced-arg column matters because `resolveCodexSpawnInvocation` passes marketplace paths that routinely contain spaces (e.g. `C:\Users\…\Market Place`).

## Fix

`src/shared/spawn.ts`, `.cmd`/`.bat` branch only:

```ts
const commandLine = [command, ...args].map(quoteWindowsCmdArgument).join(' ');
return {
  command: process.env.ComSpec ?? 'cmd.exe',
  args: ['/d', '/s', '/c', `"${commandLine}"`],            // outer-wrapped
  options: { ...invocationOptions, windowsVerbatimArguments: true },
};
```

Scope is limited to the shim branch. Native `.exe`/`.com` (spawned directly) and non-Windows paths are unchanged — forcing verbatim there would break Node's normal quoting of spaced arguments, so a regression test pins that down too.

## Tests

- **Updated** `tests/services/integrations/spawn-contract-windows.test.ts`: its assertions encoded the **broken** payload (they checked the constructed string but never executed it through cmd.exe). They now assert the outer-wrapped payload and the `windowsVerbatimArguments` invariant.
- **Added** `tests/shared/spawn-cmd-verbatim.test.ts`: a focused regression importing only `src/shared/spawn.ts`, so it runs even without the full dependency tree installed.

## Verification

- `bun test tests/shared/spawn-cmd-verbatim.test.ts` → green.
- Ran the real `codex.cmd` through the patched `codexSpawn` path: exit `0`, stdout `codex-cli 0.144.1`, with resolved args `["/d","/s","/c","\"\"C:\\…\\codex.cmd\" \"--version\"\""]` and `windowsVerbatimArguments: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
