### PR TITLE
fix(worker): salvage prose-only observations instead of dropping them (closes #3351)

### DIFF
--- a/src/sdk/parser.ts
+++ b/src/sdk/parser.ts
@@ -34,6 +34,10 @@ export interface ParsedSummary {
   skip_reason?: string | null;
 }
 
+const OBSERVATION_TITLE_MAX_GRAPHEMES = 120;
+const OBSERVATION_TITLE_TRUNCATE_AT = 117;
+const observationGraphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+
 export type ParseResult =
   | { valid: true; observations: ParsedObservation[]; summary: ParsedSummary | null }
   | { valid: false };
@@ -260,13 +264,13 @@ function extractObservationFallback(text: string): { title: string; narrative: s
     .map(line => line.trim())
     .filter(line => line !== '');
   const firstLine = lines[0] ?? text.trim();
-  const firstLineCodePoints = Array.from(firstLine);
-  const hasOverflow = firstLineCodePoints.length > 120;
+  const firstLineGraphemes = Array.from(observationGraphemeSegmenter.segment(firstLine), part => part.segment);
+  const hasOverflow = firstLineGraphemes.length > OBSERVATION_TITLE_MAX_GRAPHEMES;
   const title = hasOverflow
-    ? `${firstLineCodePoints.slice(0, 117).join('')}...`
+    ? `${firstLineGraphemes.slice(0, OBSERVATION_TITLE_TRUNCATE_AT).join('')}...`
     : firstLine;
   const narrativeLines = hasOverflow
-    ? [firstLineCodePoints.slice(117).join('').trim(), ...lines.slice(1)]
+    ? [firstLineGraphemes.slice(OBSERVATION_TITLE_TRUNCATE_AT).join('').trim(), ...lines.slice(1)]
     : lines.slice(1);
   const narrative = narrativeLines
     .filter(line => line !== '')

--- a/src/sdk/parser.ts
+++ b/src/sdk/parser.ts
@@ -124,6 +124,8 @@ function parseObservationBlocks(text: string, correlationId?: string | number): 
         return (colonIndex === -1 ? c : c.slice(0, colonIndex)).trim();
       })
       .filter(c => c !== '' && c !== finalType);
