### PR TITLE
fix(tests): use fileURLToPath for import.meta.url paths so tests run on Windows

### DIFF
--- a/tests/hook-lifecycle.test.ts
+++ b/tests/hook-lifecycle.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { fileURLToPath } from 'node:url';
 
 describe('Hook Lifecycle - Event Handlers', () => {
   describe('worker fallback failure counter', () => {
@@ -494,7 +495,7 @@ describe('hookCommand - stderr discipline (plan 01 / #2292)', () => {
     expect(typeof hookCommand).toBe('function');
 
     const hookCommandSource = await Bun.file(
-      new URL('../src/cli/hook-command.ts', import.meta.url).pathname
+      fileURLToPath(new URL('../src/cli/hook-command.ts', import.meta.url))
     ).text();
 
     // Diagnostics still go through the structured logger.

--- a/tests/servers/mcp-tool-schemas.test.ts
+++ b/tests/servers/mcp-tool-schemas.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'bun:test';
+import { fileURLToPath } from 'node:url';
 
-const mcpServerPath = new URL('../../src/servers/mcp-server.ts', import.meta.url).pathname;
+const mcpServerPath = fileURLToPath(new URL('../../src/servers/mcp-server.ts', import.meta.url));
 
 describe('MCP tool inputSchema declarations', () => {
   let tools: any[];


### PR DESCRIPTION
## What is broken

On Windows, two test files resolve a source path with `new URL(relativePath, import.meta.url).pathname`. On Windows `import.meta.url` is a `file:///C:/...` URL, and its `.pathname` is `/C:/Users/.../mcp-server.ts` with a leading slash before the drive letter. `Bun.file()` / `fs` cannot open that shape, so every case that reads the source file fails with:

```
ENOENT: no such file or directory, open '/C:/Users/.../src/servers/mcp-server.ts'
```

The whole `tests/servers/mcp-tool-schemas.test.ts` suite (12 cases) is unrunnable on Windows for this reason, and one case in `tests/hook-lifecycle.test.ts` hits the same problem. macOS and Linux are unaffected because their `file://` pathname has no leading-slash-before-drive quirk, which is why CI stays green and this only bites Windows contributors.

## Fix

Use `fileURLToPath()` from `node:url`, which converts a `file://` URL to a correct native path on every platform (including stripping the spurious leading slash on Windows):

- `tests/servers/mcp-tool-schemas.test.ts`: `fileURLToPath(new URL('../../src/servers/mcp-server.ts', import.meta.url))`
- `tests/hook-lifecycle.test.ts`: `fileURLToPath(new URL('../src/cli/hook-command.ts', import.meta.url))`

Two lines changed plus one import per file. No source or production code touched.

## Verification (real output, Windows 11, bun 1.3.11)

Before, on `origin/main`, the file carries the buggy line and every case throws ENOENT on a `/C:/...` path.

After, the documented suite is green:

```
$ bun test tests/servers/mcp-tool-schemas.test.ts
 12 pass
 0 fail
 46 expect() calls
Ran 12 tests across 1 file.
```

Zero `ENOENT '/C:/...'` failures remain across both changed files. `tests/hook-lifecycle.test.ts` has other cases that dynamically import runtime modules and therefore report `Cannot find module` in a bare checkout without `node_modules`; those are missing-dependency failures, present regardless of this change, and unrelated to path handling.

Diff:

```
 tests/hook-lifecycle.test.ts           | 3 ++-
 tests/servers/mcp-tool-schemas.test.ts | 3 ++-
 2 files changed, 4 insertions(+), 2 deletions(-)
```

## Notes

This was found and reproduced on a real Windows 11 machine while running the suite; there was no existing issue for it. The change is a plain, cross-platform-safe path fix that makes the two suites runnable on Windows.

AI-assisted: investigated and implemented with Claude (Claude Code); a human reviewed the diff and is submitting the PR.
