### PR TITLE
fix(chroma): close killProcessTree TOCTOU races that orphan chroma-mcp trees

### DIFF
--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -958,13 +958,19 @@ export class ChromaMcpManager {
   /**
    * Kill a process and all its descendants (tree-kill).
    *
-   * POSIX: Sends SIGTERM to the process, then uses `pkill -P` to signal
-   * children recursively. Falls back to single-PID kill if pkill is unavailable.
+   * POSIX: Sends SIGTERM to the process and every descendant collected via
+   * collectDescendantPids(), polls for death (waitForExit) instead of a
+   * fixed sleep, re-collects descendants (layers can re-parent during the
+   * grace window) and SIGKILLs the union, then verifies death and runs one
+   * best-effort straggler round against anything still alive before giving
+   * up — closes the TOCTOU races that previously let orphaned chroma-mcp
+   * trees survive silently (#3230).
    *
    * Windows: Uses `taskkill /T /F /PID` for full subtree teardown (same
    * pattern as shutdown.ts).
    *
-   * Best-effort — swallows ESRCH (already dead) and logs other errors.
+   * Best-effort — swallows ESRCH (already dead), logs other errors, and
+   * never throws.
    */
   private static async killProcessTree(pid: number): Promise<void> {
     logger.debug('CHROMA_MCP', `Killing process tree rooted at PID ${pid}`);
@@ -1011,8 +1017,10 @@ export class ChromaMcpManager {
         }
       }
 
-      // Brief wait for SIGTERM to propagate, then SIGKILL stragglers.
-      await new Promise(resolve => setTimeout(resolve, 500));
+      // Poll for death instead of a fixed 500ms sleep — resolves as soon as
+      // everything is gone (the common case, often well under 500ms) and
+      // still bounds the wait when something is slow to exit.
+      await ChromaMcpManager.waitForExit([...descendantsBeforeTerm, pid], 500);
 
       // Re-collect descendants — some layers may have re-parented during the
       // SIGTERM grace window.
@@ -1038,6 +1046,38 @@ export class ChromaMcpManager {
       } catch {
         // Already dead — fine.
       }
+
+      // Verify death after SIGKILL — previously nothing checked this, so a
+      // survivor here (e.g. a grandchild SIGKILL never reached) silently
+      // orphaned, which is exactly the #3230 leak. One best-effort straggler
+      // round: re-collect descendants of anything still alive and SIGKILL
+      // those too, then a final death check. Anything still alive after
+      // that is logged (not thrown — this method stays best-effort).
+      let survivors = await ChromaMcpManager.waitForExit([...killTargets, pid], 250);
+      if (survivors.length > 0) {
+        const stragglerTargets = new Set<number>(survivors);
+        for (const survivor of survivors) {
+          try {
+            const stragglerDescendants = await ChromaMcpManager.collectDescendantPids(survivor);
+            for (const descendant of stragglerDescendants) {
+              stragglerTargets.add(descendant);
+            }
+          } catch {
+            // Best-effort — fall through and retry just the survivor pid.
+          }
+        }
+        for (const target of stragglerTargets) {
+          try {
+            process.kill(target, 'SIGKILL');
+          } catch {
+            // Already dead — fine.
+          }
+        }
+        survivors = await ChromaMcpManager.waitForExit([...stragglerTargets], 250);
+        if (survivors.length > 0) {
+          logger.warn('CHROMA_MCP', 'Process tree kill left survivors', { pids: survivors });
+        }
+      }
     } catch (error) {
       logger.debug('CHROMA_MCP', `Process tree kill completed (best-effort)`, {
         pid,
@@ -1047,11 +1087,30 @@ export class ChromaMcpManager {
   }
 
   /**
-   * Recursively collect all descendant PIDs of `rootPid` using `pgrep -P`.
-   * Returned bottom-up (leaves first) so callers can signal leaves before
-   * their ancestors. Best-effort: missing pgrep / non-zero exits return [].
+   * Recursively collect all descendant PIDs of `rootPid`. Returned bottom-up
+   * (leaves first) so callers can signal leaves before their ancestors.
+   *
+   * Primary mechanism is a `pgrep -P` walk (collectDescendantPidsViaPgrep):
+   * pgrep exiting 1 is the expected "no children" leaf case on every
+   * recursive step, but ENOENT (pgrep missing) or a timeout means the walk
+   * ITSELF failed rather than found no descendants — returning [] in that
+   * case would make killProcessTree silently miss every descendant (#3230).
+   * Those infra failures (signalled as a null return) fall back to a single
+   * `ps -axo pid=,ppid=` snapshot (collectDescendantPidsViaPs) instead.
    */
   private static async collectDescendantPids(rootPid: number): Promise<number[]> {
+    return (await ChromaMcpManager.collectDescendantPidsViaPgrep(rootPid))
+      ?? ChromaMcpManager.collectDescendantPidsViaPs(rootPid);
+  }
+
+  /**
+   * `pgrep -P` recursive descendant walk. Returned bottom-up (leaves first).
+   * Returns null when the walk itself fails (ENOENT, timeout, or any exit
+   * code other than the genuine-leaf `1`) so collectDescendantPids can fall
+   * back to collectDescendantPidsViaPs instead of treating an unwalked
+   * subtree as childless.
+   */
+  private static async collectDescendantPidsViaPgrep(rootPid: number): Promise<number[] | null> {
     const seen = new Set<number>();
     const collected: number[] = [];
 
@@ -1060,9 +1119,23 @@ export class ChromaMcpManager {
       try {
         const result = await execFileAsync('pgrep', ['-P', String(pid)], { timeout: 2_000 });
         stdout = result.stdout;
-      } catch {
-        // [ANTI-PATTERN IGNORED]: pgrep exits 1 whenever a PID has no children, which is the expected leaf case on every recursive walk; recovery is treating the node as childless and returning early.
-        return;
+      } catch (error) {
+        const err = error as Error & { code?: string | number; killed?: boolean; signal?: string | null };
+        if (err.code === 1) {
+          // [ANTI-PATTERN IGNORED]: pgrep exits 1 whenever a PID has no children, which is the expected leaf case on every recursive walk; recovery is treating the node as childless and returning early.
+          return;
+        }
+        // ENOENT (pgrep missing), a timeout (execFileAsync sets killed:true /
+        // signal:'SIGTERM'), or any other non-1 exit means the walk itself
+        // failed rather than found no children — surface it so the caller
+        // falls back to a ps snapshot instead of silently treating an
+        // unwalked subtree as childless.
+        const reason = err.code === 'ENOENT'
+          ? 'pgrep not found'
+          : err.killed
+            ? `pgrep timed out (signal ${err.signal ?? 'unknown'})`
+            : `pgrep failed with code ${String(err.code)}`;
+        throw new Error(reason);
       }
       const children = stdout
         .split('\n')
@@ -1079,8 +1152,93 @@ export class ChromaMcpManager {
       }
     }
 
-    await walk(rootPid);
+    try {
+      await walk(rootPid);
+    } catch (error) {
+      logger.debug('CHROMA_MCP', 'pgrep descendant walk failed, falling back to ps snapshot', {
+        pid: rootPid,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      return null;
+    }
     return collected;
+  }
+
+  /**
+   * Fallback descendant collection used when the pgrep walk itself fails
+   * (see collectDescendantPids). Takes ONE `ps -axo pid=,ppid=` snapshot,
+   * builds a ppid -> children map, and DFS's from rootPid with the same
+   * bottom-up (leaves first) ordering and cycle guard as the pgrep path.
+   * Best-effort: if `ps` itself fails, returns [] — today's degraded
+   * behavior, but now only after BOTH mechanisms have failed.
+   */
+  private static async collectDescendantPidsViaPs(rootPid: number): Promise<number[]> {
+    let stdout = '';
+    try {
+      const result = await execFileAsync('ps', ['-axo', 'pid=,ppid='], { timeout: 2_000 });
+      stdout = result.stdout;
+    } catch (error) {
+      logger.debug('CHROMA_MCP', 'ps descendant snapshot fallback failed', {
+        pid: rootPid,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      return [];
+    }
+
+    const childrenByParent = new Map<number, number[]>();
+    for (const line of stdout.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+      const [pidText, ppidText] = trimmed.split(/\s+/);
+      const childPid = Number.parseInt(pidText, 10);
+      const parentPid = Number.parseInt(ppidText, 10);
+      if (!Number.isFinite(childPid) || !Number.isFinite(parentPid)) {
+        continue;
+      }
+      const siblings = childrenByParent.get(parentPid);
+      if (siblings) {
+        siblings.push(childPid);
+      } else {
+        childrenByParent.set(parentPid, [childPid]);
+      }
+    }
+
+    const seen = new Set<number>();
+    const collected: number[] = [];
+
+    function walk(pid: number): void {
+      for (const child of childrenByParent.get(pid) ?? []) {
+        if (seen.has(child)) {
+          continue;
+        }
+        seen.add(child);
+        walk(child);
+        // Bottom-up: push after recursion so leaves come first.
+        collected.push(child);
+      }
+    }
+
+    walk(rootPid);
+    return collected;
+  }
+
+  /**
+   * Poll `pids` via isPidAlive until every one is dead or `timeoutMs`
+   * elapses, whichever is first. Replaces a fixed grace-period sleep
+   * between SIGTERM/SIGKILL phases with an early-exit poll — fast when the
+   * tree dies promptly, still bounded when it doesn't. Returns whichever
+   * PIDs are still alive at the end (empty = everyone died).
+   */
+  private static async waitForExit(pids: number[], timeoutMs: number, intervalMs = 50): Promise<number[]> {
+    const deadline = Date.now() + timeoutMs;
+    let alive = pids.filter(isPidAlive);
+    while (alive.length > 0 && Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, intervalMs));
+      alive = alive.filter(isPidAlive);
+    }
+    return alive;
   }
 
   /**

--- a/tests/services/sync/chroma-mcp-manager-tree-kill.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-tree-kill.test.ts
@@ -12,7 +12,7 @@ import { ChromaMcpManager } from '../../../src/services/sync/ChromaMcpManager.js
 const managerInternals = ChromaMcpManager as unknown as {
   killProcessTree: (pid: number) => Promise<void>;
   collectDescendantPids: (rootPid: number) => Promise<number[]>;
-  collectDescendantPidsViaPgrep: (rootPid: number) => Promise<number[]>;
+  collectDescendantPidsViaPgrep: (rootPid: number) => Promise<number[] | null>;
   collectDescendantPidsViaPs: (rootPid: number) => Promise<number[]>;
   waitForExit: (pids: number[], timeoutMs: number, intervalMs?: number) => Promise<number[]>;
 };
@@ -126,12 +126,17 @@ describe('ChromaMcpManager tree-kill primitives (#3230)', () => {
 
     const viaPgrep = await managerInternals.collectDescendantPidsViaPgrep(rootPid);
     const viaPs = await managerInternals.collectDescendantPidsViaPs(rootPid);
-    for (const pid of [...viaPgrep, ...viaPs]) {
+    for (const pid of [...(viaPgrep ?? []), ...viaPs]) {
       spawnedPids.add(pid);
     }
 
-    expect(viaPgrep.length).toBeGreaterThan(0);
     expect(viaPs.length).toBeGreaterThan(0);
+    if (viaPgrep === null) {
+      // pgrep unavailable/failed on this host — the ps fallback above is the
+      // behavior under test in that case, and it was exercised.
+      return;
+    }
+    expect(viaPgrep.length).toBeGreaterThan(0);
     expect(new Set(viaPgrep)).toEqual(new Set(viaPs));
   }, 10_000);
 });

--- a/tests/services/sync/chroma-mcp-manager-tree-kill.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-tree-kill.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { spawn, type ChildProcess } from 'node:child_process';
+
+import { ChromaMcpManager } from '../../../src/services/sync/ChromaMcpManager.js';
+
+// Regression coverage for the reworked tree-kill primitives (#3230):
+// killProcessTree, collectDescendantPids (+ its pgrep / ps implementations),
+// and waitForExit. These tests spawn REAL processes (no child_process
+// mocking) so the pgrep/ps walks and process.kill(pid, 0) liveness checks
+// exercise actual OS behavior on macOS/Linux CI runners.
+
+const managerInternals = ChromaMcpManager as unknown as {
+  killProcessTree: (pid: number) => Promise<void>;
+  collectDescendantPids: (rootPid: number) => Promise<number[]>;
+  collectDescendantPidsViaPgrep: (rootPid: number) => Promise<number[]>;
+  collectDescendantPidsViaPs: (rootPid: number) => Promise<number[]>;
+  waitForExit: (pids: number[], timeoutMs: number, intervalMs?: number) => Promise<number[]>;
+};
+
+// Tracks every PID this file spawns (or discovers as a descendant) so
+// afterEach can reap anything a test failure left alive.
+const spawnedPids = new Set<number>();
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function killIfAlive(pid: number): void {
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch {
+    // ESRCH — already dead. Fine.
+  }
+}
+
+function spawnBashTree(): ChildProcess {
+  // A bash tree with two grandchild `sleep` processes forked via `&`, kept
+  // alive by `wait` so the parent bash process stays alive until killed.
+  const child = spawn('bash', ['-c', 'sleep 30 & sleep 30 & wait']);
+  if (child.pid) {
+    spawnedPids.add(child.pid);
+  }
+  return child;
+}
+
+function spawnSleep(): ChildProcess {
+  const child = spawn('sleep', ['30']);
+  if (child.pid) {
+    spawnedPids.add(child.pid);
+  }
+  return child;
+}
+
+function sleepMs(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+afterEach(() => {
+  for (const pid of spawnedPids) {
+    killIfAlive(pid);
+  }
+  spawnedPids.clear();
+});
+
+describe('ChromaMcpManager tree-kill primitives (#3230)', () => {
+  it('killProcessTree kills a real spawned process tree, root and every descendant', async () => {
+    const root = spawnBashTree();
+    expect(root.pid).toBeDefined();
+    const rootPid = root.pid as number;
+
+    // Give bash time to fork both sleep children.
+    await sleepMs(200);
+
+    const descendants = await managerInternals.collectDescendantPids(rootPid);
+    for (const pid of descendants) {
+      spawnedPids.add(pid);
+    }
+    expect(descendants.length).toBeGreaterThan(0);
+
+    await managerInternals.killProcessTree(rootPid);
+
+    expect(isAlive(rootPid)).toBe(false);
+    for (const pid of descendants) {
+      expect(isAlive(pid)).toBe(false);
+    }
+  }, 10_000);
+
+  it('waitForExit resolves early with an empty list once the PID is already dead', async () => {
+    const child = spawnSleep();
+    const pid = child.pid as number;
+    expect(pid).toBeDefined();
+
+    process.kill(pid, 'SIGKILL');
+    // Give the OS a moment to reap the signal before polling.
+    await sleepMs(50);
+
+    const t0 = Date.now();
+    const survivors = await managerInternals.waitForExit([pid], 5_000);
+    const elapsed = Date.now() - t0;
+
+    expect(survivors).toEqual([]);
+    expect(elapsed).toBeLessThan(1_000);
+  }, 10_000);
+
+  it('waitForExit reports a still-alive PID as a survivor when the timeout elapses', async () => {
+    const child = spawnSleep();
+    const pid = child.pid as number;
+    expect(pid).toBeDefined();
+
+    const survivors = await managerInternals.waitForExit([pid], 150);
+
+    expect(survivors).toEqual([pid]);
+  }, 10_000);
+
+  it('collectDescendantPidsViaPgrep and collectDescendantPidsViaPs agree on the same tree', async () => {
+    const root = spawnBashTree();
+    const rootPid = root.pid as number;
+    expect(rootPid).toBeDefined();
+
+    await sleepMs(200);
+
+    const viaPgrep = await managerInternals.collectDescendantPidsViaPgrep(rootPid);
+    const viaPs = await managerInternals.collectDescendantPidsViaPs(rootPid);
+    for (const pid of [...viaPgrep, ...viaPs]) {
+      spawnedPids.add(pid);
+    }
+
+    expect(viaPgrep.length).toBeGreaterThan(0);
+    expect(viaPs.length).toBeGreaterThan(0);
+    expect(new Set(viaPgrep)).toEqual(new Set(viaPs));
+  }, 10_000);
+});


### PR DESCRIPTION
## Problem

`killProcessTree()` in `ChromaMcpManager` has three time-of-check/time-of-use gaps that let `uvx chroma-mcp` process trees survive worker shutdown and accumulate as orphans. On my Mac this reached **974 orphaned processes / ~30 GB RAM** with swap maxed out — the same failure reported in #3230 (1,057 processes / 48 GB on Linux).

Refs #3230

### The three races

1. **A failed pgrep walk reads as "no descendants".** The recursive `pgrep -P` walk swallowed *every* error — including ENOENT (pgrep missing) and the 2s timeout — and returned early, so an infra failure was indistinguishable from a genuine leaf. `killProcessTree` then signaled only the root while the whole `uv → python → chroma-mcp` subtree survived.
2. **Fixed 500ms SIGTERM grace sleep.** A blind `setTimeout(500)` between SIGTERM and SIGKILL: too short when the tree is slow to exit (SIGKILL targets re-collected *after* the sleep can miss late re-parenting), and needlessly slow when the tree exits in 50ms.
3. **No verification after SIGKILL.** Nothing checked that the kill actually worked. A grandchild the SIGKILL pass never reached (e.g. spawned during the grace window) orphaned silently — exactly the #3230 leak.

## Fix

All changes stay inside `ChromaMcpManager`'s private statics; the Windows/taskkill path is untouched, and the method remains best-effort (never throws).

- **pgrep walk failure now falls back to a `ps` snapshot.** pgrep exit code 1 is still the expected "no children" leaf case, but ENOENT / timeout / other failures now fall back to a single `ps -axo pid=,ppid=` snapshot (`collectDescendantPidsViaPs`) with the same bottom-up ordering. Only when *both* mechanisms fail does it degrade to the old empty-list behavior (logged).
- **Poll-until-dead replaces the fixed sleep.** New `waitForExit(pids, timeoutMs)` polls liveness (via the existing `isPidAlive` helper) every 50ms and early-resolves as soon as everything is gone — faster in the common case, no blind window, still bounded.
- **Post-SIGKILL verification + straggler round.** After the SIGKILL pass, survivors are detected, their descendants re-collected and SIGKILLed once more, and anything *still* alive is logged at `warn` (previously: silent).

## Relationship to #3232

#3232 moves `killProcessTree` verbatim into `src/supervisor/tree-kill.ts` to fix a different gap (worker exiting without cleanup). These PRs are **complementary, not competing**: this one hardens the kill logic itself, #3232 makes sure it gets called. If #3232 lands first, this diff ports trivially to the new file (same function body); happy to rebase either way.

Note: the process-group approach (`kill(-pgid)`) is not viable here — `StdioClientTransport` spawns without `detached: true`, so chroma-mcp shares the *worker's* process group and a group kill would take down the worker itself.

## Testing

New `tests/services/sync/chroma-mcp-manager-tree-kill.test.ts` (real processes, no child_process mocking):

- `killProcessTree` kills a real spawned tree (`bash -c 'sleep 30 & sleep 30 & wait'`) — root and every descendant verified dead after
- `waitForExit` early-resolves (returns `[]` well under the timeout once the PID is dead)
- `waitForExit` reports a still-alive PID as a survivor at timeout
- `collectDescendantPidsViaPgrep` and `collectDescendantPidsViaPs` agree (Set-equal) on the same real tree

```
bun test tests/services/sync/
 29 pass, 0 fail, 131 expect() calls (5 files)
```

`tsc --noEmit` clean on both configs (`bun run typecheck`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)