### PR TITLE
feat(sync-hub): internal reset endpoint + protocol-v2 canary

### DIFF
--- a/workers/sync-hub/DEPLOY.md
+++ b/workers/sync-hub/DEPLOY.md
@@ -163,6 +163,27 @@ The Pro-side command owns server lifecycle and supplies its relative Hub path
 to the helper. No production URL or workstation-specific absolute path belongs
 in the E2E config.
 
+### 1.6 Internal per-user reset (pre-launch state hygiene)
+
+`POST /internal/v1/sync/reset` wipes ONE user's Durable Object back to
+pristine state: empty log/heads/devices, projection checkpoint `0`, and a
+fresh random epoch (so any device still holding an old cursor is forced to
+re-bootstrap instead of silently mixing histories). Purpose: clearing
+stale/corrupt **pre-launch** per-user DO state — it deletes the user's entire
+ordered log, so never point it at a live post-launch account casually.
+Auth and body contract mirror the drain endpoint (§1.3): the shared
+`CMEM_INTERNAL_PROJECTOR_SECRET` bearer, exact-keys JSON body, 401 without the
+secret, 400 on any contract deviation. The kill switch (§3) is Workers KV
+state and is deliberately untouched by a reset.
+
+```sh
+curl -fsS https://<sync-hub>/internal/v1/sync/reset \
+  -H "Authorization: Bearer $CMEM_INTERNAL_PROJECTOR_SECRET" \
+  -H 'Content-Type: application/json' \
+  --data '{"protocol_version":1,"user_id":"<canonical-lowercase-uuid>"}'
+# → 200 {"protocol_version":1,"epoch":"<new>","head_seq":"0"}
+```
+
 For a Bun- or process-isolated Pro client, start the actual Hub in its own Node
 process instead of importing workerd into Bun:
 

--- a/workers/sync-hub/canary/canary.ts
+++ b/workers/sync-hub/canary/canary.ts
@@ -38,7 +38,7 @@
  *
  * OUTPUT (one JSON object per line)
  *   {"event":"cycle","cycle":3,"origin":"canary-dev-a","converged":true,
- *    "latency_ms":412,"seq":57,"sync_mode":"live",...}
+ *    "latency_ms":412,"seq":"57","sync_mode":"live",...}
  *   sync_mode mirrors the hub's X-Sync-Mode header ("live" when absent,
  *   "poll" while the kill switch is tripped) — the canary doubles as a
  *   kill-switch observability probe.
