### PR TITLE
fix(hooks): keep UserPromptSubmit synchronous while making SessionStart hooks async (refs #3303)

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -22,13 +22,15 @@
             "type": "command",
             "shell": "bash",
             "command": "export PATH=\"$($SHELL -lc 'echo $PATH' 2>/dev/null):$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _F=; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; for _V in \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/; do [ -d \"$_V\" ] || continue; [ -e \"${_V}.orphaned_at\" ] && continue; _B=${_V%/}; _B=${_B##*/}; case \"$_B\" in (*-*) _G=0;; (*) _G=1;; esac; _N=${_B%%-*}; _M1=${_N%%.*}; case \"$_N\" in (*.*) _T=${_N#*.};; (*) _T=0;; esac; _M2=${_T%%.*}; case \"$_T\" in (*.*) _U=${_T#*.};; (*) _U=0;; esac; _M3=${_U%%.*}; _M1=${_M1%%[!0-9]*}; _M2=${_M2%%[!0-9]*}; _M3=${_M3%%[!0-9]*}; printf '%08d%08d%08d%d %s\\n' \"${_M1:-0}\" \"${_M2:-0}\" \"${_M3:-0}\" \"$_G\" \"$_V\"; done 2>/dev/null | sort -r | sed 's/^[^ ]* //'; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/bun-runner.js\" ] && [ -f \"$_Q/scripts/worker-service.cjs\" ] && [ -z \"$_F\" ] && { _F=1; printf '%s\\n' \"$_Q\"; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: plugin scripts not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/bun-runner.js\" \"$_P/scripts/worker-service.cjs\" start",
-            "timeout": 60
+            "timeout": 60,
+            "async": true
           },
           {
             "type": "command",
             "shell": "bash",
             "command": "export PATH=\"$($SHELL -lc 'echo $PATH' 2>/dev/null):$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _F=; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; for _V in \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/; do [ -d \"$_V\" ] || continue; [ -e \"${_V}.orphaned_at\" ] && continue; _B=${_V%/}; _B=${_B##*/}; case \"$_B\" in (*-*) _G=0;; (*) _G=1;; esac; _N=${_B%%-*}; _M1=${_N%%.*}; case \"$_N\" in (*.*) _T=${_N#*.};; (*) _T=0;; esac; _M2=${_T%%.*}; case \"$_T\" in (*.*) _U=${_T#*.};; (*) _U=0;; esac; _M3=${_U%%.*}; _M1=${_M1%%[!0-9]*}; _M2=${_M2%%[!0-9]*}; _M3=${_M3%%[!0-9]*}; printf '%08d%08d%08d%d %s\\n' \"${_M1:-0}\" \"${_M2:-0}\" \"${_M3:-0}\" \"$_G\" \"$_V\"; done 2>/dev/null | sort -r | sed 's/^[^ ]* //'; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/bun-runner.js\" ] && [ -f \"$_Q/scripts/worker-service.cjs\" ] && [ -z \"$_F\" ] && { _F=1; printf '%s\\n' \"$_Q\"; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: plugin scripts not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/bun-runner.js\" \"$_P/scripts/worker-service.cjs\" hook claude-code context",
-            "timeout": 60
+            "timeout": 60,
+            "async": true
           }
         ]
       }
@@ -40,7 +42,8 @@
             "type": "command",
             "shell": "bash",
             "command": "export PATH=\"$($SHELL -lc 'echo $PATH' 2>/dev/null):$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _F=; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; for _V in \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/; do [ -d \"$_V\" ] || continue; [ -e \"${_V}.orphaned_at\" ] && continue; _B=${_V%/}; _B=${_B##*/}; case \"$_B\" in (*-*) _G=0;; (*) _G=1;; esac; _N=${_B%%-*}; _M1=${_N%%.*}; case \"$_N\" in (*.*) _T=${_N#*.};; (*) _T=0;; esac; _M2=${_T%%.*}; case \"$_T\" in (*.*) _U=${_T#*.};; (*) _U=0;; esac; _M3=${_U%%.*}; _M1=${_M1%%[!0-9]*}; _M2=${_M2%%[!0-9]*}; _M3=${_M3%%[!0-9]*}; printf '%08d%08d%08d%d %s\\n' \"${_M1:-0}\" \"${_M2:-0}\" \"${_M3:-0}\" \"$_G\" \"$_V\"; done 2>/dev/null | sort -r | sed 's/^[^ ]* //'; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/bun-runner.js\" ] && [ -f \"$_Q/scripts/worker-service.cjs\" ] && [ -z \"$_F\" ] && { _F=1; printf '%s\\n' \"$_Q\"; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: plugin scripts not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/bun-runner.js\" \"$_P/scripts/worker-service.cjs\" hook claude-code session-init",
