### PR TITLE
fix(worker): self-heal when Claude CLI becomes unspawnable after auto-update

### DIFF
--- a/src/services/infrastructure/ProcessManager.ts
+++ b/src/services/infrastructure/ProcessManager.ts
@@ -565,6 +565,14 @@ export function spawnDaemon(
     ? [runtimePath, scriptPath, '--daemon']
     : [scriptPath, '--daemon'];
 
+  // Pin the daemon's cwd to the claude-mem data dir (daemonWorkingDirectory).
+  // The daemon outlives the session that spawned it, but an inherited cwd can
+  // vanish underneath it: spawn one from inside a git worktree and remove the
+  // worktree, and every later child spawn in the daemon fails with ENOENT even
+  // though the binary is fine (the second trigger of the #3290 wedge). A
+  // pinned cwd also keeps the self-heal restart effective: without it the
+  // successor inherits the same dead directory and re-wedges against its
+  // restart budget.
   const child = spawnHidden(execPath, args, {
     detached: true,
     stdio: 'ignore',

--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -30,6 +30,7 @@ import { ClassifiedProviderError } from './provider-errors.js';
 import { resolveTierAlias } from './model-aliases.js';
 import { telemetryBuffer } from '../telemetry/buffer.js';
 import { clearDependencyStatus, recordClaudeCliSetupRequired } from '../../shared/dependency-health.js';
+import { clearClaudeCliSelfHealAttempts } from './stale-spawn-recovery.js';
 
 /**
  * Module-scoped guard so the "effort parameter" hint only fires once per
@@ -180,6 +181,7 @@ export class ClaudeProvider {
     try {
       claudePath = findClaudeExecutable('SDK');
       clearDependencyStatus('claude_cli');
+      clearClaudeCliSelfHealAttempts();
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       const classified = classifyClaudeError(err);

--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -39,6 +39,7 @@ import { optimizeObservationFields, buildFieldCompressionPrompt, type FieldCompr
 import { telemetryBuffer } from '../telemetry/buffer.js';
 import { captureEvent } from '../telemetry/telemetry.js';
 import { clearDependencyStatus, recordClaudeCliSetupRequired } from '../../shared/dependency-health.js';
+import { clearClaudeCliSelfHealAttempts } from './stale-spawn-recovery.js';
 
 /**
  * Module-scoped guard so the "effort parameter" hint only fires once per
@@ -218,6 +219,7 @@ export class ClaudeProvider {
     try {
       claudePath = findClaudeExecutable('SDK');
       clearDependencyStatus('claude_cli');
+      clearClaudeCliSelfHealAttempts();
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       const classified = classifyClaudeError(err);

--- a/src/services/worker/dependency-preflight.ts
+++ b/src/services/worker/dependency-preflight.ts
@@ -11,6 +11,7 @@ import {
   snapshotDependencyHealth,
   type DependencyHealthSnapshot,
 } from '../../shared/dependency-health.js';
+import { clearClaudeCliSelfHealAttempts } from './stale-spawn-recovery.js';
 
 interface DependencyPreflightSettings {
   CLAUDE_MEM_PROVIDER?: string;
@@ -163,6 +164,7 @@ export function runWorkerDependencyPreflight(options: WorkerDependencyPreflightO
     try {
       findClaudeExecutable();
       clearDependencyStatus('claude_cli');
+      clearClaudeCliSelfHealAttempts();
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       const classified = options.classifyClaudeError(error);

--- a/src/services/worker/dependency-preflight.ts
+++ b/src/services/worker/dependency-preflight.ts
@@ -13,6 +13,7 @@ import {
   snapshotDependencyHealth,
   type DependencyHealthSnapshot,
 } from '../../shared/dependency-health.js';
+import { clearClaudeCliSelfHealAttempts } from './stale-spawn-recovery.js';
 
 interface DependencyPreflightSettings {
   CLAUDE_MEM_PROVIDER?: string;
@@ -167,6 +168,7 @@ export function runWorkerDependencyPreflight(options: WorkerDependencyPreflightO
     try {
       findClaudeExecutable();
       clearDependencyStatus('claude_cli');
+      clearClaudeCliSelfHealAttempts();
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       const classified = options.classifyClaudeError(error);

--- a/src/services/worker/http/routes/SessionRoutes.ts
+++ b/src/services/worker/http/routes/SessionRoutes.ts
@@ -28,9 +28,16 @@ import {
   isDependencyStatusInCooldown,
   recordClaudeCliSetupRequired,
 } from '../../../../shared/dependency-health.js';
-import { findClaudeExecutable } from '../../../../shared/find-claude-executable.js';
-import { isClassified } from '../../provider-errors.js';
+import { findClaudeExecutable, isClaudeExecutableUnspawnable } from '../../../../shared/find-claude-executable.js';
+import { isClassified, ClassifiedProviderError } from '../../provider-errors.js';
 import { classifyClaudeError } from '../../ClaudeProvider.js';
+import {
+  canAttemptClaudeCliSelfHeal,
+  recordClaudeCliSelfHealAttempt,
+  clearClaudeCliSelfHealAttempts,
+  claudeCliSelfHealAttemptsInWindow,
+  SELF_HEAL_MAX_ATTEMPTS,
+} from '../../stale-spawn-recovery.js';
 
 const MAX_USER_PROMPT_BYTES = 256 * 1024;
 
@@ -66,11 +73,57 @@ export class SessionRoutes extends BaseRouteHandler {
     super();
   }
 
+  /**
+   * A worker process self-heals the stale-Claude-spawn wedge at most once: the
+   * restart replaces this process, so concurrent sessions hitting the same wedge
+   * must not each burn a slot in the per-generation persistent budget.
+   */
+  private claudeSelfHealTriggered = false;
+
   private getSelectedProvider(): 'claude' | 'gemini' | 'openrouter' {
     if (isOpenRouterSelected() && isOpenRouterAvailable()) {
       return 'openrouter';
     }
     return (isGeminiSelected() && isGeminiAvailable()) ? 'gemini' : 'claude';
+  }
+
+  /**
+   * When the Claude CLI is present on disk but this worker process can no longer
+   * spawn it (ENOENT after a CLI auto-update swapped the binary underneath a
+   * long-running process), an in-process re-probe can never recover — only a
+   * fresh process can. Self-restart the worker via the successor-handoff path,
+   * bounded by a cross-process-persistent budget so a genuinely broken install
+   * cannot thrash. Returns true when a restart was triggered.
+   */
+  private maybeSelfHealStaleClaudeSpawn(error: unknown, source: string, sessionDbId: number): boolean {
+    const cause = isClassified(error) ? (error as ClassifiedProviderError).cause : undefined;
+    const unspawnable = isClaudeExecutableUnspawnable(error) || isClaudeExecutableUnspawnable(cause);
+    if (!unspawnable) return false;
+
+    // Restart already scheduled by an earlier session in this process — the
+    // successor will re-resolve the CLI; do not record another attempt.
+    if (this.claudeSelfHealTriggered) return true;
+
+    if (!canAttemptClaudeCliSelfHeal()) {
+      logger.warn('SESSION', 'Claude CLI present but unspawnable; self-heal restart budget exhausted — leaving in setup_required (restart claude-mem manually / verify the CLI)', {
+        sessionId: sessionDbId,
+        source,
+        attemptsInWindow: claudeCliSelfHealAttemptsInWindow(),
+        maxAttempts: SELF_HEAL_MAX_ATTEMPTS,
+      });
+      return false;
+    }
+
+    const attempt = recordClaudeCliSelfHealAttempt();
+    logger.warn('SESSION', 'Claude CLI present on disk but unspawnable from this worker (stale process after CLI auto-update) — self-restarting to recover', {
+      sessionId: sessionDbId,
+      source,
+      selfHealAttempt: attempt,
+      maxAttempts: SELF_HEAL_MAX_ATTEMPTS,
+    });
+    this.claudeSelfHealTriggered = true;
+    void this.workerService.shutdown('restart');
+    return true;
   }
 
   public async ensureGeneratorRunning(sessionDbId: number, source: string): Promise<void> {
@@ -97,11 +150,13 @@ export class SessionRoutes extends BaseRouteHandler {
           try {
             findClaudeExecutable('SDK');
             clearDependencyStatus('claude_cli');
+            clearClaudeCliSelfHealAttempts();
             logger.info('SESSION', 'Claude setup dependency repaired; resuming generator start', {
               sessionId: sessionDbId,
               source,
             });
           } catch (error) {
+            if (this.maybeSelfHealStaleClaudeSpawn(error, source, sessionDbId)) return;
             const err = error instanceof Error ? error : new Error(String(error));
             const classified = classifyClaudeError(error);
             if (classified.kind === 'setup_required') {
@@ -180,6 +235,7 @@ export class SessionRoutes extends BaseRouteHandler {
         if (provider === 'claude' && isClassified(error) && error.kind === 'setup_required') {
           skipGeneratorExitFinalization = true;
           recordClaudeCliSetupRequired(error.message);
+          this.maybeSelfHealStaleClaudeSpawn(error, source, session.sessionDbId);
           logger.warn('SESSION', 'Claude generator start requires setup; future Claude starts will be skipped until repaired', {
             sessionId: session.sessionDbId,
             provider,

--- a/src/services/worker/http/routes/SessionRoutes.ts
+++ b/src/services/worker/http/routes/SessionRoutes.ts
@@ -31,7 +31,7 @@ import {
   isDependencyStatusInCooldown,
   recordClaudeCliSetupRequired,
 } from '../../../../shared/dependency-health.js';
-import { findClaudeExecutable } from '../../../../shared/find-claude-executable.js';
+import { findClaudeExecutable, isClaudeExecutableUnspawnable } from '../../../../shared/find-claude-executable.js';
 import { recordObserverFailure } from '../../../../shared/observer-health.js';
 import {
   tryAdmitQuotaProbe,
@@ -40,9 +40,16 @@ import {
   getQuotaCooldown,
   QUOTA_EXHAUSTED_RECHECK_COOLDOWN_MS,
 } from '../../../../shared/quota-cooldown.js';
-import { isClassified, describeProviderError } from '../../provider-errors.js';
+import { isClassified, ClassifiedProviderError, describeProviderError } from '../../provider-errors.js';
 import { classifyClaudeError } from '../../ClaudeProvider.js';
 import { isSessionParkedForSlot } from '../../../../supervisor/process-registry.js';
+import {
+  canAttemptClaudeCliSelfHeal,
+  recordClaudeCliSelfHealAttempt,
+  clearClaudeCliSelfHealAttempts,
+  claudeCliSelfHealAttemptsInWindow,
+  SELF_HEAL_MAX_ATTEMPTS,
+} from '../../stale-spawn-recovery.js';
 
 const MAX_USER_PROMPT_BYTES = 256 * 1024;
 
@@ -92,6 +99,52 @@ export class SessionRoutes extends BaseRouteHandler {
     private completionHandler: SessionCompletionHandler,
   ) {
     super();
+  }
+
+  /**
+   * A worker process self-heals the stale-Claude-spawn wedge at most once: the
+   * restart replaces this process, so concurrent sessions hitting the same wedge
+   * must not each burn a slot in the per-generation persistent budget.
+   */
+  private claudeSelfHealTriggered = false;
+
+  /**
+   * When the Claude CLI is present on disk but this worker process can no longer
+   * spawn it (ENOENT after a CLI auto-update swapped the binary underneath a
+   * long-running process), an in-process re-probe can never recover — only a
+   * fresh process can. Self-restart the worker via the successor-handoff path,
+   * bounded by a cross-process-persistent budget so a genuinely broken install
+   * cannot thrash. Returns true when a restart was triggered.
+   */
+  private maybeSelfHealStaleClaudeSpawn(error: unknown, source: string, sessionDbId: number): boolean {
+    const cause = isClassified(error) ? (error as ClassifiedProviderError).cause : undefined;
+    const unspawnable = isClaudeExecutableUnspawnable(error) || isClaudeExecutableUnspawnable(cause);
+    if (!unspawnable) return false;
+
+    // Restart already scheduled by an earlier session in this process — the
+    // successor will re-resolve the CLI; do not record another attempt.
+    if (this.claudeSelfHealTriggered) return true;
+
+    if (!canAttemptClaudeCliSelfHeal()) {
+      logger.warn('SESSION', 'Claude CLI present but unspawnable; self-heal restart budget exhausted — leaving in setup_required (restart claude-mem manually / verify the CLI)', {
+        sessionId: sessionDbId,
+        source,
+        attemptsInWindow: claudeCliSelfHealAttemptsInWindow(),
+        maxAttempts: SELF_HEAL_MAX_ATTEMPTS,
+      });
+      return false;
+    }
+
+    const attempt = recordClaudeCliSelfHealAttempt();
+    logger.warn('SESSION', 'Claude CLI present on disk but unspawnable from this worker (stale process after CLI auto-update) — self-restarting to recover', {
+      sessionId: sessionDbId,
+      source,
+      selfHealAttempt: attempt,
+      maxAttempts: SELF_HEAL_MAX_ATTEMPTS,
+    });
+    this.claudeSelfHealTriggered = true;
+    void this.workerService.shutdown('restart');
+    return true;
   }
 
   public ensureGeneratorRunning(sessionDbId: number, source: string): Promise<void> {
@@ -171,11 +224,13 @@ export class SessionRoutes extends BaseRouteHandler {
           try {
             findClaudeExecutable('SDK');
             clearDependencyStatus('claude_cli');
+            clearClaudeCliSelfHealAttempts();
             logger.info('SESSION', 'Claude setup dependency repaired; resuming generator start', {
               sessionId: sessionDbId,
               source,
             });
           } catch (error) {
+            if (this.maybeSelfHealStaleClaudeSpawn(error, source, sessionDbId)) return;
             const err = error instanceof Error ? error : new Error(String(error));
             const classified = classifyClaudeError(error);
             if (classified.kind === 'setup_required') {
@@ -348,6 +403,7 @@ export class SessionRoutes extends BaseRouteHandler {
         if (provider === 'claude' && isClassified(error) && error.kind === 'setup_required') {
           skipGeneratorExitFinalization = true;
           recordClaudeCliSetupRequired(error.message);
+          this.maybeSelfHealStaleClaudeSpawn(error, source, session.sessionDbId);
           logger.warn('SESSION', 'Claude generator start requires setup; future Claude starts will be skipped until repaired', {
             sessionId: session.sessionDbId,
             provider,

--- a/src/services/worker/http/routes/SessionRoutes.ts
+++ b/src/services/worker/http/routes/SessionRoutes.ts
@@ -230,7 +230,18 @@ export class SessionRoutes extends BaseRouteHandler {
               source,
             });
           } catch (error) {
-            if (this.maybeSelfHealStaleClaudeSpawn(error, source, sessionDbId)) return;
+            if (this.maybeSelfHealStaleClaudeSpawn(error, source, sessionDbId)) {
+              // The self-heal restart can be delayed or fail to hand off, and a
+              // second session hitting the already-triggered flag returns here
+              // while the first restart is still pending — in any of those
+              // windows this worker keeps running. No generator is started to
+              // carry the claim, so release it now like every other early
+              // return in this block; otherwise the gateway probe stays
+              // in-flight and suppresses later gateway checks in a worker that
+              // survived its own restart trigger.
+              releaseCmemGatewayProbe(selection.gatewayProbeClaimId);
+              return;
+            }
             const err = error instanceof Error ? error : new Error(String(error));
             const classified = classifyClaudeError(error);
             if (classified.kind === 'setup_required') {

--- a/src/services/worker/stale-spawn-recovery.ts
+++ b/src/services/worker/stale-spawn-recovery.ts
@@ -1,0 +1,63 @@
+/**
+ * Persistent, cross-process self-heal restart budget for the Claude CLI
+ * stale-spawn wedge (issue #3290).
+ *
+ * When a long-running worker can no longer `posix_spawn` the `claude` CLI
+ * after Claude Code's native auto-updater swaps the binary underneath it,
+ * the CLI is present and valid on disk but `execFileSync` from the wedged
+ * worker throws ENOENT forever. Only a fresh process can recover. The
+ * SessionRoutes layer detects this (via ClaudeExecutableUnspawnableError)
+ * and self-restarts the worker — but a genuinely broken install must not
+ * thrash. This module bounds the restarts: at most
+ * {@link SELF_HEAL_MAX_ATTEMPTS} attempts within a sliding
+ * {@link SELF_HEAL_WINDOW_MS} window, persisted to disk so a restart loop
+ * across worker generations cannot exceed the budget.
+ *
+ * All IO here is best-effort: every read/write swallows errors and degrades
+ * to an empty budget. Persisting self-heal state must never break the worker.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { DATA_DIR } from '../../shared/paths.js';
+import { logger } from '../../utils/logger.js';
+
+const SELF_HEAL_STATE_PATH = path.join(DATA_DIR, 'state', 'claude-cli-selfheal.json');
+export const SELF_HEAL_WINDOW_MS = 60 * 60_000;   // 1 hour
+export const SELF_HEAL_MAX_ATTEMPTS = 3;
+
+interface SelfHealState { attempts: number[]; }
+
+function readAttempts(): number[] {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(SELF_HEAL_STATE_PATH, 'utf8')) as SelfHealState;
+    return Array.isArray(parsed?.attempts) ? parsed.attempts.filter(n => typeof n === 'number') : [];
+  } catch { return []; }
+}
+function writeAttempts(attempts: number[]): void {
+  try {
+    fs.mkdirSync(path.dirname(SELF_HEAL_STATE_PATH), { recursive: true });
+    fs.writeFileSync(SELF_HEAL_STATE_PATH, JSON.stringify({ attempts }));
+  } catch (e) {
+    logger.warn('WORKER', 'Failed to persist Claude CLI self-heal state', {}, e instanceof Error ? e : new Error(String(e)));
+  }
+}
+function prune(attempts: number[], nowMs: number): number[] {
+  return attempts.filter(t => nowMs - t < SELF_HEAL_WINDOW_MS);
+}
+
+export function claudeCliSelfHealAttemptsInWindow(nowMs: number = Date.now()): number {
+  return prune(readAttempts(), nowMs).length;
+}
+export function canAttemptClaudeCliSelfHeal(nowMs: number = Date.now()): boolean {
+  return claudeCliSelfHealAttemptsInWindow(nowMs) < SELF_HEAL_MAX_ATTEMPTS;
+}
+export function recordClaudeCliSelfHealAttempt(nowMs: number = Date.now()): number {
+  const attempts = prune(readAttempts(), nowMs);
+  attempts.push(nowMs);
+  writeAttempts(attempts);
+  return attempts.length;
+}
+export function clearClaudeCliSelfHealAttempts(): void {
+  try { fs.rmSync(SELF_HEAL_STATE_PATH, { force: true }); } catch { /* best effort */ }
+}

--- a/src/services/worker/stale-spawn-recovery.ts
+++ b/src/services/worker/stale-spawn-recovery.ts
@@ -15,6 +15,12 @@
  *
  * All IO here is best-effort: every read/write swallows errors and degrades
  * to an empty budget. Persisting self-heal state must never break the worker.
+ *
+ * The budget clears on every successful CLI resolution — including the
+ * successor worker's own boot — so each distinct wedge (at most one per CLI
+ * auto-update) gets a fresh budget. The cap therefore only bites when a fresh
+ * process cannot resolve the CLI either (genuinely broken install), which is
+ * exactly the case that must not thrash.
  */
 
 import fs from 'fs';
@@ -31,13 +37,17 @@ interface SelfHealState { attempts: number[]; }
 function readAttempts(): number[] {
   try {
     const parsed = JSON.parse(fs.readFileSync(SELF_HEAL_STATE_PATH, 'utf8')) as SelfHealState;
-    return Array.isArray(parsed?.attempts) ? parsed.attempts.filter(n => typeof n === 'number') : [];
+    return Array.isArray(parsed?.attempts)
+      ? parsed.attempts.filter(n => typeof n === 'number' && Number.isFinite(n))
+      : [];
   } catch { return []; }
 }
 function writeAttempts(attempts: number[]): void {
+  const tmp = `${SELF_HEAL_STATE_PATH}.tmp`;
   try {
     fs.mkdirSync(path.dirname(SELF_HEAL_STATE_PATH), { recursive: true });
-    fs.writeFileSync(SELF_HEAL_STATE_PATH, JSON.stringify({ attempts }));
+    fs.writeFileSync(tmp, JSON.stringify({ attempts }), 'utf-8');
+    fs.renameSync(tmp, SELF_HEAL_STATE_PATH);
   } catch (e) {
     logger.warn('WORKER', 'Failed to persist Claude CLI self-heal state', {}, e instanceof Error ? e : new Error(String(e)));
   }

--- a/src/shared/find-claude-executable.ts
+++ b/src/shared/find-claude-executable.ts
@@ -343,10 +343,13 @@ export function findClaudeExecutable(logComponent: Component = 'SDK'): string {
         `Install Claude Code CLI: npm install -g @anthropic-ai/claude-code`
       );
     }
-    throw new Error(
-      `CLAUDE_CODE_PATH is set to "${settings.CLAUDE_CODE_PATH}" but it failed the --version check (${probe.detail}). ` +
-      `Ensure this is a working Claude Code CLI binary.`
-    );
+    // Present on disk (existsSync guard above) but every probe failed — the
+    // same stale-worker signature as the discovered-candidate path (#3290).
+    // Pinned installs must surface the self-heal discriminator too, or a
+    // wedged CLAUDE_CODE_PATH parks the worker in setup_required forever.
+    throw new ClaudeExecutableUnspawnableError([
+      { path: settings.CLAUDE_CODE_PATH, detail: probe.detail },
+    ]);
   }
 
   // --- 2. Probe every discovered candidate ---------------------------------

--- a/src/shared/find-claude-executable.ts
+++ b/src/shared/find-claude-executable.ts
@@ -89,6 +89,37 @@ export const _internals = {
 };
 
 /**
+ * A Claude CLI binary exists on disk at a discovered path but this worker
+ * process can no longer spawn it (ENOENT on posix_spawn despite the file
+ * being present — typically a stale worker after Claude Code's native
+ * auto-updater swapped the binary underneath a long-running process).
+ *
+ * Carries every present-but-unspawnable candidate plus the probe detail, so
+ * callers can surface a single actionable error rather than a generic
+ * not-found. The message deliberately includes the literal token `ENOENT` so
+ * `classifyClaudeError` keeps mapping it to `setup_required` — but the
+ * `isClaudeExecutableUnspawnable` discriminator lets the routes layer
+ * distinguish it from a genuine setup gap and trigger a self-heal restart.
+ */
+export class ClaudeExecutableUnspawnableError extends Error {
+  readonly candidates: ReadonlyArray<{ path: string; detail: string }>;
+  constructor(candidates: ReadonlyArray<{ path: string; detail: string }>) {
+    const list = candidates.map(c => `  - ${c.path} — ${c.detail}`).join('\n');
+    super(
+      'Claude executable(s) exist on disk but could not be spawned by this worker process ' +
+      '(ENOENT on posix_spawn despite the file being present — typically a stale worker after a ' +
+      `Claude Code CLI auto-update):\n${list}\n` +
+      `Restarting the worker resolves this. ${updateInstructions()}`
+    );
+    this.name = 'ClaudeExecutableUnspawnableError';
+    this.candidates = candidates;
+  }
+}
+export function isClaudeExecutableUnspawnable(err: unknown): err is ClaudeExecutableUnspawnableError {
+  return err instanceof ClaudeExecutableUnspawnableError;
+}
+
+/**
  * Returns true if the path looks like a Windows desktop-app installation
  * (AppData or Program Files) rather than a CLI installed via npm/volta/etc.
  */
@@ -321,6 +352,11 @@ export function findClaudeExecutable(logComponent: Component = 'SDK'): string {
   // --- 2. Probe every discovered candidate ---------------------------------
   const capable: Array<{ path: string; version: string; key: [number, number, number]; order: number }> = [];
   const incompatible: Array<{ path: string; version: string; detail: string }> = [];
+  // Candidates that are present on disk but every probe failed (broken/ENOENT).
+  // When this set is non-empty AND nothing capable was found, the final throw
+  // is a ClaudeExecutableUnspawnableError so callers can self-heal restart
+  // instead of looping forever in setup_required cooldown.
+  const presentButUnspawnable: Array<{ path: string; detail: string }> = [];
 
   const candidates = discoverCandidates();
   for (let order = 0; order < candidates.length; order++) {
@@ -349,6 +385,13 @@ export function findClaudeExecutable(logComponent: Component = 'SDK'): string {
       );
     } else {
       logger.warn(logComponent, `Skipping "${candidate}" — failed --version check (${probe.detail})`);
+      // A file that is present on disk but cannot be spawned is the signature
+      // of a stale worker after a CLI auto-update — collected here so the
+      // final throw can be a ClaudeExecutableUnspawnableError (which callers
+      // use to self-heal restart) instead of a generic not-found.
+      if (_internals.existsSync(candidate)) {
+        presentButUnspawnable.push({ path: candidate, detail: probe.detail });
+      }
     }
   }
 
@@ -379,6 +422,9 @@ export function findClaudeExecutable(logComponent: Component = 'SDK'): string {
     );
   }
 
+  if (presentButUnspawnable.length > 0) {
+    throw new ClaudeExecutableUnspawnableError(presentButUnspawnable);
+  }
   throw new Error(
     'Claude executable not found. Please either:\n' +
     '1. Add "claude" to your system PATH, or\n' +

--- a/src/shared/find-claude-executable.ts
+++ b/src/shared/find-claude-executable.ts
@@ -89,6 +89,37 @@ export const _internals = {
 };
 
 /**
+ * A Claude CLI binary exists on disk at a discovered path but this worker
+ * process can no longer spawn it (ENOENT on posix_spawn despite the file
+ * being present — typically a stale worker after Claude Code's native
+ * auto-updater swapped the binary underneath a long-running process).
+ *
+ * Carries every present-but-unspawnable candidate plus the probe detail, so
+ * callers can surface a single actionable error rather than a generic
+ * not-found. The message deliberately includes the literal token `ENOENT` so
+ * `classifyClaudeError` keeps mapping it to `setup_required` — but the
+ * `isClaudeExecutableUnspawnable` discriminator lets the routes layer
+ * distinguish it from a genuine setup gap and trigger a self-heal restart.
+ */
+export class ClaudeExecutableUnspawnableError extends Error {
+  readonly candidates: ReadonlyArray<{ path: string; detail: string }>;
+  constructor(candidates: ReadonlyArray<{ path: string; detail: string }>) {
+    const list = candidates.map(c => `  - ${c.path} — ${c.detail}`).join('\n');
+    super(
+      'Claude executable(s) exist on disk but could not be spawned by this worker process ' +
+      '(ENOENT on posix_spawn despite the file being present — typically a stale worker after a ' +
+      `Claude Code CLI auto-update):\n${list}\n` +
+      `Restarting the worker resolves this. ${updateInstructions()}`
+    );
+    this.name = 'ClaudeExecutableUnspawnableError';
+    this.candidates = candidates;
+  }
+}
+export function isClaudeExecutableUnspawnable(err: unknown): err is ClaudeExecutableUnspawnableError {
+  return err instanceof ClaudeExecutableUnspawnableError;
+}
+
+/**
  * Returns true if the path looks like a Windows desktop-app installation
  * (AppData or Program Files) rather than a CLI installed via npm/volta/etc.
  */
@@ -412,6 +443,11 @@ export function findClaudeExecutable(logComponent: Component = 'SDK'): string {
   // --- 2. Probe every discovered candidate ---------------------------------
   const capable: Array<{ path: string; version: string; key: [number, number, number]; order: number }> = [];
   const incompatible: Array<{ path: string; version: string; detail: string }> = [];
+  // Candidates that are present on disk but every probe failed (broken/ENOENT).
+  // When this set is non-empty AND nothing capable was found, the final throw
+  // is a ClaudeExecutableUnspawnableError so callers can self-heal restart
+  // instead of looping forever in setup_required cooldown.
+  const presentButUnspawnable: Array<{ path: string; detail: string }> = [];
 
   const candidates = discoverCandidates();
   for (let order = 0; order < candidates.length; order++) {
@@ -440,6 +476,13 @@ export function findClaudeExecutable(logComponent: Component = 'SDK'): string {
       );
     } else {
       logger.warn(logComponent, `Skipping "${candidate}" — failed --version check (${probe.detail})`);
+      // A file that is present on disk but cannot be spawned is the signature
+      // of a stale worker after a CLI auto-update — collected here so the
+      // final throw can be a ClaudeExecutableUnspawnableError (which callers
+      // use to self-heal restart) instead of a generic not-found.
+      if (_internals.existsSync(candidate)) {
+        presentButUnspawnable.push({ path: candidate, detail: probe.detail });
+      }
     }
   }
 
@@ -470,6 +513,9 @@ export function findClaudeExecutable(logComponent: Component = 'SDK'): string {
     );
   }
 
+  if (presentButUnspawnable.length > 0) {
+    throw new ClaudeExecutableUnspawnableError(presentButUnspawnable);
+  }
   throw new Error(
     'Claude executable not found. Please either:\n' +
     '1. Add "claude" to your system PATH, or\n' +

--- a/src/shared/find-claude-executable.ts
+++ b/src/shared/find-claude-executable.ts
@@ -485,11 +485,17 @@ export function findClaudeExecutable(logComponent: Component = 'SDK'): string {
       );
     } else {
       logger.warn(logComponent, `Skipping "${candidate}" — failed --version check (${probe.detail})`);
-      // A file that is present on disk but cannot be spawned is the signature
-      // of a stale worker after a CLI auto-update — collected here so the
-      // final throw can be a ClaudeExecutableUnspawnableError (which callers
-      // use to self-heal restart) instead of a generic not-found.
-      if (_internals.existsSync(candidate)) {
+      // A file that is present on disk but the OS could not launch is the
+      // signature of a stale worker after a CLI auto-update — collected here
+      // so the final throw can be a ClaudeExecutableUnspawnableError (which
+      // callers use to self-heal restart) instead of a generic not-found.
+      // Two guards, both load-bearing: launchFailed because a candidate that
+      // RAN but failed its version probe is a wrong program, not a stale
+      // spawn — a restart can never fix it, so it must not burn the self-heal
+      // budget (matches the configured-path branch); existsSync because a
+      // MISSING file also probes as launchFailed (spawn ENOENT sets no status
+      // or signal) and a dangling PATH entry is the genuine not-found case.
+      if (probe.launchFailed && _internals.existsSync(candidate)) {
         presentButUnspawnable.push({ path: candidate, detail: probe.detail });
       }
     }

--- a/src/shared/find-claude-executable.ts
+++ b/src/shared/find-claude-executable.ts
@@ -427,11 +427,20 @@ export function findClaudeExecutable(logComponent: Component = 'SDK'): string {
     // that ran but exited non-zero, timed out, or printed no version is a
     // different problem — do not claim it "could not be executed".
     if (probe.launchFailed) {
-      throw new Error(
-        `CLAUDE_CODE_PATH is set to ${describedPath} — the file exists but could not be executed (${probe.detail}). ` +
-        `A launcher script whose interpreter (shebang) is missing, or a native-installer stub pointing at a deleted version directory, fails this way. ` +
-        `Reinstall the Claude Code CLI or point CLAUDE_CODE_PATH at a working binary.`
-      );
+      // Present on disk (existsSync guard above) but the OS could not launch
+      // it — the same stale-worker signature as the discovered-candidate path
+      // (#3290). Pinned installs must surface the self-heal discriminator too,
+      // or a wedged CLAUDE_CODE_PATH parks the worker in setup_required
+      // forever; the launch-failure guidance rides in the candidate detail.
+      throw new ClaudeExecutableUnspawnableError([
+        {
+          path: configuredPath,
+          detail:
+            `CLAUDE_CODE_PATH is set to ${describedPath} — the file exists but could not be executed (${probe.detail}). ` +
+            `A launcher script whose interpreter (shebang) is missing, or a native-installer stub pointing at a deleted version directory, fails this way. ` +
+            `Reinstall the Claude Code CLI or point CLAUDE_CODE_PATH at a working binary.`,
+        },
+      ]);
     }
     throw new Error(
       `CLAUDE_CODE_PATH is set to ${describedPath} — the file ran but failed its version probe (${probe.detail}). ` +

--- a/tests/services/worker/stale-spawn-recovery.test.ts
+++ b/tests/services/worker/stale-spawn-recovery.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+/**
+ * DATA_DIR is resolved at module import time (src/shared/paths.ts), so the
+ * self-heal state file path is locked in the moment stale-spawn-recovery.ts
+ * first loads. To isolate state on disk per test file we set
+ * CLAUDE_MEM_DATA_DIR BEFORE the dynamic import below — any static import
+ * graph that touches paths.ts would defeat this, so only node builtins are
+ * statically imported here.
+ */
+const TMP_DIR = mkdtempSync(join(tmpdir(), 'cm-selfheal-'));
+process.env.CLAUDE_MEM_DATA_DIR = TMP_DIR;
+
+const {
+  canAttemptClaudeCliSelfHeal,
+  recordClaudeCliSelfHealAttempt,
+  clearClaudeCliSelfHealAttempts,
+  claudeCliSelfHealAttemptsInWindow,
+  SELF_HEAL_MAX_ATTEMPTS,
+  SELF_HEAL_WINDOW_MS,
+} = await import('../../../src/services/worker/stale-spawn-recovery.js');
+
+afterAll(() => {
+  delete process.env.CLAUDE_MEM_DATA_DIR;
+  rmSync(TMP_DIR, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  clearClaudeCliSelfHealAttempts();
+});
+
+describe('claude CLI self-heal budget', () => {
+  it('starts empty: zero attempts and canAttempt is true', () => {
+    expect(claudeCliSelfHealAttemptsInWindow()).toBe(0);
+    expect(canAttemptClaudeCliSelfHeal()).toBe(true);
+  });
+
+  it('records an attempt and reflects the new count', () => {
+    const t0 = 1_000_000;
+    expect(recordClaudeCliSelfHealAttempt(t0)).toBe(1);
+    expect(claudeCliSelfHealAttemptsInWindow(t0)).toBe(1);
+    expect(canAttemptClaudeCliSelfHeal(t0)).toBe(true);
+  });
+
+  it('blocks further attempts once MAX_ATTEMPTS is reached within the window', () => {
+    const base = 5_000_000;
+    for (let i = 0; i < SELF_HEAL_MAX_ATTEMPTS; i++) {
+      recordClaudeCliSelfHealAttempt(base + i);
+    }
+    expect(claudeCliSelfHealAttemptsInWindow(base + SELF_HEAL_MAX_ATTEMPTS)).toBe(SELF_HEAL_MAX_ATTEMPTS);
+    expect(canAttemptClaudeCliSelfHeal(base + SELF_HEAL_MAX_ATTEMPTS)).toBe(false);
+  });
+
+  it('prunes attempts older than SELF_HEAL_WINDOW_MS, reopening the budget', () => {
+    const oldTs = 10_000_000;
+    recordClaudeCliSelfHealAttempt(oldTs);
+    // Just inside the window still counts.
+    expect(claudeCliSelfHealAttemptsInWindow(oldTs + SELF_HEAL_WINDOW_MS - 1)).toBe(1);
+    // One ms past the window is pruned — budget reopens.
+    const after = oldTs + SELF_HEAL_WINDOW_MS + 1;
+    expect(claudeCliSelfHealAttemptsInWindow(after)).toBe(0);
+    expect(canAttemptClaudeCliSelfHeal(after)).toBe(true);
+  });
+
+  it('clearClaudeCliSelfHealAttempts resets the budget to zero', () => {
+    const t = 20_000_000;
+    for (let i = 0; i < SELF_HEAL_MAX_ATTEMPTS; i++) {
+      recordClaudeCliSelfHealAttempt(t + i);
+    }
+    expect(canAttemptClaudeCliSelfHeal(t)).toBe(false);
+
+    clearClaudeCliSelfHealAttempts();
+
+    expect(claudeCliSelfHealAttemptsInWindow(t)).toBe(0);
+    expect(canAttemptClaudeCliSelfHeal(t)).toBe(true);
+  });
+
+  it('prunes only stale entries, preserving in-window attempts mixed with old ones', () => {
+    const old = 30_000_000;
+    const recent = old + SELF_HEAL_WINDOW_MS + 5_000;
+    recordClaudeCliSelfHealAttempt(old);          // stale
+    recordClaudeCliSelfHealAttempt(recent);       // in-window
+    recordClaudeCliSelfHealAttempt(recent + 10);  // in-window
+
+    expect(claudeCliSelfHealAttemptsInWindow(recent + 20)).toBe(2);
+    expect(canAttemptClaudeCliSelfHeal(recent + 20)).toBe(true);
+  });
+});

--- a/tests/shared/find-claude-executable.test.ts
+++ b/tests/shared/find-claude-executable.test.ts
@@ -3,6 +3,7 @@ import {
   findClaudeExecutable,
   resetClaudeExecutableCache,
   CAPABILITY_PROBE_ARGS,
+  isClaudeExecutableUnspawnable,
   _internals,
 } from '../../src/shared/find-claude-executable.js';
 import { logger } from '../../src/utils/logger.js';
@@ -198,10 +199,15 @@ describe('findClaudeExecutable broken candidates', () => {
     expect(warnings.some((m) => m.includes('desktop app') && m.includes('AnthropicClaude'))).toBe(true);
   });
 
-  it('falls through to not-found when the only candidate is broken', () => {
+  it('falls through to not-found when the only candidate is broken and not present on disk', () => {
+    // A candidate that is broken AND missing from disk (e.g. a dangling PATH
+    // entry left by an uninstall) is the genuine not-found case — distinct
+    // from a present-but-unspawnable binary, which would surface as
+    // ClaudeExecutableUnspawnableError (covered in its own describe block).
     installFakes();
     whichOutput = '/broken/claude\n';
-    fakeClis.set('/broken/claude', { version: '0.0.0', supportsDontAsk: false, broken: true });
+    // Deliberately NOT added to fakeClis: existsSync returns false, so the
+    // broken probe is not collected as present-but-unspawnable.
 
     expect(() => findClaudeExecutable('SDK')).toThrow(/Claude executable not found/);
   });
@@ -299,6 +305,70 @@ describe('findClaudeExecutable on Windows', () => {
     fakeClis.set('C:\\new\\claude.exe', { version: '2.1.176', supportsDontAsk: true });
 
     expect(findClaudeExecutable('SDK')).toBe('C:\\new\\claude.exe');
+  });
+});
+
+describe('findClaudeExecutable present-but-unspawnable detection', () => {
+  // The #3290 incident shape: a candidate that exists on disk but every probe
+  // fails (broken/ENOENT — a stale worker after the Claude Code native
+  // auto-updater swapped the binary). When no capable CLI is found, the
+  // resolver surfaces ClaudeExecutableUnspawnableError so SessionRoutes can
+  // self-heal restart instead of looping forever in setup_required cooldown.
+  const ORIGINAL_WARN = logger.warn;
+  let warnings: string[];
+
+  beforeEach(() => {
+    warnings = [];
+    logger.warn = ((_component: unknown, message: string) => {
+      warnings.push(message);
+    }) as typeof logger.warn;
+  });
+
+  afterEach(() => {
+    logger.warn = ORIGINAL_WARN;
+  });
+
+  it('throws ClaudeExecutableUnspawnableError when a broken candidate exists on disk', () => {
+    installFakes();
+    whichOutput = '/stale/claude\n';
+    fakeClis.set('/stale/claude', { version: '0.0.0', supportsDontAsk: false, broken: true });
+
+    let caught: unknown;
+    try {
+      findClaudeExecutable('SDK');
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeDefined();
+    expect(isClaudeExecutableUnspawnable(caught)).toBe(true);
+    if (isClaudeExecutableUnspawnable(caught)) {
+      expect(caught.candidates).toEqual([
+        { path: '/stale/claude', detail: expect.any(String) },
+      ]);
+      // The literal ENOENT token keeps classifyClaudeError on setup_required.
+      expect(caught.message).toContain('ENOENT');
+      expect(caught.message).toContain('/stale/claude');
+    }
+    // Existing per-candidate warn still fires.
+    expect(warnings.some((m) => m.includes('/stale/claude') && m.includes('failed --version check'))).toBe(true);
+  });
+
+  it('throws the generic not-found Error (NOT ClaudeExecutableUnspawnableError) when nothing exists on disk', () => {
+    installFakes();
+    // PATH returns a candidate that does not exist on disk → broken probe,
+    // but it is NOT collected as present-but-unspawnable.
+    whichOutput = '/missing/claude\n';
+
+    let caught: unknown;
+    try {
+      findClaudeExecutable('SDK');
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeDefined();
+    expect(isClaudeExecutableUnspawnable(caught)).toBe(false);
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain('Claude executable not found');
   });
 });
 

--- a/tests/shared/find-claude-executable.test.ts
+++ b/tests/shared/find-claude-executable.test.ts
@@ -216,7 +216,10 @@ describe('findClaudeExecutable broken candidates', () => {
     installFakes({ settingsPath: '/custom/claude' });
     fakeClis.set('/custom/claude', { version: '0.0.0', supportsDontAsk: false, broken: true });
 
-    expect(() => findClaudeExecutable('SDK')).toThrow(/failed the --version check/);
+    // A configured path that exists but fails every probe now surfaces as
+    // present-but-unspawnable (type contract covered in its own describe
+    // block); the probe detail must still be carried in the message.
+    expect(() => findClaudeExecutable('SDK')).toThrow(/cannot execute binary file/);
   });
 
   it('reports a desktop-app CLAUDE_CODE_PATH with CLI install guidance', () => {
@@ -351,6 +354,29 @@ describe('findClaudeExecutable present-but-unspawnable detection', () => {
     }
     // Existing per-candidate warn still fires.
     expect(warnings.some((m) => m.includes('/stale/claude') && m.includes('failed --version check'))).toBe(true);
+  });
+
+  it('throws ClaudeExecutableUnspawnableError when the configured CLAUDE_CODE_PATH exists but cannot be spawned', () => {
+    // Same wedge, pinned install: CLAUDE_CODE_PATH points at a binary that is
+    // on disk but fails every probe. Without the discriminator the routes
+    // layer sees a generic setup failure and never self-heals.
+    installFakes({ settingsPath: '/pinned/claude' });
+    fakeClis.set('/pinned/claude', { version: '0.0.0', supportsDontAsk: false, broken: true });
+
+    let caught: unknown;
+    try {
+      findClaudeExecutable('SDK');
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeDefined();
+    expect(isClaudeExecutableUnspawnable(caught)).toBe(true);
+    if (isClaudeExecutableUnspawnable(caught)) {
+      expect(caught.candidates).toEqual([
+        { path: '/pinned/claude', detail: expect.any(String) },
+      ]);
+      expect(caught.message).toContain('/pinned/claude');
+    }
   });
 
   it('throws the generic not-found Error (NOT ClaudeExecutableUnspawnableError) when nothing exists on disk', () => {

--- a/tests/shared/find-claude-executable.test.ts
+++ b/tests/shared/find-claude-executable.test.ts
@@ -3,6 +3,7 @@ import {
   findClaudeExecutable,
   resetClaudeExecutableCache,
   CAPABILITY_PROBE_ARGS,
+  isClaudeExecutableUnspawnable,
   _internals,
 } from '../../src/shared/find-claude-executable.js';
 import { logger } from '../../src/utils/logger.js';
@@ -276,10 +277,15 @@ describe('findClaudeExecutable broken candidates', () => {
     expect(warnings.some((m) => m.includes('desktop app') && m.includes('AnthropicClaude'))).toBe(true);
   });
 
-  it('falls through to not-found when the only candidate is broken', () => {
+  it('falls through to not-found when the only candidate is broken and not present on disk', () => {
+    // A candidate that is broken AND missing from disk (e.g. a dangling PATH
+    // entry left by an uninstall) is the genuine not-found case — distinct
+    // from a present-but-unspawnable binary, which would surface as
+    // ClaudeExecutableUnspawnableError (covered in its own describe block).
     installFakes();
     whichOutput = '/broken/claude\n';
-    fakeClis.set('/broken/claude', { version: '0.0.0', supportsDontAsk: false, broken: true });
+    // Deliberately NOT added to fakeClis: existsSync returns false, so the
+    // broken probe is not collected as present-but-unspawnable.
 
     expect(() => findClaudeExecutable('SDK')).toThrow(/Claude executable not found/);
   });
@@ -419,6 +425,70 @@ describe('findClaudeExecutable on Windows', () => {
     fakeClis.set('C:\\new\\claude.exe', { version: '2.1.176', supportsDontAsk: true });
 
     expect(findClaudeExecutable('SDK')).toBe('C:\\new\\claude.exe');
+  });
+});
+
+describe('findClaudeExecutable present-but-unspawnable detection', () => {
+  // The #3290 incident shape: a candidate that exists on disk but every probe
+  // fails (broken/ENOENT — a stale worker after the Claude Code native
+  // auto-updater swapped the binary). When no capable CLI is found, the
+  // resolver surfaces ClaudeExecutableUnspawnableError so SessionRoutes can
+  // self-heal restart instead of looping forever in setup_required cooldown.
+  const ORIGINAL_WARN = logger.warn;
+  let warnings: string[];
+
+  beforeEach(() => {
+    warnings = [];
+    logger.warn = ((_component: unknown, message: string) => {
+      warnings.push(message);
+    }) as typeof logger.warn;
+  });
+
+  afterEach(() => {
+    logger.warn = ORIGINAL_WARN;
+  });
+
+  it('throws ClaudeExecutableUnspawnableError when a broken candidate exists on disk', () => {
+    installFakes();
+    whichOutput = '/stale/claude\n';
+    fakeClis.set('/stale/claude', { version: '0.0.0', supportsDontAsk: false, broken: true });
+
+    let caught: unknown;
+    try {
+      findClaudeExecutable('SDK');
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeDefined();
+    expect(isClaudeExecutableUnspawnable(caught)).toBe(true);
+    if (isClaudeExecutableUnspawnable(caught)) {
+      expect(caught.candidates).toEqual([
+        { path: '/stale/claude', detail: expect.any(String) },
+      ]);
+      // The literal ENOENT token keeps classifyClaudeError on setup_required.
+      expect(caught.message).toContain('ENOENT');
+      expect(caught.message).toContain('/stale/claude');
+    }
+    // Existing per-candidate warn still fires.
+    expect(warnings.some((m) => m.includes('/stale/claude') && m.includes('failed --version check'))).toBe(true);
+  });
+
+  it('throws the generic not-found Error (NOT ClaudeExecutableUnspawnableError) when nothing exists on disk', () => {
+    installFakes();
+    // PATH returns a candidate that does not exist on disk → broken probe,
+    // but it is NOT collected as present-but-unspawnable.
+    whichOutput = '/missing/claude\n';
+
+    let caught: unknown;
+    try {
+      findClaudeExecutable('SDK');
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeDefined();
+    expect(isClaudeExecutableUnspawnable(caught)).toBe(false);
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain('Claude executable not found');
   });
 });
 

--- a/tests/shared/find-claude-executable.test.ts
+++ b/tests/shared/find-claude-executable.test.ts
@@ -531,6 +531,27 @@ describe('findClaudeExecutable present-but-unspawnable detection', () => {
     expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).message).toContain('Claude executable not found');
   });
+
+  it('throws the generic not-found Error (NOT ClaudeExecutableUnspawnableError) when the only candidate ran but failed its version probe', () => {
+    // A wrong wrapper that launches fine and exits non-zero is an install
+    // problem a restart can never fix. Collecting it as present-but-unspawnable
+    // would burn the self-heal restart budget on every worker start before
+    // parking in setup_required, instead of surfacing the bad install now.
+    installFakes();
+    whichOutput = '/wrong/claude\n';
+    fakeClis.set('/wrong/claude', { version: '0.0.0', supportsDontAsk: false, ranButFailed: true });
+
+    let caught: unknown;
+    try {
+      findClaudeExecutable('SDK');
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeDefined();
+    expect(isClaudeExecutableUnspawnable(caught)).toBe(false);
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain('Claude executable not found');
+  });
 });
 
 describe('capability probe contract', () => {

--- a/tests/shared/find-claude-executable.test.ts
+++ b/tests/shared/find-claude-executable.test.ts
@@ -295,10 +295,19 @@ describe('findClaudeExecutable broken candidates', () => {
     fakeClis.set('/custom/claude', { version: '0.0.0', supportsDontAsk: false, broken: true });
 
     // The file exists (existsSync passes) and the OS could not launch it (no
-    // exit status), so it is reported as "exists but could not be executed" —
-    // not "file does not exist" and not the old dead-end "--version check".
-    expect(() => findClaudeExecutable('SDK')).toThrow(/exists but could not be executed/);
-    expect(() => findClaudeExecutable('SDK')).toThrow(/shebang|native-installer/);
+    // exit status): the stale-worker signature, so it surfaces as the
+    // ClaudeExecutableUnspawnableError self-heal discriminator (type contract
+    // covered in its own describe block) while still carrying the
+    // launch-failure guidance (shebang / native-installer stub).
+    let caught: unknown;
+    try {
+      findClaudeExecutable('SDK');
+    } catch (error) {
+      caught = error;
+    }
+    expect(isClaudeExecutableUnspawnable(caught)).toBe(true);
+    expect((caught as Error).message).toMatch(/exists but could not be executed/);
+    expect((caught as Error).message).toMatch(/shebang|native-installer/);
   });
 
   it('reports a configured CLAUDE_CODE_PATH that ran but failed its version probe without claiming it could not launch', () => {
@@ -306,9 +315,18 @@ describe('findClaudeExecutable broken candidates', () => {
     fakeClis.set('/custom/claude', { version: '0.0.0', supportsDontAsk: false, ranButFailed: true });
 
     // The process started and exited non-zero, so the launch-failure guidance
-    // (shebang / native-installer stub) must NOT appear.
-    expect(() => findClaudeExecutable('SDK')).toThrow(/ran but failed its version probe/);
-    expect(() => findClaudeExecutable('SDK')).not.toThrow(/could not be executed|shebang|native-installer/);
+    // (shebang / native-installer stub) must NOT appear — and since the probe
+    // actually ran, this is NOT the stale-worker signature: a plain Error, no
+    // self-heal discriminator.
+    let caught: unknown;
+    try {
+      findClaudeExecutable('SDK');
+    } catch (error) {
+      caught = error;
+    }
+    expect(isClaudeExecutableUnspawnable(caught)).toBe(false);
+    expect((caught as Error).message).toMatch(/ran but failed its version probe/);
+    expect((caught as Error).message).not.toMatch(/could not be executed|shebang|native-installer/);
   });
 
   it('reports a desktop-app CLAUDE_CODE_PATH with CLI install guidance', () => {
@@ -471,6 +489,29 @@ describe('findClaudeExecutable present-but-unspawnable detection', () => {
     }
     // Existing per-candidate warn still fires.
     expect(warnings.some((m) => m.includes('/stale/claude') && m.includes('failed --version check'))).toBe(true);
+  });
+
+  it('throws ClaudeExecutableUnspawnableError when the configured CLAUDE_CODE_PATH exists but cannot be spawned', () => {
+    // Same wedge, pinned install: CLAUDE_CODE_PATH points at a binary that is
+    // on disk but fails every probe. Without the discriminator the routes
+    // layer sees a generic setup failure and never self-heals.
+    installFakes({ settingsPath: '/pinned/claude' });
+    fakeClis.set('/pinned/claude', { version: '0.0.0', supportsDontAsk: false, broken: true });
+
+    let caught: unknown;
+    try {
+      findClaudeExecutable('SDK');
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeDefined();
+    expect(isClaudeExecutableUnspawnable(caught)).toBe(true);
+    if (isClaudeExecutableUnspawnable(caught)) {
+      expect(caught.candidates).toEqual([
+        { path: '/pinned/claude', detail: expect.any(String) },
+      ]);
+      expect(caught.message).toContain('/pinned/claude');
+    }
   });
 
   it('throws the generic not-found Error (NOT ClaudeExecutableUnspawnableError) when nothing exists on disk', () => {


### PR DESCRIPTION
## Summary

- Self-restart the worker (via the existing successor handoff) when the Claude CLI is present on disk but this long-lived process can no longer spawn it. First seen when Claude Code's auto-updater swapped the binary (#3290); the same signature shows up whenever only a fresh process can spawn the CLI, for example a daemon whose cwd was a git worktree that later got removed.
- New `ClaudeExecutableUnspawnableError` distinguishes this from a genuine not-found; `SessionRoutes` detects it and triggers the restart
- Restarts are bounded by a persisted budget (3/hour, reset on successful CLI resolution) so a genuinely broken install cannot thrash
- The daemon now spawns with `cwd: os.homedir()`, so neither the daemon nor a self-heal successor can inherit a working directory that later disappears (second trigger reported [in the discussion](https://github.com/thedotmack/claude-mem/pull/3291#issuecomment-5388571971); same fix as #3706)

## Root cause

The 30s setup re-probe runs `execFileSync` from the same long-lived worker process. When the auto-updater swaps the binary, or the process cwd has been deleted, that probe keeps failing with ENOENT while a fresh process spawns the CLI fine. An in-process retry can never recover; only a new process can. The worker parks in `setup_required` and observation generation silently stops, while prompt capture (no CLI needed) keeps working.

## Incident evidence

Observations stopped for ~30h; queue reached 1066 with zero drains; the log spammed `ENOENT ... posix_spawn` every 30s. The identical probe from a fresh shell returned `2.1.211`, exit 0. A manual worker restart recovered instantly.

## Verification

- `tsc --noEmit` clean
- `bun test` (current `main` merged in): 2703 tests, green on a clean run. The only red on this machine is the `workers/sync-hub` suite erroring on a missing `cloudflare:test` package, a local environment gap present on `main` as well
- Targeted suites green and stable across reruns: `stale-spawn-recovery`, resolver present-but-unspawnable cases, `process-manager` (daemon cwd pin), `worker-shutdown-sequence`, `worker-spawner`

Closes #3290. Related: #3138 (worker lifecycle / liveness cluster), #3706 (daemon cwd).
