### PR TITLE
fix: roll back failed provider prompts before retry

### DIFF
--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -164,7 +164,14 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
           await this.processSummaryMessage(session, message, worker, config, mode, originalTimestamp, lastCwd);
         }
       } catch (error) {
-        session.conversationHistory.length = messageHistoryLength;
+        // Only erase the prompt/response when the claimed queue item still
+        // exists and can actually be retried. processAgentResponse confirms
+        // the item immediately after durable SQLite storage; a later
+        // broadcast/sync failure must not erase that already-completed turn.
+        const retryableMessages = this.sessionManager.getClaimedMessages(session.sessionDbId);
+        if (retryableMessages.length > 0) {
+          session.conversationHistory.length = messageHistoryLength;
+        }
         throw error;
       }
     }

--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -102,6 +102,7 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
       : buildContinuationPrompt(session.userPrompt, session.lastPromptNumber, session.contentSessionId, mode);
     const initContext = snapshotResponseContext(session);
 
+    const initHistoryLength = session.conversationHistory.length;
     session.conversationHistory.push({ role: 'user', content: initPrompt });
 
     try {
@@ -115,6 +116,7 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
       } else {
         logger.error('SDK', `${this.providerName} init query failed with non-Error`, { sessionId: session.sessionDbId, model }, new Error(String(error)));
       }
+      session.conversationHistory.length = initHistoryLength;
       return this.handleSessionError(error, session, worker);
     }
 
@@ -153,11 +155,17 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
         lastCwd = message.cwd;
       }
       const originalTimestamp = session.earliestPendingTimestamp;
+      const messageHistoryLength = session.conversationHistory.length;
 
-      if (message.type === 'observation') {
-        await this.processObservationMessage(session, message, worker, config, originalTimestamp, lastCwd);
-      } else if (message.type === 'summarize') {
-        await this.processSummaryMessage(session, message, worker, config, mode, originalTimestamp, lastCwd);
+      try {
+        if (message.type === 'observation') {
+          await this.processObservationMessage(session, message, worker, config, originalTimestamp, lastCwd);
+        } else if (message.type === 'summarize') {
+          await this.processSummaryMessage(session, message, worker, config, mode, originalTimestamp, lastCwd);
+        }
+      } catch (error) {
+        session.conversationHistory.length = messageHistoryLength;
+        throw error;
       }
     }
   }

