### PR TITLE
fix: fail-fast guard for empty assistant responses instead of retry fan-out

### DIFF
--- a/src/server/generation/ProviderObservationGenerator.ts
+++ b/src/server/generation/ProviderObservationGenerator.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Job } from 'bullmq';
+import { UnrecoverableError, type Job } from 'bullmq';
 import { logger } from '../../utils/logger.js';
 import { PostgresAgentEventsRepository } from '../../storage/postgres/agent-events.js';
 import { PostgresObservationGenerationJobRepository } from '../../storage/postgres/generation-jobs.js';
@@ -32,6 +32,24 @@ export class ServerGenerationScopeViolationError extends Error {
   constructor(reason: 'scope_mismatch' | 'revoked_key', message: string) {
     super(message);
     this.reason = reason;
+  }
+}
+
+// Terminal generation outcomes (empty provider response, unparseable XML)
+// already move the outbox row to `failed` before throwing. Extending
+// UnrecoverableError makes BullMQ fail the job immediately instead of
+// burning its remaining retry attempts re-running a job whose outbox row is
+// already terminal. The name must stay 'UnrecoverableError' — BullMQ
+// identifies these by name, so the subclass must not override it.
+export class ServerGenerationTerminalOutcomeError extends UnrecoverableError {
+  readonly classification: 'parse_error' | 'empty_response';
+  constructor(classification: 'parse_error' | 'empty_response', message: string) {
+    super(message);
+    this.classification = classification;
+    // BullMQ also detects unrecoverable errors by name (job.js checks
+    // `err.name == 'UnrecoverableError'`), and instanceof breaks across
+    // duplicated bullmq installs — keep the parent name.
+    this.name = 'UnrecoverableError';
   }
 }
 
@@ -191,18 +209,23 @@ export class ProviderObservationGenerator {
     try {
       return await this.generateAndPersist(job, payload, fresh, correlationId, payloadRequestId);
     } catch (error) {
-      const classified = error instanceof ServerClassifiedProviderError ? error : null;
-      const retryable = classified
-        ? classified.kind === 'transient' || classified.kind === 'rate_limit'
-        : false;
-      await markGenerationFailed({
-        pool: this.options.pool,
-        job: fresh,
-        reason: error instanceof Error ? error.message : String(error),
-        classification: classified?.kind ?? 'unknown',
-        retryable,
-        ...(this.options.workerId !== undefined ? { workerId: this.options.workerId } : {}),
-      });
+      // Terminal outcomes already moved the outbox to `failed` before
+      // throwing; re-marking here would append a duplicate lifecycle event
+      // under a bogus 'unknown' classification.
+      if (!(error instanceof ServerGenerationTerminalOutcomeError)) {
+        const classified = error instanceof ServerClassifiedProviderError ? error : null;
+        const retryable = classified
+          ? classified.kind === 'transient' || classified.kind === 'rate_limit'
+          : false;
+        await markGenerationFailed({
+          pool: this.options.pool,
+          job: fresh,
+          reason: error instanceof Error ? error.message : String(error),
+          classification: classified?.kind ?? 'unknown',
+          retryable,
+          ...(this.options.workerId !== undefined ? { workerId: this.options.workerId } : {}),
+        });
+      }
       throw error;
     }
   }
