### PR TITLE
fix(search): fall back to FTS5 when Chroma has no usable matches

### DIFF
--- a/src/services/worker/SearchManager.ts
+++ b/src/services/worker/SearchManager.ts
@@ -401,9 +401,9 @@ export class SearchManager {
           platformSource: options.platformSource
         });
       }
-    } else {
-      if (options.platformSource) {
-        logger.debug('SEARCH', 'Platform-scoped ChromaDB search found no matches; falling back to scoped FTS5 search', {});
+
+      if (obsIds.length === 0 && sessionIds.length === 0 && promptIds.length === 0) {
+        logger.debug('SEARCH', 'ChromaDB matches did not survive date filtering; falling back to FTS5 search', {});
         platformScopedChromaZeroFallback = true;
 
         if (searchObservations) {
@@ -415,8 +415,19 @@ export class SearchManager {
         if (searchPrompts) {
           prompts = this.sessionSearch.searchUserPrompts(query, options);
         }
-      } else {
-        logger.debug('SEARCH', 'ChromaDB found no matches (final result, no FTS5 fallback)', {});
+      }
+    } else {
+      logger.debug('SEARCH', 'ChromaDB search found no matches; falling back to FTS5 search', {});
+      platformScopedChromaZeroFallback = true;
+
+      if (searchObservations) {
+        observations = this.sessionSearch.searchObservations(query, { ...options, type: obs_type, concepts, files });
+      }
+      if (searchSessions) {
+        sessions = this.sessionSearch.searchSessions(query, options);
+      }
+      if (searchPrompts) {
+        prompts = this.sessionSearch.searchUserPrompts(query, options);
       }
     }
 

--- a/tests/worker/search-manager.test.ts
+++ b/tests/worker/search-manager.test.ts
@@ -374,8 +374,26 @@ describe('SearchManager platform-scoped Chroma hydration', () => {
     }));
   });
 
