### PR TITLE
fix(deploy): pin container identity/ports, fix worker queue-prefix mismatch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@
 services:
   postgres:
     image: postgres:17-alpine
+    container_name: claude-mem-postgres
     restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER is required}
@@ -70,6 +71,7 @@ services:
 
   valkey:
     image: valkey/valkey:8-alpine
+    container_name: claude-mem-valkey
     restart: unless-stopped
     # BullMQ requires noeviction; AOF gives durability across restarts.
     command:
@@ -89,9 +91,11 @@ services:
       retries: 12
 
   claude-mem-server:
+    image: claude-mem-server:${CLAUDE_MEM_IMAGE_TAG:-v13.11.0}
     build:
       context: .
       dockerfile: docker/claude-mem/Dockerfile
+    container_name: claude-mem-server
     restart: unless-stopped
     depends_on:
       postgres:
@@ -123,7 +127,12 @@ services:
       # does. This split keeps HTTP latency unaffected by provider calls.
       CLAUDE_MEM_GENERATION_DISABLED: "true"
     ports:
-      - "37877:37877"
+      # CRITICAL: never bind 0.0.0.0 — VPS INPUT policy is open and ufw is
+      # inactive, so an unqualified "37877:37877" here would expose the
+      # server to the public internet. Loopback (local hooks/healthcheck)
+      # + the box's own Tailscale IP (cross-machine access) only.
+      - "127.0.0.1:37877:37877"
+      - "${CLAUDE_MEM_TAILSCALE_IP:-100.96.136.102}:37877:37877"
     volumes:
       - claude-mem-data:/data/claude-mem
       # #2558 — credentials-file mount. Place provider/API secrets in a file
@@ -139,9 +148,11 @@ services:
       start_period: 20s
 
   claude-mem-worker:
+    image: claude-mem-server:${CLAUDE_MEM_IMAGE_TAG:-v13.11.0}
     build:
       context: .
       dockerfile: docker/claude-mem/Dockerfile
+    container_name: claude-mem-worker
     restart: unless-stopped
     depends_on:
       postgres:
@@ -156,6 +167,12 @@ services:
       CLAUDE_MEM_RUNTIME: server-beta
       CLAUDE_MEM_DATA_DIR: /data/claude-mem
       CLAUDE_MEM_QUEUE_ENGINE: bullmq
+      # MUST match the server's SERVER_PORT/WORKER_PORT: the BullMQ queue prefix is
+      # derived from CLAUDE_MEM_WORKER_PORT (default falls back to a UID-derived port
+      # if unset), so a mismatch here means the worker silently reads from a different,
+      # never-populated queue while the server enqueues jobs under the real prefix.
+      CLAUDE_MEM_SERVER_PORT: "37877"
+      CLAUDE_MEM_WORKER_PORT: "37877"
       # #2558 — REDIS_URL fallback (see server service above).
       CLAUDE_MEM_REDIS_URL: ${CLAUDE_MEM_REDIS_URL:-redis://valkey:6379}
       CLAUDE_MEM_REDIS_MODE: docker
@@ -166,6 +183,8 @@ services:
       # CLAUDE_MEM_ANTHROPIC_API_KEY) is required for real generation; the
       # worker stays running but never produces observations without one.
       CLAUDE_MEM_SERVER_PROVIDER: ${CLAUDE_MEM_SERVER_PROVIDER:-claude}
+      CLAUDE_MEM_SERVER_MODEL: ${CLAUDE_MEM_SERVER_MODEL:-}
+      CLAUDE_MEM_OPENROUTER_BASE_URL: ${CLAUDE_MEM_OPENROUTER_BASE_URL:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       CLAUDE_MEM_ANTHROPIC_API_KEY: ${CLAUDE_MEM_ANTHROPIC_API_KEY:-}
       GEMINI_API_KEY: ${GEMINI_API_KEY:-}
@@ -178,5 +197,11 @@ services:
 
 volumes:
   claude-mem-data:
+    external: true
+    name: claude-mem-data
   postgres-data:
+    external: true
+    name: claude-mem-postgres-data
   valkey-data:
+    external: true
+    name: claude-mem-valkey-data


### PR DESCRIPTION
## Summary

- `docker-compose.yml`'s `claude-mem-server` published port 37877 as an unqualified `"37877:37877"`, which Docker Compose resolves to `0.0.0.0` — exposing the server on every interface, including the public one, on any host without a hardened default-deny firewall. Changed to explicit `127.0.0.1` (local hooks/healthcheck) + a configurable Tailscale-style IP (`CLAUDE_MEM_TAILSCALE_IP`, cross-machine access) bind only.
- `claude-mem-worker` never set `CLAUDE_MEM_SERVER_PORT`/`CLAUDE_MEM_WORKER_PORT`. The BullMQ queue prefix is derived from `CLAUDE_MEM_WORKER_PORT` (falling back to a UID-derived port when unset — see `SettingsDefaultsManager.ts`), so with these unset the worker silently consumed a different, permanently-empty queue than the one the server enqueued jobs under. Generation looked "disabled" but was actually just listening to the wrong queue, indefinitely, with no error. Pinned both to `37877` to match the server.
- `CLAUDE_MEM_OPENROUTER_BASE_URL` was missing from the worker service's environment block entirely, so a bare `docker compose up` using an OpenRouter-compatible custom endpoint would silently fall back to the default instead.
- Pinned `image:` on both server/worker services (alongside the existing `build:`) so a bare `docker compose up` reuses the last-built image instead of implicitly rebuilding and potentially drifting from a known-good state.
- Added `container_name` to all four services so they match what ops tooling / runbooks typically reference by fixed name.
- Marked the three named volumes `external: true` so redeploying via compose reuses existing data (Postgres tables, Valkey queue state, claude-mem data dir) instead of silently creating fresh empty volumes on next `up`.

## Context

Found and fixed while debugging a production deployment where the worker had been silently stuck on an empty queue for a week — `docker compose up` from this file reproduces the exact same silent failure from a clean state, since the missing port env vars and the unqualified port bind are present in the tracked file itself, not just a runtime drift issue.

## Test plan

- [x] `docker compose config --quiet` validates cleanly
- [x] Verified port bindings resolve to explicit `127.0.0.1` + configured IP (not `0.0.0.0`) via `docker compose config`
- [x] Confirmed via BullMQ Redis keys that server and worker now share the same `claude_mem_37877` queue prefix
- [x] Full stack (`postgres`, `valkey`, `claude-mem-server`, `claude-mem-worker`) brought up via `docker compose up -d` against pre-existing external volumes — all four report healthy, worker resumed draining a real backlog (observed `completed` counters incrementing, `waiting` decreasing) with zero new errors