### PR TITLE
feat(sqlite): periodically optimize FTS5 indexes to reclaim delete-marker bloat (refs #2793)

### DIFF
--- a/src/services/infrastructure/FtsMaintenance.ts
+++ b/src/services/infrastructure/FtsMaintenance.ts
@@ -1,0 +1,104 @@
+import path from 'path';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { Database } from 'bun:sqlite';
+import { DATA_DIR } from '../../shared/paths.js';
+import { logger } from '../../utils/logger.js';
+
+// FTS5 external-content indexes delete logically: removing a row appends a
+// delete-marker segment rather than reclaiming the original postings. Neither
+// VACUUM nor auto_vacuum can compact this — only an FTS 'optimize' (or
+// 'rebuild') merges the segments and drops the deleted-row content. Without it,
+// a heavy-delete install grows an unbounded shadow index: #2793 reported a
+// user_prompts_fts data table reaching ~12GB against an 18MB source table,
+// reclaimable only via the manual troubleshooting recipe. Running a throttled
+// optimize on startup makes that reclaim automatic.
+
+const MARKER_FILENAME = '.fts-optimize-applied';
+const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1000; // once per day
+
+// Constant identifiers (never user input), so interpolating them into the
+// maintenance statements below is not dynamic SQL.
+const FTS_TABLES = ['observations_fts', 'session_summaries_fts', 'user_prompts_fts'] as const;
+
+interface MarkerPayload {
+  optimizedAt: string;
+  tables: string[];
+}
+
+export interface FtsOptimizeResult {
+  optimized: boolean;
+  tables: string[];
+}
+
+function ftsTableExists(db: Database, name: string): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(name) as { name: string } | undefined;
+  return row != null;
+}
+
+function readLastOptimizedAt(markerPath: string): number | null {
+  if (!existsSync(markerPath)) return null;
+  try {
+    const payload = JSON.parse(readFileSync(markerPath, 'utf-8')) as MarkerPayload;
+    const parsed = Date.parse(payload.optimizedAt);
+    return Number.isNaN(parsed) ? null : parsed;
+  } catch {
+    // A corrupt/unreadable marker should not wedge maintenance forever — treat
+    // it as "never optimized" so the next run rewrites a clean marker.
+    return null;
+  }
+}
+
+/**
+ * Compact the app's FTS5 indexes, throttled to at most once per `intervalMs`
+ * via a marker file in the data directory. Safe to call on every worker
+ * startup: it no-ops when it ran recently and skips FTS tables that do not
+ * exist. Returns whether any table was optimized (false when throttled or when
+ * there are no FTS tables).
+ */
+export function runPeriodicFtsOptimize(
+  db: Database,
+  options: { dataDir?: string; intervalMs?: number; now?: number } = {},
+): FtsOptimizeResult {
+  const dataDir = options.dataDir ?? DATA_DIR;
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const now = options.now ?? Date.now();
+  const markerPath = path.join(dataDir, MARKER_FILENAME);
+
+  const lastOptimizedAt = readLastOptimizedAt(markerPath);
+  if (lastOptimizedAt != null && now - lastOptimizedAt < intervalMs) {
+    logger.debug('SYSTEM', 'FTS optimize skipped — ran within throttle window', {
+      lastOptimizedAt,
+      intervalMs,
+    });
+    return { optimized: false, tables: [] };
+  }
+
+  const optimized: string[] = [];
+  for (const table of FTS_TABLES) {
+    if (!ftsTableExists(db, table)) continue;
+    try {
+      db.run(`INSERT INTO ${table}(${table}) VALUES('optimize')`);
+      optimized.push(table);
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      logger.warn('SYSTEM', `FTS optimize failed for ${table}`, {}, err);
+    }
+  }
+
+  try {
+    mkdirSync(dataDir, { recursive: true });
+    const payload: MarkerPayload = { optimizedAt: new Date(now).toISOString(), tables: optimized };
+    writeFileSync(markerPath, JSON.stringify(payload, null, 2));
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    logger.warn('SYSTEM', 'Failed to write FTS optimize marker', {}, err);
+  }
+
+  if (optimized.length > 0) {
+    logger.info('SYSTEM', 'FTS indexes optimized', { tables: optimized });
+  }
+
+  return { optimized: optimized.length > 0, tables: optimized };
+}

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -47,6 +47,7 @@ import {
   touchPidFile
 } from './infrastructure/ProcessManager.js';
 import { runOneTimeV12_4_3Cleanup } from './infrastructure/CleanupV12_4_3.js';