--- a/tests/gemini_provider.test.ts
+++ b/tests/gemini_provider.test.ts
@@ -374,6 +374,10 @@ describe('GeminiProvider', () => {
 
   it('rolls back a failed observation prompt before buffered work is retried', async () => {
     const session = makeSession();
+    (mockSessionManager as any).getClaimedMessages = mock(() => [{
+      type: 'observation',
+      _persistentId: 1,
+    }]);
     (mockSessionManager as any).getMessageIterator = async function* () {
       yield {
         type: 'observation',
@@ -401,6 +405,44 @@ describe('GeminiProvider', () => {
 
     expect(session.conversationHistory.some((message: { content: string }) =>
       message.content.includes('FAILED_RETRY_MARKER'))).toBe(false);
+  });
+
+  it('keeps a completed conversation turn when downstream work fails after queue confirmation', async () => {
+    const session = makeSession({
+      claimedMessageIds: [1],
+    });
+    (mockSessionManager as any).getClaimedMessages = mock(() => []);
+    (mockSessionManager as any).getMessageIterator = async function* () {
+      yield {
+        type: 'observation',
+        tool_name: 'Read',
+        tool_input: { marker: 'COMPLETED_TURN_MARKER' },
+        tool_response: { ok: true },
+        prompt_number: 1,
+        _persistentId: 1,
+        _originalTimestamp: Date.now(),
+      };
+    };
+    (mockDbManager as any).getChromaSync = () => {
+      throw new Error('downstream broadcast failed after confirmation');
+    };
+
+    let callCount = 0;
+    global.fetch = mock(() => {
+      callCount += 1;
+      const text = callCount === 1
+        ? 'No observations to record.'
+        : '<observation><type>discovery</type><title>Stored turn</title></observation>';
+      return Promise.resolve(new Response(JSON.stringify({
+        candidates: [{ content: { parts: [{ text }] } }],
+      })));
+    });
+
+    await expect(agent.startSession(session)).rejects.toThrow('downstream broadcast failed after confirmation');
+
+    expect((mockSessionManager as any).confirmClaimedMessages).toHaveBeenCalled();
+    expect(session.conversationHistory.some((message: { content: string }) =>
+      message.content.includes('COMPLETED_TURN_MARKER'))).toBe(true);
   });
 
   it('should throw on rate limit (429) error — no Claude fallback (#2087)', async () => {

--- a/tests/gemini_provider.test.ts
+++ b/tests/gemini_provider.test.ts
@@ -372,6 +372,37 @@ describe('GeminiProvider', () => {
     expect(promptNumber).toBe(1);
   });
 
+  it('rolls back a failed observation prompt before buffered work is retried', async () => {
+    const session = makeSession();
+    (mockSessionManager as any).getMessageIterator = async function* () {
+      yield {
+        type: 'observation',
+        tool_name: 'Read',
+        tool_input: { marker: 'FAILED_RETRY_MARKER' },
+        tool_response: { ok: false },
+        prompt_number: 1,
+        _persistentId: 1,
+        _originalTimestamp: Date.now(),
+      };
+    };
+
+    let callCount = 0;
+    global.fetch = mock(() => {
+      callCount += 1;
+      if (callCount === 1) {
+        return Promise.resolve(new Response(JSON.stringify({
+          candidates: [{ content: { parts: [{ text: 'No observations to record.' }] } }],
+        })));
+      }
+      return Promise.resolve(new Response('bad observation request', { status: 400 }));
+    });
+
+    await expect(agent.startSession(session)).rejects.toThrow('Gemini bad request');
+
+    expect(session.conversationHistory.some((message: { content: string }) =>
+      message.content.includes('FAILED_RETRY_MARKER'))).toBe(false);
+  });
+
   it('should throw on rate limit (429) error — no Claude fallback (#2087)', async () => {
     const session = {
       sessionDbId: 1,
@@ -392,6 +423,7 @@ describe('GeminiProvider', () => {
     global.fetch = mock(() => Promise.resolve(new Response('Resource has been exhausted (e.g. check quota).', { status: 429 })));
 
     await expect(agent.startSession(session)).rejects.toThrow(/429/);
+    expect(session.conversationHistory).toEqual([]);
   });
 
   it('should throw on other errors', async () => {

--- a/tests/gemini_provider.test.ts
+++ b/tests/gemini_provider.test.ts
@@ -172,7 +172,6 @@ describe('GeminiProvider', () => {
     if (modeManagerSpy) modeManagerSpy.mockRestore();
     if (loadFromFileSpy) loadFromFileSpy.mockRestore();
     if (getSpy) getSpy.mockRestore();
-    mock.restore();
   });
 
   it('should initialize with correct config', async () => {


### PR DESCRIPTION
## What changed

Restore `conversationHistory` to its pre-request length when an OpenAI-compatible provider request fails:

- initialization failures remove the failed init prompt
- observation or summary failures remove messages appended while processing that queue item

Successful requests keep their existing history unchanged.

## Why

Observation and summary handlers append a user prompt before calling the provider. If that provider call throws, the persistent queue item remains available for retry, but the failed prompt was left in `conversationHistory`.

The retry then sends both the stale failed prompt and the newly rebuilt prompt. Over repeated failures this grows duplicate history, can break provider role ordering, and makes a retry operate on different input than the original attempt.

The shared provider layer is the narrowest place to fix this for Gemini and OpenRouter without adding recovery logic to every caller.

## Impact

- Retried queue items start from the same conversation history as their first attempt.
- Failed initialization does not poison a later session retry.
- Successful response history and accounting are unchanged.

## Validation

- `bun test tests/gemini_provider.test.ts` — 13 pass, 0 fail
- `npm run typecheck` — pass
- `git diff --check origin/main...HEAD` — pass
