### PR TITLE
fix(windows): hide consoles for IDE detection and npm install

### DIFF
--- a/src/npx-cli/commands/ide-detection.ts
+++ b/src/npx-cli/commands/ide-detection.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { existsSync, readdirSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
@@ -13,8 +13,14 @@ export interface IDEInfo {
 
 function isCommandInPath(command: string): boolean {
   try {
-    const whichCommand = IS_WINDOWS ? 'where' : 'which';
-    execSync(`${whichCommand} ${command}`, { stdio: 'pipe' });
+    if (IS_WINDOWS) {
+      execFileSync('where.exe', [command], {
+        stdio: 'ignore',
+        windowsHide: true,
+      });
+    } else {
+      execFileSync('which', [command], { stdio: 'ignore' });
+    }
     return true;
   } catch (error: unknown) {
     if (process.env.DEBUG) {

--- a/src/npx-cli/install/npm-install-helper.ts
+++ b/src/npx-cli/install/npm-install-helper.ts
@@ -56,7 +56,9 @@ export function runNpmStrict(cwd: string, flags: string[]): Promise<NpmResult> {
     const child = spawn('npm', flags, {
       cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
-      ...(IS_WINDOWS ? { shell: process.env.ComSpec ?? 'cmd.exe' } : {}),
+      ...(IS_WINDOWS
+        ? { shell: process.env.ComSpec ?? 'cmd.exe', windowsHide: true }
+        : {}),
     });
 
     let stdout = '';

--- a/src/services/integrations/CodexCliInstaller.ts
+++ b/src/services/integrations/CodexCliInstaller.ts
@@ -31,7 +31,7 @@ const WINDOWS_CODEX_EXTENSIONS = new Set(['.cmd', '.exe', '.bat', '.com']);
 function commandExists(command: string): boolean {
   try {
     if (process.platform === 'win32') {
-      execFileSync('where', [command], { stdio: 'ignore' });
+      execFileSync('where.exe', [command], { stdio: 'ignore', windowsHide: true });
     } else {
       execFileSync('which', [command], { stdio: 'ignore' });
     }
@@ -90,7 +90,7 @@ function resolvePluginMarketplaceRoot(preferredRoot?: string): string {
 function lookupCodexOnWindows(): string | null {
   let stdout: string;
   try {
-    stdout = execFileSync('where', ['codex'], {
+    stdout = execFileSync('where.exe', ['codex'], {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
       windowsHide: true,


### PR DESCRIPTION
## Summary
Hide Windows console flashes during IDE PATH probes and marketplace npm install.

- `ide-detection.ts`: `where.exe`/`which` via `execFileSync` + `windowsHide`
- `npm-install-helper.ts`: `windowsHide: true` when spawning npm through cmd.exe
- `CodexCliInstaller.ts`: `where.exe` + `windowsHide` on `commandExists`

## AI assistance
Prepared with Cursor (Grok). Human reviewed and verified on Windows 11.

## Evidence
Live Win11:
```
where.exe node -> hasCR=True, first=C:\Program Files\nodejs\node.exe
```
Targeted review of the three call sites; no covering open PR for this surface.

## Test plan
- [x] Manual review of spawn options
- [ ] CI