+import { runPeriodicFtsOptimize } from './infrastructure/FtsMaintenance.js';
 import {
   isPortInUse,
   waitForHealth,
@@ -503,6 +504,15 @@ export class WorkerService implements WorkerRef {
       await this.dbManager.initialize();
 
       runOneTimeV12_4_3Cleanup();
+
+      // Reclaim FTS5 delete-marker bloat that VACUUM/auto_vacuum can't touch
+      // (refs #2793). Throttled to once/day via a marker file and wrapped so a
+      // maintenance failure never blocks worker startup.
+      try {
+        runPeriodicFtsOptimize(this.dbManager.getConnection());
+      } catch (error) {
+        logger.warn('WORKER', 'Periodic FTS optimize failed', {}, error instanceof Error ? error : undefined);
+      }
 
       logger.info('WORKER', 'Initializing search services...');
       const formattingService = new FormattingService();

--- a/tests/services/infrastructure/fts-maintenance.test.ts
+++ b/tests/services/infrastructure/fts-maintenance.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runPeriodicFtsOptimize } from '../../../src/services/infrastructure/FtsMaintenance.js';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function ftsBlockBytes(db: Database): number {
+  const row = db
+    .query('SELECT IFNULL(SUM(LENGTH(block)), 0) AS bytes FROM user_prompts_fts_data')
+    .get() as { bytes: number };
+  return row.bytes;
+}
+
+// Build a user_prompts + external-content FTS mirror, then insert-and-delete a
+// pile of rows so the FTS index accumulates delete-marker segments — the exact
+// bloat shape from #2793.
+function seedBloatedFts(db: Database): void {
+  db.run('PRAGMA journal_mode = WAL');
+  db.run('CREATE TABLE user_prompts (id INTEGER PRIMARY KEY, prompt_text TEXT)');
+  db.run(`
+    CREATE VIRTUAL TABLE user_prompts_fts USING fts5(
+      prompt_text,
+      content='user_prompts',
+      content_rowid='id'
+    )
+  `);
+  db.run(`
+    CREATE TRIGGER user_prompts_ai AFTER INSERT ON user_prompts BEGIN
+      INSERT INTO user_prompts_fts(rowid, prompt_text) VALUES (new.id, new.prompt_text);
+    END;
+    CREATE TRIGGER user_prompts_ad AFTER DELETE ON user_prompts BEGIN
+      INSERT INTO user_prompts_fts(user_prompts_fts, rowid, prompt_text) VALUES('delete', old.id, old.prompt_text);
+    END;
+  `);
+
+  const insert = db.prepare('INSERT INTO user_prompts (prompt_text) VALUES (?)');
+  const body = 'lorem ipsum dolor sit amet consectetur adipiscing elit '.repeat(200);
+  for (let i = 0; i < 400; i++) {
+    insert.run(`${body} row-${i}`);
+  }
+  db.run('DELETE FROM user_prompts');
+}
+
+describe('runPeriodicFtsOptimize', () => {
+  let tempDir: string;
+  let db: Database | null = null;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'claude-mem-fts-'));
+  });
+
+  afterEach(() => {
+    db?.close();
+    db = null;
+    try {
+      rmSync(tempDir, { force: true, recursive: true });
+    } catch (error) {
+      if (!(error instanceof Error) || !error.message.includes('EBUSY')) throw error;
+    }
+  });
+
+  it('optimizes existing FTS indexes, reclaims delete-marker bloat, and writes a marker', () => {
+    db = new Database(join(tempDir, 'fts.db'));
+    seedBloatedFts(db);
+    const before = ftsBlockBytes(db);
+    expect(before).toBeGreaterThan(0);
+
+    const result = runPeriodicFtsOptimize(db, { dataDir: tempDir, now: 1_000_000 });
+
+    expect(result.optimized).toBe(true);
+    expect(result.tables).toContain('user_prompts_fts');
+    // optimize merges the insert+delete segments, dropping deleted-row content.
+    expect(ftsBlockBytes(db)).toBeLessThan(before);
+    expect(existsSync(join(tempDir, '.fts-optimize-applied'))).toBe(true);
+  });
+
+  it('is throttled: a second run inside the interval is a no-op', () => {
+    db = new Database(join(tempDir, 'fts.db'));
+    seedBloatedFts(db);
+
+    const first = runPeriodicFtsOptimize(db, { dataDir: tempDir, now: 1_000_000, intervalMs: DAY_MS });
+    expect(first.optimized).toBe(true);
+
+    const second = runPeriodicFtsOptimize(db, { dataDir: tempDir, now: 1_000_000 + DAY_MS - 1, intervalMs: DAY_MS });
+    expect(second.optimized).toBe(false);
+    expect(second.tables).toEqual([]);
+  });
+
+  it('runs again once the interval has elapsed', () => {
+    db = new Database(join(tempDir, 'fts.db'));
+    seedBloatedFts(db);
+
+    runPeriodicFtsOptimize(db, { dataDir: tempDir, now: 1_000_000, intervalMs: DAY_MS });
+    const later = runPeriodicFtsOptimize(db, { dataDir: tempDir, now: 1_000_000 + DAY_MS + 1, intervalMs: DAY_MS });
+
+    expect(later.optimized).toBe(true);
+    expect(later.tables).toContain('user_prompts_fts');
+  });
+
+  it('skips gracefully when no FTS tables exist, still writing the marker', () => {
+    db = new Database(join(tempDir, 'fts.db'));
+    db.run('CREATE TABLE unrelated (id INTEGER PRIMARY KEY)');
+
+    const result = runPeriodicFtsOptimize(db, { dataDir: tempDir, now: 1_000_000 });
+
+    expect(result.optimized).toBe(false);
+    expect(result.tables).toEqual([]);
+    const marker = JSON.parse(readFileSync(join(tempDir, '.fts-optimize-applied'), 'utf-8'));
+    expect(marker.tables).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

FTS5 external-content indexes delete **logically** — removing a row appends a delete-marker segment rather than reclaiming the original postings. Neither `VACUUM` nor `auto_vacuum` can compact this; only an FTS `'optimize'` (or `'rebuild'`) merges the segments and drops the deleted-row content. claude-mem never runs `'optimize'` outside migrations, so a heavy-delete install grows an **unbounded shadow index that survives every other reclaim path**.

This is a **distinct root cause** from the incremental-`auto_vacuum` work already on `main`:

- On a real install (relevant to #2793), `user_prompts_fts_data` reached **~12.3 GB against an 18 MB `user_prompts` source table**. The source rows had already been cleaned up; the bloat was entirely stale FTS postings.
- `auto_vacuum = INCREMENTAL` and `incremental_vacuum` could only reclaim the ~1 GB freelist — they can't touch FTS segment bloat.
- After `INSERT INTO user_prompts_fts(user_prompts_fts) VALUES('optimize')` + `VACUUM`, the same DB dropped **~14 GB → ~140 MB** with `observations`/`session_summaries`/`user_prompts` fully intact and `PRAGMA quick_check` clean.

The rebuild recipe is currently only documented manually in `troubleshooting.mdx`; this makes the reclaim automatic.

## Change

`runPeriodicFtsOptimize(db, opts)` in `src/services/infrastructure/FtsMaintenance.ts`:

- Runs `'optimize'` on each **existing** FTS index (`observations_fts`, `session_summaries_fts`, `user_prompts_fts`); missing tables are skipped.
- **Throttled to once/day** via a `.fts-optimize-applied` marker file, mirroring the `CleanupV12_4_3` marker pattern — cheap to call on every startup.
- A corrupt/unreadable marker is treated as "never optimized" so maintenance can't wedge itself.
- Table names are a constant array (never user input), so the interpolated statements are not dynamic SQL.

Wired into `worker-service.ts` startup right after `runOneTimeV12_4_3Cleanup()`, using the shared connection (`dbManager.getConnection()`), wrapped in try/catch so a maintenance failure never blocks startup.

## Tests

`tests/services/infrastructure/fts-maintenance.test.ts` (TDD, 4 cases):
- **Reclaim**: seed an external-content FTS, insert 400 rows → delete all → `SUM(LENGTH(block))` shrinks after optimize; marker written.
- **Throttle**: a second run inside the interval is a no-op; runs again once the interval elapses.
- **No-FTS-tables**: skips gracefully and still writes the marker.

`npm run typecheck` clean; `npm run build` OK; local `bun test` across infrastructure + worker + sqlite suites: **300 pass / 0 fail**. Source + test only (built artifacts excluded; CI rebuilds them).