### PR TITLE
fix: preserve Codex transcript offsets after archival

### DIFF
--- a/src/services/transcripts/watcher.ts
+++ b/src/services/transcripts/watcher.ts
@@ -69,11 +69,11 @@ class FileTailer {
     }
 
     this.tailState.offset = size;
-    this.onOffset(this.tailState.offset);
 
     const combined = this.tailState.partial + data;
     const lines = combined.split('\n');
     this.tailState.partial = lines.pop() ?? '';
+    this.onOffset(this.tailState.offset - Buffer.byteLength(this.tailState.partial, 'utf8'));
 
     for (const line of lines) {
       const trimmed = line.trim();
@@ -243,7 +243,9 @@ export class TranscriptWatcher {
 
     const sessionIdOverride = this.extractSessionIdFromPath(filePath);
 
-    let offset = this.state.offsets[filePath] ?? 0;
+    let offset = this.state.offsets[filePath]
+      ?? this.findOriginalCodexOffset(filePath, watch, schema)
+      ?? 0;
     if (offset === 0 && watch.startAtEnd) {
       try {
         offset = statSync(filePath).size;
@@ -272,6 +274,33 @@ export class TranscriptWatcher {
       watch: watch.name,
       schema: schema.name
     });
+  }
+
+  private findOriginalCodexOffset(
+    filePath: string,
+    watch: WatchTarget,
+    schema: TranscriptSchema
+  ): number | undefined {
+    const normalized = filePath.replace(/\\/g, '/');
+    const isCodexWatch = watch.name === 'codex' || schema.name === 'codex';
+    if (!isCodexWatch || !/\/\.codex\/archived_sessions\//i.test(normalized)) {
+      return undefined;
+    }
+
+    const fileName = basename(filePath);
+    const original = Object.entries(this.state.offsets).find(([candidate]) => {
+      const normalizedCandidate = candidate.replace(/\\/g, '/');
+      return /\/\.codex\/sessions\//i.test(normalizedCandidate)
+        && basename(candidate) === fileName;
+    });
+
+    if (!original) return undefined;
+
+    try {
+      return Math.min(original[1], statSync(filePath).size);
+    } catch {
+      return original[1];
+    }
   }
 
   private async handleLine(

--- a/tests/transcripts/watcher-start-at-end.test.ts
+++ b/tests/transcripts/watcher-start-at-end.test.ts
@@ -119,4 +119,138 @@ describe('TranscriptWatcher startAtEnd', () => {
     expect(prompts).toContain('live prompt');
     expect(prompts).not.toContain('historical prompt that must not be replayed');
   });
+
+  it('continues from the original offset when Codex moves a session into the archive', async () => {
+    const sessionId = '019e050e-7ae0-71b2-b19f-6cc428e5763a';
+    const fileName = `rollout-${sessionId}.jsonl`;
+    const originalPath = join(tmpRoot, '.codex', 'sessions', '2026', '07', '12', fileName);
+    const archivedPath = join(tmpRoot, '.codex', 'archived_sessions', fileName);
+    const statePath = join(tmpRoot, 'state.json');
+    const historicalEntry = `${JSON.stringify({
+      type: 'event',
+      payload: {
+        type: 'user_message',
+        session_id: sessionId,
+        message: 'historical prompt that was already observed',
+      },
+    })}\n`;
+
+    mkdirSync(join(originalPath, '..'), { recursive: true });
+    mkdirSync(join(archivedPath, '..'), { recursive: true });
+    writeFileSync(originalPath, historicalEntry, 'utf8');
+    writeFileSync(archivedPath, historicalEntry, 'utf8');
+    writeFileSync(statePath, JSON.stringify({ offsets: { [originalPath]: Buffer.byteLength(historicalEntry) + 100 } }), 'utf8');
+
+    const schema: TranscriptSchema = {
+      name: 'custom-codex',
+      events: [
+        {
+          name: 'user-message',
+          match: { path: 'payload.type', equals: 'user_message' },
+          action: 'session_init',
+          fields: {
+            sessionId: 'payload.session_id',
+            prompt: 'payload.message',
+          },
+        },
+      ],
+    };
+    const watch: WatchTarget = {
+      name: 'codex',
+      path: join(tmpRoot, '.codex', 'archived_sessions', '*.jsonl'),
+      schema,
+      startAtEnd: false,
+    };
+    const watcher = new TranscriptWatcher({ version: 1, watches: [watch] }, statePath);
+
+    await (watcher as any).addTailer(archivedPath, watch, schema);
+    await waitForAsyncTail();
+
+    expect(sessionInitCalls).toHaveLength(0);
+
+    appendFileSync(
+      archivedPath,
+      `${JSON.stringify({
+        type: 'event',
+        payload: {
+          type: 'user_message',
+          session_id: sessionId,
+          message: 'new prompt after archive',
+        },
+      })}\n`,
+      'utf8',
+    );
+
+    await waitForAsyncTail();
+    watcher.stop();
+
+    const prompts = sessionInitCalls.map(call => call.prompt);
+    expect(prompts).toEqual(['new prompt after archive']);
+  });
+
+  it('preserves a partial JSONL record when Codex archives the session mid-write', async () => {
+    const sessionId = '019e050e-7ae0-71b2-b19f-6cc428e5763a';
+    const fileName = `rollout-${sessionId}.jsonl`;
+    const originalPath = join(tmpRoot, '.codex', 'sessions', '2026', '07', '12', fileName);
+    const archivedPath = join(tmpRoot, '.codex', 'archived_sessions', fileName);
+    const statePath = join(tmpRoot, 'state.json');
+    const entry = JSON.stringify({
+      type: 'event',
+      payload: {
+        type: 'user_message',
+        session_id: sessionId,
+        message: 'prompt split across archive move',
+      },
+    });
+    const splitAt = Math.floor(entry.length / 2);
+    const prefix = entry.slice(0, splitAt);
+    const suffix = entry.slice(splitAt);
+
+    mkdirSync(join(originalPath, '..'), { recursive: true });
+    mkdirSync(join(archivedPath, '..'), { recursive: true });
+    writeFileSync(originalPath, prefix, 'utf8');
+
+    const schema: TranscriptSchema = {
+      name: 'codex',
+      events: [
+        {
+          name: 'user-message',
+          match: { path: 'payload.type', equals: 'user_message' },
+          action: 'session_init',
+          fields: {
+            sessionId: 'payload.session_id',
+            prompt: 'payload.message',
+          },
+        },
+      ],
+    };
+    const originalWatch: WatchTarget = {
+      name: 'codex-sessions',
+      path: join(tmpRoot, '.codex', 'sessions', '**', '*.jsonl'),
+      schema,
+      startAtEnd: false,
+    };
+    const archivedWatch: WatchTarget = {
+      name: 'codex-archived',
+      path: join(tmpRoot, '.codex', 'archived_sessions', '*.jsonl'),
+      schema,
+      startAtEnd: false,
+    };
+    const watcher = new TranscriptWatcher({ version: 1, watches: [originalWatch, archivedWatch] }, statePath);
+
+    await (watcher as any).addTailer(originalPath, originalWatch, schema);
+    await waitForAsyncTail();
+    expect(sessionInitCalls).toHaveLength(0);
+
+    writeFileSync(archivedPath, prefix, 'utf8');
+    await (watcher as any).addTailer(archivedPath, archivedWatch, schema);
+    await waitForAsyncTail();
+
+    appendFileSync(archivedPath, `${suffix}\n`, 'utf8');
+    (watcher as any).tailers.get(archivedPath)?.poke();
+    await waitForAsyncTail();
+    watcher.stop();
+
+    expect(sessionInitCalls.map(call => call.prompt)).toEqual(['prompt split across archive move']);
+  });
 });


### PR DESCRIPTION
## What changed

When Codex moves a rollout from `.codex/sessions/...` to `.codex/archived_sessions/`, the transcript watcher now:

- finds the prior path by the rollout filename
- resumes from the prior persisted byte offset
- clamps that offset to the archived file size
- persists the offset before an incomplete JSONL fragment so a move during a write cannot lose the unfinished record
- recognizes Codex through either the watch name or schema name

## Why

Transcript offsets are keyed by absolute file path. Archiving a Codex rollout changes that path, so the new tailer previously started with no matching offset. Depending on `startAtEnd`, it could replay the full historical transcript or skip existing content.

There was also a boundary case where an incomplete JSONL record was held only in the old tailer's memory while the persisted offset pointed to EOF. If Codex archived the file mid-write, the new tailer inherited the EOF offset and permanently skipped the completed record.

## Impact

- Already-consumed Codex events are not replayed after archival.
- New events appended after archival continue to be ingested.
- A JSONL record split across the archive move is retained.
- Other transcript platforms and non-Codex archive paths are unchanged.

## Validation

- `bun test tests/transcripts/watcher-start-at-end.test.ts` — 3 pass, 0 fail
- `npm run typecheck` — pass
- `git diff --check origin/main...HEAD` — pass
