### PR TITLE
fix(shutdown): tolerate ERR_SERVER_NOT_RUNNING so full teardown completes (#3380)

### DIFF
--- a/src/services/infrastructure/GracefulShutdown.ts
+++ b/src/services/infrastructure/GracefulShutdown.ts
@@ -65,7 +65,25 @@ async function closeHttpServer(server: http.Server): Promise<void> {
   }
 
   await new Promise<void>((resolve, reject) => {
-    server.close(err => err ? reject(err) : resolve());
+    server.close(err => {
+      if (!err) {
+        resolve();
+        return;
+      }
+      // #3380 — Node's http.Server.close(cb) reports ERR_SERVER_NOT_RUNNING
+      // when the handle is not listening (e.g. the bind failed or the server
+      // already closed). Closing an already-closed server is the desired end
+      // state, not a failure: rejecting here aborted ALL remaining teardown
+      // (session drain, MCP close, chroma stop, db close, supervisor stop).
+      // Same tolerance as ServerService.stop() in
+      // src/server/runtime/ServerService.ts.
+      if ((err as NodeJS.ErrnoException).code === 'ERR_SERVER_NOT_RUNNING') {
+        logger.warn('SYSTEM', 'Server was already stopped when close was requested', {}, err);
+        resolve();
+        return;
+      }
+      reject(err);
+    });
   });
 
   if (process.platform === 'win32') {

--- a/src/services/server/Server.ts
+++ b/src/services/server/Server.ts
@@ -140,13 +140,16 @@ export class Server {
   async listen(port: number, host: string): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       const server = http.createServer(this.app);
-      this.server = server;
       const onError = (err: Error) => {
         server.off('listening', onListening);
         reject(err);
       };
       const onListening = () => {
         server.off('error', onError);
+        // #3380 — retain the handle only once it is actually listening. A
+        // failed bind (e.g. EADDRINUSE) must never leave a non-listening
+        // handle behind for graceful shutdown to trip on.
+        this.server = server;
         logger.info('SYSTEM', 'HTTP server started', { host, port, pid: process.pid });
         resolve();
       };

--- a/tests/infrastructure/graceful-shutdown.test.ts
+++ b/tests/infrastructure/graceful-shutdown.test.ts
@@ -30,6 +30,7 @@ const {
   removePidFile,
 } = await import('../../src/services/infrastructure/index.js');
 const { paths } = await import('../../src/shared/paths.js');
+const { getSupervisor } = await import('../../src/supervisor/index.js');
 
 // If an earlier test file already evaluated paths.ts, the module cache wins
 // and DATA_DIR stays frozen on that earlier value — the preload tripwire's
@@ -284,6 +285,85 @@ describe('GracefulShutdown', () => {
       await performGracefulShutdown(config);
 
       expect(callOrder).toEqual(['sessionManager', 'mcpClient', 'chromaMcpManager', 'dbManager']);
+    });
+
+    it('resolves on ERR_SERVER_NOT_RUNNING from server.close and still runs every remaining step (#3380)', async () => {
+      // Node's http.Server.close(cb) reports ERR_SERVER_NOT_RUNNING when the
+      // handle is not listening. An already-closed server is the desired end
+      // state — teardown (session drain, MCP close, chroma stop, db close,
+      // supervisor stop) must still run.
+      const mockServer = {
+        closeAllConnections: mock(() => {}),
+        close: mock((cb: (err?: Error) => void) => {
+          cb(Object.assign(new Error('Server is not running.'), { code: 'ERR_SERVER_NOT_RUNNING' }));
+        })
+      } as unknown as http.Server;
+
+      const mockSessionManager: ShutdownableService = {
+        shutdownAll: mock(async () => {})
+      };
+      const mockMcpClient: CloseableClient = {
+        close: mock(async () => {})
+      };
+      const mockDbManager: CloseableDatabase = {
+        close: mock(async () => {})
+      };
+      const mockChromaMcpManager = {
+        stop: mock(async () => {})
+      };
+
+      // Same module instance performGracefulShutdown uses — the spy calls
+      // through to the real (no-op against the temp registry) cascade.
+      const supervisorStopSpy = spyOn(getSupervisor(), 'stop');
+
+      try {
+        const config: GracefulShutdownConfig = {
+          server: mockServer,
+          sessionManager: mockSessionManager,
+          mcpClient: mockMcpClient,
+          dbManager: mockDbManager,
+          chromaMcpManager: mockChromaMcpManager
+        };
+
+        await expect(performGracefulShutdown(config)).resolves.toBeUndefined();
+
+        expect(mockSessionManager.shutdownAll).toHaveBeenCalledTimes(1);
+        expect(mockMcpClient.close).toHaveBeenCalledTimes(1);
+        expect(mockChromaMcpManager.stop).toHaveBeenCalledTimes(1);
+        expect(mockDbManager.close).toHaveBeenCalledTimes(1);
+        expect(supervisorStopSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        supervisorStopSpy.mockRestore();
+      }
+    }, 15000);
+
+    it('still rejects when server.close reports any other error code', async () => {
+      const mockServer = {
+        closeAllConnections: mock(() => {}),
+        close: mock((cb: (err?: Error) => void) => {
+          cb(Object.assign(new Error('bad handle'), { code: 'EBADF' }));
+        })
+      } as unknown as http.Server;
+
+      const mockSessionManager: ShutdownableService = {
+        shutdownAll: mock(async () => {})
+      };
+      const mockDbManager: CloseableDatabase = {
+        close: mock(async () => {})
+      };
+
+      const config: GracefulShutdownConfig = {
+        server: mockServer,
+        sessionManager: mockSessionManager,
+        dbManager: mockDbManager
+      };
+
+      await expect(performGracefulShutdown(config)).rejects.toThrow('bad handle');
+
+      // Only ERR_SERVER_NOT_RUNNING is tolerated — anything else keeps the
+      // existing fail-fast propagation.
+      expect(mockSessionManager.shutdownAll).not.toHaveBeenCalled();
+      expect(mockDbManager.close).not.toHaveBeenCalled();
     });
 
     it('should handle shutdown when PID file does not exist', async () => {

--- a/tests/server/server.test.ts
+++ b/tests/server/server.test.ts
@@ -120,10 +120,9 @@ describe('Server', () => {
 
       await expect(server2.listen(testPort, '127.0.0.1')).rejects.toThrow();
 
-      const httpServer = server2.getHttpServer();
-      if (httpServer) {
-        expect(httpServer.listening).toBe(false);
-      }
+      // #3380 — a failed bind must never leave a non-listening handle behind
+      // for graceful shutdown to trip on.
+      expect(server2.getHttpServer()).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Defect

`performGracefulShutdown` closes the HTTP server as its **first** step, and `closeHttpServer` rejected on any error from `server.close(cb)`. When the handle was not listening — e.g. the bind had failed, or the server was already closed — Node reports its native `ERR_SERVER_NOT_RUNNING` ("Server is not running."), and that rejection skipped **all** remaining teardown: session drain (`sessionManager.shutdownAll`), MCP client close, Chroma MCP stop, database close, and supervisor stop. The rejection was caught and logged as "Graceful shutdown failed — proceeding" in `worker-shutdown.ts`, so the process still exited, but without a graceful teardown — the socket could be left un-drained (the Windows port-hold symptom in #3380).

A contributing state bug made this reachable: `Server.listen()` assigned `this.server` **before** the socket bound and never cleared it on a rejected listen (EADDRINUSE), leaving a non-null, non-listening handle for shutdown to trip on.

## Fix

- **`src/services/infrastructure/GracefulShutdown.ts` (`closeHttpServer`)** — in the `server.close` callback, treat `err.code === 'ERR_SERVER_NOT_RUNNING'` as success with a `logger.warn` ("Server was already stopped when close was requested"): an already-closed server is the desired end state, not a failure. This is the same tolerance `ServerService.stop()` already uses (`src/server/runtime/ServerService.ts`). **Only** this code is tolerated — any other close error still rejects; no generic catch, no step reordering, no per-step catch-and-continue.
- **`src/services/server/Server.ts` (`listen`)** — assign `this.server` only inside the `onListening` handler, so a failed bind never leaves a non-listening handle behind (`getHttpServer()` stays `null`). Promise semantics unchanged.

## Tests

- `tests/infrastructure/graceful-shutdown.test.ts`: close callback erroring with `ERR_SERVER_NOT_RUNNING` → `performGracefulShutdown` **resolves** and every remaining step (`sessionManager.shutdownAll`, `mcpClient.close`, chroma stop, `dbManager.close`, supervisor `stop`) is still called; a different error code (`EBADF`) still rejects with fail-fast propagation.
- `tests/server/server.test.ts`: after a rejected listen (EADDRINUSE), `getHttpServer()` returns `null` (strengthened from a conditional check that was written around the bug).
- Both new tests fail against the unfixed source (verified red → green).

## Verification

- `bun test tests/infrastructure/ tests/server/ tests/services/worker-shutdown-sequence.test.ts` — 392 pass, 0 fail
- `npx tsc --noEmit` — clean
- `grep -n "ERR_SERVER_NOT_RUNNING" src/services/infrastructure/GracefulShutdown.ts` — explicit code check, not a bare catch

Addresses #3380 — left open pending reporter verification on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSNZmfi4vSYjTeEWtwqKrW