### PR TITLE
fix(hooks): memory-worker outage must never block the editor (fail-open) + build guard for the worker zod closure

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "scripts": {
     "dev": "npm run build-and-sync",
-    "build": "node scripts/sync-plugin-manifests.js && node scripts/build-hooks.js && node scripts/gen-plugin-lockfile.cjs",
+    "build": "node scripts/sync-plugin-manifests.js && node scripts/build-hooks.js && node scripts/gen-plugin-lockfile.cjs && node scripts/check-worker-runtime-deps.cjs",
     "build-and-sync": "npm run build && npm run sync-marketplace && (cd ~/.claude/plugins/marketplaces/thedotmack && npm run worker:restart)",
     "sync-marketplace": "node scripts/sync-marketplace.cjs",
     "sync-marketplace:force": "node scripts/sync-marketplace.cjs --force",

--- a/scripts/check-worker-runtime-deps.cjs
+++ b/scripts/check-worker-runtime-deps.cjs
@@ -109,7 +109,9 @@ function main() {
     // Off by default because it spawns bun on the real bundle; the maintainers
     // keep daemon-spawning out of the default test/build path (flaky in CI, see
     // tests/cli/hook-stream-discipline.test.ts). `status` loads the bundle then
-    // reports "not running" without leaving a daemon behind.
+    // reports "not running" and exits 0 without leaving a daemon behind — so a
+    // top-level require("zod/v3") failure surfaces as a NON-ZERO exit / spawn
+    // error / timeout signal, which is exactly what we gate on below.
     if (process.env.CLAUDE_MEM_VERIFY_WORKER_BOOT === '1') {
       const workerCopy = path.join(tmp, 'worker-service.cjs');
       copyFileSync(worker, workerCopy);
@@ -119,9 +121,18 @@ function main() {
         env: { ...process.env, CLAUDE_MEM_DATA_DIR: path.join(tmp, 'data') },
         timeout: 30000,
       });
-      const out = `${load.stdout || ''}${load.stderr || ''}`;
-      if (/cannot find module|error: .*resolve|failed to load/i.test(out)) {
-        fail(`the built worker bundle failed to LOAD against the clean closure:\n\n${out}`);
+      // Gate on the PROCESS outcome, not a stderr regex: a non-zero exit, a spawn
+      // error, or a timeout kill (load.signal) all mean the bundle did not load
+      // cleanly. Regex-only matching let a failed/timed-out boot report success
+      // and pass a broken artifact (PR #3225 review).
+      if (load.error || load.signal || load.status !== 0) {
+        const out = `${load.stdout || ''}${load.stderr || ''}`;
+        fail(
+          'the built worker bundle failed to LOAD against the clean closure' +
+          (load.error ? ` (${load.error.message})` : '') +
+          (load.signal ? ` (killed by ${load.signal})` : '') +
+          `:\n\n${out}`
+        );
       }
       console.log('✓ worker bundle loads against the clean closure (CLAUDE_MEM_VERIFY_WORKER_BOOT)');
     }

--- a/scripts/check-worker-runtime-deps.cjs
+++ b/scripts/check-worker-runtime-deps.cjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+// check-worker-runtime-deps.cjs — blocking build/CI gate for the worker's
+// EXTERNALIZED runtime dependency closure.
+//
+// WHY THIS EXISTS (the 13.11.0 lockout):
+//   build-hooks.js externalizes `zod` from the worker bundle (external: ['zod',
+//   …]) — the shipped worker-service.cjs contains bare `require("zod/v3")` /
+//   `require("zod/v4")` calls that MUST resolve at runtime against the plugin's
+//   installed node_modules. The runtime installer (setup-runtime.ts) materializes
+//   that closure with `bun install --frozen-lockfile`. mcp-server.cjs is already
+//   guarded — build-hooks.js FAILS the build if it externalizes zod (Claude
+//   Desktop can launch it without plugin node_modules). The WORKER had the exact
+//   same exposure but NO equivalent guard: when a shipped bun.lock drifts from
+//   plugin/package.json (or the install is otherwise incomplete), the frozen
+//   install produces no resolvable zod and the worker crashes at startup with
+//   "Cannot find module 'zod/v3'" — which, via the hook fail-loud path, used to
+//   lock the editor entirely. This gate reproduces a clean frozen install and
+//   asserts the worker's always-required externals resolve, so a broken closure
+//   can never ship again.
+//
+// Usage:
+//   node scripts/check-worker-runtime-deps.cjs [--plugin-dir <dir>]
+//   CLAUDE_MEM_VERIFY_WORKER_BOOT=1 node scripts/check-worker-runtime-deps.cjs
+//     └ also loads the built worker bundle against the clean closure (deeper
+//       smoke: proves the bundle's top-level require("zod/v3") actually loads).
+
+const { execFileSync, spawnSync } = require('child_process');
+const { mkdtempSync, rmSync, copyFileSync, existsSync } = require('fs');
+const { tmpdir } = require('os');
+const path = require('path');
+
+// The worker bundle require()s these at load time (grep 'require("zod' in the
+// built worker-service.cjs). They are externalized, so they must resolve from
+// the shipped plugin closure. Keep in sync with build-hooks.js `external`.
+const REQUIRED_WORKER_MODULES = ['zod', 'zod/v3', 'zod/v4', 'zod/v4-mini'];
+
+function fail(msg) {
+  console.error(`\n❌ check-worker-runtime-deps: ${msg}\n`);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  let pluginDir = null;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--plugin-dir') pluginDir = argv[++i];
+  }
+  return { pluginDir };
+}
+
+function main() {
+  const { pluginDir: pluginArg } = parseArgs(process.argv.slice(2));
+  const pluginDir = pluginArg
+    ? path.resolve(pluginArg)
+    : path.join(__dirname, '..', 'plugin');
+
+  const manifest = path.join(pluginDir, 'package.json');
+  const lockfile = path.join(pluginDir, 'bun.lock');
+  const worker = path.join(pluginDir, 'scripts', 'worker-service.cjs');
+
+  if (!existsSync(manifest)) fail(`missing ${manifest}. Run scripts/build-hooks.js first (it generates plugin/package.json).`);
+  if (!existsSync(lockfile)) fail(`missing ${lockfile}. Run scripts/gen-plugin-lockfile.cjs first (it generates plugin/bun.lock).`);
+  if (!existsSync(worker)) fail(`missing ${worker}. Run scripts/build-hooks.js first (it builds the worker bundle).`);
+
+  try {
+    execFileSync('bun', ['--version'], { stdio: 'ignore' });
+  } catch {
+    fail('bun is not on PATH — this gate needs bun to reproduce the runtime install (https://bun.sh).');
+  }
+
+  console.log('🔒 Verifying worker runtime dependency closure (zod externals)…');
+
+  const tmp = mkdtempSync(path.join(tmpdir(), 'cmem-depguard-'));
+  try {
+    // Reproduce exactly what the runtime installer ships + runs.
+    copyFileSync(manifest, path.join(tmp, 'package.json'));
+    copyFileSync(lockfile, path.join(tmp, 'bun.lock'));
+
+    const install = spawnSync('bun', ['install', '--frozen-lockfile', '--ignore-scripts'], {
+      cwd: tmp,
+      encoding: 'utf-8',
+    });
+    if (install.status !== 0) {
+      fail(
+        'a clean `bun install --frozen-lockfile` FAILED — plugin/bun.lock is drifted from ' +
+        'plugin/package.json, so the runtime install produces no dependency closure ' +
+        '(this is the 13.11.0 breakage). Regenerate the lockfile: run `npm run build` ' +
+        '(build-hooks.js → gen-plugin-lockfile.cjs).\n\n' +
+        (install.stderr || install.stdout || '')
+      );
+    }
+
+    // The bundle's bare require("zod/v3") etc. must resolve under bun (the worker
+    // runtime) from this clean closure. This is the deterministic 13.11.0 gate.
+    const probe = REQUIRED_WORKER_MODULES.map((m) => `require.resolve(${JSON.stringify(m)})`).join('; ');
+    const resolved = spawnSync('bun', ['-e', probe], { cwd: tmp, encoding: 'utf-8' });
+    if (resolved.status !== 0) {
+      fail(
+        `the worker bundle require()s [${REQUIRED_WORKER_MODULES.join(', ')}] at load, but they ` +
+        'do NOT resolve from a clean frozen install of the shipped plugin closure. The worker ' +
+        'would crash at startup with "Cannot find module \'zod/v3\'" (the 13.11.0 lockout). ' +
+        'Ensure zod is a declared plugin dependency and the lockfile is in sync.\n\n' +
+        (resolved.stderr || resolved.stdout || '')
+      );
+    }
+
+    // Opt-in deeper smoke: load the actual built worker bundle against the clean
+    // closure, proving its top-level require("zod/v3") loads (not just resolves).
+    // Off by default because it spawns bun on the real bundle; the maintainers
+    // keep daemon-spawning out of the default test/build path (flaky in CI, see
+    // tests/cli/hook-stream-discipline.test.ts). `status` loads the bundle then
+    // reports "not running" without leaving a daemon behind.
+    if (process.env.CLAUDE_MEM_VERIFY_WORKER_BOOT === '1') {
+      const workerCopy = path.join(tmp, 'worker-service.cjs');
+      copyFileSync(worker, workerCopy);
+      const load = spawnSync('bun', [workerCopy, 'status'], {
+        cwd: tmp,
+        encoding: 'utf-8',
+        env: { ...process.env, CLAUDE_MEM_DATA_DIR: path.join(tmp, 'data') },
+        timeout: 30000,
+      });
+      const out = `${load.stdout || ''}${load.stderr || ''}`;
+      if (/cannot find module|error: .*resolve|failed to load/i.test(out)) {
+        fail(`the built worker bundle failed to LOAD against the clean closure:\n\n${out}`);
+      }
+      console.log('✓ worker bundle loads against the clean closure (CLAUDE_MEM_VERIFY_WORKER_BOOT)');
+    }
+
+    console.log(`✓ worker runtime deps resolve from a clean frozen install: ${REQUIRED_WORKER_MODULES.join(', ')}`);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+main();

--- a/src/shared/hook-io.ts
+++ b/src/shared/hook-io.ts
@@ -12,6 +12,7 @@
  *  - MODEL_CONTEXT     content the assistant consumes. stdout JSON only.
  *  - USER_HINT         short advisory shown to the human, via HookResult.systemMessage.
  *  - BLOCKING_FEEDBACK error message the model must see (stderr + exit 2).
+ *  - DEGRADED_NOTICE   loud auxiliary-outage warning (stderr, NO exit — never blocks).
  *  - EXIT_SIGNAL       pure status, no payload (exit 0).
  *
  * Lives in src/shared/ (not src/cli/) so that src/shared/worker-utils.ts and
@@ -144,6 +145,26 @@ export function emitBlockingError(msg: string, options: ExitOptions = {}): void 
   if (!options.skipExit) {
     process.exit(2);
   }
+}
+
+/**
+ * DEGRADED_NOTICE: flush buffered stderr (so preceding diagnostics reach the
+ * operator/model), then write `msg` loudly to real stderr — but DO NOT exit.
+ *
+ * This is the loud-but-non-blocking channel. It exists so an AUXILIARY service
+ * outage (the memory worker being unreachable) can stay highly visible without
+ * ever blocking the user's critical path. Unlike emitBlockingError it never
+ * calls process.exit(2): the fail-loud counter uses it to surface a degradation
+ * warning while the hook still exits 0 via exitGraceful. A memory outage must
+ * never be able to lock the editor: an auxiliary service must not block the
+ * user's critical path (SRE: cascading failures / graceful degradation).
+ */
+export function emitDegradedNotice(msg: string): void {
+  if (bufferedChunks && bufferedChunks.length > 0) {
+    bypassWrite(bufferedChunks.join(''));
+    bufferedChunks = [];
+  }
+  bypassWrite(msg.endsWith('\n') ? msg : `${msg}\n`);
 }
 
 /**

--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -7,7 +7,7 @@ import { SettingsDefaultsManager, type SettingsDefaults } from "./SettingsDefaul
 import { MARKETPLACE_ROOT, DATA_DIR } from "./paths.js";
 import { loadFromFileOnce } from "./hook-settings.js";
 import { validateWorkerPidFile } from "../supervisor/index.js";
-import { emitBlockingError } from "./hook-io.js";
+import { emitDegradedNotice } from "./hook-io.js";
 import { captureCliEvent } from "../services/telemetry/cli-telemetry.js";
 import { checkVersionMatch } from "../services/infrastructure/index.js";
 // Imported from ProcessManager.js directly (not the infrastructure barrel):
@@ -644,10 +644,8 @@ export async function recordWorkerUnreachable(): Promise<number> {
     // hook_failed distress signal. Gated to the failure that JUST reached the
     // threshold (`===`, not `>=`): the stderr warning below repeats on every
     // failure past the threshold, but telemetry emits once per failure streak
-    // to bound volume. MUST be awaited BEFORE emitBlockingError — it calls
-    // process.exit(2) immediately, which would kill a fire-and-forget POST
-    // mid-flight. captureCliEvent never throws and is hard-capped at 2s, so
-    // this cannot hang the fail-loud path. Closed-enum/count props only —
+    // to bound volume. captureCliEvent never throws and is hard-capped at 2s,
+    // so this cannot hang the fail-loud path. Closed-enum/count props only —
     // never error text. Transport is the direct CLI POST, never the worker
     // API (the defining failure here IS "worker unreachable").
     if (next.consecutiveFailures === threshold) {
@@ -658,12 +656,22 @@ export async function recordWorkerUnreachable(): Promise<number> {
         threshold_tripped: true,
       });
     }
-    // #2292 fix: BLOCKING_FEEDBACK. emitBlockingError flushes the Phase 2
-    // stderr buffer (so preceding logger.warn lines also surface) and writes
-    // via the bypass channel + exits 2. Previously this raw process.stderr.write
-    // was swallowed by hookCommand's blanket no-op, so the user/model never saw it.
-    emitBlockingError(
-      `claude-mem worker unreachable for ${next.consecutiveFailures} consecutive hooks.`
+    // DEGRADED_NOTICE (fail-open). The memory worker is an AUXILIARY service; a
+    // memory outage must NEVER block the user's critical path. This previously
+    // called emitBlockingError → process.exit(2), which — on the UserPromptSubmit
+    // hook — blocked prompt submission and locked the editor entirely (a benign
+    // memory outage cascaded into a total lockout; the user had to relaunch in
+    // safe-mode from a terminal). We now surface a LOUD but non-blocking warning
+    // and let hookCommand exit 0 via exitGraceful. The counter/telemetry above
+    // still fire for diagnosis. Rationale: an auxiliary service must never block
+    // the user's critical path — blocking input to force attention is a DevEx
+    // anti-pattern (SRE: cascading failures / graceful degradation).
+    // emitDegradedNotice flushes the Phase 2 stderr buffer so preceding
+    // logger.warn lines also surface.
+    emitDegradedNotice(
+      `claude-mem: memory worker unreachable for ${next.consecutiveFailures} consecutive hooks — ` +
+      `memory features are degraded but your prompt was NOT blocked. ` +
+      `Restart the worker (npm run worker:restart) or run claude-mem doctor.`
     );
   }
   return next.consecutiveFailures;

--- a/tests/build/worker-runtime-deps-guard.test.ts
+++ b/tests/build/worker-runtime-deps-guard.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'bun:test';
+import { spawnSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync, copyFileSync, writeFileSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const REPO_ROOT = join(import.meta.dir, '..', '..');
+const GUARD = join(REPO_ROOT, 'scripts', 'check-worker-runtime-deps.cjs');
+
+describe('check-worker-runtime-deps — build gate for the worker zod closure', () => {
+  it('is wired into the build script so a broken closure can never ship silently', () => {
+    const pkg = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf-8'));
+    expect(pkg.scripts.build).toContain('check-worker-runtime-deps');
+  });
+
+  it('passes on the real shipped plugin closure (zod/v3 resolves from a clean frozen install)', () => {
+    const r = spawnSync('node', [GUARD], { cwd: REPO_ROOT, encoding: 'utf-8' });
+    expect(r.status).toBe(0);
+    expect(`${r.stdout}${r.stderr}`).toContain('resolve from a clean frozen install');
+  });
+
+  it('FAILS the build when plugin/bun.lock drifts from plugin/package.json (the 13.11.0 breakage)', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'cmem-guard-drift-'));
+    try {
+      // Real lockfile paired with a package.json that has zod removed → a clean
+      // `bun install --frozen-lockfile` must refuse (lockfile drift), which is
+      // exactly what shipped a resolvable-zod-less worker in 13.11.0.
+      copyFileSync(join(REPO_ROOT, 'plugin', 'bun.lock'), join(tmp, 'bun.lock'));
+      const manifest = readFileSync(join(REPO_ROOT, 'plugin', 'package.json'), 'utf-8');
+      const stripped = manifest.split('\n').filter((l) => !l.includes('"zod"')).join('\n');
+      writeFileSync(join(tmp, 'package.json'), stripped);
+      mkdirSync(join(tmp, 'scripts'), { recursive: true });
+      writeFileSync(join(tmp, 'scripts', 'worker-service.cjs'), '');
+
+      const r = spawnSync('node', [GUARD, '--plugin-dir', tmp], { cwd: REPO_ROOT, encoding: 'utf-8' });
+      expect(r.status).not.toBe(0);
+      expect(`${r.stdout}${r.stderr}`).toMatch(/drift|13\.11\.0|frozen/i);
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/cli/hook-io.test.ts
+++ b/tests/cli/hook-io.test.ts
@@ -4,6 +4,7 @@ import {
   emitDiagnostic,
   emitModelContext,
   emitBlockingError,
+  emitDegradedNotice,
   exitGraceful,
   resetHookIoState,
 } from '../../src/shared/hook-io.js';
@@ -155,6 +156,33 @@ describe('emitBlockingError', () => {
       emitBlockingError('boom', { skipExit: true });
       // buffered content surfaces first, then the blocking message.
       expect(real.chunks.join('')).toBe('preceding\nboom\n');
+    } finally {
+      buffer.restore();
+      real.restore();
+    }
+  });
+});
+
+describe('emitDegradedNotice', () => {
+  it('writes msg to real stderr and RETURNS (never exits) — the loud-but-non-blocking channel', () => {
+    const real = captureRealStderr();
+    try {
+      // If this called process.exit, the test process would die here and the
+      // assertion below would never run. Reaching it proves non-blocking.
+      emitDegradedNotice('degraded');
+      expect(real.chunks.join('')).toBe('degraded\n');
+    } finally {
+      real.restore();
+    }
+  });
+
+  it('flushes buffered stderr BEFORE its own message (preceding diagnostics still surface)', () => {
+    const real = captureRealStderr();
+    const buffer = installHookStderrBuffer();
+    try {
+      process.stderr.write('preceding\n'); // buffered
+      emitDegradedNotice('degraded');
+      expect(real.chunks.join('')).toBe('preceding\ndegraded\n');
     } finally {
       buffer.restore();
       real.restore();

--- a/tests/cli/hook-stream-discipline.test.ts
+++ b/tests/cli/hook-stream-discipline.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import {
   installHookStderrBuffer,
-  emitBlockingError,
+  emitDegradedNotice,
   exitGraceful,
   emitModelContext,
   resetHookIoState,
@@ -14,8 +14,10 @@ import type { HookResult } from '../../src/cli/types.js';
 // Windows Terminal tab-accumulation rationale (per CLAUDE.md):
 // The exit-0-on-error policy is intentional — non-zero exits keep Windows
 // Terminal tabs open. exitGraceful() exits 0 and drops buffered stderr for the
-// transient worker-unavailable path. emitBlockingError() exits 2 only for the
-// fail-loud counter (recordWorkerUnreachable) and unrecoverable handler errors.
+// transient worker-unavailable path. The fail-loud counter (recordWorkerUnreachable)
+// now surfaces via emitDegradedNotice() — LOUD but non-blocking (no exit) so a
+// memory outage can never lock the editor. emitBlockingError() (exit 2) is
+// reserved for unrecoverable handler errors, never the auxiliary-service path.
 //
 // These tests assert the IO-discipline CONTRACT at the seam level rather than
 // spawning the built worker daemon, because worker-service auto-spawns a Bun
@@ -36,20 +38,21 @@ function captureRealStderr(): { chunks: string[]; restore: () => void } {
 
 afterEach(() => resetHookIoState());
 
-describe('#2292 — fail-loud diagnostic is no longer swallowed', () => {
-  it('emitBlockingError surfaces the worker-unreachable message through the buffered window', () => {
+describe('#2292 — fail-loud diagnostic is no longer swallowed (now non-blocking)', () => {
+  it('emitDegradedNotice surfaces the worker-unreachable message through the buffered window', () => {
     // Simulate hookCommand: install the stderr buffer that previously swallowed
     // EVERYTHING (the #2292 no-op). recordWorkerUnreachable now calls
-    // emitBlockingError, which must bypass the buffer and reach real stderr.
+    // emitDegradedNotice, which must bypass the buffer and reach real stderr —
+    // WITHOUT exiting (fail-open: a memory outage never blocks the user).
     const real = captureRealStderr();
     const buffer = installHookStderrBuffer();
     try {
       // A swallowed write (what the old no-op did to library noise) stays buffered.
       process.stderr.write('library noise that should NOT surface on success\n');
-      // The fail-loud path:
-      emitBlockingError('claude-mem worker unreachable for 3 consecutive hooks.', { skipExit: true });
+      // The fail-loud (now non-blocking) path:
+      emitDegradedNotice('claude-mem: memory worker unreachable for 3 consecutive hooks — NOT blocked.');
       const surfaced = real.chunks.join('');
-      expect(surfaced).toContain('claude-mem worker unreachable for 3 consecutive hooks.');
+      expect(surfaced).toContain('worker unreachable for 3 consecutive hooks');
       // and the preceding buffered noise is flushed too (operator gets full context).
       expect(surfaced).toContain('library noise');
     } finally {
@@ -58,11 +61,18 @@ describe('#2292 — fail-loud diagnostic is no longer swallowed', () => {
     }
   });
 
-  it('worker-utils recordWorkerUnreachable routes through emitBlockingError (source contract)', () => {
+  it('worker-utils recordWorkerUnreachable routes through emitDegradedNotice, never a hard block (source contract)', () => {
     const src = readFileSync(join(REPO_ROOT, 'src', 'shared', 'worker-utils.ts'), 'utf-8');
-    // The fail-loud branch must NOT call process.stderr.write / process.exit directly.
-    expect(src).toContain('emitBlockingError(');
-    expect(src).not.toMatch(/process\.stderr\.write\(\s*\n\s*`claude-mem worker unreachable/);
+    const fn = src.slice(
+      src.indexOf('export async function recordWorkerUnreachable'),
+      src.indexOf('function resetWorkerFailureCounter'),
+    );
+    const code = fn.split('\n').filter((l) => !l.trim().startsWith('//')).join('\n');
+    // Fail-open: the auxiliary-service escalation surfaces loudly but never blocks.
+    expect(code).toContain('emitDegradedNotice(');
+    expect(code).not.toContain('emitBlockingError(');
+    expect(code).not.toContain('process.exit');
+    expect(code).not.toMatch(/process\.stderr\.write\(\s*\n\s*`claude-mem/);
   });
 });
 

--- a/tests/cli/worker-failopen.test.ts
+++ b/tests/cli/worker-failopen.test.ts
@@ -1,88 +1,68 @@
-import { describe, it, expect, afterAll } from 'bun:test';
+import { describe, it, expect } from 'bun:test';
+import { spawnSync } from 'child_process';
 import { mkdtempSync, rmSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
-// Sandbox DATA_DIR BEFORE importing paths/worker-utils so the fail-loud counter
-// state file lands in a tmp dir and this test can drive the threshold path
-// without touching the real ~/.claude-mem state. paths.ts resolves DATA_DIR from
-// this env at first import, and worker-utils reads that resolved DATA_DIR.
-const TMP = mkdtempSync(join(tmpdir(), 'cmem-failopen-'));
-const ORIG_DATA_DIR = process.env.CLAUDE_MEM_DATA_DIR;
-const ORIG_THRESHOLD = process.env.CLAUDE_MEM_HOOK_FAIL_LOUD_THRESHOLD;
-process.env.CLAUDE_MEM_DATA_DIR = TMP;
-// Keep the fail-loud threshold at its default (3); make the intent explicit.
-process.env.CLAUDE_MEM_HOOK_FAIL_LOUD_THRESHOLD = '3';
-
-function restoreEnv(key: string, orig: string | undefined): void {
-  if (orig === undefined) delete process.env[key];
-  else process.env[key] = orig;
-}
-
-afterAll(async () => {
-  // Never leak our sandbox env into sibling test files (bun test shares one
-  // process): restore what we found so nothing else sees the TMP overrides.
-  restoreEnv('CLAUDE_MEM_DATA_DIR', ORIG_DATA_DIR);
-  restoreEnv('CLAUDE_MEM_HOOK_FAIL_LOUD_THRESHOLD', ORIG_THRESHOLD);
-  // Clean the counter state file wherever it actually landed: the TMP sandbox
-  // when this file imported paths.ts first, or the real DATA_DIR when an earlier
-  // suite file had already frozen the module-level DATA_DIR. Removing it just
-  // resets the counter to its healthy zero default — no lasting pollution.
-  try {
-    const { DATA_DIR } = await import('../../src/shared/paths.js');
-    rmSync(join(DATA_DIR, 'state', 'hook-failures.json'), { force: true });
-  } catch { /* best-effort */ }
-  try { rmSync(TMP, { recursive: true, force: true }); } catch { /* best-effort */ }
-});
-
-/** Capture real stderr by replacing the bound writer. Returns captured chunks. */
-function captureRealStderr(): { chunks: string[]; restore: () => void } {
-  const chunks: string[] = [];
-  const original = process.stderr.write.bind(process.stderr);
-  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
-    chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
-    return true;
-  }) as typeof process.stderr.write;
-  return { chunks, restore: () => { process.stderr.write = original as typeof process.stderr.write; } };
-}
+const REPO_ROOT = join(import.meta.dir, '..', '..');
+const WORKER_UTILS = join(REPO_ROOT, 'src', 'shared', 'worker-utils.ts');
 
 describe('recordWorkerUnreachable — fail-open: a memory-service outage never blocks the user', () => {
-  it('never exits the process at/over the fail-loud threshold, keeps counting, and emits a loud NON-blocking notice', async () => {
-    const { recordWorkerUnreachable } = await import('../../src/shared/worker-utils.js');
-    const real = captureRealStderr();
-    // Monotonic assertions (previous + 1) rather than absolute counts, so the
-    // proof holds regardless of the starting counter value — the module-level
-    // DATA_DIR may already be frozen to the real dir by an earlier suite file.
-    let counts: number[] = [];
+  it('never exits the process at/over the fail-loud threshold, keeps counting, and emits a loud NON-blocking notice', () => {
+    // Run in a FRESH bun process with an isolated DATA_DIR. bun shares its module
+    // cache across test files, so an in-process env override can be ignored when
+    // paths.ts (which resolves DATA_DIR once) was already imported by an earlier
+    // suite file — that would make the calls hit and delete the REAL user counter
+    // (PR #3225 review: "Cached Path Escapes Sandbox"). A subprocess gets a fresh
+    // module cache, so DATA_DIR is honored and the real state is never touched.
+    const TMP = mkdtempSync(join(tmpdir(), 'cmem-failopen-'));
     try {
-      // Under the OLD design, the call that reaches the fail-loud threshold ran
-      // emitBlockingError → process.exit(2), which would kill this test process
-      // mid-run (the ultimate proof of the lockout). Five calls guarantee we
-      // cross the default threshold (3) and keep going PAST it; reaching every
-      // assertion below proves not one of them blocked the critical path.
-      for (let i = 0; i < 5; i++) counts.push(await recordWorkerUnreachable());
+      const code =
+        `const { recordWorkerUnreachable } = await import(${JSON.stringify(WORKER_UTILS)});\n` +
+        `const counts = [];\n` +
+        `for (let i = 0; i < 5; i++) counts.push(await recordWorkerUnreachable());\n` +
+        `process.stdout.write('COUNTS=' + JSON.stringify(counts));\n`;
+      const r = spawnSync('bun', ['-e', code], {
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          CLAUDE_MEM_DATA_DIR: TMP,
+          CLAUDE_MEM_HOOK_FAIL_LOUD_THRESHOLD: '3',
+        },
+        timeout: 30000,
+      });
+
+      // Under the OLD design, the call reaching the threshold ran
+      // emitBlockingError -> process.exit(2); the subprocess would exit 2. A clean
+      // exit 0 across all five calls is the proof that a memory outage no longer
+      // blocks the critical path.
+      expect(r.status).toBe(0);
+
+      const m = /COUNTS=(\[[^\]]*\])/.exec(r.stdout || '');
+      expect(m).toBeTruthy();
+      const counts: number[] = JSON.parse(m![1]);
+      // Fresh sandbox counter starts at 0 and strictly increments by 1 each call.
+      expect(counts).toEqual([1, 2, 3, 4, 5]);
+      expect(counts[counts.length - 1]).toBeGreaterThanOrEqual(3);
+
+      const err = (r.stderr || '').toLowerCase();
+      // Loud: the operator/model sees the degradation...
+      expect(err).toContain('unreachable');
+      // ...and it is explicitly non-blocking.
+      expect(err).toContain('not blocked');
+
+      // The counter landed in the sandbox, never the real user dir.
+      const state = JSON.parse(readFileSync(join(TMP, 'state', 'hook-failures.json'), 'utf-8'));
+      expect(state.consecutiveFailures).toBe(5);
     } finally {
-      real.restore();
+      rmSync(TMP, { recursive: true, force: true });
     }
-
-    // Strictly increments by 1 each call — the counter keeps working.
-    for (let i = 1; i < counts.length; i++) {
-      expect(counts[i]).toBe(counts[i - 1] + 1);
-    }
-    // We are at/over the fail-loud threshold, and the process is still alive.
-    expect(counts[counts.length - 1]).toBeGreaterThanOrEqual(3);
-
-    const err = real.chunks.join('');
-    // Loud: the operator/model sees the degradation.
-    expect(err.toLowerCase()).toContain('unreachable');
-    // Reassuring + non-blocking contract surfaced to the reader.
-    expect(err.toLowerCase()).toContain('not blocked');
   });
 });
 
 describe('recordWorkerUnreachable — source contract', () => {
   it('escalates via the non-blocking emitDegradedNotice, not emitBlockingError/process.exit', () => {
-    const source = readFileSync('src/shared/worker-utils.ts', 'utf-8');
+    const source = readFileSync(join(REPO_ROOT, 'src', 'shared', 'worker-utils.ts'), 'utf-8');
     const fn = source.slice(
       source.indexOf('export async function recordWorkerUnreachable'),
       source.indexOf('function resetWorkerFailureCounter'),

--- a/tests/cli/worker-failopen.test.ts
+++ b/tests/cli/worker-failopen.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// Sandbox DATA_DIR BEFORE importing paths/worker-utils so the fail-loud counter
+// state file lands in a tmp dir and this test can drive the threshold path
+// without touching the real ~/.claude-mem state. paths.ts resolves DATA_DIR from
+// this env at first import, and worker-utils reads that resolved DATA_DIR.
+const TMP = mkdtempSync(join(tmpdir(), 'cmem-failopen-'));
+const ORIG_DATA_DIR = process.env.CLAUDE_MEM_DATA_DIR;
+const ORIG_THRESHOLD = process.env.CLAUDE_MEM_HOOK_FAIL_LOUD_THRESHOLD;
+process.env.CLAUDE_MEM_DATA_DIR = TMP;
+// Keep the fail-loud threshold at its default (3); make the intent explicit.
+process.env.CLAUDE_MEM_HOOK_FAIL_LOUD_THRESHOLD = '3';
+
+function restoreEnv(key: string, orig: string | undefined): void {
+  if (orig === undefined) delete process.env[key];
+  else process.env[key] = orig;
+}
+
+afterAll(async () => {
+  // Never leak our sandbox env into sibling test files (bun test shares one
+  // process): restore what we found so nothing else sees the TMP overrides.
+  restoreEnv('CLAUDE_MEM_DATA_DIR', ORIG_DATA_DIR);
+  restoreEnv('CLAUDE_MEM_HOOK_FAIL_LOUD_THRESHOLD', ORIG_THRESHOLD);
+  // Clean the counter state file wherever it actually landed: the TMP sandbox
+  // when this file imported paths.ts first, or the real DATA_DIR when an earlier
+  // suite file had already frozen the module-level DATA_DIR. Removing it just
+  // resets the counter to its healthy zero default — no lasting pollution.
+  try {
+    const { DATA_DIR } = await import('../../src/shared/paths.js');
+    rmSync(join(DATA_DIR, 'state', 'hook-failures.json'), { force: true });
+  } catch { /* best-effort */ }
+  try { rmSync(TMP, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+/** Capture real stderr by replacing the bound writer. Returns captured chunks. */
+function captureRealStderr(): { chunks: string[]; restore: () => void } {
+  const chunks: string[] = [];
+  const original = process.stderr.write.bind(process.stderr);
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    chunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+    return true;
+  }) as typeof process.stderr.write;
+  return { chunks, restore: () => { process.stderr.write = original as typeof process.stderr.write; } };
+}
+
+describe('recordWorkerUnreachable — fail-open: a memory-service outage never blocks the user', () => {
+  it('never exits the process at/over the fail-loud threshold, keeps counting, and emits a loud NON-blocking notice', async () => {
+    const { recordWorkerUnreachable } = await import('../../src/shared/worker-utils.js');
+    const real = captureRealStderr();
+    // Monotonic assertions (previous + 1) rather than absolute counts, so the
+    // proof holds regardless of the starting counter value — the module-level
+    // DATA_DIR may already be frozen to the real dir by an earlier suite file.
+    let counts: number[] = [];
+    try {
+      // Under the OLD design, the call that reaches the fail-loud threshold ran
+      // emitBlockingError → process.exit(2), which would kill this test process
+      // mid-run (the ultimate proof of the lockout). Five calls guarantee we
+      // cross the default threshold (3) and keep going PAST it; reaching every
+      // assertion below proves not one of them blocked the critical path.
+      for (let i = 0; i < 5; i++) counts.push(await recordWorkerUnreachable());
+    } finally {
+      real.restore();
+    }
+
+    // Strictly increments by 1 each call — the counter keeps working.
+    for (let i = 1; i < counts.length; i++) {
+      expect(counts[i]).toBe(counts[i - 1] + 1);
+    }
+    // We are at/over the fail-loud threshold, and the process is still alive.
+    expect(counts[counts.length - 1]).toBeGreaterThanOrEqual(3);
+
+    const err = real.chunks.join('');
+    // Loud: the operator/model sees the degradation.
+    expect(err.toLowerCase()).toContain('unreachable');
+    // Reassuring + non-blocking contract surfaced to the reader.
+    expect(err.toLowerCase()).toContain('not blocked');
+  });
+});
+
+describe('recordWorkerUnreachable — source contract', () => {
+  it('escalates via the non-blocking emitDegradedNotice, not emitBlockingError/process.exit', () => {
+    const source = readFileSync('src/shared/worker-utils.ts', 'utf-8');
+    const fn = source.slice(
+      source.indexOf('export async function recordWorkerUnreachable'),
+      source.indexOf('function resetWorkerFailureCounter'),
+    );
+    // Strip // comments so the contract is asserted against executable code only
+    // (the explanatory comment intentionally names the old process.exit(2) path).
+    const code = fn.split('\n').filter((l) => !l.trim().startsWith('//')).join('\n');
+    expect(code).toContain('emitDegradedNotice(');
+    // The worker-unavailable escalation must not hard-block the critical path.
+    expect(code).not.toContain('emitBlockingError(');
+    expect(code).not.toContain('process.exit');
+  });
+});


### PR DESCRIPTION
## Summary

Two independent reliability fixes for the memory worker. Together they make a memory-worker outage a *degraded* experience instead of a hard editor lockout, and prevent the specific packaging drift that caused it from shipping again.

## The problem — a memory outage could lock the editor

When the worker becomes unreachable, `recordWorkerUnreachable()` counts consecutive failures and, at the fail-loud threshold, called `emitBlockingError()` → `process.exit(2)`.

On the **`UserPromptSubmit`** hook, exit code 2 **blocks prompt submission**. So a *benign, recoverable* memory-worker outage escalated into a **total editor lockout** — the user could no longer submit anything and had to relaunch in `--safe-mode` from an external terminal to recover.

A concrete trigger: the worker bundle externalizes `zod` (the shipped `worker-service.cjs` contains bare `require("zod/v3")` resolved at runtime from the plugin's installed `node_modules`). If a shipped `bun.lock` drifts from `plugin/package.json`, the runtime `bun install --frozen-lockfile` produces no resolvable `zod` and the worker crashes at startup with `Cannot find module 'zod/v3'` → unreachable → the fail-loud path above → lockout.

## Fix A — hook fail-open (an auxiliary service must never block the critical path)

- New non-blocking primitive **`emitDegradedNotice()`** in `src/shared/hook-io.ts`: flushes the buffered stderr and writes a loud warning to real stderr, but **never calls `process.exit`**.
- `recordWorkerUnreachable()` now escalates through `emitDegradedNotice()` instead of `emitBlockingError()`. The hook still exits `0` via `exitGraceful`, so the prompt is never blocked. The failure counter and `hook_failed` telemetry still fire for diagnosis.
- The message is explicit that the memory features are degraded **but the prompt was not blocked**, with a recovery hint.
- The generic blocking-error path (real handler bugs → exit 2) is **unchanged**. Only the auxiliary-service (worker-unreachable) escalation is made non-blocking.

Rationale: the memory worker is an auxiliary service; it should degrade gracefully, not take down the critical path it augments (SRE cascading-failures / graceful degradation; blocking user input to force attention is a DevEx anti-pattern).

## Fix B — build/CI gate for the worker's externalized zod closure

`mcp-server.cjs` is already guarded (the build fails if it externalizes `zod`, because Claude Desktop can launch it without plugin `node_modules`). The worker had the exact same exposure but **no equivalent guard**.

New `scripts/check-worker-runtime-deps.cjs`, wired into `npm run build` after `gen-plugin-lockfile.cjs`:

1. Reproduces a clean `bun install --frozen-lockfile --ignore-scripts` of the shipped `plugin/package.json` + `plugin/bun.lock` in a temp dir.
2. Asserts the worker's always-required externals (`zod`, `zod/v3`, `zod/v4`, `zod/v4-mini`) resolve under `bun` from that clean closure.
3. **Fails the build** on lockfile drift or an unresolvable `zod` — i.e. before a broken artifact can ship.
4. Opt-in `CLAUDE_MEM_VERIFY_WORKER_BOOT=1` additionally loads the built worker bundle against the clean closure.

## Proofs

- **Reproduced the lockout**: the old escalation `process.exit(2)`-ed at the threshold, killing the test runner mid-run (`exit_code=2`) — the literal lockout.
- **Fail-open verified**: `recordWorkerUnreachable()` no longer exits at/over the threshold, keeps counting, and emits a loud non-blocking notice.
- **Build guard verified**: passes on the real shipped closure, and fails with a clear message on a drifted `bun.lock` (the reproduction of the original breakage).
- Full suite parity with the pre-change baseline (the only remaining failures are pre-existing, isolation-dependent flakes that pass when run alone); `typecheck` clean.

## Tests added / updated

- `tests/cli/worker-failopen.test.ts` — no-exit at/over threshold + loud non-blocking notice + source contract.
- `tests/cli/hook-io.test.ts` — `emitDegradedNotice` (writes + never exits, flushes buffer first).
- `tests/build/worker-runtime-deps-guard.test.ts` — passes on real closure, fails on drift, wired into `build`.
- `tests/cli/hook-stream-discipline.test.ts` — updated to the new non-blocking contract.

## Notes

- No behavior change to the generic blocking-error path or to successful hooks.
- Draft: opening for review of the approach before finalizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
