### PR TITLE
fix(worker): enforce CLAUDE_MEM_MAX_CONCURRENT_AGENTS with slot reservations in waitForSlot

### DIFF
--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -211,50 +211,54 @@ export class ClaudeProvider {
 
     const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
     const maxConcurrent = parseInt(settings.CLAUDE_MEM_MAX_CONCURRENT_AGENTS, 10) || 2;
-    await waitForSlot(maxConcurrent, session.abortController.signal);
-
-    const isolatedEnv = sanitizeEnv(await buildIsolatedEnvWithFreshOAuth());
-    const authMethod = getAuthMethodDescription();
-
-    logger.info('SDK', 'Starting SDK query', {
-      sessionDbId: session.sessionDbId,
-      contentSessionId: session.contentSessionId,
-      memorySessionId: session.memorySessionId ?? undefined,
-      hasRealMemorySessionId,
-      shouldResume,
-      resume_parameter: shouldResume ? session.memorySessionId : '(none - fresh start)',
-      lastPromptNumber: session.lastPromptNumber,
-      authMethod
-    });
-
-    if (session.lastPromptNumber > 1) {
-      logger.debug('SDK', `[ALIGNMENT] Resume Decision | contentSessionId=${session.contentSessionId} | memorySessionId=${session.memorySessionId} | prompt#=${session.lastPromptNumber} | hasRealMemorySessionId=${hasRealMemorySessionId} | shouldResume=${shouldResume} | resumeWith=${shouldResume ? session.memorySessionId : 'NONE'}`);
-    } else {
-      const hasStaleMemoryId = hasRealMemorySessionId;
-      logger.debug('SDK', `[ALIGNMENT] First Prompt (INIT) | contentSessionId=${session.contentSessionId} | prompt#=${session.lastPromptNumber} | hasStaleMemoryId=${hasStaleMemoryId} | action=START_FRESH | Will capture new memorySessionId from SDK response`);
-      if (hasStaleMemoryId) {
-        logger.warn('SDK', `Skipping resume for INIT prompt despite existing memorySessionId=${session.memorySessionId} - SDK context was lost (worker restart or crash recovery)`);
-      }
-    }
-
-    ensureDir(OBSERVER_SESSIONS_DIR);
-    const queryResult = query({
-      prompt: messageGenerator,
-      options: buildHardenedSdkOptions({
-        source: 'Observer',
-        sessionDbId: session.sessionDbId,
-        contentSessionId: session.contentSessionId,
-        project: session.project,
-        model: modelId,
-        env: isolatedEnv,  // Use isolated credentials from ~/.claude-mem/.env, not process.env
-        pathToClaudeCodeExecutable: claudePath,
-        abortController: session.abortController,
-        ...(shouldResume && session.memorySessionId ? { resume: session.memorySessionId } : {}),
-        spawnClaudeCodeProcess: createSdkSpawnFactory(session.sessionDbId),
-      }),
-    });
+    // waitForSlot reserves the slot it grants (#3287). The spawn factory
+    // releases the reservation once the spawned process is a registry record;
+    // the finally below covers every path where the spawn never happens
+    // (OAuth failure, abort, query() throwing). release() is idempotent.
+    const slotReservation = await waitForSlot(maxConcurrent, session.abortController.signal);
 
     try {
+      const isolatedEnv = sanitizeEnv(await buildIsolatedEnvWithFreshOAuth());
+      const authMethod = getAuthMethodDescription();
+
+      logger.info('SDK', 'Starting SDK query', {
+        sessionDbId: session.sessionDbId,
+        contentSessionId: session.contentSessionId,
+        memorySessionId: session.memorySessionId ?? undefined,
+        hasRealMemorySessionId,
+        shouldResume,
+        resume_parameter: shouldResume ? session.memorySessionId : '(none - fresh start)',
+        lastPromptNumber: session.lastPromptNumber,
+        authMethod
+      });
+
+      if (session.lastPromptNumber > 1) {
+        logger.debug('SDK', `[ALIGNMENT] Resume Decision | contentSessionId=${session.contentSessionId} | memorySessionId=${session.memorySessionId} | prompt#=${session.lastPromptNumber} | hasRealMemorySessionId=${hasRealMemorySessionId} | shouldResume=${shouldResume} | resumeWith=${shouldResume ? session.memorySessionId : 'NONE'}`);
+      } else {
+        const hasStaleMemoryId = hasRealMemorySessionId;
+        logger.debug('SDK', `[ALIGNMENT] First Prompt (INIT) | contentSessionId=${session.contentSessionId} | prompt#=${session.lastPromptNumber} | hasStaleMemoryId=${hasStaleMemoryId} | action=START_FRESH | Will capture new memorySessionId from SDK response`);
+        if (hasStaleMemoryId) {
+          logger.warn('SDK', `Skipping resume for INIT prompt despite existing memorySessionId=${session.memorySessionId} - SDK context was lost (worker restart or crash recovery)`);
+        }
+      }
+
+      ensureDir(OBSERVER_SESSIONS_DIR);
+      const queryResult = query({
+        prompt: messageGenerator,
+        options: buildHardenedSdkOptions({
+          source: 'Observer',
+          sessionDbId: session.sessionDbId,
+          contentSessionId: session.contentSessionId,
+          project: session.project,
+          model: modelId,
+          env: isolatedEnv,  // Use isolated credentials from ~/.claude-mem/.env, not process.env
+          pathToClaudeCodeExecutable: claudePath,
+          abortController: session.abortController,
+          ...(shouldResume && session.memorySessionId ? { resume: session.memorySessionId } : {}),
+          spawnClaudeCodeProcess: createSdkSpawnFactory(session.sessionDbId, slotReservation),
+        }),
+      });
+
       for await (const message of queryResult) {
         // Quota-aware wall-clock guard (#2234): the SDK pushes `system` events
         // with subtype `rate_limit` carrying live subscription quota state.
@@ -428,6 +432,9 @@ export class ClaudeProvider {
         }
       }
     } finally {
+      // Safety net for paths where the SDK never invoked the spawn factory;
+      // a leaked reservation would occupy an agent slot until worker restart.
+      slotReservation.release();
       // A stashed compression event whose turn never reached a result message
       // (abort/kill) still ships — without token fields, per the no-estimates
       // rule — instead of being silently dropped.

--- a/src/supervisor/process-registry.ts
+++ b/src/supervisor/process-registry.ts
@@ -498,8 +498,35 @@ const TOTAL_PROCESS_HARD_CAP = 10;
 const SLOT_RECHECK_INTERVAL_MS = 5_000;
 const slotWaiters: Array<() => void> = [];
 
+/**
+ * Slots granted by waitForSlot() that are not yet visible as registry
+ * records. Registration only happens after spawn() returns a PID, and the
+ * caller has a wide await gap (OAuth refresh) between the grant and the
+ * spawn. Without a reservation, every concurrent caller observes the same
+ * stale count and all of them spawn (#3287: 9 agents against a max of 2).
+ */
+let reservedSlots = 0;
+
+export interface SlotReservation {
+  /** Frees the reserved slot. Idempotent: calls after the first are no-ops. */
+  release(): void;
+}
+
+function takeSlotReservation(): SlotReservation {
+  reservedSlots += 1;
+  let released = false;
+  return {
+    release(): void {
+      if (released) return;
+      released = true;
+      reservedSlots -= 1;
+      notifySlotAvailable();
+    },
+  };
+}
+
 function getActiveSdkCount(): number {
-  return getProcessRegistry().getAll().filter(record => record.type === 'sdk').length;
+  return getProcessRegistry().getAll().filter(record => record.type === 'sdk').length + reservedSlots;
 }
 
 function notifySlotAvailable(): void {
@@ -507,14 +534,22 @@ function notifySlotAvailable(): void {
   if (waiter) waiter();
 }
 
-export async function waitForSlot(maxConcurrent: number, signal?: AbortSignal): Promise<void> {
+/**
+ * Waits until an SDK agent slot is free, then reserves it. The count check
+ * and the reservation happen in the same synchronous block, so no concurrent
+ * caller can be granted the same slot. The caller must release the returned
+ * reservation once the spawned process is registered (the registry record
+ * takes over the accounting) or when the spawn fails or never happens:
+ * a leaked reservation would occupy the slot until the worker restarts.
+ */
+export async function waitForSlot(maxConcurrent: number, signal?: AbortSignal): Promise<SlotReservation> {
   getProcessRegistry().pruneDeadEntries();
   const activeCount = getActiveSdkCount();
   if (activeCount >= TOTAL_PROCESS_HARD_CAP) {
     throw new Error(`Hard cap exceeded: ${activeCount} processes in registry (cap=${TOTAL_PROCESS_HARD_CAP}). Refusing to spawn more.`);
   }
 
-  if (activeCount < maxConcurrent) return;
+  if (activeCount < maxConcurrent) return takeSlotReservation();
 
   if (signal?.aborted) {
     throw new Error('waitForSlot aborted before queuing');
@@ -522,7 +557,7 @@ export async function waitForSlot(maxConcurrent: number, signal?: AbortSignal): 
 
   logger.info('PROCESS', `Pool limit reached (${activeCount}/${maxConcurrent}), waiting for slot...`);
 
-  return new Promise<void>((resolve, reject) => {
+  return new Promise<SlotReservation>((resolve, reject) => {
     let recheckTimer: ReturnType<typeof setInterval> | null = null;
     let abortHandler: (() => void) | null = null;
     const cleanup = () => {
@@ -541,7 +576,7 @@ export async function waitForSlot(maxConcurrent: number, signal?: AbortSignal): 
 
       if (count < maxConcurrent) {
         cleanup();
-        resolve();
+        resolve(takeSlotReservation());
       } else {
         slotWaiters.push(onSlot);
       }
@@ -728,7 +763,7 @@ function sigtermDuplicateSdkProcess(record: ManagedProcessRecord, sessionDbId: n
   });
 }
 
-export function createSdkSpawnFactory(sessionDbId: number) {
+export function createSdkSpawnFactory(sessionDbId: number, slotReservation?: SlotReservation) {
   return (spawnOptions: SpawnSdkOptions): SpawnedSdkProcess => {
     const registry = getProcessRegistry();
 
@@ -751,7 +786,17 @@ export function createSdkSpawnFactory(sessionDbId: number) {
       }
     }
 
-    const result = spawnSdkProcess(sessionDbId, spawnOptions);
+    let result: ReturnType<typeof spawnSdkProcess>;
+    try {
+      result = spawnSdkProcess(sessionDbId, spawnOptions);
+    } finally {
+      // The waitForSlot() reservation is consumed here: on success the
+      // process is now a registry record (registered inside spawnSdkProcess)
+      // and takes over the slot accounting; on failure the slot goes back to
+      // the pool. Both statements above are synchronous, so no other caller
+      // can observe the reservation and the record at the same time.
+      slotReservation?.release();
+    }
     if (!result) {
       throw new Error(`Failed to spawn SDK subprocess for session ${sessionDbId}`);
     }

--- a/tests/supervisor/wait-for-slot.test.ts
+++ b/tests/supervisor/wait-for-slot.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import {
+  getProcessRegistry,
+  waitForSlot,
+  type SlotReservation,
+} from '../../src/supervisor/process-registry.js';
+
+/**
+ * Concurrency contract of waitForSlot() (#3287).
+ *
+ * The production caller (ClaudeProvider.startSession) has a wide await gap
+ * between the slot grant and the moment the spawned process becomes a
+ * registry record (OAuth refresh + SDK spawn). A grant that does not reserve
+ * anything lets every concurrent caller observe the same stale count and all
+ * of them spawn (the reporter saw 9 SDK agents against a max of 2). These
+ * tests drive waitForSlot the same way: grant first, register (or never
+ * register) later.
+ *
+ * State hygiene: waitForSlot works against the module-level singleton
+ * registry plus a module-level reservation count, so every test releases
+ * everything it acquired (afterEach re-releases defensively; release is
+ * idempotent).
+ */
+
+const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms));
+
+const granted: SlotReservation[] = [];
+const registeredIds: string[] = [];
+
+async function acquire(maxConcurrent: number, signal?: AbortSignal): Promise<SlotReservation> {
+  const reservation = await waitForSlot(maxConcurrent, signal);
+  granted.push(reservation);
+  return reservation;
+}
+
+function registerFakeSdkProcess(id: string): void {
+  getProcessRegistry().register(id, {
+    pid: process.pid,
+    type: 'sdk',
+    sessionId: 3287,
+    startedAt: new Date().toISOString(),
+  });
+  registeredIds.push(id);
+}
+
+describe('waitForSlot reservations (#3287)', () => {
+  afterEach(() => {
+    while (registeredIds.length > 0) {
+      const id = registeredIds.pop();
+      if (id) getProcessRegistry().unregister(id);
+    }
+    while (granted.length > 0) {
+      granted.pop()?.release?.();
+    }
+  });
+
+  it('admits at most maxConcurrent concurrent callers before any process registers', async () => {
+    const maxConcurrent = 2;
+    let admitted = 0;
+    const grants = Array.from({ length: 5 }, () =>
+      acquire(maxConcurrent).then(reservation => {
+        admitted += 1;
+        return reservation;
+      })
+    );
+
+    // Nothing registers during this window, exactly like the OAuth-refresh
+    // gap in production. A non-reserving check admits all 5 here.
+    await sleep(50);
+    expect(admitted).toBe(maxConcurrent);
+
+    // Drain: each release wakes one queued caller, so every grant resolves.
+    await Promise.all(grants.map(grant => grant.then(reservation => reservation.release())));
+    expect(admitted).toBe(5);
+  });
+
+  it('holds the reserved slot until the reservation is released', async () => {
+    const first = await acquire(1);
+
+    let admitted = false;
+    const second = acquire(1).then(reservation => {
+      admitted = true;
+      return reservation;
+    });
+
+    await sleep(30);
+    expect(admitted).toBe(false);
+
+    first.release();
+    (await second).release();
+    expect(admitted).toBe(true);
+  });
+
+  it('release is idempotent: double-releasing frees only one slot', async () => {
+    const first = await acquire(2);
+    const second = await acquire(2);
+
+    first.release();
+    first.release();
+
+    // The double release must free exactly one slot: a third caller gets it,
+    // and a fourth must queue behind the still-held second reservation.
+    const third = await acquire(2);
+    let fourthAdmitted = false;
+    const fourth = acquire(2).then(reservation => {
+      fourthAdmitted = true;
+      return reservation;
+    });
+
+    await sleep(30);
+    expect(fourthAdmitted).toBe(false);
+
+    second.release();
+    (await fourth).release();
+    third.release();
+  });
+
+  it('counts a registered process and its released reservation as one occupant', async () => {
+    const reservation = await acquire(1);
+
+    // Mirror the spawn factory: the real registry record appears, then the
+    // reservation is released. Total occupancy must stay at one.
+    registerFakeSdkProcess('sdk:3287:reservation-convert');
+    reservation.release();
+
+    let admitted = false;
+    const next = acquire(1).then(r => {
+      admitted = true;
+      return r;
+    });
+
+    await sleep(30);
+    expect(admitted).toBe(false);
+
+    getProcessRegistry().unregister(registeredIds.pop()!);
+    (await next).release();
+    expect(admitted).toBe(true);
+  });
+
+  it('a queued caller that aborts does not consume a slot', async () => {
+    const first = await acquire(1);
+
+    const controller = new AbortController();
+    const queued = waitForSlot(1, controller.signal);
+    await sleep(10);
+    controller.abort();
+    await expect(queued).rejects.toThrow('waitForSlot aborted');
+
+    first.release();
+
+    // The slot freed by the release must be grantable despite the abort.
+    const again = await acquire(1);
+    again.release();
+  });
+});


### PR DESCRIPTION
Closes #3287

## What was broken

`waitForSlot()` derived occupancy from the process registry alone, but a spawned agent only becomes a registry record after `spawn()` returns a PID, and the caller in `ClaudeProvider.startSession` has a wide await gap (the OAuth refresh in `buildIsolatedEnvWithFreshOAuth()`) between the slot grant and the spawn. Every concurrent caller observed the same stale count, passed the `activeCount < maxConcurrent` check, and spawned. On my machine that produced 9 concurrent SDK agents against a configured max of 2, roughly a 2.9 GB burst, stopped only by `TOTAL_PROCESS_HARD_CAP = 10`. The process listing and full analysis are in the issue.

## What the change does

`waitForSlot()` now reserves the slot it grants in the same synchronous block as the count check and returns a `SlotReservation`. `getActiveSdkCount()` counts registry records plus outstanding reservations, so there is no window in which a second caller can be granted the same slot.

The reservation is released at the first of two points:

1. In `createSdkSpawnFactory`, right after `spawnSdkProcess()` returns. On success the process is already a registry record at that point and takes over the accounting; on failure the slot goes back to the pool. Registration and release happen in one synchronous block, so no other caller can observe the reservation and the record at the same time.
2. In a `finally` in `ClaudeProvider.startSession`, as a safety net for paths where the SDK never invokes the spawn factory (OAuth failure, abort, `query()` throwing).

`release()` is idempotent, so the double release on the happy path is a no-op and a failed spawn cannot leak a slot and wedge the pool. Releases wake queued waiters through the existing `notifySlotAvailable()` path, and the 5s recheck interval stays as the fallback.

I went with a reservation count folded into `getActiveSdkCount()` rather than a separate semaphore because occupancy is already derived from the registry in several places (the hard cap check and the waiter requeue loop). One count that includes reservations keeps a single source of truth instead of two counters that can drift.

## Verification

All run on Windows 11 with bun 1.3.11.

The new test fails on main; the check-then-act race admits all 5 concurrent callers:

```
$ git checkout origin/main -- src/supervisor/process-registry.ts src/services/worker/ClaudeProvider.ts
$ bun test tests/supervisor/wait-for-slot.test.ts
70 |     expect(admitted).toBe(maxConcurrent);
error: expect(received).toBe(expected)
Expected: 2
Received: 5
(fail) waitForSlot reservations (#3287) > admits at most maxConcurrent concurrent callers before any process registers [62.00ms]
...
 0 pass
 5 fail
```

With the fix:

```
$ bun test tests/supervisor/wait-for-slot.test.ts
 5 pass
 0 fail
 8 expect() calls
Ran 5 tests across 1 file. [267.00ms]
```

Every test file that touches the changed modules:

```
$ bun test tests/supervisor/ tests/claude-provider-error-classifier.test.ts tests/claude-provider-resume.test.ts tests/worker/claude-setup-gate.test.ts tests/worker/provider-classifiers.test.ts
 120 pass
 1 skip
 0 fail
 259 expect() calls
Ran 121 tests across 10 files. [534.00ms]
```

Typecheck, lint, build:

```
$ bun run typecheck
$ tsc --noEmit && tsc --noEmit -p src/ui/viewer/tsconfig.json   (exit 0)
$ bun run lint:hook-io
hook-io discipline: OK (handlers + adapters are pure)
$ bun run lint:spawn-env
spawn-env discipline: OK (all env-bearing spawns sanitize process.env)
$ npm run build   (exit 0)
```

The `plugin/` artifacts regenerated by the build are not part of this PR; recent src-level fixes upstream also ship without them.

This fix was developed with AI assistance (Claude Code) and verified locally as shown above.
