### PR TITLE
fix(installer): provision tree-sitter-cli past script suppression and resolve tree-sitter.exe on Windows (refs #2910)

### DIFF
--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -16,6 +16,7 @@ import { ensureWorkerStarted, type WorkerStartResult } from '../../services/work
 import { formatHostForUrl } from '../../shared/worker-utils.js';
 import {
   ensureBun,
+  ensureTreeSitterCliBinary,
   ensureUv,
   installPluginDependencies,
   writeInstallMarker,
@@ -715,7 +716,10 @@ async function runNpmInstallInMarketplace(summary: InstallSummary): Promise<void
 
   const baseFlags = ['install', '--omit=dev', '--ignore-scripts'];
   const strictResult = await runNpmStrict(marketplaceDir, baseFlags);
-  if (strictResult.code === 0) return;
+  if (strictResult.code === 0) {
+    await warnMarketplaceTreeSitterCliIfUnavailable(summary, marketplaceDir);
+    return;
+  }
 
   if (strictResult.timedOut) {
     installerError(ErrorSeverity.ABORT, {
@@ -747,6 +751,7 @@ async function runNpmInstallInMarketplace(summary: InstallSummary): Promise<void
       message: 'tree-sitter peer-dep ERESOLVE was resolved with the --legacy-peer-deps fallback. Benign for the marketplace install; re-evaluate when tree-sitter peer ranges change.',
       remediation: 'No action required.',
     });
+    await warnMarketplaceTreeSitterCliIfUnavailable(summary, marketplaceDir);
     return;
   }
 
@@ -756,6 +761,19 @@ async function runNpmInstallInMarketplace(summary: InstallSummary): Promise<void
     cause: new Error(`npm install --legacy-peer-deps still failed (exit ${legacyResult.code}): ERESOLVE`),
     details: legacyResult.stderr.slice(0, 4000),
   }, summary);
