### PR TITLE
fix(chroma): contain chroma-mcp orphans from ungraceful worker deaths

### DIFF
--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -220,6 +220,15 @@ export class ChromaMcpManager {
       await this.disposeCurrentSubprocess();
       throw error;
     }
+
+    // Track the child from the moment it exists, not only after the handshake
+    // succeeds: connect() calls transport.start(), which spawns synchronously
+    // before awaiting, so a worker exiting during the pending/timed-out
+    // connection window must still be able to kill the already-running child
+    // (PR #3369 review). Failure paths route through
+    // disposeCurrentSubprocess(), which clears the tracked pid.
+    ChromaMcpManager.liveChildPid = (this.transport as unknown as { _process?: ChildProcess })._process?.pid;
+    ChromaMcpManager.registerExitSafetyNet();
     let timeoutId: ReturnType<typeof setTimeout>;
     const timeoutPromise = new Promise<never>((_, reject) => {
       timeoutId = setTimeout(
@@ -263,16 +272,6 @@ export class ChromaMcpManager {
 
     const currentTransport = this.transport;
     const currentTrackedPid = (this.transport as unknown as { _process?: ChildProcess })._process?.pid;
-
-    // Exit-time safety net: if this process exits while the chroma child is
-    // still alive (graceful shutdown failed or hit its deadline and
-    // worker-shutdown.ts proceeded anyway, or any stray process.exit), the
-    // 'exit' handler below sync-kills the child tree as the final act. This
-    // is the last in-process line of defense; SIGKILL deaths are covered by
-    // reapOrphanedChromaProcesses on the next boot.
-    ChromaMcpManager.liveChildPid = currentTrackedPid;
-    ChromaMcpManager.registerExitSafetyNet();
-
     this.transport.onclose = () => {
       if (this.transport !== currentTransport) {
         logger.debug('CHROMA_MCP', 'Ignoring stale onclose from previous transport');
@@ -291,9 +290,10 @@ export class ChromaMcpManager {
       this.client = null;
       this.transport = null;
       this.lastConnectionFailureTimestamp = Date.now();
-      if (ChromaMcpManager.liveChildPid === currentTrackedPid) {
-        ChromaMcpManager.liveChildPid = undefined;
-      }
+      // liveChildPid is NOT cleared here: the background cleanup below still
+      // has to tree-kill surviving descendants, and a worker exit during that
+      // window must leave the exit handler able to finish the job. The pid is
+      // cleared when the cleanup completes (PR #3369 review).
 
       // Direct child (uvx) emitted close, but on Linux the grandchildren
       // (uv/python/chroma-mcp) often outlive their parent because MCP SDK
@@ -325,6 +325,13 @@ export class ChromaMcpManager {
         error: error instanceof Error ? error.message : String(error)
       });
     } finally {
+      // Only now is the descendant sweep done — release the exit-time
+      // tracking so the handler doesn't re-kill a completed tree, but never
+      // earlier, so a worker exit mid-cleanup can still finish the job
+      // (PR #3369 review).
+      if (pid && ChromaMcpManager.liveChildPid === pid) {
+        ChromaMcpManager.liveChildPid = undefined;
+      }
       this.releaseChromaWriterLock();
     }
   }
@@ -629,6 +636,11 @@ export class ChromaMcpManager {
       windowsHide: process.platform === 'win32',
     });
     this.activePrewarmChild = child;
+    // Same spawn-time tracking rationale as the transport child: a worker
+    // exiting mid-prewarm (uvx resolution can take minutes cold) must be able
+    // to kill the in-flight uvx tree from the exit handler (PR #3369 review).
+    ChromaMcpManager.liveChildPid = child.pid;
+    ChromaMcpManager.registerExitSafetyNet();
 
     const stdoutTail = ChromaMcpManager.captureOutputTail(child.stdout);
     const stderrTail = ChromaMcpManager.captureOutputTail(child.stderr);
@@ -707,6 +719,12 @@ export class ChromaMcpManager {
       }
       if (this.activePrewarmChild === child) {
         this.activePrewarmChild = null;
+      }
+      // The prewarm child has exited (or been tree-killed) on every path out
+      // of the race above; release the exit-time tracking so it never holds
+      // a stale pid. The transport spawn that follows re-populates it.
+      if (child.pid && ChromaMcpManager.liveChildPid === child.pid) {
+        ChromaMcpManager.liveChildPid = undefined;
       }
     }
   }
@@ -1136,6 +1154,7 @@ export class ChromaMcpManager {
   private static liveChildPid: number | undefined;
   private static exitSafetyNetRegistered = false;
   private static orphanReapDone = false;
+  private static orphanReapInFlight = false;
 
   private static registerExitSafetyNet(): void {
     if (ChromaMcpManager.exitSafetyNetRegistered) {
@@ -1215,11 +1234,18 @@ export class ChromaMcpManager {
    * Pure parser for the orphan reaper: given `ps -axo pid=,ppid=,command=`
    * output, return the pids of chroma-mcp processes that (a) have been
    * re-parented to init/launchd (ppid 1 — only true orphans qualify; live
-   * workers' children keep their worker as ppid) and (b) reference OUR chroma
-   * data dir (never another install's, and never the http/remote mode which
-   * has no local dir).
+   * workers' children keep their worker as ppid) and (b) carry OUR chroma
+   * data dir as their `--data-dir` argument (never another install's, and
+   * never the http/remote mode which has no local dir).
    */
   static findOrphanedChromaRoots(psOutput: string, normalizedDataDir: string): number[] {
+    // Boundary-anchored match: `--data-dir <dir>` followed by whitespace or
+    // end-of-command. A bare substring test would also match sibling dirs
+    // that merely share the prefix (e.g. `.claude-mem/chroma-backup`) and
+    // kill an unrelated install's process tree (PR #3369 review).
+    const escapedDataDir = normalizedDataDir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const dataDirArgPattern = new RegExp(`(?:^|\\s)--data-dir\\s+${escapedDataDir}(?:\\s|$)`);
+
     const orphanRoots: number[] = [];
     for (const row of psOutput.split('\n')) {
       const match = row.match(/^\s*(\d+)\s+(\d+)\s+(.*)$/);
@@ -1230,7 +1256,7 @@ export class ChromaMcpManager {
       if (ppidText !== '1') {
         continue;
       }
-      if (!command.includes('chroma-mcp') || !command.includes(normalizedDataDir)) {
+      if (!command.includes('chroma-mcp') || !dataDirArgPattern.test(command)) {
         continue;
       }
       const pid = Number.parseInt(pidText, 10);
@@ -1248,14 +1274,16 @@ export class ChromaMcpManager {
    * tree, and ppid-based matching is unsafe there due to pid reuse).
    */
   private static async reapOrphanedChromaProcesses(localChromaDataDir: string | null): Promise<void> {
-    if (ChromaMcpManager.orphanReapDone) {
+    if (ChromaMcpManager.orphanReapDone || ChromaMcpManager.orphanReapInFlight) {
       return;
     }
-    ChromaMcpManager.orphanReapDone = true;
 
     if (process.platform === 'win32' || !localChromaDataDir) {
+      ChromaMcpManager.orphanReapDone = true;
       return;
     }
+
+    ChromaMcpManager.orphanReapInFlight = true;
 
     const normalizedDataDir = localChromaDataDir.replace(/\\/g, '/');
 
@@ -1266,11 +1294,19 @@ export class ChromaMcpManager {
         maxBuffer: 4 * 1024 * 1024
       }));
     } catch (error) {
-      logger.debug('CHROMA_MCP', 'Orphan reap skipped: ps enumeration failed (best-effort)', {
+      // Do NOT latch orphanReapDone on a failed enumeration — a transient ps
+      // failure would otherwise disable reaping for this worker's entire
+      // lifetime, leaving existing orphans running until the NEXT worker
+      // boots (PR #3369 review). The next reconnect retries.
+      ChromaMcpManager.orphanReapInFlight = false;
+      logger.debug('CHROMA_MCP', 'Orphan reap skipped: ps enumeration failed (best-effort, will retry on next connect)', {
         error: error instanceof Error ? error.message : String(error)
       });
       return;
     }
+
+    ChromaMcpManager.orphanReapDone = true;
+    ChromaMcpManager.orphanReapInFlight = false;
 
     const orphanRoots = ChromaMcpManager.findOrphanedChromaRoots(stdout, normalizedDataDir);
     if (orphanRoots.length === 0) {

--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -149,6 +149,18 @@ export class ChromaMcpManager {
     this.assertConnectionNotCancelled(connectionGeneration);
 
     const localChromaDataDir = this.getLocalPersistentChromaDataDir();
+
+    // Reap orphans left by UNGRACEFUL worker deaths (SIGKILL, crash, or a
+    // restart whose graceful shutdown failed/timed out and proceeded per
+    // worker-shutdown.ts). #2313's in-process sweeps cannot cover those paths
+    // by construction — nothing in the dying process runs — and chroma-mcp
+    // does not exit on stdin EOF, so each such death leaks a uv+python pair
+    // to init/launchd forever (observed: 221 pairs / ~3 GB RSS on one
+    // machine during a version-mismatch recycle storm). Fire-and-forget so
+    // connect latency is unaffected; matching is scoped to processes
+    // re-parented to init AND referencing OUR data dir, so live workers'
+    // children are never touched.
+    void ChromaMcpManager.reapOrphanedChromaProcesses(localChromaDataDir);
     const commandArgs = this.buildCommandArgs(localChromaDataDir);
     const uvxPreflightEnv = ChromaMcpManager.getUvxPreflightEnv();
     getSupervisor().assertCanSpawn('chroma mcp');
@@ -251,6 +263,16 @@ export class ChromaMcpManager {
 
     const currentTransport = this.transport;
     const currentTrackedPid = (this.transport as unknown as { _process?: ChildProcess })._process?.pid;
+
+    // Exit-time safety net: if this process exits while the chroma child is
+    // still alive (graceful shutdown failed or hit its deadline and
+    // worker-shutdown.ts proceeded anyway, or any stray process.exit), the
+    // 'exit' handler below sync-kills the child tree as the final act. This
+    // is the last in-process line of defense; SIGKILL deaths are covered by
+    // reapOrphanedChromaProcesses on the next boot.
+    ChromaMcpManager.liveChildPid = currentTrackedPid;
+    ChromaMcpManager.registerExitSafetyNet();
+
     this.transport.onclose = () => {
       if (this.transport !== currentTransport) {
         logger.debug('CHROMA_MCP', 'Ignoring stale onclose from previous transport');
@@ -269,6 +291,9 @@ export class ChromaMcpManager {
       this.client = null;
       this.transport = null;
       this.lastConnectionFailureTimestamp = Date.now();
+      if (ChromaMcpManager.liveChildPid === currentTrackedPid) {
+        ChromaMcpManager.liveChildPid = undefined;
+      }
 
       // Direct child (uvx) emitted close, but on Linux the grandchildren
       // (uv/python/chroma-mcp) often outlive their parent because MCP SDK
@@ -863,6 +888,9 @@ export class ChromaMcpManager {
 
     if (trackedPid) {
       getSupervisor().unregisterProcess(CHROMA_SUPERVISOR_ID);
+      if (ChromaMcpManager.liveChildPid === trackedPid) {
+        ChromaMcpManager.liveChildPid = undefined;
+      }
     }
     this.releaseChromaWriterLock();
 
@@ -1081,6 +1109,189 @@ export class ChromaMcpManager {
 
     await walk(rootPid);
     return collected;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Orphan containment for UNGRACEFUL worker deaths.
+  //
+  // #2313 hardened every in-process path (reconnect, failed connect,
+  // unexpected close, stop()), but none of those can run when the WORKER
+  // itself dies without cleanup: SIGKILL/crash, or a restart whose graceful
+  // shutdown failed or hit its hard deadline and proceeded by design
+  // (worker-shutdown.ts). chroma-mcp does not exit on stdin EOF, so the
+  // uv -> python pair re-parents to init/launchd and lives forever. Observed
+  // in production logs: 128 chroma spawns and zero "Stopping chroma-mcp"
+  // events in a single day during a version-mismatch recycle storm, leaving
+  // 221 orphaned pairs (~3 GB RSS).
+  //
+  // Two complementary defenses:
+  //   1. registerExitSafetyNet(): a process 'exit' handler that synchronously
+  //      tree-kills the live child — covers every path where the worker exits
+  //      under its own power, including failed-graceful restarts.
+  //   2. reapOrphanedChromaProcesses(): at connect time, kill chroma-mcp
+  //      processes already re-parented to init that reference OUR data dir —
+  //      covers SIGKILL/crash, which no in-process handler can.
+  // ---------------------------------------------------------------------------
+
+  private static liveChildPid: number | undefined;
+  private static exitSafetyNetRegistered = false;
+  private static orphanReapDone = false;
+
+  private static registerExitSafetyNet(): void {
+    if (ChromaMcpManager.exitSafetyNetRegistered) {
+      return;
+    }
+    ChromaMcpManager.exitSafetyNetRegistered = true;
+    process.on('exit', () => {
+      const pid = ChromaMcpManager.liveChildPid;
+      if (!pid) {
+        return;
+      }
+      try {
+        ChromaMcpManager.killProcessTreeSyncBestEffort(pid);
+      } catch {
+        // Exiting anyway — nothing useful to do.
+      }
+    });
+  }
+
+  /**
+   * Synchronous best-effort tree-kill for use inside a process 'exit'
+   * handler, where async killProcessTree cannot run. Same layering rationale
+   * as killProcessTree: signal descendants (deepest first) before the root so
+   * re-parenting can't strand the grandchildren.
+   */
+  private static killProcessTreeSyncBestEffort(rootPid: number): void {
+    if (process.platform === 'win32') {
+      try {
+        execSync(`taskkill /PID ${rootPid} /T /F`, { timeout: 5_000, windowsHide: true, stdio: 'ignore' });
+      } catch {
+        // Already dead — fine.
+      }
+      return;
+    }
+
+    const collected: number[] = [];
+    const seen = new Set<number>([rootPid]);
+    const queue: number[] = [rootPid];
+    // Bounded BFS: the real tree is uvx -> uv -> python (depth 3, a handful
+    // of pids); the caps only guard against pathological pgrep output.
+    while (queue.length > 0 && collected.length < 64) {
+      const pid = queue.shift()!;
+      let stdout = '';
+      try {
+        stdout = execSync(`pgrep -P ${pid}`, { timeout: 2_000, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] });
+      } catch {
+        // pgrep exits 1 when a pid has no children — expected leaf case.
+        continue;
+      }
+      for (const line of stdout.split('\n')) {
+        const child = Number.parseInt(line.trim(), 10);
+        if (Number.isFinite(child) && child > 0 && !seen.has(child)) {
+          seen.add(child);
+          collected.push(child);
+          queue.push(child);
+        }
+      }
+    }
+
+    // BFS order is shallow-first; reverse so leaves get SIGKILL before their
+    // parents, mirroring killProcessTree's bottom-up ordering.
+    for (const pid of [...collected].reverse()) {
+      try {
+        process.kill(pid, 'SIGKILL');
+      } catch {
+        // Already dead — fine.
+      }
+    }
+    try {
+      process.kill(rootPid, 'SIGKILL');
+    } catch {
+      // Already dead — fine.
+    }
+  }
+
+  /**
+   * Pure parser for the orphan reaper: given `ps -axo pid=,ppid=,command=`
+   * output, return the pids of chroma-mcp processes that (a) have been
+   * re-parented to init/launchd (ppid 1 — only true orphans qualify; live
+   * workers' children keep their worker as ppid) and (b) reference OUR chroma
+   * data dir (never another install's, and never the http/remote mode which
+   * has no local dir).
+   */
+  static findOrphanedChromaRoots(psOutput: string, normalizedDataDir: string): number[] {
+    const orphanRoots: number[] = [];
+    for (const row of psOutput.split('\n')) {
+      const match = row.match(/^\s*(\d+)\s+(\d+)\s+(.*)$/);
+      if (!match) {
+        continue;
+      }
+      const [, pidText, ppidText, command] = match;
+      if (ppidText !== '1') {
+        continue;
+      }
+      if (!command.includes('chroma-mcp') || !command.includes(normalizedDataDir)) {
+        continue;
+      }
+      const pid = Number.parseInt(pidText, 10);
+      if (Number.isFinite(pid) && pid > 1) {
+        orphanRoots.push(pid);
+      }
+    }
+    return orphanRoots;
+  }
+
+  /**
+   * Kill chroma-mcp orphans left behind by a previous worker's ungraceful
+   * death. Runs once per process, POSIX only (init re-parenting is a POSIX
+   * phenomenon; on Windows taskkill /T at spawn teardown already handles the
+   * tree, and ppid-based matching is unsafe there due to pid reuse).
+   */
+  private static async reapOrphanedChromaProcesses(localChromaDataDir: string | null): Promise<void> {
+    if (ChromaMcpManager.orphanReapDone) {
+      return;
+    }
+    ChromaMcpManager.orphanReapDone = true;
+
+    if (process.platform === 'win32' || !localChromaDataDir) {
+      return;
+    }
+
+    const normalizedDataDir = localChromaDataDir.replace(/\\/g, '/');
+
+    let stdout = '';
+    try {
+      ({ stdout } = await execFileAsync('ps', ['-axo', 'pid=,ppid=,command='], {
+        timeout: 5_000,
+        maxBuffer: 4 * 1024 * 1024
+      }));
+    } catch (error) {
+      logger.debug('CHROMA_MCP', 'Orphan reap skipped: ps enumeration failed (best-effort)', {
+        error: error instanceof Error ? error.message : String(error)
+      });
+      return;
+    }
+
+    const orphanRoots = ChromaMcpManager.findOrphanedChromaRoots(stdout, normalizedDataDir);
+    if (orphanRoots.length === 0) {
+      return;
+    }
+
+    logger.warn('CHROMA_MCP', 'Reaping orphaned chroma-mcp processes from a previous ungraceful worker death', {
+      pids: orphanRoots.join(','),
+      dataDir: normalizedDataDir
+    });
+
+    for (const pid of orphanRoots) {
+      try {
+        await ChromaMcpManager.killProcessTree(pid);
+      } catch (error) {
+        logger.debug('CHROMA_MCP', 'Orphan tree-kill finished (best-effort)', {
+          pid,
+          error: error instanceof Error ? error.message : String(error)
+        });
+      }
+    }
   }
 
   /**

--- a/tests/services/sync/chroma-mcp-orphan-reaper.test.ts
+++ b/tests/services/sync/chroma-mcp-orphan-reaper.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'bun:test';
+import { ChromaMcpManager } from '../../../src/services/sync/ChromaMcpManager.js';
+
+// Orphan-reaper selection coverage.
+//
+// Hypothesis under test: chroma-mcp subprocess pairs orphaned by an UNGRACEFUL
+// worker death (SIGKILL / crash / failed-graceful restart) re-parent to
+// init/launchd (ppid 1) and, because chroma-mcp does not exit on stdin EOF,
+// live forever — observed in production as 221 leaked uv+python pairs (~3 GB
+// RSS) accumulated during a version-mismatch recycle storm. The reaper must
+// select exactly those processes: re-parented to init AND referencing OUR
+// chroma data dir. It must never select live workers' children (ppid != 1),
+// other installs' data dirs, or unrelated processes.
+
+const DATA_DIR = '/Users/someone/.claude-mem/chroma';
+
+function psRow(pid: number, ppid: number, command: string): string {
+  return `${String(pid).padStart(5)} ${String(ppid).padStart(5)} ${command}`;
+}
+
+const UV_ORPHAN = psRow(
+  88562,
+  1,
+  `/Users/someone/.local/bin/uv tool uvx --python 3.13 --with onnxruntime>=1.20 --with protobuf<7 --from chroma-mcp==0.2.6 chroma-mcp --client-type persistent --data-dir ${DATA_DIR}`
+);
+const PYTHON_ORPHAN = psRow(
+  90001,
+  1,
+  `/opt/homebrew/bin/python3.13 /Users/someone/.cache/uv/archive-v0/abc/bin/chroma-mcp --client-type persistent --data-dir ${DATA_DIR}`
+);
+const LIVE_WORKER_CHILD = psRow(
+  88816,
+  88778,
+  `/Users/someone/.local/bin/uv tool uvx --from chroma-mcp==0.2.6 chroma-mcp --client-type persistent --data-dir ${DATA_DIR}`
+);
+const OTHER_INSTALL_ORPHAN = psRow(
+  91000,
+  1,
+  `/Users/someone/.local/bin/uv tool uvx --from chroma-mcp==0.2.6 chroma-mcp --client-type persistent --data-dir /Users/other/.claude-mem/chroma`
+);
+const UNRELATED_INIT_CHILD = psRow(2001, 1, '/usr/libexec/secd');
+
+describe('ChromaMcpManager.findOrphanedChromaRoots', () => {
+  it('selects chroma-mcp processes re-parented to init that reference our data dir', () => {
+    const psOutput = [UV_ORPHAN, PYTHON_ORPHAN, LIVE_WORKER_CHILD, UNRELATED_INIT_CHILD].join('\n');
+    expect(ChromaMcpManager.findOrphanedChromaRoots(psOutput, DATA_DIR)).toEqual([88562, 90001]);
+  });
+
+  it('never selects a live worker\'s chroma child (ppid is the worker, not init)', () => {
+    expect(ChromaMcpManager.findOrphanedChromaRoots(LIVE_WORKER_CHILD, DATA_DIR)).toEqual([]);
+  });
+
+  it('never selects another install\'s orphans (data dir mismatch)', () => {
+    expect(ChromaMcpManager.findOrphanedChromaRoots(OTHER_INSTALL_ORPHAN, DATA_DIR)).toEqual([]);
+  });
+
+  it('ignores unrelated init children and malformed rows', () => {
+    const psOutput = [UNRELATED_INIT_CHILD, 'garbage row', '', '   '].join('\n');
+    expect(ChromaMcpManager.findOrphanedChromaRoots(psOutput, DATA_DIR)).toEqual([]);
+  });
+
+  it('returns an empty list for empty ps output', () => {
+    expect(ChromaMcpManager.findOrphanedChromaRoots('', DATA_DIR)).toEqual([]);
+  });
+});

--- a/tests/services/sync/chroma-mcp-orphan-reaper.test.ts
+++ b/tests/services/sync/chroma-mcp-orphan-reaper.test.ts
@@ -38,6 +38,13 @@ const OTHER_INSTALL_ORPHAN = psRow(
   1,
   `/Users/someone/.local/bin/uv tool uvx --from chroma-mcp==0.2.6 chroma-mcp --client-type persistent --data-dir /Users/other/.claude-mem/chroma`
 );
+// Shares OUR data dir as a path PREFIX — a bare substring match would kill it
+// (PR #3369 review); the boundary-anchored --data-dir match must not.
+const PREFIXED_PEER_ORPHAN = psRow(
+  92000,
+  1,
+  `/Users/someone/.local/bin/uv tool uvx --from chroma-mcp==0.2.6 chroma-mcp --client-type persistent --data-dir ${DATA_DIR}-backup`
+);
 const UNRELATED_INIT_CHILD = psRow(2001, 1, '/usr/libexec/secd');
 
 describe('ChromaMcpManager.findOrphanedChromaRoots', () => {
@@ -52,6 +59,11 @@ describe('ChromaMcpManager.findOrphanedChromaRoots', () => {
 
   it('never selects another install\'s orphans (data dir mismatch)', () => {
     expect(ChromaMcpManager.findOrphanedChromaRoots(OTHER_INSTALL_ORPHAN, DATA_DIR)).toEqual([]);
+  });
+
+  it('never selects a peer whose data dir merely shares our dir as a prefix', () => {
+    const psOutput = [PREFIXED_PEER_ORPHAN, UV_ORPHAN].join('\n');
+    expect(ChromaMcpManager.findOrphanedChromaRoots(psOutput, DATA_DIR)).toEqual([88562]);
   });
 
   it('ignores unrelated init children and malformed rows', () => {


### PR DESCRIPTION
## The gap

#2313 hardened every **in-process** leak path (reconnect, failed connect, unexpected close, `stop()`), but none of those can run when the **worker itself** dies without cleanup:

- SIGKILL / crash - nothing in the dying process runs at all
- a restart whose graceful shutdown **failed or hit its hard deadline** and proceeded by design (`worker-shutdown.ts`'s documented "proceed on error, never abort the handoff" policy)

`chroma-mcp` does not exit on stdin EOF, so on those paths the `uv -> python` pair re-parents to init/launchd and lives forever.

## Real-world impact (how I found this)

On my machine (macOS, 13.11.0 -> 13.12.0 upgrade window), a version-mismatch recycle storm repeatedly killed and respawned the worker. One day of logs showed **128 "Prewarming chroma-mcp" / 116 "Connecting to chroma-mcp" events and zero "Stopping chroma-mcp" events** - every death was ungraceful. Result: **221 orphaned uv+python pairs totalling ~3 GB RSS**, all parented to launchd, some alive for days:

```
pid=1829  ppid=1  .../bin/uv tool uvx --python 3.13 --with onnxruntime>=1.20 ... chroma-mcp --client-type persistent --data-dir ~/.claude-mem/chroma
pid=1982  ppid=1829  .../Python  (chroma-mcp)
... x221
```

## The fix - two complementary defenses in `ChromaMcpManager`

1. **Exit-time safety net**: a `process.on('exit')` handler that synchronously tree-kills the live chroma child (pid tracked at connect, cleared on dispose/unexpected close). Covers every path where the worker exits under its own power - including the failed-graceful restart path, which today deliberately proceeds without chroma cleanup.

2. **Boot-time orphan reaper**: at connect time (fire-and-forget, once per process), kill chroma-mcp processes **already re-parented to init** that **reference our data dir**. Covers SIGKILL/crash, which no in-process handler can. Selection is deliberately narrow - `ppid == 1` AND command contains our normalized chroma data dir - so live workers' children (ppid = worker) and other installs' processes are never touched. POSIX-only: init re-parenting is a POSIX phenomenon, and ppid matching is unsafe on Windows due to pid reuse (win32 keeps its existing `taskkill /T` handling).

Both reuse the existing `killProcessTree` layering (descendants first, then root). The reaper's selection logic is extracted as a pure static (`findOrphanedChromaRoots`) with unit coverage (orphan uv + orphan python selected; live worker's child, other install's orphan, malformed rows, empty output all rejected).

## Verification

- `bun test tests/services/sync/` - 30 pass (existing #2313 lifecycle tests + 5 new)
- End-to-end on macOS against the built worker:
  - `SIGKILL` the worker -> pair re-parents to `ppid 1` -> next worker boot reaps both within seconds
  - `SIGTERM` (graceful) -> exit handler leaves zero chroma processes
  - Steady state: exactly one properly-parented pair per worker

## Related observation (not addressed here)

The leak *amplifier* on my machine was a recycle storm: with two cached plugin versions present, hook-side plugin-root resolution (`ls -dt` = directory mtime) can keep spawning the older version's worker while the version check demands the newer one, producing an endless kill/respawn loop (135 worker starts in a day). This PR contains the damage (each cycle no longer leaks a pair); resolving versions by semver rather than dir mtime would kill the storm itself - happy to file that separately if useful.