### PR TITLE
fix(project): preserve worktree compound key from subdirectory

### DIFF
--- a/src/utils/project-name.ts
+++ b/src/utils/project-name.ts
@@ -83,7 +83,11 @@ export function getProjectContext(cwd: string | null | undefined): ProjectContex
   }
 
   const expandedCwd = expandTilde(cwd);
-  const worktreeInfo = detectWorktree(expandedCwd);
+  // #3262 — detectWorktree stats `<cwd>/.git`, which only exists at the
+  // worktree root. Resolve the git working-tree root first (same pattern as
+  // getProjectName / #2663) so sessions started in a subdirectory still get
+  // the parent/worktree compound key.
+  const worktreeInfo = detectWorktree(findGitRepoRoot(expandedCwd) ?? expandedCwd);
 
   if (worktreeInfo.isWorktree && worktreeInfo.parentProjectName) {
     const composite = `${worktreeInfo.parentProjectName}/${cwdProjectName}`;

--- a/tests/utils/project-name.test.ts
+++ b/tests/utils/project-name.test.ts
@@ -174,4 +174,75 @@ describe('getProjectContext', () => {
       expect(project).not.toBe('my-worktree');
     });
   });
+
+  // #3262 — detectWorktree must run at the git worktree root, not raw cwd.
+  // A session started in a subdirectory of a worktree must keep the same
+  // parent/worktree compound key as a session at the worktree root.
+  describe('#3262 — worktree compound key from subdirectory', () => {
+    let tmp: string;
+    let worktreeCheckout: string;
+    let worktreeSubdir: string;
+
+    beforeAll(async () => {
+      const { mkdtempSync, mkdirSync, realpathSync, writeFileSync } = await import('fs');
+      const { execFileSync } = await import('child_process');
+      const { join } = await import('path');
+      const { tmpdir } = await import('os');
+
+      tmp = realpathSync(mkdtempSync(join(tmpdir(), 'cm-wt-subdir-')));
+      const mainRepo = join(tmp, 'main-repo');
+      worktreeCheckout = join(tmp, 'feature-x');
+      worktreeSubdir = join(worktreeCheckout, 'packages', 'nested');
+
+      mkdirSync(mainRepo, { recursive: true });
+      execFileSync('git', ['init', '-q'], { cwd: mainRepo });
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: mainRepo });
+      execFileSync('git', ['config', 'user.name', 'Test'], { cwd: mainRepo });
+      writeFileSync(join(mainRepo, 'README'), 'init\n');
+      execFileSync('git', ['add', '.'], { cwd: mainRepo });
+      execFileSync('git', ['commit', '-q', '-m', 'init'], { cwd: mainRepo });
+      execFileSync('git', ['worktree', 'add', '-q', worktreeCheckout, '-b', 'feature-x'], {
+        cwd: mainRepo,
+      });
+      mkdirSync(worktreeSubdir, { recursive: true });
+    });
+
+    afterAll(async () => {
+      const { rmSync } = await import('fs');
+      const { execFileSync } = await import('child_process');
+      const { join } = await import('path');
+      try {
+        execFileSync('git', ['worktree', 'remove', '--force', worktreeCheckout], {
+          cwd: join(tmp, 'main-repo'),
+        });
+      } catch {
+        // Best-effort cleanup; rmSync below still removes the temp tree.
+      }
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    it('worktree root yields parent/worktree composite', () => {
+      const ctx = getProjectContext(worktreeCheckout);
+      expect(ctx.isWorktree).toBe(true);
+      expect(ctx.primary).toBe('main-repo/feature-x');
+      expect(ctx.parent).toBe('main-repo');
+      expect(ctx.allProjects).toEqual(['main-repo', 'main-repo/feature-x']);
+    });
+
+    it('subdirectory of a worktree yields the same composite key', () => {
+      const ctx = getProjectContext(worktreeSubdir);
+      expect(ctx.isWorktree).toBe(true);
+      expect(ctx.primary).toBe('main-repo/feature-x');
+      expect(ctx.parent).toBe('main-repo');
+      expect(ctx.allProjects).toEqual(['main-repo', 'main-repo/feature-x']);
+    });
+
+    it('subdirectory and worktree root share the same primary key', () => {
+      const atRoot = getProjectContext(worktreeCheckout).primary;
+      const inSubdir = getProjectContext(worktreeSubdir).primary;
+      expect(inSubdir).toBe(atRoot);
+      expect(inSubdir).not.toBe('feature-x');
+      expect(inSubdir).not.toBe('nested');
+    });
+  });
 });


### PR DESCRIPTION
Closes #3262

## What was broken

Sessions started in a subdirectory of a git worktree lost the `parent/worktree` compound project key and fell back to a bare key (usually the worktree folder name). Observations then accumulated under a third fragmented key, and SessionStart could show "This project has no memory yet" even when the same worktree already had history under `parent/worktree`.

Root cause: `getProjectContext()` passed the raw cwd to `detectWorktree()`, which stats `<cwd>/.git`. That file only exists at the worktree root, so any subdirectory returned `NOT_A_WORKTREE`. `getProjectName()` already resolved `git rev-parse --show-toplevel` first (#2663); the worktree-detection path did not.

## What this change does

- In `getProjectContext()`, call `detectWorktree(findGitRepoRoot(expandedCwd) ?? expandedCwd)` so detection runs at the worktree root.
- Add a real `git worktree` fixture under `tests/utils/project-name.test.ts` covering worktree root, nested subdirectory, and shared primary key.

Source only; no regenerated plugin bundles.

## Verification

Windows 11, bun 1.3.11.

New #3262 tests fail without the fix and pass with it:

```
$ bun test tests/utils/project-name.test.ts --test-name-pattern "3262"   (pre-fix source + new tests)
(pass) ... worktree root yields parent/worktree composite
(fail) ... subdirectory of a worktree yields the same composite key
        Expected: true
        Received: false
(fail) ... subdirectory and worktree root share the same primary key
        Expected: "main-repo/feature-x"
        Received: "feature-x"
 1 pass
 2 fail

$ bun test tests/utils/project-name.test.ts --test-name-pattern "3262"   (this branch)
(pass) ... worktree root yields parent/worktree composite
(pass) ... subdirectory of a worktree yields the same composite key
(pass) ... subdirectory and worktree root share the same primary key
 3 pass
 0 fail
```

Full file on this branch:

```
$ bun test tests/utils/project-name.test.ts
 21 pass
 2 fail
```

The two failures are pre-existing on `main` on Windows (tilde tests split `homedir()` on `/` before `\`, so Expected is `C:\Users\stans` while Received is `stans`). Unrelated to this change; A/B confirmed against unmodified `main`.

```
$ bun run typecheck
tsc --noEmit && tsc --noEmit -p src/ui/viewer/tsconfig.json   (exit 0)

$ bun run lint:hook-io
hook-io discipline: OK (handlers + adapters are pure)

$ bun run lint:spawn-env
spawn-env discipline: OK (all env-bearing spawns sanitize process.env)
```

This fix was developed with AI assistance (Cursor/Grok) and verified locally as shown above.
