### PR TITLE
fix(windows): detect worker ESM main via pathToFileURL

### DIFF
--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -2,6 +2,7 @@
 import path from 'path';
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
 import { spawn } from 'child_process';
+import { pathToFileURL } from 'url';
 import type { Database } from 'bun:sqlite';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
@@ -1502,7 +1503,7 @@ function printQueueStatusIfBullMq(health: WorkerHealthSnapshot): void {
 
 const isMainModule = typeof require !== 'undefined' && typeof module !== 'undefined'
   ? require.main === module || !module.parent || process.env.CLAUDE_MEM_MANAGED === 'true'
-  : import.meta.url === `file://${process.argv[1]}`
+  : (Boolean(process.argv[1]) && import.meta.url === pathToFileURL(process.argv[1]).href)
     || process.argv[1]?.endsWith('worker-service')
     || process.argv[1]?.endsWith('worker-service.cjs')
     || process.argv[1]?.replaceAll('\\', '/') === __filename?.replaceAll('\\', '/');


### PR DESCRIPTION
## Summary
- ESM main detection compared `import.meta.url` to `` `file://${process.argv[1]}` ``, which does not produce a valid file URL for Windows paths (backslashes, missing `/` after `file:`).
- Use `pathToFileURL(process.argv[1]).href`, matching existing scripts such as `export-memories.ts`.

## AI assistance
This PR was prepared with AI assistance (Cursor/Grok). Human author: Stan Shih (@stantheman0128). Please review carefully.

## Verification / Evidence
Windows path URL mismatch repro:

```
old would match false
new matches true
bad  file://C:\\Users\\stans\\Projects\\oss\\...
good file:///C:/Users/stans/Projects/oss/clau...
```

`bun run typecheck` (pass)