### PR TITLE
fix(windows): resolve PATH binaries via where.exe argv

### DIFF
--- a/src/services/infrastructure/ProcessManager.ts
+++ b/src/services/infrastructure/ProcessManager.ts
@@ -2,7 +2,7 @@
 import path from 'path';
 import { homedir } from 'os';
 import { existsSync, writeFileSync, readFileSync, unlinkSync, mkdirSync, statSync, utimesSync, copyFileSync } from 'fs';
-import { execSync, spawnSync } from 'child_process';
+import { execFileSync, execSync, spawnSync } from 'child_process';
 import { spawnHidden } from '../../shared/spawn.js';
 import { logger } from '../../utils/logger.js';
 import { sanitizeEnv } from '../../supervisor/env-sanitizer.js';
@@ -30,20 +30,31 @@ function isBunExecutablePath(executablePath: string | undefined | null): boolean
 }
 
 function lookupBinaryInPath(binaryName: string, platform: NodeJS.Platform): string | null {
-  const command = platform === 'win32' ? `where ${binaryName}` : `which ${binaryName}`;
+  const lookupCommand = platform === 'win32' ? 'where.exe' : 'which';
+  const lookupArgs = [binaryName];
 
   let output: string;
   try {
-    output = execSync(command, {
+    output = execFileSync(lookupCommand, lookupArgs, {
       stdio: ['ignore', 'pipe', 'ignore'],
       encoding: 'utf-8',
       windowsHide: true
     });
   } catch (error: unknown) {
     if (error instanceof Error) {
-      logger.debug('SYSTEM', `Binary lookup failed for ${binaryName}`, { command }, error);
+      logger.debug(
+        'SYSTEM',
+        `Binary lookup failed for ${binaryName}`,
+        { command: lookupCommand, args: lookupArgs },
+        error,
+      );
     } else {
-      logger.debug('SYSTEM', `Binary lookup failed for ${binaryName}`, { command }, new Error(String(error)));
+      logger.debug(
+        'SYSTEM',
+        `Binary lookup failed for ${binaryName}`,
+        { command: lookupCommand, args: lookupArgs },
+        new Error(String(error)),
+      );
     }
     return null;
   }

--- a/src/shared/find-claude-executable.ts
+++ b/src/shared/find-claude-executable.ts
@@ -200,14 +200,16 @@ function discoverCandidates(): string[] {
   if (_internals.platform() === 'win32') {
     // claude.cmd first: spawning the .cmd wrapper avoids spawn issues with
     // spaces in the .exe path (long-standing Windows preference).
-    for (const command of ['where claude.cmd', 'where claude']) {
+    // Use where.exe argv (not a shell string) so PATH lookups do not flash a
+    // console and binary names with spaces stay argv-safe.
+    for (const name of ['claude.cmd', 'claude']) {
       try {
-        const output = _internals.execSync(command, {
+        const output = _internals.execFileSync('where.exe', [name], {
           encoding: 'utf8',
           windowsHide: true,
           stdio: ['ignore', 'pipe', 'ignore'],
         });
-        candidates.push(...output.split('\n').map((line) => line.trim()).filter(Boolean));
+        candidates.push(...output.split(/\r?\n/).map((line) => line.trim()).filter(Boolean));
       } catch {
         // Not found via this lookup — try the next discovery source.
       }

--- a/tests/shared/find-claude-executable.test.ts
+++ b/tests/shared/find-claude-executable.test.ts
@@ -31,7 +31,12 @@ let realPaths: Map<string, string>;
 /** stdout of `which -a claude`; null = which fails. */
 let whichOutput: string | null;
 
-function installFakes(options: { settingsPath?: string; platform?: NodeJS.Platform; whereOutputs?: Record<string, string> } = {}): void {
+function installFakes(options: {
+  settingsPath?: string;
+  platform?: NodeJS.Platform;
+  /** Keys are where.exe argv names (e.g. `claude.cmd`), values are stdout. */
+  whereOutputs?: Record<string, string>;
+} = {}): void {
   _internals.platform = () => options.platform ?? 'darwin';
   _internals.homedir = () => '/home/tester';
   _internals.loadSettings = () => ({ CLAUDE_CODE_PATH: options.settingsPath ?? '' }) as ReturnType<typeof ORIGINALS.loadSettings>;
@@ -39,9 +44,6 @@ function installFakes(options: { settingsPath?: string; platform?: NodeJS.Platfo
   _internals.realpathSync = ((path: string) => realPaths.get(path) ?? path) as typeof ORIGINALS.realpathSync;
 
   _internals.execSync = ((command: string) => {
-    if (options.whereOutputs && command in options.whereOutputs) {
-      return options.whereOutputs[command];
-    }
     if (command === 'which -a claude' && whichOutput !== null) {
       return whichOutput;
     }
@@ -49,6 +51,14 @@ function installFakes(options: { settingsPath?: string; platform?: NodeJS.Platfo
   }) as typeof ORIGINALS.execSync;
 
   _internals.execFileSync = ((path: string, args: string[]) => {
+    if (path === 'where.exe') {
+      const name = args[0] ?? '';
+      if (options.whereOutputs && name in options.whereOutputs) {
+        return options.whereOutputs[name];
+      }
+      throw new Error(`not found: where.exe ${name}`);
+    }
+
     probeCalls.push({ path, args });
     const real = realPaths.get(path) ?? path;
     const cli = fakeClis.get(path) ?? fakeClis.get(real);
@@ -188,7 +198,7 @@ describe('findClaudeExecutable broken candidates', () => {
     installFakes({
       platform: 'win32',
       whereOutputs: {
-        'where claude': 'C:\\Users\\tester\\AppData\\Local\\AnthropicClaude\\claude.exe\r\nC:\\good\\claude.exe\r\n',
+        claude: 'C:\\Users\\tester\\AppData\\Local\\AnthropicClaude\\claude.exe\r\nC:\\good\\claude.exe\r\n',
       },
     });
     fakeClis.set('C:\\Users\\tester\\AppData\\Local\\AnthropicClaude\\claude.exe', { version: '0.0.0', supportsDontAsk: false, broken: true });
@@ -302,8 +312,8 @@ describe('findClaudeExecutable on Windows', () => {
     installFakes({
       platform: 'win32',
       whereOutputs: {
-        'where claude.cmd': 'C:\\old\\claude.cmd\r\n',
-        'where claude': 'C:\\new\\claude.exe\r\n',
+        'claude.cmd': 'C:\\old\\claude.cmd\r\n',
+        claude: 'C:\\new\\claude.exe\r\n',
       },
     });
     fakeClis.set('C:\\old\\claude.cmd', { version: '2.0.42', supportsDontAsk: false });


### PR DESCRIPTION
## Summary
Resolve PATH binaries with where.exe argv instead of shell `where ...` strings.

- ProcessManager.lookupBinaryInPath: execFileSync("where.exe"|"which", ...) + windowsHide
- findClaudeExecutable Windows discovery: same pattern, CRLF-safe split
- Unit tests updated for where.exe argv keys

## AI assistance
Prepared with Cursor (Grok). Human reviewed and verified on Windows 11.

## Evidence
```
bun test tests/shared/find-claude-executable.test.ts -t "on Windows"
1 pass (Windows where-discovery preference)
```
Pre-existing Windows-only failure remains in the darwin known-install-locations case (path.join separators). A/B against origin/main shows the same fail before this diff.

## Test plan
- [x] bun test tests/shared/find-claude-executable.test.ts -t "on Windows"
- [ ] CI
