### PR TITLE
fix(context): honor CLAUDE_MEM_EXCLUDED_PROJECTS on session-start injection

### DIFF
--- a/src/cli/handlers/context.ts
+++ b/src/cli/handlers/context.ts
@@ -14,6 +14,7 @@ import { getProjectContext } from '../../utils/project-name.js';
 import { HOOK_EXIT_CODES } from '../../shared/hook-constants.js';
 import { logger } from '../../utils/logger.js';
 import { loadFromFileOnce } from '../../shared/hook-settings.js';
+import { shouldTrackProject } from '../../shared/should-track-project.js';
 import { readStaleMarker } from '../../shared/oauth-token.js';
 import { normalizePlatformSource } from '../../shared/platform-source.js';
 import { callMcpToolOnce } from '../../shared/mcp-client.js';
@@ -55,6 +56,18 @@ async function fetchSessionStartContextViaMcp(args: {
 export const contextHandler: EventHandler = {
   async execute(input: NormalizedHookInput): Promise<HookResult> {
     const cwd = input.cwd ?? process.cwd();
+
+    // Honor CLAUDE_MEM_EXCLUDED_PROJECTS on the inject/read path too. The
+    // write path (ingestObservation) already skips excluded projects, but the
+    // SessionStart summary was injected regardless — so an excluded dir (e.g.
+    // "~") still got a context dump on every new session. Suppress it here.
+    if (!shouldTrackProject(cwd)) {
+      return {
+        hookSpecificOutput: { hookEventName: 'SessionStart', additionalContext: '' },
+        exitCode: HOOK_EXIT_CODES.SUCCESS,
+      };
+    }
+
     const context = getProjectContext(cwd);
     const port = getWorkerPort();
 


### PR DESCRIPTION
## Problem

`CLAUDE_MEM_EXCLUDED_PROJECTS` is only enforced on the **write** path — `ingestObservation()` in `src/services/worker/http/shared.ts` skips projects that match the exclusion list. The **read/inject** path does not check it: the SessionStart context handler (`src/cli/handlers/context.ts`) fetches and injects a context summary for the current `cwd` regardless of the exclusion list, and `/api/context/inject` (`SearchRoutes.handleContextInject`) has no exclusion guard either.

As a result, an excluded directory (e.g. `CLAUDE_MEM_EXCLUDED_PROJECTS=~`) is correctly excluded from *capture* but still gets a full context dump injected on **every new session** — which is surprising and defeats the purpose of excluding it.

## Fix

Guard the inject path at its entry point — the SessionStart context handler — with the existing `shouldTrackProject(cwd)` helper, returning empty `additionalContext` for excluded projects. This:

- mirrors the write-side check (`shared.ts` already uses `isProjectExcluded`),
- reuses the same glob / leading-`~` expansion semantics via `shouldTrackProject` → `isProjectExcluded`, so no new matching logic is introduced,
- also naturally covers the observer-sessions dir exclusion that `shouldTrackProject` already handles.

Only the source handler is changed; built bundles under `plugin/` need a `npm run build` to regenerate.

## Verification

Ran the SessionStart context hook directly against the built bundle:

- `cwd` = an excluded dir (`~`) → `additionalContext: ""` (summary suppressed). ✅
- `cwd` = a non-excluded project → unchanged vs. the pre-fix bundle (no regression). ✅
- Exclusion pattern `~` expands to `^/Users/<user>$` (anchored), so **child** directories of home are not affected — only the exact home dir. ✅