### PR TITLE
fix(windows): hide console when npm install helper spawns npm

### DIFF
--- a/src/npx-cli/install/npm-install-helper.ts
+++ b/src/npx-cli/install/npm-install-helper.ts
@@ -56,6 +56,7 @@ export function runNpmStrict(cwd: string, flags: string[]): Promise<NpmResult> {
     const child = spawn('npm', flags, {
       cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
       ...(IS_WINDOWS ? { shell: process.env.ComSpec ?? 'cmd.exe' } : {}),
     });
 

--- a/tests/npm-install-windows-hide.test.ts
+++ b/tests/npm-install-windows-hide.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const SOURCE = readFileSync(
+  join(import.meta.dir, '../src/npx-cli/install/npm-install-helper.ts'),
+  'utf8',
+);
+
+describe('npm-install-helper Windows spawn', () => {
+  it('hides the console window when spawning npm (incl. Windows shell)', () => {
+    expect(SOURCE).toContain('windowsHide: true');
+    expect(SOURCE).toMatch(
+      /spawn\(\s*'npm',\s*flags,\s*\{[\s\S]*?windowsHide:\s*true[\s\S]*?\}\)/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `runNpmStrict` in the marketplace install helper spawns `npm` with a Windows shell but without `windowsHide`.
- That flashes a console window during `npx claude-mem install` dependency install.
- Add `windowsHide: true` (keeps the existing Windows `shell: ComSpec` path for `.cmd` shims).

## AI assistance
This PR was prepared with AI assistance (Cursor/Grok). Human author: Stan Shih (@stantheman0128). Please review carefully.

## Verification / Evidence
Focused test:
```
bun test tests/npm-install-windows-hide.test.ts
# 1 pass, 0 fail
```

## Test plan
- [x] Source regression asserts `windowsHide: true` on the npm spawn
- [ ] Maintainer: run marketplace npm install step on Windows and confirm no console flash
