### PR TITLE
fix(worker): quote script path in Start-Process -ArgumentList so spaced Windows profile paths survive

### DIFF
--- a/src/services/infrastructure/ProcessManager.ts
+++ b/src/services/infrastructure/ProcessManager.ts
@@ -336,6 +336,11 @@ function executeCwdRemap(dbPath: string, effectiveDataDir: string, markerPath: s
   }
 }
 
+export function buildWindowsDaemonStartCommand(runtimePath: string, scriptPath: string): string {
+  const psSingleQuote = (value: string) => value.replace(/'/g, "''");
+  return `Start-Process -FilePath '${psSingleQuote(runtimePath)}' -ArgumentList @('${psSingleQuote(scriptPath)}','--daemon') -WindowStyle Hidden`;
+}
+
 export function spawnDaemon(
   scriptPath: string,
   port: number,
@@ -359,7 +364,7 @@ export function spawnDaemon(
   }
 
   if (process.platform === 'win32') {
-    const psScript = `Start-Process -FilePath '${runtimePath.replace(/'/g, "''")}' -ArgumentList @('${scriptPath.replace(/'/g, "''")}','--daemon') -WindowStyle Hidden`;
+    const psScript = buildWindowsDaemonStartCommand(runtimePath, scriptPath);
     const encodedCommand = Buffer.from(psScript, 'utf16le').toString('base64');
 
     try {

--- a/src/services/infrastructure/ProcessManager.ts
+++ b/src/services/infrastructure/ProcessManager.ts
@@ -338,7 +338,14 @@ function executeCwdRemap(dbPath: string, effectiveDataDir: string, markerPath: s
 
 export function buildWindowsDaemonStartCommand(runtimePath: string, scriptPath: string): string {
   const psSingleQuote = (value: string) => value.replace(/'/g, "''");
-  return `Start-Process -FilePath '${psSingleQuote(runtimePath)}' -ArgumentList @('${psSingleQuote(scriptPath)}','--daemon') -WindowStyle Hidden`;
+  // Windows PowerShell 5.1 joins -ArgumentList elements with spaces WITHOUT
+  // quoting them when it builds the child's native command line, so a script
+  // path under a spaced %USERPROFILE% splits into multiple argv entries and
+  // bun exits instantly with "Module not found" (#3195). Embedding literal
+  // double quotes inside the single-quoted PS string keeps the path a single
+  // argument. -FilePath is safe as-is: it is a single-string parameter and
+  // never goes through that join.
+  return `Start-Process -FilePath '${psSingleQuote(runtimePath)}' -ArgumentList @('"${psSingleQuote(scriptPath)}"','--daemon') -WindowStyle Hidden`;
 }
 
 export function spawnDaemon(

--- a/tests/infrastructure/process-manager.test.ts
+++ b/tests/infrastructure/process-manager.test.ts
@@ -26,6 +26,7 @@ const {
   isPidFileRecent,
   touchPidFile,
   spawnDaemon,
+  buildWindowsDaemonStartCommand,
   resolveWorkerRuntimePath,
   captureProcessStartToken,
   verifyPidFileOwnership,
@@ -670,6 +671,46 @@ describe('ProcessManager', () => {
       const isFailure = (pid: number | undefined) => pid === undefined;
       expect(isFailure(windowsSuccessSentinel)).toBe(false);
       expect(isFailure(failureSentinel)).toBe(true);
+    });
+  });
+
+  describe('buildWindowsDaemonStartCommand (#3195)', () => {
+    // Windows PowerShell 5.1 (powershell.exe, which spawnDaemon invokes via
+    // -EncodedCommand) builds the native command line for Start-Process by
+    // joining -ArgumentList elements with spaces WITHOUT quoting them. The
+    // single quotes in the PS source only delimit the PS string literal; they
+    // never reach the child. So the script path must carry its own embedded
+    // double quotes or a spaced %USERPROFILE% splits it into multiple argv
+    // entries and bun dies with "Module not found".
+    it('embeds double quotes around a script path containing spaces', () => {
+      const runtimePath = String.raw`C:\Users\Test User\.bun\bin\bun.exe`;
+      const scriptPath = String.raw`C:\Users\Test User\.claude\plugins\marketplaces\thedotmack\plugin\scripts\worker-service.cjs`;
+
+      const command = buildWindowsDaemonStartCommand(runtimePath, scriptPath);
+
+      expect(command).toBe(
+        `Start-Process -FilePath '${runtimePath}' -ArgumentList @('"${scriptPath}"','--daemon') -WindowStyle Hidden`
+      );
+    });
+
+    it('keeps --daemon as its own ArgumentList element', () => {
+      const command = buildWindowsDaemonStartCommand(
+        String.raw`C:\bun\bun.exe`,
+        String.raw`C:\plugin\worker-service.cjs`
+      );
+
+      expect(command).toContain(`,'--daemon')`);
+    });
+
+    it('still doubles single quotes for PowerShell string escaping', () => {
+      const command = buildWindowsDaemonStartCommand(
+        String.raw`C:\Users\O'Brien\.bun\bin\bun.exe`,
+        String.raw`C:\Users\O'Brien\plugin\scripts\worker-service.cjs`
+      );
+
+      expect(command).toBe(
+        `Start-Process -FilePath 'C:\\Users\\O''Brien\\.bun\\bin\\bun.exe' -ArgumentList @('"C:\\Users\\O''Brien\\plugin\\scripts\\worker-service.cjs"','--daemon') -WindowStyle Hidden`
+      );
     });
   });
 


### PR DESCRIPTION
Closes #3195

## What was broken

On Windows, the worker daemon never starts when %USERPROFILE% contains a space (for example `C:\Users\Anil pc`). `spawnDaemon()` builds

```
Start-Process -FilePath '<runtime>' -ArgumentList @('<scriptPath>','--daemon') -WindowStyle Hidden
```

and runs it through `powershell -NoProfile -EncodedCommand`. Windows PowerShell 5.1 joins `-ArgumentList` elements with spaces and does not quote them when it builds the child's native command line, so a spaced script path reaches bun as several argv entries. Bun exits immediately with `error: Module not found "C:\Users\Anil"`, and nothing is logged because the spawn uses `stdio: 'ignore'` and `-WindowStyle Hidden`. Full analysis is in the issue. This is a regression of the bug fixed in #1594 and #1843; the later rewrite to the EncodedCommand form dropped the quoting.

## What this change does

- Extracts the PowerShell command construction into an exported pure function, `buildWindowsDaemonStartCommand()`, so the quoting can be unit tested. That commit changes no behavior.
- Embeds literal double quotes around the script path inside the single-quoted PowerShell string: `-ArgumentList @('"<scriptPath>"','--daemon')`. `-FilePath` stays as it was, since it takes a single string and never goes through the argument join. This is the same fix shape as #1594, applied to the current EncodedCommand call site.
- Adds unit tests in `tests/infrastructure/process-manager.test.ts` covering a path with spaces, `--daemon` staying its own element, and single quote escaping.

The PR is source only. I did not commit the regenerated `plugin/scripts` bundles, following what recent PRs such as #3232 do; those get rebuilt at release.

## Verification

All on Windows 11, bun 1.3.11, Windows PowerShell 5.1.26100.8875.

The new tests fail against the unquoted builder and pass with the fix:

```
(pre-fix source + new tests)
(fail) ProcessManager > buildWindowsDaemonStartCommand (#3195) > embeds double quotes around a script path containing spaces
(fail) ProcessManager > buildWindowsDaemonStartCommand (#3195) > still doubles single quotes for PowerShell string escaping

$ bun test tests/infrastructure/process-manager.test.ts   (at HEAD)
 52 pass
 5 skip
 1 fail
```

The one failure (`resolveWorkerRuntimePath > should look up Bun on non-Windows when caller is Node`) is pre-existing on any Windows host and unrelated to this change; unmodified `main` shows the same failure here (49 pass, 1 fail). That test injects POSIX paths, but the implementation builds candidates with `path.join`, which emits backslashes on Windows, so the injected `pathExists` never matches.

```
$ bun run typecheck
tsc --noEmit && tsc --noEmit -p src/ui/viewer/tsconfig.json   (exit 0)

$ bun run lint:hook-io
hook-io discipline: OK (handlers + adapters are pure)

$ bun run lint:spawn-env
spawn-env discipline: OK (all env-bearing spawns sanitize process.env)

$ npm run build   (exit 0)
```

Live reproduction with a dummy worker script under a path containing two spaces, executed through `powershell -NoProfile -EncodedCommand` exactly the way `spawnDaemon()` does. The dummy script writes its argv to a file, so a missing file means bun died before the script ran:

```
powershell.exe version: 5.1.26100.8875
OLD (main):        worker never ran (no argv-out.json written)
NEW (this branch): WORKER RAN, argv = ["...\repro 3195\plugin scripts\dummy-worker.cjs","--daemon"]
```

Running bun directly with the split argv reproduces the silent death the issue describes:

```
$ bun.exe "...\scratchpad\repro" "3195\plugin"
error: Module not found "...\scratchpad\repro"
(exit 1)
```

This fix was developed with AI assistance (Claude Code) and verified locally as shown above.
