### PR TITLE
fix(sqlite): hydrate `merged_into_project` records on semantic-search ID lookups (closes #3331)

### DIFF
--- a/src/services/infrastructure/WorktreeAdoption.ts
+++ b/src/services/infrastructure/WorktreeAdoption.ts
@@ -4,7 +4,7 @@ import { existsSync } from 'fs';
 import { spawnSync } from 'child_process';
 import { logger } from '../../utils/logger.js';
 import { getProjectContext } from '../../utils/project-name.js';
-import { ChromaSync } from '../sync/ChromaSync.js';
+import { ChromaSync, MergedIntoProjectTarget } from '../sync/ChromaSync.js';
 import { paths } from '../../shared/paths.js';
 import { openConfiguredSqliteDatabase } from '../sqlite/connection.js';
 
@@ -178,7 +178,7 @@ export async function adoptMergedWorktrees(opts: {
     return result;
   }
 
-  const adoptedSqliteIds: number[] = [];
+  const adoptedChromaTargets: MergedIntoProjectTarget[] = [];
 
   let db: import('bun:sqlite').Database | null = null;
   try {
@@ -207,6 +207,11 @@ export async function adoptMergedWorktrees(opts: {
        WHERE project = ?
          AND (merged_into_project IS NULL OR merged_into_project = ?)`
     );
+    const selectSumForPatch = db.prepare(
+      `SELECT id FROM session_summaries
+       WHERE project = ?
+         AND (merged_into_project IS NULL OR merged_into_project = ?)`
+    );
     const updateObs = db.prepare(
       'UPDATE observations SET merged_into_project = ? WHERE project = ? AND merged_into_project IS NULL'
     );
@@ -220,10 +225,19 @@ export async function adoptMergedWorktrees(opts: {
         worktreeProject,
         parentProject
       ) as Array<{ id: number }>;
+      const summaryRows = selectSumForPatch.all(
+        worktreeProject,
+        parentProject
+      ) as Array<{ id: number }>;
 
       const obsChanges = updateObs.run(parentProject, worktreeProject).changes;
       const sumChanges = updateSum.run(parentProject, worktreeProject).changes;
-      for (const r of rows) adoptedSqliteIds.push(r.id);
+      for (const r of rows) {
+        adoptedChromaTargets.push({ docType: 'observation', sqliteId: r.id });
+      }
+      for (const r of summaryRows) {
+        adoptedChromaTargets.push({ docType: 'session_summary', sqliteId: r.id });
+      }
       result.adoptedObservations += obsChanges;
       result.adoptedSummaries += sumChanges;
     };
@@ -264,27 +278,27 @@ export async function adoptMergedWorktrees(opts: {
     db?.close();
   }
 
-  if (!dryRun && adoptedSqliteIds.length > 0) {
+  if (!dryRun && adoptedChromaTargets.length > 0) {
     const chromaSync = new ChromaSync('claude-mem');
     try {
-      await chromaSync.updateMergedIntoProject(adoptedSqliteIds, parentProject);
-      result.chromaUpdates = adoptedSqliteIds.length;
+      await chromaSync.updateMergedIntoProject(adoptedChromaTargets, parentProject);
+      result.chromaUpdates = adoptedChromaTargets.length;
     } catch (err) {
       if (err instanceof Error) {
         logger.error(
           'SYSTEM',
           'Worktree adoption Chroma patch failed (SQL already committed)',
-          { parentProject, sqliteIdCount: adoptedSqliteIds.length },
+          { parentProject, sqliteIdCount: adoptedChromaTargets.length },
           err
         );
       } else {
         logger.error(
           'SYSTEM',
           'Worktree adoption Chroma patch failed (SQL already committed)',
-          { parentProject, sqliteIdCount: adoptedSqliteIds.length, error: String(err) }
+          { parentProject, sqliteIdCount: adoptedChromaTargets.length, error: String(err) }
         );
       }
-      result.chromaFailed = adoptedSqliteIds.length;
+      result.chromaFailed = adoptedChromaTargets.length;
     }
   }
 

--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -2295,13 +2295,18 @@ export class SessionStore {
     prompts: any[];
   } {
     const normalizedPlatformSource = platformSource ? normalizePlatformSource(platformSource) : undefined;
-    const buildScope = (rowAlias: string, sessionAlias: string): { clause: string; params: any[] } => {
+    const buildScope = (rowAlias: string, sessionAlias: string, includeMergedProject: boolean = false): { clause: string; params: any[] } => {
       const conditions: string[] = [];
       const params: any[] = [];
 
       if (project) {
-        conditions.push(`${rowAlias}.project = ?`);
-        params.push(project);
+        if (includeMergedProject) {
+          conditions.push(`(${rowAlias}.project = ? OR ${rowAlias}.merged_into_project = ?)`);
+          params.push(project, project);
+        } else {
+          conditions.push(`${rowAlias}.project = ?`);
+          params.push(project);
+        }
       }
 
       if (normalizedPlatformSource) {
@@ -2314,8 +2319,8 @@ export class SessionStore {
         params
       };
     };
-    const observationScope = buildScope('o', 'src');
-    const summaryScope = buildScope('ss', 'src');
+    const observationScope = buildScope('o', 'src', true);
+    const summaryScope = buildScope('ss', 'src', true);
     const promptScope = buildScope('s', 's');
 
     let startEpoch: number;

--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -1744,8 +1744,8 @@ export class SessionStore {
     const additionalConditions: string[] = [];
 
     if (project) {
-      additionalConditions.push('o.project = ?');
-      params.push(project);
+      additionalConditions.push('(o.project = ? OR o.merged_into_project = ?)');
+      params.push(project, project);
     }
 
     if (platformSource) {
@@ -2190,8 +2190,8 @@ export class SessionStore {
     const additionalConditions: string[] = [];
 
     if (project) {
-      additionalConditions.push('ss.project = ?');
-      params.push(project);
+      additionalConditions.push('(ss.project = ? OR ss.merged_into_project = ?)');
+      params.push(project, project);
     }
 
     if (platformSource) {

--- a/src/services/sync/ChromaSync.ts
+++ b/src/services/sync/ChromaSync.ts
@@ -44,6 +44,11 @@ export interface ChromaDocument {
   metadata: Record<string, string | number>;
 }
 
+export interface MergedIntoProjectTarget {
+  docType: 'observation' | 'session_summary';
+  sqliteId: number;
+}
+
 interface StoredObservation {
   id: number;
   memory_session_id: string;
@@ -986,52 +991,63 @@ export class ChromaSync {
   }
 
   async updateMergedIntoProject(
-    sqliteIds: number[],
+    targets: MergedIntoProjectTarget[],
     mergedIntoProject: string
   ): Promise<void> {
-    if (sqliteIds.length === 0) return;
+    if (targets.length === 0) return;
 
     await this.ensureCollectionExists();
     const chromaMcp = ChromaMcpManager.getInstance();
 
     let totalPatched = 0;
 
-    for (let i = 0; i < sqliteIds.length; i += this.BATCH_SIZE) {
-      const idBatch = sqliteIds.slice(i, i + this.BATCH_SIZE);
+    for (const docType of ['observation', 'session_summary'] as const) {
+      const sqliteIds = targets
+        .filter(target => target.docType === docType)
+        .map(target => target.sqliteId);
 
-      const existing = await chromaMcp.callTool('chroma_get_documents', {
-        collection_name: this.collectionName,
-        where: { sqlite_id: { $in: idBatch } },
-        include: ['metadatas']
-      }) as { ids?: string[]; metadatas?: Array<Record<string, any> | null> };
+      for (let i = 0; i < sqliteIds.length; i += this.BATCH_SIZE) {
+        const idBatch = sqliteIds.slice(i, i + this.BATCH_SIZE);
 
-      const docIds: string[] = existing?.ids ?? [];
-      if (docIds.length === 0) continue;
+        const existing = await chromaMcp.callTool('chroma_get_documents', {
+          collection_name: this.collectionName,
+          where: {
+            $and: [
+              { doc_type: docType },
+              { sqlite_id: { $in: idBatch } }
+            ]
+          },
+          include: ['metadatas']
+        }) as { ids?: string[]; metadatas?: Array<Record<string, any> | null> };
 
-      const metadatas = (existing?.metadatas ?? []).map(m => {
-        const merged: Record<string, any> = {
-          ...(m ?? {}),
-          merged_into_project: mergedIntoProject
-        };
-        return Object.fromEntries(
-          Object.entries(merged).filter(
-            ([, v]) => v !== null && v !== undefined && v !== ''
-          )
-        );
-      });
+        const docIds: string[] = existing?.ids ?? [];
+        if (docIds.length === 0) continue;
 
-      await chromaMcp.callTool('chroma_update_documents', {
-        collection_name: this.collectionName,
-        ids: docIds,
-        metadatas
-      });
-      totalPatched += docIds.length;
+        const metadatas = (existing?.metadatas ?? []).map(m => {
+          const merged: Record<string, any> = {
+            ...(m ?? {}),
+            merged_into_project: mergedIntoProject
+          };
+          return Object.fromEntries(
+            Object.entries(merged).filter(
+              ([, v]) => v !== null && v !== undefined && v !== ''
+            )
+          );
+        });
+
+        await chromaMcp.callTool('chroma_update_documents', {
+          collection_name: this.collectionName,
+          ids: docIds,
+          metadatas
+        });
+        totalPatched += docIds.length;
+      }
     }
 
     logger.info('CHROMA_SYNC', 'merged_into_project metadata patched', {
       collection: this.collectionName,
       mergedIntoProject,
-      sqliteIdCount: sqliteIds.length,
+      sqliteIdCount: targets.length,
       chromaDocsPatched: totalPatched
     });
   }

--- a/tests/context/formatters/agent-formatter.test.ts
+++ b/tests/context/formatters/agent-formatter.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { describe, it, expect, mock, beforeEach, afterAll } from 'bun:test';
+
+import * as realModeManager from '../../../src/services/domain/ModeManager.js';
+
+const realModeManagerSnapshot = { ...realModeManager };
 
 mock.module('../../../src/services/domain/ModeManager.js', () => ({
   ModeManager: {
@@ -89,6 +93,10 @@ function createTestConfig(overrides: Partial<ContextConfig> = {}): ContextConfig
     ...overrides,
   };
 }
+
+afterAll(() => {
+  mock.module('../../../src/services/domain/ModeManager.js', () => realModeManagerSnapshot);
+});
 
 describe('AgentFormatter', () => {
   describe('renderAgentHeader', () => {

--- a/tests/hooks/server-client.test.ts
+++ b/tests/hooks/server-client.test.ts
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
+
+import * as realWorkerUtils from '../../src/shared/worker-utils.js';
+
+const realWorkerUtilsSnapshot = { ...realWorkerUtils };
 
 mock.module('../../src/shared/worker-utils.js', () => ({
   fetchWithTimeout: async (url: string, init: RequestInit, _timeoutMs: number) => {
@@ -51,6 +55,10 @@ describe('ServerClient', () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+  });
+
+  afterAll(() => {
+    mock.module('../../src/shared/worker-utils.js', () => realWorkerUtilsSnapshot);
   });
 
   it('throws missing_api_key when apiKey is empty', async () => {

--- a/tests/services/infrastructure/worktree-adoption-chroma.test.ts
+++ b/tests/services/infrastructure/worktree-adoption-chroma.test.ts
@@ -1,10 +1,12 @@
-import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { afterAll, afterEach, describe, expect, it, mock } from 'bun:test';
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
+import * as realChromaMcpManager from '../../../src/services/sync/ChromaMcpManager.js';
 
 const chromaCalls: Array<{ name: string; args: Record<string, unknown> }> = [];
+const realChromaMcpManagerSnapshot = { ...realChromaMcpManager };
 
 mock.module('../../../src/services/sync/ChromaMcpManager.js', () => ({
   ChromaMcpManager: {
@@ -40,6 +42,10 @@ afterEach(() => {
   }
   tempRoot = undefined;
   mainRepoForCleanup = undefined;
+});
+
+afterAll(() => {
+  mock.module('../../../src/services/sync/ChromaMcpManager.js', () => realChromaMcpManagerSnapshot);
 });
 
 function git(cwd: string, ...args: string[]): void {

--- a/tests/services/infrastructure/worktree-adoption-chroma.test.ts
+++ b/tests/services/infrastructure/worktree-adoption-chroma.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+
+const chromaCalls: Array<{ name: string; args: Record<string, unknown> }> = [];
+
+mock.module('../../../src/services/sync/ChromaMcpManager.js', () => ({
+  ChromaMcpManager: {
+    getInstance: () => ({
+      callTool: async (name: string, args: Record<string, unknown>) => {
+        chromaCalls.push({ name, args });
+        if (name === 'chroma_create_collection') return {};
+        if (name === 'chroma_get_documents') {
+          return {
+            ids: ['summary_1_request'],
+            metadatas: [{ sqlite_id: 1, doc_type: 'session_summary' }]
+          };
+        }
+        return {};
+      }
+    })
+  }
+}));
+
+import { adoptMergedWorktrees } from '../../../src/services/infrastructure/WorktreeAdoption.js';
+import { SessionStore } from '../../../src/services/sqlite/SessionStore.js';
+
+let tempRoot: string | undefined;
+let mainRepoForCleanup: string | undefined;
+
+afterEach(() => {
+  chromaCalls.length = 0;
+  if (mainRepoForCleanup && existsSync(mainRepoForCleanup)) {
+    try { git(mainRepoForCleanup, 'worktree', 'remove', '--force', path.join(tempRoot!, 'summary-worktree')); } catch {}
+  }
+  if (tempRoot) {
+    try { rmSync(tempRoot, { recursive: true, force: true }); } catch {}
+  }
+  tempRoot = undefined;
+  mainRepoForCleanup = undefined;
+});
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync('git', ['-C', cwd, ...args], { stdio: 'ignore' });
+}
+
+describe('worktree adoption Chroma hydration', () => {
+  it('patches a session-summary document when the adopted worktree has no observations', async () => {
+    tempRoot = mkdtempSync(path.join(tmpdir(), 'claude-mem-3331-'));
+    const mainRepo = path.join(tempRoot, 'parent-repo');
+    mainRepoForCleanup = mainRepo;
+    const worktree = path.join(tempRoot, 'summary-worktree');
+    const dataDirectory = path.join(tempRoot, 'data');
+    mkdirSync(mainRepo, { recursive: true });
+    mkdirSync(dataDirectory);
+
+    git(mainRepo, 'init', '-b', 'main');
+    git(mainRepo, 'config', 'user.email', 'test@example.com');
+    git(mainRepo, 'config', 'user.name', 'Test');
+    writeFileSync(path.join(mainRepo, 'README.md'), 'base\n');
+    git(mainRepo, 'add', 'README.md');
+    git(mainRepo, 'commit', '-m', 'base');
+    git(mainRepo, 'worktree', 'add', '-b', 'feature', worktree);
+
+    const dbPath = path.join(dataDirectory, 'claude-mem.db');
+    const store = new SessionStore(dbPath);
+    const sdkSessionId = store.createSDKSession('content-summary', 'parent-repo/summary-worktree', 'prompt');
+    store.ensureMemorySessionIdRegistered(sdkSessionId, 'summary-session');
+    const summary = store.importSessionSummary({
+      memory_session_id: 'summary-session',
+      project: 'parent-repo/summary-worktree',
+      request: 'summary only',
+      investigated: null,
+      learned: null,
+      completed: null,
+      next_steps: null,
+      files_read: null,
+      files_edited: null,
+      notes: null,
+      prompt_number: 1,
+      discovery_tokens: 0,
+      created_at: new Date(1_700_000_000_000).toISOString(),
+      created_at_epoch: 1_700_000_000_000,
+    });
+    store.close();
+
+    const result = await adoptMergedWorktrees({
+      repoPath: mainRepo,
+      dataDirectory,
+      onlyBranch: 'feature'
+    });
+
+    const verify = new SessionStore(dbPath);
+    const mergedProject = (verify.db.prepare(
+      'SELECT merged_into_project FROM session_summaries WHERE id = ?'
+    ).get(summary.id) as { merged_into_project: string }).merged_into_project;
+    verify.close();
+
+    expect(result.adoptedObservations).toBe(0);
+    expect(result.adoptedSummaries).toBe(1);
+    expect(mergedProject).toBe('parent-repo');
+    expect(chromaCalls.find(call => call.name === 'chroma_update_documents')?.args.ids)
+      .toEqual(['summary_1_request']);
+  });
+});

--- a/tests/services/sqlite/merged-project-id-hydration.test.ts
+++ b/tests/services/sqlite/merged-project-id-hydration.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { SessionStore } from '../../../src/services/sqlite/SessionStore.js';
+
+describe('merged project ID hydration', () => {
+  let store: SessionStore;
+
+  beforeEach(() => {
+    store = new SessionStore(':memory:');
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  function seedObservation(memorySessionId: string, project: string, title: string): number {
+    const sdkSessionId = store.createSDKSession(`content-${memorySessionId}`, project, 'prompt');
+    store.ensureMemorySessionIdRegistered(sdkSessionId, memorySessionId);
+    const result = store.storeObservations(memorySessionId, project, [{
+      type: 'discovery',
+      title,
+      subtitle: null,
+      facts: [],
+      narrative: `${title} narrative`,
+      concepts: [],
+      files_read: [],
+      files_modified: [],
+    }], null, 1, 0, 1_700_000_000_000);
+    return result.observationIds[0];
+  }
+
+  function seedSummary(memorySessionId: string, project: string, request: string): number {
+    const sdkSessionId = store.createSDKSession(`content-${memorySessionId}`, project, 'prompt');
+    store.ensureMemorySessionIdRegistered(sdkSessionId, memorySessionId);
+    return store.importSessionSummary({
+      memory_session_id: memorySessionId,
+      project,
+      request,
+      investigated: null,
+      learned: null,
+      completed: null,
+      next_steps: null,
+      files_read: null,
+      files_edited: null,
+      notes: null,
+      prompt_number: 1,
+      discovery_tokens: 0,
+      created_at: new Date(1_700_000_000_000).toISOString(),
+      created_at_epoch: 1_700_000_000_000,
+    }).id;
+  }
+
+  it('hydrates a redirected observation by ID under the merged parent project', () => {
+    const observationId = seedObservation('merged-observation', 'parent/worktree', 'redirected observation');
+    store.db.prepare('UPDATE observations SET merged_into_project = ? WHERE id = ?').run('parent', observationId);
+
+    const results = store.getObservationsByIds([observationId], { orderBy: 'relevance', project: 'parent' });
+
+    expect(results.map(result => result.id)).toEqual([observationId]);
+  });
+
+  it('hydrates a redirected session summary by ID under the merged parent project', () => {
+    const summaryId = seedSummary('merged-summary', 'parent/worktree', 'redirected summary');
+    store.db.prepare('UPDATE session_summaries SET merged_into_project = ? WHERE id = ?').run('parent', summaryId);
+
+    const results = store.getSessionSummariesByIds([summaryId], { orderBy: 'relevance', project: 'parent' });
+
+    expect(results.map(result => result.id)).toEqual([summaryId]);
+  });
+
+  it('keeps native rows in and foreign rows out while widening merged-project hydration', () => {
+    const nativeObservationId = seedObservation('native-observation', 'parent', 'native observation');
+    const foreignObservationId = seedObservation('foreign-observation', 'other', 'foreign observation');
+    const nativeSummaryId = seedSummary('native-summary', 'parent', 'native summary');
+    const foreignSummaryId = seedSummary('foreign-summary', 'other', 'foreign summary');
+
+    expect(store.getObservationsByIds([nativeObservationId, foreignObservationId], { orderBy: 'relevance', project: 'parent' }).map(result => result.id))
+      .toEqual([nativeObservationId]);
+    expect(store.getSessionSummariesByIds([nativeSummaryId, foreignSummaryId], { orderBy: 'relevance', project: 'parent' }).map(result => result.id))
+      .toEqual([nativeSummaryId]);
+  });
+
+  it('keeps prompt hydration native-session scoped on this target', () => {
+    const parentSessionId = store.createSDKSession('parent-prompt-session', 'parent', 'prompt');
+    const foreignSessionId = store.createSDKSession('foreign-prompt-session', 'other', 'prompt');
+    const parentPromptId = store.saveUserPrompt('parent-prompt-session', 1, 'parent prompt', parentSessionId);
+    const foreignPromptId = store.saveUserPrompt('foreign-prompt-session', 1, 'foreign prompt', foreignSessionId);
+
+    const results = store.getUserPromptsByIds([parentPromptId, foreignPromptId], { orderBy: 'relevance', project: 'parent' });
+
+    expect(results.map(result => result.id)).toEqual([parentPromptId]);
+  });
+});

--- a/tests/services/sqlite/merged-project-id-hydration.test.ts
+++ b/tests/services/sqlite/merged-project-id-hydration.test.ts
@@ -79,6 +79,25 @@ describe('merged project ID hydration', () => {
       .toEqual([nativeSummaryId]);
   });
 
+  it('keeps redirected timeline context under the merged parent project', () => {
+    const observationId = seedObservation('timeline-observation', 'parent/worktree', 'redirected observation');
+    const summaryId = seedSummary('timeline-summary', 'parent/worktree', 'redirected summary');
+    store.db.prepare('UPDATE observations SET merged_into_project = ? WHERE id = ?').run('parent', observationId);
+    store.db.prepare('UPDATE session_summaries SET merged_into_project = ? WHERE id = ?').run('parent', summaryId);
+
+    const timeline = store.getTimelineAroundObservation(
+      observationId,
+      1_700_000_000_000,
+      0,
+      0,
+      'parent'
+    );
+
+    expect(timeline.observations.map(result => result.id)).toEqual([observationId]);
+    expect(timeline.sessions.map(result => result.id)).toEqual([summaryId]);
+    expect(timeline.prompts).toEqual([]);
+  });
+
   it('keeps prompt hydration native-session scoped on this target', () => {
     const parentSessionId = store.createSDKSession('parent-prompt-session', 'parent', 'prompt');
     const foreignSessionId = store.createSDKSession('foreign-prompt-session', 'other', 'prompt');

--- a/tests/services/sync/chroma-mcp-manager-singleton.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-singleton.test.ts
@@ -4,6 +4,8 @@ import { PassThrough } from 'node:stream';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import * as realMcpClient from '@modelcontextprotocol/sdk/client/index.js';
+import * as realStdioClient from '@modelcontextprotocol/sdk/client/stdio.js';
 
 // Capture real exports before mock.module mutates the live namespace, then
 // re-register the snapshots in afterAll so these mocks do not leak into later
@@ -13,6 +15,8 @@ import * as realPaths from '../../../src/shared/paths.js';
 import * as realLogger from '../../../src/utils/logger.js';
 import * as realSupervisor from '../../../src/supervisor/index.ts';
 import * as realEnvSanitizer from '../../../src/supervisor/env-sanitizer.js';
+const realMcpClientSnapshot = { ...realMcpClient };
+const realStdioClientSnapshot = { ...realStdioClient };
 const realSettingsSnapshot = { ...realSettingsDefaultsManager };
 const realPathsSnapshot = { ...realPaths };
 const realLoggerSnapshot = { ...realLogger };
@@ -288,6 +292,8 @@ afterAll(() => {
   if (realProcessPlatform) {
     Object.defineProperty(process, 'platform', realProcessPlatform);
   }
+  mock.module('@modelcontextprotocol/sdk/client/index.js', () => realMcpClientSnapshot);
+  mock.module('@modelcontextprotocol/sdk/client/stdio.js', () => realStdioClientSnapshot);
   mock.module('../../../src/shared/SettingsDefaultsManager.js', () => realSettingsSnapshot);
   mock.module('../../../src/shared/paths.js', () => realPathsSnapshot);
   mock.module('../../../src/utils/logger.js', () => realLoggerSnapshot);

--- a/tests/services/sync/chroma-mcp-manager-ssl.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-ssl.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, afterAll, mock } from 'bun:test';
 import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
+import * as realMcpClient from '@modelcontextprotocol/sdk/client/index.js';
+import * as realStdioClient from '@modelcontextprotocol/sdk/client/stdio.js';
 
 // Capture real exports before mock.module mutates the live namespace, then
 // re-register the snapshots in afterAll so these mocks do not leak into later
@@ -8,6 +10,8 @@ import { PassThrough } from 'node:stream';
 import * as realSettingsDefaultsManager from '../../../src/shared/SettingsDefaultsManager.js';
 import * as realPaths from '../../../src/shared/paths.js';
 import * as realLogger from '../../../src/utils/logger.js';
+const realMcpClientSnapshot = { ...realMcpClient };
+const realStdioClientSnapshot = { ...realStdioClient };
 const realSettingsSnapshot = { ...realSettingsDefaultsManager };
 const realPathsSnapshot = { ...realPaths };
 const realLoggerSnapshot = { ...realLogger };
@@ -101,6 +105,8 @@ import { ChromaMcpManager } from '../../../src/services/sync/ChromaMcpManager.js
 
 afterAll(() => {
   ChromaMcpManager.setUvxAvailabilityProbeForTesting(null);
+  mock.module('@modelcontextprotocol/sdk/client/index.js', () => realMcpClientSnapshot);
+  mock.module('@modelcontextprotocol/sdk/client/stdio.js', () => realStdioClientSnapshot);
   mock.module('../../../src/shared/SettingsDefaultsManager.js', () => realSettingsSnapshot);
   mock.module('../../../src/shared/paths.js', () => realPathsSnapshot);
   mock.module('../../../src/utils/logger.js', () => realLoggerSnapshot);

--- a/tests/services/sync/chroma-merged-project-typed-lookup.test.ts
+++ b/tests/services/sync/chroma-merged-project-typed-lookup.test.ts
@@ -1,6 +1,8 @@
-import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { afterAll, afterEach, describe, expect, it, mock } from 'bun:test';
+import * as realChromaMcpManager from '../../../src/services/sync/ChromaMcpManager.js';
 
 const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
+const realChromaMcpManagerSnapshot = { ...realChromaMcpManager };
 
 mock.module('../../../src/services/sync/ChromaMcpManager.js', () => ({
   ChromaMcpManager: {
@@ -40,6 +42,10 @@ import { ChromaSync } from '../../../src/services/sync/ChromaSync.js';
 
 afterEach(() => {
   calls.length = 0;
+});
+
+afterAll(() => {
+  mock.module('../../../src/services/sync/ChromaMcpManager.js', () => realChromaMcpManagerSnapshot);
 });
 
 describe('ChromaSync merged project hydration', () => {

--- a/tests/services/sync/chroma-merged-project-typed-lookup.test.ts
+++ b/tests/services/sync/chroma-merged-project-typed-lookup.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+
+const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
+
+mock.module('../../../src/services/sync/ChromaMcpManager.js', () => ({
+  ChromaMcpManager: {
+    getInstance: () => ({
+      callTool: async (name: string, args: Record<string, unknown>) => {
+        calls.push({ name, args });
+        if (name === 'chroma_create_collection') return {};
+
+        if (name === 'chroma_get_documents') {
+          const where = args.where as { $and?: Array<Record<string, unknown>> };
+          const docType = where.$and?.find(condition => condition.doc_type)?.doc_type;
+          if (docType === 'session_summary') {
+            return {
+              ids: ['summary_7_request'],
+              metadatas: [{ sqlite_id: 7, doc_type: 'session_summary' }]
+            };
+          }
+          return {
+            ids: ['prompt_7'],
+            metadatas: [{ sqlite_id: 7, doc_type: 'user_prompt' }]
+          };
+        }
+
+        return {};
+      }
+    })
+  }
+}));
+
+import { ChromaSync } from '../../../src/services/sync/ChromaSync.js';
+
+afterEach(() => {
+  calls.length = 0;
+});
+
+describe('ChromaSync merged project hydration', () => {
+  it('patches session-summary documents for summary-only adoption', async () => {
+    await new ChromaSync('claude-mem').updateMergedIntoProject(
+      [{ docType: 'session_summary', sqliteId: 7 }],
+      'parent'
+    );
+
+    const getCall = calls.find(call => call.name === 'chroma_get_documents');
+    expect(getCall?.args.where).toEqual({
+      $and: [
+        { doc_type: 'session_summary' },
+        { sqlite_id: { $in: [7] } }
+      ]
+    });
+
+    const updateCall = calls.find(call => call.name === 'chroma_update_documents');
+    expect(updateCall?.args.ids).toEqual(['summary_7_request']);
+    expect(updateCall?.args.metadatas).toEqual([{
+      sqlite_id: 7,
+      doc_type: 'session_summary',
+      merged_into_project: 'parent'
+    }]);
+  });
+
+  it('does not update a prompt document with a colliding sqlite ID', async () => {
+    await new ChromaSync('claude-mem').updateMergedIntoProject(
+      [{ docType: 'session_summary', sqliteId: 7 }],
+      'parent'
+    );
+
+    expect(calls.filter(call => call.name === 'chroma_update_documents')).toHaveLength(1);
+    expect(calls.find(call => call.name === 'chroma_update_documents')?.args.ids)
+      .toEqual(['summary_7_request']);
+  });
+});

--- a/tests/services/sync/chroma-merged-project-typed-lookup.test.ts
+++ b/tests/services/sync/chroma-merged-project-typed-lookup.test.ts
@@ -12,6 +12,12 @@ mock.module('../../../src/services/sync/ChromaMcpManager.js', () => ({
         if (name === 'chroma_get_documents') {
           const where = args.where as { $and?: Array<Record<string, unknown>> };
           const docType = where.$and?.find(condition => condition.doc_type)?.doc_type;
+          if (docType === 'observation') {
+            return {
+              ids: ['obs_9_narrative'],
+              metadatas: [{ sqlite_id: 9, doc_type: 'observation' }]
+            };
+          }
           if (docType === 'session_summary') {
             return {
               ids: ['summary_7_request'],
@@ -69,5 +75,28 @@ describe('ChromaSync merged project hydration', () => {
     expect(calls.filter(call => call.name === 'chroma_update_documents')).toHaveLength(1);
     expect(calls.find(call => call.name === 'chroma_update_documents')?.args.ids)
       .toEqual(['summary_7_request']);
+  });
+
+  it('patches observation documents with an observation-typed lookup', async () => {
+    await new ChromaSync('claude-mem').updateMergedIntoProject(
+      [{ docType: 'observation', sqliteId: 9 }],
+      'parent'
+    );
+
+    const getCall = calls.find(call => call.name === 'chroma_get_documents');
+    expect(getCall?.args.where).toEqual({
+      $and: [
+        { doc_type: 'observation' },
+        { sqlite_id: { $in: [9] } }
+      ]
+    });
+
+    const updateCall = calls.find(call => call.name === 'chroma_update_documents');
+    expect(updateCall?.args.ids).toEqual(['obs_9_narrative']);
+    expect(updateCall?.args.metadatas).toEqual([{
+      sqlite_id: 9,
+      doc_type: 'observation',
+      merged_into_project: 'parent'
+    }]);
   });
 });

--- a/tests/worker/SearchManager.timeline-anchor.test.ts
+++ b/tests/worker/SearchManager.timeline-anchor.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
+
+import * as realModeManager from '../../src/services/domain/ModeManager.js';
+
+const realModeManagerSnapshot = { ...realModeManager };
 
 mock.module('../../src/services/domain/ModeManager.js', () => ({
   ModeManager: {
@@ -110,6 +114,10 @@ describe('SearchManager.timeline() anchor dispatch', () => {
 
   afterEach(() => {
     db.close();
+  });
+
+  afterAll(() => {
+    mock.module('../../src/services/domain/ModeManager.js', () => realModeManagerSnapshot);
   });
 
   it('(a) numeric anchor passed as JS number returns the 7-id window around the anchor', async () => {

--- a/tests/worker/agents/response-processor.test.ts
+++ b/tests/worker/agents/response-processor.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from 'bun:test';
+import { describe, it, expect, mock, beforeEach, afterEach, afterAll, spyOn } from 'bun:test';
 import { logger } from '../../../src/utils/logger.js';
+
+import * as realWorkerService from '../../../src/services/worker-service.js';
+import * as realWorkerUtils from '../../../src/shared/worker-utils.js';
+import * as realModeManager from '../../../src/services/domain/ModeManager.js';
+
+const realWorkerServiceSnapshot = { ...realWorkerService };
+const realWorkerUtilsSnapshot = { ...realWorkerUtils };
+const realModeManagerSnapshot = { ...realModeManager };
 
 mock.module('../../../src/services/worker-service.js', () => ({
   updateCursorContextForProject: () => Promise.resolve(),
@@ -102,6 +110,12 @@ describe('ResponseProcessor', () => {
   afterEach(() => {
     loggerSpies.forEach(spy => spy.mockRestore());
     mock.restore();
+  });
+
+  afterAll(() => {
+    mock.module('../../../src/services/worker-service.js', () => realWorkerServiceSnapshot);
+    mock.module('../../../src/shared/worker-utils.js', () => realWorkerUtilsSnapshot);
+    mock.module('../../../src/services/domain/ModeManager.js', () => realModeManagerSnapshot);
   });
 
   function createMockSession(

--- a/tests/worker/claude-setup-gate.test.ts
+++ b/tests/worker/claude-setup-gate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
 import { ClassifiedProviderError } from '../../src/services/worker/provider-errors.js';
 import {
   CLAUDE_CLI_SETUP_RECHECK_COOLDOWN_MS,
@@ -6,6 +6,9 @@ import {
   resetDependencyStatusesForTesting,
 } from '../../src/shared/dependency-health.js';
 import type { ActiveSession } from '../../src/services/worker-types.js';
+import * as realFindClaudeExecutable from '../../src/shared/find-claude-executable.js';
+
+const realFindClaudeExecutableSnapshot = { ...realFindClaudeExecutable };
 
 let findClaudeExecutableImpl: () => string = () => '/mock/claude';
 
@@ -51,6 +54,10 @@ describe('Claude setup-required generator gate', () => {
 
   afterEach(() => {
     Date.now = realDateNow;
+  });
+
+  afterAll(() => {
+    mock.module('../../src/shared/find-claude-executable.js', () => realFindClaudeExecutableSnapshot);
   });
 
   it('skips immediate repeat starts, then rechecks and clears status after cooldown repair', async () => {

--- a/tests/worker/http/routes/data-routes-coercion.test.ts
+++ b/tests/worker/http/routes/data-routes-coercion.test.ts
@@ -1,7 +1,13 @@
 
-import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from 'bun:test';
+import { describe, it, expect, mock, beforeEach, afterEach, afterAll, spyOn } from 'bun:test';
 import type { Request, Response } from 'express';
 import { logger } from '../../../../src/utils/logger.js';
+
+import * as realPaths from '../../../../src/shared/paths.js';
+import * as realWorkerUtils from '../../../../src/shared/worker-utils.js';
+
+const realPathsSnapshot = { ...realPaths };
+const realWorkerUtilsSnapshot = { ...realWorkerUtils };
 
 mock.module('../../../../src/shared/paths.js', () => ({
   getPackageRoot: () => '/tmp/test',
@@ -87,6 +93,11 @@ describe('DataRoutes Type Coercion', () => {
   afterEach(() => {
     loggerSpies.forEach(spy => spy.mockRestore());
     mock.restore();
+  });
+
+  afterAll(() => {
+    mock.module('../../../../src/shared/paths.js', () => realPathsSnapshot);
+    mock.module('../../../../src/shared/worker-utils.js', () => realWorkerUtilsSnapshot);
   });
 
   describe('handleGetObservationsByIds — ids coercion', () => {

--- a/tests/worker/http/routes/memory-routes.test.ts
+++ b/tests/worker/http/routes/memory-routes.test.ts
@@ -1,7 +1,13 @@
 
-import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from 'bun:test';
+import { describe, it, expect, mock, beforeEach, afterEach, afterAll, spyOn } from 'bun:test';
 import type { Request, Response } from 'express';
 import { logger } from '../../../../src/utils/logger.js';
+
+import * as realPaths from '../../../../src/shared/paths.js';
+import * as realWorkerUtils from '../../../../src/shared/worker-utils.js';
+
+const realPathsSnapshot = { ...realPaths };
+const realWorkerUtilsSnapshot = { ...realWorkerUtils };
 
 mock.module('../../../../src/shared/paths.js', () => ({
   getPackageRoot: () => '/tmp/test',
@@ -87,6 +93,11 @@ describe('MemoryRoutes — POST /api/memory/save (#2116)', () => {
   afterEach(() => {
     loggerSpies.forEach(spy => spy.mockRestore());
     mock.restore();
+  });
+
+  afterAll(() => {
+    mock.module('../../../../src/shared/paths.js', () => realPathsSnapshot);
+    mock.module('../../../../src/shared/worker-utils.js', () => realWorkerUtilsSnapshot);
   });
 
   function buildHandler(): (req: Request, res: Response) => void {


### PR DESCRIPTION
## Summary

Project-scoped semantic search already matches redirected observation and summary records in Chroma, but the follow-up SQLite consumers still filter those rows with exact `project = ?`. This change unions `merged_into_project` into the two schema-backed ID hydrators, keeps redirected observation timelines on the same merged-parent scope, and carries adopted observation and session-summary IDs with explicit Chroma document types so summary-only worktrees hydrate their Chroma metadata without selecting colliding user prompts.

Closes #3331

## Why

`SearchManager` already builds a semantic-search where-filter that matches either `project` or `merged_into_project`. The loss happens later, when `getObservationsByIds(...)`, `getSessionSummariesByIds(...)`, and the downstream observation timeline scope narrow those matched IDs back to exact project equality. The fix belongs in those schema-backed consumers, because the redirect discriminator already exists there.

## Scope

This PR changes observation and session-summary ID hydration, redirected observation timeline scope, and the existing worktree-adoption-to-Chroma patch seam. Adoption writes still use the existing `merged_into_project` fields. Chroma lookups now constrain each batch by `doc_type`; user-prompt documents remain outside this patch path.

## Risk

Low. The widened predicates key on the schema's existing redirect discriminator and only affect project scoping inside the two ID hydrators plus redirected observation timeline expansion. Native rows, foreign-project exclusion, prompt behavior, and platform-source filtering stay intact.

## Verification

- [x] `bun test tests/services/sqlite/merged-project-id-hydration.test.ts` — 5 passing, 0 failing, 8 assertions
- [x] `bun test tests/services/sqlite/search-platform-source-scoping.test.ts` — 11 passing, 0 failing, 23 assertions
- [x] `bun test tests/worker/SearchManager.timeline-anchor.test.ts` — 8 passing, 0 failing, 32 assertions
- [x] `npm run typecheck` — passed
- [x] `npm run build` — passed, all build targets compiled successfully
- [x] `npm run lint:hook-io` — `hook-io discipline: OK (handlers + adapters are pure)`
- [x] `npm run lint:spawn-env` — `spawn-env discipline: OK (all env-bearing spawns sanitize process.env)`
- [ ] `npm run strip-comments:check` — exits 1 with `Changed:   316 (check mode, no writes)`
- [x] Runtime base/head reproduction — base drops redirected observation and summary IDs; head hydrates both under the merged parent project
- [x] Redirected timeline regression — base drops redirected timeline context under the merged parent project; head keeps the redirected observation and summary context
- [x] Summary-only adoption regression — `bun test tests/services/infrastructure/worktree-adoption-chroma.test.ts` — 1 passing, 0 failing
- [x] Typed Chroma lookup regression — `bun test tests/services/sync/chroma-merged-project-typed-lookup.test.ts` — 3 passing, 0 failing

Closes #3331