-            "timeout": 60
+            "timeout": 60,
+            "async": true
           }
         ]
       }

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -42,8 +42,7 @@
             "type": "command",
             "shell": "bash",
             "command": "export PATH=\"$($SHELL -lc 'echo $PATH' 2>/dev/null):$PATH\"; _C=\"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"; _E=\"${CLAUDE_PLUGIN_ROOT:-${PLUGIN_ROOT:-}}\"; _F=; _P=$({ [ -n \"$_E\" ] && printf '%s\\n' \"$_E\"; for _V in \"$_C/plugins/cache/thedotmack/claude-mem\"/[0-9]*/; do [ -d \"$_V\" ] || continue; [ -e \"${_V}.orphaned_at\" ] && continue; _B=${_V%/}; _B=${_B##*/}; case \"$_B\" in (*-*) _G=0;; (*) _G=1;; esac; _N=${_B%%-*}; _M1=${_N%%.*}; case \"$_N\" in (*.*) _T=${_N#*.};; (*) _T=0;; esac; _M2=${_T%%.*}; case \"$_T\" in (*.*) _U=${_T#*.};; (*) _U=0;; esac; _M3=${_U%%.*}; _M1=${_M1%%[!0-9]*}; _M2=${_M2%%[!0-9]*}; _M3=${_M3%%[!0-9]*}; printf '%08d%08d%08d%d %s\\n' \"${_M1:-0}\" \"${_M2:-0}\" \"${_M3:-0}\" \"$_G\" \"$_V\"; done 2>/dev/null | sort -r | sed 's/^[^ ]* //'; printf '%s\\n' \"$_C/plugins/marketplaces/thedotmack/plugin\"; } | while IFS= read -r _R; do _R=\"${_R%/}\"; [ -d \"$_R/plugin/scripts\" ] && _Q=\"$_R/plugin\" || _Q=\"$_R\"; [ -f \"$_Q/scripts/bun-runner.js\" ] && [ -f \"$_Q/scripts/worker-service.cjs\" ] && [ -z \"$_F\" ] && { _F=1; printf '%s\\n' \"$_Q\"; }; done); [ -n \"$_P\" ] || { echo \"claude-mem: plugin scripts not found\" >&2; exit 1; }; command -v cygpath >/dev/null 2>&1 && { _W=$(cygpath -w \"$_P\" 2>/dev/null); [ -n \"$_W\" ] && _P=\"$_W\"; }; node \"$_P/scripts/bun-runner.js\" \"$_P/scripts/worker-service.cjs\" hook claude-code session-init",
-            "timeout": 60,
-            "async": true
+            "timeout": 60
           }
         ]
       }

--- a/tests/infrastructure/plugin-distribution.test.ts
+++ b/tests/infrastructure/plugin-distribution.test.ts
@@ -311,6 +311,22 @@ describe('Plugin Distribution - Non-blocking bookkeeping hooks (#3206)', () => {
     expect(stop.command).toContain('summarize');
     expect(stop.async).toBe(true);
   });
