### PR TITLE
fix(codex): preserve runtime marker across marketplace refresh

### DIFF
--- a/plugin/scripts/version-check.js
+++ b/plugin/scripts/version-check.js
@@ -174,9 +174,26 @@ function readInstallMarkerVersion(markerPath) {
   }
 }
 
+function resolveInstallMarkerPath(root, version) {
+  const localMarkerPath = join(root, '.install-version');
+  if (existsSync(localMarkerPath)) return localMarkerPath;
+
+  const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+  const cacheMarkerPath = join(
+    claudeConfigDir,
+    'plugins',
+    'cache',
+    'thedotmack',
+    'claude-mem',
+    version,
+    '.install-version',
+  );
+  return existsSync(cacheMarkerPath) ? cacheMarkerPath : localMarkerPath;
+}
+
 try {
   const pkg = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8'));
-  const markerPath = join(ROOT, '.install-version');
+  const markerPath = resolveInstallMarkerPath(ROOT, pkg.version);
   if (!existsSync(markerPath)) {
     emitUpgradeHint('claude-mem: runtime not yet set up - run: npx claude-mem@latest install');
     process.exit(0);

--- a/tests/plugin-version-check.test.ts
+++ b/tests/plugin-version-check.test.ts
@@ -7,8 +7,8 @@ import { tmpdir } from 'os';
 const VERSION_CHECK_SCRIPT = join(import.meta.dir, '..', 'plugin', 'scripts', 'version-check.js');
 const versionCheckSource = readFileSync(VERSION_CHECK_SCRIPT, 'utf-8');
 
-function runVersionCheck(root: string) {
-  const env = { ...process.env, CLAUDE_PLUGIN_ROOT: root };
+function runVersionCheck(root: string, envOverrides: Record<string, string> = {}) {
+  const env = { ...process.env, CLAUDE_PLUGIN_ROOT: root, ...envOverrides };
   delete env.CLAUDE_MEM_CODEX_HOOK;
 
   return spawnSync('node', [VERSION_CHECK_SCRIPT], {
@@ -66,6 +66,26 @@ describe('plugin/scripts/version-check.js install marker compatibility', () => {
     expect(result.stderr).toContain(
       'claude-mem: upgraded to v12.4.4 - run: npx claude-mem@latest install',
     );
+  });
+
+  it('accepts a matching durable cache marker after marketplace refresh removes the local marker', () => {
+    const claudeConfigDir = join(tempDir, 'claude-config');
+    const cacheDir = join(
+      claudeConfigDir,
+      'plugins',
+      'cache',
+      'thedotmack',
+      'claude-mem',
+      '12.4.4',
+    );
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(join(cacheDir, '.install-version'), JSON.stringify({ version: '12.4.4' }));
+
+    const result = runVersionCheck(tempDir, { CLAUDE_CONFIG_DIR: claudeConfigDir });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toBe('');
   });
 });
 


### PR DESCRIPTION
## Summary

- fall back to the versioned Claude plugin cache marker when a rematerialized plugin root no longer contains its local install marker
- preserve the local marker as the authoritative first choice when it exists
- add regression coverage for a marketplace refresh followed by Codex caching the nested plugin root

## Root cause

PR #3210 writes the runtime marker into both the marketplace root and its nested plugin directory. That fixes the initial Codex copy, but the marketplace is also an auto-updating Git checkout. A subsequent Claude Code marketplace refresh can replace that checkout and remove the ignored, untracked install marker.

The versioned Claude plugin cache still retains its marker because the installer writes it only after the runtime dependencies are ready. SessionStart can therefore use that version-matched cache marker as a durable fallback when the local marker is absent, instead of emitting a false runtime not yet set up warning.

Observed lifecycle:

1. the installer completed the versioned cache runtime and wrote its marker
2. Claude Code refreshed the Git-backed marketplace afterward
3. the refreshed nested plugin root no longer contained the ignored marker
4. Codex cached that markerless plugin root and SessionStart emitted the false warning

## Verification

- bun test tests/plugin-version-check.test.ts: 5 pass, 0 fail
- npm run typecheck:root: pass
- bun test --only-failures: 2288 pass, 15 skip, 0 fail

Follow-up to #3210 and the marker failure class reported in #3092.