### PR TITLE
docs(i18n): add Persian (fa) README translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="docs/i18n/README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.ar.md
+++ b/docs/i18n/README.ar.md
@@ -29,6 +29,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.bn.md
+++ b/docs/i18n/README.bn.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.cs.md
+++ b/docs/i18n/README.cs.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.da.md
+++ b/docs/i18n/README.da.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.de.md
+++ b/docs/i18n/README.de.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.el.md
+++ b/docs/i18n/README.el.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.es.md
+++ b/docs/i18n/README.es.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.fa.md
+++ b/docs/i18n/README.fa.md
@@ -1,0 +1,439 @@
+🌐 این ترجمه به‌صورت خودکار انجام شده است. اصلاحات جامعه پذیرفته می‌شود!
+
+<section dir="rtl">
+
+<h1 align="center">
+  <br>
+  <a href="https://github.com/thedotmack/claude-mem">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/thedotmack/claude-mem/main/docs/public/claude-mem-logo-for-dark-mode.webp">
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/thedotmack/claude-mem/main/docs/public/claude-mem-logo-for-light-mode.webp">
+      <img src="https://raw.githubusercontent.com/thedotmack/claude-mem/main/docs/public/claude-mem-logo-for-light-mode.webp" alt="Claude-Mem" width="400">
+    </picture>
+  </a>
+  <br>
+  <a href="https://vercel.com/open-source-program">
+    <img alt="Vercel OSS Program" src="https://vercel.com/oss/program-badge-2026.svg" />
+  </a>
+</h1>
+
+<p align="center">
+  <a href="README.zh.md">🇨🇳 中文</a> •
+  <a href="README.zh-tw.md">🇹🇼 繁體中文</a> •
+  <a href="README.ja.md">🇯🇵 日本語</a> •
+  <a href="README.pt.md">🇵🇹 Português</a> •
+  <a href="README.pt-br.md">🇧🇷 Português</a> •
+  <a href="README.ko.md">🇰🇷 한국어</a> •
+  <a href="README.es.md">🇪🇸 Español</a> •
+  <a href="README.de.md">🇩🇪 Deutsch</a> •
+  <a href="README.fr.md">🇫🇷 Français</a> •
+  <a href="README.he.md">🇮🇱 עברית</a> •
+  <a href="README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
+  <a href="README.ru.md">🇷🇺 Русский</a> •
+  <a href="README.pl.md">🇵🇱 Polski</a> •
+  <a href="README.cs.md">🇨🇿 Čeština</a> •
+  <a href="README.nl.md">🇳🇱 Nederlands</a> •
+  <a href="README.tr.md">🇹🇷 Türkçe</a> •
+  <a href="README.uk.md">🇺🇦 Українська</a> •
+  <a href="README.vi.md">🇻🇳 Tiếng Việt</a> •
+  <a href="README.tl.md">🇵🇭 Tagalog</a> •
+  <a href="README.id.md">🇮🇩 Indonesia</a> •
+  <a href="README.th.md">🇹🇭 ไทย</a> •
+  <a href="README.hi.md">🇮🇳 हिन्दी</a> •
+  <a href="README.bn.md">🇧🇩 বাংলা</a> •
+  <a href="README.ur.md">🇵🇰 اردو</a> •
+  <a href="README.ro.md">🇷🇴 Română</a> •
+  <a href="README.sv.md">🇸🇪 Svenska</a> •
+  <a href="README.it.md">🇮🇹 Italiano</a> •
+  <a href="README.el.md">🇬🇷 Ελληνικά</a> •
+  <a href="README.hu.md">🇭🇺 Magyar</a> •
+  <a href="README.fi.md">🇫🇮 Suomi</a> •
+  <a href="README.da.md">🇩🇰 Dansk</a> •
+  <a href="README.no.md">🇳🇴 Norsk</a>
+</p>
+
+<h4 align="center">سیستم فشرده‌سازی حافظهٔ پایدار که برای <a href="https://claude.com/claude-code" target="_blank">Claude Code</a> ساخته شده است.</h4>
+
+<p align="center">
+  <a href="../../LICENSE">
+    <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License">
+  </a>
+  <a href="../../package.json">
+    <img src="https://img.shields.io/badge/version-13.4.0-green.svg" alt="Version">
+  </a>
+  <a href="../../package.json">
+    <img src="https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg" alt="Node">
+  </a>
+  <a href="https://github.com/thedotmack/awesome-claude-code">
+    <img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Claude Code">
+  </a>
+</p>
+
+<p align="center">
+  <a href="https://trendshift.io/repositories/15496" target="_blank">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/thedotmack/claude-mem/main/docs/public/trendshift-badge-dark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/thedotmack/claude-mem/main/docs/public/trendshift-badge.svg">
+      <img src="https://raw.githubusercontent.com/thedotmack/claude-mem/main/docs/public/trendshift-badge.svg" alt="thedotmack/claude-mem | Trendshift" width="250" height="55"/>
+    </picture>
+  </a>
+</p>
+
+<br>
+
+<table align="center">
+  <tr>
+    <td align="center">
+      <a href="https://github.com/thedotmack/claude-mem">
+        <picture>
+          <img
+            src="https://raw.githubusercontent.com/thedotmack/claude-mem/main/docs/public/cm-preview.gif"
+            alt="Claude-Mem Preview"
+            width="500"
+          >
+        </picture>
+      </a>
+    </td>
+    <td align="center">
+      <a href="https://www.star-history.com/#thedotmack/claude-mem&Date">
+        <picture>
+          <source
+            media="(prefers-color-scheme: dark)"
+            srcset="https://api.star-history.com/image?repos=thedotmack/claude-mem&type=date&theme=dark&legend=top-left"
+          />
+          <source
+            media="(prefers-color-scheme: light)"
+            srcset="https://api.star-history.com/image?repos=thedotmack/claude-mem&type=date&legend=top-left"
+          />
+          <img
+            alt="Star History Chart"
+            src="https://api.star-history.com/image?repos=thedotmack/claude-mem&type=date&legend=top-left"
+            width="500"
+          />
+        </picture>
+      </a>
+    </td>
+  </tr>
+</table>
+
+<p align="center">
+  <a href="#شروع-سریع">شروع سریع</a> •
+  <a href="#چگونه-کار-می‌کند">چگونه کار می‌کند</a> •
+  <a href="#ابزارهای-جستجوی-mcp">ابزارهای جستجو</a> •
+  <a href="#مستندات">مستندات</a> •
+  <a href="#پیکربندی">پیکربندی</a> •
+  <a href="#عیب‌یابی">عیب‌یابی</a> •
+  <a href="#مجوز">مجوز</a>
+</p>
+
+<p align="center">
+  Claude-Mem با ثبت خودکار مشاهدات مربوط به استفاده از ابزارها، تولید خلاصه‌های معنایی و در دسترس قرار دادن آن‌ها برای جلسات آینده، بافتار (context) را به‌طور یکپارچه در طول جلسات حفظ می‌کند. این کار به Claude امکان می‌دهد حتی پس از پایان یا اتصال مجدد جلسات، پیوستگی دانش خود دربارهٔ پروژه‌ها را حفظ کند.
+</p>
+
+---
+
+## شروع سریع
+
+با یک دستور نصب کنید:
+
+```bash
+npx claude-mem install
+```
+
+یا برای OpenCode نصب کنید:
+
+```bash
+npx claude-mem install --ide opencode
+```
+
+یا برای Antigravity CLI نصب کنید ([راهنمای راه‌اندازی](https://docs.claude-mem.ai/antigravity-cli/setup)):
+
+```bash
+npx claude-mem install --ide antigravity
+```
+
+یا از فروشگاه افزونه‌ها (plugin marketplace) در داخل Claude Code نصب کنید:
+
+```bash
+/plugin marketplace add thedotmack/claude-mem
+
+/plugin install claude-mem
+```
+
+Claude Code را دوباره راه‌اندازی کنید. بافتار جلسات قبلی به‌طور خودکار در جلسات جدید ظاهر می‌شود.
+
+> **توجه:** Claude-Mem روی npm نیز منتشر شده است، اما `npm install -g claude-mem` تنها **کتابخانه/SDK را نصب می‌کند** — این دستور نه هوک‌های افزونه (plugin hooks) را ثبت می‌کند و نه سرویس worker را راه‌اندازی می‌کند. همیشه از طریق `npx claude-mem install` یا دستورهای `/plugin` بالا نصب کنید.
+
+### 🦞 دروازهٔ OpenClaw (OpenClaw Gateway)
+
+claude-mem را به‌عنوان یک افزونهٔ حافظهٔ پایدار روی دروازه‌های [OpenClaw](https://openclaw.ai) با یک دستور نصب کنید:
+
+```bash
+curl -fsSL https://install.cmem.ai/openclaw.sh | bash
+```
+
+برنامهٔ نصب، وابستگی‌ها، راه‌اندازی افزونه، پیکربندی ارائه‌دهندهٔ هوش مصنوعی، شروع worker و همچنین ارسال اختیاری مشاهدات به‌صورت بلادرنگ به Telegram، Discord، Slack و موارد دیگر را مدیریت می‌کند. برای جزئیات به [راهنمای یکپارچه‌سازی OpenClaw](https://docs.claude-mem.ai/openclaw-integration) مراجعه کنید.
+
+**ویژگی‌های کلیدی:**
+
+- 🧠 **حافظهٔ پایدار** - بافتار در طول جلسات باقی می‌ماند
+- 📊 **افشای تدریجی (Progressive Disclosure)** - بازیابی لایه‌بندی‌شدهٔ حافظه همراه با نمایش هزینهٔ token
+- 🔍 **جستجوی مبتنی بر مهارت** - تاریخچهٔ پروژهٔ خود را با مهارت mem-search جستجو کنید
+- 🖥️ **رابط کاربری نمایشگر وب** - جریان بلادرنگ حافظه در worker URL که هنگام شروع چاپ می‌شود
+- 💻 **مهارت Claude Desktop** - از دل گفتگوهای Claude Desktop در حافظه جستجو کنید
+- 🔒 **کنترل حریم خصوصی** - از برچسب‌های `<private>` برای کنار گذاشتن محتوای حساس از ذخیره‌سازی استفاده کنید
+- ⚙️ **پیکربندی بافتار** - کنترل دقیق بر اینکه چه بافتاری تزریق می‌شود
+- 🤖 **عملکرد خودکار** - نیازی به دخالت دستی نیست
+- 🔗 **ارجاعات (Citations)** - مشاهدات گذشته را با شناسه‌ها (IDs) از طریق worker API ارجاع دهید یا همه را در نمایشگر وب ببینید
+
+---
+
+## مستندات
+
+📚 **[مشاهدهٔ مستندات کامل](https://docs.claude-mem.ai/)** - مرور در وب‌سایت رسمی
+
+### شروع به کار
+
+- **[راهنمای نصب](https://docs.claude-mem.ai/installation)** - شروع سریع و نصب پیشرفته
+- **[راهنمای استفاده](https://docs.claude-mem.ai/usage/getting-started)** - نحوهٔ کار خودکار Claude-Mem
+- **[ابزارهای جستجو](https://docs.claude-mem.ai/usage/search-tools)** - تاریخچهٔ پروژهٔ خود را با زبان طبیعی جستجو کنید
+- **[همگام‌سازی ابری (Cloud Sync)](https://docs.claude-mem.ai/cloud-sync)** - حافظه‌های خود را در cmem.ai پشتیبان‌گیری کنید — بدون هیچ daemon، worker هنگام نوشتن همگام‌سازی می‌کند
+
+### بهترین روش‌ها
+
+- **[مهندسی بافتار](https://docs.claude-mem.ai/context-engineering)** - اصول بهینه‌سازی بافتار عامل هوش مصنوعی
+- **[افشای تدریجی](https://docs.claude-mem.ai/progressive-disclosure)** - فلسفهٔ پشت استراتژی آماده‌سازی بافتار Claude-Mem
+
+### معماری
+
+- **[نمای کلی](https://docs.claude-mem.ai/architecture/overview)** - اجزای سیستم و جریان داده
+- **[تکامل معماری](https://docs.claude-mem.ai/architecture-evolution)** - مسیر تکامل از v3 به v5
+- **[معماری هوک‌ها (Hooks)](https://docs.claude-mem.ai/hooks-architecture)** - نحوهٔ استفادهٔ Claude-Mem از هوک‌های چرخهٔ حیات
+- **[مرجع هوک‌ها (Hooks)](https://docs.claude-mem.ai/architecture/hooks)** - توضیح ۷ اسکریپت هوک
+- **[سرویس Worker](https://docs.claude-mem.ai/architecture/worker-service)** - HTTP API و مدیریت Bun
+- **[پایگاه داده](https://docs.claude-mem.ai/architecture/database)** - طرح‌وارهٔ SQLite و جستجوی FTS5
+- **[معماری جستجو](https://docs.claude-mem.ai/architecture/search-architecture)** - جستجوی ترکیبی با پایگاه دادهٔ برداری Chroma
+
+### پیکربندی و توسعه
+
+- **[پیکربندی](https://docs.claude-mem.ai/configuration)** - متغیرهای محیطی و تنظیمات
+- **[توسعه](https://docs.claude-mem.ai/development)** - ساخت، آزمایش و مشارکت
+- **[شاخه‌های انتشار](https://docs.claude-mem.ai/branches)** - جریان شاخه‌های stable، core-dev و community-edge
+- **[عیب‌یابی](https://docs.claude-mem.ai/troubleshooting)** - مشکلات رایج و راه‌حل‌ها
+
+---
+
+## چگونه کار می‌کند
+
+**اجزای اصلی:**
+
+1. **۵ هوک چرخهٔ حیات (Lifecycle Hooks)** - SessionStart، UserPromptSubmit، PostToolUse، Stop، SessionEnd (۶ اسکریپت هوک)
+2. **نصب هوشمند** - بررسی‌کنندهٔ وابستگی‌های ذخیره‌شده (اسکریپت پیش‌هوک، نه یک هوک چرخهٔ حیات)
+3. **سرویس Worker** - HTTP API محلی همراه با رابط کاربری نمایشگر وب و نقاط پایانی جستجو، که توسط Bun مدیریت می‌شود
+4. **پایگاه دادهٔ SQLite** - جلسات، مشاهدات و خلاصه‌ها را ذخیره می‌کند
+5. **مهارت mem-search** - پرس‌وجوهای زبان طبیعی همراه با افشای تدریجی
+6. **پایگاه دادهٔ برداری Chroma** - جستجوی ترکیبی معنایی + کلیدواژه برای بازیابی هوشمند بافتار
+
+برای جزئیات به [نمای کلی معماری](https://docs.claude-mem.ai/architecture/overview) مراجعه کنید.
+
+---
+
+## ابزارهای جستجوی MCP
+
+Claude-Mem جستجوی هوشمند حافظه را از طریق **۴ ابزار MCP** ارائه می‌دهد که از یک الگوی گردش‌کار **۳ لایه‌ای** بهینه از نظر مصرف token پیروی می‌کنند:
+
+**گردش‌کار ۳ لایه‌ای:**
+
+1. **`search`** - دریافت فهرست فشرده همراه با شناسه‌ها (IDs) (حدود ۵۰ تا ۱۰۰ token در هر نتیجه)
+2. **`timeline`** - دریافت بافتار زمانی پیرامون نتایج جالب توجه
+3. **`get_observations`** - واکشی جزئیات کامل تنها برای شناسه‌های (IDs) فیلترشده (حدود ۵۰۰ تا ۱۰۰۰ token در هر نتیجه)
+
+**چگونه کار می‌کند:**
+- Claude از ابزارهای MCP برای جستجو در حافظهٔ شما استفاده می‌کند
+- با `search` شروع کنید تا فهرستی از نتایج به دست آورید
+- از `timeline` برای دیدن آنچه پیرامون مشاهدات خاص در حال رخ دادن بوده استفاده کنید
+- از `get_observations` برای واکشی جزئیات کامل شناسه‌های مرتبط استفاده کنید
+- **صرفه‌جویی حدود ۱۰ برابری در مصرف token** با فیلتر کردن پیش از واکشی جزئیات
+
+**ابزارهای MCP موجود:**
+
+1. **`search`** - جستجو در فهرست حافظه با پرس‌وجوهای تمام‌متن، همراه با فیلتر بر اساس نوع/تاریخ/پروژه
+2. **`timeline`** - دریافت بافتار زمانی پیرامون یک مشاهده یا پرس‌وجوی مشخص
+3. **`get_observations`** - واکشی جزئیات کامل مشاهدات بر اساس شناسه‌ها (IDs) (همیشه چند شناسه را در یک درخواست دسته‌ای بفرستید)
+
+**نمونهٔ استفاده:**
+
+```typescript
+// Step 1: Search for index
+search(query="authentication bug", type="bugfix", limit=10)
+
+// Step 2: Review index, identify relevant IDs (e.g., #123, #456)
+
+// Step 3: Fetch full details
+get_observations(ids=[123, 456])
+```
+
+برای نمونه‌های مفصل به [راهنمای ابزارهای جستجو](https://docs.claude-mem.ai/usage/search-tools) مراجعه کنید.
+
+---
+
+## شاخه‌های انتشار
+
+نسخه‌های پایدار از شاخهٔ `main` عرضه شده و روی npm منتشر می‌شوند. شاخه‌های `core-dev` و
+`community-edge` شاخه‌هایی هستند که از روی سورس اجرا می‌شوند و برای رفع زودهنگام مشکلات پایداری و
+یکپارچه‌سازی‌های جامعه به کار می‌روند. برای آشنایی با جریان شاخه‌ها و دستورالعمل‌های اجرای نسخه‌های ناپایدار به **[شاخه‌های انتشار](https://docs.claude-mem.ai/branches)**
+مراجعه کنید.
+
+---
+
+## نیازمندی‌های سیستم
+
+- **Node.js**: نسخهٔ 20.0.0 یا بالاتر
+- **Claude Code**: آخرین نسخه با پشتیبانی از افزونه‌ها
+- **Bun**: زمان اجرای JavaScript و مدیر فرایند (در صورت نبود، به‌طور خودکار نصب می‌شود)
+- **uv**: مدیر بستهٔ Python برای جستجوی برداری (در صورت نبود، به‌طور خودکار نصب می‌شود)
+- **SQLite 3**: برای ذخیره‌سازی پایدار (به‌همراه بسته ارائه می‌شود)
+
+---
+### نکات نصب در Windows
+
+اگر خطایی مانند زیر مشاهده کردید:
+
+```powershell
+npm : The term 'npm' is not recognized as the name of a cmdlet
+```
+
+مطمئن شوید Node.js و npm نصب شده و به متغیر PATH شما افزوده شده‌اند. آخرین برنامهٔ نصب Node.js را از https://nodejs.org دانلود کنید و پس از نصب، ترمینال خود را دوباره راه‌اندازی کنید.
+
+---
+
+## پیکربندی
+
+تنظیمات در `~/.claude-mem/settings.json` مدیریت می‌شوند (که در نخستین اجرا به‌طور خودکار با مقادیر پیش‌فرض ایجاد می‌شود). می‌توانید مدل هوش مصنوعی، پورت worker، پوشهٔ داده، سطح گزارش (log level) و تنظیمات تزریق بافتار را پیکربندی کنید.
+
+برای مشاهدهٔ همهٔ تنظیمات موجود و نمونه‌ها به **[راهنمای پیکربندی](https://docs.claude-mem.ai/configuration)** مراجعه کنید.
+
+### پیکربندی حالت و زبان
+
+Claude-Mem از چندین حالت گردش‌کار و زبان مختلف از طریق تنظیم `CLAUDE_MEM_MODE` پشتیبانی می‌کند.
+
+این گزینه هر دو مورد زیر را کنترل می‌کند:
+- رفتار گردش‌کار (مانند code، chill، investigation)
+- زبان مورد استفاده در مشاهدات تولیدشده
+
+#### نحوهٔ پیکربندی
+
+فایل تنظیمات خود را در مسیر `~/.claude-mem/settings.json` ویرایش کنید:
+
+```json
+{
+  "CLAUDE_MEM_MODE": "code--zh"
+}
+```
+
+حالت‌ها در `plugin/modes/` تعریف شده‌اند. برای دیدن همهٔ حالت‌های موجود به‌صورت محلی:
+
+```bash
+ls ~/.claude/plugins/marketplaces/thedotmack/plugin/modes/
+```
+
+#### حالت‌های موجود
+
+| حالت | توضیحات |
+|------------|-------------------------|
+| `code` | حالت پیش‌فرض (انگلیسی) |
+| `code--zh` | حالت چینی ساده‌شده |
+| `code--ja` | حالت ژاپنی |
+
+حالت‌های مخصوص هر زبان از الگوی `code--[lang]` پیروی می‌کنند که در آن `[lang]` کد زبان بر اساس استاندارد ISO 639-1 است (برای مثال، `zh` برای چینی، `ja` برای ژاپنی و `es` برای اسپانیایی).
+
+> توجه: حالت `code--zh` (چینی ساده‌شده) از پیش تعبیه شده است — نیازی به نصب اضافی یا به‌روزرسانی افزونه نیست.
+
+#### پس از تغییر حالت
+
+برای اعمال پیکربندی حالت جدید، Claude Code را دوباره راه‌اندازی کنید.
+
+---
+
+## توسعه
+
+برای دستورالعمل‌های ساخت، آزمایش و گردش‌کار مشارکت به **[راهنمای توسعه](https://docs.claude-mem.ai/development)** مراجعه کنید.
+
+---
+
+## عیب‌یابی
+
+اگر با مشکلاتی روبه‌رو شدید، مشکل را برای Claude شرح دهید و مهارت troubleshoot به‌طور خودکار آن را تشخیص داده و راه‌حل ارائه می‌دهد.
+
+برای مشکلات رایج و راه‌حل‌ها به **[راهنمای عیب‌یابی](https://docs.claude-mem.ai/troubleshooting)** مراجعه کنید.
+
+---
+
+## گزارش اشکالات
+
+با استفاده از تولیدکنندهٔ خودکار، گزارش‌های جامع اشکال ایجاد کنید:
+
+```bash
+cd ~/.claude/plugins/marketplaces/thedotmack
+npm run bug-report
+```
+
+## مشارکت
+
+از مشارکت‌ها استقبال می‌شود! لطفاً:
+
+1. مخزن (repository) را Fork کنید
+2. یک شاخهٔ (branch) ویژگی ایجاد کنید
+3. تغییرات خود را همراه با آزمون‌ها اعمال کنید
+4. مستندات را به‌روزرسانی کنید
+5. یک Pull Request ثبت کنید
+
+Claude-Mem از سه شاخه عرضه می‌شود: `main` (پایدار)، `core-dev` و
+`community-edge`. تنها `main` روی npm منتشر می‌شود؛ بقیه از روی
+سورس اجرا می‌شوند. برای آشنایی با این استراتژی و دستورالعمل‌های اجرای محلی به [شاخه‌های انتشار](https://docs.claude-mem.ai/branches)
+مراجعه کنید.
+
+برای گردش‌کار مشارکت به [راهنمای توسعه](https://docs.claude-mem.ai/development) مراجعه کنید.
+
+---
+
+## مجوز
+
+Claude-Mem تحت مجوز Apache License 2.0 منتشر شده است.
+
+ما Apache-2.0 را انتخاب کردیم زیرا حافظهٔ عاملی پایدار (durable agentic memory) باید به‌آسانی در
+ابزارهای توسعه‌دهندگان، عامل‌های محلی، سرورهای MCP، سیستم‌های سازمانی، پشته‌های رباتیک
+و بسترهای اجرای عامل در محیط تولید (production) قابل جاسازی باشد.
+
+برای جزئیات کامل به فایل [LICENSE](../../LICENSE) مراجعه کنید. برای آگاهی از دامنهٔ مجوز و مرز میان بخش متن‌باز و تجاری به [docs/license.md](../../docs/license.md)
+و [docs/ip-boundary.md](../../docs/ip-boundary.md) مراجعه کنید.
+
+**نکته دربارهٔ Ragtime**: پوشهٔ `ragtime/` تحت **Apache License 2.0** منتشر شده است. برای جزئیات به [ragtime/LICENSE](../../ragtime/LICENSE) مراجعه کنید.
+
+---
+
+## پشتیبانی
+
+- **مستندات**: [docs/](../../docs/)
+- **مشکلات (Issues)**: [GitHub Issues](https://github.com/thedotmack/claude-mem/issues)
+- **مخزن**: [github.com/thedotmack/claude-mem](https://github.com/thedotmack/claude-mem)
+- **حساب رسمی X**: [@Claude_Memory](https://x.com/Claude_Memory)
+- **Discord رسمی**: [پیوستن به Discord](https://discord.com/invite/J4wttp9vDu)
+- **نویسنده**: Alex Newman ([@thedotmack](https://github.com/thedotmack))
+
+---
+
+**ساخته‌شده با Claude Agent SDK** | **سازگار با Claude Code** | **ساخته‌شده با TypeScript**
+
+---
+
+### CMEM چیست؟
+
+CMEM توکنی است که توسط یک شخص ثالث ایجاد شده اما به‌طور رسمی از سوی سازندهٔ Claude-Mem (Alex Newman، @thedotmack) پذیرفته شده است. این توکن به‌عنوان کاتالیزوری برای رشد جامعه و ابزاری برای رساندن CMEM به دست توسعه‌دهندگان و کارکنان دانشی که بیش از همه به آن نیاز دارند عمل می‌کند.
+
+آدرس رسمی قرارداد در BASE (BASE CA): 0x76b1967eec0ccaeb001bbbb2b40dc4badba31ba3
+
+</section>
+
+---

--- a/docs/i18n/README.fi.md
+++ b/docs/i18n/README.fi.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.he.md
+++ b/docs/i18n/README.he.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.hi.md
+++ b/docs/i18n/README.hi.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.hu.md
+++ b/docs/i18n/README.hu.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.id.md
+++ b/docs/i18n/README.id.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.it.md
+++ b/docs/i18n/README.it.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.ja.md
+++ b/docs/i18n/README.ja.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.ko.md
+++ b/docs/i18n/README.ko.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.nl.md
+++ b/docs/i18n/README.nl.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.no.md
+++ b/docs/i18n/README.no.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.pl.md
+++ b/docs/i18n/README.pl.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.pt-br.md
+++ b/docs/i18n/README.pt-br.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.pt.md
+++ b/docs/i18n/README.pt.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.ro.md
+++ b/docs/i18n/README.ro.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.ru.md
+++ b/docs/i18n/README.ru.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.sv.md
+++ b/docs/i18n/README.sv.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.th.md
+++ b/docs/i18n/README.th.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.tl.md
+++ b/docs/i18n/README.tl.md
@@ -27,6 +27,7 @@
   <a href="README.fr.md">🇫🇷 Français</a> •
   <a href="README.he.md">🇮🇱 עברית</a> •
   <a href="README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="README.ru.md">🇷🇺 Русский</a> •
   <a href="README.pl.md">🇵🇱 Polski</a> •
   <a href="README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.tr.md
+++ b/docs/i18n/README.tr.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.uk.md
+++ b/docs/i18n/README.uk.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.ur.md
+++ b/docs/i18n/README.ur.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.vi.md
+++ b/docs/i18n/README.vi.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.zh-tw.md
+++ b/docs/i18n/README.zh-tw.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/docs/i18n/README.zh.md
+++ b/docs/i18n/README.zh.md
@@ -27,6 +27,7 @@
   <a href="docs/i18n/README.fr.md">🇫🇷 Français</a> •
   <a href="docs/i18n/README.he.md">🇮🇱 עברית</a> •
   <a href="docs/i18n/README.ar.md">🇸🇦 العربية</a> •
+  <a href="README.fa.md">🇮🇷 فارسی</a> •
   <a href="docs/i18n/README.ru.md">🇷🇺 Русский</a> •
   <a href="docs/i18n/README.pl.md">🇵🇱 Polski</a> •
   <a href="docs/i18n/README.cs.md">🇨🇿 Čeština</a> •

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "strip-comments:dry-run": "bun scripts/strip-comments.ts --dry-run",
     "translate-readme": "bun scripts/translate-readme/cli.ts -v -o docs/i18n README.md",
     "translate:tier1": "npm run translate-readme -- zh zh-tw ja pt pt-br ko es de fr",
-    "translate:tier2": "npm run translate-readme -- he ar ru pl cs nl tr uk",
+    "translate:tier2": "npm run translate-readme -- he ar fa ru pl cs nl tr uk",
     "translate:tier3": "npm run translate-readme -- vi tl id th hi bn ur ro sv",
     "translate:tier4": "npm run translate-readme -- it el hu fi da no",
     "translate:all": "npm run translate:tier1 & npm run translate:tier2 & npm run translate:tier3 & npm run translate:tier4 & wait",

--- a/scripts/translate-readme/cli.ts
+++ b/scripts/translate-readme/cli.ts
@@ -77,6 +77,7 @@ function printLanguages(): void {
     fr: "French",
     he: "Hebrew",
     ar: "Arabic",
+    fa: "Persian",
     ru: "Russian",
     pl: "Polish",
     cs: "Czech",

--- a/scripts/translate-readme/index.ts
+++ b/scripts/translate-readme/index.ts
@@ -69,6 +69,7 @@ const LANGUAGE_NAMES: Record<string, string> = {
   fr: "French",
   he: "Hebrew",
   ar: "Arabic",
+  fa: "Persian",
   ru: "Russian",
   pl: "Polish",
   cs: "Czech",


### PR DESCRIPTION
## Summary

Adds Persian (Farsi, `fa`) to the README translations, following the existing i18n pattern.

## Changes

- **Register `fa`** in the README translator:
  - Added `fa: "Persian"` to `LANGUAGE_NAMES` in `scripts/translate-readme/index.ts` and `scripts/translate-readme/cli.ts` (`--list-languages`).
  - Added `fa` to `translate:tier2` in `package.json` (grouped with the other RTL languages `he`/`ar`).
- **New translation**: `docs/i18n/README.fa.md` — full Persian translation of the README, wrapped in `<section dir="rtl">` to match the existing Arabic (`ar`) locale.
- **Language selector**: added the `🇮🇷 فارسی` entry to the language bar in `README.md` and all 32 existing translations.

## Notes

- Automated translation via the repo's `translate-readme` tooling, carrying the standard "🌐 automated translation, community corrections welcome" note.
- Code blocks, commands, file paths, URLs, badges, and proper nouns preserved verbatim.

## Verification

- `bun scripts/translate-readme/cli.ts --list-languages` lists `fa  Persian`.
- All 33 files show the فارسی entry; language bar byte-identical apart from the new link.
