### PR TITLE
fix(packaging): stop shipping maintainer directives in CLAUDE.md via marketplace clone (#3381)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ plugin/.cli-installed
 plugin/scripts/claude-mem
 
 CONTRIB_NOTES.md
+CLAUDE.local.md
 
 .docker-claude-mem-data/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,17 +31,3 @@ npm run build-and-sync        # Build, sync to marketplace, restart worker
 ## Important
 
 No need to edit the changelog ever, it's generated automatically.
-
-## Local Status Notes
-
-- 2026-06-15: Issue #2909 is intentionally split. PR #2919 covers session-isolation/read-path behavior, while target 29 covers the observer `.jsonl` accumulation half by disabling session persistence for observer tool-use SDK queries.
-
-## Daily Maintenance
-
-Run a daily version check across all package manifests and upgrade every dependency to its latest version — including major version bumps. Staying on the latest is the goal; do not skip majors.
-
-- Check `package.json` (root) and all nested `package.json` files (e.g. `plugin/`, `openclaw/`) for outdated dependencies via `npm outdated`.
-- Upgrade every package to `latest` (use `npm install <pkg>@latest` for each, or `npx npm-check-updates -u && npm install`). Bump majors too.
-- Run `npm audit fix` to resolve advisories.
-- After upgrades, run `npm run build-and-sync` and verify the worker starts and tests pass. Fix any breakage caused by major bumps in the same change.
-- Commit the updated `package.json` and `package-lock.json` files.

--- a/scripts/sync-marketplace.cjs
+++ b/scripts/sync-marketplace.cjs
@@ -75,7 +75,7 @@ try {
   const gitignoreExcludes = getGitignoreExcludes(rootDir);
 
   execSync(
-    `rsync -av --delete --exclude=.git --exclude=bun.lock --exclude=package-lock.json --exclude=scripts/package.json --exclude=scripts/node_modules --exclude=/workers ${gitignoreExcludes} ./ ~/.claude/plugins/marketplaces/thedotmack/`,
+    `rsync -av --delete --exclude=.git --exclude=bun.lock --exclude=package-lock.json --exclude=scripts/package.json --exclude=scripts/node_modules --exclude=/workers --exclude=/CLAUDE.md ${gitignoreExcludes} ./ ~/.claude/plugins/marketplaces/thedotmack/`,
     { stdio: 'inherit' }
   );
 

--- a/scripts/sync-marketplace.cjs
+++ b/scripts/sync-marketplace.cjs
@@ -75,7 +75,7 @@ try {
   const gitignoreExcludes = getGitignoreExcludes(rootDir);
 
   execSync(
-    `rsync -av --delete --exclude=.git --exclude=bun.lock --exclude=package-lock.json --exclude=scripts/package.json --exclude=scripts/node_modules --exclude=/workers --exclude=/CLAUDE.md ${gitignoreExcludes} ./ ~/.claude/plugins/marketplaces/thedotmack/`,
+    `rsync -av --delete --exclude=.git --exclude=bun.lock --exclude=package-lock.json --exclude=scripts/package.json --exclude=scripts/node_modules --exclude=/workers ${gitignoreExcludes} ./ ~/.claude/plugins/marketplaces/thedotmack/`,
     { stdio: 'inherit' }
   );
 


### PR DESCRIPTION
## Leak vector

The GitHub marketplace install channel is a **git clone** of this repo (`known_marketplaces.json`: `source: github, repo: thedotmack/claude-mem` → `~/.claude/plugins/marketplaces/thedotmack/`), so every tracked file ships to end users — including root `CLAUDE.md`. Its maintainer-only sections (`## Local Status Notes`, `## Daily Maintenance`) contained autonomous agent directives (a daily auto-upgrade-and-commit instruction) that end-user Claude instances then obey.

The `.npmignore` guard added in #2537 (`/CLAUDE.md` etc.) governs only the **npm tarball** — which is exactly why GitHub-source installs bypass it, as reported in #3359. A git clone ships every tracked file, so the dangerous content simply must not be tracked.

## Fix

- **Relocate the maintainer directives**: `## Local Status Notes` and `## Daily Maintenance` moved verbatim out of root `CLAUDE.md` into `CLAUDE.local.md`, which is gitignored and auto-loaded locally by Claude Code for the maintainer. Root `CLAUDE.md` keeps only legitimate contributor content (Build, File Locations, Requirements, Documentation, Important).
- **Ignore it**: `CLAUDE.local.md` added to `.gitignore` (next to the existing `CONTRIB_NOTES.md` entry).
- **Maintainer sync unchanged (intentional)**: the rsync in `scripts/sync-marketplace.cjs` deliberately copies the slim tracked `CLAUDE.md` over any stale directive-bearing copy in `~/.claude/plugins/marketplaces/thedotmack/` — an `--exclude=/CLAUDE.md` would have protected the stale destination file from rsync's `--delete`/overwrite, preserving the leak locally, and a fresh GitHub clone of the slimmed repo still contains the contributor `CLAUDE.md` anyway. `CLAUDE.local.md` never syncs because the script builds its exclude list from `.gitignore` (`getGitignoreExcludes()`), which now lists it.

## Verification

- `grep -n "Daily Maintenance\|Local Status Notes" CLAUDE.md` → no hits
- Moved sections are byte-identical to the originals (diff against `HEAD:CLAUDE.md` lines 35-47 clean)
- `git check-ignore -v CLAUDE.local.md` → `.gitignore:44:CLAUDE.local.md`; the file is untracked-and-ignored, not part of this PR
- `getGitignoreExcludes()` output confirmed to contain `--exclude="CLAUDE.local.md"`, so the marketplace rsync never copies the maintainer-local file
- `git diff origin/main...HEAD -- scripts/` → empty; net PR diff is `CLAUDE.md` (−14) and `.gitignore` (+1) only
- `plugin/modes/law-study-CLAUDE.md` (functional mode template) and `CHANGELOG.md` untouched

Closes #3381

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RSNZmfi4vSYjTeEWtwqKrW