+
+  it('runs SessionStart and UserPromptSubmit asynchronously (#3303)', () => {
+    const hooksPath = path.join(projectRoot, 'plugin/hooks/hooks.json');
+    const parsed = JSON.parse(readFileSync(hooksPath, 'utf-8'));
+
+    const sessionStart = parsed.hooks.SessionStart[0].hooks;
+    const userPromptSubmit = parsed.hooks.UserPromptSubmit[0].hooks[0];
+
+    expect(sessionStart).toHaveLength(2);
+    expect(sessionStart[0].command).toContain(' start');
+    expect(sessionStart[0].async).toBe(true);
+    expect(sessionStart[1].command).toContain(' hook claude-code context');
+    expect(sessionStart[1].async).toBe(true);
+    expect(userPromptSubmit.command).toContain(' hook claude-code session-init');
+    expect(userPromptSubmit.async).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/infrastructure/plugin-distribution.test.ts
+++ b/tests/infrastructure/plugin-distribution.test.ts
@@ -325,6 +325,7 @@ describe('Plugin Distribution - Non-blocking bookkeeping hooks (#3206)', () => {
     expect(sessionStart[1].command).toContain(' hook claude-code context');
     expect(sessionStart[1].async).toBe(true);
     expect(userPromptSubmit.command).toContain(' hook claude-code session-init');
+    expect(userPromptSubmit.timeout).toBe(60);
     expect(userPromptSubmit).not.toHaveProperty('async');
   });
 });

--- a/tests/infrastructure/plugin-distribution.test.ts
+++ b/tests/infrastructure/plugin-distribution.test.ts
@@ -325,6 +325,7 @@ describe('Plugin Distribution - Non-blocking bookkeeping hooks (#3206)', () => {
     expect(sessionStart[1].command).toContain(' hook claude-code context');
     expect(sessionStart[1].async).toBe(true);
     expect(userPromptSubmit.command).toContain(' hook claude-code session-init');
+    // Keep prompt-row persistence ordered before downstream hooks consume it.
     expect(userPromptSubmit.timeout).toBe(60);
     expect(userPromptSubmit).not.toHaveProperty('async');
   });

--- a/tests/infrastructure/plugin-distribution.test.ts
+++ b/tests/infrastructure/plugin-distribution.test.ts
@@ -312,7 +312,7 @@ describe('Plugin Distribution - Non-blocking bookkeeping hooks (#3206)', () => {
     expect(stop.async).toBe(true);
   });
 
-  it('runs SessionStart and UserPromptSubmit asynchronously (#3303)', () => {
+  it('runs SessionStart asynchronously and UserPromptSubmit synchronously (#3303)', () => {
     const hooksPath = path.join(projectRoot, 'plugin/hooks/hooks.json');
     const parsed = JSON.parse(readFileSync(hooksPath, 'utf-8'));
 
@@ -325,7 +325,7 @@ describe('Plugin Distribution - Non-blocking bookkeeping hooks (#3206)', () => {
     expect(sessionStart[1].command).toContain(' hook claude-code context');
     expect(sessionStart[1].async).toBe(true);
     expect(userPromptSubmit.command).toContain(' hook claude-code session-init');
-    expect(userPromptSubmit.async).toBe(true);
+    expect(userPromptSubmit).not.toHaveProperty('async');
   });
 });
 


### PR DESCRIPTION
## Summary

The two Claude Code `SessionStart` hooks now run asynchronously, while `UserPromptSubmit` `session-init` remains synchronous so `/api/sessions/init` can persist the `user_prompts` row before downstream observation and summary hooks read it.

## Why

Startup worker launch and context loading don't need to hold the session-start lifecycle open. Prompt initialization does: `session-init` creates or resolves the session and writes the prompt row that downstream privacy and observation paths use. The manifest keeps those scheduling contracts separate.

## Scope

This PR covers the hook scheduling half of #3303. The version-resolver behavior remains unchanged.

## Risk

Startup context may arrive after the session-start event completes. `UserPromptSubmit` keeps its existing synchronous command and 60-second timeout, preserving prompt-row ordering for downstream hooks.

## Verification

- [x] `bun test tests/infrastructure/plugin-distribution.test.ts --test-name-pattern "runs SessionStart asynchronously and UserPromptSubmit synchronously"`
- [x] `npm run lint:hook-io`
- [x] `npm run lint:spawn-env`
- [x] `npm run build`

Refs #3303
