### PR TITLE
fix: restore missing sqlite/observations/files.js shipped module

### DIFF
--- a/plugin/sqlite/observations/files.js
+++ b/plugin/sqlite/observations/files.js
@@ -1,0 +1,13 @@
+"use strict";
+
+function parseFileList(value) {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [String(parsed)];
+  } catch (error) {
+    return [value];
+  }
+}
+
+module.exports = { parseFileList };

--- a/plugin/sqlite/package.json
+++ b/plugin/sqlite/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary

- `worker-service.cjs` dynamically requires `../sqlite/observations/files.js` via `createRequire(__IMPORT_META_URL__)`, sourced from `src/services/sqlite/observations/files.ts`. This file is intentionally excluded from the main esbuild/bundler output (it's loaded lazily at runtime instead of being statically bundled), but the build does not currently copy/compile it into the shipped `plugin/` output directory.
- As a result, **every** Chroma backfill and live observation sync fails at `formatObservationDocs` → `jce()` with:
  ```
  ResolveMessage: Cannot find module '../sqlite/observations/files.js' from '.../plugin/scripts/worker-service.cjs'
  ```
- This silently breaks Chroma vector sync for all users on affected installs — primary SQLite storage and FTS5 full-text search keep working, but semantic/vector search over memories never gets populated.

## Fix

Adds the missing module at the exact path `worker-service.cjs` resolves it to:
- `plugin/sqlite/observations/files.js` — minimal, dependency-free CommonJS reimplementation of `parseFileList` (the only export this call site needs). Left dependency-free (no `utils/logger.js` import) since that module isn't shipped in `plugin/` either.
- `plugin/sqlite/package.json` — `{ "type": "commonjs" }`, so Node/Bun parse the `.js` file as CommonJS despite the parent `plugin/package.json` declaring `"type": "module"` (Node resolves module type from the nearest `package.json` up the directory tree).

This is a packaging-only fix at the shipped-output level. The real fix likely belongs in the build pipeline (`src/build`) so this file gets compiled/copied automatically on release — flagging that as the more durable long-term fix, but wanted to get a working patch out first.

## Test plan

- [x] Reproduced: confirmed the exact `Cannot find module '../sqlite/observations/files.js'` error in a live worker's logs, across every project during backfill.
- [x] Simulated the exact `createRequire(pathToFileURL(worker-service.cjs).href)("../sqlite/observations/files.js")` call directly with `bun` — resolves and returns `parseFileList` correctly after the fix.
- [x] Restarted the worker for real with the fix applied: Chroma backfill succeeded end-to-end for multiple projects (`Dheva-oracle-deploy`, `aeimathes-oracle`, `aris-oracle`, `captain-maid/*`, ...) with zero module-resolution errors, where previously every single project failed at this step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)