### PR TITLE
fix(windows): add windowsHide to remaining git spawn sites

### DIFF
--- a/src/services/infrastructure/ProcessManager.ts
+++ b/src/services/infrastructure/ProcessManager.ts
@@ -192,7 +192,8 @@ type CwdClassification =
 function gitQuery(cwd: string, args: string[]): string | null {
   const r = spawnSync('git', ['-C', cwd, ...args], {
     encoding: 'utf8',
-    timeout: 5000
+    timeout: 5000,
+    windowsHide: true
   });
   if (r.status !== 0) return null;
   return (r.stdout ?? '').trim();

--- a/src/services/infrastructure/WorktreeAdoption.ts
+++ b/src/services/infrastructure/WorktreeAdoption.ts
@@ -41,7 +41,8 @@ function gitCapture(cwd: string, args: string[]): string | null {
   const startTime = Date.now();
   const r = spawnSync('git', ['-C', cwd, ...args], {
     encoding: 'utf8',
-    timeout: GIT_TIMEOUT_MS
+    timeout: GIT_TIMEOUT_MS,
+    windowsHide: true
   });
   const duration = Date.now() - startTime;
   

--- a/src/utils/project-name.ts
+++ b/src/utils/project-name.ts
@@ -24,6 +24,7 @@ function findGitRepoRoot(dir: string): string | null {
       cwd: dir,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
     }).trim();
     return root || null;
   } catch (error: unknown) {


### PR DESCRIPTION
## Problem

On Windows, the worker daemon runs without a console. When a consoleless process spawns a console program (like `git.exe`) without `windowsHide: true`, Windows allocates a **visible console window** for it. Since the worker polls git every ~20s, this causes constant black window flashes on users' screens.

## Root cause

Three git spawn sites were missing `windowsHide: true`:

| File | Function |
|---|---|
| `src/services/infrastructure/WorktreeAdoption.ts` | `gitCapture()` |
| `src/services/infrastructure/ProcessManager.ts` | `gitQuery()` |
| `src/utils/project-name.ts` | `findGitRepoRoot()` |

All other spawn sites in the codebase already pass `windowsHide: true` (e.g. `mcp-client.ts`, `find-claude-executable.ts`, `oauth-token.ts`) — these three were the stragglers.

## Verification

Diagnosed on Windows 11 with an EnumWindows-based console window monitor: visible `git.exe` console windows appeared with parent chain `git.exe <= bun.exe (worker-service.cjs --daemon)` roughly every 20-120s. After patching these three sites in the bundled `worker-service.cjs` (adding `windowsHide`) and restarting the worker, the visible flashes from the worker stopped while git polling continued normally (verified via worker.pid heartbeat and port listener).

`windowsHide` is a no-op on non-Windows platforms, so this change only affects Windows behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqcTVwxV7jiwGeez1KYjBq