@@ -250,16 +273,21 @@ export class ProviderObservationGenerator {
       ? await processSessionSummaryResponse(persistInput)
       : await processGeneratedResponse(persistInput);
 
-    if (outcome.kind === 'parse_error') {
+    if (outcome.kind === 'parse_error' || outcome.kind === 'empty_response') {
       await markGenerationFailed({
         pool: this.options.pool,
         job: fresh,
         reason: outcome.reason,
-        classification: 'parse_error',
+        classification: outcome.kind,
         retryable: false,
         ...(this.options.workerId !== undefined ? { workerId: this.options.workerId } : {}),
       });
-      throw new Error(`generation parse error: ${outcome.reason}`);
+      throw new ServerGenerationTerminalOutcomeError(
+        outcome.kind,
+        outcome.kind === 'empty_response'
+          ? `generation empty response: ${outcome.reason}`
+          : `generation parse error: ${outcome.reason}`,
+      );
     }
 
     logger.info('SYSTEM', 'generation completed', {

--- a/src/server/generation/processGeneratedResponse.ts
+++ b/src/server/generation/processGeneratedResponse.ts
@@ -42,7 +42,12 @@ export type ProcessGeneratedResponseOutcome =
       observations: PostgresObservation[];
       privateContentDetected: boolean;
     }
-  | { kind: 'parse_error'; jobId: string; reason: string };
+  | { kind: 'parse_error'; jobId: string; reason: string }
+  // Distinct from parse_error: the provider returned no content at all
+  // (safety block, MAX_TOKENS truncation, gateway hiccup). Detected before
+  // parsing so the failure is attributed to the provider, not the parser,
+  // and the caller can fail fast instead of burning queue retries.
+  | { kind: 'empty_response'; jobId: string; reason: string };
 
 export interface ProcessGeneratedResponseInput {
   pool: PostgresPool;
@@ -66,6 +71,10 @@ export async function processGeneratedResponse(
   input: ProcessGeneratedResponseInput,
 ): Promise<ProcessGeneratedResponseOutcome> {
   const { job, rawText } = input;
+
+  if (!rawText.trim()) {
+    return { kind: 'empty_response', jobId: job.id, reason: 'provider returned empty content' };
+  }
 
   const parsed = parseAgentXml(rawText, job.id);
   if (!parsed.valid) {
@@ -187,6 +196,10 @@ export async function processSessionSummaryResponse(
 
   if (job.sourceType !== 'session_summary') {
     return { kind: 'parse_error', jobId: job.id, reason: 'session summary processor invoked on non-summary job' };
+  }
+
+  if (!rawText.trim()) {
+    return { kind: 'empty_response', jobId: job.id, reason: 'provider returned empty content' };
   }
 
   const parsed = parseAgentXml(rawText, job.id);

--- a/src/services/worker-types.ts
+++ b/src/services/worker-types.ts
@@ -30,6 +30,13 @@ export interface ActiveSession {
    * accumulate respawn debt.
    */
   consecutiveInvalidOutputs: number;
+  /**
+   * Consecutive empty assistant responses for claimed observation/summary
+   * batches. Bounds the leave-queue-intact retry path: once the guard
+   * threshold is hit the batch is dropped loudly instead of being re-claimed
+   * and re-queried on every generator start.
+   */
+  consecutiveEmptyResponses: number;
   forceInit?: boolean;
   idleTimedOut?: boolean;  
   lastGeneratorActivity: number;

--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -12,6 +12,45 @@ import {
 } from './agents/index.js';
 
 /**
+ * Fail-fast guard for empty assistant responses on the observer output path.
+ *
+ * On the non-forwarding path (Gemini) an empty observation/summary response
+ * used to leave the claimed batch in the queue unconditionally. Because
+ * getMessageIterator resets claimed-but-unconfirmed messages back to pending
+ * on every generator start, a model that persistently returns empty content
+ * (safety block, MAX_TOKENS truncation) re-queried the same batch on every
+ * restart — an unbounded retry loop burning one full query per stuck message.
+ * Allow a bounded number of consecutive empties to stay queued (a transient
+ * blip resolves on the next pass), then drop the batch loudly.
+ */
+export const MAX_CONSECUTIVE_EMPTY_RESPONSES = 3;
+
+export async function guardEmptyMessageResponse(
+  session: ActiveSession,
+  sessionManager: SessionManager,
+  providerName: string,
+  messageType: 'observation' | 'summary'
+): Promise<void> {
+  session.consecutiveEmptyResponses = (session.consecutiveEmptyResponses ?? 0) + 1;
+
+  if (session.consecutiveEmptyResponses < MAX_CONSECUTIVE_EMPTY_RESPONSES) {
+    logger.warn('SDK', `Empty ${providerName} ${messageType} response, leaving queue intact`, {
+      sessionId: session.sessionDbId,
+      consecutiveEmptyResponses: session.consecutiveEmptyResponses,
+    });
+    return;
+  }
+
+  logger.error('SDK', `Empty ${providerName} ${messageType} response ${session.consecutiveEmptyResponses}x in a row — dropping claimed batch instead of retrying`, {
+    sessionId: session.sessionDbId,
+    consecutiveEmptyResponses: session.consecutiveEmptyResponses,
+  });
+  await sessionManager.confirmClaimedMessages(session.sessionDbId);
+  session.earliestPendingTimestamp = null;
+  session.consecutiveEmptyResponses = 0;
+}
+
+/**
  * Normalized result returned by a concrete provider's `query()`.
  * Optional fields (costUsd, servedModel) are populated only by providers that
  * surface them; absent fields are simply not forwarded.
@@ -212,6 +251,7 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
 
     let tokensUsed = 0;
     if (obsResponse.content) {
+      session.consecutiveEmptyResponses = 0;
       session.conversationHistory.push({ role: 'assistant', content: obsResponse.content });
       tokensUsed = obsResponse.tokensUsed || 0;
       session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
@@ -227,9 +267,7 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
         worker, tokensUsed, originalTimestamp, this.providerName, lastCwd, obsResponse.servedModel ?? config.model
       );
     } else {
-      logger.warn('SDK', `Empty ${this.providerName} observation response, leaving queue intact`, {
-        sessionId: session.sessionDbId
-      });
+      await guardEmptyMessageResponse(session, this.sessionManager, this.providerName, 'observation');
     }
   }
 
@@ -261,6 +299,7 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
 
     let tokensUsed = 0;
     if (summaryResponse.content) {
+      session.consecutiveEmptyResponses = 0;
       session.conversationHistory.push({ role: 'assistant', content: summaryResponse.content });
       tokensUsed = summaryResponse.tokensUsed || 0;
       session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
@@ -274,9 +313,7 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
         worker, tokensUsed, originalTimestamp, this.providerName, lastCwd, summaryResponse.servedModel ?? config.model
       );
     } else {
-      logger.warn('SDK', `Empty ${this.providerName} summary response, leaving queue intact`, {
-        sessionId: session.sessionDbId
-      });
+      await guardEmptyMessageResponse(session, this.sessionManager, this.providerName, 'summary');
     }
   }
 

--- a/src/services/worker/SessionManager.ts
+++ b/src/services/worker/SessionManager.ts
@@ -118,6 +118,7 @@ export class SessionManager {
       currentProvider: null,  // Will be set when generator starts
       consecutiveRestarts: 0,
       consecutiveInvalidOutputs: 0,
+      consecutiveEmptyResponses: 0,
       lastGeneratorActivity: Date.now(),  // Initialize for stale detection (Issue #1099)
       pendingAgentId: null,   // Subagent identity carried from the most recent claimed message
       pendingAgentType: null

--- a/tests/server/generation/empty-response-guard.test.ts
+++ b/tests/server/generation/empty-response-guard.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Fail-fast guard for empty assistant responses on the server observer output
+// path. An empty rawText used to fall through parseAgentXml and surface as a
+// generic 'parse_error' ("parser rejected response"), and the generic Error
+// thrown afterwards burned all 3 BullMQ retry attempts on a job whose outbox
+// row was already terminally failed. These tests pin the new behavior:
+//
+//   - processGeneratedResponse / processSessionSummaryResponse detect empty
+//     rawText BEFORE parsing and return a distinct 'empty_response' outcome
+//     without touching the database.
+//   - the generator surfaces terminal outcomes as a bullmq UnrecoverableError
+//     subclass so BullMQ fails the job immediately instead of retry fan-out.
+//
+// These tests deliberately run without CLAUDE_MEM_TEST_POSTGRES_URL: the
+// empty-response path must return before any pool usage, which the poisoned
+// pool below enforces for real.
+
+import { describe, expect, it } from 'bun:test';
+import { UnrecoverableError } from 'bullmq';
+import {
+  processGeneratedResponse,
+  processSessionSummaryResponse,
+  type ProcessGeneratedResponseInput,
+} from '../../../src/server/generation/processGeneratedResponse.js';
+import { ServerGenerationTerminalOutcomeError } from '../../../src/server/generation/ProviderObservationGenerator.js';
+import type { PostgresObservationGenerationJob } from '../../../src/storage/postgres/generation-jobs.js';
+
+// Any pool method call means the guard leaked past the early return.
+const poisonedPool = new Proxy({}, {
+  get(_target, prop) {
+    throw new Error(`empty-response guard touched the database (pool.${String(prop)})`);
+  },
+}) as ProcessGeneratedResponseInput['pool'];
+
+function makeJob(sourceType: PostgresObservationGenerationJob['sourceType']): PostgresObservationGenerationJob {
+  return {
+    id: 'job-1',
+    projectId: 'project-1',
+    teamId: 'team-1',
+    agentEventId: sourceType === 'agent_event' ? 'event-1' : null,
+    sourceType,
+    sourceId: 'source-1',
+    serverSessionId: sourceType === 'session_summary' ? 'session-1' : null,
+    jobType: 'observation_generate_for_event',
+    status: 'processing',
+    idempotencyKey: 'idem-1',
+    bullmqJobId: 'bull-1',
+    attempts: 1,
+    maxAttempts: 3,
+    nextAttemptAtEpoch: null,
+    lockedAtEpoch: Date.now(),
+    lockedBy: 'test-worker',
+    completedAtEpoch: null,
+    failedAtEpoch: null,
+    cancelledAtEpoch: null,
+    lastError: null,
+    payload: {},
+    createdAtEpoch: Date.now(),
+    updatedAtEpoch: Date.now(),
+  };
+}
+
+function makeInput(rawText: string, sourceType: PostgresObservationGenerationJob['sourceType'] = 'agent_event'): ProcessGeneratedResponseInput {
+  return {
+    pool: poisonedPool,
+    job: makeJob(sourceType),
+    rawText,
+    providerLabel: 'claude',
+  };
+}
+
+describe('empty assistant response fail-fast guard', () => {
+  it('processGeneratedResponse returns empty_response for an empty rawText without touching the database', async () => {
+    const outcome = await processGeneratedResponse(makeInput(''));
+    expect(outcome.kind).toBe('empty_response');
+    if (outcome.kind === 'empty_response') {
+      expect(outcome.jobId).toBe('job-1');
+      expect(outcome.reason).toMatch(/empty/i);
+    }
+  });
+
+  it('processGeneratedResponse treats whitespace-only rawText as empty', async () => {
+    const outcome = await processGeneratedResponse(makeInput('  \n\t '));
+    expect(outcome.kind).toBe('empty_response');
+  });
+
+  it('processSessionSummaryResponse returns empty_response for an empty rawText', async () => {
+    const outcome = await processSessionSummaryResponse(makeInput('', 'session_summary'));
+    expect(outcome.kind).toBe('empty_response');
+  });
+
+  it('non-empty malformed text still classifies as parse_error, not empty_response', async () => {
+    const outcome = await processGeneratedResponse(makeInput('not xml at all'));
+    expect(outcome.kind).toBe('parse_error');
+  });
+
+  it('terminal outcome error is a bullmq UnrecoverableError so BullMQ skips remaining attempts', () => {
+    const error = new ServerGenerationTerminalOutcomeError('empty_response', 'generation empty response: provider returned empty content');
+    expect(error).toBeInstanceOf(UnrecoverableError);
+    expect(error.classification).toBe('empty_response');
+    // BullMQ identifies unrecoverable errors by name, so subclassing must not change it.
+    expect(error.name).toBe('UnrecoverableError');
+  });
+});

--- a/tests/server/generation/provider-observation-generator.test.ts
+++ b/tests/server/generation/provider-observation-generator.test.ts
@@ -131,6 +131,33 @@ describe('ProviderObservationGenerator', () => {
     expect(reloaded?.status).toBe('completed');
   });
 
+  it('fails fast with an UnrecoverableError when provider returns an empty response', async () => {
+    const provider = new StubProvider('');
+    const generator = new ProviderObservationGenerator({
+      pool: pool as unknown as pg.Pool,
+      provider,
+    } as unknown as ConstructorParameters<typeof ProviderObservationGenerator>[0]);
+
+    // UnrecoverableError name is what makes BullMQ skip its remaining retry
+    // attempts instead of re-dispatching a job whose outbox row is terminal.
+    const rejection = await generator.process(makeJob()).then(
+      () => null,
+      (error: unknown) => error as Error,
+    );
+    expect(rejection).not.toBeNull();
+    expect(rejection?.name).toBe('UnrecoverableError');
+    expect(rejection?.message).toMatch(/empty response/);
+    expect(provider.calls).toBe(1);
+
+    const reloaded = await storage.observationGenerationJobs.getByIdForScope({
+      id: jobId,
+      projectId,
+      teamId,
+    });
+    expect(reloaded?.status).toBe('failed');
+    expect(reloaded?.lastError?.classification).toBe('empty_response');
+  });
+
   it('marks a job as failed (no retry) when provider returns malformed XML', async () => {
     const provider = new StubProvider('not xml at all');
     const generator = new ProviderObservationGenerator({

--- a/tests/worker/empty-response-guard.test.ts
+++ b/tests/worker/empty-response-guard.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import {
+  guardEmptyMessageResponse,
+  MAX_CONSECUTIVE_EMPTY_RESPONSES,
+} from '../../src/services/worker/OpenAICompatibleProvider';
+import type { ActiveSession } from '../../src/services/worker-types';
+import type { SessionManager } from '../../src/services/worker/SessionManager';
+
+function makeSession(overrides: Partial<ActiveSession> = {}): ActiveSession {
+  return {
+    sessionDbId: 1,
+    contentSessionId: 'content-1',
+    memorySessionId: 'mem-1',
+    project: 'test-project',
+    platformSource: 'claude-code',
+    userPrompt: 'prompt',
+    abortController: new AbortController(),
+    generatorPromise: null,
+    lastPromptNumber: 1,
+    startTime: Date.now(),
+    cumulativeInputTokens: 0,
+    cumulativeOutputTokens: 0,
+    earliestPendingTimestamp: 12345,
+    claimedMessageIds: [10, 11],
+    conversationHistory: [],
+    currentProvider: 'gemini',
+    consecutiveRestarts: 0,
+    consecutiveInvalidOutputs: 0,
+    consecutiveEmptyResponses: 0,
+    lastGeneratorActivity: Date.now(),
+    ...overrides,
+  } as ActiveSession;
+}
+
+function makeSessionManager() {
+  const calls: number[] = [];
+  const sessionManager = {
+    confirmClaimedMessages: async (sessionDbId: number) => {
+      calls.push(sessionDbId);
+      return 0;
+    },
+  } as unknown as SessionManager;
+  return { sessionManager, calls };
+}
+
+describe('guardEmptyMessageResponse', () => {
+  let session: ActiveSession;
+
+  beforeEach(() => {
+    session = makeSession();
+  });
+
+  it('leaves the queue intact below the threshold', async () => {
+    const { sessionManager, calls } = makeSessionManager();
+
+    for (let i = 1; i < MAX_CONSECUTIVE_EMPTY_RESPONSES; i++) {
+      await guardEmptyMessageResponse(session, sessionManager, 'Gemini', 'observation');
+      expect(session.consecutiveEmptyResponses).toBe(i);
+      expect(calls.length).toBe(0);
+      expect(session.earliestPendingTimestamp).toBe(12345);
+    }
+  });
+
+  it('drops the claimed batch once the threshold is reached', async () => {
+    const { sessionManager, calls } = makeSessionManager();
+    session.consecutiveEmptyResponses = MAX_CONSECUTIVE_EMPTY_RESPONSES - 1;
+
+    await guardEmptyMessageResponse(session, sessionManager, 'Gemini', 'summary');
+
+    expect(calls).toEqual([1]);
+    expect(session.earliestPendingTimestamp).toBeNull();
+    // Counter resets so the next batch gets a fresh allowance.
+    expect(session.consecutiveEmptyResponses).toBe(0);
+  });
+
+  it('tolerates sessions created before the counter existed', async () => {
+    const { sessionManager, calls } = makeSessionManager();
+    delete (session as { consecutiveEmptyResponses?: number }).consecutiveEmptyResponses;
+
+    await guardEmptyMessageResponse(session, sessionManager, 'Gemini', 'observation');
+
+    expect(session.consecutiveEmptyResponses).toBe(1);
+    expect(calls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

An empty assistant response (safety block, MAX_TOKENS truncation, gateway hiccup) is mishandled on both observer output paths:

**Worker path** (`OpenAICompatibleProvider` → Gemini/OpenRouter): an empty observation/summary response left the claimed batch in the queue unconditionally. Because `getMessageIterator` resets claimed-but-unconfirmed messages back to pending on every generator start, a model persistently returning empty content re-queried the same batch on every restart — an unbounded retry loop.

**Server path** (BullMQ → `ProviderObservationGenerator`): all three server adapters log a warning and pass empty `rawText` downstream. `parseAgentXml('')` rejects it, so the failure was misattributed as `parse_error` ("parser rejected response") instead of a provider failure. The plain `Error` thrown afterwards then burned all 3 BullMQ retry attempts re-dispatching a job whose outbox row was already terminally `failed` — pure retry fan-out where every attempt was a no-op. The catch block also re-marked the failure a second time under a bogus `unknown` classification.

## Fix

**Worker path** — track consecutive empty responses per session; after 3 in a row, drop the claimed batch loudly instead of leaving it queued. Any non-empty response resets the counter.

**Server path** —
- `processGeneratedResponse` / `processSessionSummaryResponse` detect empty `rawText` **before** parsing and return a distinct `empty_response` outcome without touching the database.
- The generator throws `ServerGenerationTerminalOutcomeError extends UnrecoverableError` (bullmq) for terminal outcomes (`empty_response`, `parse_error`), so BullMQ fails the job immediately instead of consuming its remaining attempts. The error name is pinned to `UnrecoverableError` because BullMQ also detects these by name (`job.js`: `err.name == 'UnrecoverableError'`), which survives duplicated bullmq installs where `instanceof` breaks.
- `process()`'s catch no longer re-marks already-terminal failures, removing the duplicate lifecycle event.

## Tests

- `tests/worker/empty-response-guard.test.ts` — worker-path counter/drop behavior.
- `tests/server/generation/empty-response-guard.test.ts` — runs without Postgres; a poisoned pool proves the empty-response path never touches the DB. Also pins: whitespace-only counts as empty, malformed-but-non-empty text still classifies as `parse_error`, and the terminal error is BullMQ-unrecoverable by both `instanceof` and name.
- `tests/server/generation/provider-observation-generator.test.ts` — PG-gated end-to-end: empty response → exactly 1 provider call, job `failed`, `lastError.classification === 'empty_response'`, rejection named `UnrecoverableError`.

`bun test tests/server/ tests/worker/`: **412 pass, 0 fail** (13 PG-gated skips locally). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)