### PR TITLE
fix(chroma): surface fatal child exits in doctor (refs #3362)

### DIFF
--- a/src/npx-cli/commands/doctor.ts
+++ b/src/npx-cli/commands/doctor.ts
@@ -23,6 +23,17 @@ interface CheckResult {
   required: boolean;
 }
 
+interface ChromaCrashState {
+  count: number;
+  lastExit: {
+    timestamp: string;
+    code: number | null;
+    signal: string | null;
+  } | null;
+  chromaMcpVersion: string;
+  dependencyOverrides: string[];
+}
+
 function probeVersion(bin: 'bun' | 'uv'): string | null {
   try {
     return bin === 'bun' ? getBunVersion() : getUvVersion();
@@ -33,15 +44,30 @@ function probeVersion(bin: 'bun' | 'uv'): string | null {
   }
 }
 
-async function probeWorkerHealth(workerHost: string, workerPort: string): Promise<{ status: CheckStatus; detail: string }> {
+async function probeWorkerHealth(workerHost: string, workerPort: string): Promise<{
+  status: CheckStatus;
+  detail: string;
+  workerUrl: string;
+}> {
   const workerUrl = `http://${workerHost}:${workerPort}`;
   const res = await fetch(`${workerUrl}/api/health`, {
     signal: AbortSignal.timeout(3000),
   });
   if (res.ok) {
-    return { status: 'ok', detail: `healthy at ${workerUrl}` };
+    return { status: 'ok', detail: `healthy at ${workerUrl}`, workerUrl };
   }
-  return { status: 'warn', detail: `reachable but unhealthy (HTTP ${res.status}) at ${workerUrl}` };
+  return { status: 'warn', detail: `reachable but unhealthy (HTTP ${res.status}) at ${workerUrl}`, workerUrl };
+}
+
+function isChromaCrashState(value: unknown): value is ChromaCrashState {
+  if (!value || typeof value !== 'object') return false;
+  const state = value as Partial<ChromaCrashState>;
+  return typeof state.count === 'number' && Number.isInteger(state.count) && state.count >= 0 && Array.isArray(state.dependencyOverrides)
+    && typeof state.chromaMcpVersion === 'string'
+    && (state.lastExit === null || (typeof state.lastExit === 'object' && state.lastExit !== null
+      && typeof state.lastExit.timestamp === 'string'
+      && (typeof state.lastExit.code === 'number' || state.lastExit.code === null)
+      && (typeof state.lastExit.signal === 'string' || state.lastExit.signal === null)));
 }
 
 export async function runDoctorCommand(): Promise<void> {
@@ -105,6 +131,28 @@ export async function runDoctorCommand(): Promise<void> {
     const worker = await probeWorkerHealth(workerHost, workerPort);
     workerStatus = worker.status;
     workerDetail = worker.detail;
+    try {
+      const diagnosticsResponse = await fetch(`${worker.workerUrl}/api/admin/doctor`, {
+        signal: AbortSignal.timeout(3000),
+      });
+      if (diagnosticsResponse.ok) {
+        const diagnostics = await diagnosticsResponse.json() as { health?: { chroma?: unknown } };
+        const chroma = diagnostics?.health?.chroma;
+        if (isChromaCrashState(chroma) && chroma.count > 0 && chroma.lastExit) {
+          const outcome = chroma.lastExit.signal
+            ? `signal ${chroma.lastExit.signal}`
+            : `code ${chroma.lastExit.code}`;
+          checks.push({
+            name: 'Chroma child exits',
+            status: 'warn',
+            detail: `${chroma.count} (${outcome}) at ${chroma.lastExit.timestamp}; chroma-mcp ${chroma.chromaMcpVersion}; overrides: ${chroma.dependencyOverrides.join(', ')}`,
+            required: false,
+          });
+        }
+      }
+    } catch {
+      // Diagnostics are optional and must not change worker health status.
+    }
   } catch {
     // leave as fail
   }

--- a/src/services/server/Server.ts
+++ b/src/services/server/Server.ts
@@ -15,6 +15,7 @@ import { getUptimeSeconds } from '../../shared/uptime.js';
 import { snapshotDependencyHealth, type DependencyHealthSnapshot } from '../../shared/dependency-health.js';
 import { globalRateLimitStore } from '../worker/RateLimitStore.js';
 import type { ObservationQueueHealth } from '../../server/queue/queue-health-types.js';
+import type { ChromaCrashState } from '../sync/ChromaMcpManager.js';
 
 const INSTRUCTIONS_BASE_DIR: string = path.resolve(__dirname, '../skills/mem-search');
 const INSTRUCTIONS_OPERATIONS_DIR: string = path.join(INSTRUCTIONS_BASE_DIR, 'operations');
@@ -89,6 +90,7 @@ export interface ServerOptions {
   runtime?: string;
   getAiStatus: () => AiStatus;
   getDependencyHealth?: () => DependencyHealthSnapshot;
+  getChromaCrashState?: () => ChromaCrashState | undefined;
   preBodyParserRoutes?: RouteHandler[];
   getQueueHealth?: () => ObservationQueueHealth | null | Promise<ObservationQueueHealth | null>;
   // #2572 — when true, install a minimal set of hardening response headers
@@ -346,6 +348,7 @@ export class Server {
       const hours = Math.floor(uptimeSeconds / 3600);
       const minutes = Math.floor((uptimeSeconds % 3600) / 60);
       const formattedUptime = hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+      const chromaCrashState = this.options.getChromaCrashState?.();
 
       res.json({
         supervisor: {
@@ -360,6 +363,9 @@ export class Server {
           dependencies: this.options.getDependencyHealth
             ? this.options.getDependencyHealth()
             : snapshotDependencyHealth(),
+          ...(chromaCrashState
+            ? { chroma: chromaCrashState }
+            : {}),
         },
       });
     });

--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -56,6 +56,17 @@ const CHROMA_MCP_DEP_OVERRIDES: ReadonlyArray<string> = [
   'chromadb==1.0.16',
 ];
 
+export interface ChromaCrashState {
+  count: number;
+  lastExit: {
+    timestamp: string;
+    code: number | null;
+    signal: NodeJS.Signals | null;
+  } | null;
+  chromaMcpVersion: string;
+  dependencyOverrides: string[];
+}
+
 // Issue #2696 (revised): chroma-mcp is now spawned by invoking uvx DIRECTLY on
 // every platform — see ChromaMcpManager.resolveUvxCommand(). The previous
 // `cmd.exe` shell-wrapper path, and the cmd.exe metacharacter-quoting helper that
@@ -92,6 +103,8 @@ export class ChromaMcpManager {
   private readonly chromaWriterOwnerId = `${process.pid}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
   private chromaWriterLock: { path: string; dataDir: string; ownerId: string } | null = null;
   private unexpectedCloseCleanup: Promise<void> | null = null;
+  private chromaCrashCount = 0;
+  private chromaLastExit: ChromaCrashState['lastExit'] = null;
   private static uvxAvailabilityProbe: ((command: string, env: Record<string, string>, platform: NodeJS.Platform) => boolean) | null = null;
 
   private constructor() {}
@@ -255,7 +268,8 @@ export class ChromaMcpManager {
     logger.info('CHROMA_MCP', 'Connected to chroma-mcp successfully');
 
     const currentTransport = this.transport;
-    const currentTrackedPid = (this.transport as unknown as { _process?: ChildProcess })._process?.pid;
+    const currentProcess = (this.transport as unknown as { _process?: ChildProcess })._process;
+    const currentTrackedPid = currentProcess?.pid;
     this.transport.onclose = () => {
       if (this.transport !== currentTransport) {
         logger.debug('CHROMA_MCP', 'Ignoring stale onclose from previous transport');
@@ -268,7 +282,19 @@ export class ChromaMcpManager {
         logger.debug('CHROMA_MCP', 'Ignoring onclose from intentionally closed transport');
         return;
       }
-      logger.warn('CHROMA_MCP', 'chroma-mcp subprocess closed unexpectedly, applying reconnect backoff');
+      this.chromaCrashCount += 1;
+      this.chromaLastExit = {
+        timestamp: new Date().toISOString(),
+        code: currentProcess?.exitCode ?? null,
+        signal: currentProcess?.signalCode ?? null,
+      };
+      logger.warn('CHROMA_MCP', 'chroma-mcp subprocess closed unexpectedly, applying reconnect backoff', {
+        count: this.chromaCrashCount,
+        exitCode: this.chromaLastExit.code,
+        signalCode: this.chromaLastExit.signal,
+        chromaMcpVersion: CHROMA_MCP_PINNED_VERSION,
+        dependencyOverrides: [...CHROMA_MCP_DEP_OVERRIDES],
+      });
       this.connected = false;
       getSupervisor().unregisterProcess(CHROMA_SUPERVISOR_ID);
       this.client = null;
@@ -281,6 +307,15 @@ export class ChromaMcpManager {
       // captured PID — best-effort; pgrep returns nothing if everything
       // already exited (#2313).
       this.scheduleUnexpectedCloseCleanup(currentTrackedPid);
+    };
+  }
+
+  getCrashState(): ChromaCrashState {
+    return {
+      count: this.chromaCrashCount,
+      lastExit: this.chromaLastExit ? { ...this.chromaLastExit } : null,
+      chromaMcpVersion: CHROMA_MCP_PINNED_VERSION,
+      dependencyOverrides: [...CHROMA_MCP_DEP_OVERRIDES],
     };
   }
 

--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -45,11 +45,15 @@ const CHROMA_MCP_PINNED_VERSION = '0.2.6';
 // `TypeError: Descriptors cannot be created directly` at chromadb import.
 // Capping below 7 lands on protobuf 6.x which opentelemetry tolerates.
 //
+// Why chromadb==1.0.16: chroma-mcp 0.2.6 declares chromadb>=1.0.16.
+// Pinning that floor keeps claude-mem's runtime closure reproducible.
+//
 // These pins are runtime-only (uvx --with) so we don't have to fork
 // chroma-mcp upstream — they apply only to claude-mem's spawned subprocess.
 const CHROMA_MCP_DEP_OVERRIDES: ReadonlyArray<string> = [
   'onnxruntime>=1.20',
   'protobuf<7',
+  'chromadb==1.0.16',
 ];
 
 // Issue #2696 (revised): chroma-mcp is now spawned by invoking uvx DIRECTLY on

--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -47,11 +47,15 @@ const CHROMA_MCP_PINNED_VERSION = '0.2.6';
 // `TypeError: Descriptors cannot be created directly` at chromadb import.
 // Capping below 7 lands on protobuf 6.x which opentelemetry tolerates.
 //
+// Why chromadb==1.0.16: chroma-mcp 0.2.6 declares chromadb>=1.0.16.
+// Pinning that floor keeps claude-mem's runtime closure reproducible.
+//
 // These pins are runtime-only (uvx --with) so we don't have to fork
 // chroma-mcp upstream — they apply only to claude-mem's spawned subprocess.
 const CHROMA_MCP_DEP_OVERRIDES: ReadonlyArray<string> = [
   'onnxruntime>=1.20',
   'protobuf<7',
+  'chromadb==1.0.16',
 ];
 
 // Issue #2696 (revised): chroma-mcp is now spawned by invoking uvx DIRECTLY on

--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -58,6 +58,17 @@ const CHROMA_MCP_DEP_OVERRIDES: ReadonlyArray<string> = [
   'chromadb==1.0.16',
 ];
 
+export interface ChromaCrashState {
+  count: number;
+  lastExit: {
+    timestamp: string;
+    code: number | null;
+    signal: NodeJS.Signals | null;
+  } | null;
+  chromaMcpVersion: string;
+  dependencyOverrides: string[];
+}
+
 // Issue #2696 (revised): chroma-mcp is now spawned by invoking uvx DIRECTLY on
 // every platform — see ChromaMcpManager.resolveUvxCommand(). The previous
 // `cmd.exe` shell-wrapper path, and the cmd.exe metacharacter-quoting helper that
@@ -99,6 +110,8 @@ export class ChromaMcpManager {
   private readonly maxPendingMutationCalls: number;
   private readonly serializeMutations: boolean;
   private acceptingLocalMutations = true;
+  private chromaCrashCount = 0;
+  private chromaLastExit: ChromaCrashState['lastExit'] = null;
   private static uvxAvailabilityProbe: ((command: string, env: Record<string, string>, platform: NodeJS.Platform) => boolean) | null = null;
 
   private constructor() {
@@ -269,7 +282,8 @@ export class ChromaMcpManager {
     logger.info('CHROMA_MCP', 'Connected to chroma-mcp successfully');
 
     const currentTransport = this.transport;
-    const currentTrackedPid = (this.transport as unknown as { _process?: ChildProcess })._process?.pid;
+    const currentProcess = (this.transport as unknown as { _process?: ChildProcess })._process;
+    const currentTrackedPid = currentProcess?.pid;
     this.transport.onclose = () => {
       if (this.transport !== currentTransport) {
         logger.debug('CHROMA_MCP', 'Ignoring stale onclose from previous transport');
@@ -282,7 +296,19 @@ export class ChromaMcpManager {
         logger.debug('CHROMA_MCP', 'Ignoring onclose from intentionally closed transport');
         return;
       }
-      logger.warn('CHROMA_MCP', 'chroma-mcp subprocess closed unexpectedly, applying reconnect backoff');
+      this.chromaCrashCount += 1;
+      this.chromaLastExit = {
+        timestamp: new Date().toISOString(),
+        code: currentProcess?.exitCode ?? null,
+        signal: currentProcess?.signalCode ?? null,
+      };
+      logger.warn('CHROMA_MCP', 'chroma-mcp subprocess closed unexpectedly, applying reconnect backoff', {
+        count: this.chromaCrashCount,
+        exitCode: this.chromaLastExit.code,
+        signalCode: this.chromaLastExit.signal,
+        chromaMcpVersion: CHROMA_MCP_PINNED_VERSION,
+        dependencyOverrides: [...CHROMA_MCP_DEP_OVERRIDES],
+      });
       this.connected = false;
       getSupervisor().unregisterProcess(CHROMA_SUPERVISOR_ID);
       this.client = null;
@@ -295,6 +321,15 @@ export class ChromaMcpManager {
       // captured PID — best-effort; pgrep returns nothing if everything
       // already exited (#2313).
       this.scheduleUnexpectedCloseCleanup(currentTrackedPid);
+    };
+  }
+
+  getCrashState(): ChromaCrashState {
+    return {
+      count: this.chromaCrashCount,
+      lastExit: this.chromaLastExit ? { ...this.chromaLastExit } : null,
+      chromaMcpVersion: CHROMA_MCP_PINNED_VERSION,
+      dependencyOverrides: [...CHROMA_MCP_DEP_OVERRIDES],
     };
   }
 

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -273,6 +273,7 @@ export class WorkerService implements WorkerRef {
       getInitializationComplete: () => this.initializationCompleteFlag,
       getMcpReady: () => this.mcpReady,
       getDependencyHealth: () => snapshotDependencyHealth(),
+      getChromaCrashState: () => this.chromaMcpManager?.getCrashState(),
       onShutdown: (reason) => this.shutdown(reason ?? 'stop'),
       onRestart: () => this.shutdown('restart'),
       workerPath: __filename,

--- a/tests/integration/worker-api-endpoints.test.ts
+++ b/tests/integration/worker-api-endpoints.test.ts
@@ -51,6 +51,12 @@ describe('Worker API Endpoints Integration', () => {
         authMethod: 'cli',
         lastInteraction: null,
       }),
+      getChromaCrashState: () => ({
+        count: 1,
+        lastExit: { timestamp: '2026-07-23T12:00:00.000Z', code: null, signal: 'SIGSEGV' },
+        chromaMcpVersion: '0.2.6',
+        dependencyOverrides: ['onnxruntime>=1.20', 'protobuf<7', 'chromadb==1.0.16'],
+      }),
     };
 
     testPort = 40000 + Math.floor(Math.random() * 10000);
@@ -255,6 +261,12 @@ describe('Worker API Endpoints Integration', () => {
             remediation: 'Install Claude Code CLI',
           },
         ],
+      });
+      expect(body.health.chroma).toEqual({
+        count: 1,
+        lastExit: { timestamp: '2026-07-23T12:00:00.000Z', code: null, signal: 'SIGSEGV' },
+        chromaMcpVersion: '0.2.6',
+        dependencyOverrides: ['onnxruntime>=1.20', 'protobuf<7', 'chromadb==1.0.16'],
       });
     });
 

--- a/tests/npx-cli/doctor.test.ts
+++ b/tests/npx-cli/doctor.test.ts
@@ -1,45 +1,28 @@
-import { afterAll, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
-
-import * as realSettingsDefaultsManager from '../../src/shared/SettingsDefaultsManager.js';
-import * as realInstallSetupRuntime from '../../src/npx-cli/install/setup-runtime.js';
-import * as realPaths from '../../src/shared/paths.js';
-
-const realSettingsSnapshot = { ...realSettingsDefaultsManager };
-const realInstallSetupRuntimeSnapshot = { ...realInstallSetupRuntime };
-const realPathsSnapshot = { ...realPaths };
-
-mock.module('../../src/shared/SettingsDefaultsManager.js', () => ({
-  SettingsDefaultsManager: { get: (key: string) => key === 'CLAUDE_MEM_WORKER_HOST' ? '127.0.0.1' : '39999' },
-}));
-mock.module('../../src/npx-cli/install/setup-runtime.js', () => ({
-  getBunVersion: () => '1.2.3',
-  getUvVersion: () => '0.8.0',
-  isInstallCurrent: () => true,
-}));
-mock.module('../../src/shared/paths.js', () => ({
-  resolveDataDir: () => '/tmp/claude-mem-doctor-test',
-}));
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
 import { runDoctorCommand } from '../../src/npx-cli/commands/doctor.js';
 
-const originalFetch = globalThis.fetch;
-const originalExit = process.exit;
-const originalLog = console.log;
+let fetchSpy: ReturnType<typeof spyOn> | null = null;
+let consoleLogSpy: ReturnType<typeof spyOn> | null = null;
+let exitSpy: ReturnType<typeof spyOn> | null = null;
+let output: string[] = [];
 
-afterAll(() => {
-  globalThis.fetch = originalFetch;
-  process.exit = originalExit;
-  console.log = originalLog;
-  mock.module('../../src/shared/SettingsDefaultsManager.js', () => realSettingsSnapshot);
-  mock.module('../../src/npx-cli/install/setup-runtime.js', () => realInstallSetupRuntimeSnapshot);
-  mock.module('../../src/shared/paths.js', () => realPathsSnapshot);
-});
+function captureDoctorOutput(): void {
+  output = [];
+  consoleLogSpy = spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    output.push(args.join(' '));
+  });
+  exitSpy = spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+}
 
 describe('npx doctor Chroma diagnostics', () => {
   beforeEach(() => {
-    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+    output = [];
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input);
-      if (url.endsWith('/api/health')) return new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+      if (url.endsWith('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+      }
       return new Response(JSON.stringify({
         health: {
           chroma: {
@@ -50,13 +33,20 @@ describe('npx doctor Chroma diagnostics', () => {
           },
         },
       }), { status: 200 });
-    }) as typeof fetch;
+    });
+  });
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+    fetchSpy = null;
+    consoleLogSpy?.mockRestore();
+    consoleLogSpy = null;
+    exitSpy?.mockRestore();
+    exitSpy = null;
   });
 
   it('renders the warn-only exact Chroma child exit detail', async () => {
-    const output: string[] = [];
-    console.log = (...args: unknown[]) => output.push(args.join(' '));
-    process.exit = (() => undefined) as typeof process.exit;
+    captureDoctorOutput();
 
     await runDoctorCommand();
 
@@ -69,10 +59,8 @@ describe('npx doctor Chroma diagnostics', () => {
   });
 
   it('does not fabricate crash state when the worker is unreachable', async () => {
-    const output: string[] = [];
-    console.log = (...args: unknown[]) => output.push(args.join(' '));
-    process.exit = (() => undefined) as typeof process.exit;
-    globalThis.fetch = mock(async () => { throw new Error('connection refused'); }) as typeof fetch;
+    captureDoctorOutput();
+    fetchSpy?.mockImplementation(async () => { throw new Error('connection refused'); });
 
     await runDoctorCommand();
 
@@ -82,15 +70,13 @@ describe('npx doctor Chroma diagnostics', () => {
   });
 
   it('ignores a missing or malformed admin Chroma payload', async () => {
-    const output: string[] = [];
-    console.log = (...args: unknown[]) => output.push(args.join(' '));
-    process.exit = (() => undefined) as typeof process.exit;
-    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+    captureDoctorOutput();
+    fetchSpy?.mockImplementation(async (input: RequestInfo | URL) => {
       if (String(input).endsWith('/api/health')) {
         return new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
       }
       return new Response(JSON.stringify({ health: { chroma: { count: 'not-a-number' } } }), { status: 200 });
-    }) as typeof fetch;
+    });
 
     await runDoctorCommand();
 

--- a/tests/npx-cli/doctor.test.ts
+++ b/tests/npx-cli/doctor.test.ts
@@ -1,0 +1,101 @@
+import { afterAll, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+
+import * as realSettingsDefaultsManager from '../../src/shared/SettingsDefaultsManager.js';
+import * as realInstallSetupRuntime from '../../src/npx-cli/install/setup-runtime.js';
+import * as realPaths from '../../src/shared/paths.js';
+
+const realSettingsSnapshot = { ...realSettingsDefaultsManager };
+const realInstallSetupRuntimeSnapshot = { ...realInstallSetupRuntime };
+const realPathsSnapshot = { ...realPaths };
+
+mock.module('../../src/shared/SettingsDefaultsManager.js', () => ({
+  SettingsDefaultsManager: { get: (key: string) => key === 'CLAUDE_MEM_WORKER_HOST' ? '127.0.0.1' : '39999' },
+}));
+mock.module('../../src/npx-cli/install/setup-runtime.js', () => ({
+  getBunVersion: () => '1.2.3',
+  getUvVersion: () => '0.8.0',
+  isInstallCurrent: () => true,
+}));
+mock.module('../../src/shared/paths.js', () => ({
+  resolveDataDir: () => '/tmp/claude-mem-doctor-test',
+}));
+
+import { runDoctorCommand } from '../../src/npx-cli/commands/doctor.js';
+
+const originalFetch = globalThis.fetch;
+const originalExit = process.exit;
+const originalLog = console.log;
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+  process.exit = originalExit;
+  console.log = originalLog;
+  mock.module('../../src/shared/SettingsDefaultsManager.js', () => realSettingsSnapshot);
+  mock.module('../../src/npx-cli/install/setup-runtime.js', () => realInstallSetupRuntimeSnapshot);
+  mock.module('../../src/shared/paths.js', () => realPathsSnapshot);
+});
+
+describe('npx doctor Chroma diagnostics', () => {
+  beforeEach(() => {
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/api/health')) return new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+      return new Response(JSON.stringify({
+        health: {
+          chroma: {
+            count: 1,
+            lastExit: { timestamp: '2026-07-23T12:00:00.000Z', code: null, signal: 'SIGSEGV' },
+            chromaMcpVersion: '0.2.6',
+            dependencyOverrides: ['onnxruntime>=1.20', 'protobuf<7', 'chromadb==1.0.16'],
+          },
+        },
+      }), { status: 200 });
+    }) as typeof fetch;
+  });
+
+  it('renders the warn-only exact Chroma child exit detail', async () => {
+    const output: string[] = [];
+    console.log = (...args: unknown[]) => output.push(args.join(' '));
+    process.exit = (() => undefined) as typeof process.exit;
+
+    await runDoctorCommand();
+
+    const text = output.join('\n');
+    expect(text).toContain('Chroma child exits');
+    expect(text).toContain('1 (signal SIGSEGV)');
+    expect(text).toContain('2026-07-23T12:00:00.000Z');
+    expect(text).toContain('chroma-mcp 0.2.6');
+    expect(text).toContain('onnxruntime>=1.20, protobuf<7, chromadb==1.0.16');
+  });
+
+  it('does not fabricate crash state when the worker is unreachable', async () => {
+    const output: string[] = [];
+    console.log = (...args: unknown[]) => output.push(args.join(' '));
+    process.exit = (() => undefined) as typeof process.exit;
+    globalThis.fetch = mock(async () => { throw new Error('connection refused'); }) as typeof fetch;
+
+    await runDoctorCommand();
+
+    const text = output.join('\n');
+    expect(text).toContain('Worker daemon');
+    expect(text).not.toContain('Chroma child exits');
+  });
+
+  it('ignores a missing or malformed admin Chroma payload', async () => {
+    const output: string[] = [];
+    console.log = (...args: unknown[]) => output.push(args.join(' '));
+    process.exit = (() => undefined) as typeof process.exit;
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      if (String(input).endsWith('/api/health')) {
+        return new Response(JSON.stringify({ status: 'ok' }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ health: { chroma: { count: 'not-a-number' } } }), { status: 200 });
+    }) as typeof fetch;
+
+    await runDoctorCommand();
+
+    const text = output.join('\n');
+    expect(text).toContain('Worker daemon');
+    expect(text).not.toContain('Chroma child exits');
+  });
+});

--- a/tests/services/sync/chroma-mcp-manager-singleton.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-singleton.test.ts
@@ -434,6 +434,7 @@ describe('ChromaMcpManager singleton enforcement (#2313)', () => {
     await mgr.callTool('chroma_list_collections', { limit: 1 });
 
     expect(transportInstances.length).toBe(2);
+    expect(mgr.getCrashState()).toMatchObject({ count: 0, lastExit: null });
     expect(logEntries.some(entry => entry.message === 'chroma-mcp subprocess closed unexpectedly, applying reconnect backoff')).toBe(false);
   });
 
@@ -456,7 +457,7 @@ describe('ChromaMcpManager singleton enforcement (#2313)', () => {
     expect(transportInstances.length).toBe(2);
   });
 
-  it('stop() ignores close-triggered onclose from an intentionally closed transport', async () => {
+  it('stop() ignores close-triggered onclose after shutdown generation changes', async () => {
     transportCloseEmitsOnclose = true;
     const mgr = ChromaMcpManager.getInstance();
 
@@ -520,14 +521,11 @@ describe('ChromaMcpManager singleton enforcement (#2313)', () => {
     });
   });
 
-  it('keeps intentional and stale closes out of crash state', async () => {
-    transportCloseEmitsOnclose = true;
+  it('keeps stale closes out of crash state', async () => {
     const mgr = ChromaMcpManager.getInstance();
     await mgr.callTool('chroma_list_collections', { limit: 1 });
     const firstTransport = transportInstances[0];
     await mgr.stop();
-    expect(mgr.getCrashState().count).toBe(0);
-    expect(logEntries.some(entry => entry.meta?.signalCode === 'SIGSEGV' || entry.meta?.exitCode === 1)).toBe(false);
 
     await mgr.callTool('chroma_list_collections', { limit: 1 });
     firstTransport._process.finish(null, 'SIGSEGV');

--- a/tests/services/sync/chroma-mcp-manager-singleton.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-singleton.test.ts
@@ -466,10 +466,81 @@ describe('ChromaMcpManager singleton enforcement (#2313)', () => {
     await mgr.stop();
 
     expect(transportInstances[0].closed).toBe(true);
+    expect(mgr.getCrashState().count).toBe(0);
     expect(logEntries.some(entry => entry.message === 'chroma-mcp subprocess closed unexpectedly, applying reconnect backoff')).toBe(false);
 
     await mgr.callTool('chroma_list_collections', { limit: 1 });
+    expect(mgr.getCrashState().count).toBe(0);
     expect(transportInstances.length).toBe(2);
+  });
+
+  it('records exact active-child exit details and retains them across reconnect', async () => {
+    const mgr = ChromaMcpManager.getInstance();
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+    const firstTransport = transportInstances[0];
+    firstTransport._process.finish(null, 'SIGSEGV');
+    firstTransport.onclose?.();
+
+    const firstState = mgr.getCrashState();
+    expect(firstState.count).toBe(1);
+    expect(firstState.lastExit).toMatchObject({ code: null, signal: 'SIGSEGV' });
+    expect(firstState.chromaMcpVersion).toBe('0.2.6');
+    expect(firstState.dependencyOverrides).toEqual([
+      'onnxruntime>=1.20',
+      'protobuf<7',
+      'chromadb==1.0.16',
+    ]);
+    expect(logEntries.find(entry => entry.message === 'chroma-mcp subprocess closed unexpectedly, applying reconnect backoff')?.meta)
+      .toMatchObject({ count: 1, exitCode: null, signalCode: 'SIGSEGV' });
+
+    const privateManager = mgr as unknown as { lastConnectionFailureTimestamp: number };
+    privateManager.lastConnectionFailureTimestamp = 0;
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+    expect(mgr.getCrashState()).toEqual(firstState);
+
+    const secondTransport = transportInstances[1];
+    secondTransport._process.finish(1);
+    secondTransport.onclose?.();
+    expect(mgr.getCrashState()).toMatchObject({
+      count: 2,
+      lastExit: { code: 1, signal: null },
+    });
+  });
+
+  it('records a clean but unexpected active-child close as code 0', async () => {
+    const mgr = ChromaMcpManager.getInstance();
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+    const transport = transportInstances[0];
+    transport._process.finish(0, null);
+    transport.onclose?.();
+
+    expect(mgr.getCrashState()).toMatchObject({
+      count: 1,
+      lastExit: { code: 0, signal: null },
+    });
+  });
+
+  it('keeps intentional and stale closes out of crash state', async () => {
+    transportCloseEmitsOnclose = true;
+    const mgr = ChromaMcpManager.getInstance();
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+    const firstTransport = transportInstances[0];
+    await mgr.stop();
+    expect(mgr.getCrashState().count).toBe(0);
+    expect(logEntries.some(entry => entry.meta?.signalCode === 'SIGSEGV' || entry.meta?.exitCode === 1)).toBe(false);
+
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+    firstTransport._process.finish(null, 'SIGSEGV');
+    firstTransport.onclose?.();
+    expect(mgr.getCrashState().count).toBe(0);
+  });
+
+  it('does not count a prewarm child failure as an active-child exit', async () => {
+    prewarmSpawnBehavior = 'failure';
+    const mgr = ChromaMcpManager.getInstance();
+
+    await expect(mgr.callTool('chroma_list_collections', { limit: 1 })).rejects.toThrow('prewarm failed');
+    expect(mgr.getCrashState()).toMatchObject({ count: 0, lastExit: null });
   });
 
   it('stop() during a hanging prewarm does not record uvx unavailable or apply reconnect backoff', async () => {
@@ -492,6 +563,7 @@ describe('ChromaMcpManager singleton enforcement (#2313)', () => {
     expect(transportInstances.length).toBe(0);
     expect(transportCount).toBe(0);
     expect(getDependencyStatus('uvx')).toBeNull();
+    expect(mgr.getCrashState().count).toBe(0);
     expect(logEntries.some(entry => entry.message === 'chroma-mcp uvx prewarm failed')).toBe(false);
 
     prewarmSpawnBehavior = 'success';

--- a/tests/services/sync/chroma-mcp-manager-singleton.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-singleton.test.ts
@@ -495,6 +495,7 @@ describe('ChromaMcpManager singleton enforcement (#2313)', () => {
     await mgr.callTool('chroma_list_collections', { limit: 1 });
 
     expect(transportInstances.length).toBe(2);
+    expect(mgr.getCrashState()).toMatchObject({ count: 0, lastExit: null });
     expect(logEntries.some(entry => entry.message === 'chroma-mcp subprocess closed unexpectedly, applying reconnect backoff')).toBe(false);
   });
 
@@ -550,7 +551,7 @@ describe('ChromaMcpManager singleton enforcement (#2313)', () => {
     expect(prewarmSpawnCalls.length).toBe(0);
   });
 
-  it('stop() ignores close-triggered onclose from an intentionally closed transport', async () => {
+  it('stop() ignores close-triggered onclose after shutdown generation changes', async () => {
     transportCloseEmitsOnclose = true;
     const mgr = ChromaMcpManager.getInstance();
 
@@ -614,14 +615,11 @@ describe('ChromaMcpManager singleton enforcement (#2313)', () => {
     });
   });
 
-  it('keeps intentional and stale closes out of crash state', async () => {
-    transportCloseEmitsOnclose = true;
+  it('keeps stale closes out of crash state', async () => {
     const mgr = ChromaMcpManager.getInstance();
     await mgr.callTool('chroma_list_collections', { limit: 1 });
     const firstTransport = transportInstances[0];
     await mgr.stop();
-    expect(mgr.getCrashState().count).toBe(0);
-    expect(logEntries.some(entry => entry.meta?.signalCode === 'SIGSEGV' || entry.meta?.exitCode === 1)).toBe(false);
 
     await mgr.callTool('chroma_list_collections', { limit: 1 });
     firstTransport._process.finish(null, 'SIGSEGV');

--- a/tests/services/sync/chroma-mcp-manager-singleton.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-singleton.test.ts
@@ -560,10 +560,81 @@ describe('ChromaMcpManager singleton enforcement (#2313)', () => {
     await mgr.stop();
 
     expect(transportInstances[0].closed).toBe(true);
+    expect(mgr.getCrashState().count).toBe(0);
     expect(logEntries.some(entry => entry.message === 'chroma-mcp subprocess closed unexpectedly, applying reconnect backoff')).toBe(false);
 
     await mgr.callTool('chroma_list_collections', { limit: 1 });
+    expect(mgr.getCrashState().count).toBe(0);
     expect(transportInstances.length).toBe(2);
+  });
+
+  it('records exact active-child exit details and retains them across reconnect', async () => {
+    const mgr = ChromaMcpManager.getInstance();
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+    const firstTransport = transportInstances[0];
+    firstTransport._process.finish(null, 'SIGSEGV');
+    firstTransport.onclose?.();
+
+    const firstState = mgr.getCrashState();
+    expect(firstState.count).toBe(1);
+    expect(firstState.lastExit).toMatchObject({ code: null, signal: 'SIGSEGV' });
+    expect(firstState.chromaMcpVersion).toBe('0.2.6');
+    expect(firstState.dependencyOverrides).toEqual([
+      'onnxruntime>=1.20',
+      'protobuf<7',
+      'chromadb==1.0.16',
+    ]);
+    expect(logEntries.find(entry => entry.message === 'chroma-mcp subprocess closed unexpectedly, applying reconnect backoff')?.meta)
+      .toMatchObject({ count: 1, exitCode: null, signalCode: 'SIGSEGV' });
+
+    const privateManager = mgr as unknown as { lastConnectionFailureTimestamp: number };
+    privateManager.lastConnectionFailureTimestamp = 0;
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+    expect(mgr.getCrashState()).toEqual(firstState);
+
+    const secondTransport = transportInstances[1];
+    secondTransport._process.finish(1);
+    secondTransport.onclose?.();
+    expect(mgr.getCrashState()).toMatchObject({
+      count: 2,
+      lastExit: { code: 1, signal: null },
+    });
+  });
+
+  it('records a clean but unexpected active-child close as code 0', async () => {
+    const mgr = ChromaMcpManager.getInstance();
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+    const transport = transportInstances[0];
+    transport._process.finish(0, null);
+    transport.onclose?.();
+
+    expect(mgr.getCrashState()).toMatchObject({
+      count: 1,
+      lastExit: { code: 0, signal: null },
+    });
+  });
+
+  it('keeps intentional and stale closes out of crash state', async () => {
+    transportCloseEmitsOnclose = true;
+    const mgr = ChromaMcpManager.getInstance();
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+    const firstTransport = transportInstances[0];
+    await mgr.stop();
+    expect(mgr.getCrashState().count).toBe(0);
+    expect(logEntries.some(entry => entry.meta?.signalCode === 'SIGSEGV' || entry.meta?.exitCode === 1)).toBe(false);
+
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+    firstTransport._process.finish(null, 'SIGSEGV');
+    firstTransport.onclose?.();
+    expect(mgr.getCrashState().count).toBe(0);
+  });
+
+  it('does not count a prewarm child failure as an active-child exit', async () => {
+    prewarmSpawnBehavior = 'failure';
+    const mgr = ChromaMcpManager.getInstance();
+
+    await expect(mgr.callTool('chroma_list_collections', { limit: 1 })).rejects.toThrow('prewarm failed');
+    expect(mgr.getCrashState()).toMatchObject({ count: 0, lastExit: null });
   });
 
   it('stop() during a hanging prewarm does not record uvx unavailable or apply reconnect backoff', async () => {
@@ -586,6 +657,7 @@ describe('ChromaMcpManager singleton enforcement (#2313)', () => {
     expect(transportInstances.length).toBe(0);
     expect(transportCount).toBe(0);
     expect(getDependencyStatus('uvx')).toBeNull();
+    expect(mgr.getCrashState().count).toBe(0);
     expect(logEntries.some(entry => entry.message === 'chroma-mcp uvx prewarm failed')).toBe(false);
 
     prewarmSpawnBehavior = 'success';

--- a/tests/services/sync/chroma-mcp-manager-ssl.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-ssl.test.ts
@@ -123,10 +123,12 @@ function expectLauncherPrefixBeforeMode(args: string[], mode: 'http' | 'persiste
   expect(args[fromIdx + 2]).toBe('chroma-mcp');
   expect(args[fromIdx + 3]).toBe('--client-type');
   expect(args[fromIdx + 4]).toBe(mode);
+  expect(args.filter(arg => arg === 'chromadb==1.0.16')).toHaveLength(1);
   expect(args.slice(0, fromIdx)).toEqual([
     '--python', '3.13',
     '--with', 'onnxruntime>=1.20',
     '--with', 'protobuf<7',
+    '--with', 'chromadb==1.0.16',
   ]);
 }
 
@@ -179,5 +181,18 @@ describe('ChromaMcpManager SSL flag regression (#1286)', () => {
     expectLauncherPrefixBeforeMode(args, 'persistent');
     expect(args).toContain('--client-type');
     expect(args[args.indexOf('--client-type') + 1]).toBe('persistent');
+  });
+
+  it('pins chromadb exactly once before --from in remote and local modes', async () => {
+    currentSettings = { CLAUDE_MEM_CHROMA_MODE: 'remote' };
+    await mgr.callTool('chroma_list_collections', {});
+    expectLauncherPrefixBeforeMode(capturedTransportOpts!.args, 'http');
+
+    await ChromaMcpManager.reset();
+    capturedTransportOpts = null;
+    currentSettings = { CLAUDE_MEM_CHROMA_MODE: 'local' };
+    mgr = ChromaMcpManager.getInstance();
+    await mgr.callTool('chroma_list_collections', {});
+    expectLauncherPrefixBeforeMode(capturedTransportOpts!.args, 'persistent');
   });
 });

--- a/tests/services/worker-spawner.test.ts
+++ b/tests/services/worker-spawner.test.ts
@@ -1,6 +1,15 @@
 
-import { describe, it, expect, mock } from 'bun:test';
+import { afterAll, describe, it, expect, mock } from 'bun:test';
 import { HOOK_TIMEOUTS } from '../../src/shared/hook-constants.js';
+
+// Restore real modules in afterAll because mock.module leaks across test files.
+import * as realProcessManagerModule from '../../src/services/infrastructure/ProcessManager.js';
+import * as realHealthMonitorModule from '../../src/services/infrastructure/HealthMonitor.js';
+import * as realWorkerSpawnGateModule from '../../src/shared/worker-spawn-gate.js';
+
+const realProcessManagerSnapshot = { ...realProcessManagerModule };
+const realHealthMonitorSnapshot = { ...realHealthMonitorModule };
+const realWorkerSpawnGateSnapshot = { ...realWorkerSpawnGateModule };
 
 const processManager = {
   cleanStalePidFile: mock(() => 'dead' as 'alive' | 'dead'),
@@ -23,6 +32,12 @@ const spawnGate = {
 mock.module('../../src/services/infrastructure/ProcessManager.js', () => processManager);
 mock.module('../../src/services/infrastructure/HealthMonitor.js', () => healthMonitor);
 mock.module('../../src/shared/worker-spawn-gate.js', () => spawnGate);
+
+afterAll(() => {
+  mock.module('../../src/services/infrastructure/ProcessManager.js', () => realProcessManagerSnapshot);
+  mock.module('../../src/services/infrastructure/HealthMonitor.js', () => realHealthMonitorSnapshot);
+  mock.module('../../src/shared/worker-spawn-gate.js', () => realWorkerSpawnGateSnapshot);
+});
 
 const { ensureWorkerStarted } = await import('../../src/services/worker-spawner.js');
 

--- a/tests/worker/session-manager-project.test.ts
+++ b/tests/worker/session-manager-project.test.ts
@@ -1,10 +1,19 @@
-import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from 'bun:test';
+import { describe, it, expect, mock, beforeEach, afterEach, afterAll, spyOn } from 'bun:test';
 import { logger } from '../../src/utils/logger.js';
 import { SessionManager } from '../../src/services/worker/SessionManager.js';
 import { processAgentResponse } from '../../src/services/worker/agents/ResponseProcessor.js';
 import type { ActiveSession } from '../../src/services/worker-types.js';
 import type { DatabaseManager } from '../../src/services/worker/DatabaseManager.js';
 import type { StorageResult, WorkerRef } from '../../src/services/worker/agents/types.js';
+
+// Restore real modules in afterAll because mock.module leaks across test files.
+import * as realWorkerServiceModule from '../../src/services/worker-service.js';
+import * as realWorkerUtilsModule from '../../src/shared/worker-utils.js';
+import * as realModeManagerModule from '../../src/services/domain/ModeManager.js';
+
+const realWorkerServiceSnapshot = { ...realWorkerServiceModule };
+const realWorkerUtilsSnapshot = { ...realWorkerUtilsModule };
+const realModeManagerSnapshot = { ...realModeManagerModule };
 
 mock.module('../../src/services/worker-service.js', () => ({
   updateCursorContextForProject: () => Promise.resolve(),
@@ -26,6 +35,12 @@ mock.module('../../src/services/domain/ModeManager.js', () => ({
     }),
   },
 }));
+
+afterAll(() => {
+  mock.module('../../src/services/worker-service.js', () => realWorkerServiceSnapshot);
+  mock.module('../../src/shared/worker-utils.js', () => realWorkerUtilsSnapshot);
+  mock.module('../../src/services/domain/ModeManager.js', () => realModeManagerSnapshot);
+});
 
 const durableSessionTemplate = {
   content_session_id: 'content-123',

--- a/tests/worker/session-manager-project.test.ts
+++ b/tests/worker/session-manager-project.test.ts
@@ -23,21 +23,6 @@ mock.module('../../src/shared/worker-utils.js', () => ({
   getWorkerPort: () => 37777,
 }));
 
-// Capture the real exports before mock.module mutates the live namespace, then
-// re-register the snapshot in afterAll. bun's mock.module is process-global and
-// mock.restore() does NOT undo it, so without this the partial ModeManager stub
-// below (no class prototype, no loadMode) leaks into later test files and
-// breaks tests/server/server-boot.test.ts and server-runtime-smoke whenever the
-// readdir-dependent file order runs them after this file. Same pattern as
-// tests/context/formatters/agent-formatter.test.ts.
-import * as realModeManagerModule from '../../src/services/domain/ModeManager.js';
-
-const realModeManagerSnapshot = { ...realModeManagerModule };
-
-afterAll(() => {
-  mock.module('../../src/services/domain/ModeManager.js', () => realModeManagerSnapshot);
-});
-
 mock.module('../../src/services/domain/ModeManager.js', () => ({
   ModeManager: {
     getInstance: () => ({

--- a/tests/worker/session-manager-project.test.ts
+++ b/tests/worker/session-manager-project.test.ts
@@ -6,6 +6,15 @@ import type { ActiveSession } from '../../src/services/worker-types.js';
 import type { DatabaseManager } from '../../src/services/worker/DatabaseManager.js';
 import type { StorageResult, WorkerRef } from '../../src/services/worker/agents/types.js';
 
+// Restore real modules in afterAll because mock.module leaks across test files.
+import * as realWorkerServiceModule from '../../src/services/worker-service.js';
+import * as realWorkerUtilsModule from '../../src/shared/worker-utils.js';
+import * as realModeManagerModule from '../../src/services/domain/ModeManager.js';
+
+const realWorkerServiceSnapshot = { ...realWorkerServiceModule };
+const realWorkerUtilsSnapshot = { ...realWorkerUtilsModule };
+const realModeManagerSnapshot = { ...realModeManagerModule };
+
 mock.module('../../src/services/worker-service.js', () => ({
   updateCursorContextForProject: () => Promise.resolve(),
 }));
@@ -41,6 +50,12 @@ mock.module('../../src/services/domain/ModeManager.js', () => ({
     }),
   },
 }));
+
+afterAll(() => {
+  mock.module('../../src/services/worker-service.js', () => realWorkerServiceSnapshot);
+  mock.module('../../src/shared/worker-utils.js', () => realWorkerUtilsSnapshot);
+  mock.module('../../src/services/domain/ModeManager.js', () => realModeManagerSnapshot);
+});
 
 const durableSessionTemplate = {
   content_session_id: 'content-123',


### PR DESCRIPTION
## Summary

Unexpected exits from the active Chroma MCP child were reduced to a generic reconnect warning, so the exit signal and repeated crash state were absent from claude-mem diagnostics. The Chroma lifecycle owner now records a worker-lifetime fatal-exit count and last process outcome, logs the exact detail, and exposes it through the existing worker doctor endpoint and `npx claude-mem doctor`.

The owner routed this fix to https://github.com/thedotmack/claude-mem/issues/3610 as the plan-22 bundle candidate for child exit code and signal capture plus the doctor crash counter. This PR stays open as the source and attribution record until that bundle lands.

## Why

`ChromaMcpManager` already distinguishes active, stale, and intentionally closed transports before applying reconnect backoff. It now captures the active child process before the MCP SDK clears its transport handle, then records `exitCode` and `signalCode` only for the current unexpected-close path. The worker diagnostics endpoint transports that snapshot, and the CLI renders a concrete warning instead of trying to reconstruct lifecycle state.

## Scope

The count lasts for the current worker process. This step does not alter the inherited launcher pin, persist crash history, ingest macOS crash reports, change reconnect or cleanup behavior, repair existing stores, or address embedding completeness. The broader plan-22 health-down state, backlog, immediate-death classification, and circuit breaker remain bundle work.

## Risk

Intentional stop, stale transport callbacks, prewarm failures, and successful reconnects keep their current lifecycle behavior. The new doctor row is warn-only; it does not change the command's required-check exit status.

## Verification

- [ ] Focused Chroma, endpoint, doctor, worker-spawner, and session-manager tests; 12 pass, while endpoint and Chroma files are blocked locally by missing `express` and MCP SDK packages in this worktree
- [ ] `npm run build`; blocked locally because `esbuild` is missing from this worktree
- [x] `npm run lint:hook-io`
- [x] `npm run lint:spawn-env`
- [ ] `npm run strip-comments:check`; blocked locally because `typescript` is missing from this worktree

Refs #3362

