### PR TITLE
fix(version-bump): match skill frontmatter name to its directory (#3122)

### DIFF
--- a/plugin/skills/version-bump/SKILL.md
+++ b/plugin/skills/version-bump/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: claude-code-plugin-release
+name: version-bump
 description: Automated semantic versioning and release workflow for Claude Code plugins. Handles version increments across package.json, marketplace.json, plugin.json manifests, build verification, git tagging, GitHub releases, and changelog generation. NPM publishing (so `npx claude-mem@X.Y.Z` resolves) is handed off to the human maintainer, who raised npm security.
 ---
 


### PR DESCRIPTION
Fixes #3122

## What this changes

`plugin/skills/version-bump/SKILL.md` declared a frontmatter `name: claude-code-plugin-release` that did not match its directory `plugin/skills/version-bump/`. This change sets the frontmatter to `name: version-bump` so the declared name matches the directory.

## Why

Skill tooling treats the directory name as the skill's identity (install path, the `/version-bump` invocation, and dedup or ownership tracking). When the frontmatter name disagrees with the directory:

- indexers that key on the frontmatter name register the skill under `claude-code-plugin-release` while it lives at `skills/version-bump/`, so a lookup by either identifier can miss it;
- name-equals-directory health checks flag it. All 43 other bundled skills (claude-mem, superpowers, caveman, claude-skills) already satisfy that check.

I aligned the frontmatter to the directory rather than renaming the directory, because the directory and the `/version-bump` invocation are the established identity and renaming the directory would break the invocation path.

## Verification

- Reproduced at HEAD (`f5633c1f`): the frontmatter still read `name: claude-code-plugin-release` while the directory is `version-bump`.
- Repo-wide grep shows `claude-code-plugin-release` was referenced only on that one frontmatter line. No manifest, script, or source keys off the old name, so aligning the name is non-breaking.

```
$ git diff
-name: claude-code-plugin-release
+name: version-bump
```

## AI disclosure

This change was prepared with AI assistance (Claude). I reviewed the diff and verified the claims above, and I take responsibility for the contents.
