### PR TITLE
fix(windows): resolve bun.exe absolute path and skip cmd.exe for .exe targets (#3196)

### DIFF
--- a/docs/public/troubleshooting.mdx
+++ b/docs/public/troubleshooting.mdx
@@ -567,6 +567,30 @@ sqlite3 ~/.claude-mem/claude-mem.db "
    sqlite3 ~/.claude-mem/claude-mem.db "VACUUM;"
    ```
 
+### Windows: `"bun" is not recognized` Hook Errors
+
+**Symptoms**: Every hook fails on Windows with:
+
+```
+SessionStart:startup hook error
+Failed with non-blocking status code: ""bun"" is not recognized as an internal or external command
+```
+
+(or the localized equivalent), even though `bun --version` works fine in any terminal and `where bun` resolves correctly.
+
+**Cause**: cmd.exe silently drops environment variables longer than ~8,191 characters. The hooks prepend the login-shell PATH to the inherited PATH, which can double it past that limit — inside cmd.exe the PATH is then empty, so a bare `bun` command cannot be resolved even though `where.exe` (which uses Win32 APIs and has no such limit) finds it. This only reproduces when the combined PATH exceeds the limit, which is why the same setup works on machines with a shorter PATH.
+
+**Solutions**:
+
+1. Update claude-mem — the launcher now resolves the absolute `bun.exe` path and spawns it directly without cmd.exe.
+
+2. Check your PATH length; if it is near or above ~4,000 characters it will exceed the cmd.exe limit once doubled:
+   ```powershell
+   $env:Path.Length
+   ```
+
+3. Trim duplicate or dead PATH entries (Windows merges the machine and user PATH, and many installers add both).
+
 ### Dependencies Not Installing
 
 **Symptoms**: SessionStart hook fails with "module not found" errors.

--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -38,8 +38,16 @@ function findBun() {
       if (bunCmdPath) {
         return bunCmdPath.trim();
       }
+      // The official installer ships bun.exe only (no bun.cmd shim). Return
+      // the resolved absolute path instead of falling through to the bare
+      // name: resolving a bare `bun` later relies on the child's PATH, which
+      // cmd.exe drops entirely when it exceeds ~8191 chars (issue #3196).
+      const bunExePath = pathCheck.stdout.split(/\r?\n/).map(line => line.trim()).find(Boolean);
+      if (bunExePath) {
+        return bunExePath;
+      }
     }
-    return 'bun'; 
+    return 'bun';
   }
 
   const bunPaths = IS_WINDOWS
@@ -136,7 +144,15 @@ const spawnOptions = {
 let spawnCmd = bunPath;
 let spawnArgs = args;
 
-if (IS_WINDOWS) {
+// Only .cmd/.bat shims need cmd.exe; a resolved bun.exe must be spawned
+// directly. Routing it through `shell: true` breaks when the environment
+// grows past cmd.exe's ~8191-char per-variable limit (e.g. a long PATH,
+// which these hooks double via the login-shell prepend): cmd silently
+// sees an empty PATH and fails with `"bun" is not recognized` even though
+// `where bun` succeeded moments earlier (issue #3196).
+const needsCmdShell = IS_WINDOWS && /\.(cmd|bat)$/i.test(bunPath);
+
+if (needsCmdShell) {
   const quote = (s) => `"${String(s).replace(/"/g, '\\"')}"`;
   spawnOptions.shell = true;
   spawnCmd = [bunPath, ...args].map(quote).join(' ');

--- a/tests/bun-runner.test.ts
+++ b/tests/bun-runner.test.ts
@@ -1,9 +1,43 @@
 import { describe, it, expect } from 'bun:test';
 import { readFileSync } from 'fs';
-import { join } from 'path';
+import { join, win32 } from 'path';
 
 const BUN_RUNNER_PATH = join(import.meta.dir, '..', 'plugin', 'scripts', 'bun-runner.js');
 const source = readFileSync(BUN_RUNNER_PATH, 'utf-8');
