### PR TITLE
fix(worker): resolve cache version by semver, not mtime

### DIFF
--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -216,21 +216,44 @@ function candidateWorkerScriptPath(root: string): string {
   return path.join(pluginRoot, 'scripts', 'worker-service.cjs');
 }
 
+/**
+ * Compare two `<major>.<minor>.<patch>` version strings, descending (newest
+ * first). Non-numeric or missing components compare as 0. Exported for unit
+ * testing (see tests/shared/worker-utils-cache-version-resolution.test.ts).
+ */
+export function compareVersionDescending(a: string, b: string): number {
+  const partsA = a.split('.').map(part => Number.parseInt(part, 10));
+  const partsB = b.split('.').map(part => Number.parseInt(part, 10));
+  const length = Math.max(partsA.length, partsB.length);
+  for (let i = 0; i < length; i += 1) {
+    const numA = Number.isFinite(partsA[i]) ? partsA[i] : 0;
+    const numB = Number.isFinite(partsB[i]) ? partsB[i] : 0;
+    if (numA !== numB) {
+      return numB - numA;
+    }
+  }
+  return 0;
+}
+
 function cacheWorkerScriptCandidates(): string[] {
   const pluginsRoot = path.dirname(path.dirname(MARKETPLACE_ROOT));
   const cacheRoot = path.join(pluginsRoot, 'cache', 'thedotmack', 'claude-mem');
   try {
     return readdirSync(cacheRoot)
       .filter(name => /^\d/.test(name))
-      .map(name => path.join(cacheRoot, name))
-      .filter(candidate => {
+      .filter(name => {
         try {
-          return statSync(candidate).isDirectory();
+          return statSync(path.join(cacheRoot, name)).isDirectory();
         } catch {
           return false;
         }
       })
-      .sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs)
+      // Sort by the version directory name itself (semver descending), not
+      // mtime: an in-place update can leave two version dirs with identical
+      // mtimes, making mtime-sort order undefined and letting the worker
+      // spawn from a stale version indefinitely (issue #2424).
+      .sort(compareVersionDescending)
+      .map(name => path.join(cacheRoot, name))
       .map(candidateWorkerScriptPath);
   } catch {
     return [];

--- a/tests/shared/worker-utils-cache-version-resolution.test.ts
+++ b/tests/shared/worker-utils-cache-version-resolution.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'bun:test';
+import { compareVersionDescending } from '../../src/shared/worker-utils.js';
+
+// Regression test for issue #2424: an in-place plugin update can leave two
+// cache/thedotmack/claude-mem/<version> directories with identical mtimes
+// (both extracted in the same update pass). cacheWorkerScriptCandidates()
+// used to sort candidates by directory mtime, so a tie left the sort order —
+// and therefore which version's worker-service.cjs got spawned — undefined.
+// It now sorts by the version directory name itself via this comparator, so
+// mtime ties (or even reversed mtimes) can never pick a stale version.
+
+describe('compareVersionDescending', () => {
+  it('orders a higher minor version before a lower one', () => {
+    expect(compareVersionDescending('13.11.0', '13.10.2')).toBeLessThan(0);
+    expect(compareVersionDescending('13.10.2', '13.11.0')).toBeGreaterThan(0);
+  });
+
+  it('orders a higher patch version before a lower one', () => {
+    expect(compareVersionDescending('13.10.3', '13.10.2')).toBeLessThan(0);
+  });
+
+  it('orders a higher major version before a lower one regardless of minor/patch', () => {
+    expect(compareVersionDescending('14.0.0', '13.99.99')).toBeLessThan(0);
+  });
+
+  it('treats equal versions as equal', () => {
+    expect(compareVersionDescending('13.11.0', '13.11.0')).toBe(0);
+  });
+
+  it('sorts a realistic cache-directory listing to the highest version first', () => {
+    const dirs = ['13.9.0', '13.11.0', '13.10.2', '13.10.10'];
+    expect([...dirs].sort(compareVersionDescending)).toEqual([
+      '13.11.0',
+      '13.10.10',
+      '13.10.2',
+      '13.9.0',
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem

`cacheWorkerScriptCandidates()` (src/shared/worker-utils.ts) picks which
`cache/thedotmack/claude-mem/<version>/scripts/worker-service.cjs` to spawn
by sorting version directories on `mtimeMs`. An in-place plugin update
extracts the old and new version directories in the same pass, so they
frequently end up with **identical mtimes** — at that point
`Array.prototype.sort`'s comparator returns `0` for every pair, and the
resulting order is whatever `readdirSync` happened to return, not version
order.

This is exactly the scenario in #2424, which was closed as not planned. I'm
reopening it as a PR because it reproduced live rather than theoretically:

## What I observed

On a machine with both `13.10.2` and `13.11.0` cached (mtimes tied to the
second), the resolver kept picking `13.10.2`. Every worker restart re-ran
the same resolution, so:

1. Worker spawns from the stale `13.10.2` script.
2. `checkVersionMatch()` notices the plugin (`13.11.0`) and running worker
   (`13.10.2`) disagree and requests a recycle.
3. The recycle's own spawn hits the identical tied-mtime resolution and
   picks `13.10.2` again.
4. Repeat — the worker crash-loop-restarted every few seconds.

Each cycle left behind an orphaned chroma-mcp/uvx process pair (the old
worker's `ChromaMcpManager` never got a chance to tear its subprocess down
cleanly before being replaced). Over roughly 10 minutes this produced ~75
orphaned pairs (~150 processes, several GB RSS) before I killed the loop
manually — a variant of the accumulation described in #499/#789/#803/#1090,
but caused by the *resolver*, not by `ChromaMcpManager`'s own cleanup paths.

## Fix

Sort candidates by the version directory **name** itself (semver
descending) rather than by mtime. The directory name *is* the version
identifier, so this is deterministic regardless of extraction order or
mtime ties — no filesystem timestamp involved at all.

## Testing

- Added `tests/shared/worker-utils-cache-version-resolution.test.ts`:
  unit tests for the new comparator (major/minor/patch ordering, equal
  versions, a realistic multi-version directory listing).
- `bun test tests/shared/` — 126 pass, 0 fail (no regressions).
- `tsc --noEmit` clean.

I didn't touch the equivalent mtime-sort in `src/build/hook-shell-template.ts`
(the generated shell/Node launcher embedded in `hooks.json`/`.mcp.json`/
codex hooks) — that path has its own byte-matching generator test and is a
separate, larger surface; happy to follow up there if this approach looks
right to you.