### PR TITLE
fix(opencode): honor persisted worker port settings (closes #3365)

### DIFF
--- a/src/integrations/opencode-plugin/index.ts
+++ b/src/integrations/opencode-plugin/index.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { join } from "node:path";
 import { SettingsDefaultsManager } from "../../shared/SettingsDefaultsManager.js";
 
 /**
@@ -91,9 +92,11 @@ interface BusEvent {
 }
 
 function resolveWorkerPort(): string {
-  // Canonical resolution: CLAUDE_MEM_WORKER_PORT env override, else the
-  // UID-derived default — identical to the rest of the codebase (#2406).
-  return SettingsDefaultsManager.get("CLAUDE_MEM_WORKER_PORT");
+  const settingsPath = join(
+    SettingsDefaultsManager.get("CLAUDE_MEM_DATA_DIR"),
+    "settings.json",
+  );
+  return SettingsDefaultsManager.loadFromFile(settingsPath).CLAUDE_MEM_WORKER_PORT;
 }
 
 function resolveWorkerHost(): string {

--- a/tests/integrations/opencode-plugin-contract.test.ts
+++ b/tests/integrations/opencode-plugin-contract.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from "bun:test";
+import { mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   ClaudeMemPlugin,
   parseSearchResponse,
@@ -50,6 +53,55 @@ const pluginCtx = {
 };
 
 describe("OpenCode plugin event contract", () => {
+  it("reads the worker port from persisted settings without importing worker-utils", () => {
+    const source = readFileSync(
+      "src/integrations/opencode-plugin/index.ts",
+      "utf8",
+    );
+
+    expect(source).not.toContain('from "../../shared/worker-utils.js"');
+    expect(source).toContain('SettingsDefaultsManager.loadFromFile(settingsPath).CLAUDE_MEM_WORKER_PORT');
+  });
+
+  it("uses the persisted worker port in OpenCode worker requests", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "claude-mem-opencode-settings-"));
+    const originalDataDir = process.env.CLAUDE_MEM_DATA_DIR;
+    const originalPort = process.env.CLAUDE_MEM_WORKER_PORT;
+    process.env.CLAUDE_MEM_DATA_DIR = dataDir;
+    delete process.env.CLAUDE_MEM_WORKER_PORT;
+    writeFileSync(
+      join(dataDir, "settings.json"),
+      JSON.stringify({ CLAUDE_MEM_WORKER_PORT: "45678" }),
+    );
+
+    const originalFetch = globalThis.fetch;
+    const seenUrls: string[] = [];
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      seenUrls.push(String(url));
+      return new Response(JSON.stringify({ status: "queued" }), { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      const { ClaudeMemPlugin: ReloadedPlugin } = await import(
+        `../../src/integrations/opencode-plugin/index.ts?opencode-settings-${Date.now()}`
+      );
+      const plugin = await ReloadedPlugin(pluginCtx);
+      await plugin["tool.execute.after"](
+        { tool: "read", sessionID: "ses_45678", callID: "c1" },
+        { title: "Read", output: "file contents", metadata: {}, args: { path: "/a" } },
+      );
+
+      expect(seenUrls.some((url) => url.startsWith("http://127.0.0.1:45678/"))).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalDataDir === undefined) delete process.env.CLAUDE_MEM_DATA_DIR;
+      else process.env.CLAUDE_MEM_DATA_DIR = originalDataDir;
+      if (originalPort === undefined) delete process.env.CLAUDE_MEM_WORKER_PORT;
+      else process.env.CLAUDE_MEM_WORKER_PORT = originalPort;
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+
   it("only registers hooks that are part of OpenCode's real contract", async () => {
     const plugin = await ClaudeMemPlugin(pluginCtx);
     const hookKeys = Object.keys(plugin);


### PR DESCRIPTION
## Summary
The OpenCode plugin resolved its worker port from env-or-default settings only, so a persisted `CLAUDE_MEM_WORKER_PORT` in `~/.claude-mem/settings.json` could point the plugin at the wrong worker. This switches the plugin to the shared settings-backed worker-port resolver and adds a regression test for a persisted port override.

## Why
`resolveWorkerPort()` called `SettingsDefaultsManager.get("CLAUDE_MEM_WORKER_PORT")`, which never reads `settings.json`. The worker itself already uses the shared settings-backed resolver, so the plugin and worker could disagree on the port as soon as the user pinned a non-default value on disk.

## Verification
- [x] `bun test tests/integrations/opencode-plugin-contract.test.ts`
- [x] `git diff --check`

Closes #3365