### PR TITLE
feat: honor CLAUDE_MEM_PUBLIC_URL for the live-view URL printed to users

### DIFF
--- a/src/cli/handlers/context.ts
+++ b/src/cli/handlers/context.ts
@@ -9,6 +9,7 @@ import {
   executeWithWorkerFallback,
   isWorkerFallback,
   getWorkerPort,
+  getViewerBaseUrl,
 } from '../../shared/worker-utils.js';
 import { getProjectContext } from '../../utils/project-name.js';
 import { HOOK_EXIT_CODES } from '../../shared/hook-constants.js';
@@ -141,7 +142,7 @@ export const contextHandler: EventHandler = {
     const displayContent = coloredTimeline || (platform === 'antigravity-cli' ? additionalContext : '');
 
     const systemMessage = showTerminalOutput && displayContent
-      ? `${displayContent}\n\nView Observations Live @ http://localhost:${port}`
+      ? `${displayContent}\n\nView Observations Live @ ${getViewerBaseUrl(port)}`
       : undefined;
 
     return {

--- a/src/cli/handlers/user-message.ts
+++ b/src/cli/handlers/user-message.ts
@@ -5,6 +5,7 @@ import {
   executeWithWorkerFallback,
   isWorkerFallback,
   getWorkerPort,
+  getViewerBaseUrl,
 } from '../../shared/worker-utils.js';
 import { HOOK_EXIT_CODES } from '../../shared/hook-constants.js';
 import { normalizePlatformSource } from '../../shared/platform-source.js';
@@ -37,7 +38,7 @@ export const userMessageHandler: EventHandler = {
       output +
       "\n\n" + String.fromCodePoint(0x1F4A1) + " Wrap any message with <private> ... </private> to prevent storing sensitive information.\n" +
       "\n" + String.fromCodePoint(0x1F4AC) + " Community https://discord.gg/J4wttp9vDu" +
-      `\n` + String.fromCodePoint(0x1F4FA) + ` Watch live in browser http://localhost:${port}/\n`;
+      `\n` + String.fromCodePoint(0x1F4FA) + ` Watch live in browser ${getViewerBaseUrl(port)}/\n`;
 
     return { exitCode: HOOK_EXIT_CODES.SUCCESS, systemMessage: bannerText };
   },

--- a/src/services/worker/http/routes/SearchRoutes.ts
+++ b/src/services/worker/http/routes/SearchRoutes.ts
@@ -11,6 +11,7 @@ import { logger } from '../../../../utils/logger.js';
 import { groupByDate } from '../../../../shared/timeline-formatting.js';
 import { countObservationsByProjects } from '../../../context/ObservationCompiler.js';
 import { SettingsDefaultsManager } from '../../../../shared/SettingsDefaultsManager.js';
+import { getViewerBaseUrl } from '../../../../shared/worker-utils.js';
 import { USER_SETTINGS_PATH } from '../../../../shared/paths.js';
 import type { ObservationSearchResult, SessionSummarySearchResult } from '../../../sqlite/types.js';
 import { captureEvent } from '../../../telemetry/telemetry.js';
@@ -306,7 +307,7 @@ export class SearchRoutes extends BaseRouteHandler {
       // observations. Hot-path: PostToolUse fires after every Read/Edit.
       if (!this.projectsHaveObservations(sessionStore, projects, platformSource)) {
         const port = process.env.CLAUDE_MEM_WORKER_PORT ?? settings.CLAUDE_MEM_WORKER_PORT;
-        const viewerUrl = `http://localhost:${port}`;
+        const viewerUrl = getViewerBaseUrl(port);
         const hintBody = WELCOME_HINT_TEMPLATE.replace('{viewer_url}', viewerUrl);
         res.setHeader('Content-Type', 'text/plain; charset=utf-8');
         res.send(hintBody);

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -10,6 +10,7 @@ export interface SettingsDefaults {
   CLAUDE_MEM_CONTEXT_OBSERVATIONS: string;
   CLAUDE_MEM_WORKER_PORT: string;
   CLAUDE_MEM_WORKER_HOST: string;
+  CLAUDE_MEM_PUBLIC_URL: string;
   CLAUDE_MEM_API_TIMEOUT_MS: string;
   CLAUDE_MEM_SKIP_TOOLS: string;
   CLAUDE_MEM_PROVIDER: string;  
@@ -101,6 +102,9 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_CONTEXT_OBSERVATIONS: '50',
     CLAUDE_MEM_WORKER_PORT: String(37700 + ((process.getuid?.() ?? 77) % 100)),
     CLAUDE_MEM_WORKER_HOST: '127.0.0.1',
+    CLAUDE_MEM_PUBLIC_URL: '',  // Browser-reachable base for the live-view URL when the
+                                // worker runs behind a port-forward (e.g.
+                                // https://37700.host.<user>.<domain>). Empty => localhost.
     CLAUDE_MEM_API_TIMEOUT_MS: String(getTimeout(HOOK_TIMEOUTS.API_REQUEST)),
     CLAUDE_MEM_SKIP_TOOLS: 'ListMcpResourcesTool,SlashCommand,Skill,TodoWrite,AskUserQuestion',
     CLAUDE_MEM_PROVIDER: 'claude',  // Default to Claude

--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -143,6 +143,21 @@ export function getWorkerHost(): string {
   return cachedHost;
 }
 
+/**
+ * Base URL for the live-view UI as printed to users. Prefers an explicit public
+ * URL (env `CLAUDE_MEM_PUBLIC_URL`, else the settings value) — the
+ * browser-reachable alias when the worker runs in a remote sandbox behind a
+ * port-forward — and falls back to loopback on the given port. Empty/unset
+ * preserves the historical `http://localhost:<port>` output for local users.
+ */
+export function getViewerBaseUrl(port: number | string): string {
+  const pub = process.env.CLAUDE_MEM_PUBLIC_URL ?? getWorkerSettings().CLAUDE_MEM_PUBLIC_URL;
+  if (pub && pub.trim()) {
+    return pub.trim().replace(/\/+$/, '');
+  }
+  return `http://localhost:${port}`;
+}
+
 export function getWorkerApiRequestTimeoutMs(): number {
   if (cachedApiRequestTimeoutMs !== null) {
     return cachedApiRequestTimeoutMs;

--- a/tests/shared/worker-utils-viewer-url.test.ts
+++ b/tests/shared/worker-utils-viewer-url.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { SettingsDefaultsManager } from '../../src/shared/SettingsDefaultsManager.js';
+// See worker-utils-timeout.test.ts: eagerly freeze paths.ts on the stable
+// per-run temp dir before any per-test env override poisons a later import.
+import '../../src/shared/paths.js';
+
+describe('getViewerBaseUrl', () => {
+  let tempDir: string;
+  let settingsPath: string;
+  const originalDataDir = process.env.CLAUDE_MEM_DATA_DIR;
+  const originalPublicUrl = process.env.CLAUDE_MEM_PUBLIC_URL;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `worker-viewer-url-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tempDir, { recursive: true });
+    settingsPath = join(tempDir, 'settings.json');
+    process.env.CLAUDE_MEM_DATA_DIR = tempDir;
+    delete process.env.CLAUDE_MEM_PUBLIC_URL;
+    mock.restore();
+  });
+
+  afterEach(() => {
+    mock.restore();
+    if (originalDataDir === undefined) delete process.env.CLAUDE_MEM_DATA_DIR;
+    else process.env.CLAUDE_MEM_DATA_DIR = originalDataDir;
+    if (originalPublicUrl === undefined) delete process.env.CLAUDE_MEM_PUBLIC_URL;
+    else process.env.CLAUDE_MEM_PUBLIC_URL = originalPublicUrl;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function writeSettings(publicUrl: string): void {
+    const settings = SettingsDefaultsManager.getAllDefaults();
+    settings.CLAUDE_MEM_DATA_DIR = tempDir;
+    settings.CLAUDE_MEM_PUBLIC_URL = publicUrl;
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
+  }
+
+  it('prefers the CLAUDE_MEM_PUBLIC_URL env var over settings.json', async () => {
+    writeSettings('https://from-settings.example');
+    process.env.CLAUDE_MEM_PUBLIC_URL = 'https://from-env.example';
+
+    const workerUtils = await import('../../src/shared/worker-utils.js');
+    workerUtils.clearPortCache();
+
+    expect(workerUtils.getViewerBaseUrl(37700)).toBe('https://from-env.example');
+  });
+
+  it('uses the settings.json value when no env override is present', async () => {
+    writeSettings('https://37700.host.alice.example');
+
+    const workerUtils = await import('../../src/shared/worker-utils.js');
+    workerUtils.clearPortCache();
+
+    expect(workerUtils.getViewerBaseUrl(37700)).toBe('https://37700.host.alice.example');
+  });
+
+  it('trims a trailing slash from the public URL', async () => {
+    writeSettings('https://37700.host.alice.example/');
+
+    const workerUtils = await import('../../src/shared/worker-utils.js');
+    workerUtils.clearPortCache();
+
+    expect(workerUtils.getViewerBaseUrl(37700)).toBe('https://37700.host.alice.example');
+  });
+
+  it('falls back to http://localhost:<port> when unset', async () => {
+    writeSettings('');
+
+    const workerUtils = await import('../../src/shared/worker-utils.js');
+    workerUtils.clearPortCache();
+
+    expect(workerUtils.getViewerBaseUrl(37742)).toBe('http://localhost:37742');
+  });
+});


### PR DESCRIPTION
## What

When claude-mem runs in a remote sandbox / dev-container, the worker's live view is reached through a port-forward alias (e.g. `https://37700.host.<user>.<domain>`), not `localhost`. The three places that print the viewer URL hardcode `http://localhost:<port>`, which is unreachable from the user's browser:

- the "no memory yet" welcome hint — `SearchRoutes.ts`
- the SessionStart "View Observations Live @ …" line — `cli/handlers/context.ts`
- the per-message "📺 Watch live in browser …" banner — `cli/handlers/user-message.ts`

## How

- Register `CLAUDE_MEM_PUBLIC_URL` in `SettingsDefaultsManager.DEFAULTS` (and the `SettingsDefaults` interface). This is what makes `loadFromFile` (settings.json) and `applyEnvOverrides` (env) carry the value through to loaded settings — both drop keys not present in `DEFAULTS`.
- Add a `getViewerBaseUrl(port)` helper in `worker-utils.ts`. It prefers `process.env.CLAUDE_MEM_PUBLIC_URL`, then the settings value (trailing slash trimmed), and falls back to `http://localhost:<port>`.
- Use it at the three print sites.

Empty/unset preserves the exact current `http://localhost:<port>` output — **no behavior change for local users.**

## Test

`tests/shared/worker-utils-viewer-url.test.ts` — env precedence over settings, settings value used when env unset, trailing-slash trim, and the localhost fallback. `bun test` green; `tsc --noEmit` clean.

## Why (context)

We run claude-mem inside remote editor sandboxes where the worker binds `0.0.0.0` and is reached at a per-user proxy alias. An external carrier already writes the browser-reachable `CLAUDE_MEM_PUBLIC_URL` into `~/.claude-mem/settings.json` per editor; today the worker discards the key and prints `localhost`. This change lets the plugin honor it. It's fully opt-in and inert unless the value is set.
