### PR TITLE
fix(tests): restore worker-spawner's process-global module mocks — root cause of the order-dependent HealthMonitor/ProcessManager CI flake (refs #3392)

### DIFF
--- a/tests/services/worker-spawner.test.ts
+++ b/tests/services/worker-spawner.test.ts
@@ -1,6 +1,19 @@
 
-import { describe, it, expect, mock } from 'bun:test';
+import { describe, it, expect, afterAll, mock } from 'bun:test';
 import { HOOK_TIMEOUTS } from '../../src/shared/hook-constants.js';
+import * as realProcessManager from '../../src/services/infrastructure/ProcessManager.js';
+import * as realHealthMonitor from '../../src/services/infrastructure/HealthMonitor.js';
+import * as realSpawnGate from '../../src/shared/worker-spawn-gate.js';
+
+// bun's mock.module() is process-global and survives this file: the whole
+// suite runs in one bun process, so without a restore every test file that
+// loads ProcessManager/HealthMonitor after this one gets the stubs below
+// (and exports missing from the stub factories vanish entirely). Snapshot
+// the real modules before mocking and re-register them in afterAll — same
+// pattern as worker-utils-version-recycle.test.ts.
+const realProcessManagerSnapshot = { ...realProcessManager };
+const realHealthMonitorSnapshot = { ...realHealthMonitor };
+const realSpawnGateSnapshot = { ...realSpawnGate };
 
 const processManager = {
   cleanStalePidFile: mock(() => 'dead' as 'alive' | 'dead'),
@@ -25,6 +38,12 @@ mock.module('../../src/services/infrastructure/HealthMonitor.js', () => healthMo
 mock.module('../../src/shared/worker-spawn-gate.js', () => spawnGate);
 
 const { ensureWorkerStarted } = await import('../../src/services/worker-spawner.js');
+
+afterAll(() => {
+  mock.module('../../src/services/infrastructure/ProcessManager.js', () => realProcessManagerSnapshot);
+  mock.module('../../src/services/infrastructure/HealthMonitor.js', () => realHealthMonitorSnapshot);
+  mock.module('../../src/shared/worker-spawn-gate.js', () => realSpawnGateSnapshot);
+});
 
 type TimedProbe = (port: number, timeout: number) => Promise<boolean>;
 


### PR DESCRIPTION
## Symptom

Issue #3392, signature A: in full-suite CI runs, every `HealthMonitor` test (isPortInUse / waitForHealth / waitForPortFree) plus `ProcessManager > getPlatformTimeout` fails instantly (0.1–0.4 ms) with `toBe` / `toHaveBeenCalled` mismatches — "the mocks are simply not in effect" — while the identical suites pass 411/411 in isolation, and a re-run with zero code changes goes green.

## Root cause

`tests/services/worker-spawner.test.ts` installs three top-level module mocks and never restores them:

```ts
mock.module('../../src/services/infrastructure/ProcessManager.js', () => processManager);
mock.module('../../src/services/infrastructure/HealthMonitor.js', () => healthMonitor);
mock.module('../../src/shared/worker-spawn-gate.js', () => spawnGate);
```

Two bun behaviors turn that into the CI flake:

1. **`mock.module()` is process-global and is never rolled back at test-file boundaries.** The whole suite runs in one bun process; once this file evaluates, every file that runs after it resolves `ProcessManager.js` / `HealthMonitor.js` to the stubs. A minimal two-file probe (bun 1.3.14) confirms it: file A `mock.module`s a module, file B then imports it and receives the mock; if the factory omits an export, a later `import { thatExport }` even dies with `SyntaxError: Export named '…' not found`.

2. **bun discovers test files in directory (readdir) order, not a sorted order** — verified locally by renaming probe files and watching execution order follow dirent hashing, not the alphabet. Readdir order varies between checkouts (ext4 htree hashing on CI runners), so whether the HealthMonitor/ProcessManager consumers run before or after `worker-spawner.test.ts` differs run to run. That is exactly why signature A hit 4 of ~8 runs on identical code.

The failing set matches the stub factories key-for-key: the `healthMonitor` stub defines `isPortInUse` / `waitForHealth` / `waitForReadiness` (everything else vanishes per the probe above — hence *every* HealthMonitor test), and the `processManager` stub's `getPlatformTimeout: (t) => t` is precisely the one ProcessManager test that fails (`should return doubled value on Windows` expects `t * 2`).

This is the **last unrestored `mock.module` in the suite**: `parser.test.ts`, `parse-summary.test.ts` and `find-claude-executable.test.ts` already migrated away from `mock.module`, with comments citing exactly this process-global hazard, and `worker-utils-version-recycle.test.ts` / `worktree-adoption-chroma.test.ts` restore via real-module snapshots.

## Fix

Apply the repo's existing snapshot-restore pattern (same as `worker-utils-version-recycle.test.ts`): import the real modules first, snapshot their exports, and re-register the snapshots in `afterAll`. One file, +20/-1, test-only.

(Signature B of #3392 — the CORS port collision — is a separate defect with its own in-flight fix, #3400.)

## Verification

- `bun test tests/services/worker-spawner.test.ts` — 9/9 pass (the file's own tests are unaffected).
- `bun test tests/infrastructure/ tests/services/ tests/shared/` — identical results before/after the fix (443 pass; the 12 failures on my machine are a local missing-dependency artifact, present on a clean checkout too).
- Full `bun test tests` — identical pass/fail sets with and without the change.
- Standalone probe demonstrating the leak and that an `afterAll` re-registration of the real snapshot heals subsequent importers.

Refs #3392

🤖 Generated with [Claude Code](https://claude.com/claude-code)