+}
+
+export async function warnMarketplaceTreeSitterCliIfUnavailable(summary: InstallSummary, marketplaceDir: string): Promise<void> {
+  if (!existsSync(join(marketplaceDir, 'node_modules', 'tree-sitter-cli'))) return;
+  try {
+    await ensureTreeSitterCliBinary(marketplaceDir);
+  } catch (error: unknown) {
+    summary.warnings.push({
+      component: 'marketplace-tree-sitter-cli',
+      message: `tree-sitter-cli binary provisioning unavailable: ${error instanceof Error ? error.message : String(error)}`,
+      remediation: 'Smart-explore may use a PATH tree-sitter binary if available.',
+    });
+  }
 }
 
 function mergeSettings(updates: Record<string, string>): boolean {

--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -1645,7 +1645,7 @@ async function runInstallCommandInner(options: InstallOptions, summary: InstallS
           const cacheDir = pluginCacheDirectory(version);
           if (!isInstallCurrent(cacheDir, version)) {
             const { bunPath } = await ensureBun();
-            const stopHeartbeat = startHeartbeat(message, 'Installing plugin dependencies (bun install)…');
+            const stopHeartbeat = startHeartbeat(message, 'Installing plugin dependencies (Bun + tree-sitter CLI)…');
             try {
               await installPluginDependencies(cacheDir, bunPath);
             } finally {

--- a/src/npx-cli/install/error-taxonomy.ts
+++ b/src/npx-cli/install/error-taxonomy.ts
@@ -100,8 +100,8 @@ export const ERROR_CATEGORIES: ErrorCategory[] = [
     id: 'tree-sitter-cli-cache-provisioning-failed',
     severity: ErrorSeverity.ABORT,
     match: (_cause, ctx) => ctx.component === 'tree-sitter-cli-cache',
-    remediation: () =>
-      'The cached tree-sitter CLI could not be provisioned. Re-run `npx claude-mem install`; if it persists, check the reported install output and network connectivity. For a timeout, raise the budget with CLAUDE_MEM_INSTALL_TIMEOUT_MS and re-run.',
+    remediation: (ctx) =>
+      `The cached tree-sitter CLI could not be provisioned. Re-run \`npx claude-mem install\`; if it persists, inspect ${ctx.dataDir}/last-install-error.json and check network connectivity. For a timeout, raise the budget with CLAUDE_MEM_INSTALL_TIMEOUT_MS and re-run.`,
   },
   {
     id: 'marketplace-dir-not-writable',

--- a/src/npx-cli/install/error-taxonomy.ts
+++ b/src/npx-cli/install/error-taxonomy.ts
@@ -101,7 +101,7 @@ export const ERROR_CATEGORIES: ErrorCategory[] = [
     severity: ErrorSeverity.ABORT,
     match: (_cause, ctx) => ctx.component === 'tree-sitter-cli-cache',
     remediation: () =>
-      'The cached tree-sitter CLI could not be provisioned. Re-run `npx claude-mem install`; if it persists, check the reported install output and network connectivity.',
+      'The cached tree-sitter CLI could not be provisioned. Re-run `npx claude-mem install`; if it persists, check the reported install output and network connectivity. For a timeout, raise the budget with CLAUDE_MEM_INSTALL_TIMEOUT_MS and re-run.',
   },
   {
     id: 'marketplace-dir-not-writable',

--- a/src/npx-cli/install/error-taxonomy.ts
+++ b/src/npx-cli/install/error-taxonomy.ts
@@ -97,6 +97,13 @@ export const ERROR_CATEGORIES: ErrorCategory[] = [
       'ERESOLVE peer-dependency conflict in marketplace deps that --legacy-peer-deps could not resolve. Open an issue at https://github.com/thedotmack/claude-mem/issues with the conflicting peer ranges shown above.',
   },
   {
+    id: 'tree-sitter-cli-cache-provisioning-failed',
+    severity: ErrorSeverity.ABORT,
+    match: (_cause, ctx) => ctx.component === 'tree-sitter-cli-cache',
+    remediation: () =>
+      'The cached tree-sitter CLI could not be provisioned. Re-run `npx claude-mem install`; if it persists, check the reported install output and network connectivity.',
+  },
+  {
     id: 'marketplace-dir-not-writable',
     severity: ErrorSeverity.ABORT,
     match: (cause) => /\b(EACCES|EPERM)\b/.test(causeMessage(cause)),

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs';
-import { exec, execSync, spawnSync, type SpawnSyncOptionsWithStringEncoding } from 'child_process';
+import { exec, execFile, execSync, spawnSync, type SpawnSyncOptionsWithStringEncoding } from 'child_process';
 import { createRequire } from 'module';
 import { join } from 'path';
 import { homedir } from 'os';
@@ -7,6 +7,7 @@ import { ErrorSeverity } from './error-taxonomy.js';
 import { installerError, type InstallSummary } from './error-reporter.js';
 import { USER_SETTINGS_PATH } from '../../shared/paths.js';
 import { buildSpawnSyncInvocation, lookupWindowsCommand } from '../../shared/spawn.js';
+import { selectTreeSitterBinary } from '../../shared/tree-sitter-binary.js';
 import { IS_WINDOWS } from '../utils/paths.js';
 import { parseJsonWithBom } from '../../shared/atomic-json.js';
 
@@ -241,6 +242,60 @@ function installUv(): void {
  * we resolve subpaths, never a pinned version.
  */
 const ZOD_REQUIRED_SUBPATHS = ['zod/v3', 'zod/v4', 'zod/v4-mini'] as const;
+const TREE_SITTER_VERSION_TIMEOUT_MS = 10_000;
+
+function treeSitterCliPackageDir(targetDir: string): string {
+  return join(targetDir, 'node_modules', 'tree-sitter-cli');
+}
+
+export function treeSitterCliBinaryPath(targetDir: string): string {
+  return selectTreeSitterBinary(treeSitterCliPackageDir(targetDir))
+    ?? join(treeSitterCliPackageDir(targetDir), IS_WINDOWS ? 'tree-sitter.exe' : 'tree-sitter');
+}
+
+export function isTreeSitterCliBinaryUsable(targetDir: string): boolean {
+  const result = spawnSync(treeSitterCliBinaryPath(targetDir), ['--version'], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: TREE_SITTER_VERSION_TIMEOUT_MS,
+    windowsHide: true,
+  });
+  return result.status === 0
+    && /^tree-sitter \d+\.\d+\.\d+(?:\s|$)/.test((result.stdout ?? '').trim());
+}
+
+export async function ensureTreeSitterCliBinary(
+  targetDir: string,
+  isUsable: (targetDir: string) => boolean = isTreeSitterCliBinaryUsable,
+): Promise<void> {
+  const binaryPath = treeSitterCliBinaryPath(targetDir);
+  if (isUsable(targetDir)) return;
+
+  const cliDir = treeSitterCliPackageDir(targetDir);
+  const installScript = join(cliDir, 'install.js');
+  if (!existsSync(installScript)) {
+    throw new Error(`tree-sitter-cli install script not found: ${installScript}`);
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    execFile(process.execPath, [installScript], {
+      cwd: cliDir,
+      timeout: INSTALL_TIMEOUT_MS,
+      maxBuffer: 16 * 1024 * 1024,
+      windowsHide: true,
+    }, (error, stdout, stderr) => {
+      if (error) {
+        reject(Object.assign(error, { stdout, stderr }));
+        return;
+      }
+      resolve();
+    });
+  });
+
+  if (!isUsable(targetDir)) {
+    throw new Error(`tree-sitter-cli install completed without creating a working executable ${binaryPath}`);
+  }
+}
 
 export function verifyCriticalModules(targetDir: string): void {
   const pkg = JSON.parse(readFileSync(join(targetDir, 'package.json'), 'utf-8'));

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -149,7 +149,7 @@ export function getUvVersion(): string | null {
   }
 }
 
-function describeExecError(error: unknown): string {
+function describeExecError(error: unknown, includeStdoutWithStderr = false): string {
   if (error && typeof error === 'object') {
     const e = error as { message?: string; stdout?: Buffer | string; stderr?: Buffer | string };
     const parts: string[] = [];
@@ -157,7 +157,7 @@ function describeExecError(error: unknown): string {
     const stderr = e.stderr ? e.stderr.toString().trim() : '';
     if (stderr) parts.push(`stderr: ${stderr}`);
     const stdout = e.stdout ? e.stdout.toString().trim() : '';
-    if (stdout) parts.push(`stdout: ${stdout}`);
+    if (stdout && (!stderr || includeStdoutWithStderr)) parts.push(`stdout: ${stdout}`);
     return parts.join('\n');
   }
   return String(error);
@@ -535,7 +535,7 @@ export async function installPluginDependencies(
     await ensureTreeSitterCliBinary(targetDir, isTreeSitterCliBinaryUsable, treeSitterTimeoutMs);
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));
-    const details = describeExecError(err).slice(0, 4000);
+    const details = describeExecError(err, true).slice(0, 4000);
     const cause = Object.assign(
       new Error(`tree-sitter-cli provisioning failed in ${targetDir}: ${err.message}`),
       {

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -510,6 +510,7 @@ export async function installPluginDependencies(targetDir: string, bunPath: stri
     throw new Error(`bun install failed in ${targetDir}\n${describeExecError(err)}`);
   }
 
+  await ensureTreeSitterCliBinary(targetDir);
   verifyCriticalModules(targetDir);
 }
 

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -11,11 +11,11 @@ import { selectTreeSitterBinary } from '../../shared/tree-sitter-binary.js';
 import { IS_WINDOWS } from '../utils/paths.js';
 import { parseJsonWithBom } from '../../shared/atomic-json.js';
 
-const INSTALL_TIMEOUT_MS = (() => {
+function installTimeoutMs(): number {
   const override = process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS;
   if (override && Number.isFinite(Number(override))) return Number(override);
   return 5 * 60 * 1000;
-})();
+}
 
 /**
  * Platform-specific manual-install instructions, surfaced as the PRIMARY ABORT
@@ -162,13 +162,13 @@ function runBunInstaller(): void {
   if (IS_WINDOWS) {
     execSync('powershell -c "irm bun.sh/install.ps1 | iex"', {
       stdio: 'pipe',
-      timeout: INSTALL_TIMEOUT_MS,
+      timeout: installTimeoutMs(),
       shell: process.env.ComSpec ?? 'cmd.exe',
     });
   } else {
     execSync('curl -fsSL https://bun.sh/install | bash', {
       stdio: 'pipe',
-      timeout: INSTALL_TIMEOUT_MS,
+      timeout: installTimeoutMs(),
       shell: '/bin/bash',
     });
   }
@@ -200,13 +200,13 @@ function runUvInstaller(): void {
   if (IS_WINDOWS) {
     execSync('powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"', {
       stdio: 'pipe',
-      timeout: INSTALL_TIMEOUT_MS,
+      timeout: installTimeoutMs(),
       shell: process.env.ComSpec ?? 'cmd.exe',
     });
   } else {
     execSync('curl -LsSf https://astral.sh/uv/install.sh | sh', {
       stdio: 'pipe',
-      timeout: INSTALL_TIMEOUT_MS,
+      timeout: installTimeoutMs(),
       shell: '/bin/bash',
     });
   }
@@ -280,7 +280,7 @@ export async function ensureTreeSitterCliBinary(
   await new Promise<void>((resolve, reject) => {
     execFile(process.execPath, [installScript], {
       cwd: cliDir,
-      timeout: INSTALL_TIMEOUT_MS,
+      timeout: installTimeoutMs(),
       maxBuffer: 16 * 1024 * 1024,
       windowsHide: true,
     }, (error, stdout, stderr) => {
@@ -495,7 +495,7 @@ export async function installPluginDependencies(targetDir: string, bunPath: stri
     new Promise<void>((resolve, reject) => {
       exec(`${bunCmd} install --frozen-lockfile --ignore-scripts`, {
         cwd: targetDir,
-        timeout: INSTALL_TIMEOUT_MS,
+        timeout: installTimeoutMs(),
         maxBuffer: 16 * 1024 * 1024,
         ...(IS_WINDOWS ? { shell: process.env.ComSpec ?? 'cmd.exe' } : {}),
       }, (error, stdout, stderr) =>

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, statSync, writeFileSync } from 'fs';
 import { exec, execFile, execSync, spawnSync, type SpawnSyncOptionsWithStringEncoding } from 'child_process';
 import { createRequire } from 'module';
 import { join } from 'path';
@@ -11,10 +11,14 @@ import { selectTreeSitterBinary } from '../../shared/tree-sitter-binary.js';
 import { IS_WINDOWS } from '../utils/paths.js';
 import { parseJsonWithBom } from '../../shared/atomic-json.js';
 
-const INSTALL_TIMEOUT_MS = 5 * 60 * 1000;
+const INSTALL_TIMEOUT_MS = (() => {
+  const override = process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS;
+  if (override && Number.isFinite(Number(override))) return Number(override);
+  return 5 * 60 * 1000;
+})();
 
 function treeSitterInstallTimeoutMs(): number {
-  const override = process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS;
+  const override = process.env.CLAUDE_MEM_TREE_SITTER_INSTALL_TIMEOUT_MS;
   if (override && Number.isFinite(Number(override))) return Number(override);
   return INSTALL_TIMEOUT_MS;
 }
@@ -275,6 +279,9 @@ export async function ensureTreeSitterCliBinary(
   if (await isUsable(targetDir)) return;
 
   const cliDir = treeSitterCliPackageDir(targetDir);
+  if (existsSync(cliDir) && !statSync(cliDir).isDirectory()) {
+    throw new Error(`tree-sitter-cli package path is not a directory: ${cliDir}`);
+  }
   const installScript = join(cliDir, 'install.js');
   if (!existsSync(installScript)) {
     throw new Error(`tree-sitter-cli install script not found: ${installScript}`);

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -23,12 +23,6 @@ const INSTALL_TIMEOUT_MS = (() => {
   return 5 * 60 * 1000;
 })();
 
-function treeSitterInstallTimeoutMs(): number {
-  const override = process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS;
-  if (override && Number.isFinite(Number(override))) return Number(override);
-  return INSTALL_TIMEOUT_MS;
-}
-
 /**
  * Platform-specific manual-install instructions, surfaced as the PRIMARY ABORT
  * message when auto-install fails or the binary can't be found afterward.
@@ -281,6 +275,7 @@ export async function isTreeSitterCliBinaryUsable(targetDir: string): Promise<bo
 export async function ensureTreeSitterCliBinary(
   targetDir: string,
   isUsable: (targetDir: string) => boolean | Promise<boolean> = isTreeSitterCliBinaryUsable,
+  installTimeoutMs: number = INSTALL_TIMEOUT_MS,
 ): Promise<void> {
   const binaryPath = treeSitterCliBinaryPath(targetDir);
   if (await isUsable(targetDir)) return;
@@ -297,7 +292,7 @@ export async function ensureTreeSitterCliBinary(
   await new Promise<void>((resolve, reject) => {
     execFile(process.execPath, [installScript], {
       cwd: cliDir,
-      timeout: treeSitterInstallTimeoutMs(),
+      timeout: installTimeoutMs,
       maxBuffer: 16 * 1024 * 1024,
       windowsHide: true,
     }, (error, stdout, stderr) => {
@@ -495,7 +490,11 @@ export async function ensureUv(
   return { uvPath, version };
 }
 
-export async function installPluginDependencies(targetDir: string, bunPath: string): Promise<void> {
+export async function installPluginDependencies(
+  targetDir: string,
+  bunPath: string,
+  treeSitterTimeoutMs: number = INSTALL_TIMEOUT_MS,
+): Promise<void> {
   if (!existsSync(join(targetDir, 'package.json'))) {
     throw new Error(`installPluginDependencies: no package.json at ${targetDir}`);
   }
@@ -528,7 +527,7 @@ export async function installPluginDependencies(targetDir: string, bunPath: stri
   }
 
   try {
-    await ensureTreeSitterCliBinary(targetDir);
+    await ensureTreeSitterCliBinary(targetDir, isTreeSitterCliBinaryUsable, treeSitterTimeoutMs);
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));
     const cause = Object.assign(

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -4,7 +4,6 @@ import {
   execFile,
   execSync,
   spawnSync,
-  type ExecFileOptionsWithStringEncoding,
   type SpawnSyncOptionsWithStringEncoding,
 } from 'child_process';
 import { createRequire } from 'module';
@@ -268,15 +267,14 @@ export function treeSitterCliBinaryPath(targetDir: string): string {
 
 export async function isTreeSitterCliBinaryUsable(targetDir: string): Promise<boolean> {
   return await new Promise<boolean>((resolve) => {
-    const options = {
+    const child = execFile(treeSitterCliBinaryPath(targetDir), ['--version'], {
       encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'pipe'],
       timeout: TREE_SITTER_VERSION_TIMEOUT_MS,
       windowsHide: true,
-    } as ExecFileOptionsWithStringEncoding & { stdio: ['ignore', 'pipe', 'pipe'] };
-    execFile(treeSitterCliBinaryPath(targetDir), ['--version'], options, (error, stdout) => {
+    }, (error, stdout) => {
       resolve(!error && /^tree-sitter \d+\.\d+\.\d+(?:\s|$)/.test((stdout ?? '').trim()));
     });
+    child.stdin?.end();
   });
 }
 

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -291,7 +291,7 @@ export async function ensureTreeSitterCliBinary(
 
   let installOutput: { stdout: string; stderr: string } | undefined;
   await new Promise<void>((resolve, reject) => {
-    execFile(process.execPath, [installScript], {
+    const child = execFile(process.execPath, [installScript], {
       cwd: cliDir,
       timeout: installTimeoutMs,
       maxBuffer: 16 * 1024 * 1024,
@@ -304,6 +304,7 @@ export async function ensureTreeSitterCliBinary(
       installOutput = { stdout, stderr };
       resolve();
     });
+    child.stdin?.end();
   });
 
   if (!(await isUsable(targetDir))) {
@@ -535,12 +536,18 @@ export async function installPluginDependencies(
     await ensureTreeSitterCliBinary(targetDir, isTreeSitterCliBinaryUsable, treeSitterTimeoutMs);
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));
+    const processError = err as Error & { code?: number; killed?: boolean };
     const details = describeExecError(err, true).slice(0, 4000);
+    const failure = processError.killed
+      ? 'timed out'
+      : processError.code !== undefined
+        ? `exited with code ${processError.code}`
+        : err.message;
     const cause = Object.assign(
-      new Error(`tree-sitter-cli provisioning failed in ${targetDir}: ${err.message}`),
+      new Error(`tree-sitter-cli provisioning failed in ${targetDir}: ${failure}`),
       {
-        code: (err as Error & { code?: number }).code,
-        killed: (err as Error & { killed?: boolean }).killed,
+        code: processError.code,
+        killed: processError.killed,
       },
     );
     installerError(ErrorSeverity.ABORT, {

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -24,7 +24,7 @@ const INSTALL_TIMEOUT_MS = (() => {
 })();
 
 function treeSitterInstallTimeoutMs(): number {
-  const override = process.env.CLAUDE_MEM_TREE_SITTER_INSTALL_TIMEOUT_MS;
+  const override = process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS;
   if (override && Number.isFinite(Number(override))) return Number(override);
   return INSTALL_TIMEOUT_MS;
 }
@@ -527,7 +527,24 @@ export async function installPluginDependencies(targetDir: string, bunPath: stri
     throw new Error(`bun install failed in ${targetDir}\n${describeExecError(err)}`);
   }
 
-  await ensureTreeSitterCliBinary(targetDir);
+  try {
+    await ensureTreeSitterCliBinary(targetDir);
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    const cause = Object.assign(
+      new Error(`tree-sitter-cli provisioning failed in ${targetDir}\n${describeExecError(err)}`),
+      {
+        code: (err as Error & { code?: number }).code,
+        killed: (err as Error & { killed?: boolean }).killed,
+      },
+    );
+    installerError(ErrorSeverity.ABORT, {
+      component: 'tree-sitter-cli-cache',
+      phase: 'dependency-install',
+      cause,
+    }, summaryOrEphemeral());
+    throw new Error('unreachable');
+  }
   verifyCriticalModules(targetDir);
 }
 

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -277,13 +277,13 @@ export async function ensureTreeSitterCliBinary(
   isUsable: (targetDir: string) => boolean | Promise<boolean> = isTreeSitterCliBinaryUsable,
   installTimeoutMs: number = INSTALL_TIMEOUT_MS,
 ): Promise<void> {
-  const binaryPath = treeSitterCliBinaryPath(targetDir);
-  if (await isUsable(targetDir)) return;
-
   const cliDir = treeSitterCliPackageDir(targetDir);
   if (existsSync(cliDir) && !statSync(cliDir).isDirectory()) {
     throw new Error(`tree-sitter-cli package path is not a directory: ${cliDir}`);
   }
+  const binaryPath = treeSitterCliBinaryPath(targetDir);
+  if (await isUsable(targetDir)) return;
+
   const installScript = join(cliDir, 'install.js');
   if (!existsSync(installScript)) {
     throw new Error(`tree-sitter-cli install script not found: ${installScript}`);

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -157,7 +157,7 @@ function describeExecError(error: unknown): string {
     const stderr = e.stderr ? e.stderr.toString().trim() : '';
     if (stderr) parts.push(`stderr: ${stderr}`);
     const stdout = e.stdout ? e.stdout.toString().trim() : '';
-    if (!stderr && stdout) parts.push(`stdout: ${stdout}`);
+    if (stdout) parts.push(`stdout: ${stdout}`);
     return parts.join('\n');
   }
   return String(error);
@@ -289,6 +289,7 @@ export async function ensureTreeSitterCliBinary(
     throw new Error(`tree-sitter-cli install script not found: ${installScript}`);
   }
 
+  let installOutput: { stdout: string; stderr: string } | undefined;
   await new Promise<void>((resolve, reject) => {
     execFile(process.execPath, [installScript], {
       cwd: cliDir,
@@ -300,12 +301,16 @@ export async function ensureTreeSitterCliBinary(
         reject(Object.assign(error, { stdout, stderr }));
         return;
       }
+      installOutput = { stdout, stderr };
       resolve();
     });
   });
 
   if (!(await isUsable(targetDir))) {
-    throw new Error(`tree-sitter-cli install completed without creating a working executable ${binaryPath}`);
+    throw Object.assign(
+      new Error(`tree-sitter-cli install completed without creating a working executable ${binaryPath}`),
+      installOutput,
+    );
   }
 }
 
@@ -530,8 +535,9 @@ export async function installPluginDependencies(
     await ensureTreeSitterCliBinary(targetDir, isTreeSitterCliBinaryUsable, treeSitterTimeoutMs);
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));
+    const details = describeExecError(err);
     const cause = Object.assign(
-      new Error(`tree-sitter-cli provisioning failed in ${targetDir}\n${describeExecError(err)}`),
+      new Error(`tree-sitter-cli provisioning failed in ${targetDir}\n${details}`),
       {
         code: (err as Error & { code?: number }).code,
         killed: (err as Error & { killed?: boolean }).killed,
@@ -541,6 +547,7 @@ export async function installPluginDependencies(
       component: 'tree-sitter-cli-cache',
       phase: 'dependency-install',
       cause,
+      details,
     }, summaryOrEphemeral());
     throw new Error('unreachable');
   }

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -1,5 +1,12 @@
 import { existsSync, readFileSync, statSync, writeFileSync } from 'fs';
-import { exec, execFile, execSync, spawnSync, type SpawnSyncOptionsWithStringEncoding } from 'child_process';
+import {
+  exec,
+  execFile,
+  execSync,
+  spawnSync,
+  type ExecFileOptionsWithStringEncoding,
+  type SpawnSyncOptionsWithStringEncoding,
+} from 'child_process';
 import { createRequire } from 'module';
 import { join } from 'path';
 import { homedir } from 'os';
@@ -261,11 +268,13 @@ export function treeSitterCliBinaryPath(targetDir: string): string {
 
 export async function isTreeSitterCliBinaryUsable(targetDir: string): Promise<boolean> {
   return await new Promise<boolean>((resolve) => {
-    execFile(treeSitterCliBinaryPath(targetDir), ['--version'], {
+    const options = {
       encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
       timeout: TREE_SITTER_VERSION_TIMEOUT_MS,
       windowsHide: true,
-    }, (error, stdout) => {
+    } as ExecFileOptionsWithStringEncoding & { stdio: ['ignore', 'pipe', 'pipe'] };
+    execFile(treeSitterCliBinaryPath(targetDir), ['--version'], options, (error, stdout) => {
       resolve(!error && /^tree-sitter \d+\.\d+\.\d+(?:\s|$)/.test((stdout ?? '').trim()));
     });
   });

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -535,9 +535,9 @@ export async function installPluginDependencies(
     await ensureTreeSitterCliBinary(targetDir, isTreeSitterCliBinaryUsable, treeSitterTimeoutMs);
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));
-    const details = describeExecError(err);
+    const details = describeExecError(err).slice(0, 4000);
     const cause = Object.assign(
-      new Error(`tree-sitter-cli provisioning failed in ${targetDir}\n${details}`),
+      new Error(`tree-sitter-cli provisioning failed in ${targetDir}: ${err.message}`),
       {
         code: (err as Error & { code?: number }).code,
         killed: (err as Error & { killed?: boolean }).killed,

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -11,10 +11,12 @@ import { selectTreeSitterBinary } from '../../shared/tree-sitter-binary.js';
 import { IS_WINDOWS } from '../utils/paths.js';
 import { parseJsonWithBom } from '../../shared/atomic-json.js';
 
-function installTimeoutMs(): number {
+const INSTALL_TIMEOUT_MS = 5 * 60 * 1000;
+
+function treeSitterInstallTimeoutMs(): number {
   const override = process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS;
   if (override && Number.isFinite(Number(override))) return Number(override);
-  return 5 * 60 * 1000;
+  return INSTALL_TIMEOUT_MS;
 }
 
 /**
@@ -162,13 +164,13 @@ function runBunInstaller(): void {
   if (IS_WINDOWS) {
     execSync('powershell -c "irm bun.sh/install.ps1 | iex"', {
       stdio: 'pipe',
-      timeout: installTimeoutMs(),
+      timeout: INSTALL_TIMEOUT_MS,
       shell: process.env.ComSpec ?? 'cmd.exe',
     });
   } else {
     execSync('curl -fsSL https://bun.sh/install | bash', {
       stdio: 'pipe',
-      timeout: installTimeoutMs(),
+      timeout: INSTALL_TIMEOUT_MS,
       shell: '/bin/bash',
     });
   }
@@ -200,13 +202,13 @@ function runUvInstaller(): void {
   if (IS_WINDOWS) {
     execSync('powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"', {
       stdio: 'pipe',
-      timeout: installTimeoutMs(),
+      timeout: INSTALL_TIMEOUT_MS,
       shell: process.env.ComSpec ?? 'cmd.exe',
     });
   } else {
     execSync('curl -LsSf https://astral.sh/uv/install.sh | sh', {
       stdio: 'pipe',
-      timeout: installTimeoutMs(),
+      timeout: INSTALL_TIMEOUT_MS,
       shell: '/bin/bash',
     });
   }
@@ -253,23 +255,24 @@ export function treeSitterCliBinaryPath(targetDir: string): string {
     ?? join(treeSitterCliPackageDir(targetDir), IS_WINDOWS ? 'tree-sitter.exe' : 'tree-sitter');
 }
 
-export function isTreeSitterCliBinaryUsable(targetDir: string): boolean {
-  const result = spawnSync(treeSitterCliBinaryPath(targetDir), ['--version'], {
-    encoding: 'utf-8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-    timeout: TREE_SITTER_VERSION_TIMEOUT_MS,
-    windowsHide: true,
+export async function isTreeSitterCliBinaryUsable(targetDir: string): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    execFile(treeSitterCliBinaryPath(targetDir), ['--version'], {
+      encoding: 'utf-8',
+      timeout: TREE_SITTER_VERSION_TIMEOUT_MS,
+      windowsHide: true,
+    }, (error, stdout) => {
+      resolve(!error && /^tree-sitter \d+\.\d+\.\d+(?:\s|$)/.test((stdout ?? '').trim()));
+    });
   });
-  return result.status === 0
-    && /^tree-sitter \d+\.\d+\.\d+(?:\s|$)/.test((result.stdout ?? '').trim());
 }
 
 export async function ensureTreeSitterCliBinary(
   targetDir: string,
-  isUsable: (targetDir: string) => boolean = isTreeSitterCliBinaryUsable,
+  isUsable: (targetDir: string) => boolean | Promise<boolean> = isTreeSitterCliBinaryUsable,
 ): Promise<void> {
   const binaryPath = treeSitterCliBinaryPath(targetDir);
-  if (isUsable(targetDir)) return;
+  if (await isUsable(targetDir)) return;
 
   const cliDir = treeSitterCliPackageDir(targetDir);
   const installScript = join(cliDir, 'install.js');
@@ -280,7 +283,7 @@ export async function ensureTreeSitterCliBinary(
   await new Promise<void>((resolve, reject) => {
     execFile(process.execPath, [installScript], {
       cwd: cliDir,
-      timeout: installTimeoutMs(),
+      timeout: treeSitterInstallTimeoutMs(),
       maxBuffer: 16 * 1024 * 1024,
       windowsHide: true,
     }, (error, stdout, stderr) => {
@@ -292,7 +295,7 @@ export async function ensureTreeSitterCliBinary(
     });
   });
 
-  if (!isUsable(targetDir)) {
+  if (!(await isUsable(targetDir))) {
     throw new Error(`tree-sitter-cli install completed without creating a working executable ${binaryPath}`);
   }
 }
@@ -495,7 +498,7 @@ export async function installPluginDependencies(targetDir: string, bunPath: stri
     new Promise<void>((resolve, reject) => {
       exec(`${bunCmd} install --frozen-lockfile --ignore-scripts`, {
         cwd: targetDir,
-        timeout: installTimeoutMs(),
+        timeout: INSTALL_TIMEOUT_MS,
         maxBuffer: 16 * 1024 * 1024,
         ...(IS_WINDOWS ? { shell: process.env.ComSpec ?? 'cmd.exe' } : {}),
       }, (error, stdout, stderr) =>

--- a/src/services/smart-file-read/parser.ts
+++ b/src/services/smart-file-read/parser.ts
@@ -5,6 +5,7 @@ import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { createRequire } from "node:module";
 import { logger } from "../../utils/logger.js";
+import { selectTreeSitterBinary } from "../../shared/tree-sitter-binary.js";
 
 const _require = typeof __filename !== 'undefined'
   ? createRequire(__filename)
@@ -359,8 +360,8 @@ function getTreeSitterBin(): string {
 
   try {
     const pkgPath = _require.resolve("tree-sitter-cli/package.json");
-    const binPath = join(dirname(pkgPath), "tree-sitter");
-    if (existsSync(binPath)) {
+    const binPath = selectTreeSitterBinary(dirname(pkgPath));
+    if (binPath) {
       cachedBinPath = binPath;
       return binPath;
     }

--- a/src/shared/tree-sitter-binary.ts
+++ b/src/shared/tree-sitter-binary.ts
@@ -1,0 +1,24 @@
+import { statSync } from 'fs';
+import { join } from 'path';
+
+export function treeSitterBinaryCandidates(platform: string = process.platform): string[] {
+  return platform === 'win32' ? ['tree-sitter.exe', 'tree-sitter'] : ['tree-sitter'];
+}
+
+function defaultIsFile(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export function selectTreeSitterBinary(
+  pkgDir: string,
+  platform: string = process.platform,
+  isFile: (path: string) => boolean = defaultIsFile,
+): string | null {
+  return treeSitterBinaryCandidates(platform)
+    .map((name) => join(pkgDir, name))
+    .find((path) => isFile(path)) ?? null;
+}

--- a/tests/install-error-matrix.test.ts
+++ b/tests/install-error-matrix.test.ts
@@ -78,7 +78,9 @@ describe('error taxonomy', () => {
     });
     expect(cat.id).toBe('tree-sitter-cli-cache-provisioning-failed');
     expect(cat.severity).toBe(ErrorSeverity.ABORT);
-    expect(cat.remediation({ platform: 'win32', dataDir: 'C:\\temp\\claude-mem' })).toContain('Re-run');
+    const remediation = cat.remediation({ platform: 'win32', dataDir: 'C:\\temp\\claude-mem' });
+    expect(remediation).toContain('C:\\temp\\claude-mem/last-install-error.json');
+    expect(remediation).toContain('CLAUDE_MEM_INSTALL_TIMEOUT_MS');
   });
 
   it('defaults unknown errors to ABORT (fail-loud)', () => {

--- a/tests/install-error-matrix.test.ts
+++ b/tests/install-error-matrix.test.ts
@@ -71,6 +71,16 @@ describe('error taxonomy', () => {
     expect(cat.severity).toBe(ErrorSeverity.ABORT);
   });
 
+  it('classifies cache tree-sitter provisioning failures as ABORT', () => {
+    const cat = classifyError(new Error('tree-sitter install failed'), {
+      component: 'tree-sitter-cli-cache',
+      phase: 'dependency-install',
+    });
+    expect(cat.id).toBe('tree-sitter-cli-cache-provisioning-failed');
+    expect(cat.severity).toBe(ErrorSeverity.ABORT);
+    expect(cat.remediation({ platform: 'win32', dataDir: 'C:\\temp\\claude-mem' })).toContain('Re-run');
+  });
+
   it('defaults unknown errors to ABORT (fail-loud)', () => {
     const cat = classifyError(new Error('something we have never seen'), {
       component: 'mystery',

--- a/tests/install-non-tty.test.ts
+++ b/tests/install-non-tty.test.ts
@@ -177,6 +177,16 @@ describe('Install Non-TTY Support', () => {
       expect(markerWrite).toBeGreaterThan(installCall);
     });
 
+    it('labels the initial runtime heartbeat for Bun and tree-sitter provisioning', () => {
+      const runtimeSetupRegion = installSource.slice(
+        installSource.indexOf("title: 'Setting up runtime"),
+        installSource.indexOf("return `Runtime ready"),
+      );
+      expect(runtimeSetupRegion).toContain(
+        "startHeartbeat(message, 'Installing plugin dependencies (Bun + tree-sitter CLI)…')",
+      );
+    });
+
     it('replaces stale Codex marketplace registrations from a different source', () => {
       const registerRegion = codexInstallerSource.slice(
         codexInstallerSource.indexOf('function registerCodexMarketplace'),

--- a/tests/install-non-tty.test.ts
+++ b/tests/install-non-tty.test.ts
@@ -171,8 +171,10 @@ describe('Install Non-TTY Support', () => {
         installSource.indexOf("title: 'Setting up runtime"),
         installSource.indexOf("return `Runtime ready"),
       );
-      expect(runtimeSetupRegion.indexOf('await installPluginDependencies(cacheDir, bunPath)'))
-        .toBeLessThan(runtimeSetupRegion.indexOf('writeInstallMarker(cacheDir, version, bunVersion, uvVersion)'));
+      const installCall = runtimeSetupRegion.indexOf('await installPluginDependencies(cacheDir, bunPath)');
+      const markerWrite = runtimeSetupRegion.indexOf('writeInstallMarker(cacheDir, version, bunVersion, uvVersion)');
+      expect(installCall).toBeGreaterThanOrEqual(0);
+      expect(markerWrite).toBeGreaterThan(installCall);
     });
 
     it('replaces stale Codex marketplace registrations from a different source', () => {
@@ -270,8 +272,10 @@ describe('Install Non-TTY Support', () => {
       expect(repairRegion).toContain("title: 'Repairing marketplace runtime'");
       expect(repairRegion).toContain('copyPluginToCache(version)');
       expect(repairRegion).toContain('writeInstallMarker(cacheDir, version, bunVersion, uvVersion)');
-      expect(repairRegion.indexOf('await installPluginDependencies(cacheDir, bunPath)'))
-        .toBeLessThan(repairRegion.indexOf('writeInstallMarker(cacheDir, version, bunVersion, uvVersion)'));
+      const installCall = repairRegion.indexOf('await installPluginDependencies(cacheDir, bunPath)');
+      const markerWrite = repairRegion.indexOf('writeInstallMarker(cacheDir, version, bunVersion, uvVersion)');
+      expect(installCall).toBeGreaterThanOrEqual(0);
+      expect(markerWrite).toBeGreaterThan(installCall);
       expect(repairRegion).toContain('Repopulating marketplace root from npm package');
       expect(repairRegion).toContain('copyPluginToMarketplace()');
       expect(repairRegion).toContain('await runNpmInstallInMarketplace(summary)');

--- a/tests/install-non-tty.test.ts
+++ b/tests/install-non-tty.test.ts
@@ -166,6 +166,15 @@ describe('Install Non-TTY Support', () => {
       expect(runtimeSetupRegion).toContain("writeInstallMarker(join(marketplaceDirectory(), 'plugin'), version, bunVersion, uvVersion)");
     });
 
+    it('awaits cache dependencies before writing the initial install marker', () => {
+      const runtimeSetupRegion = installSource.slice(
+        installSource.indexOf("title: 'Setting up runtime"),
+        installSource.indexOf("return `Runtime ready"),
+      );
+      expect(runtimeSetupRegion.indexOf('await installPluginDependencies(cacheDir, bunPath)'))
+        .toBeLessThan(runtimeSetupRegion.indexOf('writeInstallMarker(cacheDir, version, bunVersion, uvVersion)'));
+    });
+
     it('replaces stale Codex marketplace registrations from a different source', () => {
       const registerRegion = codexInstallerSource.slice(
         codexInstallerSource.indexOf('function registerCodexMarketplace'),
@@ -261,6 +270,8 @@ describe('Install Non-TTY Support', () => {
       expect(repairRegion).toContain("title: 'Repairing marketplace runtime'");
       expect(repairRegion).toContain('copyPluginToCache(version)');
       expect(repairRegion).toContain('writeInstallMarker(cacheDir, version, bunVersion, uvVersion)');
+      expect(repairRegion.indexOf('await installPluginDependencies(cacheDir, bunPath)'))
+        .toBeLessThan(repairRegion.indexOf('writeInstallMarker(cacheDir, version, bunVersion, uvVersion)'));
       expect(repairRegion).toContain('Repopulating marketplace root from npm package');
       expect(repairRegion).toContain('copyPluginToMarketplace()');
       expect(repairRegion).toContain('await runNpmInstallInMarketplace(summary)');

--- a/tests/services/smart-file-read/parser-bin-resolution.test.ts
+++ b/tests/services/smart-file-read/parser-bin-resolution.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { selectTreeSitterBinary } from '../../../src/shared/tree-sitter-binary';
+
+describe('tree-sitter package-local binary selection', () => {
+  let pkgDir: string;
+
+  beforeEach(() => {
+    pkgDir = join(tmpdir(), `tree-sitter-bin-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(pkgDir, { recursive: true });
+  });
+
+  afterEach(() => rmSync(pkgDir, { recursive: true, force: true }));
+
+  it('selects the existing Windows executable', () => {
+    const exe = join(pkgDir, 'tree-sitter.exe');
+    writeFileSync(exe, '');
+    expect(selectTreeSitterBinary(pkgDir, 'win32')).toBe(exe);
+    expect(existsSync(selectTreeSitterBinary(pkgDir, 'win32')!)).toBe(true);
+  });
+
+  it('keeps the extensionless Windows workaround', () => {
+    const binary = join(pkgDir, 'tree-sitter');
+    writeFileSync(binary, '');
+    expect(selectTreeSitterBinary(pkgDir, 'win32')).toBe(binary);
+  });
+
+  it('selects only the extensionless binary off Windows', () => {
+    writeFileSync(join(pkgDir, 'tree-sitter.exe'), '');
+    expect(selectTreeSitterBinary(pkgDir, 'linux')).toBeNull();
+    writeFileSync(join(pkgDir, 'tree-sitter'), '');
+    expect(selectTreeSitterBinary(pkgDir, 'linux')).toBe(join(pkgDir, 'tree-sitter'));
+  });
+
+  it('ignores candidate paths that are directories', () => {
+    mkdirSync(join(pkgDir, 'tree-sitter.exe'));
+    mkdirSync(join(pkgDir, 'tree-sitter'));
+    expect(selectTreeSitterBinary(pkgDir, 'win32')).toBeNull();
+    expect(selectTreeSitterBinary(pkgDir, 'linux')).toBeNull();
+  });
+});

--- a/tests/setup-runtime.test.ts
+++ b/tests/setup-runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
+import { copyFileSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync } from 'fs';
 import { spawnSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -9,11 +9,21 @@ import {
   isInstallCurrent,
   platformBunRemediation,
   platformUvRemediation,
+  ensureTreeSitterCliBinary,
 } from '../src/npx-cli/install/setup-runtime';
+import { warnMarketplaceTreeSitterCliIfUnavailable } from '../src/npx-cli/commands/install';
+import type { InstallSummary } from '../src/npx-cli/install/error-reporter';
 
 const SETUP_RUNTIME_SOURCE_PATH = join(import.meta.dir, '..', 'src', 'npx-cli', 'install', 'setup-runtime.ts');
 const SHARED_SPAWN_SOURCE_PATH = join(import.meta.dir, '..', 'src', 'shared', 'spawn.ts');
 const DOCTOR_SOURCE_PATH = join(import.meta.dir, '..', 'src', 'npx-cli', 'commands', 'doctor.ts');
+const REPO_TREE_SITTER_BINARY = join(
+  import.meta.dir,
+  '..',
+  'node_modules',
+  'tree-sitter-cli',
+  process.platform === 'win32' ? 'tree-sitter.exe' : 'tree-sitter',
+);
 
 function probeBunVersion(): string | null {
   try {
@@ -152,6 +162,71 @@ describe('setup-runtime install marker', () => {
       expect(text.length).toBeGreaterThan(0);
       expect(text.toLowerCase()).toContain('uv');
       expect(text).toContain('claude-mem install');
+    });
+  });
+
+  describe('marketplace tree-sitter warning', () => {
+    function summaryWithWarnings(): InstallSummary {
+      return { warnings: [] } as unknown as InstallSummary;
+    }
+
+    it('does nothing when tree-sitter-cli is not installed in the marketplace root', async () => {
+      const summary = summaryWithWarnings();
+
+      await warnMarketplaceTreeSitterCliIfUnavailable(summary, tempDir);
+
+      expect(summary.warnings).toEqual([]);
+    });
+
+    it('warns when the marketplace tree-sitter-cli package lacks a usable binary', async () => {
+      const cliDir = join(tempDir, 'node_modules', 'tree-sitter-cli');
+      mkdirSync(cliDir, { recursive: true });
+      writeFileSync(join(cliDir, 'package.json'), '{}');
+      const summary = summaryWithWarnings();
+
+      await warnMarketplaceTreeSitterCliIfUnavailable(summary, tempDir);
+
+      expect(summary.warnings).toEqual([
+        expect.objectContaining({
+          component: 'marketplace-tree-sitter-cli',
+          remediation: 'Smart-explore may use a PATH tree-sitter binary if available.',
+        }),
+      ]);
+    });
+
+    it('does not warn when the marketplace tree-sitter-cli package already has a usable binary', async () => {
+      const cliDir = join(tempDir, 'node_modules', 'tree-sitter-cli');
+      mkdirSync(cliDir, { recursive: true });
+      writeFileSync(join(cliDir, 'package.json'), '{}');
+      copyFileSync(REPO_TREE_SITTER_BINARY, join(cliDir, process.platform === 'win32' ? 'tree-sitter.exe' : 'tree-sitter'));
+      if (process.platform !== 'win32') {
+        chmodSync(join(cliDir, 'tree-sitter'), 0o755);
+      }
+      const summary = summaryWithWarnings();
+
+      await warnMarketplaceTreeSitterCliIfUnavailable(summary, tempDir);
+
+      expect(summary.warnings).toEqual([]);
+    });
+
+    it('provisions an absent binary by running the package install script', async () => {
+      const cliDir = join(tempDir, 'node_modules', 'tree-sitter-cli');
+      mkdirSync(cliDir, { recursive: true });
+      writeFileSync(join(cliDir, 'package.json'), '{}');
+      writeFileSync(
+        join(cliDir, 'install.js'),
+        [
+          `const fs = require('fs');`,
+          `const source = ${JSON.stringify(REPO_TREE_SITTER_BINARY)};`,
+          `const target = require('path').join(__dirname, ${JSON.stringify(process.platform === 'win32' ? 'tree-sitter.exe' : 'tree-sitter')});`,
+          `fs.copyFileSync(source, target);`,
+          process.platform === 'win32' ? '' : `fs.chmodSync(target, 0o755);`,
+          '',
+        ].join('\n'),
+      );
+
+      await expect(ensureTreeSitterCliBinary(tempDir)).resolves.toBeUndefined();
+      expect(existsSync(join(cliDir, process.platform === 'win32' ? 'tree-sitter.exe' : 'tree-sitter'))).toBe(true);
     });
   });
 });

--- a/tests/setup-runtime.test.ts
+++ b/tests/setup-runtime.test.ts
@@ -380,27 +380,19 @@ describe('setup-runtime install marker', () => {
         'setTimeout(() => {}, 5000);',
       ].join('\n'));
       writeFileSync(fixture.eventsPath, '');
-      const previousTimeout = process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS;
-      process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS = '2000';
-
       try {
-        try {
-          await installPluginDependencies(fixture.cacheDir, fixture.bunPath);
-          throw new Error('expected cache provisioner to time out');
-        } catch (error) {
-          expect(error).toMatchObject({
-            category: { id: 'tree-sitter-cli-cache-provisioning-failed' },
-            cause: { killed: true },
-          });
-        }
-        expect(readFileSync(fixture.eventsPath, 'utf-8').trim().split('\n')).toEqual([
-          'bun install --frozen-lockfile --ignore-scripts',
-          'provision',
-        ]);
-      } finally {
-        if (previousTimeout === undefined) delete process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS;
-        else process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS = previousTimeout;
+        await installPluginDependencies(fixture.cacheDir, fixture.bunPath, 2000);
+        throw new Error('expected cache provisioner to time out');
+      } catch (error) {
+        expect(error).toMatchObject({
+          category: { id: 'tree-sitter-cli-cache-provisioning-failed' },
+          cause: { killed: true },
+        });
       }
+      expect(readFileSync(fixture.eventsPath, 'utf-8').trim().split('\n')).toEqual([
+        'bun install --frozen-lockfile --ignore-scripts',
+        'provision',
+      ]);
     });
   });
 });

--- a/tests/setup-runtime.test.ts
+++ b/tests/setup-runtime.test.ts
@@ -237,7 +237,7 @@ describe('setup-runtime install marker', () => {
       mkdirSync(cliDir, { recursive: true });
       writeFileSync(binaryPath, [
         '#!/usr/bin/env node',
-        "process.stdin.on('end', () => process.stdout.write('tree-sitter 0.26.8\\n'));",
+        "process.stdin.resume(); process.stdin.on('end', () => process.stdout.write('tree-sitter 0.26.8\\n'));",
       ].join('\n'));
       chmodSync(binaryPath, 0o755);
 
@@ -265,8 +265,17 @@ describe('setup-runtime install marker', () => {
   });
 
   describe('cache dependency installation', () => {
+    let previousDataDir: string | undefined;
+
+    beforeEach(() => {
+      previousDataDir = process.env.CLAUDE_MEM_DATA_DIR;
+      process.env.CLAUDE_MEM_DATA_DIR = join(tempDir, 'install-errors');
+    });
+
     afterEach(() => {
       delete process.env.CLAUDE_MEM_TEST_EVENTS;
+      if (previousDataDir === undefined) delete process.env.CLAUDE_MEM_DATA_DIR;
+      else process.env.CLAUDE_MEM_DATA_DIR = previousDataDir;
     });
 
     function createCacheFixture(installScript: string) {
@@ -354,7 +363,10 @@ describe('setup-runtime install marker', () => {
         await installPluginDependencies(fixture.cacheDir, fixture.bunPath);
         throw new Error('expected cache provisioner to reject');
       } catch (error) {
-        expect(error).toMatchObject({ code: 2 });
+        expect(error).toMatchObject({
+          category: { id: 'tree-sitter-cli-cache-provisioning-failed' },
+          cause: { code: 2 },
+        });
       }
       expect(readFileSync(fixture.eventsPath, 'utf-8').trim().split('\n')).toEqual([
         'bun install --frozen-lockfile --ignore-scripts',
@@ -368,23 +380,26 @@ describe('setup-runtime install marker', () => {
         'setTimeout(() => {}, 5000);',
       ].join('\n'));
       writeFileSync(fixture.eventsPath, '');
-      const previousTimeout = process.env.CLAUDE_MEM_TREE_SITTER_INSTALL_TIMEOUT_MS;
-      process.env.CLAUDE_MEM_TREE_SITTER_INSTALL_TIMEOUT_MS = '2000';
+      const previousTimeout = process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS;
+      process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS = '2000';
 
       try {
         try {
           await installPluginDependencies(fixture.cacheDir, fixture.bunPath);
           throw new Error('expected cache provisioner to time out');
         } catch (error) {
-          expect(error).toMatchObject({ killed: true });
+          expect(error).toMatchObject({
+            category: { id: 'tree-sitter-cli-cache-provisioning-failed' },
+            cause: { killed: true },
+          });
         }
         expect(readFileSync(fixture.eventsPath, 'utf-8').trim().split('\n')).toEqual([
           'bun install --frozen-lockfile --ignore-scripts',
           'provision',
         ]);
       } finally {
-        if (previousTimeout === undefined) delete process.env.CLAUDE_MEM_TREE_SITTER_INSTALL_TIMEOUT_MS;
-        else process.env.CLAUDE_MEM_TREE_SITTER_INSTALL_TIMEOUT_MS = previousTimeout;
+        if (previousTimeout === undefined) delete process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS;
+        else process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS = previousTimeout;
       }
     });
   });

--- a/tests/setup-runtime.test.ts
+++ b/tests/setup-runtime.test.ts
@@ -264,7 +264,7 @@ describe('setup-runtime install marker', () => {
       writeFileSync(join(cacheDir, 'package.json'), JSON.stringify({
         dependencies: {
           'tree-sitter-cli': '0.26.8',
-          'provisioned-dependency': '1.0.0',
+          'provisioned-after-tree-sitter': '1.0.0',
         },
       }));
       writeFileSync(join(cliDir, 'package.json'), JSON.stringify({ bin: { 'tree-sitter': 'tree-sitter' } }));
@@ -288,8 +288,8 @@ describe('setup-runtime install marker', () => {
       const binaryName = process.platform === 'win32' ? 'tree-sitter.exe' : 'tree-sitter';
       return [
         `require('fs').appendFileSync(process.env.CLAUDE_MEM_TEST_EVENTS, 'provision\\n');`,
-        `require('fs').mkdirSync(require('path').join(__dirname, '..', 'provisioned-dependency'), { recursive: true });`,
-        `require('fs').writeFileSync(require('path').join(__dirname, '..', 'provisioned-dependency', 'package.json'), '{}');`,
+        `require('fs').mkdirSync(require('path').join(__dirname, '..', 'provisioned-after-tree-sitter'), { recursive: true });`,
+        `require('fs').writeFileSync(require('path').join(__dirname, '..', 'provisioned-after-tree-sitter', 'package.json'), '{}');`,
         `require('fs').copyFileSync(${JSON.stringify(REPO_TREE_SITTER_BINARY)}, require('path').join(__dirname, ${JSON.stringify(binaryName)}));`,
         process.platform === 'win32' ? '' : `require('fs').chmodSync(require('path').join(__dirname, ${JSON.stringify(binaryName)}), 0o755);`,
       ].join('\n');
@@ -308,7 +308,7 @@ describe('setup-runtime install marker', () => {
         'provision',
         'returned',
       ]);
-      expect(existsSync(join(fixture.cacheDir, 'node_modules', 'provisioned-dependency', 'package.json'))).toBe(true);
+      expect(existsSync(join(fixture.cacheDir, 'node_modules', 'provisioned-after-tree-sitter', 'package.json'))).toBe(true);
       expect(existsSync(treeSitterCliBinaryPath(fixture.cacheDir))).toBe(true);
     });
 

--- a/tests/setup-runtime.test.ts
+++ b/tests/setup-runtime.test.ts
@@ -310,6 +310,37 @@ describe('setup-runtime install marker', () => {
       ]);
       expect(existsSync(treeSitterCliBinaryPath(fixture.cacheDir))).toBe(false);
     });
+
+    it('rejects when the cache provisioner exits non-zero', async () => {
+      const fixture = createCacheFixture([
+        `require('fs').appendFileSync(process.env.CLAUDE_MEM_TEST_EVENTS, 'provision\\n');`,
+        'process.exitCode = 2;',
+      ].join('\n'));
+      writeFileSync(fixture.eventsPath, '');
+
+      await expect(installPluginDependencies(fixture.cacheDir, fixture.bunPath)).rejects.toBeTruthy();
+      expect(readFileSync(fixture.eventsPath, 'utf-8').trim().split('\n')).toEqual([
+        'bun install --frozen-lockfile --ignore-scripts',
+        'provision',
+      ]);
+    });
+
+    it('rejects when the cache provisioner times out', async () => {
+      const fixture = createCacheFixture([
+        `require('fs').appendFileSync(process.env.CLAUDE_MEM_TEST_EVENTS, 'provision\\n');`,
+        'setTimeout(() => {}, 500);',
+      ].join('\n'));
+      writeFileSync(fixture.eventsPath, '');
+      const previousTimeout = process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS;
+      process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS = '25';
+
+      try {
+        await expect(installPluginDependencies(fixture.cacheDir, fixture.bunPath)).rejects.toBeTruthy();
+      } finally {
+        if (previousTimeout === undefined) delete process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS;
+        else process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS = previousTimeout;
+      }
+    });
   });
 });
 

--- a/tests/setup-runtime.test.ts
+++ b/tests/setup-runtime.test.ts
@@ -350,6 +350,7 @@ describe('setup-runtime install marker', () => {
       const errorRecord = JSON.parse(readFileSync(join(tempDir, 'install-errors', 'last-install-error.json'), 'utf-8'));
       expect(errorRecord.details).toContain('Downloading https://example/tree-sitter');
       expect(errorRecord.details).toContain('release asset unavailable');
+      expect(errorRecord.details.length).toBeLessThanOrEqual(4000);
       expect(readFileSync(fixture.eventsPath, 'utf-8').trim().split('\n')).toEqual([
         'bun install --frozen-lockfile --ignore-scripts',
         'provision',

--- a/tests/setup-runtime.test.ts
+++ b/tests/setup-runtime.test.ts
@@ -311,6 +311,7 @@ describe('setup-runtime install marker', () => {
     function materializingInstallScript(): string {
       const binaryName = process.platform === 'win32' ? 'tree-sitter.exe' : 'tree-sitter';
       return [
+        `process.stdin.resume(); process.stdin.on('end', () => {});`,
         `require('fs').appendFileSync(process.env.CLAUDE_MEM_TEST_EVENTS, 'provision\\n');`,
         `require('fs').mkdirSync(require('path').join(__dirname, '..', 'provisioned-after-tree-sitter'), { recursive: true });`,
         `require('fs').writeFileSync(require('path').join(__dirname, '..', 'provisioned-after-tree-sitter', 'package.json'), '{}');`,
@@ -379,6 +380,9 @@ describe('setup-runtime install marker', () => {
         'bun install --frozen-lockfile --ignore-scripts',
         'provision',
       ]);
+      const errorRecord = JSON.parse(readFileSync(join(tempDir, 'install-errors', 'last-install-error.json'), 'utf-8'));
+      expect(errorRecord.cause).toContain('exited with code 2');
+      expect(errorRecord.cause.length).toBeLessThan(4000);
     });
 
     it('rejects when the cache provisioner times out', async () => {

--- a/tests/setup-runtime.test.ts
+++ b/tests/setup-runtime.test.ts
@@ -231,6 +231,21 @@ describe('setup-runtime install marker', () => {
       expect(existsSync(join(cliDir, process.platform === 'win32' ? 'tree-sitter.exe' : 'tree-sitter'))).toBe(true);
     });
 
+    it.skipIf(process.platform === 'win32')('closes stdin before accepting a package-local version response', async () => {
+      const cliDir = join(tempDir, 'node_modules', 'tree-sitter-cli');
+      const binaryPath = join(cliDir, 'tree-sitter');
+      mkdirSync(cliDir, { recursive: true });
+      writeFileSync(binaryPath, [
+        '#!/usr/bin/env node',
+        "process.stdin.on('end', () => process.stdout.write('tree-sitter 0.26.8\\n'));",
+      ].join('\n'));
+      chmodSync(binaryPath, 0o755);
+
+      const startedAt = Date.now();
+      await expect(ensureTreeSitterCliBinary(tempDir)).resolves.toBeUndefined();
+      expect(Date.now() - startedAt).toBeLessThan(2000);
+    });
+
     it('does not resolve a tree-sitter package from an ancestor node_modules', async () => {
       const nestedDir = join(tempDir, 'nested', 'cache');
       const ancestorCliDir = join(tempDir, 'node_modules', 'tree-sitter-cli');

--- a/tests/setup-runtime.test.ts
+++ b/tests/setup-runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { copyFileSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync } from 'fs';
+import { appendFileSync, copyFileSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync } from 'fs';
 import { spawnSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -10,6 +10,8 @@ import {
   platformBunRemediation,
   platformUvRemediation,
   ensureTreeSitterCliBinary,
+  installPluginDependencies,
+  treeSitterCliBinaryPath,
 } from '../src/npx-cli/install/setup-runtime';
 import { warnMarketplaceTreeSitterCliIfUnavailable } from '../src/npx-cli/commands/install';
 import type { InstallSummary } from '../src/npx-cli/install/error-reporter';
@@ -227,6 +229,80 @@ describe('setup-runtime install marker', () => {
 
       await expect(ensureTreeSitterCliBinary(tempDir)).resolves.toBeUndefined();
       expect(existsSync(join(cliDir, process.platform === 'win32' ? 'tree-sitter.exe' : 'tree-sitter'))).toBe(true);
+    });
+  });
+
+  describe('cache dependency installation', () => {
+    afterEach(() => {
+      delete process.env.CLAUDE_MEM_TEST_EVENTS;
+    });
+
+    function createCacheFixture(installScript: string) {
+      const cacheDir = join(tempDir, 'cache');
+      const cliDir = join(cacheDir, 'node_modules', 'tree-sitter-cli');
+      const eventsPath = join(tempDir, 'events.log');
+      const bunPath = join(tempDir, process.platform === 'win32' ? 'fake-bun.cmd' : 'fake-bun');
+
+      mkdirSync(cliDir, { recursive: true });
+      writeFileSync(join(cacheDir, 'package.json'), JSON.stringify({
+        dependencies: { 'tree-sitter-cli': '0.26.8' },
+      }));
+      writeFileSync(join(cliDir, 'package.json'), JSON.stringify({ bin: { 'tree-sitter': 'tree-sitter' } }));
+      writeFileSync(join(cliDir, 'install.js'), installScript);
+      writeFileSync(join(tempDir, 'fake-bun.js'), [
+        `require('fs').appendFileSync(process.env.CLAUDE_MEM_TEST_EVENTS, 'bun ' + process.argv.slice(2).join(' ') + '\\n');`,
+      ].join('\n'));
+
+      if (process.platform === 'win32') {
+        writeFileSync(bunPath, '@echo off\r\nnode "%~dp0fake-bun.js" %*\r\n');
+      } else {
+        writeFileSync(bunPath, '#!/bin/sh\nnode "$(dirname "$0")/fake-bun.js" "$@"\n');
+        chmodSync(bunPath, 0o755);
+      }
+
+      process.env.CLAUDE_MEM_TEST_EVENTS = eventsPath;
+      return { cacheDir, cliDir, eventsPath, bunPath };
+    }
+
+    function materializingInstallScript(): string {
+      const binaryName = process.platform === 'win32' ? 'tree-sitter.exe' : 'tree-sitter';
+      return [
+        `require('fs').appendFileSync(process.env.CLAUDE_MEM_TEST_EVENTS, 'provision\\n');`,
+        `require('fs').copyFileSync(${JSON.stringify(REPO_TREE_SITTER_BINARY)}, require('path').join(__dirname, ${JSON.stringify(binaryName)}));`,
+        process.platform === 'win32' ? '' : `require('fs').chmodSync(require('path').join(__dirname, ${JSON.stringify(binaryName)}), 0o755);`,
+      ].join('\n');
+    }
+
+    it('provisions the cache binary after script-suppressed Bun install', async () => {
+      const fixture = createCacheFixture(materializingInstallScript());
+      writeFileSync(fixture.eventsPath, '');
+
+      expect(existsSync(treeSitterCliBinaryPath(fixture.cacheDir))).toBe(false);
+      await installPluginDependencies(fixture.cacheDir, fixture.bunPath);
+      appendFileSync(fixture.eventsPath, 'returned\n');
+
+      expect(readFileSync(fixture.eventsPath, 'utf-8').trim().split('\n')).toEqual([
+        'bun install --frozen-lockfile --ignore-scripts',
+        'provision',
+        'returned',
+      ]);
+      expect(existsSync(treeSitterCliBinaryPath(fixture.cacheDir))).toBe(true);
+    });
+
+    it('rejects when cache binary provisioning cannot produce a usable executable', async () => {
+      const fixture = createCacheFixture([
+        `require('fs').appendFileSync(process.env.CLAUDE_MEM_TEST_EVENTS, 'provision\\n');`,
+      ].join('\n'));
+      writeFileSync(fixture.eventsPath, '');
+
+      await expect(installPluginDependencies(fixture.cacheDir, fixture.bunPath)).rejects.toThrow(
+        'without creating a working executable',
+      );
+      expect(readFileSync(fixture.eventsPath, 'utf-8').trim().split('\n')).toEqual([
+        'bun install --frozen-lockfile --ignore-scripts',
+        'provision',
+      ]);
+      expect(existsSync(treeSitterCliBinaryPath(fixture.cacheDir))).toBe(false);
     });
   });
 });

--- a/tests/setup-runtime.test.ts
+++ b/tests/setup-runtime.test.ts
@@ -341,6 +341,7 @@ describe('setup-runtime install marker', () => {
         `require('fs').appendFileSync(process.env.CLAUDE_MEM_TEST_EVENTS, 'provision\\n');`,
         "console.log('Downloading https://example/tree-sitter');",
         "console.error('release asset unavailable');",
+        "process.stdout.write('x'.repeat(5000));",
       ].join('\n'));
       writeFileSync(fixture.eventsPath, '');
 
@@ -350,7 +351,7 @@ describe('setup-runtime install marker', () => {
       const errorRecord = JSON.parse(readFileSync(join(tempDir, 'install-errors', 'last-install-error.json'), 'utf-8'));
       expect(errorRecord.details).toContain('Downloading https://example/tree-sitter');
       expect(errorRecord.details).toContain('release asset unavailable');
-      expect(errorRecord.details.length).toBeLessThanOrEqual(4000);
+      expect(errorRecord.details.length).toBe(4000);
       expect(readFileSync(fixture.eventsPath, 'utf-8').trim().split('\n')).toEqual([
         'bun install --frozen-lockfile --ignore-scripts',
         'provision',

--- a/tests/setup-runtime.test.ts
+++ b/tests/setup-runtime.test.ts
@@ -339,12 +339,17 @@ describe('setup-runtime install marker', () => {
     it('rejects when cache binary provisioning cannot produce a usable executable', async () => {
       const fixture = createCacheFixture([
         `require('fs').appendFileSync(process.env.CLAUDE_MEM_TEST_EVENTS, 'provision\\n');`,
+        "console.log('Downloading https://example/tree-sitter');",
+        "console.error('release asset unavailable');",
       ].join('\n'));
       writeFileSync(fixture.eventsPath, '');
 
       await expect(installPluginDependencies(fixture.cacheDir, fixture.bunPath)).rejects.toThrow(
         'without creating a working executable',
       );
+      const errorRecord = JSON.parse(readFileSync(join(tempDir, 'install-errors', 'last-install-error.json'), 'utf-8'));
+      expect(errorRecord.details).toContain('Downloading https://example/tree-sitter');
+      expect(errorRecord.details).toContain('release asset unavailable');
       expect(readFileSync(fixture.eventsPath, 'utf-8').trim().split('\n')).toEqual([
         'bun install --frozen-lockfile --ignore-scripts',
         'provision',

--- a/tests/setup-runtime.test.ts
+++ b/tests/setup-runtime.test.ts
@@ -230,6 +230,15 @@ describe('setup-runtime install marker', () => {
       await expect(ensureTreeSitterCliBinary(tempDir)).resolves.toBeUndefined();
       expect(existsSync(join(cliDir, process.platform === 'win32' ? 'tree-sitter.exe' : 'tree-sitter'))).toBe(true);
     });
+
+    it('does not resolve a tree-sitter package from an ancestor node_modules', async () => {
+      const nestedDir = join(tempDir, 'nested', 'cache');
+      const ancestorCliDir = join(tempDir, 'node_modules', 'tree-sitter-cli');
+      mkdirSync(ancestorCliDir, { recursive: true });
+      copyFileSync(REPO_TREE_SITTER_BINARY, join(ancestorCliDir, process.platform === 'win32' ? 'tree-sitter.exe' : 'tree-sitter'));
+
+      await expect(ensureTreeSitterCliBinary(nestedDir)).rejects.toThrow('install script not found');
+    });
   });
 
   describe('cache dependency installation', () => {
@@ -318,7 +327,12 @@ describe('setup-runtime install marker', () => {
       ].join('\n'));
       writeFileSync(fixture.eventsPath, '');
 
-      await expect(installPluginDependencies(fixture.cacheDir, fixture.bunPath)).rejects.toBeTruthy();
+      try {
+        await installPluginDependencies(fixture.cacheDir, fixture.bunPath);
+        throw new Error('expected cache provisioner to reject');
+      } catch (error) {
+        expect(error).toMatchObject({ code: 2 });
+      }
       expect(readFileSync(fixture.eventsPath, 'utf-8').trim().split('\n')).toEqual([
         'bun install --frozen-lockfile --ignore-scripts',
         'provision',
@@ -328,14 +342,18 @@ describe('setup-runtime install marker', () => {
     it('rejects when the cache provisioner times out', async () => {
       const fixture = createCacheFixture([
         `require('fs').appendFileSync(process.env.CLAUDE_MEM_TEST_EVENTS, 'provision\\n');`,
-        'setTimeout(() => {}, 500);',
+        'setTimeout(() => {}, 5000);',
       ].join('\n'));
       writeFileSync(fixture.eventsPath, '');
       const previousTimeout = process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS;
-      process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS = '25';
+      process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS = '1000';
 
       try {
         await expect(installPluginDependencies(fixture.cacheDir, fixture.bunPath)).rejects.toBeTruthy();
+        expect(readFileSync(fixture.eventsPath, 'utf-8').trim().split('\n')).toEqual([
+          'bun install --frozen-lockfile --ignore-scripts',
+          'provision',
+        ]);
       } finally {
         if (previousTimeout === undefined) delete process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS;
         else process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS = previousTimeout;

--- a/tests/setup-runtime.test.ts
+++ b/tests/setup-runtime.test.ts
@@ -245,7 +245,10 @@ describe('setup-runtime install marker', () => {
 
       mkdirSync(cliDir, { recursive: true });
       writeFileSync(join(cacheDir, 'package.json'), JSON.stringify({
-        dependencies: { 'tree-sitter-cli': '0.26.8' },
+        dependencies: {
+          'tree-sitter-cli': '0.26.8',
+          'provisioned-dependency': '1.0.0',
+        },
       }));
       writeFileSync(join(cliDir, 'package.json'), JSON.stringify({ bin: { 'tree-sitter': 'tree-sitter' } }));
       writeFileSync(join(cliDir, 'install.js'), installScript);
@@ -268,6 +271,8 @@ describe('setup-runtime install marker', () => {
       const binaryName = process.platform === 'win32' ? 'tree-sitter.exe' : 'tree-sitter';
       return [
         `require('fs').appendFileSync(process.env.CLAUDE_MEM_TEST_EVENTS, 'provision\\n');`,
+        `require('fs').mkdirSync(require('path').join(__dirname, '..', 'provisioned-dependency'), { recursive: true });`,
+        `require('fs').writeFileSync(require('path').join(__dirname, '..', 'provisioned-dependency', 'package.json'), '{}');`,
         `require('fs').copyFileSync(${JSON.stringify(REPO_TREE_SITTER_BINARY)}, require('path').join(__dirname, ${JSON.stringify(binaryName)}));`,
         process.platform === 'win32' ? '' : `require('fs').chmodSync(require('path').join(__dirname, ${JSON.stringify(binaryName)}), 0o755);`,
       ].join('\n');
@@ -286,6 +291,7 @@ describe('setup-runtime install marker', () => {
         'provision',
         'returned',
       ]);
+      expect(existsSync(join(fixture.cacheDir, 'node_modules', 'provisioned-dependency', 'package.json'))).toBe(true);
       expect(existsSync(treeSitterCliBinaryPath(fixture.cacheDir))).toBe(true);
     });
 

--- a/tests/setup-runtime.test.ts
+++ b/tests/setup-runtime.test.ts
@@ -239,6 +239,14 @@ describe('setup-runtime install marker', () => {
 
       await expect(ensureTreeSitterCliBinary(nestedDir)).rejects.toThrow('install script not found');
     });
+
+    it('rejects a tree-sitter package path that is not a directory', async () => {
+      const cliPath = join(tempDir, 'node_modules', 'tree-sitter-cli');
+      mkdirSync(join(tempDir, 'node_modules'), { recursive: true });
+      writeFileSync(cliPath, 'not a directory');
+
+      await expect(ensureTreeSitterCliBinary(tempDir)).rejects.toThrow('package path is not a directory');
+    });
   });
 
   describe('cache dependency installation', () => {
@@ -345,18 +353,23 @@ describe('setup-runtime install marker', () => {
         'setTimeout(() => {}, 5000);',
       ].join('\n'));
       writeFileSync(fixture.eventsPath, '');
-      const previousTimeout = process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS;
-      process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS = '1000';
+      const previousTimeout = process.env.CLAUDE_MEM_TREE_SITTER_INSTALL_TIMEOUT_MS;
+      process.env.CLAUDE_MEM_TREE_SITTER_INSTALL_TIMEOUT_MS = '2000';
 
       try {
-        await expect(installPluginDependencies(fixture.cacheDir, fixture.bunPath)).rejects.toBeTruthy();
+        try {
+          await installPluginDependencies(fixture.cacheDir, fixture.bunPath);
+          throw new Error('expected cache provisioner to time out');
+        } catch (error) {
+          expect(error).toMatchObject({ killed: true });
+        }
         expect(readFileSync(fixture.eventsPath, 'utf-8').trim().split('\n')).toEqual([
           'bun install --frozen-lockfile --ignore-scripts',
           'provision',
         ]);
       } finally {
-        if (previousTimeout === undefined) delete process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS;
-        else process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS = previousTimeout;
+        if (previousTimeout === undefined) delete process.env.CLAUDE_MEM_TREE_SITTER_INSTALL_TIMEOUT_MS;
+        else process.env.CLAUDE_MEM_TREE_SITTER_INSTALL_TIMEOUT_MS = previousTimeout;
       }
     });
   });


### PR DESCRIPTION
## Summary

Clean installs can leave `tree-sitter-cli` without its downloaded executable, and Windows can ignore an existing `tree-sitter.exe` when resolving the package-local CLI. This change keeps bulk dependency scripts suppressed, runs the trusted target-local `tree-sitter-cli/install.js` after cache installation when the CLI is unusable, and resolves `tree-sitter.exe` before PATH fallback on Windows through the shared package-local selector.

The version-cache path now awaits provisioning before critical-module verification. Initial install and repair write their cache marker only after provisioning succeeds. Marketplace provisioning remains best-effort and records the existing warning when it fails.

Refs #2910
Refs #2964

## Why

`runNpmInstallInMarketplace()` still uses `--ignore-scripts`, and `installPluginDependencies()` still uses `bun install --frozen-lockfile --ignore-scripts`. The repository trusts `tree-sitter-cli`, but those bulk installs suppress its package-owned download step. Bin-only verification does not detect the missing executable, so the cache path must invoke the existing package-local provisioner explicitly.

The parser has a separate Windows resolution defect. Its package-local probe checks only `tree-sitter`, while Windows releases can provide `tree-sitter.exe`. One shared selector now covers both installer and parser paths.

## Scope

This PR fixes the trusted CLI provisioning step, cache marker boundary, bounded failure reporting, and Windows package-local binary resolution. It does not change native `tree-sitter` runtime packaging, grammar dependency reconciliation, bundle contents, or WASM migration. The external release download and native runtime remain unverified here.

Attribution: https://github.com/thedotmack/claude-mem/pull/2918 and https://github.com/thedotmack/claude-mem/pull/3095 explored the same installer and resolver surface and closed unmerged.

## Risk

Cache provisioning failure now aborts `npx claude-mem install` and `npx claude-mem repair` before either cache marker is written, with process details retained in `last-install-error.json` and timeout remediation naming `CLAUDE_MEM_INSTALL_TIMEOUT_MS`. Marketplace provisioning still warns and continues. Bulk lifecycle scripts remain suppressed, and the bounded package-local subprocess runs only for the trusted top-level package.

## Verification

- [x] `bun test tests/setup-runtime.test.ts`, 26 pass, 1 Windows-only skip, 0 fail
- [x] `bun test tests/install-error-matrix.test.ts`, 61 pass, 0 fail
- [x] `bun test tests/install-non-tty.test.ts`, 45 pass, 0 fail
- [x] `bun test tests/services/smart-file-read/parser-bin-resolution.test.ts`, 4 pass, 0 fail
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] `npm run lint:hook-io`
- [x] `npm run lint:spawn-env`
- [ ] `npm run strip-comments:check`, repository baseline reports `Changed: 375`
- [ ] Verified on a real Windows install

Refs #2910
Refs #2964
