### PR TITLE
feat(hooks): env opt-out for PreToolUse/PostToolUse (#3106)

### DIFF
--- a/docs/public/configuration.mdx
+++ b/docs/public/configuration.mdx
@@ -22,6 +22,11 @@ Settings are managed in `~/.claude-mem/settings.json`. The file is auto-created 
 | `CLAUDE_MEM_WORKER_HOST`      | `127.0.0.1`                     | Worker service host address           |
 | `CLAUDE_MEM_DATA_DIR`         | `~/.claude-mem`                 | Data root — every other path (database, chroma, logs, settings.json, worker.pid) derives from this |
 | `CLAUDE_MEM_SKIP_TOOLS`       | `ListMcpResourcesTool,SlashCommand,Skill,TodoWrite,AskUserQuestion` | Comma-separated tools to exclude from observations |
+| `CLAUDE_MEM_DISABLE_TOOL_HOOKS` | _(unset)_                         | Set to `1` to no-op PreToolUse (`file-context`) and PostToolUse (`observation`) hooks while keeping SessionStart / UserPromptSubmit / Stop active (useful on Windows when bash hook consoles steal focus) |
+| `CLAUDE_MEM_DISABLE_OBSERVATION` | _(unset)_                      | Set to `1` to no-op only the PostToolUse `observation` hook |
+| `CLAUDE_MEM_DISABLE_FILE_CONTEXT` | _(unset)_                     | Set to `1` to no-op only the PreToolUse `file-context` hook |
+
+These disable flags can also be set under the `env` block in `~/.claude/settings.json` so Claude Code inherits them for every hook spawn.
 
 ### Gemini Provider Settings
 

--- a/docs/public/troubleshooting.mdx
+++ b/docs/public/troubleshooting.mdx
@@ -150,6 +150,24 @@ PORT=${CLAUDE_MEM_WORKER_PORT:-$(jq -r .CLAUDE_MEM_WORKER_PORT ~/.claude-mem/set
 
 5. If Chroma continues to fail, hybrid search will gracefully degrade to SQLite FTS5 only
 
+### Windows: console windows steal focus on every tool call
+
+**Symptoms**: On Windows, Claude Code flashes a console window (and steals focus) on nearly every Read / tool call while claude-mem is enabled.
+
+**Cause**: High-frequency `PreToolUse` (`file-context`) and `PostToolUse` (`observation`) hooks run as bash commands. Renaming those keys in `hooks.json` is no longer a valid workaround; Claude Code rejects unknown hook keys and drops the entire plugin hook set.
+
+**Opt-out** (keeps SessionStart / UserPromptSubmit / Stop memory capture):
+
+```json
+{
+  "env": {
+    "CLAUDE_MEM_DISABLE_TOOL_HOOKS": "1"
+  }
+}
+```
+
+Add that under `~/.claude/settings.json` (or export the variable in your shell). Granular flags: `CLAUDE_MEM_DISABLE_OBSERVATION=1` and `CLAUDE_MEM_DISABLE_FILE_CONTEXT=1`. See [Configuration](configuration).
+
 ### Smart Install Caching Issues (v5.0.3+)
 
 **Symptoms**: Dependencies not updating after plugin update, stale version marker.

--- a/src/cli/hook-command.ts
+++ b/src/cli/hook-command.ts
@@ -3,7 +3,7 @@ import { getPlatformAdapter } from './adapters/index.js';
 import { AdapterRejectedInput } from './adapters/errors.js';
 import { getEventHandler } from './handlers/index.js';
 import type { HookResult } from './types.js';
-import { HOOK_EXIT_CODES } from '../shared/hook-constants.js';
+import { HOOK_EXIT_CODES, isToolHookDisabledByEnv } from '../shared/hook-constants.js';
 import {
   installHookStderrBuffer,
   emitModelContext,
@@ -105,6 +105,15 @@ export async function hookCommand(platform: string, event: string, options: Hook
   // Register the hook event for the threshold-gated hook_failed telemetry
   // (closed enum enforced inside; non-enum events just omit hook_type).
   setActiveHookType(event);
+
+  // #3106: defense in depth if hookCommand is invoked without the worker-service
+  // pre-gate (tests / alternate entry points). Skip stdin + handler work.
+  if (isToolHookDisabledByEnv(event)) {
+    const adapter = getPlatformAdapter(platform);
+    emitModelContext(adapter, buildNoOpResult(event));
+    exitGraceful(options);
+    return HOOK_EXIT_CODES.SUCCESS;
+  }
 
   // Hook IO Discipline (issue #2292):
   // We BUFFER stderr during handler execution so that unsolicited writes from

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -10,7 +10,7 @@ import { getWorkerPort, getWorkerHost, fetchWithTimeout, resolveWorkerScriptPath
 import { getCurrentWorkerPid, verifyRestartedWorker } from './restart-verify.js';
 import { runShutdownSequence, type WorkerShutdownReason } from './worker-shutdown.js';
 import { DATA_DIR, DB_PATH, ensureDir } from '../shared/paths.js';
-import { HOOK_TIMEOUTS } from '../shared/hook-constants.js';
+import { HOOK_EXIT_CODES, HOOK_TIMEOUTS, isToolHookDisabledByEnv } from '../shared/hook-constants.js';
 import { getUptimeSeconds } from '../shared/uptime.js';
 import { SettingsDefaultsManager } from '../shared/SettingsDefaultsManager.js';
 import { getAuthMethodDescription } from '../shared/EnvManager.js';
@@ -1320,6 +1320,12 @@ async function main() {
         console.error('Platforms: claude-code, codex, cursor, antigravity-cli, raw');
         console.error('Events: context, session-init, observation, summarize, user-message');
         process.exit(1);
+      }
+
+      // #3106: exit before ensureWorkerStarted so disabled tool hooks do no
+      // stdin / worker / handler work (Windows console focus opt-out).
+      if (isToolHookDisabledByEnv(event)) {
+        process.exit(HOOK_EXIT_CODES.SUCCESS);
       }
 
       const workerStartResult = await ensureWorkerStarted(port);

--- a/src/shared/hook-constants.ts
+++ b/src/shared/hook-constants.ts
@@ -14,6 +14,45 @@ export const HOOK_EXIT_CODES = {
   BLOCKING_ERROR: 2,
 } as const;
 
+/** High-frequency tool hooks that fire on nearly every Claude Code action. */
+export const TOOL_HOOK_EVENTS = ['observation', 'file-context'] as const;
+export type ToolHookEvent = (typeof TOOL_HOOK_EVENTS)[number];
+
+function isEnvFlagOn(value: string | undefined): boolean {
+  return value === '1';
+}
+
+/**
+ * Opt-out gate for PreToolUse / PostToolUse hooks (#3106).
+ *
+ * When set, observation / file-context exit 0 before worker start or stdin
+ * work so Windows users can stop the focus-stealing console flash without
+ * editing shipped hooks.json (which schema validation now rejects for
+ * renamed keys). SessionStart / UserPromptSubmit / Stop stay active.
+ *
+ * - CLAUDE_MEM_DISABLE_TOOL_HOOKS=1 — both tool hooks
+ * - CLAUDE_MEM_DISABLE_OBSERVATION=1 — PostToolUse observation only
+ * - CLAUDE_MEM_DISABLE_FILE_CONTEXT=1 — PreToolUse file-context only
+ */
+export function isToolHookDisabledByEnv(
+  event: string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (!(TOOL_HOOK_EVENTS as readonly string[]).includes(event)) {
+    return false;
+  }
+  if (isEnvFlagOn(env.CLAUDE_MEM_DISABLE_TOOL_HOOKS)) {
+    return true;
+  }
+  if (event === 'observation' && isEnvFlagOn(env.CLAUDE_MEM_DISABLE_OBSERVATION)) {
+    return true;
+  }
+  if (event === 'file-context' && isEnvFlagOn(env.CLAUDE_MEM_DISABLE_FILE_CONTEXT)) {
+    return true;
+  }
+  return false;
+}
+
 export function getTimeout(baseTimeout: number): number {
   return process.platform === 'win32'
     ? Math.round(baseTimeout * HOOK_TIMEOUTS.WINDOWS_MULTIPLIER)

--- a/tests/hook-command.test.ts
+++ b/tests/hook-command.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'bun:test';
-import { buildNoOpResult, isNonBlockingHookInputError, isWorkerUnavailableError } from '../src/cli/hook-command.js';
+import { describe, it, expect, afterEach } from 'bun:test';
+import {
+  buildNoOpResult,
+  hookCommand,
+  isNonBlockingHookInputError,
+  isWorkerUnavailableError,
+} from '../src/cli/hook-command.js';
+import { HOOK_EXIT_CODES } from '../src/shared/hook-constants.js';
 
 describe('buildNoOpResult', () => {
   it('attaches a valid SessionStart hookSpecificOutput for the context event (#2972)', () => {
@@ -16,6 +22,27 @@ describe('buildNoOpResult', () => {
     for (const event of ['session-init', 'observation', 'summarize', 'user-message', 'file-edit', 'file-context']) {
       expect(buildNoOpResult(event)).toEqual({ continue: true, suppressOutput: true });
     }
+  });
+});
+
+describe('hookCommand tool-hook disable (#3106)', () => {
+  afterEach(() => {
+    delete process.env.CLAUDE_MEM_DISABLE_TOOL_HOOKS;
+    delete process.env.CLAUDE_MEM_DISABLE_OBSERVATION;
+    delete process.env.CLAUDE_MEM_DISABLE_FILE_CONTEXT;
+  });
+
+  it('exits success without reading stdin when CLAUDE_MEM_DISABLE_TOOL_HOOKS=1', async () => {
+    process.env.CLAUDE_MEM_DISABLE_TOOL_HOOKS = '1';
+    // No stdin JSON is provided; a disabled early-return must not hang on readJsonFromStdin.
+    const code = await hookCommand('claude-code', 'observation', { skipExit: true });
+    expect(code).toBe(HOOK_EXIT_CODES.SUCCESS);
+  });
+
+  it('also no-ops file-context when CLAUDE_MEM_DISABLE_TOOL_HOOKS=1', async () => {
+    process.env.CLAUDE_MEM_DISABLE_TOOL_HOOKS = '1';
+    const code = await hookCommand('claude-code', 'file-context', { skipExit: true });
+    expect(code).toBe(HOOK_EXIT_CODES.SUCCESS);
   });
 });
 

--- a/tests/hook-constants.test.ts
+++ b/tests/hook-constants.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { HOOK_TIMEOUTS, HOOK_EXIT_CODES, getTimeout } from '../src/shared/hook-constants.js';
+import {
+  HOOK_TIMEOUTS,
+  HOOK_EXIT_CODES,
+  getTimeout,
+  isToolHookDisabledByEnv,
+} from '../src/shared/hook-constants.js';
 
 describe('hook-constants', () => {
   const originalPlatform = process.platform;
@@ -85,6 +90,39 @@ describe('hook-constants', () => {
       });
 
       expect(getTimeout(1000)).toBe(1000);
+    });
+  });
+
+  describe('isToolHookDisabledByEnv (#3106)', () => {
+    it('is off by default for tool and non-tool events', () => {
+      const env = {};
+      expect(isToolHookDisabledByEnv('observation', env)).toBe(false);
+      expect(isToolHookDisabledByEnv('file-context', env)).toBe(false);
+      expect(isToolHookDisabledByEnv('context', env)).toBe(false);
+      expect(isToolHookDisabledByEnv('session-init', env)).toBe(false);
+      expect(isToolHookDisabledByEnv('summarize', env)).toBe(false);
+    });
+
+    it('CLAUDE_MEM_DISABLE_TOOL_HOOKS=1 disables observation and file-context only', () => {
+      const env = { CLAUDE_MEM_DISABLE_TOOL_HOOKS: '1' };
+      expect(isToolHookDisabledByEnv('observation', env)).toBe(true);
+      expect(isToolHookDisabledByEnv('file-context', env)).toBe(true);
+      expect(isToolHookDisabledByEnv('context', env)).toBe(false);
+      expect(isToolHookDisabledByEnv('session-init', env)).toBe(false);
+      expect(isToolHookDisabledByEnv('summarize', env)).toBe(false);
+      expect(isToolHookDisabledByEnv('user-message', env)).toBe(false);
+    });
+
+    it('ignores non-1 values for the coarse flag', () => {
+      expect(isToolHookDisabledByEnv('observation', { CLAUDE_MEM_DISABLE_TOOL_HOOKS: 'true' })).toBe(false);
+      expect(isToolHookDisabledByEnv('observation', { CLAUDE_MEM_DISABLE_TOOL_HOOKS: '0' })).toBe(false);
+    });
+
+    it('supports granular observation / file-context flags', () => {
+      expect(isToolHookDisabledByEnv('observation', { CLAUDE_MEM_DISABLE_OBSERVATION: '1' })).toBe(true);
+      expect(isToolHookDisabledByEnv('file-context', { CLAUDE_MEM_DISABLE_OBSERVATION: '1' })).toBe(false);
+      expect(isToolHookDisabledByEnv('file-context', { CLAUDE_MEM_DISABLE_FILE_CONTEXT: '1' })).toBe(true);
+      expect(isToolHookDisabledByEnv('observation', { CLAUDE_MEM_DISABLE_FILE_CONTEXT: '1' })).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Closes #3106

## Summary

On Windows, every PreToolUse (file-context) and PostToolUse (observation) hook can flash a console window and steal focus. Renaming those keys in hooks.json is no longer valid: Claude Code rejects unknown hook keys and drops the whole plugin hook set.

This adds an env opt-out that exits those two hooks with code 0 before `ensureWorkerStarted` / stdin work:

- `CLAUDE_MEM_DISABLE_TOOL_HOOKS=1` — both tool hooks
- `CLAUDE_MEM_DISABLE_OBSERVATION=1` / `CLAUDE_MEM_DISABLE_FILE_CONTEXT=1` — granular

SessionStart / UserPromptSubmit / Stop stay active. Documented in configuration + troubleshooting. Source-only (no regenerated `worker-service.cjs`); takes effect on the next release build that bundles worker-service.

## Verification

Windows 11, bun 1.3.11.

```
$ bun test tests/hook-constants.test.ts tests/hook-command.test.ts
 50 pass
 0 fail

$ bun run typecheck
tsc --noEmit && tsc --noEmit -p src/ui/viewer/tsconfig.json   (exit 0)

$ bun run lint:hook-io
hook-io discipline: OK (handlers + adapters are pure)

$ bun run lint:spawn-env
spawn-env discipline: OK (all env-bearing spawns sanitize process.env)
```

This fix was developed with AI assistance (Cursor/Grok) and verified locally as shown above.