@@ -134,10 +134,40 @@ function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * RFC-8259 JSON with recursively sorted object keys — the hub's canonical
+ * wire form (src/canonical-content.ts). Reimplemented locally on purpose:
+ * the canary imports nothing from the hub.
+ */
+function canonicalJson(value: unknown): string {
+	if (Array.isArray(value)) return `[${value.map((item) => canonicalJson(item)).join(",")}]`;
+	if (value !== null && typeof value === "object") {
+		const record = value as Record<string, unknown>;
+		const parts = Object.keys(record)
+			.sort()
+			.map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`);
+		return `{${parts.join(",")}}`;
+	}
+	return JSON.stringify(value);
+}
+
+/** Unpadded base64url SHA-256 (matches the hub's digest form). */
+async function sha256Base64Url(value: string): Promise<string> {
+	const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+	let binary = "";
+	for (const byte of new Uint8Array(digest)) binary += String.fromCharCode(byte);
+	return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+/** Max of two canonical unsigned decimal strings (hub cursors are uint64). */
+function decimalMax(left: string, right: string): string {
+	return BigInt(left) >= BigInt(right) ? left : right;
+}
+
 class Canary {
 	private readonly args: Args;
-	/** Per-device pull cursor (hub seq). */
-	private readonly cursors: Record<string, number> = { [DEVICE_A]: 0, [DEVICE_B]: 0 };
+	/** Per-device pull cursor (hub seq, canonical unsigned decimal string). */
+	private readonly cursors: Record<string, string> = { [DEVICE_A]: "0", [DEVICE_B]: "0" };
 	/** Last X-Sync-Mode seen on any response ("live" when absent). */
 	private syncMode = "live";
 	/** Unique-per-run origin-id prefix (no state file needed). */
@@ -159,16 +189,49 @@ class Canary {
 		this.syncMode = res.headers.get("X-Sync-Mode") ?? "live";
 	}
 
+	/**
+	 * Push one canonical protocol-v2 observation op (the full envelope the
+	 * hub validates in src/canonical-content.ts). Returns the acked seq plus
+	 * the operation digest — the digest is how the replica recognizes the op.
+	 */
 	private async push(
 		deviceId: string,
-		originId: string,
-		body: Record<string, unknown>,
-	): Promise<{ seq: number; headSeq: number }> {
+		localId: string,
+		info: Record<string, string>,
+	): Promise<{ seq: string; headSeq: string; opSha: string }> {
+		const payload = {
+			created_at: new Date().toISOString(),
+			created_at_epoch: Date.now().toString(10),
+			memory_session_id: `canary-${this.runId}`,
+			project: "sync-canary",
+			text: JSON.stringify(info),
+			title: "sync-hub canary op",
+			type: "canary",
+		};
+		const envelope = {
+			body_schema_version: 1,
+			deleted: false,
+			deleted_at: null,
+			entity_rev: "1",
+			id: `observation:${await sha256Base64Url(
+				canonicalJson(["cmem-doc-id-v1", "device", "observation", deviceId, localId]),
+			)}`,
+			kind: "observation",
+			mutation: null,
+			origin_device_id: deviceId,
+			origin_local_id: localId,
+			payload,
+			payload_schema_version: 2,
+			payload_sha256: await sha256Base64Url(canonicalJson(payload)),
+		};
+		const body = canonicalJson(envelope);
+		const operationSha256 = await sha256Base64Url(body);
 		const res = await fetch(`${this.args.hub}/v1/sync/ops`, {
 			method: "POST",
 			headers: { ...this.headers(deviceId), "Content-Type": "application/json" },
 			body: JSON.stringify({
-				ops: [{ kind: "observation", origin_id: originId, rev: 1, body: JSON.stringify(body) }],
+				protocol_version: 2,
+				ops: [{ body, operation_sha256: operationSha256 }],
 			}),
 			signal: AbortSignal.timeout(this.args.timeoutMs),
 		});
@@ -177,18 +240,18 @@ class Canary {
 			throw new Error(`push ${res.status}: ${(await res.text().catch(() => "")).slice(0, 200)}`);
 		}
 		const parsed = (await res.json()) as {
-			acked: Array<{ origin_id: string; seq: number }>;
-			head_seq: number;
+			acked: Array<{ operation_sha256: string; seq: string }>;
+			head_seq: string;
 		};
-		const ack = parsed.acked.find((a) => a.origin_id === originId);
+		const ack = parsed.acked.find((a) => a.operation_sha256 === operationSha256);
 		if (!ack) throw new Error("push response did not ack the canary op");
-		return { seq: ack.seq, headSeq: parsed.head_seq };
+		return { seq: ack.seq, headSeq: parsed.head_seq, opSha: operationSha256 };
 	}
 
 	private async pull(
 		deviceId: string,
-		since: number,
-	): Promise<{ ops: Array<{ seq: number; origin_id: string; origin_device: string }>; headSeq: number }> {
+		since: string,
+	): Promise<{ ops: Array<{ seq: string; operation_sha256: string }>; headSeq: string }> {
 		const res = await fetch(`${this.args.hub}/v1/sync/changes?since=${since}&limit=500`, {
 			headers: this.headers(deviceId),
 			signal: AbortSignal.timeout(this.args.timeoutMs),
@@ -198,8 +261,8 @@ class Canary {
 			throw new Error(`pull ${res.status}: ${(await res.text().catch(() => "")).slice(0, 200)}`);
 		}
 		const parsed = (await res.json()) as {
-			ops: Array<{ seq: number; origin_id: string; origin_device: string }>;
-			head_seq: number;
+			ops: Array<{ seq: string; operation_sha256: string }>;
+			head_seq: string;
 		};
 		return { ops: parsed.ops, headSeq: parsed.head_seq };
 	}
@@ -214,9 +277,9 @@ class Canary {
 		if (!res.ok) {
 			throw new Error(`status ${res.status}: ${(await res.text().catch(() => "")).slice(0, 200)}`);
 		}
-		const status = (await res.json()) as { head_seq: number; epoch: string };
-		this.cursors[DEVICE_A] = status.head_seq;
-		this.cursors[DEVICE_B] = status.head_seq;
+		const status = (await res.json()) as { head_seq: string; epoch: string };
+		this.cursors[DEVICE_A] = String(status.head_seq);
+		this.cursors[DEVICE_B] = String(status.head_seq);
 		log({
 			event: "init",
 			hub: this.args.hub,
@@ -234,12 +297,13 @@ class Canary {
 	async cycle(n: number): Promise<boolean> {
 		const origin = n % 2 === 0 ? DEVICE_A : DEVICE_B;
 		const replica = origin === DEVICE_A ? DEVICE_B : DEVICE_A;
-		const originId = `c-${this.runId}-${n}`;
+		// Canonical decimal, unique per push: ms timestamp + zero-padded cycle.
+		const localId = `${Date.now()}${String(n % 1000).padStart(3, "0")}`;
 		const startedAt = Date.now();
 		try {
-			const pushed = await this.push(origin, originId, {
-				canary: true,
-				cycle: n,
+			const pushed = await this.push(origin, localId, {
+				canary: "true",
+				cycle: String(n),
 				sent_at: new Date(startedAt).toISOString(),
 			});
 			// Poll the replica cursor forward until the op shows up.
@@ -248,8 +312,8 @@ class Canary {
 			while (Date.now() < deadline && !converged) {
 				const page = await this.pull(replica, this.cursors[replica]);
 				for (const op of page.ops) {
-					this.cursors[replica] = Math.max(this.cursors[replica], op.seq);
-					if (op.origin_id === originId && op.origin_device === origin) {
+					this.cursors[replica] = decimalMax(this.cursors[replica], op.seq);
+					if (op.operation_sha256 === pushed.opSha) {
 						converged = true;
 					}
 				}
@@ -259,13 +323,13 @@ class Canary {
 			// own echo is consumed, keeping pages tiny forever).
 			const originPage = await this.pull(origin, this.cursors[origin]);
 			for (const op of originPage.ops) {
-				this.cursors[origin] = Math.max(this.cursors[origin], op.seq);
+				this.cursors[origin] = decimalMax(this.cursors[origin], op.seq);
 			}
 			log({
 				event: "cycle",
 				cycle: n,
 				origin,
-				origin_id: originId,
+				origin_local_id: localId,
 				seq: pushed.seq,
 				converged,
 				latency_ms: Date.now() - startedAt,

--- a/workers/sync-hub/src/do/SyncHub.ts
+++ b/workers/sync-hub/src/do/SyncHub.ts
@@ -128,6 +128,12 @@ export interface ProjectionState {
 	projected_seq: string;
 }
 
+export interface ResetResult {
+	protocol_version: 1;
+	epoch: string;
+	head_seq: string;
+}
+
 export const INVALID_OPS_PREFIX = "invalid_ops:";
 export const PROJECTION_ERROR_PREFIX = "projection_error:";
 
@@ -178,55 +184,98 @@ export class SyncHub extends DurableObject<Env> {
 	constructor(ctx: DurableObjectState, env: Env) {
 		super(ctx, env);
 		ctx.setWebSocketAutoResponse(new WebSocketRequestResponsePair("ping", "pong"));
-		ctx.blockConcurrencyWhile(async () => {
-			ctx.storage.sql.exec(
-				`CREATE TABLE IF NOT EXISTS canonical_ops (
-					seq                 TEXT PRIMARY KEY,
-					entity_id           TEXT NOT NULL,
-					kind                TEXT NOT NULL,
-					origin_device_id    TEXT NOT NULL,
-					origin_local_id     TEXT,
-					entity_rev          TEXT NOT NULL,
-					operation_sha256    TEXT NOT NULL,
-					body                TEXT NOT NULL,
-					deleted             INTEGER NOT NULL CHECK (deleted IN (0, 1)),
-					server_ts           TEXT NOT NULL
-				);
-				CREATE UNIQUE INDEX IF NOT EXISTS canonical_ops_entity_rev
-					ON canonical_ops(entity_id, entity_rev);
-				CREATE TABLE IF NOT EXISTS entity_heads (
-					entity_id           TEXT PRIMARY KEY,
-					kind                TEXT NOT NULL,
-					origin_device_id    TEXT NOT NULL,
-					origin_local_id     TEXT,
-					entity_rev          TEXT NOT NULL,
-					operation_sha256    TEXT NOT NULL,
-					deleted             INTEGER NOT NULL CHECK (deleted IN (0, 1)),
-					seq                 TEXT NOT NULL
-				);
-				CREATE TABLE IF NOT EXISTS devices (
-					device_id           TEXT PRIMARY KEY,
-					name                TEXT,
-					last_ack_seq        TEXT NOT NULL DEFAULT '0',
-					last_seen           INTEGER
-				);
-				CREATE TABLE IF NOT EXISTS meta (k TEXT PRIMARY KEY, v TEXT);`,
+		ctx.blockConcurrencyWhile(() => this.initializePristineState());
+	}
+
+	/**
+	 * Idempotent schema + pristine-state bootstrap, shared by the constructor
+	 * (cold start) and resetAllState() (post-wipe). Existing state is never
+	 * overwritten: tables are IF NOT EXISTS, meta defaults are DO NOTHING, and
+	 * the daily no-op alarm is scheduled only when none is pending.
+	 */
+	private async initializePristineState(): Promise<void> {
+		const storage = this.ctx.storage;
+		storage.sql.exec(
+			`CREATE TABLE IF NOT EXISTS canonical_ops (
+				seq                 TEXT PRIMARY KEY,
+				entity_id           TEXT NOT NULL,
+				kind                TEXT NOT NULL,
+				origin_device_id    TEXT NOT NULL,
+				origin_local_id     TEXT,
+				entity_rev          TEXT NOT NULL,
+				operation_sha256    TEXT NOT NULL,
+				body                TEXT NOT NULL,
+				deleted             INTEGER NOT NULL CHECK (deleted IN (0, 1)),
+				server_ts           TEXT NOT NULL
 			);
-			const defaults: Array<[string, string]> = [
-				["epoch", newEpoch()],
-				["head_seq", "0"],
-				["projected_seq", "0"],
-			];
-			for (const [key, value] of defaults) {
-				ctx.storage.sql.exec(
-					"INSERT INTO meta (k, v) VALUES (?, ?) ON CONFLICT(k) DO NOTHING",
-					key,
-					value,
-				);
+			CREATE UNIQUE INDEX IF NOT EXISTS canonical_ops_entity_rev
+				ON canonical_ops(entity_id, entity_rev);
+			CREATE TABLE IF NOT EXISTS entity_heads (
+				entity_id           TEXT PRIMARY KEY,
+				kind                TEXT NOT NULL,
+				origin_device_id    TEXT NOT NULL,
+				origin_local_id     TEXT,
+				entity_rev          TEXT NOT NULL,
+				operation_sha256    TEXT NOT NULL,
+				deleted             INTEGER NOT NULL CHECK (deleted IN (0, 1)),
+				seq                 TEXT NOT NULL
+			);
+			CREATE TABLE IF NOT EXISTS devices (
+				device_id           TEXT PRIMARY KEY,
+				name                TEXT,
+				last_ack_seq        TEXT NOT NULL DEFAULT '0',
+				last_seen           INTEGER
+			);
+			CREATE TABLE IF NOT EXISTS meta (k TEXT PRIMARY KEY, v TEXT);`,
+		);
+		const defaults: Array<[string, string]> = [
+			["epoch", newEpoch()],
+			["head_seq", "0"],
+			["projected_seq", "0"],
+		];
+		for (const [key, value] of defaults) {
+			storage.sql.exec(
+				"INSERT INTO meta (k, v) VALUES (?, ?) ON CONFLICT(k) DO NOTHING",
+				key,
+				value,
+			);
+		}
+		const scheduled = await storage.getAlarm();
+		if (scheduled === null) await storage.setAlarm(Date.now() + DAY_MS);
+	}
+
+	/**
+	 * Wipe ALL durable state for this user and reinitialize a pristine hub —
+	 * fresh random epoch, empty log/heads/devices, projection checkpoint "0".
+	 * Reached only via the secret-gated internal route in ../index.ts
+	 * (POST /internal/v1/sync/reset); no public route can invoke it. Like every
+	 * other method here, it performs zero outbound I/O — in particular the
+	 * kill switch lives in Workers KV owned by the stateless Worker and is
+	 * deliberately untouched by a reset.
+	 *
+	 * Re-initialization is EAGER (inside the same blockConcurrencyWhile as the
+	 * wipe) rather than lazy via the constructor path: the constructor only
+	 * runs on a cold start, but this very in-memory instance keeps serving
+	 * RPCs after the reset — deferring re-init would leave every subsequent
+	 * call (headSeq(), pushOps, ...) reading missing tables until the object
+	 * happened to be evicted. Eager re-init restores the exact constructor
+	 * invariants before any other event can interleave.
+	 */
+	async resetAllState(): Promise<ResetResult> {
+		await this.ctx.blockConcurrencyWhile(async () => {
+			// Advisory sockets reference device rows this wipe deletes; close
+			// them so clients re-handshake against the pristine hub. (Hints
+			// only — HTTP remains authoritative, so this loses nothing.)
+			for (const ws of this.ctx.getWebSockets()) {
+				try { ws.close(1000, "sync-hub reset"); } catch {}
 			}
-			const scheduled = await ctx.storage.getAlarm();
-			if (scheduled === null) await ctx.storage.setAlarm(Date.now() + DAY_MS);
+			// deleteAll() clears SQL tables and KV state but never the alarm —
+			// delete it explicitly so re-init schedules a fresh one.
+			await this.ctx.storage.deleteAlarm();
+			await this.ctx.storage.deleteAll();
+			await this.initializePristineState();
 		});
+		return { protocol_version: 1, epoch: this.meta("epoch"), head_seq: this.headSeq() };
 	}
 
 	// ---------------------------------------------------------------------

--- a/workers/sync-hub/src/index.ts
+++ b/workers/sync-hub/src/index.ts
@@ -24,6 +24,11 @@
  *                            nothing durable — it is a downstream hint lane.
  *   POST /internal/v1/sync/metadata    — payload-free Hub state for Pro.
  *   POST /internal/v1/sync/device-name — rename an existing Hub device.
+ *   POST /internal/v1/sync/reset       — wipe one user's Hub to pristine
+ *                                        state (pre-launch hygiene; DEPLOY.md
+ *                                        §1.6). Secret-gated like the other
+ *                                        internal routes; kill-switch KV is
+ *                                        deliberately untouched.
  */
 
 import type { PushOp } from "./do/SyncHub";
@@ -442,6 +447,32 @@ async function handleMetadataRead(request: Request, env: Env): Promise<Response>
 	}
 }
 
+/**
+ * Secret-gated per-user reset (auth + body contract mirror the internal
+ * metadata route exactly). The DO wipes its storage and reinitializes a
+ * pristine hub; the kill switch is KV state owned by this Worker and is
+ * deliberately NOT touched by a reset.
+ */
+async function handleHubReset(request: Request, env: Env): Promise<Response> {
+	if (!hasInternalCredential(request, env)) return errorResponse(401, "invalid internal credential");
+	const body = await readInternalBody(request);
+	if (
+		body === null
+		|| !exactKeys(body, ["protocol_version", "user_id"])
+		|| body.protocol_version !== 1
+		|| typeof body.user_id !== "string"
+		|| body.user_id.trim().length === 0
+	) {
+		return errorResponse(400, "expected exactly {protocol_version:1,user_id}");
+	}
+	const userId = body.user_id.trim();
+	try {
+		return json(200, await env.SYNC_HUB.getByName(userId).resetAllState());
+	} catch (error) {
+		return mapHubError(error);
+	}
+}
+
 async function handleDeviceRename(request: Request, env: Env): Promise<Response> {
 	if (!hasInternalCredential(request, env)) return errorResponse(401, "invalid internal credential");
 	const body = await readInternalBody(request);
@@ -835,6 +866,10 @@ export default {
 		if (pathname === "/internal/v1/sync/device-name") {
 			if (request.method !== "POST") return errorResponse(405, "use POST");
 			return handleDeviceRename(request, env);
+		}
+		if (pathname === "/internal/v1/sync/reset") {
+			if (request.method !== "POST") return errorResponse(405, "use POST");
+			return handleHubReset(request, env);
 		}
 
 		if (

--- a/workers/sync-hub/test/sync-hub.test.ts
+++ b/workers/sync-hub/test/sync-hub.test.ts
@@ -26,6 +26,7 @@ import {
 	type StatusResult,
 	type SyncHub,
 } from "../src/do/SyncHub";
+import { KILL_SWITCH_KEY } from "../src/kill-switch";
 import {
 	PROJECTION_FETCH_TIMEOUT_MS,
 	PROJECTION_PAGE_MAX_BYTES,
@@ -957,6 +958,166 @@ describe("internal payload-free Hub metadata", () => {
 			body: JSON.stringify({ protocol_version: 1, user_id: "user", include_content_counts: true }),
 		});
 		expect(extended.status).toBe(400);
+	});
+});
+
+describe("internal per-user hub reset", () => {
+	const base = "https://sync-hub.test";
+	const internalHeaders = {
+		Authorization: "Bearer test-projector-secret",
+		"Content-Type": "application/json",
+	};
+
+	function reset(body: unknown, headers: Record<string, string> = internalHeaders): Promise<Response> {
+		return SELF.fetch(`${base}/internal/v1/sync/reset`, {
+			method: "POST",
+			headers,
+			body: JSON.stringify(body),
+		});
+	}
+
+	it("fails closed without the internal secret and refuses non-POST", async () => {
+		const absent = await reset({ protocol_version: 1, user_id: "user" }, {
+			"Content-Type": "application/json",
+		});
+		expect(absent.status).toBe(401);
+		const wrong = await reset({ protocol_version: 1, user_id: "user" }, {
+			Authorization: "Bearer wrong",
+			"Content-Type": "application/json",
+		});
+		expect(wrong.status).toBe(401);
+		// A valid SUBSCRIBER token is not the internal credential either.
+		const subscriber = await reset({ protocol_version: 1, user_id: "user" }, {
+			Authorization: "Bearer valid-for:user",
+			"Content-Type": "application/json",
+		});
+		expect(subscriber.status).toBe(401);
+		const get = await SELF.fetch(`${base}/internal/v1/sync/reset`);
+		expect(get.status).toBe(405);
+	});
+
+	it("rejects every malformed body with 400", async () => {
+		for (const body of [
+			{ user_id: "user" },
+			{ protocol_version: 2, user_id: "user" },
+			{ protocol_version: 1 },
+			{ protocol_version: 1, user_id: "" },
+			{ protocol_version: 1, user_id: "   " },
+			{ protocol_version: 1, user_id: 7 },
+			{ protocol_version: 1, user_id: "user", force: true },
+			["not", "an", "object"],
+		]) {
+			expect((await reset(body)).status).toBe(400);
+		}
+		const notJson = await SELF.fetch(`${base}/internal/v1/sync/reset`, {
+			method: "POST",
+			headers: internalHeaders,
+			body: "{",
+		});
+		expect(notJson.status).toBe(400);
+	});
+
+	it("wipes pushed state to a pristine hub and accepts a fresh seq-1 push under the new epoch", async () => {
+		const userId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+		const clientHeaders = {
+			Authorization: `Bearer valid-for:${userId}`,
+			"X-User-Id": userId,
+			"X-Device-Id": "dev-a",
+			"Content-Type": "application/json",
+		};
+		const first = await SELF.fetch(`${base}/v1/sync/ops`, {
+			method: "POST",
+			headers: clientHeaders,
+			body: JSON.stringify({
+				protocol_version: 2,
+				ops: [await observationOp("1", "1", "dev-a"), await observationOp("2", "1", "dev-a")],
+			}),
+		});
+		expect(first.status).toBe(200);
+		const pull = await SELF.fetch(`${base}/v1/sync/changes?since=0`, {
+			headers: { ...clientHeaders, "X-Device-Id": "dev-b" },
+		});
+		expect(pull.status).toBe(200);
+		const stub = hub(userId);
+		const populated = status(await stub.getStatus());
+		expect(populated).toMatchObject({ head_seq: "2", projected_seq: "2", op_count: 2, device_count: 2 });
+
+		const response = await reset({ protocol_version: 1, user_id: userId });
+		expect(response.status).toBe(200);
+		const body = await response.json() as { protocol_version: number; epoch: string; head_seq: string };
+		expect(body).toMatchObject({ protocol_version: 1, head_seq: "0" });
+		expect(body.epoch).toMatch(/^[1-9][0-9]*$/);
+		expect(body.epoch).not.toBe(populated.epoch);
+
+		const pristine = status(await stub.getStatus());
+		expect(pristine).toMatchObject({
+			epoch: body.epoch,
+			head_seq: "0",
+			projected_seq: "0",
+			op_count: 0,
+			device_count: 0,
+		});
+		// The daily no-op alarm is rescheduled along with the pristine state.
+		await runInDurableObject(stub, async (_instance, state) => {
+			expect(await state.storage.getAlarm()).not.toBeNull();
+		});
+
+		// The same device replays its op from scratch: fresh entity ledger,
+		// seq restarts at 1, and the page carries the NEW epoch end to end.
+		const repush = await SELF.fetch(`${base}/v1/sync/ops`, {
+			method: "POST",
+			headers: clientHeaders,
+			body: JSON.stringify({ protocol_version: 2, ops: [await observationOp("1", "1", "dev-a")] }),
+		});
+		expect(repush.status).toBe(200);
+		const repushed = await repush.json() as {
+			acked: Array<{ seq: string }>;
+			head_seq: string;
+			projected_seq: string;
+		};
+		expect(repushed.acked[0].seq).toBe("1");
+		expect(repushed).toMatchObject({ head_seq: "1", projected_seq: "1" });
+		const page = changes(await stub.getChanges("dev-b", "0", 500));
+		expect(page.epoch).toBe(body.epoch);
+		expect(page.ops).toHaveLength(1);
+		expect(page.ops[0].seq).toBe("1");
+	});
+
+	it("creates a pristine hub when resetting a never-seen user", async () => {
+		const userId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+		const response = await reset({ protocol_version: 1, user_id: userId });
+		expect(response.status).toBe(200);
+		const body = await response.json() as { epoch: string; head_seq: string };
+		expect(body.head_seq).toBe("0");
+		expect(body.epoch).toMatch(/^[1-9][0-9]*$/);
+		expect(status(await hub(userId).getStatus())).toMatchObject({
+			epoch: body.epoch,
+			head_seq: "0",
+			projected_seq: "0",
+			op_count: 0,
+			device_count: 0,
+		});
+	});
+
+	it("trims user_id to the canonical hub name", async () => {
+		const userId = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+		const stub = hub(userId);
+		ok(await stub.pushOps("dev-a", [await observationOp("1")]));
+		const response = await reset({ protocol_version: 1, user_id: `  ${userId}  ` });
+		expect(response.status).toBe(200);
+		expect(status(await stub.getStatus())).toMatchObject({ head_seq: "0", op_count: 0 });
+	});
+
+	it("leaves the kill switch untouched — it is Worker-owned KV, not hub state", async () => {
+		const userId = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+		await env.AUTH_CACHE.put(KILL_SWITCH_KEY, JSON.stringify({ source: "manual", reason: "test" }));
+		try {
+			const response = await reset({ protocol_version: 1, user_id: userId });
+			expect(response.status).toBe(200);
+			expect(await env.AUTH_CACHE.get(KILL_SWITCH_KEY)).not.toBeNull();
+		} finally {
+			await env.AUTH_CACHE.delete(KILL_SWITCH_KEY);
+		}
 	});
 });
 


### PR DESCRIPTION
## Summary

Phase 1 unblock for the cmem.ai launch: two changes to `workers/sync-hub`, no deploy in this PR.

### 1. Canary speaks protocol v2 (`canary/canary.ts`)

The deployed hub validates `protocol_version: 2` pushes with canonical content envelopes; the canary still spoke the removed v1 shape and 400'd on every cycle.

- Builds the full canonical observation envelope locally (sorted-key RFC-8259 JSON, base64url SHA-256 payload/operation digests, stable doc id) — deliberately still importing nothing from the hub.
- Pushes `{protocol_version: 2, ops: [{body, operation_sha256}]}`; ack + replica convergence are matched by `operation_sha256`.
- Cursors/seqs are canonical unsigned decimal strings end to end.
- Verified byte-for-byte: the locally built envelope passes the hub's `parseCanonicalOperation` and matches `stableDocumentId`.

### 2. Secret-gated internal reset (`POST /internal/v1/sync/reset`)

For clearing stale/corrupt **pre-launch** per-user DO state.

- Auth + body contract mirror the existing internal endpoints exactly: `CMEM_INTERNAL_PROJECTOR_SECRET` bearer, exact-keys `{"protocol_version":1,"user_id":"<canonical-lowercase-uuid>"}`, trimmed `user_id`, 401 fail-closed, 400 on any deviation; no public route reaches it.
- New DO RPC `SyncHub.resetAllState()`: `deleteAlarm()` + `storage.deleteAll()`, then **eager** re-init inside the same `blockConcurrencyWhile` via the constructor's now-shared bootstrap — fresh random decimal epoch (`newEpoch()`), empty log/heads/devices, projection checkpoint `"0"`, daily no-op alarm rescheduled. Eager because the in-memory instance keeps serving RPCs after the wipe (rationale in a code comment). Zero outbound I/O from the DO.
- Kill-switch state is Worker-owned KV and deliberately untouched by reset.
- Response: `200 {"protocol_version":1,"epoch":"<new>","head_seq":"0"}`.
- Docs: DEPLOY.md §1.6 with a curl example mirroring the drain example.

## Test plan

- [x] `bun run test` — 93 passed (new describe block: auth fail-closed + 405, malformed-body 400 matrix, populated→reset→pristine→re-push-from-seq-1 under the new epoch through the HTTP lanes, never-seen-user pristine reset, `user_id` trimming, kill-switch KV survival)
- [x] `bun run test:ws` — 9 passed
- [x] `bun run lint`, `bunx tsc --noEmit` — clean
- [x] Root `bun test tests` — 2371 pass / 0 fail (unaffected)

Merge + deploy are handled separately by the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JS4kwJj5GkVFEhe1X7XNox