### PR TITLE
fix: Windows isPortInUse returns false for zombie-held ports causing infinite worker startup failures

### DIFF
--- a/src/services/infrastructure/HealthMonitor.ts
+++ b/src/services/infrastructure/HealthMonitor.ts
@@ -34,17 +34,38 @@ async function httpRequestToWorker(
 
 export async function isPortInUse(port: number): Promise<boolean> {
   if (process.platform === 'win32') {
+    // Fast path: HTTP health check. A live claude-mem worker responds to
+    // /api/health, so this is the cheapest non-disruptive probe for the
+    // common case (worker is running and healthy).
     try {
       const response = await fetch(`http://${formatHostForUrl(getWorkerHost())}:${port}/api/health`);
-      return response.ok;
+      if (response.ok) return true;
+      // Non-ok response: port is reachable but the worker is unhealthy.
+      // Fall through to the net.createServer check below so we still report
+      // the port as in-use rather than falsely claiming it is free.
+      logger.debug('SYSTEM', 'Windows health check returned non-ok; falling through to socket probe', {
+        port,
+        status: response.status,
+      });
     } catch (error) {
+      // fetch threw (ECONNREFUSED, timeout, etc.): the port may still be in
+      // use by a non-HTTP process (zombie worker, foreign service, etc.).
+      // Fall through to the net.createServer probe — only a definitive bind
+      // attempt can tell whether the port is truly free.
       if (error instanceof Error) {
-        logger.debug('SYSTEM', 'Windows health check failed (port not in use)', {}, error);
+        logger.debug('SYSTEM', 'Windows health check threw; falling through to socket probe', {
+          port,
+          message: error.message,
+        });
       } else {
-        logger.debug('SYSTEM', 'Windows health check failed (port not in use)', { error: String(error) });
+        logger.debug('SYSTEM', 'Windows health check threw; falling through to socket probe', {
+          port,
+          error: String(error),
+        });
       }
-      return false;
     }
+    // Fall through: the HTTP probe was inconclusive. Use the POSIX
+    // net.createServer() approach to definitively check port occupancy.
   }
 
   return new Promise((resolve) => {

--- a/tests/infrastructure/health-monitor.test.ts
+++ b/tests/infrastructure/health-monitor.test.ts
@@ -100,14 +100,79 @@ describe('HealthMonitor', () => {
         }),
         listen: mock(() => {})
       }));
-      
+
       const spy = spyOn(net, 'createServer').mockImplementation(createServerMock as any);
 
       const result = await isPortInUse(37777);
 
       expect(result).toBe(false);
-      
+
       spy.mockRestore();
+    });
+
+    it('should fall through to socket probe on Windows when health check fails and port is actually in use (zombie port)', async () => {
+      // Simulate a zombie process: the port is occupied but does not serve HTTP.
+      // fetch for /api/health throws, then net.createServer hits EADDRINUSE.
+      const origPlatform = process.platform;
+      try {
+        Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+        global.fetch = mock(() => Promise.reject(new Error('fetch failed')));
+
+        const createServerMock = mock(() => ({
+          once: mock((event: string, cb: Function) => {
+            if (event === 'error') {
+              setTimeout(() => cb({ code: 'EADDRINUSE' }), 0);
+            }
+          }),
+          listen: mock(() => {}),
+        }));
+
+        const netSpy = spyOn(net, 'createServer').mockImplementation(createServerMock as any);
+
+        const result = await isPortInUse(37777);
+
+        expect(result).toBe(true);
+        expect(global.fetch).toHaveBeenCalled();
+        expect(net.createServer).toHaveBeenCalled();
+
+        netSpy.mockRestore();
+      } finally {
+        Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
+      }
+    });
+
+    it('should fall through to socket probe on Windows when health check fails and port is actually free', async () => {
+      const origPlatform = process.platform;
+      try {
+        Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+        global.fetch = mock(() => Promise.reject(new Error('ECONNREFUSED')));
+
+        const closeMock = mock((cb: Function) => cb());
+        const createServerMock = mock(() => ({
+          once: mock((event: string, cb: Function) => {
+            if (event === 'listening') {
+              setTimeout(() => cb(), 0);
+            }
+          }),
+          listen: mock(() => {}),
+          close: closeMock,
+        }));
+
+        const netSpy = spyOn(net, 'createServer').mockImplementation(createServerMock as any);
+
+        const result = await isPortInUse(39999);
+
+        expect(result).toBe(false);
+        expect(global.fetch).toHaveBeenCalled();
+        expect(net.createServer).toHaveBeenCalled();
+        expect(closeMock).toHaveBeenCalled();
+
+        netSpy.mockRestore();
+      } finally {
+        Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
+      }
     });
   });
 


### PR DESCRIPTION
## Problem

On Windows, when a claude-mem worker process crashes without releasing its port (creating a zombie port), the plugin enters an unrecoverable failure loop:

1. `isPortInUse()` on Windows only uses an HTTP health check (`fetch /api/health`) to determine port occupancy
2. A zombie process holds the port but doesn't serve HTTP → fetch throws → `isPortInUse` incorrectly returns `false`
3. Worker daemon skips the "port already in use" guard and tries to bind → hits `EADDRINUSE`
4. Worker logs `✗ Worker failed to start Failed to start server. Is port 37777 in use?` and exits with error
5. Hook failure counter increments indefinitely (observed: 71 consecutive failures across multiple sessions)

## Root Cause

In `src/services/infrastructure/HealthMonitor.ts`, the Windows implementation of `isPortInUse()` only uses an HTTP health check:

```typescript
if (process.platform === 'win32') {
    try {
        const response = await fetch(`http://...:${port}/api/health`);
        return response.ok;
    } catch (error) {
        return false;  // ← BUG: assumes port is free when fetch fails
    }
}
```

But the POSIX implementation correctly uses `net.createServer().listen()` — a definitive socket-level probe that detects ANY process holding the port, not just HTTP servers.

## Fix

When the HTTP health check is inconclusive (fetch throws or returns non-ok), **fall through to the POSIX `net.createServer()` socket probe** instead of returning `false`:

- **Healthy worker** → HTTP check succeeds → fast path (unchanged, zero overhead)
- **Zombie/foreign process** → HTTP check fails → socket probe returns `true` → worker daemon exits cleanly with "Port already in use, refusing to start duplicate"
- **Port free** → HTTP check fails → socket probe binds successfully → returns `false`

## Changes

- `src/services/infrastructure/HealthMonitor.ts`: Windows `isPortInUse` now falls through to the POSIX `net.createServer()` probe when the HTTP health check is inconclusive
- `tests/infrastructure/health-monitor.test.ts`: Added 2 tests covering the Windows zombie port scenario and the Windows port-free scenario

## Testing

All existing tests pass (22/22), plus 2 new tests for the fixed behavior.