### PR TITLE
fix: preserve Chroma relevance ranking in SearchManager.performChromaSemanticSearch

### DIFF
--- a/src/services/worker/SearchManager.ts
+++ b/src/services/worker/SearchManager.ts
@@ -382,8 +382,9 @@ export class SearchManager {
       }
 
       if (obsIds.length > 0) {
-        const obsOptions = { ...options, type: obs_type, concepts, files };
+        const obsOptions = { ...options, type: obs_type, concepts, files, orderBy: 'relevance' };
         observations = this.sessionStore.getObservationsByIds(obsIds, obsOptions);
+        observations.sort((a, b) => obsIds.indexOf(a.id) - obsIds.indexOf(b.id));
       }
       if (sessionIds.length > 0) {
         sessions = this.sessionStore.getSessionSummariesByIds(sessionIds, {


### PR DESCRIPTION
Fixes #2978

## Problem
`performChromaSemanticSearch` queries Chroma for observation IDs ranked by semantic similarity, but the subsequent SQLite hydration call (`getObservationsByIds`) is never told to preserve that order. `getObservationsByIds` defaults its `orderBy` param to `'date_desc'`, so the Chroma ranking is silently discarded and results come back sorted by recency instead of relevance.

This is the same class of bug fixed in #2153 for `ChromaSearchStrategy.ts` — same root cause, different call site. `SearchManager.performChromaSemanticSearch` is the code path actually serving `/api/search` and the `search` MCP tool, so it's user-facing for anyone relying on semantic search.

## Fix
Match the pattern already used correctly in `HybridSearchStrategy.rankAndHydrateForFile`: pass `orderBy: 'relevance'` (so `getObservationsByIds` skips its `ORDER BY created_at_epoch` clause) and then re-sort the hydrated rows in application code to match Chroma's original ID order.

## Diff
```diff
      if (obsIds.length > 0) {
-        const obsOptions = { ...options, type: obs_type, concepts, files };
+        const obsOptions = { ...options, type: obs_type, concepts, files, orderBy: 'relevance' };
         observations = this.sessionStore.getObservationsByIds(obsIds, obsOptions);
+        observations.sort((a, b) => obsIds.indexOf(a.id) - obsIds.indexOf(b.id));
      }
```

## Testing
- `tsc --noEmit` passes with no new errors.
- Manually verified against a live worker instance: before the fix, semantically unrelated queries returned identical result sets (recency-ordered); after rebuilding with this change, results differ appropriately by query content.

No behavior change for the `sessions`/`prompts` branches (unaffected) or for non-Chroma fallback paths.
