### PR TITLE
fix(installer): tolerate non-string OpenCode context bodies (refs #3330)

### DIFF
--- a/src/services/integrations/OpenCodeInstaller.ts
+++ b/src/services/integrations/OpenCodeInstaller.ts
@@ -191,7 +191,7 @@ async function fetchRealContextFromWorker(): Promise<string | null> {
   if (!contextResponse.ok) return null;
 
   const realContext = await contextResponse.text();
-  return realContext && realContext.trim() ? realContext : null;
+  return typeof realContext === 'string' && realContext.trim() ? realContext : null;
 }
 
 function writeOrRemoveCleanedAgentsMd(agentsMdPath: string, trimmedContent: string): void {

--- a/tests/integration/opencode-installer.test.ts
+++ b/tests/integration/opencode-installer.test.ts
@@ -6,9 +6,12 @@ import {
   addOpenCodePluginReference,
   deregisterOpenCodePluginFromConfig,
   getOpenCodeConfigPath,
+  getOpenCodeAgentsMdPath,
+  installOpenCodeIntegration,
   removeOpenCodePluginReference,
   registerOpenCodePluginInConfig,
 } from '../../src/services/integrations/OpenCodeInstaller.js';
+import { logger } from '../../src/utils/logger.js';
 
 describe('OpenCode installer config registration', () => {
   let tempDir: string;
@@ -103,5 +106,83 @@ describe('OpenCode installer config registration', () => {
     expect(result).toBe(0);
     const config = JSON.parse(readFileSync(getOpenCodeConfigPath(), 'utf-8'));
     expect(config.plugin).toEqual(['context-mode']);
+  });
+});
+
+describe('OpenCode installer context retrieval', () => {
+  let tempDir: string;
+  let previousConfigDir: string | undefined;
+  let previousClaudeConfigDir: string | undefined;
+  let previousFetch: typeof globalThis.fetch;
+  let previousDebug: typeof logger.debug;
+  let previousInfo: typeof logger.info;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `opencode-context-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    const marketplacePluginPath = join(tempDir, 'plugins', 'marketplaces', 'thedotmack', 'dist', 'opencode-plugin', 'index.js');
+    mkdirSync(join(marketplacePluginPath, '..'), { recursive: true });
+    writeFileSync(marketplacePluginPath, 'export default {}\n', 'utf-8');
+
+    previousConfigDir = process.env.OPENCODE_CONFIG_DIR;
+    previousClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    previousFetch = globalThis.fetch;
+    previousDebug = logger.debug;
+    previousInfo = logger.info;
+    process.env.OPENCODE_CONFIG_DIR = tempDir;
+    process.env.CLAUDE_CONFIG_DIR = tempDir;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = previousFetch;
+    logger.debug = previousDebug;
+    logger.info = previousInfo;
+    if (previousConfigDir === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+    else process.env.OPENCODE_CONFIG_DIR = previousConfigDir;
+    if (previousClaudeConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = previousClaudeConfigDir;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function stubWorkerContext(body: unknown, diagnostics: string[]): void {
+    logger.debug = (_component, message) => diagnostics.push(message);
+    logger.info = () => {};
+    globalThis.fetch = async (input) => ({
+      ok: true,
+      text: async () => input.toString().includes('/api/context/inject') ? body : '',
+    }) as Response;
+  }
+
+  it('rejects a wrapped object body without coercion or unavailable-worker diagnostics', async () => {
+    const diagnostics: string[] = [];
+    const wrappedBody = Object.freeze({ wrapped: true, value: '# Existing memory' });
+    stubWorkerContext(wrappedBody, diagnostics);
+
+    expect(await installOpenCodeIntegration()).toBe(0);
+
+    const agentsMd = readFileSync(getOpenCodeAgentsMdPath(), 'utf-8');
+    expect(agentsMd).toContain('*No context yet. Complete your first session and context will appear here.*');
+    expect(agentsMd).not.toContain('# Existing memory');
+    expect(diagnostics).toEqual([]);
+  });
+
+  it('preserves valid existing context exactly', async () => {
+    const diagnostics: string[] = [];
+    const context = '  # Existing memory  ';
+    stubWorkerContext(context, diagnostics);
+
+    expect(await installOpenCodeIntegration()).toBe(0);
+
+    expect(readFileSync(getOpenCodeAgentsMdPath(), 'utf-8')).toContain(context);
+    expect(diagnostics).toEqual([]);
+  });
+
+  it('uses placeholder context for blank strings', async () => {
+    const diagnostics: string[] = [];
+    stubWorkerContext(' \t\n ', diagnostics);
+
+    expect(await installOpenCodeIntegration()).toBe(0);
+
+    expect(readFileSync(getOpenCodeAgentsMdPath(), 'utf-8')).toContain('*No context yet. Complete your first session and context will appear here.*');
+    expect(diagnostics).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

OpenCode installation assumes the worker context response body is a string and calls `.trim()` immediately. A non-string value returned by the response's `text()` method can throw at that boundary and be misclassified as an unavailable worker. Validate the body type there so valid text remains unchanged and every non-string body follows the existing placeholder-context path safely.

## Why

`fetchRealContextFromWorker` already owns readiness checks, context retrieval, and blank-body rejection. Its declared result is `string | null`, but the runtime value returned by `text()` was never checked before `.trim()`. Keeping the check there prevents an object from throwing or being stringified into `AGENTS.md` while preserving the installer's established fallback.

## Scope

This is the standalone fetch-boundary guard routed under https://github.com/thedotmack/claude-mem/issues/3611, and it can merge independently once CI is green. The broader OpenCode plugin contract remains with that plan. This change only hardens installer context retrieval and does not alter plugin exports or npx cache refresh behavior.

## Risk

The accepted path becomes stricter at runtime: only primitive strings can be injected as existing context. Unknown objects use the same placeholder path as blank or unavailable context, and no wrapper-specific fields are guessed.

## Verification

- [x] `bun test tests/integration/opencode-installer.test.ts`
- [ ] `npm run build`
- [x] `npm run lint:hook-io`
- [x] `npm run lint:spawn-env`
- [ ] `npm run strip-comments:check`

Reported by @kai1949 in https://github.com/thedotmack/claude-mem/issues/3330

Refs #3330

