### PR TITLE
fix(sqlite): apply limit after reordering in getUserPromptsByIds (follow-up to #2153)

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -2229,7 +2229,7 @@ export class SessionStore {
     const { orderBy = 'date_desc', limit, project, platformSource } = options;
     const preserveIdOrder = orderBy === 'relevance';
     const orderClause = preserveIdOrder ? '' : `ORDER BY up.created_at_epoch ${orderBy === 'date_asc' ? 'ASC' : 'DESC'}`;
-    const limitClause = limit ? `LIMIT ${limit}` : '';
+    const limitClause = limit && !preserveIdOrder ? `LIMIT ${limit}` : '';
     const placeholders = ids.map(() => '?').join(',');
     const params: any[] = [...ids];
     const additionalConditions: string[] = [];
@@ -2265,7 +2265,8 @@ export class SessionStore {
     if (!preserveIdOrder) return rows;
 
     const rowMap = new Map(rows.map(r => [r.id, r]));
-    return ids.map(id => rowMap.get(id)).filter((r): r is UserPromptRecord => !!r);
+    const ordered = ids.map(id => rowMap.get(id)).filter((r): r is UserPromptRecord => !!r);
+    return limit ? ordered.slice(0, limit) : ordered;
   }
 
   getTimelineAroundTimestamp(

--- a/tests/services/sqlite/get-observations-by-ids-relevance.test.ts
+++ b/tests/services/sqlite/get-observations-by-ids-relevance.test.ts
@@ -73,8 +73,46 @@ describe('SessionStore.*ByIds — orderBy: "relevance" preserves caller ID order
       inserted.push(result.observationIds[0]);
     }
 
-    const callerOrder = [...inserted].reverse(); 
+    const callerOrder = [...inserted].reverse();
     const results = store.getObservationsByIds(callerOrder);
     expect(results.map(r => r.id)).toEqual([...inserted].reverse());
+  });
+
+  // getUserPromptsByIds diverged from its two siblings: it applied LIMIT without
+  // guarding on !preserveIdOrder, and returned without the trailing .slice(0, limit).
+  // Under 'relevance' the ORDER BY clause is empty, so SQLite satisfied the LIMIT
+  // straight from the id-index scan in ascending rowid order -- truncating to the
+  // OLDEST n candidates and only then permuting the survivors into caller order.
+  it('getUserPromptsByIds applies limit AFTER reordering, not before (top-n, not oldest-n)', () => {
+    const sdkId = store.createSDKSession('content-prompts', 'p', 'prompt');
+    store.updateMemorySessionId(sdkId, 'session-prompts');
+
+    const inserted: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      inserted.push(store.saveUserPrompt('content-prompts', i, `prompt text ${i}`, sdkId));
+    }
+
+    // Ask for them highest-id-first, so "oldest n" and "first n of caller order" differ.
+    const callerOrder = [...inserted].reverse();
+    const results = store.getUserPromptsByIds(callerOrder, { orderBy: 'relevance', limit: 3 });
+
+    // Pre-fix this returned a single row: SQL LIMIT 3 kept the three lowest ids, then
+    // the reorder discarded the two of those that were not in the top 3 of callerOrder.
+    expect(results.map(r => r.id)).toEqual(callerOrder.slice(0, 3));
+  });
+
+  it('getUserPromptsByIds returns every row in caller order when no limit is given', () => {
+    const sdkId = store.createSDKSession('content-prompts-order', 'p', 'prompt');
+    store.updateMemorySessionId(sdkId, 'session-prompts-order');
+
+    const inserted: number[] = [];
+    for (let i = 0; i < 4; i++) {
+      inserted.push(store.saveUserPrompt('content-prompts-order', i, `prompt text ${i}`, sdkId));
+    }
+
+    const callerOrder = [...inserted].reverse();
+    const results = store.getUserPromptsByIds(callerOrder, { orderBy: 'relevance' });
+
+    expect(results.map(r => r.id)).toEqual(callerOrder);
   });
 });


### PR DESCRIPTION
Follow-up to #2153.

That fix added `'relevance'` support to all three `SessionStore` hydration methods. `getObservationsByIds` and `getSessionSummariesByIds` also got the matching limit handling; `getUserPromptsByIds` did not, and still has the original behaviour.

### The divergence

Both siblings guard the LIMIT and slice after the reorder:

```ts
const limitClause = limit && !preserveIdOrder ? `LIMIT ${limit}` : '';
...
const ordered = ids.map(id => rowMap.get(id)).filter(...);
return limit ? ordered.slice(0, limit) : ordered;
```

`getUserPromptsByIds` has neither — it applies `LIMIT` unconditionally and returns straight from the reorder.

### Why that breaks

Under `orderBy: 'relevance'` the ORDER BY clause is deliberately empty, so SQLite is free to satisfy the LIMIT directly from the id-index scan — in ascending rowid order. The method therefore truncates to the **oldest n** candidates and only then permutes the survivors into caller order. A caller passing a ranked id list loses its top hits before the reorder ever runs.

Concretely, with 5 prompts requested highest-id-first and `limit: 3`, it returns **one** row rather than the caller's top 3: SQL keeps the three lowest ids, then the reorder discards the two of those that aren't in the caller's first 3.

### Scope

This is **latent, not user-visible**. No caller in the tree passes `'relevance'` to this method today, so nothing currently misbehaves — I'd rather say that plainly than oversell it. It bites the moment a caller does, which is the case #2153 set out to make safe, and the asymmetry between the three methods is the kind of thing that's much cheaper to fix now than to debug later.

### Changes

- `src/services/sqlite/SessionStore.ts` — the two lines that bring the method in line with its siblings.
- `tests/services/sqlite/get-observations-by-ids-relevance.test.ts` — two tests appended to the existing #2153 suite. The first (`applies limit AFTER reordering`) fails on `main` and passes with the fix; the second covers the no-limit path.

No behaviour change for any existing caller: with `preserveIdOrder` false the generated SQL and the return value are identical to before.

### Verification

```
bun test tests/services/sqlite/ tests/worker/   # 298 pass, 0 fail
npx tsc --noEmit                                # clean
```

Branched from `main` at f5633c1f (v13.11.0).
