### PR TITLE
fix(search): fall back after empty semantic misses (closes #3361)

### DIFF
--- a/src/services/worker/search/SearchOrchestrator.ts
+++ b/src/services/worker/search/SearchOrchestrator.ts
@@ -58,8 +58,8 @@ export class SearchOrchestrator {
       logger.debug('SEARCH', 'Orchestrator: Using Chroma semantic search', {});
       try {
         const chromaResult = await this.chromaStrategy.search(options);
-        if (options.platformSource && this.isEmptyResult(chromaResult)) {
-          logger.debug('SEARCH', 'Orchestrator: platform-scoped Chroma search returned zero matches; falling back to SQLite', {});
+        if (this.isEmptyResult(chromaResult)) {
+          logger.debug('SEARCH', 'Orchestrator: Chroma search returned zero matches; falling back to SQLite', {});
           return await this.sqliteStrategy.search(options);
         }
         return chromaResult;

--- a/tests/worker/search/search-orchestrator.test.ts
+++ b/tests/worker/search/search-orchestrator.test.ts
@@ -20,7 +20,7 @@ const observation = {
   created_at_epoch: 1735689600000,
 };
 
-describe('SearchOrchestrator platform-scoped Chroma zero fallback', () => {
+describe('SearchOrchestrator Chroma zero fallback', () => {
   it('normalizes date_from/date_to filters into dateRange for SQLite search', async () => {
     const searchObservations = mock(() => [observation]);
     const orchestrator = new SearchOrchestrator(
@@ -89,7 +89,7 @@ describe('SearchOrchestrator platform-scoped Chroma zero fallback', () => {
     expect(result.results.observations).toEqual([observation]);
   });
 
-  it('keeps unscoped Chroma zero matches final', async () => {
+  it('falls back to SQLiteStrategy when unscoped Chroma search returns no rows', async () => {
     const queryChroma = mock(() => Promise.resolve({ ids: [], distances: [], metadatas: [] }));
     const searchObservations = mock(() => [observation]);
     const orchestrator = new SearchOrchestrator(
@@ -113,9 +113,45 @@ describe('SearchOrchestrator platform-scoped Chroma zero fallback', () => {
       limit: 5,
     });
 
+    expect(searchObservations).toHaveBeenCalledWith('legacy docs', expect.objectContaining({
+      project: 'orchestrator-project',
+    }));
+    expect(result.usedChroma).toBe(false);
+    expect(result.strategy).toBe('sqlite');
+    expect(result.results.observations).toEqual([observation]);
+  });
+
+  it('keeps non-empty Chroma matches final', async () => {
+    const queryChroma = mock(() => Promise.resolve({
+      ids: [21],
+      distances: [0.1],
+      metadatas: [{ sqlite_id: 21, doc_type: 'observation', created_at_epoch: Date.now() }],
+    }));
+    const searchObservations = mock(() => [observation]);
+    const orchestrator = new SearchOrchestrator(
+      {
+        searchObservations,
+        searchSessions: mock(() => []),
+        searchUserPrompts: mock(() => []),
+      } as any,
+      {
+        getObservationsByIds: mock(() => [observation]),
+        getSessionSummariesByIds: mock(() => []),
+        getUserPromptsByIds: mock(() => []),
+      } as any,
+      { queryChroma } as any,
+    );
+
+    const result = await orchestrator.search({
+      query: 'legacy docs',
+      searchType: 'observations',
+      project: 'orchestrator-project',
+      limit: 5,
+    });
+
     expect(searchObservations).not.toHaveBeenCalled();
     expect(result.usedChroma).toBe(true);
     expect(result.strategy).toBe('chroma');
-    expect(result.results.observations).toHaveLength(0);
+    expect(result.results.observations).toEqual([observation]);
   });
 });


### PR DESCRIPTION
## Summary
A zero-hit Chroma search could return an authoritative empty result when the caller omitted `platformSource`, even when the same query still had SQLite matches. This changes the fallback to key on emptiness instead of the filter shape, so empty semantic misses fall through to SQLite for the same search.

## Why
`SearchOrchestrator.executeWithFallback()` only retried SQLite when `options.platformSource && isEmptyResult(chromaResult)` was true. That made project-scoped and other no-`platformSource` searches treat an empty Chroma response as final. The existing test suite already covered the platform-scoped branch; this extends it to the unscoped zero-hit case and preserves non-empty Chroma results.

## Verification
- [x] `bun test tests/worker/search/search-orchestrator.test.ts`

Closes #3361