### PR TITLE
fix(paths): expand ~ in CLAUDE_MEM_DATA_DIR (stray ~ dirs)

### DIFF
--- a/src/shared/paths.ts
+++ b/src/shared/paths.ts
@@ -14,9 +14,30 @@ function getDirname(): string {
 
 const _dirname = getDirname();
 
+/**
+ * Expand a leading `~/` (or a bare `~`) to the user's home directory.
+ *
+ * Node's `path.join` / `fs` do NOT expand `~` — only the shell does. So a
+ * literal `~/.claude-mem` read from `settings.json` or an env var is treated
+ * as a *relative* path, creating a directory literally named `~` in the
+ * process cwd. claude-mem workers inherit the cwd of whatever spawned them
+ * (subagents pinned to a subdirectory, a plugin-install dir, etc.), so a
+ * `~`-prefixed DATA_DIR scattered stray `~/.claude-mem/` trees across the
+ * workspace. Expanding here keeps every downstream path absolute regardless
+ * of how the value was written.
+ */
+export function expandHome(p: string): string {
+  if (typeof p !== 'string' || p.length === 0) return p;
+  if (p === '~') return homedir();
+  if (p.startsWith('~/')) return join(homedir(), p.slice(2));
+  // A `~user/...` form is intentionally left untouched — resolving another
+  // user's home is out of scope and platform-dependent.
+  return p;
+}
+
 export function resolveDataDir(): string {
   if (process.env.CLAUDE_MEM_DATA_DIR) {
-    return process.env.CLAUDE_MEM_DATA_DIR;
+    return expandHome(process.env.CLAUDE_MEM_DATA_DIR);
   }
 
   const defaultDataDir = join(homedir(), '.claude-mem');
@@ -24,9 +45,9 @@ export function resolveDataDir(): string {
   try {
     if (existsSync(settingsPath)) {
       const raw = parseJsonWithBom<Record<string, any>>(readFileSync(settingsPath, 'utf-8'));
-      const settings = raw.env ?? raw; 
+      const settings = raw.env ?? raw;
       if (settings.CLAUDE_MEM_DATA_DIR) {
-        return settings.CLAUDE_MEM_DATA_DIR;
+        return expandHome(settings.CLAUDE_MEM_DATA_DIR);
       }
     }
   } catch {

--- a/tests/shared/paths.test.ts
+++ b/tests/shared/paths.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from 'bun:test';
-import { paths, DATA_DIR } from '../../src/shared/paths.js';
+import { describe, it, expect, afterEach } from 'bun:test';
+import { paths, DATA_DIR, resolveDataDir, expandHome } from '../../src/shared/paths.js';
+import { homedir } from 'os';
+import { join } from 'path';
 
 describe('paths namespace', () => {
   it('exposes at least the known core accessors', () => {
@@ -29,5 +31,65 @@ describe('paths namespace', () => {
     for (const key of Object.keys(paths) as Array<keyof typeof paths>) {
       expect(typeof paths[key]).toBe('function');
     }
+  });
+});
+
+describe('expandHome', () => {
+  it('expands a leading ~/ to the home directory', () => {
+    expect(expandHome('~/foo/bar')).toBe(join(homedir(), 'foo/bar'));
+  });
+
+  it('expands a bare ~ to the home directory', () => {
+    expect(expandHome('~')).toBe(homedir());
+  });
+
+  it('leaves an absolute path untouched', () => {
+    const abs = join(homedir(), '.claude-mem');
+    expect(expandHome(abs)).toBe(abs);
+  });
+
+  it('leaves a relative path (no ~) untouched', () => {
+    expect(expandHome('foo/bar')).toBe('foo/bar');
+  });
+
+  it('does not expand ~ not at position 0', () => {
+    // a tilde mid-path is a literal character, not a home reference
+    expect(expandHome('foo/~bar')).toBe('foo/~bar');
+  });
+
+  it('does not touch a ~user/ form (out of scope)', () => {
+    expect(expandHome('~someone/data')).toBe('~someone/data');
+  });
+});
+
+describe('resolveDataDir tilde expansion', () => {
+  // resolveDataDir consults process.env.CLAUDE_MEM_DATA_DIR first, so we can
+  // exercise the expansion without touching the real settings.json on disk.
+  const sentinel = '/__claude_mem_test_no_real_dir__';
+  const origEnv = process.env.CLAUDE_MEM_DATA_DIR;
+
+  afterEach(() => {
+    if (origEnv === undefined) delete process.env.CLAUDE_MEM_DATA_DIR;
+    else process.env.CLAUDE_MEM_DATA_DIR = origEnv;
+  });
+
+  it('returns an absolute path when the env var is a literal ~ (no stray ~ dir)', () => {
+    process.env.CLAUDE_MEM_DATA_DIR = '~/.claude-mem';
+    const resolved = resolveDataDir();
+    expect(resolved).toBe(join(homedir(), '.claude-mem'));
+    // the regression: a non-absolute, ~-prefixed value used to slip through and
+    // become a cwd-relative path → a literal `~` directory on disk.
+    expect(resolved.startsWith('~')).toBe(false);
+    expect(join(resolved, 'logs')).toBe(join(homedir(), '.claude-mem', 'logs'));
+  });
+
+  it('returns the home dir when the env var is a bare ~', () => {
+    process.env.CLAUDE_MEM_DATA_DIR = '~';
+    expect(resolveDataDir()).toBe(homedir());
+  });
+
+  it('still returns a real env-var value when it is already absolute', () => {
+    process.env.CLAUDE_MEM_DATA_DIR = sentinel;
+    expect(resolveDataDir()).toBe(sentinel);
   });
 });


### PR DESCRIPTION
## Problem

A literal `~`-prefixed `CLAUDE_MEM_DATA_DIR` (e.g. `~/.claude-mem` written into `settings.json`, or set as an env var from a non-shell context) produced stray directories literally named `~` across the workspace.

`resolveDataDir()` returned the value verbatim from both the env var and `settings.json`, without tilde expansion. Node's `path.join` / `fs` do **not** expand `~` (only the shell does), so the value was treated as a *relative* path and resolved against the process cwd. claude-mem workers inherit the cwd of whatever spawned them — a subagent pinned to a subdirectory, a plugin-install dir, the repo root, an Obsidian plugin folder — so each worker created its own `cwd/~/.claude-mem/` tree (logs + a `settings.json` snapshot), e.g.:

```
<repo>/~/.claude-mem/logs/...
<repo>/<subdir>/~/.claude-mem/logs/...
<repo>/<subdir>/<nested-dir>/~/.claude-mem/logs/...
<repo>/<plugin-dir>/~/.claude-mem/...
```

The default value (`join(homedir(), '.claude-mem')`) was already absolute, so this only bit users whose `settings.json` literally contained `"~/.claude-mem"` (hand-edited configs, or configs written by tooling that didn't expand `~`).

## Fix

Add `expandHome()` in `src/shared/paths.ts` and route both return paths of `resolveDataDir()` through it:

- `~/foo` → `join(homedir(), 'foo')`
- bare `~` → `homedir()`
- absolute paths → untouched
- relative paths without `~` → untouched
- `~user/...` → intentionally untouched (resolving another user's home is out of scope and platform-dependent)

This keeps every downstream path (`LOGS_DIR`, `DB_PATH`, `paths.*`) absolute regardless of how the value was authored, without changing behavior for the (already-absolute) default.

## Verification

- `bun test tests/shared/paths.test.ts` → 12 pass (6 new `expandHome` cases + 3 `resolveDataDir` tilde cases + 3 existing)
- `bun test tests/shared/` → 130 pass, 0 fail
- `tsc --noEmit` → 0 errors

The `resolveDataDir` tests exercise the env-var branch (consulted first) so they don't touch the real `~/.claude-mem/settings.json` on disk.

## Workaround already in place locally

Beyond this source fix, the equivalent defense without a code change is to set `CLAUDE_MEM_DATA_DIR` to an absolute path in the Claude Code `env` block (`~/.claude/settings.json`) so `te()`/`resolveDataDir()` hits the env-var branch first — useful for anyone who can't upgrade immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
