### PR TITLE
fix(windows): prefer resolved bun.exe from where (closes #3196)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,3 +36,9 @@ jobs:
       # Build only — the build-and-sync script also runs marketplace sync + worker
       # restart from a hardcoded ~/.claude/plugins path that doesn't exist on CI.
       - run: npm run build
+
+      # Covers the Windows-only bun resolver path that Linux CI skips.
+      - shell: pwsh
+        run: |
+          $bun = Join-Path $env:USERPROFILE '.bun\\bin\\bun.exe'
+          & $bun test tests/bun-runner.test.ts

--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -35,11 +35,19 @@ function findBun() {
   if (pathCheck.status === 0 && pathCheck.stdout.trim()) {
     if (IS_WINDOWS) {
       const bunPaths = pathCheck.stdout.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
-      const bunExePath = bunPaths.find(line => line.toLowerCase().endsWith('bun.exe'));
+      const firstBunPath = bunPaths.find(line => {
+        const lowerPath = line.toLowerCase();
+        return lowerPath.endsWith('bun.exe') || lowerPath.endsWith('bun.cmd');
+      });
+      const firstBunDir = firstBunPath ? dirname(firstBunPath).toLowerCase() : null;
+      const firstInstallPaths = firstBunDir
+        ? bunPaths.filter(line => dirname(line).toLowerCase() === firstBunDir)
+        : [];
+      const bunExePath = firstInstallPaths.find(line => line.toLowerCase().endsWith('bun.exe'));
       if (bunExePath) {
         return bunExePath;
       }
-      const bunCmdPath = bunPaths.find(line => line.toLowerCase().endsWith('bun.cmd'));
+      const bunCmdPath = firstInstallPaths.find(line => line.toLowerCase().endsWith('bun.cmd'));
       if (bunCmdPath) {
         return bunCmdPath;
       }

--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -34,9 +34,14 @@ function findBun() {
 
   if (pathCheck.status === 0 && pathCheck.stdout.trim()) {
     if (IS_WINDOWS) {
-      const bunCmdPath = pathCheck.stdout.split('\n').find(line => line.trim().endsWith('bun.cmd'));
+      const bunPaths = pathCheck.stdout.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+      const bunExePath = bunPaths.find(line => line.toLowerCase().endsWith('bun.exe'));
+      if (bunExePath) {
+        return bunExePath;
+      }
+      const bunCmdPath = bunPaths.find(line => line.toLowerCase().endsWith('bun.cmd'));
       if (bunCmdPath) {
-        return bunCmdPath.trim();
+        return bunCmdPath;
       }
     }
     return 'bun'; 

--- a/tests/bun-runner.test.ts
+++ b/tests/bun-runner.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'bun:test';
 import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { spawnSync } from 'child_process';
-import { join } from 'path';
+import { join, win32 } from 'path';
 
 const BUN_RUNNER_PATH = join(import.meta.dir, '..', 'plugin', 'scripts', 'bun-runner.js');
 const source = readFileSync(BUN_RUNNER_PATH, 'utf-8');
@@ -13,9 +13,10 @@ const findBunSource = source.slice(
 type FindBun = () => string | null;
 const createFindBun = new Function(
   'deps',
-  `const { IS_WINDOWS, existsSync, homedir, join, spawnSync } = deps;\n${findBunSource}\nreturn findBun;`
+  `const { IS_WINDOWS, dirname, existsSync, homedir, join, spawnSync } = deps;\n${findBunSource}\nreturn findBun;`
 ) as (deps: {
   IS_WINDOWS: boolean;
+  dirname: typeof win32.dirname;
   existsSync: (path: string) => boolean;
   homedir: () => string;
   join: typeof join;
@@ -46,6 +47,38 @@ describe('bun-runner.js findBun: DEP0190 regression guard (#1503)', () => {
 
 const windowsDescribe = process.platform === 'win32' ? describe : describe.skip;
 
+function findBunForWhereOutput(stdout: string) {
+  return createFindBun({
+    IS_WINDOWS: true,
+    dirname: win32.dirname,
+    existsSync: () => false,
+    homedir: () => 'C:\\Users\\fixture',
+    join,
+    spawnSync: (() => ({
+      status: 0,
+      stdout,
+      stderr: ''
+    })) as typeof spawnSync
+  })();
+}
+
+describe('bun-runner.js Windows PATH ordering', () => {
+  it('keeps an earlier bun.cmd ahead of a later bun.exe', () => {
+    expect(findBunForWhereOutput([
+      'C:\\First\\bun.cmd',
+      'C:\\Second\\bun.exe'
+    ].join('\r\n'))).toBe('C:\\First\\bun.cmd');
+  });
+
+  it('prefers bun.exe when bun.cmd and bun.exe share the first directory', () => {
+    expect(findBunForWhereOutput([
+      'C:\\First\\bun.cmd',
+      'C:\\First\\bun.exe',
+      'C:\\Second\\bun.exe'
+    ].join('\r\n'))).toBe('C:\\First\\bun.exe');
+  });
+});
+
 windowsDescribe('bun-runner.js Windows executable resolution', () => {
   function withFixture<T>(files: Record<string, string | null>, run: (fixtureDir: string) => T) {
     const fixtureDir = mkdtempSync(join(tmpdir(), 'bun-runner-'));
@@ -67,20 +100,6 @@ windowsDescribe('bun-runner.js Windows executable resolution', () => {
     } finally {
       rmSync(fixtureDir, { recursive: true, force: true });
     }
-  }
-
-  function findBunForWhereOutput(stdout: string) {
-    return createFindBun({
-      IS_WINDOWS: true,
-      existsSync: () => false,
-      homedir: () => 'C:\\Users\\fixture',
-      join,
-      spawnSync: (() => ({
-        status: 0,
-        stdout,
-        stderr: ''
-      })) as typeof spawnSync
-    })();
   }
 
   function findBunBaseForWhereOutput(stdout: string) {

--- a/tests/bun-runner.test.ts
+++ b/tests/bun-runner.test.ts
@@ -1,9 +1,26 @@
 import { describe, it, expect } from 'bun:test';
-import { readFileSync } from 'fs';
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { spawnSync } from 'child_process';
 import { join } from 'path';
 
 const BUN_RUNNER_PATH = join(import.meta.dir, '..', 'plugin', 'scripts', 'bun-runner.js');
 const source = readFileSync(BUN_RUNNER_PATH, 'utf-8');
+const findBunSource = source.slice(
+  source.indexOf('function findBun() {'),
+  source.indexOf('\nfunction isPluginDisabledInClaudeSettings() {')
+);
+type FindBun = () => string | null;
+const createFindBun = new Function(
+  'deps',
+  `const { IS_WINDOWS, existsSync, homedir, join, spawnSync } = deps;\n${findBunSource}\nreturn findBun;`
+) as (deps: {
+  IS_WINDOWS: boolean;
+  existsSync: (path: string) => boolean;
+  homedir: () => string;
+  join: typeof join;
+  spawnSync: typeof spawnSync;
+}) => FindBun;
 
 describe('bun-runner.js findBun: DEP0190 regression guard (#1503)', () => {
   it('does not use separate args array with shell:true (DEP0190 trigger pattern)', () => {
@@ -24,5 +41,115 @@ describe('bun-runner.js findBun: DEP0190 regression guard (#1503)', () => {
       expect(unixCallMatch[1]).not.toContain('shell');
     }
     expect(source).toContain("spawnSync('which', ['bun']");
+  });
+});
+
+const windowsDescribe = process.platform === 'win32' ? describe : describe.skip;
+
+windowsDescribe('bun-runner.js Windows executable resolution', () => {
+  function withFixture<T>(files: Record<string, string | null>, run: (fixtureDir: string) => T) {
+    const fixtureDir = mkdtempSync(join(tmpdir(), 'bun-runner-'));
+    const scriptPath = join(fixtureDir, 'fixture.js');
+    const bunExecutable = process.execPath;
+
+    try {
+      writeFileSync(scriptPath, 'console.log("fixture launched");\n');
+      for (const [name, content] of Object.entries(files)) {
+        const filePath = join(fixtureDir, name);
+        if (name.toLowerCase().endsWith('.exe')) {
+          cpSync(bunExecutable, filePath);
+        } else {
+          writeFileSync(filePath, content || '');
+        }
+      }
+
+      return run(fixtureDir);
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
+  }
+
+  function findBunForWhereOutput(stdout: string) {
+    return createFindBun({
+      IS_WINDOWS: true,
+      existsSync: () => false,
+      homedir: () => 'C:\\Users\\fixture',
+      join,
+      spawnSync: (() => ({
+        status: 0,
+        stdout,
+        stderr: ''
+      })) as typeof spawnSync
+    })();
+  }
+
+  function findBunBaseForWhereOutput(stdout: string) {
+    const bunCmdPath = stdout.split('\n').find(line => line.trim().endsWith('bun.cmd'));
+    if (bunCmdPath) {
+      return bunCmdPath.trim();
+    }
+    return 'bun';
+  }
+
+  function runFixture(fixtureDir: string) {
+    const scriptPath = join(fixtureDir, 'fixture.js');
+    const systemPath = process.env.PATH || '';
+
+    return spawnSync(process.execPath, [BUN_RUNNER_PATH, scriptPath, 'start'], {
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          PATH: `${fixtureDir};${systemPath}`,
+          CLAUDE_CONFIG_DIR: fixtureDir
+        },
+        windowsHide: true
+      });
+  }
+
+  it('launches the resolved bun.exe from where', () => {
+    withFixture({ 'bun.exe': null }, fixtureDir => {
+      const bunExePath = join(fixtureDir, 'bun.exe');
+      expect(findBunBaseForWhereOutput(`${bunExePath}\r\n`)).toBe('bun');
+      expect(findBunForWhereOutput(`${bunExePath}\r\n`)).toBe(bunExePath);
+
+      const result = runFixture(fixtureDir);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('fixture launched');
+      expect(result.stderr).not.toContain('Failed to start Bun');
+      expect(result.stderr).not.toContain('doubled-quote');
+    });
+  });
+
+  it('prefers bun.exe over bun.cmd from where', () => {
+    withFixture({
+      'bun.exe': null,
+      'bun.cmd': '@echo off\r\nexit /b 91\r\n'
+    }, fixtureDir => {
+      const bunExePath = join(fixtureDir, 'bun.exe');
+      const bunCmdPath = join(fixtureDir, 'bun.cmd');
+      const whereOutput = `${bunExePath}\r\n${bunCmdPath}\r\n`;
+
+      expect(findBunBaseForWhereOutput(whereOutput)).toBe(bunCmdPath);
+      expect(findBunForWhereOutput(whereOutput)).toBe(bunExePath);
+
+      const result = runFixture(fixtureDir);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('fixture launched');
+    });
+  });
+
+  it('keeps bun.cmd as the Windows fallback', () => {
+    const bunExecutable = process.execPath.replace(/\\/g, '\\\\');
+    withFixture({
+      'bun.cmd': `@echo off\r\n"${bunExecutable}" %*\r\n`
+    }, fixtureDir => {
+      const bunCmdPath = join(fixtureDir, 'bun.cmd');
+      expect(findBunBaseForWhereOutput(`${bunCmdPath}\r\n`)).toBe(bunCmdPath);
+      expect(findBunForWhereOutput(`${bunCmdPath}\r\n`)).toBe(bunCmdPath);
+
+      const result = runFixture(fixtureDir);
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain('fixture launched');
+    });
   });
 });


### PR DESCRIPTION
## Summary

Windows hook startup discarded the absolute `bun.exe` path returned by `where bun` when the official Bun installer provided no `bun.cmd` shim. `findBun()` now prefers the resolved `.exe`, retains `.cmd` compatibility, and leaves POSIX and PATH-miss resolution unchanged.

## Why

The successful Windows lookup branch at `plugin/scripts/bun-runner.js:35-43` searched only for `bun.cmd`. An output containing only `C:\Users\<user>\.bun\bin\bun.exe` fell through to bare `bun`, which the later Windows launch could report as `""bun"" is not recognized`. Selecting the path that `where.exe` already resolved prevents that loss before the unchanged spawn path runs.

## Scope

- Keeps the Windows lookup invocation, spawn mechanism, quoting, and stdin handling unchanged.
- Keeps `.cmd` support when no `.exe` result exists.
- Leaves POSIX behavior, fallback installation paths, `version-check.js`, and generated installation copies unchanged.

## Verification

- [x] `bun test tests/bun-runner.test.ts`
- [x] `npm run build`
- [x] `npm run lint:hook-io && npm run lint:spawn-env && npm run strip-comments:check` (`lint:hook-io` and `lint:spawn-env` pass; `strip-comments:check` reports existing repo-wide drift, so the combined command exits 1)
- [x] Deterministic Windows issue-boundary reproduction: base returns bare `bun` for `.exe`-only `where.exe bun` output, head returns the resolved `.exe`, and the head runner launches successfully without the doubled-quote error

`strip-comments:check` is baseline noise in this repo. The proposal only claims the two focused lints pass locally; the combined command still exits 1 because `strip-comments:check` reports existing repository-wide drift.

Closes #3196
