### PR TITLE
fix(context): honor CLAUDE_MEM_CONTEXT_OBSERVATION_TYPES on session-start injection (closes #3409)

### DIFF
--- a/src/services/context/ContextConfigLoader.ts
+++ b/src/services/context/ContextConfigLoader.ts
@@ -4,13 +4,26 @@ import { paths } from '../../shared/paths.js';
 import { ModeManager } from '../domain/ModeManager.js';
 import type { ContextConfig } from './types.js';
 
+function parseCsvSetting(raw: string | undefined): string[] | null {
+  const values = (raw ?? '').split(',').map(v => v.trim()).filter(v => v !== '');
+  return values.length > 0 ? values : null;
+}
+
 export function loadContextConfig(): ContextConfig {
   const settingsPath = paths.settings();
   const settings = SettingsDefaultsManager.loadFromFile(settingsPath);
 
   const mode = ModeManager.getInstance().getActiveMode();
-  const observationTypes = new Set(mode.observation_types.map(t => t.id));
-  const observationConcepts = new Set(mode.observation_concepts.map(c => c.id));
+  // CLAUDE_MEM_CONTEXT_OBSERVATION_TYPES / _CONCEPTS are documented in
+  // configuration.mdx and persisted by SettingsRoutes, but these two sets were
+  // built from the mode file alone — so a user narrowing their injected context
+  // got the mode's full list regardless. Empty keeps the mode-wide default.
+  const observationTypes = new Set(
+    parseCsvSetting(settings.CLAUDE_MEM_CONTEXT_OBSERVATION_TYPES) ?? mode.observation_types.map(t => t.id)
+  );
+  const observationConcepts = new Set(
+    parseCsvSetting(settings.CLAUDE_MEM_CONTEXT_OBSERVATION_CONCEPTS) ?? mode.observation_concepts.map(c => c.id)
+  );
 
   return {
     totalObservationCount: parseInt(settings.CLAUDE_MEM_CONTEXT_OBSERVATIONS, 10),

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -31,6 +31,8 @@ export interface SettingsDefaults {
   CLAUDE_MEM_CONTEXT_SHOW_WORK_TOKENS: string;
   CLAUDE_MEM_CONTEXT_SHOW_SAVINGS_AMOUNT: string;
   CLAUDE_MEM_CONTEXT_SHOW_SAVINGS_PERCENT: string;
+  CLAUDE_MEM_CONTEXT_OBSERVATION_TYPES: string;
+  CLAUDE_MEM_CONTEXT_OBSERVATION_CONCEPTS: string;
   CLAUDE_MEM_CONTEXT_FULL_COUNT: string;
   CLAUDE_MEM_CONTEXT_FULL_FIELD: string;
   CLAUDE_MEM_CONTEXT_SESSION_COUNT: string;
@@ -125,6 +127,8 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_CONTEXT_SHOW_WORK_TOKENS: 'false',
     CLAUDE_MEM_CONTEXT_SHOW_SAVINGS_AMOUNT: 'false',
     CLAUDE_MEM_CONTEXT_SHOW_SAVINGS_PERCENT: 'true',
+    CLAUDE_MEM_CONTEXT_OBSERVATION_TYPES: '',  // Comma-separated observation types to inject. Empty = every type in the active mode
+    CLAUDE_MEM_CONTEXT_OBSERVATION_CONCEPTS: '',  // Comma-separated observation concepts to inject. Empty = every concept in the active mode
     CLAUDE_MEM_CONTEXT_FULL_COUNT: '0',
     CLAUDE_MEM_CONTEXT_FULL_FIELD: 'narrative',
     CLAUDE_MEM_CONTEXT_SESSION_COUNT: '10',

--- a/tests/context/context-config-observation-filters.test.ts
+++ b/tests/context/context-config-observation-filters.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeAll, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { SettingsDefaultsManager } from '../../src/shared/SettingsDefaultsManager.js';
+import { loadContextConfig } from '../../src/services/context/ContextConfigLoader.js';
+import { ModeManager } from '../../src/services/domain/ModeManager.js';
+
+const TYPES_KEY = 'CLAUDE_MEM_CONTEXT_OBSERVATION_TYPES';
+const CONCEPTS_KEY = 'CLAUDE_MEM_CONTEXT_OBSERVATION_CONCEPTS';
+
+describe('CLAUDE_MEM_CONTEXT_OBSERVATION_TYPES / _CONCEPTS reach the injection query', () => {
+  let modeTypes: string[];
+  let modeConcepts: string[];
+
+  beforeAll(() => {
+    const mode = ModeManager.getInstance().loadMode('code');
+    modeTypes = mode.observation_types.map(t => t.id);
+    modeConcepts = mode.observation_concepts.map(c => c.id);
+  });
+
+  afterEach(() => {
+    delete process.env[TYPES_KEY];
+    delete process.env[CONCEPTS_KEY];
+  });
+
+  // Half one of the defect: loadFromFile only copies keys that exist in
+  // DEFAULTS, so a documented setting written to settings.json was dropped
+  // before any consumer could read it.
+  describe('SettingsDefaultsManager.loadFromFile', () => {
+    it('preserves the observation filter keys written to settings.json', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'claude-mem-settings-'));
+      const settingsPath = join(dir, 'settings.json');
+      writeFileSync(
+        settingsPath,
+        JSON.stringify({ [TYPES_KEY]: 'bugfix,decision,discovery', [CONCEPTS_KEY]: 'gotcha' }),
+        'utf-8'
+      );
+
+      try {
+        const settings = SettingsDefaultsManager.loadFromFile(settingsPath, false);
+
+        expect(settings[TYPES_KEY]).toBe('bugfix,decision,discovery');
+        expect(settings[CONCEPTS_KEY]).toBe('gotcha');
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  // Half two: loadContextConfig built both sets from the mode file alone, so
+  // even a setting that survived the load never narrowed the injected context.
+  describe('loadContextConfig', () => {
+    it('honors a configured observation type list', () => {
+      process.env[TYPES_KEY] = 'bugfix,decision,discovery';
+
+      expect([...loadContextConfig().observationTypes].sort()).toEqual(['bugfix', 'decision', 'discovery']);
+    });
+
+    it('honors a configured observation concept list', () => {
+      process.env[CONCEPTS_KEY] = 'gotcha,how-it-works';
+
+      expect([...loadContextConfig().observationConcepts].sort()).toEqual(['gotcha', 'how-it-works']);
+    });
+
+    it('tolerates whitespace and empty entries', () => {
+      process.env[TYPES_KEY] = ' bugfix , ,decision, ';
+
+      expect([...loadContextConfig().observationTypes].sort()).toEqual(['bugfix', 'decision']);
+    });
+
+    it('falls back to the active mode lists when the settings are empty', () => {
+      process.env[TYPES_KEY] = '';
+      process.env[CONCEPTS_KEY] = '';
+
+      const config = loadContextConfig();
+
+      expect([...config.observationTypes].sort()).toEqual([...modeTypes].sort());
+      expect([...config.observationConcepts].sort()).toEqual([...modeConcepts].sort());
+    });
+  });
+});


### PR DESCRIPTION
## Symptom

Setting `CLAUDE_MEM_CONTEXT_OBSERVATION_TYPES` in `~/.claude-mem/settings.json` does nothing. A user who narrows their injected context to `"bugfix,decision,discovery"` still gets every observation type in the active mode injected at session start — no error, no warning. Same for `CLAUDE_MEM_CONTEXT_OBSERVATION_CONCEPTS`.

Both keys are documented in `docs/public/configuration.mdx:289` and accepted by `POST /api/settings` (`SettingsRoutes.ts:99-100`), so they are written to `settings.json` and then silently discarded.

Closes #3409

## Root cause

The value is lost twice, which is why neither the settings-file nor the env-var form works.

**1. Dropped at load time.** Neither key exists in `SettingsDefaultsManager`. `loadFromFile` copies only keys present in `DEFAULTS`:

```ts
const result: SettingsDefaults = { ...this.DEFAULTS };
for (const key of Object.keys(this.DEFAULTS) as Array<keyof SettingsDefaults>) {
  if (flatSettings[key] !== undefined) result[key] = flatSettings[key];
}
```

`applyEnvOverrides` iterates the same key list, so `CLAUDE_MEM_CONTEXT_OBSERVATION_TYPES=...` in the environment is dropped as well.

**2. Never read.** `loadContextConfig` built both sets from the mode file alone, ignoring the settings it had just loaded:

```ts
const observationTypes = new Set(mode.observation_types.map(t => t.id));
const observationConcepts = new Set(mode.observation_concepts.map(c => c.id));
```

Those two sets are exactly what `ObservationCompiler.queryObservationsMulti` filters the injection query on (`AND type IN (...)`, `ObservationCompiler.ts:66`).

## Changes

- `src/shared/SettingsDefaultsManager.ts` — add both keys to the interface and to `DEFAULTS` with `''`. Empty means the active mode's full list, matching the existing `CLAUDE_MEM_EXCLUDED_PROJECTS: ''` precedent.
- `src/services/context/ContextConfigLoader.ts` — parse the comma-separated lists and use them when non-empty; fall back to the mode lists otherwise.
- `tests/context/context-config-observation-filters.test.ts` — regression tests covering both halves of the chain.

Semantics are an override, not an intersection: the configured list is used verbatim. Intersecting with the mode list would silently drop a value the user explicitly asked for, which is the same class of failure this PR fixes.

Default behavior is unchanged — with both settings empty (the default), `loadContextConfig` returns exactly the sets it returned before.

## Verification

```
bun test tests/context/context-config-observation-filters.test.ts   # 5 pass, 0 fail
bun test tests/context/ tests/shared/ tests/context-injection.test.ts
                                                                    # 227 pass, 0 fail, 19 files
npm run typecheck                                                   # exit 0
npm run build                                                       # exit 0
```

On `main` the new suite fails 4 of 5 — `loadFromFile` drops the keys, and `loadContextConfig` returns all 8 `code`-mode types instead of the 3 configured. The one passing test is the empty-settings fallback, which asserts the unchanged behavior.

The tests set the values via `process.env` and clean up in `afterEach` rather than relying on module-load ordering of `paths.DATA_DIR`, so they pass identically alone and inside a full-suite run (no order dependence — refs #3392).

Branched from `main` at `132b4634` (v13.12.4). Build artifacts under `plugin/` are intentionally not included.
