### PR TITLE
fix(windows): strip UTF-8 BOM in readJsonSafe (#3013)

### DIFF
--- a/src/utils/json-utils.ts
+++ b/src/utils/json-utils.ts
@@ -1,11 +1,14 @@
-
 import { existsSync, readFileSync } from 'fs';
-import { logger } from './logger.js';
+import { parseJsonWithBom } from '../shared/atomic-json.js';
 
 export function readJsonSafe<T>(filePath: string, defaultValue: T): T {
   if (!existsSync(filePath)) return defaultValue;
   try {
-    return JSON.parse(readFileSync(filePath, 'utf-8'));
+    // Windows tooling (PowerShell 5.1, some editors) may rewrite JSON with a
+    // UTF-8 BOM. Node/Bun decode that to U+FEFF at offset 0, which JSON.parse
+    // rejects. Strip on read so install/uninstall and other callers survive.
+    // See #3013.
+    return parseJsonWithBom<T>(readFileSync(filePath, 'utf-8'));
   } catch (error: unknown) {
     throw new Error(`Corrupt JSON file, refusing to overwrite: ${filePath}: ${error instanceof Error ? error.message : String(error)}`);
   }

--- a/tests/json-utils.test.ts
+++ b/tests/json-utils.test.ts
@@ -116,5 +116,25 @@ describe('JSON Utils', () => {
 
       expect(result).toEqual({ ok: true });
     });
+
+    it('parses UTF-8 BOM prefixed JSON (Windows PowerShell 5.1)', () => {
+      const filePath = join(tempDir, 'settings.json');
+      const payload = { CLAUDE_MEM_MODEL: 'bom-model', nested: { ok: true } };
+      // EF BB BF is the UTF-8 BOM PowerShell 5.1 writes; decode becomes U+FEFF.
+      writeFileSync(filePath, Buffer.from([0xEF, 0xBB, 0xBF, ...Buffer.from(JSON.stringify(payload), 'utf-8')]));
+
+      const result = readJsonSafe(filePath, {});
+
+      expect(result).toEqual(payload);
+    });
+
+    it('parses string that already starts with U+FEFF', () => {
+      const filePath = join(tempDir, 'feff.json');
+      writeFileSync(filePath, '\uFEFF' + JSON.stringify({ port: 37777 }), 'utf-8');
+
+      const result = readJsonSafe<{ port: number }>(filePath, { port: 0 });
+
+      expect(result.port).toBe(37777);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #3013.

Most `~/.claude-mem/settings.json` readers already strip a leading UTF-8 BOM via `parseJsonWithBom`. Install and uninstall still go through `readJsonSafe`, which called `JSON.parse` on the raw string. On Windows, PowerShell 5.1 (and some editors) rewrite JSON with a BOM (`EF BB BF`). Bun/Node decode that to `U+FEFF` at offset 0, and parse fails with `Unrecognized token` (the invisible BOM).

This change routes `readJsonSafe` through the shared helper, drops an unused `logger` import that risked a cycle, and adds regression tests for byte-BOM and `U+FEFF` prefixes.

Note: prior PR #3033 covered this path but never landed on `main`. Worker-side readers were hardened separately; this finishes the install/uninstall path that still failed at HEAD.

## AI assistance

This PR was prepared with AI assistance (Cursor/Grok). Human author: Stan Shih (@stantheman0128). I reviewed the diff, ran the verification commands below, and take responsibility for the change.

## Evidence

Repro at HEAD (before fix):

```
readJsonSafe FAIL: Corrupt JSON file, refusing to overwrite: ...\settings.json: JSON Parse error: Unrecognized token '﻿'
parseJsonWithBom: x
SettingsDefaultsManager: x DEBUG
```

After fix:

```
bun test tests/json-utils.test.ts tests/shared/settings-defaults-manager.test.ts
47 pass
0 fail
Ran 47 tests across 2 files. [395.00ms]
```

```
bun run typecheck
# exit 0
```

```
bun run lint:hook-io
hook-io discipline: OK (handlers + adapters are pure)

bun run lint:spawn-env
spawn-env discipline: OK (all env-bearing spawns sanitize process.env)
```

## Test plan

- [x] `bun test tests/json-utils.test.ts` (includes BOM byte prefix + U+FEFF cases)
- [x] `bun test tests/shared/settings-defaults-manager.test.ts` (existing BOM cases still pass)
- [x] `bun run typecheck`
- [x] `bun run lint:hook-io` / `lint:spawn-env`