### PR TITLE
feat(sync-hub): control-plane uptime probe (5-min cron, Discord paging)

### DIFF
--- a/workers/sync-hub/DEPLOY.md
+++ b/workers/sync-hub/DEPLOY.md
@@ -422,7 +422,63 @@ silent week is the success case.
 
 ---
 
-## 7. Deploy + verify checklist
+## 7. Control-plane uptime probe (launch Phase 5 task 4)
+
+**Why it exists**: on Jul 20–22 Supabase paused the project silently — signups
+failed for 52 hours with no page, while the static landing page answered 200
+the whole time. The probe therefore runs OUTSIDE the Vercel/Supabase failure
+domain (this Worker) and checks a DB-BACKED endpoint, never the landing page.
+
+**What it checks**: every 5 minutes (cron `*/5 * * * *`, dispatched on
+`event.cron` in `src/index.ts` — the hourly `7 * * * *` watchdog is
+unaffected), `src/control-plane-probe.ts` GETs `TOKEN_VERIFY_URL` with a
+deliberately bogus bearer token (`cmem-uptime-probe-invalid-token`) and the
+all-zero user id. **Healthy = HTTP 401/403 with a JSON body** — that exact
+answer requires the Pro app AND its Postgres lookup to be alive (the endpoint
+queries `pro_users` to reject the token). Unhealthy: network error, 10 s
+timeout, any 5xx, a non-JSON 401 (an edge page answering for a dead app), or
+any other status. A **2xx for the bogus token pages a distinct SECURITY
+alert** — that is an auth bypass, not an outage.
+
+**No new configuration**: reuses `TOKEN_VERIFY_URL` (var) and
+`DISCORD_WEBHOOK_URL` (§2.2 secret). Empty `TOKEN_VERIFY_URL` ⇒ logged skip.
+No Durable Object involvement.
+
+**Anti-flap policy** (state = KV key `control:uptime-probe` in `AUTH_CACHE`,
+absent in the healthy steady state):
+
+1. Healthy steady state → one `{"status":"healthy"}` log line, **no Discord
+   post, no KV write**.
+2. First failure alerts only after one immediate in-run retry confirms it
+   (a single blip never pages); the alert writes the failing state.
+3. While failing: re-page at most every 30 minutes; in between, log-only
+   (`suppressed`), no KV writes.
+4. Healthy again after a failure state → one green "recovered" embed, state
+   key deleted.
+5. A Discord post failure is swallowed with a log (the KV state is still
+   written); a probe bug is contained by the scheduled handler's top-level
+   try/catch and can never affect the sync routes.
+
+**Silence during maintenance** (planned Pro/DB downtime):
+
+```sh
+cd workers/sync-hub
+# Silence until the maintenance window ends (ISO-8601 UTC):
+wrangler kv key put --binding AUTH_CACHE "control:uptime-probe" \
+  '{"silenced_until":"2026-08-01T09:00:00Z"}' --remote
+# Inspect / lift early:
+wrangler kv key get --binding AUTH_CACHE "control:uptime-probe" --remote
+wrangler kv key delete --binding AUTH_CACHE "control:uptime-probe" --remote
+```
+
+While `silenced_until` is in the future the probe does nothing at all (not
+even the fetch). After it expires, the first healthy run deletes the marker
+quietly; a confirmed failure alerts normally. Deleting the key always returns
+the probe to its normal state machine immediately.
+
+---
+
+## 8. Deploy + verify checklist
 
 ```sh
 cd workers/sync-hub

--- a/workers/sync-hub/src/control-plane-probe.ts
+++ b/workers/sync-hub/src/control-plane-probe.ts
@@ -1,0 +1,477 @@
+/**
+ * Control-plane uptime probe — external check that cmem.ai's DB-backed
+ * control plane is alive (launch plan Phase 5 task 4).
+ *
+ * WHY (the Jul 20–22 lesson): Supabase paused the project silently and
+ * signups failed for 52 hours with no page. The static landing page kept
+ * answering 200 the whole time, so "the site is up" proved nothing. The
+ * probe therefore lives HERE, in the sync-hub Worker — outside the
+ * Vercel/Supabase failure domain — and hits a DB-BACKED endpoint, never the
+ * landing page.
+ *
+ * WHAT IT CHECKS: GET {TOKEN_VERIFY_URL} with a deliberately bogus bearer
+ * token and the all-zero user id. A HEALTHY control plane answers 401/403
+ * WITH A JSON BODY — that specific answer requires the Pro app AND its
+ * Postgres lookup to be alive (the endpoint queries pro_users to reject the
+ * token). A paused database yields 5xx/timeout/HTML instead. And a 2xx for
+ * a bogus token is a SECURITY alarm (auth bypass), paged with a distinct
+ * red message.
+ *
+ * ANTI-FLAP: KV state in AUTH_CACHE under "control:uptime-probe" (same
+ * namespace-sharing rationale as the kill switch — src/kill-switch.ts).
+ * Absent key = healthy steady state: a log line only, NO KV write. The
+ * FIRST failure alerts only after one immediate in-run retry confirms it;
+ * while failing, re-alert at most every 30 minutes; recovery posts one
+ * green embed and clears the key. KV is written ONLY on state transitions
+ * and re-alert ticks — never on the healthy 5-minute steady state.
+ *
+ * MAINTENANCE SILENCE: put {"silenced_until":"<ISO-8601>"} at the state key
+ * (DEPLOY.md §7). The probe skips entirely (no fetch, no alerts) until that
+ * instant, then cleans the key up quietly on its first healthy run.
+ *
+ * FAILURE CONTRACT (mirrors the watchdog): runControlPlaneProbe never
+ * throws; a Discord post failure is swallowed with a log and never blocks
+ * the KV state write; an unconfigured TOKEN_VERIFY_URL is a logged skip.
+ * The scheduled handler additionally isolates this module behind its one
+ * permitted top-level try/catch, so even a probe implementation bug cannot
+ * escape the handler — and it can never touch the sync routes either way.
+ */
+
+import { postDiscordEmbed, type DiscordEmbed, type DiscordEmbedField } from "./discord";
+
+/** The 5-minute cron this module owns (dispatch on event.cron in index.ts). */
+export const CONTROL_PLANE_PROBE_CRON = "*/5 * * * *";
+
+/** KV key (in AUTH_CACHE, `control:` prefix like the kill switch). */
+export const PROBE_STATE_KEY = "control:uptime-probe";
+
+/** Deliberately invalid credentials — the probe asserts that REJECTION works. */
+export const PROBE_TOKEN = "cmem-uptime-probe-invalid-token";
+export const PROBE_USER_ID = "00000000-0000-0000-0000-000000000000";
+
+/** Hard deadline for each probe request. */
+export const PROBE_TIMEOUT_MS = 10_000;
+
+/** While failing, re-page at most this often. */
+export const PROBE_REALERT_MS = 30 * 60 * 1000;
+
+const FOOTER = "sync-hub control-plane probe • healthy = 401/403 + JSON for a bogus token";
+
+interface ProbeObservation {
+	healthy: boolean;
+	/** Machine-readable failure class ("" when healthy). */
+	kind:
+		| ""
+		| "unreachable"
+		| "timeout"
+		| "http_5xx"
+		| "non_json"
+		| "unexpected_status"
+		| "security_2xx";
+	/** Human-readable one-liner for logs and the Discord embed. */
+	reason: string;
+	httpStatus: number | null;
+}
+
+export interface ProbeResult {
+	status:
+		| "skipped" // TOKEN_VERIFY_URL unconfigured
+		| "silenced" // maintenance silence window active (no fetch at all)
+		| "healthy" // steady state — log line only
+		| "blip" // single failure, confirm-retry healthy — nothing done
+		| "alerted" // confirmed first failure — paged + state written
+		| "suppressed" // still failing, inside the 30-min re-alert window
+		| "realerted" // still failing, window elapsed — paged again
+		| "recovered" // healthy after a failure state — green post + cleared
+		| "silence_cleared"; // healthy after an EXPIRED silence — cleared quietly
+	kind?: string;
+	reason?: string;
+	httpStatus?: number | null;
+	security?: boolean;
+	discord: "sent" | "failed" | "not_configured" | "skipped";
+	kv: "written" | "cleared" | "none" | "error";
+}
+
+export interface ProbeDeps {
+	/** Injectable for tests; defaults to globalThis.fetch. */
+	fetchImpl?: typeof fetch;
+	/** Injectable clock (tests). */
+	now?: () => number;
+	/** Test seam only; production always uses PROBE_TIMEOUT_MS. */
+	timeoutMs?: number;
+}
+
+/**
+ * One GET against the verify endpoint, classified. HEALTHY iff the response
+ * is 401/403 with a JSON content-type AND a body that parses as JSON —
+ * exactly the answer that requires the app and its Postgres lookup to both
+ * be alive. Everything else is a named failure class.
+ */
+async function probeOnce(
+	url: string,
+	fetchImpl: typeof fetch,
+	timeoutMs: number,
+): Promise<ProbeObservation> {
+	const controller = new AbortController();
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const deadline = new Promise<never>((_resolve, reject) => {
+		timer = setTimeout(() => {
+			controller.abort("control-plane probe deadline exceeded");
+			reject(new Error("probe_timeout"));
+		}, timeoutMs);
+	});
+	let res: Response;
+	try {
+		// Race a hard deadline — never depend on the fetch implementation
+		// honoring AbortSignal (same rationale as fetchProjectionWithTimeout).
+		res = await Promise.race([
+			fetchImpl(url, {
+				method: "GET",
+				headers: {
+					Authorization: `Bearer ${PROBE_TOKEN}`,
+					"X-User-Id": PROBE_USER_ID,
+				},
+				signal: controller.signal,
+			}),
+			deadline,
+		]);
+	} catch (e) {
+		if (e instanceof Error && e.message === "probe_timeout") {
+			return {
+				healthy: false,
+				kind: "timeout",
+				reason: `no response within ${timeoutMs}ms`,
+				httpStatus: null,
+			};
+		}
+		return {
+			healthy: false,
+			kind: "unreachable",
+			reason: `fetch failed: ${String(e)}`,
+			httpStatus: null,
+		};
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+
+	if (res.status >= 200 && res.status < 300) {
+		// The bogus token was ACCEPTED — an auth bypass, not an outage.
+		return {
+			healthy: false,
+			kind: "security_2xx",
+			reason: `HTTP ${res.status} for a deliberately invalid token`,
+			httpStatus: res.status,
+		};
+	}
+	if (res.status === 401 || res.status === 403) {
+		const contentType = res.headers.get("Content-Type") ?? "";
+		if (!contentType.toLowerCase().includes("json")) {
+			// An HTML 401 is an edge/proxy answering FOR a dead app.
+			return {
+				healthy: false,
+				kind: "non_json",
+				reason: `HTTP ${res.status} with non-JSON content-type "${contentType}"`,
+				httpStatus: res.status,
+			};
+		}
+		try {
+			await res.json();
+		} catch {
+			return {
+				healthy: false,
+				kind: "non_json",
+				reason: `HTTP ${res.status} claims JSON but the body does not parse`,
+				httpStatus: res.status,
+			};
+		}
+		return { healthy: true, kind: "", reason: "", httpStatus: res.status };
+	}
+	if (res.status >= 500) {
+		return {
+			healthy: false,
+			kind: "http_5xx",
+			reason: `HTTP ${res.status}`,
+			httpStatus: res.status,
+		};
+	}
+	return {
+		healthy: false,
+		kind: "unexpected_status",
+		reason: `HTTP ${res.status} (expected 401/403 + JSON)`,
+		httpStatus: res.status,
+	};
+}
+
+/**
+ * Parse the KV state. null = no state. A present-but-unparseable value is
+ * treated as a failing state of unknown age (an operator hand-put counts).
+ */
+function parseState(raw: string | null): Record<string, unknown> | null {
+	if (raw === null) return null;
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		return typeof parsed === "object" && parsed !== null
+			? (parsed as Record<string, unknown>)
+			: {};
+	} catch {
+		return {};
+	}
+}
+
+async function writeState(
+	env: Env,
+	state: Record<string, unknown>,
+): Promise<"written" | "error"> {
+	try {
+		await env.AUTH_CACHE.put(PROBE_STATE_KEY, JSON.stringify(state));
+		return "written";
+	} catch (e) {
+		console.error("sync-hub control-plane probe: KV state write failed:", e);
+		return "error";
+	}
+}
+
+async function deleteState(env: Env): Promise<"cleared" | "error"> {
+	try {
+		await env.AUTH_CACHE.delete(PROBE_STATE_KEY);
+		return "cleared";
+	} catch (e) {
+		console.error("sync-hub control-plane probe: KV state delete failed:", e);
+		return "error";
+	}
+}
+
+async function sendProbeEmbed(
+	env: Env,
+	embed: DiscordEmbed,
+	fetchImpl: typeof fetch,
+): Promise<"sent" | "failed" | "not_configured"> {
+	const webhook = (env.DISCORD_WEBHOOK_URL ?? "").trim();
+	if (webhook === "") {
+		console.error(
+			"sync-hub control-plane probe: alert due but DISCORD_WEBHOOK_URL is not configured",
+		);
+		return "not_configured";
+	}
+	try {
+		await postDiscordEmbed(webhook, embed, fetchImpl);
+		return "sent";
+	} catch (e) {
+		// Swallowed by design: a Discord outage must never throw out of the
+		// scheduled handler, and the KV state write has already happened.
+		console.error("sync-hub control-plane probe: Discord post failed:", e);
+		return "failed";
+	}
+}
+
+function buildDownEmbed(
+	url: string,
+	observation: ProbeObservation,
+	firstFailureAt: string,
+	nowIso: string,
+	realert: boolean,
+): DiscordEmbed {
+	const fields: DiscordEmbedField[] = [
+		{ name: "Probe target", value: url, inline: false },
+		{ name: "Observed", value: observation.reason, inline: false },
+		{ name: "Failing since", value: firstFailureAt, inline: false },
+		{
+			name: "Policy",
+			value:
+				"Confirmed by an immediate in-run retry; re-pages every 30 min while failing; " +
+				"green embed on recovery. Maintenance silence: DEPLOY.md §7.",
+			inline: false,
+		},
+	];
+	if (observation.kind === "security_2xx") {
+		return {
+			title: "🟥 SECURITY: cmem.ai verify endpoint ACCEPTED a bogus token",
+			description:
+				`GET ${url} answered 2xx to a deliberately invalid bearer token ` +
+				`(${observation.reason}). That is an authentication bypass, not an ` +
+				"outage — any token may currently be treated as valid. Treat as a " +
+				"security incident, not a reliability one.",
+			color: 0x7f1d1d, // darkest red — visually distinct from the outage embed
+			fields,
+			footer: { text: FOOTER },
+			timestamp: nowIso,
+		};
+	}
+	return {
+		title: realert
+			? "🚨 cmem.ai control plane STILL DOWN (uptime probe)"
+			: "🚨 cmem.ai control plane DOWN (uptime probe)",
+		description:
+			`GET ${url} no longer answers 401/403 + JSON for a bogus token — the Pro ` +
+			"app and/or its Postgres lookup is not responding (the exact failure " +
+			"mode of the Jul 20–22 silent Supabase pause). Signups and token " +
+			`verification are likely failing NOW. Observed: ${observation.reason}.`,
+		color: 0xdc2626, // red
+		fields,
+		footer: { text: FOOTER },
+		timestamp: nowIso,
+	};
+}
+
+function buildRecoveredEmbed(url: string, firstFailureAt: string, nowIso: string): DiscordEmbed {
+	return {
+		title: "✅ cmem.ai control plane recovered (uptime probe)",
+		description:
+			`GET ${url} answers 401/403 + JSON again — the Pro app and its Postgres ` +
+			"lookup are back. Failure state cleared.",
+		color: 0x16a34a, // green
+		fields: [
+			{ name: "Probe target", value: url, inline: false },
+			{ name: "Was failing since", value: firstFailureAt, inline: false },
+		],
+		footer: { text: FOOTER },
+		timestamp: nowIso,
+	};
+}
+
+/**
+ * One probe pass. Never throws. Returns a structured result the scheduled
+ * handler logs as one JSON line (visible via observability).
+ */
+export async function runControlPlaneProbe(
+	env: Env,
+	deps: ProbeDeps = {},
+): Promise<ProbeResult> {
+	const fetchImpl = deps.fetchImpl ?? globalThis.fetch;
+	const now = deps.now ?? Date.now;
+	const timeoutMs = deps.timeoutMs ?? PROBE_TIMEOUT_MS;
+
+	const result: ProbeResult = { status: "healthy", discord: "skipped", kv: "none" };
+
+	const url = (env.TOKEN_VERIFY_URL ?? "").trim();
+	if (url === "") {
+		// Unconfigured is a deliberate state (local dev) — a loud log line,
+		// never a false alert and never a crash.
+		result.status = "skipped";
+		result.reason = "TOKEN_VERIFY_URL not configured";
+		return result;
+	}
+
+	// State BEFORE probing: a maintenance silence must suppress even the fetch.
+	let raw: string | null = null;
+	try {
+		raw = await env.AUTH_CACHE.get(PROBE_STATE_KEY);
+	} catch (e) {
+		// Fail toward alerting: unreadable state is treated as "no prior
+		// state", so a real outage still pages (possibly more often than every
+		// 30 min while KV itself is broken — the acceptable direction).
+		console.error("sync-hub control-plane probe: KV state read failed:", e);
+	}
+	const state = parseState(raw);
+	const nowMs = now();
+	const nowIso = new Date(nowMs).toISOString();
+
+	// Maintenance silence marker (operator-written, DEPLOY.md §7).
+	const silence = typeof state?.silenced_until === "string" ? state.silenced_until : null;
+	if (silence !== null) {
+		const until = Date.parse(silence);
+		if (Number.isFinite(until) && until > nowMs) {
+			result.status = "silenced";
+			result.reason = `silenced until ${silence}`;
+			return result;
+		}
+	}
+
+	const observation = await probeOnce(url, fetchImpl, timeoutMs);
+
+	// The prior state is a probe-written failure record unless it is a
+	// (now expired) operator silence marker.
+	const failingBefore = state !== null && silence === null;
+
+	if (observation.healthy) {
+		if (state === null) {
+			// Healthy steady state: log line only. Deliberately NO KV write.
+			return result;
+		}
+		if (silence !== null) {
+			// Expired maintenance silence + healthy endpoint: clean up quietly —
+			// there was never an alert to green-close.
+			result.status = "silence_cleared";
+			result.kv = await deleteState(env);
+			return result;
+		}
+		// Transition failing → healthy: one green embed, then clear the state.
+		result.status = "recovered";
+		const firstFailureAt =
+			typeof state.first_failure_at === "string" ? state.first_failure_at : "unknown";
+		result.kv = await deleteState(env);
+		result.discord = await sendProbeEmbed(
+			env,
+			buildRecoveredEmbed(url, firstFailureAt, nowIso),
+			fetchImpl,
+		);
+		return result;
+	}
+
+	result.kind = observation.kind;
+	result.reason = observation.reason;
+	result.httpStatus = observation.httpStatus;
+
+	if (failingBefore) {
+		// Already in the failing state: no confirm-retry needed, and no KV
+		// write unless this tick re-alerts (steady failing state stays quiet).
+		const lastAlertParsed =
+			typeof state.last_alert_at === "string" ? Date.parse(state.last_alert_at) : NaN;
+		const due = !Number.isFinite(lastAlertParsed) || nowMs - lastAlertParsed >= PROBE_REALERT_MS;
+		if (!due) {
+			result.status = "suppressed";
+			return result;
+		}
+		const firstFailureAt =
+			typeof state.first_failure_at === "string" ? state.first_failure_at : nowIso;
+		const security = observation.kind === "security_2xx";
+		result.security = security;
+		result.status = "realerted";
+		// State first, ping second (the watchdog's switch-first ordering): the
+		// record is load-bearing, the Discord post is a courtesy.
+		result.kv = await writeState(env, {
+			status: "failing",
+			first_failure_at: firstFailureAt,
+			last_alert_at: nowIso,
+			kind: observation.kind,
+			reason: observation.reason,
+			security,
+		});
+		result.discord = await sendProbeEmbed(
+			env,
+			buildDownEmbed(url, observation, firstFailureAt, nowIso, true),
+			fetchImpl,
+		);
+		return result;
+	}
+
+	// First failure (or a failure right after an expired silence): confirm
+	// with ONE immediate in-run retry before paging — a single blip never
+	// alerts. A real auth bypass (security_2xx) is deterministic and confirms.
+	const confirm = await probeOnce(url, fetchImpl, timeoutMs);
+	if (confirm.healthy) {
+		result.status = "blip";
+		return result;
+	}
+	// The confirming observation is the most recent evidence — report it.
+	result.kind = confirm.kind;
+	result.reason = confirm.reason;
+	result.httpStatus = confirm.httpStatus;
+	const security = confirm.kind === "security_2xx";
+	result.security = security;
+	result.status = "alerted";
+	result.kv = await writeState(env, {
+		status: "failing",
+		first_failure_at: nowIso,
+		last_alert_at: nowIso,
+		kind: confirm.kind,
+		reason: confirm.reason,
+		security,
+	});
+	result.discord = await sendProbeEmbed(
+		env,
+		buildDownEmbed(url, confirm, nowIso, nowIso, false),
+		fetchImpl,
+	);
+	return result;
+}

--- a/workers/sync-hub/src/discord.ts
+++ b/workers/sync-hub/src/discord.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared Discord webhook posting — the ONE place that knows the wire shape
+ * (payload = {embeds: [embed]}, copied from scripts/discord-release-notify.js).
+ * Used by the hourly watchdog (src/watchdog.ts) and the 5-minute
+ * control-plane probe (src/control-plane-probe.ts); extracted so the two
+ * monitors cannot drift apart. The webhook URL is always the
+ * DISCORD_WEBHOOK_URL secret binding — never hardcoded.
+ *
+ * Throws on any failure (network or non-2xx status): each caller decides
+ * what a failed ping means for ITS state machine. Both current callers
+ * swallow + log — an alert is a courtesy, never a load-bearing step.
+ */
+
+export interface DiscordEmbedField {
+	name: string;
+	value: string;
+	inline: boolean;
+}
+
+export interface DiscordEmbed {
+	title: string;
+	description: string;
+	color: number;
+	fields: DiscordEmbedField[];
+	footer: { text: string };
+	timestamp: string;
+}
+
+export async function postDiscordEmbed(
+	webhookUrl: string,
+	embed: DiscordEmbed,
+	fetchImpl: typeof fetch = globalThis.fetch,
+): Promise<void> {
+	const res = await fetchImpl(webhookUrl, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ embeds: [embed] }),
+	});
+	if (!res.ok) {
+		const errorText = await res.text().catch(() => "");
+		throw new Error(`Discord API error: ${res.status} - ${errorText.slice(0, 200)}`);
+	}
+}

--- a/workers/sync-hub/src/index.ts
+++ b/workers/sync-hub/src/index.ts
@@ -31,6 +31,7 @@
  *                                        deliberately untouched.
  */
 
+import { CONTROL_PLANE_PROBE_CRON, runControlPlaneProbe } from "./control-plane-probe";
 import type { PushOp } from "./do/SyncHub";
 import {
 	DEVICE_LIMIT_ERROR,
@@ -954,15 +955,38 @@ export default {
 	},
 
 	/**
-	 * Hourly watchdog (plan Phase 5 task 1; cron in wrangler.jsonc). Lives in
-	 * the stateless Worker — the DO stays I/O-free. runWatchdog never throws;
-	 * its structured result is logged as one JSON line for observability.
-	 * The metrics window is anchored to controller.scheduledTime (not
-	 * Date.now()) so a delayed invocation still measures the exact trailing
-	 * hour it was scheduled for. A persisting breach re-alerts on every
-	 * hourly run — intended (silence would hide an ongoing incident).
+	 * Scheduled entrypoint — TWO crons (wrangler.jsonc), dispatched on
+	 * event.cron. Both live in the stateless Worker — the DO stays I/O-free —
+	 * and both are anchored to controller.scheduledTime (not Date.now()) so a
+	 * delayed invocation still measures the window it was scheduled for.
+	 *
+	 *   every-5-minutes (CONTROL_PLANE_PROBE_CRON) — control-plane uptime
+	 *     probe (launch Phase 5 task 4, src/control-plane-probe.ts): is
+	 *     cmem.ai's DB-backed verify endpoint still rejecting a bogus token
+	 *     with 401/403 + JSON? Pages Discord with anti-flap KV state when it
+	 *     is not.
+	 *   "7 * * * *" (and any unrecognized cron) — hourly watchdog (plan
+	 *     Phase 5 task 1, src/watchdog.ts). A persisting breach re-alerts on
+	 *     every hourly run — intended (silence would hide an ongoing
+	 *     incident).
+	 *
+	 * Both runners never throw by contract; the probe is ADDITIONALLY wrapped
+	 * in the one permitted top-level try/catch (mirroring how the watchdog
+	 * isolates itself) so even a probe implementation bug cannot escape the
+	 * scheduled handler — and can never affect the sync routes either way.
 	 */
 	async scheduled(controller, env, _ctx): Promise<void> {
+		if (controller.cron === CONTROL_PLANE_PROBE_CRON) {
+			try {
+				const result = await runControlPlaneProbe(env, {
+					now: () => controller.scheduledTime,
+				});
+				console.log("sync-hub control-plane probe:", JSON.stringify(result));
+			} catch (e) {
+				console.error("sync-hub control-plane probe crashed:", e);
+			}
+			return;
+		}
 		const result = await runWatchdog(env, { now: () => controller.scheduledTime });
 		console.log("sync-hub watchdog:", JSON.stringify(result));
 	},

--- a/workers/sync-hub/src/watchdog.ts
+++ b/workers/sync-hub/src/watchdog.ts
@@ -52,6 +52,7 @@
  * the ping is a courtesy).
  */
 
+import { postDiscordEmbed, type DiscordEmbed, type DiscordEmbedField } from "./discord";
 import { tripKillSwitch } from "./kill-switch";
 
 export const GRAPHQL_ENDPOINT = "https://api.cloudflare.com/client/v4/graphql";
@@ -370,18 +371,19 @@ function evaluate(env: Env, metrics: WatchdogMetrics): WatchdogBreach[] {
 
 /**
  * Discord embed, shape copied from scripts/discord-release-notify.js
- * (payload = {embeds: [{title, description, color, fields, footer,
- * timestamp}]}). The webhook URL is a SECRET binding — never hardcoded.
+ * (posted via the shared src/discord.ts helper, which owns the
+ * {embeds: [embed]} envelope). The webhook URL is a SECRET binding — never
+ * hardcoded.
  */
-function buildDiscordPayload(
+function buildDiscordEmbed(
 	severe: boolean,
 	breaches: WatchdogBreach[],
 	metrics: WatchdogMetrics,
 	killSwitch: WatchdogResult["killSwitch"],
 	windowStart: string,
 	windowEnd: string,
-): Record<string, unknown> {
-	const fields = breaches.map((b) => ({
+): DiscordEmbed {
+	const fields: DiscordEmbedField[] = breaches.map((b) => ({
 		name: `${b.severe ? "🔴" : "🟠"} ${b.label}`,
 		value: `${b.value.toLocaleString("en-US")} (alert ≥ ${b.alertThreshold.toLocaleString("en-US")}, kill ≥ ${b.killThreshold.toLocaleString("en-US")})`,
 		inline: false,
@@ -397,27 +399,23 @@ function buildDiscordPayload(
 		inline: false,
 	});
 	return {
-		embeds: [
-			{
-				title: severe
-					? "🚨 sync-hub watchdog: SEVERE threshold breach"
-					: "⚠️ sync-hub watchdog: threshold breach",
-				description:
-					`DO metrics for ${windowStart} → ${windowEnd} (last hour).\n` +
-					`requests=${metrics.requests.toLocaleString("en-US")}, ` +
-					`duration=${metrics.duration_gbs.toFixed(2)} GB-s, ` +
-					`rowsRead=${metrics.rows_read.toLocaleString("en-US")}, ` +
-					`rowsWritten=${metrics.rows_written.toLocaleString("en-US")}, ` +
-					`errors=${metrics.errors.toLocaleString("en-US")}, ` +
-					`inboundWsMsgs=${metrics.inbound_ws_messages.toLocaleString("en-US")}`,
-				color: severe ? 0xdc2626 : 0xf59e0b, // red / amber
-				fields,
-				footer: {
-					text: "sync-hub watchdog • poll mode keeps the product complete",
-				},
-				timestamp: new Date().toISOString(),
-			},
-		],
+		title: severe
+			? "🚨 sync-hub watchdog: SEVERE threshold breach"
+			: "⚠️ sync-hub watchdog: threshold breach",
+		description:
+			`DO metrics for ${windowStart} → ${windowEnd} (last hour).\n` +
+			`requests=${metrics.requests.toLocaleString("en-US")}, ` +
+			`duration=${metrics.duration_gbs.toFixed(2)} GB-s, ` +
+			`rowsRead=${metrics.rows_read.toLocaleString("en-US")}, ` +
+			`rowsWritten=${metrics.rows_written.toLocaleString("en-US")}, ` +
+			`errors=${metrics.errors.toLocaleString("en-US")}, ` +
+			`inboundWsMsgs=${metrics.inbound_ws_messages.toLocaleString("en-US")}`,
+		color: severe ? 0xdc2626 : 0xf59e0b, // red / amber
+		fields,
+		footer: {
+			text: "sync-hub watchdog • poll mode keeps the product complete",
+		},
+		timestamp: new Date().toISOString(),
 	};
 }
 
@@ -504,7 +502,7 @@ export async function runWatchdog(env: Env, deps: WatchdogDeps = {}): Promise<Wa
 		return result;
 	}
 	try {
-		const payload = buildDiscordPayload(
+		const embed = buildDiscordEmbed(
 			severe,
 			breaches,
 			outcome.metrics,
@@ -512,15 +510,7 @@ export async function runWatchdog(env: Env, deps: WatchdogDeps = {}): Promise<Wa
 			result.windowStart,
 			result.windowEnd,
 		);
-		const res = await fetchImpl(webhook, {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify(payload),
-		});
-		if (!res.ok) {
-			const errorText = await res.text().catch(() => "");
-			throw new Error(`Discord API error: ${res.status} - ${errorText.slice(0, 200)}`);
-		}
+		await postDiscordEmbed(webhook, embed, fetchImpl);
 		result.discord = "sent";
 	} catch (e) {
 		result.discord = "failed";

--- a/workers/sync-hub/test/control-plane-probe.test.ts
+++ b/workers/sync-hub/test/control-plane-probe.test.ts
@@ -1,0 +1,523 @@
+/**
+ * Control-plane uptime probe suite (launch Phase 5 task 4 verification).
+ *
+ * Unit tests drive runControlPlaneProbe directly with an injected fetchImpl
+ * (the repo's fetchImpl idiom, mirroring watchdog.test.ts) so every verify /
+ * Discord response is scripted in-test; the KV side uses the REAL
+ * env.AUTH_CACHE binding so the anti-flap state machine is exercised end to
+ * end. The cron dispatch tests call worker.scheduled() with the
+ * outboundService mocks from vitest.config.ts.
+ *
+ * Covered:
+ *   - healthy 401/403+JSON → no alert, no KV write (steady state is silent)
+ *   - first failure + confirm-retry → ONE Discord post + KV failing state
+ *   - failure whose confirm-retry is healthy → blip: no alert, no state
+ *   - still failing inside 30 min → suppressed: no repost, KV untouched
+ *   - still failing after 30 min → re-alert + last_alert_at advanced
+ *   - recovery → green embed + state cleared
+ *   - 2xx for the bogus token → distinct SECURITY-flavored alert
+ *   - Discord failure → swallowed with a log, KV state still written
+ *   - timeout / network error / non-JSON 401 / unexpected status classes
+ *   - maintenance silence: future silenced_until skips everything; expired
+ *     silence is cleaned up quietly on a healthy run
+ *   - cron dispatch: "7 * * * *" still reaches the watchdog (no regression),
+ *     "*\/5 * * * *" reaches the probe and never runs the watchdog
+ */
+
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { afterEach, describe, expect, it } from "vitest";
+import worker from "../src/index";
+import {
+	CONTROL_PLANE_PROBE_CRON,
+	PROBE_REALERT_MS,
+	PROBE_STATE_KEY,
+	PROBE_TOKEN,
+	PROBE_USER_ID,
+	runControlPlaneProbe,
+	type ProbeResult,
+} from "../src/control-plane-probe";
+import { KILL_SWITCH_KEY, __resetKillSwitchCacheForTests } from "../src/kill-switch";
+
+const VERIFY_URL = "https://verify.test/api/pro/sync/verify";
+const WEBHOOK = "https://discord.test/webhooks/probe-unit";
+const NOW = Date.parse("2026-07-22T12:00:00.000Z");
+const NOW_ISO = "2026-07-22T12:00:00.000Z";
+
+interface RecordedCall {
+	url: string;
+	method: string;
+	headers: Record<string, string>;
+	parsed: unknown;
+}
+
+interface RecordedEmbed {
+	title: string;
+	description: string;
+	color: number;
+	fields: Array<{ name: string; value: string; inline: boolean }>;
+	footer: { text: string };
+	timestamp: string;
+}
+
+/** One scripted step for the verify endpoint. "hang" never resolves. */
+type VerifyStep = Response | Error | "hang";
+
+/**
+ * Scripted fetch: the verify endpoint consumes `verify` steps in order (a
+ * test bug if called more often than scripted), the webhook answers per
+ * `discord`. Records every call (URL, method, headers, parsed JSON body).
+ */
+function makeFetch(script: { verify?: VerifyStep[]; discord?: Response | Error }): {
+	impl: typeof fetch;
+	calls: RecordedCall[];
+	verifyCalls: () => RecordedCall[];
+	discordCalls: () => RecordedCall[];
+	discordEmbed: (index?: number) => RecordedEmbed;
+} {
+	const calls: RecordedCall[] = [];
+	const queue = [...(script.verify ?? [])];
+	const impl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = String(input);
+		let parsed: unknown = null;
+		try {
+			parsed = init?.body ? JSON.parse(String(init.body)) : null;
+		} catch {
+			parsed = null;
+		}
+		calls.push({
+			url,
+			method: init?.method ?? "GET",
+			headers: { ...((init?.headers as Record<string, string>) ?? {}) },
+			parsed,
+		});
+		if (url === VERIFY_URL) {
+			const step = queue.shift();
+			if (step === undefined) {
+				throw new Error("test bug: verify endpoint called more times than scripted");
+			}
+			if (step === "hang") return new Promise<Response>(() => {});
+			if (step instanceof Error) throw step;
+			return step.clone();
+		}
+		const d = script.discord ?? new Response(null, { status: 204 });
+		if (d instanceof Error) throw d;
+		return d.clone();
+	}) as typeof fetch;
+	const discordCalls = () => calls.filter((c) => c.url === WEBHOOK);
+	return {
+		impl,
+		calls,
+		verifyCalls: () => calls.filter((c) => c.url === VERIFY_URL),
+		discordCalls,
+		discordEmbed: (index = 0) => {
+			const payload = discordCalls()[index].parsed as { embeds: RecordedEmbed[] };
+			expect(payload.embeds).toHaveLength(1);
+			return payload.embeds[0];
+		},
+	};
+}
+
+function probeEnv(overrides: Partial<Record<string, string>> = {}): Env {
+	return {
+		...env,
+		TOKEN_VERIFY_URL: VERIFY_URL,
+		DISCORD_WEBHOOK_URL: WEBHOOK,
+		...overrides,
+	} as Env;
+}
+
+/** The healthy answer: 401 + JSON (requires the app AND its DB lookup). */
+function healthy401(): Response {
+	return Response.json({ error: "invalid token" }, { status: 401 });
+}
+
+function http500(): Response {
+	return new Response("Internal Server Error", { status: 500 });
+}
+
+function html401(): Response {
+	return new Response("<html>edge maintenance page</html>", {
+		status: 401,
+		headers: { "Content-Type": "text/html" },
+	});
+}
+
+/** The security alarm: the bogus token was ACCEPTED. */
+function bogus200(): Response {
+	return Response.json({ userId: PROBE_USER_ID }, { status: 200 });
+}
+
+async function seedFailingState(
+	lastAlertAgoMs: number,
+	firstFailureAt = "2026-07-22T11:00:00.000Z",
+): Promise<string> {
+	const state = JSON.stringify({
+		status: "failing",
+		first_failure_at: firstFailureAt,
+		last_alert_at: new Date(NOW - lastAlertAgoMs).toISOString(),
+		kind: "http_5xx",
+		reason: "HTTP 500",
+		security: false,
+	});
+	await env.AUTH_CACHE.put(PROBE_STATE_KEY, state);
+	return state;
+}
+
+afterEach(async () => {
+	__resetKillSwitchCacheForTests();
+	await env.AUTH_CACHE.delete(PROBE_STATE_KEY);
+	await env.AUTH_CACHE.delete(KILL_SWITCH_KEY);
+});
+
+describe("control-plane probe: configuration + healthy steady state", () => {
+	it("skips (no outbound calls) when TOKEN_VERIFY_URL is unconfigured", async () => {
+		const { impl, calls } = makeFetch({});
+		const result = await runControlPlaneProbe(probeEnv({ TOKEN_VERIFY_URL: "" }), {
+			fetchImpl: impl,
+		});
+		expect(result.status).toBe("skipped");
+		expect(calls).toHaveLength(0);
+		expect(await env.AUTH_CACHE.get(PROBE_STATE_KEY)).toBeNull();
+	});
+
+	it("healthy 401+JSON → nothing: no Discord, no KV write, exactly one probe request", async () => {
+		const { impl, verifyCalls, discordCalls } = makeFetch({ verify: [healthy401()] });
+		const result = await runControlPlaneProbe(probeEnv(), {
+			fetchImpl: impl,
+			now: () => NOW,
+		});
+		expect(result.status).toBe("healthy");
+		expect(result.discord).toBe("skipped");
+		expect(result.kv).toBe("none");
+		expect(discordCalls()).toHaveLength(0);
+		expect(await env.AUTH_CACHE.get(PROBE_STATE_KEY)).toBeNull();
+
+		// The probe presents the documented bogus identity, nothing else.
+		const [probe] = verifyCalls();
+		expect(verifyCalls()).toHaveLength(1); // healthy needs no confirm-retry
+		expect(probe.method).toBe("GET");
+		expect(probe.headers.Authorization).toBe(`Bearer ${PROBE_TOKEN}`);
+		expect(probe.headers["X-User-Id"]).toBe(PROBE_USER_ID);
+	});
+
+	it("healthy 403+JSON is also healthy", async () => {
+		const { impl } = makeFetch({
+			verify: [Response.json({ error: "forbidden" }, { status: 403 })],
+		});
+		const result = await runControlPlaneProbe(probeEnv(), { fetchImpl: impl });
+		expect(result.status).toBe("healthy");
+		expect(await env.AUTH_CACHE.get(PROBE_STATE_KEY)).toBeNull();
+	});
+});
+
+describe("control-plane probe: first failure + confirm retry", () => {
+	it("5xx confirmed by the in-run retry → ONE red Discord post + failing KV state", async () => {
+		const { impl, verifyCalls, discordCalls, discordEmbed } = makeFetch({
+			verify: [http500(), http500()],
+		});
+		const result = await runControlPlaneProbe(probeEnv(), {
+			fetchImpl: impl,
+			now: () => NOW,
+		});
+		expect(result.status).toBe("alerted");
+		expect(result.kind).toBe("http_5xx");
+		expect(result.security).toBe(false);
+		expect(result.discord).toBe("sent");
+		expect(result.kv).toBe("written");
+		expect(verifyCalls()).toHaveLength(2); // probe + confirm
+		expect(discordCalls()).toHaveLength(1);
+
+		const embed = discordEmbed();
+		expect(embed.title).toContain("control plane DOWN");
+		expect(embed.color).toBe(0xdc2626); // red = outage tier
+		expect(embed.description).toContain("HTTP 500");
+		expect(embed.fields.find((f) => f.name === "Probe target")!.value).toBe(VERIFY_URL);
+
+		const state = JSON.parse((await env.AUTH_CACHE.get(PROBE_STATE_KEY))!) as {
+			status: string;
+			first_failure_at: string;
+			last_alert_at: string;
+			kind: string;
+			security: boolean;
+		};
+		expect(state.status).toBe("failing");
+		expect(state.first_failure_at).toBe(NOW_ISO);
+		expect(state.last_alert_at).toBe(NOW_ISO);
+		expect(state.kind).toBe("http_5xx");
+		expect(state.security).toBe(false);
+	});
+
+	it("a single blip (failure whose retry is healthy) → no alert, no state", async () => {
+		const { impl, verifyCalls, discordCalls } = makeFetch({
+			verify: [http500(), healthy401()],
+		});
+		const result = await runControlPlaneProbe(probeEnv(), { fetchImpl: impl });
+		expect(result.status).toBe("blip");
+		expect(result.discord).toBe("skipped");
+		expect(result.kv).toBe("none");
+		expect(verifyCalls()).toHaveLength(2);
+		expect(discordCalls()).toHaveLength(0);
+		expect(await env.AUTH_CACHE.get(PROBE_STATE_KEY)).toBeNull();
+	});
+
+	for (const [name, steps, kind] of [
+		["network error", [new Error("boom"), new Error("boom")], "unreachable"],
+		["non-JSON 401 (HTML edge page)", [html401(), html401()], "non_json"],
+		[
+			"unexpected status (404)",
+			[new Response("nope", { status: 404 }), new Response("nope", { status: 404 })],
+			"unexpected_status",
+		],
+	] as Array<[string, VerifyStep[], string]>) {
+		it(`${name} → confirmed alert with kind "${kind}"`, async () => {
+			const { impl, discordCalls } = makeFetch({ verify: steps });
+			const result = await runControlPlaneProbe(probeEnv(), {
+				fetchImpl: impl,
+				now: () => NOW,
+			});
+			expect(result.status).toBe("alerted");
+			expect(result.kind).toBe(kind);
+			expect(discordCalls()).toHaveLength(1);
+			expect(await env.AUTH_CACHE.get(PROBE_STATE_KEY)).not.toBeNull();
+		});
+	}
+
+	it("a hung endpoint times out and alerts with kind \"timeout\"", async () => {
+		const { impl, discordCalls } = makeFetch({ verify: ["hang", "hang"] });
+		const result = await runControlPlaneProbe(probeEnv(), {
+			fetchImpl: impl,
+			now: () => NOW,
+			timeoutMs: 10, // test seam; production pins PROBE_TIMEOUT_MS = 10s
+		});
+		expect(result.status).toBe("alerted");
+		expect(result.kind).toBe("timeout");
+		expect(discordCalls()).toHaveLength(1);
+	});
+});
+
+describe("control-plane probe: anti-flap while failing", () => {
+	it("still failing inside the 30-min window → suppressed: no repost, no retry, KV untouched", async () => {
+		const seeded = await seedFailingState(10 * 60 * 1000); // alerted 10 min ago
+		const { impl, verifyCalls, discordCalls } = makeFetch({ verify: [http500()] });
+		const result = await runControlPlaneProbe(probeEnv(), {
+			fetchImpl: impl,
+			now: () => NOW,
+		});
+		expect(result.status).toBe("suppressed");
+		expect(result.discord).toBe("skipped");
+		expect(result.kv).toBe("none");
+		expect(verifyCalls()).toHaveLength(1); // already failing ⇒ no confirm-retry
+		expect(discordCalls()).toHaveLength(0);
+		// The 5-minute steady failing state writes NOTHING to KV.
+		expect(await env.AUTH_CACHE.get(PROBE_STATE_KEY)).toBe(seeded);
+	});
+
+	it("still failing after 30 min → re-alert, last_alert_at advanced, first_failure_at preserved", async () => {
+		await seedFailingState(PROBE_REALERT_MS + 60 * 1000); // alerted 31 min ago
+		const { impl, discordCalls, discordEmbed } = makeFetch({ verify: [http500()] });
+		const result = await runControlPlaneProbe(probeEnv(), {
+			fetchImpl: impl,
+			now: () => NOW,
+		});
+		expect(result.status).toBe("realerted");
+		expect(result.discord).toBe("sent");
+		expect(result.kv).toBe("written");
+		expect(discordCalls()).toHaveLength(1);
+		expect(discordEmbed().title).toContain("STILL DOWN");
+
+		const state = JSON.parse((await env.AUTH_CACHE.get(PROBE_STATE_KEY))!) as {
+			first_failure_at: string;
+			last_alert_at: string;
+		};
+		expect(state.first_failure_at).toBe("2026-07-22T11:00:00.000Z"); // preserved
+		expect(state.last_alert_at).toBe(NOW_ISO); // advanced
+	});
+
+	it("recovery → one green embed + state cleared", async () => {
+		await seedFailingState(10 * 60 * 1000);
+		const { impl, discordCalls, discordEmbed } = makeFetch({ verify: [healthy401()] });
+		const result = await runControlPlaneProbe(probeEnv(), {
+			fetchImpl: impl,
+			now: () => NOW,
+		});
+		expect(result.status).toBe("recovered");
+		expect(result.discord).toBe("sent");
+		expect(result.kv).toBe("cleared");
+		expect(discordCalls()).toHaveLength(1);
+
+		const embed = discordEmbed();
+		expect(embed.title).toContain("recovered");
+		expect(embed.color).toBe(0x16a34a); // green
+		expect(embed.fields.find((f) => f.name === "Was failing since")!.value).toBe(
+			"2026-07-22T11:00:00.000Z",
+		);
+		expect(await env.AUTH_CACHE.get(PROBE_STATE_KEY)).toBeNull();
+	});
+});
+
+describe("control-plane probe: security alarm", () => {
+	it("2xx for the bogus token → distinct SECURITY-flavored red alert + security:true state", async () => {
+		const { impl, discordEmbed } = makeFetch({ verify: [bogus200(), bogus200()] });
+		const result = await runControlPlaneProbe(probeEnv(), {
+			fetchImpl: impl,
+			now: () => NOW,
+		});
+		expect(result.status).toBe("alerted");
+		expect(result.kind).toBe("security_2xx");
+		expect(result.security).toBe(true);
+
+		const embed = discordEmbed();
+		expect(embed.title).toContain("SECURITY");
+		expect(embed.title).toContain("ACCEPTED a bogus token");
+		expect(embed.color).toBe(0x7f1d1d); // distinct from the 0xdc2626 outage red
+		expect(embed.description).toContain("authentication bypass");
+
+		const state = JSON.parse((await env.AUTH_CACHE.get(PROBE_STATE_KEY))!) as {
+			kind: string;
+			security: boolean;
+		};
+		expect(state.kind).toBe("security_2xx");
+		expect(state.security).toBe(true);
+	});
+});
+
+describe("control-plane probe: failure containment", () => {
+	it("a Discord failure is swallowed with a log — KV state still written, nothing thrown", async () => {
+		const { impl, discordCalls } = makeFetch({
+			verify: [http500(), http500()],
+			discord: new Error("webhook unreachable"),
+		});
+		const result = await runControlPlaneProbe(probeEnv(), {
+			fetchImpl: impl,
+			now: () => NOW,
+		});
+		expect(result.status).toBe("alerted");
+		expect(result.discord).toBe("failed");
+		expect(result.kv).toBe("written"); // state first, ping second
+		expect(discordCalls()).toHaveLength(1); // attempted exactly once
+		expect(await env.AUTH_CACHE.get(PROBE_STATE_KEY)).not.toBeNull();
+	});
+
+	it("no webhook configured → not_configured (logged), state still written", async () => {
+		const { impl, discordCalls } = makeFetch({ verify: [http500(), http500()] });
+		const result = await runControlPlaneProbe(probeEnv({ DISCORD_WEBHOOK_URL: "" }), {
+			fetchImpl: impl,
+			now: () => NOW,
+		});
+		expect(result.status).toBe("alerted");
+		expect(result.discord).toBe("not_configured");
+		expect(result.kv).toBe("written");
+		expect(discordCalls()).toHaveLength(0);
+		expect(await env.AUTH_CACHE.get(PROBE_STATE_KEY)).not.toBeNull();
+	});
+});
+
+describe("control-plane probe: maintenance silence (DEPLOY.md §7)", () => {
+	it("a future silenced_until skips everything — not even a probe fetch", async () => {
+		const marker = JSON.stringify({
+			silenced_until: new Date(NOW + 60 * 60 * 1000).toISOString(),
+		});
+		await env.AUTH_CACHE.put(PROBE_STATE_KEY, marker);
+		const { impl, calls } = makeFetch({});
+		const result = await runControlPlaneProbe(probeEnv(), {
+			fetchImpl: impl,
+			now: () => NOW,
+		});
+		expect(result.status).toBe("silenced");
+		expect(calls).toHaveLength(0);
+		expect(await env.AUTH_CACHE.get(PROBE_STATE_KEY)).toBe(marker);
+	});
+
+	it("an expired silence + healthy endpoint is cleaned up quietly (no green post)", async () => {
+		await env.AUTH_CACHE.put(
+			PROBE_STATE_KEY,
+			JSON.stringify({ silenced_until: new Date(NOW - 1000).toISOString() }),
+		);
+		const { impl, discordCalls } = makeFetch({ verify: [healthy401()] });
+		const result = await runControlPlaneProbe(probeEnv(), {
+			fetchImpl: impl,
+			now: () => NOW,
+		});
+		expect(result.status).toBe("silence_cleared");
+		expect(discordCalls()).toHaveLength(0); // there was never an alert to close
+		expect(await env.AUTH_CACHE.get(PROBE_STATE_KEY)).toBeNull();
+	});
+
+	it("an expired silence + confirmed failure alerts like a first failure", async () => {
+		await env.AUTH_CACHE.put(
+			PROBE_STATE_KEY,
+			JSON.stringify({ silenced_until: new Date(NOW - 1000).toISOString() }),
+		);
+		const { impl, discordCalls } = makeFetch({ verify: [http500(), http500()] });
+		const result = await runControlPlaneProbe(probeEnv(), {
+			fetchImpl: impl,
+			now: () => NOW,
+		});
+		expect(result.status).toBe("alerted");
+		expect(discordCalls()).toHaveLength(1);
+		const state = JSON.parse((await env.AUTH_CACHE.get(PROBE_STATE_KEY))!) as {
+			status: string;
+		};
+		expect(state.status).toBe("failing");
+	});
+});
+
+describe("cron dispatch: two schedules, one scheduled handler", () => {
+	function controller(cron: string): ScheduledController {
+		return { scheduledTime: Date.now(), cron, noRetry() {} } as ScheduledController;
+	}
+
+	it('"7 * * * *" still reaches the watchdog (no regression) and never the probe', async () => {
+		const ctx = createExecutionContext();
+		await worker.scheduled(
+			controller("7 * * * *"),
+			probeEnv({
+				ACCOUNT_ID: "acct-duration-severe", // outbound-mock: severe → trips the switch
+				ANALYTICS_API_TOKEN: "unit-analytics-token",
+				DISCORD_WEBHOOK_URL: "https://discord.test/webhooks/ok",
+			}),
+			ctx,
+		);
+		await waitOnExecutionContext(ctx);
+		expect(await env.AUTH_CACHE.get(KILL_SWITCH_KEY)).not.toBeNull(); // watchdog ran
+		expect(await env.AUTH_CACHE.get(PROBE_STATE_KEY)).toBeNull(); // probe did not
+	});
+
+	it(`"${CONTROL_PLANE_PROBE_CRON}" reaches the probe (recovery observed) and never the watchdog`, async () => {
+		// Pre-seed a failing state; the outbound mock answers the probe token
+		// with the healthy 401+JSON, so a probe run MUST clear it (recovery).
+		await seedFailingState(10 * 60 * 1000);
+		const ctx = createExecutionContext();
+		await worker.scheduled(
+			controller(CONTROL_PLANE_PROBE_CRON),
+			probeEnv({
+				// TOKEN_VERIFY_URL: any URL — the outboundService intercepts it.
+				TOKEN_VERIFY_URL: "https://cmem.ai/api/pro/sync/verify",
+				// Were the watchdog to run instead, THIS account would trip the
+				// kill switch — its absence below proves the dispatch.
+				ACCOUNT_ID: "acct-duration-severe",
+				ANALYTICS_API_TOKEN: "unit-analytics-token",
+				DISCORD_WEBHOOK_URL: "https://discord.test/webhooks/ok",
+			}),
+			ctx,
+		);
+		await waitOnExecutionContext(ctx);
+		expect(await env.AUTH_CACHE.get(PROBE_STATE_KEY)).toBeNull(); // probe recovered + cleared
+		expect(await env.AUTH_CACHE.get(KILL_SWITCH_KEY)).toBeNull(); // watchdog did NOT run
+	});
+});
+
+// Type-level guard: runControlPlaneProbe's result surface is what the
+// scheduled handler logs — keep the union in sync with the tests above.
+const _statusCheck: ProbeResult["status"][] = [
+	"skipped",
+	"silenced",
+	"healthy",
+	"blip",
+	"alerted",
+	"suppressed",
+	"realerted",
+	"recovered",
+	"silence_cleared",
+];
+void _statusCheck;

--- a/workers/sync-hub/vitest.config.ts
+++ b/workers/sync-hub/vitest.config.ts
@@ -22,6 +22,9 @@
  *   denied-401/403   → 401 / 403
  *   upstream-500     → 500
  *   network-error    → throws (unreachable endpoint)
+ *   cmem-uptime-probe-invalid-token
+ *                    → 401 {error} JSON — the HEALTHY answer the
+ *                      control-plane probe expects (src/control-plane-probe.ts)
  *
  * Phase 5 adds two more outbound targets, dispatched by hostname:
  *   - api.cloudflare.com/client/v4/graphql → mock GraphQL Analytics API,
@@ -47,6 +50,13 @@ function mockVerifyEndpoint(request: Request): Response {
 
 	if (token === "network-error") {
 		throw new Error("simulated network failure reaching the verify endpoint");
+	}
+	if (token === "cmem-uptime-probe-invalid-token") {
+		// Control-plane probe (src/control-plane-probe.ts): a HEALTHY verify
+		// endpoint rejects the probe's deliberately bogus token with 401 + a
+		// JSON body. (The generic unknown-token fallback below is text/plain,
+		// which the probe rightly classifies as unhealthy.)
+		return Response.json({ error: "invalid token" }, { status: 401 });
 	}
 	if (token === "denied-401") return new Response("denied", { status: 401 });
 	if (token === "denied-403") return new Response("denied", { status: 403 });

--- a/workers/sync-hub/wrangler.jsonc
+++ b/workers/sync-hub/wrangler.jsonc
@@ -33,12 +33,19 @@
 			"id": "f8b295652fed47d7ab7f739460443111"
 		}
 	],
-	// Hourly watchdog (plan Phase 5 task 1) — runs the `scheduled` handler in
-	// src/index.ts. Minute 7, not 0: gives the GraphQL adaptive datasets a
-	// few minutes of ingest headroom past each hour boundary and dodges the
-	// top-of-hour cron stampede. Activated automatically by `wrangler deploy`.
+	// Two crons, dispatched on event.cron in src/index.ts's scheduled handler
+	// (both activated automatically by `wrangler deploy`):
+	//   "7 * * * *"   — hourly watchdog (plan Phase 5 task 1). Minute 7, not 0:
+	//                   gives the GraphQL adaptive datasets a few minutes of
+	//                   ingest headroom past each hour boundary and dodges the
+	//                   top-of-hour cron stampede.
+	//   "*/5 * * * *" — control-plane uptime probe (launch Phase 5 task 4,
+	//                   src/control-plane-probe.ts): pages Discord when the
+	//                   DB-backed TOKEN_VERIFY_URL stops answering 401/403+JSON
+	//                   for a bogus token (the Jul 20–22 silent-Supabase-pause
+	//                   failure mode). Anti-flap policy + silencing: DEPLOY.md §7.
 	"triggers": {
-		"crons": ["7 * * * *"]
+		"crons": ["7 * * * *", "*/5 * * * *"]
 	},
 	"vars": {
 		// Implemented Pro verifier dependency. Deploy and canary this route first;


### PR DESCRIPTION
## Why

Lesson of the Jul 20-22 outage: Supabase paused the project silently — signups failed for **52 hours with no page**, while the static landing page answered 200 the whole time. "The site is up" proved nothing.

This adds an external uptime probe that:
- runs **outside the Vercel/Supabase failure domain** (in the sync-hub Cloudflare Worker, which already has Discord + KV plumbing), and
- checks a **DB-backed endpoint**, never the landing page.

## What

**New 5-minute cron** (`*/5 * * * *` in `wrangler.jsonc`); `src/index.ts`'s scheduled handler dispatches on `event.cron` — `7 * * * *` still reaches the hourly watchdog unchanged, and the probe branch sits behind the one permitted top-level try/catch (mirroring how the watchdog isolates itself) so a probe bug can never affect the sync routes.

**`src/control-plane-probe.ts`** — GET `TOKEN_VERIFY_URL` with `Authorization: Bearer cmem-uptime-probe-invalid-token` and the all-zero `X-User-Id`, 10 s hard deadline.

- **HEALTHY** iff the response is HTTP **401/403 with a JSON body** — that specific answer requires the Pro app AND its Postgres lookup to both be alive (the endpoint queries `pro_users` to reject the token). A paused DB yields 5xx/timeout/HTML instead.
- **UNHEALTHY**: network error, timeout, any 5xx, non-JSON content-type, or any other status.
- A **2xx for the bogus token pages a distinct SECURITY alert** — that is an auth bypass, not an outage.

**Anti-flap** (KV state in `AUTH_CACHE` under `control:uptime-probe`):
- first failure pages only after one immediate in-run retry confirms it (a single blip never pages);
- while failing: re-page at most every 30 minutes, log-only in between;
- recovery: one green embed, state cleared;
- healthy steady state: log line only — **no Discord post, no KV write** (KV is written only on transitions and re-alert ticks).

**Shared Discord helper** (`src/discord.ts`) extracted from the watchdog's inline embed-posting code; both monitors now use it — identical wire shape, no behavior change (existing watchdog tests unchanged and green).

**Constraints honored**: no DO involvement, no new secrets (reuses `DISCORD_WEBHOOK_URL` + `TOKEN_VERIFY_URL`), Discord post failures are swallowed with a log and never block the KV state write.

**DEPLOY.md §7**: what the probe checks, the anti-flap policy, and how to silence during maintenance (`{"silenced_until": "<ISO>"}` at the state key; delete to restore).

## Tests

`test/control-plane-probe.test.ts` — 20 tests mirroring `watchdog.test.ts` style (injected fetchImpl, real KV binding, injected clock): healthy steady state, confirm-retry alerting, blip, suppression inside 30 min, re-alert after 30 min, recovery, security 2xx, Discord-failure containment, timeout/non-JSON/network classes, maintenance silence, and cron dispatch in both directions (`7 * * * *` → watchdog only; `*/5 * * * *` → probe only).

Gates (all green locally):
- `bun run test` — 113 passed
- `bun run test:ws` — 9 passed
- `bun run lint` — clean
- `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JS4kwJj5GkVFEhe1X7XNox