### PR TITLE
fix(worker): repair orphaned FK parents before migration rebuilds; adoption after db init (#3378)

### DIFF
--- a/src/services/infrastructure/WorktreeAdoption.ts
+++ b/src/services/infrastructure/WorktreeAdoption.ts
@@ -24,6 +24,16 @@ export interface AdoptionResult {
   errors: Array<{ worktree: string; error: string }>;
 }
 
+/**
+ * Render per-branch adoption errors as a string for logger CONTEXT values —
+ * the logger interpolates context values with a template literal
+ * (logger.ts `${k}=${v}`), so a raw object array renders as
+ * '[object Object]' (#3378).
+ */
+export function formatAdoptionErrors(errors: AdoptionResult['errors']): string {
+  return errors.map(e => `${e.worktree}: ${e.error}`).join('; ');
+}
+
 interface WorktreeEntry {
   path: string;
   branch: string | null;

--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -1030,6 +1030,48 @@ export class SessionStore {
     this.db.prepare('INSERT OR IGNORE INTO schema_versions (version, applied_at) VALUES (?, ?)').run(6, new Date().toISOString());
   }
 
+  // #3378: legacy DBs contain child rows whose memory_session_id has no
+  // sdk_sessions parent (written historically while foreign_keys was OFF).
+  // The v7/v9 rebuilds copy those children into a freshly created table via
+  // INSERT ... SELECT with foreign_keys = ON (the connection pragma; these
+  // rebuilds, unlike v21/v33/v34, never disable it), so a single orphan
+  // aborts the whole constructor migration chain with 'FOREIGN KEY
+  // constraint failed' and the worker never reports ready. Orphaned children
+  // are live user data served by context injection — the missing side is the
+  // parent, so create a minimal completed stub session per orphaned
+  // memory_session_id immediately before the copy, mirroring
+  // SyncApply.ensureSessionForMemoryId (INSERT ... ON CONFLICT DO NOTHING;
+  // content_session_id falls back to the memory id). COUNT-then-INSERT for
+  // the log figure, per the bun:sqlite `.run().changes` trap documented in
+  // SyncApply.ts.
+  private repairOrphanedSessionParents(childTable: 'observations' | 'session_summaries'): void {
+    const orphaned = (this.db.prepare(`
+      SELECT COUNT(DISTINCT c.memory_session_id) AS n
+      FROM ${childTable} c
+      WHERE c.memory_session_id IS NOT NULL
+        AND NOT EXISTS (SELECT 1 FROM sdk_sessions s WHERE s.memory_session_id = c.memory_session_id)
+    `).get() as { n: number }).n;
+    if (orphaned === 0) return;
+
+    this.db.run(`
+      INSERT INTO sdk_sessions
+        (content_session_id, memory_session_id, project, started_at, started_at_epoch, status)
+      SELECT
+        c.memory_session_id,
+        c.memory_session_id,
+        MIN(c.project),
+        MIN(c.created_at),
+        MIN(c.created_at_epoch),
+        'completed'
+      FROM ${childTable} c
+      WHERE c.memory_session_id IS NOT NULL
+        AND NOT EXISTS (SELECT 1 FROM sdk_sessions s WHERE s.memory_session_id = c.memory_session_id)
+      GROUP BY c.memory_session_id
+      ON CONFLICT DO NOTHING
+    `);
+    logger.warn('DB', `Created ${orphaned} stub sdk_sessions parent(s) for orphaned ${childTable} rows before rebuild (#3378)`);
+  }
+
   private removeSessionSummariesUniqueConstraint(): void {
     const summariesIndexes = this.db.query('PRAGMA index_list(session_summaries)').all() as IndexInfo[];
     // Only table-level UNIQUE constraints (PRAGMA origin 'u' — the v7 target,
@@ -1048,6 +1090,10 @@ export class SessionStore {
     logger.debug('DB', 'Removing UNIQUE constraint from session_summaries.memory_session_id');
 
     this.db.run('BEGIN TRANSACTION');
+
+    // The copy below runs with foreign_keys = ON; repair orphaned parents
+    // first or a single orphan aborts the migration chain (#3378).
+    this.repairOrphanedSessionParents('session_summaries');
 
     this.db.run('DROP TABLE IF EXISTS session_summaries_new');
 
@@ -1140,6 +1186,10 @@ export class SessionStore {
     logger.debug('DB', 'Making observations.text nullable');
 
     this.db.run('BEGIN TRANSACTION');
+
+    // The copy below runs with foreign_keys = ON; repair orphaned parents
+    // first or a single orphan aborts the migration chain (#3378).
+    this.repairOrphanedSessionParents('observations');
 
     this.db.run('DROP TABLE IF EXISTS observations_new');
 

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -56,7 +56,7 @@ import {
   httpShutdown
 } from './infrastructure/HealthMonitor.js';
 import { performGracefulShutdown } from './infrastructure/GracefulShutdown.js';
-import { adoptMergedWorktrees, adoptMergedWorktreesForAllKnownRepos } from './infrastructure/WorktreeAdoption.js';
+import { adoptMergedWorktrees, adoptMergedWorktreesForAllKnownRepos, formatAdoptionErrors } from './infrastructure/WorktreeAdoption.js';
 
 import { Server } from './server/Server.js';
 import { BetterAuthRoutes } from '../server/auth/BetterAuthRoutes.js';
@@ -476,25 +476,6 @@ export class WorkerService implements WorkerRef {
       logger.info('WORKER', 'Checking for one-time CWD remap...');
       runOneTimeCwdRemap();
 
-      logger.info('WORKER', 'Adopting merged worktrees (background)...');
-      adoptMergedWorktreesForAllKnownRepos({}).then(adoptions => {
-        if (adoptions) {
-          for (const adoption of adoptions) {
-            if (adoption.adoptedObservations > 0 || adoption.adoptedSummaries > 0 || adoption.chromaUpdates > 0) {
-              logger.info('SYSTEM', 'Merged worktrees adopted in background', adoption);
-            }
-            if (adoption.errors.length > 0) {
-              logger.warn('SYSTEM', 'Worktree adoption had per-branch errors', {
-                repoPath: adoption.repoPath,
-                errors: adoption.errors
-              });
-            }
-          }
-        }
-      }).catch(err => {
-        logger.error('WORKER', 'Worktree adoption failed (background)', {}, err instanceof Error ? err : new Error(String(err)));
-      });
-
       const chromaEnabled = settings.CLAUDE_MEM_CHROMA_ENABLED !== 'false';
       if (chromaEnabled) {
         this.chromaMcpManager = ChromaMcpManager.getInstance();
@@ -507,6 +488,30 @@ export class WorkerService implements WorkerRef {
       await this.dbManager.initialize();
 
       runOneTimeV12_4_3Cleanup();
+
+      // Worktree adoption stays fire-and-forget (#2122) — init never awaits
+      // it — but it is kicked only after dbManager.initialize() and the
+      // one-time cleanup above have finished: adoption writes through its own
+      // connection, and starting it earlier raced the boot-time migration
+      // writer for the single WAL writer slot ('database is locked', #3378).
+      logger.info('WORKER', 'Adopting merged worktrees (background)...');
+      adoptMergedWorktreesForAllKnownRepos({}).then(adoptions => {
+        if (adoptions) {
+          for (const adoption of adoptions) {
+            if (adoption.adoptedObservations > 0 || adoption.adoptedSummaries > 0 || adoption.chromaUpdates > 0) {
+              logger.info('SYSTEM', 'Merged worktrees adopted in background', adoption);
+            }
+            if (adoption.errors.length > 0) {
+              logger.warn('SYSTEM', 'Worktree adoption had per-branch errors', {
+                repoPath: adoption.repoPath,
+                errors: formatAdoptionErrors(adoption.errors)
+              });
+            }
+          }
+        }
+      }).catch(err => {
+        logger.error('WORKER', 'Worktree adoption failed (background)', {}, err instanceof Error ? err : new Error(String(err)));
+      });
 
       // Two-lane sync pull loop (plan Phase 3 task 3). Constructed only when
       // CloudSync is active AND resolved a device id (fail-closed identity —

--- a/tests/services/infrastructure/worktree-adoption-errors.test.ts
+++ b/tests/services/infrastructure/worktree-adoption-errors.test.ts
@@ -1,0 +1,30 @@
+// #3378: adoption.errors (Array<{worktree, error}>) was passed as a logger
+// CONTEXT value; logger.ts renders context values with a template literal
+// (`${k}=${v}`), so the warning printed 'errors=[object Object]'. The log
+// site now passes formatAdoptionErrors(adoption.errors).
+import { describe, it, expect } from 'bun:test';
+import { formatAdoptionErrors } from '../../../src/services/infrastructure/WorktreeAdoption.js';
+
+describe('formatAdoptionErrors (#3378 [object Object] log fix)', () => {
+  it('renders actual worktree paths and error text', () => {
+    const formatted = formatAdoptionErrors([
+      { worktree: '/repos/app/.worktrees/feat-x', error: 'database is locked' },
+      { worktree: '/repos/app/.worktrees/feat-y', error: 'no such table: observations' },
+    ]);
+    expect(formatted).toBe(
+      '/repos/app/.worktrees/feat-x: database is locked; /repos/app/.worktrees/feat-y: no such table: observations'
+    );
+  });
+
+  it('survives the logger context template-literal rendering without [object Object]', () => {
+    const value = formatAdoptionErrors([{ worktree: '/w', error: 'boom' }]);
+    // Exactly how logger.ts renders a context entry: `${k}=${v}`.
+    const rendered = `${'errors'}=${value}`;
+    expect(rendered).toBe('errors=/w: boom');
+    expect(rendered).not.toContain('[object Object]');
+  });
+
+  it('renders an empty error list as an empty string', () => {
+    expect(formatAdoptionErrors([])).toBe('');
+  });
+});

--- a/tests/sqlite/session-store-orphan-fk-repair.test.ts
+++ b/tests/sqlite/session-store-orphan-fk-repair.test.ts
@@ -1,0 +1,230 @@
+// Pin-down + regression tests for #3378 (second half): a legacy DB containing
+// orphaned FK children (observations / session_summaries rows whose
+// memory_session_id has no sdk_sessions parent — written historically while
+// foreign_keys was OFF) aborts the SessionStore constructor migration chain
+// with 'FOREIGN KEY constraint failed', so dbManager.initialize() rejects and
+// the worker never reports ready.
+//
+// Faulting mechanism these tests pin: the child-table rebuild copies that run
+// with foreign_keys = ON (applySqliteConnectionPragmas sets it per
+// connection and these two migrations, unlike v21/v33/v34, never disable it):
+//   - v7  removeSessionSummariesUniqueConstraint: INSERT INTO
+//     session_summaries_new SELECT ... FROM session_summaries
+//   - v9  makeObservationsTextNullable: INSERT INTO observations_new
+//     SELECT ... FROM observations
+// Each orphaned row makes the copy INSERT violate the freshly created FK.
+//
+// The fix repairs the PARENT side: minimal stub sdk_sessions rows are created
+// for orphaned memory_session_ids immediately before each rebuild copy
+// (mirroring SyncApply.ensureSessionForMemoryId's stub semantics). Orphaned
+// child rows are live user data served by context injection and must survive.
+import { describe, it, expect, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { mkdtempSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { SessionStore } from '../../src/services/sqlite/SessionStore.js';
+import { runOneTimeV12_4_3Cleanup } from '../../src/services/infrastructure/CleanupV12_4_3.js';
+
+const ISO = '2025-07-01T00:00:00.000Z';
+const EPOCH = 1751328000000;
+
+interface OrphanSeedOptions {
+  orphanObservation?: boolean;
+  orphanSummary?: boolean;
+}
+
+/**
+ * Create a v4-era database file — the exact shape initializeSchema() creates
+ * (schema_versions stamped at 4) — with one healthy parent+child pair and,
+ * per options, orphaned child rows inserted under PRAGMA foreign_keys = OFF,
+ * mimicking historical data written before/around enforcement.
+ */
+function seedLegacyV4DbWithOrphans(dbPath: string, opts: OrphanSeedOptions = {}): void {
+  const db = new Database(dbPath);
+  db.run('PRAGMA foreign_keys = OFF');
+
+  db.run(`
+    CREATE TABLE schema_versions (
+      id INTEGER PRIMARY KEY,
+      version INTEGER UNIQUE NOT NULL,
+      applied_at TEXT NOT NULL
+    )
+  `);
+  db.run(`
+    CREATE TABLE sdk_sessions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      content_session_id TEXT NOT NULL,
+      memory_session_id TEXT UNIQUE,
+      project TEXT NOT NULL,
+      platform_source TEXT NOT NULL DEFAULT 'claude',
+      user_prompt TEXT,
+      started_at TEXT NOT NULL,
+      started_at_epoch INTEGER NOT NULL,
+      completed_at TEXT,
+      completed_at_epoch INTEGER,
+      status TEXT CHECK(status IN ('active', 'completed', 'failed')) NOT NULL DEFAULT 'active'
+    )
+  `);
+  db.run(`
+    CREATE TABLE observations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      memory_session_id TEXT NOT NULL,
+      project TEXT NOT NULL,
+      text TEXT NOT NULL,
+      type TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      created_at_epoch INTEGER NOT NULL,
+      FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE CASCADE
+    )
+  `);
+  db.run(`
+    CREATE TABLE session_summaries (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      memory_session_id TEXT UNIQUE NOT NULL,
+      project TEXT NOT NULL,
+      request TEXT,
+      investigated TEXT,
+      learned TEXT,
+      completed TEXT,
+      next_steps TEXT,
+      files_read TEXT,
+      files_edited TEXT,
+      notes TEXT,
+      created_at TEXT NOT NULL,
+      created_at_epoch INTEGER NOT NULL,
+      FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE CASCADE
+    )
+  `);
+  db.prepare('INSERT INTO schema_versions (version, applied_at) VALUES (?, ?)').run(4, ISO);
+
+  // Healthy pair: parent session + observation.
+  db.prepare(`
+    INSERT INTO sdk_sessions (content_session_id, memory_session_id, project, started_at, started_at_epoch, status)
+    VALUES ('content-healthy', 'mem-healthy', 'proj-a', ?, ?, 'completed')
+  `).run(ISO, EPOCH);
+  db.prepare(`
+    INSERT INTO observations (memory_session_id, project, text, type, created_at, created_at_epoch)
+    VALUES ('mem-healthy', 'proj-a', 'healthy text', 'discovery', ?, ?)
+  `).run(ISO, EPOCH);
+
+  if (opts.orphanObservation) {
+    db.prepare(`
+      INSERT INTO observations (memory_session_id, project, text, type, created_at, created_at_epoch)
+      VALUES ('mem-orphan-obs', 'proj-orphan', 'orphan observation text', 'discovery', ?, ?)
+    `).run(ISO, EPOCH + 1);
+  }
+  if (opts.orphanSummary) {
+    db.prepare(`
+      INSERT INTO session_summaries (memory_session_id, project, request, created_at, created_at_epoch)
+      VALUES ('mem-orphan-sum', 'proj-orphan', 'orphan summary request', ?, ?)
+    `).run(ISO, EPOCH + 2);
+  }
+
+  db.run('PRAGMA foreign_keys = ON');
+  db.close();
+}
+
+function count(db: Database, sql: string, ...params: Array<string | number>): number {
+  return (db.prepare(sql).get(...params) as { n: number }).n;
+}
+
+describe('SessionStore migration chain over a legacy DB with orphaned FK children (#3378)', () => {
+  let tempDir: string;
+
+  afterEach(() => {
+    if (tempDir && existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  function makeTempDbPath(): string {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'claude-mem-orphan-fk-'));
+    return path.join(tempDir, 'claude-mem.db');
+  }
+
+  it('v9 observations rebuild completes over an orphaned observation and repairs its parent', () => {
+    const dbPath = makeTempDbPath();
+    seedLegacyV4DbWithOrphans(dbPath, { orphanObservation: true });
+
+    // Unfixed code: this constructor throws 'FOREIGN KEY constraint failed'
+    // from makeObservationsTextNullable's INSERT INTO observations_new SELECT.
+    const store = new SessionStore(dbPath);
+
+    // Orphaned observation is live user data — it must survive the rebuild.
+    expect(count(store.db, 'SELECT COUNT(*) AS n FROM observations')).toBe(2);
+    expect(count(store.db, `SELECT COUNT(*) AS n FROM observations WHERE memory_session_id = 'mem-orphan-obs'`)).toBe(1);
+
+    // The missing side was the parent: a minimal stub session now exists,
+    // mirroring SyncApply.ensureSessionForMemoryId stub semantics.
+    expect(count(store.db, `SELECT COUNT(*) AS n FROM sdk_sessions WHERE memory_session_id = 'mem-orphan-obs'`)).toBe(1);
+    const stub = store.db.prepare(
+      `SELECT content_session_id, project, status FROM sdk_sessions WHERE memory_session_id = 'mem-orphan-obs'`
+    ).get() as { content_session_id: string; project: string; status: string };
+    expect(stub.content_session_id).toBe('mem-orphan-obs');
+    expect(stub.project).toBe('proj-orphan');
+    expect(stub.status).toBe('completed');
+
+    // Healthy rows untouched; the chain ran to completion (v9 recorded).
+    expect(count(store.db, `SELECT COUNT(*) AS n FROM observations WHERE memory_session_id = 'mem-healthy'`)).toBe(1);
+    expect(count(store.db, 'SELECT COUNT(*) AS n FROM schema_versions WHERE version = 9')).toBe(1);
+
+    store.db.close();
+  });
+
+  it('v7 session_summaries rebuild completes over an orphaned summary and repairs its parent', () => {
+    const dbPath = makeTempDbPath();
+    seedLegacyV4DbWithOrphans(dbPath, { orphanSummary: true });
+
+    // Unfixed code: this constructor throws 'FOREIGN KEY constraint failed'
+    // from removeSessionSummariesUniqueConstraint's INSERT INTO
+    // session_summaries_new SELECT.
+    const store = new SessionStore(dbPath);
+
+    expect(count(store.db, 'SELECT COUNT(*) AS n FROM session_summaries')).toBe(1);
+    expect(count(store.db, `SELECT COUNT(*) AS n FROM session_summaries WHERE memory_session_id = 'mem-orphan-sum'`)).toBe(1);
+    expect(count(store.db, `SELECT COUNT(*) AS n FROM sdk_sessions WHERE memory_session_id = 'mem-orphan-sum'`)).toBe(1);
+    expect(count(store.db, 'SELECT COUNT(*) AS n FROM schema_versions WHERE version = 7')).toBe(1);
+
+    store.db.close();
+  });
+
+  it('boot sequence over a DB with both orphan kinds: migrations then v12.4.3 cleanup, nothing lost', () => {
+    const dbPath = makeTempDbPath();
+    seedLegacyV4DbWithOrphans(dbPath, { orphanObservation: true, orphanSummary: true });
+
+    const store = new SessionStore(dbPath);
+    store.db.close();
+
+    // The next awaited boot step after dbManager.initialize(): the one-time
+    // v12.4.3 cleanup (DELETE FROM sdk_sessions with foreign_keys = ON).
+    runOneTimeV12_4_3Cleanup(tempDir);
+    expect(existsSync(path.join(tempDir, '.cleanup-v12.4.3-applied'))).toBe(true);
+
+    const db = new Database(dbPath, { readonly: true });
+    try {
+      // COUNT assertions on both tables: orphans survive, stub parents present.
+      expect(count(db, 'SELECT COUNT(*) AS n FROM observations')).toBe(2);
+      expect(count(db, 'SELECT COUNT(*) AS n FROM session_summaries')).toBe(1);
+      expect(count(db, `SELECT COUNT(*) AS n FROM sdk_sessions WHERE memory_session_id IN ('mem-orphan-obs', 'mem-orphan-sum')`)).toBe(2);
+      expect(count(db, `SELECT COUNT(*) AS n FROM sdk_sessions WHERE memory_session_id = 'mem-healthy'`)).toBe(1);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('repair is idempotent: reconstructing over the repaired DB is a no-op', () => {
+    const dbPath = makeTempDbPath();
+    seedLegacyV4DbWithOrphans(dbPath, { orphanObservation: true, orphanSummary: true });
+
+    const first = new SessionStore(dbPath);
+    const sessionsAfterFirst = count(first.db, 'SELECT COUNT(*) AS n FROM sdk_sessions');
+    first.db.close();
+
+    const second = new SessionStore(dbPath);
+    expect(count(second.db, 'SELECT COUNT(*) AS n FROM sdk_sessions')).toBe(sessionsAfterFirst);
+    expect(count(second.db, 'SELECT COUNT(*) AS n FROM observations')).toBe(2);
+    expect(count(second.db, 'SELECT COUNT(*) AS n FROM session_summaries')).toBe(1);
+    second.db.close();
+  });
+});


### PR DESCRIPTION
## The three defects (background-init half of #3378)

### 1. `FOREIGN KEY constraint failed` aborts background init — pinned by a red test first

The pin-down test (`tests/sqlite/session-store-orphan-fk-repair.test.ts`, committed red in a5f8d30a2) seeds a legacy v4-era DB with a child row whose `memory_session_id` has no `sdk_sessions` parent (inserted under `PRAGMA foreign_keys = OFF`, mimicking historical data), then constructs `SessionStore`. On unfixed code it fails 4/4 with `SQLiteError: FOREIGN KEY constraint failed`, and the stack frames pin the exact sites:

- **v9 `makeObservationsTextNullable`** — the `INSERT INTO observations_new SELECT … FROM observations` copy (`SessionStore.ts:1167` pre-fix); committed `schema_versions` stop at `[4,5,6,7,8]`, v9 absent.
- **v7 `removeSessionSummariesUniqueConstraint`** — the `INSERT INTO session_summaries_new SELECT … FROM session_summaries` copy (`SessionStore.ts:1074` pre-fix); committed `schema_versions` stop at `[4,5,6]`, v7 absent.

Both rebuilds copy a child table into a freshly created FK-bearing table with `foreign_keys = ON` (set per connection in `connection.ts:45`) and — unlike the v21/v33/v34 rebuilds — never disable it, so a single orphan aborts the whole constructor migration chain, `dbManager.initialize()` rejects, and the worker never reports ready. Adoption's own SQL cannot raise this error (it only updates non-key columns), and `runOneTimeV12_4_3Cleanup` cannot abort init at all (it swallows its own errors, `CleanupV12_4_3.ts:70-76`).

**Fix principle — repair the parent side.** Orphaned observations/summaries are live user data served by context injection; the missing side is the parent. New `repairOrphanedSessionParents()` creates a minimal completed stub `sdk_sessions` row per orphaned `memory_session_id` inside each rebuild transaction, immediately before the copy, mirroring `SyncApply.ensureSessionForMemoryId` (`INSERT … ON CONFLICT DO NOTHING`, `content_session_id` falls back to the memory id). No child rows are deleted; the repair is gated exactly like the migrations it protects and is a no-op on healthy databases.

### 2. `errors=[object Object]` in the adoption warning

`adoption.errors` (`Array<{worktree, error}>`) was passed as a logger CONTEXT value; `logger.ts` renders context entries with a template literal, so the array printed as `[object Object]`. New `formatAdoptionErrors()` serializes it to `<worktree>: <error>; …` at the log site (unit-tested through the same template rendering).

### 3. `database is locked` during boot — writer race, fixed by ordering

The fire-and-forget worktree-adoption kick started **before** `await this.dbManager.initialize()`, so adoption's separate write connection raced the boot-time migration writer for the single WAL writer slot. The kick now starts after `dbManager.initialize()` and the one-time v12.4.3 cleanup. It stays fire-and-forget — only its start moved. No `busy_timeout` increases, no retry loops.

## Verification

- Pin-down test: red on unfixed code (4 fail, `FOREIGN KEY constraint failed` at the two frames above) → green with the fix; orphan rows survive with stub parents present (COUNT assertions on both tables), repair idempotent, full boot sequence (migrations + v12.4.3 cleanup) completes over the orphan-seeded DB.
- `bun test tests/sqlite/ tests/worker/ tests/services/`: 670 pass / 0 fail (includes `tests/worker/sync/mutation-sites.test.ts` and `tests/services/infrastructure/worktree-adoption-chroma.test.ts`).
- `npx tsc --noEmit`: clean.
- Ready-flag fail-fast gating in `initializeBackground` unchanged; injection query unchanged; no catch-and-continue added.

Closes #3378 (its other half — the recycle loop — already shipped in 13.12.3 as 906ffe37b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSNZmfi4vSYjTeEWtwqKrW