### PR TITLE
fix(worker): use collision-safe ports in CORS restriction tests

### DIFF
--- a/tests/worker/middleware/cors-restriction.test.ts
+++ b/tests/worker/middleware/cors-restriction.test.ts
@@ -68,14 +68,24 @@ describe('CORS Restriction', () => {
         res.json({ ok: true });
       });
 
-      testPort = 41000 + Math.floor(Math.random() * 10000);
-      await new Promise<void>((resolve) => {
-        server = app.listen(testPort, '127.0.0.1', resolve);
+      await new Promise<void>((resolve, reject) => {
+        const onError = (error: Error) => reject(error);
+        server = app.listen(0, '127.0.0.1', () => {
+          server.removeListener('error', onError);
+          const address = server.address();
+          if (!address || typeof address === 'string') {
+            reject(new Error('Test server did not expose an assigned port'));
+            return;
+          }
+          testPort = address.port;
+          resolve();
+        });
+        server.once('error', onError);
       });
     });
 
     afterEach(async () => {
-      if (server) {
+      if (server?.listening) {
         await new Promise<void>((resolve, reject) => {
           server.close(err => err ? reject(err) : resolve());
         });


### PR DESCRIPTION
## Summary
The CORS restriction test suite picked a random fixed port for each server startup, so occasional collisions left no listener bound and turned the fetch assertion into a `ConnectionRefused` failure. This switches the suite to OS-assigned ports, captures the assigned port after bind, and only closes servers that actually started.

## Why
The previous setup used `41000 + Math.floor(Math.random() * 10000)` and assumed the listen call would always succeed. When another process won that port first, the test still fetched the guessed port and teardown hit `ERR_SERVER_NOT_RUNNING`. Binding on port `0` lets the OS choose an available listener and keeps setup and cleanup aligned with the server's real state.

## Scope
This PR only fixes the CORS port-collision slice from #3392. The separate order-dependent mock leakage in the same issue stays outside this diff.

## Verification
- [x] `bun test tests/worker/middleware/cors-restriction.test.ts`
- [x] Manual: repeated the focused test locally 25 times without a collision failure

Refs #3392