### PR TITLE
fix(worker): search(type=<custom>) drops custom observation types

### DIFF
--- a/src/services/worker/SearchManager.ts
+++ b/src/services/worker/SearchManager.ts
@@ -425,7 +425,7 @@ export class SearchManager {
 
   async search(args: any, telemetryOut?: SearchTelemetryEnvelope): Promise<any> {
     const normalized = this.normalizeParams(args);
-    const { query, type, obs_type, concepts, files, format, ...options } = normalized;
+    const { query, type: rawType, obs_type: rawObsType, concepts, files, format, ...options } = normalized;
     let observations: ObservationSearchResult[] = [];
     let sessions: SessionSummarySearchResult[] = [];
     let prompts: UserPromptSearchResult[] = [];
@@ -433,9 +433,25 @@ export class SearchManager {
     let platformScopedChromaZeroFallback = false;
     let chromaFailureReason: { message: string; isConnectionError: boolean } | null = null;
 
-    const searchObservations = !type || type === 'observations';
-    const searchSessions = !type || type === 'sessions';
-    const searchPrompts = !type || type === 'prompts';
+    // `type` is overloaded: as a doc-type SELECTOR it picks which corpora to
+    // search (observations/sessions/prompts); the MCP tool also documents it as
+    // "Filter by observation type". A `type` value that is not one of the three
+    // reserved selectors (e.g. a custom mode's `correction`, or a built-in like
+    // `bugfix`) is therefore an observation-type FILTER, not a selector. Route
+    // it into obs_type and scope the search to observations, otherwise it fails
+    // all three selector checks below and silently returns zero results (#3279).
+    const DOC_TYPE_SELECTORS = ['observations', 'sessions', 'prompts'];
+    const typeIsObsFilter = typeof rawType === 'string' && !DOC_TYPE_SELECTORS.includes(rawType);
+    const type = typeIsObsFilter ? undefined : rawType;
+    const obs_type = typeIsObsFilter
+      ? (rawObsType === undefined
+          ? rawType
+          : (Array.isArray(rawObsType) ? rawObsType : [rawObsType]).concat(rawType))
+      : rawObsType;
+
+    const searchObservations = typeIsObsFilter || !type || type === 'observations';
+    const searchSessions = !typeIsObsFilter && (!type || type === 'sessions');
+    const searchPrompts = !typeIsObsFilter && (!type || type === 'prompts');
 
     if (!query) {
       logger.debug('SEARCH', 'Filter-only query (no query text), using direct SQLite filtering', { enablesDateFilters: true });

--- a/tests/worker/search-manager.test.ts
+++ b/tests/worker/search-manager.test.ts
@@ -423,3 +423,73 @@ describe('SearchManager platform-scoped Chroma hydration', () => {
     }));
   });
 });