-  it('keeps unscoped Chroma zero matches final without SQLite/FTS fallback', async () => {
-    const searchObservations = mock(() => []);
+  it('falls back to unscoped SQLite/FTS when unscoped Chroma returns zero matches', async () => {
+    const observation = {
+      id: 12,
+      memory_session_id: 'unscoped-memory-id',
+      project: 'search-project',
+      text: null,
+      type: 'discovery',
+      title: 'unscoped fallback observation',
+      subtitle: null,
+      facts: '[]',
+      narrative: 'unscoped fallback narrative',
+      concepts: '[]',
+      files_read: '[]',
+      files_modified: '[]',
+      prompt_number: 1,
+      discovery_tokens: 0,
+      created_at: new Date().toISOString(),
+      created_at_epoch: Date.now(),
+    };
+    const searchObservations = mock(() => [observation]);
     const searchSessions = mock(() => []);
     const searchUserPrompts = mock(() => []);
     const queryChroma = mock(() => Promise.resolve({
@@ -406,20 +424,85 @@ describe('SearchManager platform-scoped Chroma hydration', () => {
       format: 'json',
     }, telemetry);
 
-    expect(searchObservations).not.toHaveBeenCalled();
-    expect(searchSessions).not.toHaveBeenCalled();
-    expect(searchUserPrompts).not.toHaveBeenCalled();
+    expect(searchObservations).toHaveBeenCalledWith('legacy metadata', expect.objectContaining({}));
     expect(result).toEqual(expect.objectContaining({
-      observations: [],
-      sessions: [],
-      prompts: [],
-      totalResults: 0,
+      observations: [observation],
+      totalResults: 1,
     }));
     expect(telemetry).toEqual(expect.objectContaining({
-      result_count: 0,
-      search_strategy: 'chroma',
+      result_count: 1,
+      search_strategy: 'fts',
       chroma_available: true,
-      fallback_reason: 'none',
+      fallback_reason: 'chroma_error',
+    }));
+  });
+
+  it('falls back to FTS5 when Chroma returns candidates but none survive the date-range filter', async () => {
+    const observation = {
+      id: 13,
+      memory_session_id: 'old-memory-id',
+      project: 'search-project',
+      text: null,
+      type: 'discovery',
+      title: 'old glossary observation',
+      subtitle: null,
+      facts: '[]',
+      narrative: 'old glossary narrative',
+      concepts: '[]',
+      files_read: '[]',
+      files_modified: '[]',
+      prompt_number: 1,
+      discovery_tokens: 0,
+      created_at: new Date(0).toISOString(),
+      created_at_epoch: 0,
+    };
+    const searchObservations = mock(() => [observation]);
+    const searchSessions = mock(() => []);
+    const searchUserPrompts = mock(() => []);
+    // Chroma returns a non-empty candidate set (nearest-neighbor match on
+    // today's unrelated session content), but its created_at_epoch is
+    // "today" -- entirely outside the caller's requested historical
+    // dateRange, so it must be filtered out by the recency check.
+    const queryChroma = mock(() => Promise.resolve({
+      ids: [999],
+      distances: [0.2],
+      metadatas: [{
+        sqlite_id: 999,
+        doc_type: 'observation',
+        project: 'search-project',
+        created_at_epoch: Date.now(),
+      }],
+    }));
+
+    const manager = new SearchManager(
+      {
+        searchObservations,
+        searchSessions,
+        searchUserPrompts,
+      } as any,
+      {
+        getObservationsByIds: mock(() => []),
+        getSessionSummariesByIds: mock(() => []),
+        getUserPromptsByIds: mock(() => []),
+      } as any,
+      { queryChroma } as any,
+      {} as any,
+      {} as any,
+    );
+
+    const result = await manager.search({
+      query: 'glossary',
+      project: 'search-project',
+      dateRange: { start: '2020-01-01', end: '2020-12-31' },
+      format: 'json',
+    });
+
+    expect(searchObservations).toHaveBeenCalledWith('glossary', expect.objectContaining({
+      project: 'search-project',
+    }));
+    expect(result).toEqual(expect.objectContaining({
+      observations: [observation],
+      totalResults: 1,
     }));
   });
 });


### PR DESCRIPTION
## Summary

\`SearchManager.performChromaSemanticSearch\` had two related gaps that left SQLite/FTS5 — which has correct, complete data — never consulted as a safety net for Chroma's incomplete coverage:

1. **Zero raw Chroma matches**: fallback to FTS5 only fired when `options.platformSource` was set. The common unscoped case (no `platformSource`) returned empty instead of falling back.
2. **Non-zero raw Chroma matches, but all filtered out by the recency window** (explicit `dateRange`, or the 90-day default): no fallback existed at all. In practice this is the *dominant* path — Chroma's nearest-neighbor search rarely returns literally zero candidates for any query across the full collection, so gap (1) alone doesn't cover most real cases.

Both surface whenever a project's Chroma coverage is incomplete — e.g. via the backfill crash in #3126 (partially fixed by #3146). Any observation that depended on backfill to reach Chroma stays invisible to `search` regardless of `platformSource` or date scoping, even though it's sitting correctly in SQLite.

Relates to #3126 ("Bug 2" in that report — `search` appearing to ignore its `query` parameter — was left as a follow-up with no dedicated issue).

## Verification

Reproduced against a real project: 13k+ SQLite observations, but only ~350 Chroma-embedded documents (incomplete backfill coverage). Historical queries returned empty even after fixing gap (1) alone — confirmed via direct SQLite comparison and via the live worker — until gap (2) was patched too. After both fixes, date-scoped and unscoped historical queries correctly surface real data.

- Existing test that asserted gap (1)'s behavior as *intended* (`searchObservations` should not be called on unscoped zero-match Chroma) rewritten to assert the corrected behavior.
- New test added reproducing gap (2): Chroma returns a non-empty but entirely out-of-range candidate set; asserts the FTS5 fallback now fires.
- `bun test tests/worker/search-manager.test.ts`: 7 pass, 0 fail.
- `bun test tests/worker/search/`: 41 pass, 0 fail.
- Full suite `bun test`: 2288 pass, 0 fail, 15 pre-existing unrelated skips.

## Test plan

- [x] Unit tests updated/added and passing
- [x] Full repo test suite passes with no regressions
- [x] Manually verified against a real installed copy with a live worker restart, confirming previously-missing historical observations now surface for both date-scoped and unscoped queries