+    let finalTitle = title;
+    let finalNarrative = narrative;
 
     if (cleanedConcepts.length !== concepts.length) {
       logger.debug('PARSER', 'Removed observation type from concepts array', {
@@ -135,19 +137,31 @@ function parseObservationBlocks(text: string, correlationId?: string | number): 
     }
 
     if (!title && !narrative && facts.length === 0 && cleanedConcepts.length === 0) {
-      logger.warn('PARSER', 'Skipping empty observation (all content fields null)', {
+      const salvageNarrative = extractUnstructuredObservationText(obsContent);
+      if (!salvageNarrative) {
+        logger.warn('PARSER', 'Skipping empty observation (all content fields null)', {
+          correlationId,
+          type: finalType
+        });
+        continue;
+      }
+
+      const salvage = extractObservationFallback(salvageNarrative);
+      finalTitle = salvage.title;
+      finalNarrative = salvage.narrative;
+      logger.warn('PARSER', 'Salvaged unstructured observation prose as narrative', {
         correlationId,
-        type: finalType
+        type: finalType,
+        chars: salvageNarrative.length
       });
-      continue;
     }
 
     observations.push({
       type: finalType,
-      title,
+      title: finalTitle,
       subtitle,
       facts,
-      narrative,
+      narrative: finalNarrative,
       concepts: cleanedConcepts,
       files_read,
       files_modified
@@ -217,4 +231,50 @@ function extractArrayElements(content: string, arrayName: string, elementName: s
   }
 
   return elements;
+}
+
+function extractUnstructuredObservationText(content: string): string | null {
+  if (/<\/?(summary|skip_summary)\b/i.test(content)) {
+    return null;
+  }
+
+  const stripped = content
+    .replace(
+      /<(type|title|subtitle|narrative|facts|concepts|files_read|files_modified)(?:\s*\/>|>[\s\S]*?<\/\1>)/g,
+      ' '
+    )
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line !== '')
+    .join('\n')
+    .trim();
+
+  return stripped === '' ? null : stripped;
+}
+
+function extractObservationFallback(text: string): { title: string; narrative: string | null } {
+  const lines = text
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line !== '');
+  const firstLine = lines[0] ?? text.trim();
+  const firstLineCodePoints = Array.from(firstLine);
+  const hasOverflow = firstLineCodePoints.length > 120;
+  const title = hasOverflow
+    ? `${firstLineCodePoints.slice(0, 117).join('')}...`
+    : firstLine;
+  const narrativeLines = hasOverflow
+    ? [firstLineCodePoints.slice(117).join('').trim(), ...lines.slice(1)]
+    : lines.slice(1);
+  const narrative = narrativeLines
+    .filter(line => line !== '')
+    .join('\n')
+    .trim();
+
+  return {
+    title,
+    narrative: narrative === '' ? null : narrative,
+  };
 }

--- a/tests/sdk/parser.test.ts
+++ b/tests/sdk/parser.test.ts
@@ -109,6 +109,67 @@ describe('parseAgentXml — observations', () => {
     expect(result.valid).toBe(false);
   });
 
+  it('salvages freeform prose inside a closed observation block', () => {
+    const xml = `<observation>
+      <type>discovery</type>
+      Refactored transformer_markdown.py helpers and narrowed the shared formatting path.
+      The follow-up kept the line-range handling aligned with the new helpers.
+    </observation>`;
+
+    const result = expectObservation(xml);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('discovery');
+    expect(result[0].title).toBe('Refactored transformer_markdown.py helpers and narrowed the shared formatting path.');
+    expect(result[0].narrative).toContain('line-range handling aligned with the new helpers');
+    expect(result[0].narrative).not.toContain('Refactored transformer_markdown.py helpers and narrowed the shared formatting path.');
+  });
+
+  it('keeps self-closing empty fields out of the prose salvage path', () => {
+    const xml = `<observation>
+      <type>bugfix</type>
+      <title/>
+      <narrative/>
+    </observation>`;
+
+    const result = parseAgentXml(xml);
+    expect(result.valid).toBe(false);
+  });
+
+  it('preserves overflow from a long first prose line in the narrative', () => {
+    const longFirstLine = 'A'.repeat(140);
+    const xml = `<observation>
+      <type>discovery</type>
+      ${longFirstLine}
+      Follow-up detail stays in the narrative.
+    </observation>`;
+
+    const result = expectObservation(xml);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe(`${'A'.repeat(117)}...`);
+    expect(result[0].narrative).toContain('A'.repeat(23));
+    expect(result[0].narrative).toContain('Follow-up detail stays in the narrative.');
+  });
+
+  it('keeps surrogate-pair characters intact when a long first prose line overflows', () => {
+    const longFirstLine = `${'A'.repeat(116)}🧠${'B'.repeat(10)}`;
+    const xml = `<observation>
+      <type>discovery</type>
+      ${longFirstLine}
+      Follow-up detail stays in the narrative.
+    </observation>`;
+
+    const result = expectObservation(xml);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe(`${'A'.repeat(116)}🧠...`);
+    expect(result[0].title).not.toContain('�');
+    expect(result[0].narrative).toContain('B'.repeat(10));
+    expect(result[0].narrative).toContain('Follow-up detail stays in the narrative.');
+    expect(result[0].narrative).not.toContain('�');
+  });
+
   it('filters out multiple ghost observations while keeping valid ones (#1625)', () => {
     const xml = `
       <observation><type>bugfix</type></observation>

--- a/tests/sdk/parser.test.ts
+++ b/tests/sdk/parser.test.ts
@@ -170,6 +170,28 @@ describe('parseAgentXml — observations', () => {
     expect(result[0].narrative).not.toContain('�');
   });
 
+  it('keeps grapheme clusters intact when a long first prose line overflows', () => {
+    const cases = [
+      { label: 'combining mark', cluster: 'e\u0301' },
+      { label: 'zwj emoji', cluster: '👩‍💻' },
+    ];
+
+    for (const { label, cluster } of cases) {
+      const longFirstLine = `${'A'.repeat(116)}${cluster}${'B'.repeat(10)}`;
+      const xml = `<observation>
+        <type>discovery</type>
+        ${longFirstLine}
+        Follow-up detail stays in the narrative.
+      </observation>`;
+
+      const result = expectObservation(xml);
+
+      expect(result, label).toHaveLength(1);
+      expect(result[0].title, label).toBe(`${'A'.repeat(116)}${cluster}...`);
+      expect(result[0].narrative, label).toBe(`${'B'.repeat(10)}\nFollow-up detail stays in the narrative.`);
+    }
+  });
+
   it('filters out multiple ghost observations while keeping valid ones (#1625)', () => {
     const xml = `
       <observation><type>bugfix</type></observation>

--- a/tests/server/generation/process-generated-response.test.ts
+++ b/tests/server/generation/process-generated-response.test.ts
@@ -140,10 +140,42 @@ describe('processGeneratedResponse + markGenerationFailed', () => {
       projectId,
       teamId,
     });
-    expect(sources).toHaveLength(1);
-    expect(sources[0]!.sourceType).toBe('agent_event');
-    expect(sources[0]!.sourceId).toBe(eventId);
-    expect(sources[0]!.generationJobId).toBe(jobId);
+  expect(sources).toHaveLength(1);
+  expect(sources[0]!.sourceType).toBe('agent_event');
+  expect(sources[0]!.sourceId).toBe(eventId);
+  expect(sources[0]!.generationJobId).toBe(jobId);
+  });
+
+  it('persists freeform prose from a closed observation block', async () => {
+    const xml = `
+      <observation>
+        This deploy unblocked the worker restart path after the queue drained.
+      </observation>
+    `;
+
+    await storage.observationGenerationJobs.transitionStatus({
+      id: jobId,
+      projectId,
+      teamId,
+      status: 'processing',
+    });
+
+    const fresh = (await reloadJob())!;
+    const outcome = await processGeneratedResponse({
+      pool: pool as unknown as Parameters<typeof processGeneratedResponse>[0]['pool'],
+      job: fresh,
+      rawText: xml,
+      providerLabel: 'fake',
+      modelId: 'fake-1',
+    });
+
+    expect(outcome.kind).toBe('completed');
+    if (outcome.kind === 'completed') {
+      expect(outcome.observations).toHaveLength(1);
+      expect(outcome.observations[0]!.content).toContain('This deploy unblocked the worker restart path');
+      expect(outcome.observations[0]!.metadata.title).toBe('This deploy unblocked the worker restart path after the queue drained.');
+      expect(outcome.observations[0]!.content).not.toContain('This deploy unblocked the worker restart path after the queue drained.\n\nThis deploy unblocked the worker restart path after the queue drained.');
+    }
   });
 
   it('records token + observation usage when metering is enabled', async () => {

--- a/tests/worker/agents/response-processor.test.ts
+++ b/tests/worker/agents/response-processor.test.ts
@@ -288,6 +288,32 @@ describe('ResponseProcessor', () => {
       expect(observations[1].type).toBe('bugfix');
     });
 
+    it('stores a closed observation block with freeform prose through the success path', async () => {
+      const session = createMockSession();
+      const responseText = `<observation>
+        <type>discovery</type>
+        Refactored transformer_markdown.py helpers and narrowed the shared formatting path.
+        The follow-up kept the line-range handling aligned with the new helpers.
+      </observation>`;
+
+      await processAgentResponse(
+        responseText,
+        session,
+        mockDbManager,
+        mockSessionManager,
+        mockWorker,
+        100,
+        null,
+        'TestAgent'
+      );
+
+      expect(mockStoreObservations).toHaveBeenCalledTimes(1);
+      const [, , observations] = mockStoreObservations.mock.calls[0];
+      expect(observations).toHaveLength(1);
+      expect(observations[0].title).toBe('Refactored transformer_markdown.py helpers and narrowed the shared formatting path.');
+      expect(observations[0].narrative).toContain('line-range handling aligned with the new helpers');
+    });
+
     it('stores observations against the dispatched prompt context when the live session has already advanced', async () => {
       const session = createMockSession({
         project: 'repo-b/worktree',


### PR DESCRIPTION
## Summary

`parseAgentXml` still corrupted a salvaged closed `<observation>...</observation>` block when the fallback title boundary landed inside a combining sequence or ZWJ emoji. The parser already kept surrogate pairs intact by splitting on code points, but that still let multi-code-point graphemes tear between `title` and `narrative`.

This switches the fallback split to grapheme segmentation, keeps the existing prose-salvage contract, and adds boundary regressions for combining-mark and ZWJ cases beside the earlier long-line and surrogate coverage.

## Why

The shared parser path in `src/sdk/parser.ts` is used by both the worker-side `ResponseProcessor` flow and the server-side `processGeneratedResponse` flow. `extractObservationFallback()` currently builds the fallback title and overflow narrative from the first prose line, and the current head's `Array.from(firstLine).slice(0, 117)` / `slice(117)` split fixed UTF-16 surrogate-pair corruption without fixing grapheme clusters that span multiple code points.

That means inputs like `e\u0301` and `👩‍💻` can still be split across `title` and `narrative`, after which the broken pair flows unchanged into persisted server content, observation dedup keys, and Chroma indexing. `Intl.Segmenter(undefined, { granularity: 'grapheme' })` is already available on the repo's supported Node and Bun runtimes, so the minimal fix is to keep the ownership in the parser and replace only the segmentation primitive.

## Scope

This only changes the fallback split for prose-only closed observation blocks whose first salvaged line overflows the title boundary.

It does not change empty-block rejection, structured observation parsing, summary parsing, or the worker/server `(title, narrative)` contract.

## Risk

Behavior only changes for overflow cases that currently corrupt Unicode graphemes. The parser still emits the same `(title, narrative)` shape, the title still truncates at 117 grapheme clusters plus `...`, and the overflow still moves into `narrative`.

## Verification / Test plan

- [x] `bun test tests/sdk/parser.test.ts tests/server/generation/process-generated-response.test.ts tests/worker/agents/response-processor.test.ts` - 50 passing, 1 skipped (`CLAUDE_MEM_TEST_POSTGRES_URL`-gated Postgres integration)
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run lint:hook-io && npm run lint:spawn-env`
- [ ] `npm run strip-comments:check`

Closes #3351