+
+describe('SearchManager type= observation-type filtering (#3279)', () => {
+  // Build a Chroma-less manager (FTS path) with recording mocks so we can
+  // assert exactly which corpus the search hit and with which filters.
+  const makeManager = (obs: any[]) => {
+    const searchObservations = mock(() => obs);
+    const searchSessions = mock(() => []);
+    const searchUserPrompts = mock(() => []);
+    const manager = new SearchManager(
+      { searchObservations, searchSessions, searchUserPrompts } as any,
+      {
+        getObservationsByIds: mock(() => []),
+        getSessionSummariesByIds: mock(() => []),
+        getUserPromptsByIds: mock(() => []),
+      } as any,
+      null as any, // no Chroma -> FTS keyword path
+      {} as any,
+      {} as any,
+    );
+    return { manager, searchObservations, searchSessions, searchUserPrompts };
+  };
+
+  it('treats a custom type as an observation-type filter, not a doc-type selector', async () => {
+    const observation = {
+      id: 42,
+      type: 'correction',
+      title: 'a captured correction',
+      created_at: new Date().toISOString(),
+      created_at_epoch: Date.now(),
+    };
+    const { manager, searchObservations, searchSessions, searchUserPrompts } = makeManager([observation]);
+
+    const result = await manager.search({
+      query: 'captured',
+      type: 'correction', // custom mode type, not observations/sessions/prompts
+      format: 'json',
+      limit: 10,
+    });
+
+    // Before the fix, `type='correction'` failed all three doc-type selector
+    // checks, so no corpus was searched and zero results came back.
+    expect(searchObservations).toHaveBeenCalledTimes(1);
+    expect(searchObservations).toHaveBeenCalledWith('captured', expect.objectContaining({
+      type: 'correction',
+    }));
+    expect(searchSessions).not.toHaveBeenCalled();
+    expect(searchUserPrompts).not.toHaveBeenCalled();
+    expect(result.observations).toEqual([observation]);
+    expect(result.totalResults).toBe(1);
+  });
+
+  it('still treats reserved doc-type selectors (observations) as selectors', async () => {
+    const { manager, searchObservations, searchSessions, searchUserPrompts } = makeManager([]);
+
+    await manager.search({
+      query: 'anything',
+      type: 'observations',
+      format: 'json',
+    });
+
+    // 'observations' is a selector: observations searched, but the obs-type
+    // filter must NOT be set to the literal string 'observations'.
+    expect(searchObservations).toHaveBeenCalledTimes(1);
+    expect(searchObservations).toHaveBeenCalledWith('anything', expect.objectContaining({
+      type: undefined,
+    }));
+    expect(searchSessions).not.toHaveBeenCalled();
+    expect(searchUserPrompts).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## The bug

On the **worker runtime**, the MCP `search` tool's `type` parameter is documented as *"Filter by observation type"*, but filtering by a **custom** observation type (one added via a custom mode, e.g. `correction`, rather than a built-in like `bugfix`/`feature`/`refactor`/…) returns **zero results** — even though the same observations are found by free-text search.

Closes #3279.

## Root cause

`type` is overloaded. In `SearchManager.search()` it is consumed only as a **doc-type selector** with three reserved values — `observations` / `sessions` / `prompts`:

```ts
const searchObservations = !type || type === 'observations';
const searchSessions     = !type || type === 'sessions';
const searchPrompts      = !type || type === 'prompts';
```

When a caller follows the tool's documented meaning and passes `type="correction"` (any value that is not one of those three selectors), **all three** flags evaluate to `false`, so no corpus is searched and the call silently returns nothing. The actual observation-type filter (`o.type = ?` in `SessionSearch.buildFilterClause`) is only reachable via the separate, less-obvious `obs_type` param — so custom types are effectively unfilterable via the documented `type` argument.

This is a dropped-parameter passthrough bug: a non-selector `type` never reaches the observation-type WHERE clause.

## The fix

In `SearchManager.search()`, distinguish the reserved doc-type **selectors** from an observation-type **filter**. A `type` value that is not `observations`/`sessions`/`prompts` is treated as an observation-type filter: it is routed into `obs_type` (which already threads into the SQL `o.type = ?` clause) and the search is scoped to observations. Reserved selectors keep their existing meaning unchanged.

Minimal, one-path change — no refactor, no new params, no schema change.

## Scope note (worker vs server)

There are two runtimes. The reporter uses the **worker** path (`/api/search` → `handleUnifiedSearch` → `SearchManager.search`), which is where the defect lives and where this fix applies.

The **server** path (`observation_search` → `/v1/search` → `buildSearchPayload`) does **not** expose a `type` parameter anywhere in its chain — not in the MCP tool schema, the request type, the client payload builder, the zod route schema, or the Postgres repo. Adding type filtering there would be a new multi-layer feature rather than a passthrough fix, so it is intentionally out of scope for this bug.

## Verification

- Added two focused tests in `tests/worker/search-manager.test.ts`:
  - `search(query, type="correction")` now searches observations with the obs-type filter set to `correction`, and does **not** search sessions/prompts. Confirmed this test **fails on the pre-fix code** (0 calls to `searchObservations`, reproducing the zero-results bug) and **passes** with the fix.
  - Reserved selector `type="observations"` still behaves as a selector (searches observations, obs-type filter unset).
- `bun test tests/worker/` — 244 pass, 0 fail.
- `tsc --noEmit` — clean (0 errors project-wide).