+
+// Extract findBun() so it can be exercised with a mocked spawnSync on any
+// platform (the script itself has top-level side effects and cannot be
+// imported directly).
+const findBunSource = source.slice(
+  source.indexOf('function findBun() {'),
+  source.indexOf('function isPluginDisabledInClaudeSettings')
+);
+
+interface WhereResult {
+  status: number | null;
+  stdout: string;
+}
+
+function runFindBun(
+  whereResult: WhereResult,
+  { isWindows = true, existingPaths = [] as string[] } = {}
+): string | null {
+  const factory = new Function(
+    'spawnSync',
+    'IS_WINDOWS',
+    'join',
+    'homedir',
+    'existsSync',
+    `${findBunSource}\nreturn findBun();`
+  );
+  return factory(
+    () => whereResult,
+    isWindows,
+    isWindows ? win32.join : join,
+    () => (isWindows ? 'C:\\Users\\test' : '/home/test'),
+    (p: string) => existingPaths.includes(p)
+  );
+}
 
 describe('bun-runner.js findBun: DEP0190 regression guard (#1503)', () => {
   it('does not use separate args array with shell:true (DEP0190 trigger pattern)', () => {
@@ -24,5 +58,68 @@ describe('bun-runner.js findBun: DEP0190 regression guard (#1503)', () => {
       expect(unixCallMatch[1]).not.toContain('shell');
     }
     expect(source).toContain("spawnSync('which', ['bun']");
+  });
+});
+
+describe('bun-runner.js findBun: absolute bun.exe resolution (#3196)', () => {
+  it('returns the resolved absolute path when where finds only bun.exe (official installer)', () => {
+    const result = runFindBun({
+      status: 0,
+      stdout: 'C:\\Users\\test\\.bun\\bin\\bun.exe\r\n'
+    });
+    expect(result).toBe('C:\\Users\\test\\.bun\\bin\\bun.exe');
+  });
+
+  it('still prefers bun.cmd when an npm shim is present', () => {
+    const result = runFindBun({
+      status: 0,
+      stdout: 'C:\\npm\\bun.cmd\r\nC:\\Users\\test\\.bun\\bin\\bun.exe\r\n'
+    });
+    expect(result).toBe('C:\\npm\\bun.cmd');
+  });
+
+  it('never returns the bare name when where produced a path', () => {
+    const result = runFindBun({
+      status: 0,
+      stdout: 'C:\\some dir with spaces\\bun.exe\r\n'
+    });
+    expect(result).not.toBe('bun');
+  });
+
+  it('falls back to ~/.bun/bin/bun.exe when where fails', () => {
+    const expected = win32.join('C:\\Users\\test', '.bun', 'bin', 'bun.exe');
+    const result = runFindBun(
+      { status: 1, stdout: '' },
+      { existingPaths: [expected] }
+    );
+    expect(result).toBe(expected);
+  });
+
+  it('keeps returning bun for Unix which hits', () => {
+    const result = runFindBun(
+      { status: 0, stdout: '/usr/local/bin/bun\n' },
+      { isWindows: false }
+    );
+    expect(result).toBe('bun');
+  });
+});
+
+describe('bun-runner.js spawn: no cmd.exe for .exe targets (#3196)', () => {
+  // cmd.exe silently drops environment variables longer than ~8191 chars.
+  // The hooks prepend the login-shell PATH to the inherited PATH, which can
+  // double it past that limit — inside a `shell: true` spawn, cmd then sees
+  // an empty PATH and cannot resolve anything by name. A resolved .exe must
+  // therefore be spawned directly; only .cmd/.bat shims require the shell.
+  it('gates the Windows shell spawn on a .cmd/.bat target', () => {
+    expect(source).toMatch(
+      /const needsCmdShell = IS_WINDOWS && \/\\\.\(cmd\|bat\)\$\/i\.test\(bunPath\)/
+    );
+    expect(source).toMatch(/if \(needsCmdShell\) \{[\s\S]*?spawnOptions\.shell = true/);
+  });
+
+  it('does not enable shell mode unconditionally on Windows', () => {
+    const shellAssignments = source.match(/spawnOptions\.shell = true/g) ?? [];
+    expect(shellAssignments.length).toBe(1);
+    expect(source).not.toMatch(/if \(IS_WINDOWS\) \{\s*const quote/);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the Windows hook failure from #3196 (`""bun"" is not recognized as an internal or external command`) with two changes to `plugin/scripts/bun-runner.js`:

1. **`findBun()` returns the absolute path from `where` output** instead of falling through to the bare name `bun` when no npm `bun.cmd` shim exists (the official installer ships `bun.exe` only).
2. **The spawn no longer routes `.exe` targets through cmd.exe** — `shell: true` is now used only for `.cmd`/`.bat` shims, which actually require a shell. A resolved `bun.exe` is spawned directly with an args array.

## Root cause (the missing piece)

#3196 correctly identifies the bare-name fallthrough, but the reason the bare `bun` fails inside cmd.exe — while `where bun` succeeds and `%PATH%` genuinely contains `.bun\bin` — was undiagnosed, and explains why the bug only reproduces for some users:

**cmd.exe silently drops environment variables longer than ~8,191 characters.** The hook prelude `export PATH="$($SHELL -lc 'echo $PATH'):$PATH"` prepends the login-shell PATH to the inherited PATH, roughly doubling it. On my machine PATH went from ~4,000 to 8,478 chars — past the limit. Inside the `shell: true` spawn, `cmd /c echo %PATH%` prints *nothing*: PATH is empty as far as cmd is concerned, so a bare `bun` cannot be resolved. `where.exe` uses Win32 APIs with no such limit, which is exactly why `findBun()`'s probe succeeds moments before the spawn fails.

This is also why change 2 matters on its own: even with an absolute path, anything routed through cmd.exe runs with a silently truncated environment once PATH crosses the limit. Spawning the `.exe` directly is immune to both that and to quoting issues. (It's an extra argument for trimming the login-shell prepend — see #3234 / #2598.)

## Relationship to #3235

Overlaps on the `findBun()` fix (happy to rebase/defer that hunk if #3235 lands first). The direct-spawn change and the root-cause documentation are complementary and not covered there.

## Verification

Reproduced deterministically on Windows 10 Pro (Italian locale, Claude Code 2.1.209, claude-mem 13.11.0) by replaying the exact hook command recorded in the session transcript:

- PATH inflated past the cmd.exe limit → **old script fails** with the exact reported error, **patched script succeeds** (worker responds, hook exits 0).
- `bun test tests/bun-runner.test.ts`: 10 pass (3 existing + 7 new — behavioral tests exercise `findBun()` with a mocked `spawnSync`, so they run on Linux CI too).

## Docs

Added a "Windows: `"bun" is not recognized` Hook Errors" section to `docs/public/troubleshooting.mdx` covering the symptom, the PATH-length root cause, and remediation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
