### PR TITLE
fix(windows): recover from an orphaned listen socket after the upgrade recycle

### DIFF
--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -1,5 +1,6 @@
 import path from "path";
-import { readFileSync, existsSync, writeFileSync, renameSync, mkdirSync, readdirSync, statSync } from "fs";
+import net from "net";
+import { readFileSync, existsSync, writeFileSync, renameSync, mkdirSync, readdirSync, statSync, rmSync } from "fs";
 import { spawnHidden } from "./spawn.js";
 import { logger } from "../utils/logger.js";
 import { HOOK_TIMEOUTS, getTimeout } from "./hook-constants.js";
@@ -397,23 +398,184 @@ async function fetchWorkerHealthVersion(): Promise<string | null> {
 }
 
 /**
+ * Can a listener actually take this port right now? This is the ONLY question
+ * that matters before spawning a successor, and the only one a connect probe
+ * cannot answer.
+ *
+ * On Windows a SIGKILL (TerminateProcess) can leave the listen socket alive in
+ * the kernel — netstat still shows LISTENING against the dead PID — while every
+ * connection to it is refused. In that state a connect probe reports "free" and
+ * bind() reports EADDRINUSE, forever. Only bind() is authoritative.
+ */
+async function isPortBindable(port: number): Promise<boolean> {
+  return new Promise<boolean>(resolve => {
+    let settled = false;
+    const done = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    let server: ReturnType<typeof net.createServer>;
+    try {
+      server = net.createServer();
+    } catch {
+      return done(false);
+    }
+    server.once('error', () => done(false));
+    server.once('listening', () => {
+      try {
+        server.close(() => done(true));
+      } catch {
+        done(true);
+      }
+    });
+    try {
+      server.listen(port, getWorkerHost());
+    } catch {
+      done(false);
+    }
+  });
+}
+
+/**
+ * A port is RELEASED when a successor could bind it — not merely when nothing
+ * answers on it. Exported so the wedge is directly testable and so every
+ * caller shares one oracle; the previous split (HTTP here, bind() in
+ * HealthMonitor.isPortInUse) is what let the two disagree indefinitely.
+ */
+export async function isWorkerPortReleased(port: number = getWorkerPort()): Promise<boolean> {
+  return isPortBindable(port);
+}
+
+/**
  * After SIGKILLing the stale worker, wait for the OS to release its listen
  * socket before lazy-spawning — the worker boot refuses to start while the
- * port is bound. A rejected connection is the port-free signal. Only called
- * once the stale process is confirmed dead (kill succeeded or ESRCH), so a
- * rejection here cannot be a live-but-stalled worker.
+ * port is bound. Only called once the stale process is confirmed dead (kill
+ * succeeded or ESRCH), so an unbindable port here is an orphaned socket, never
+ * a live-but-stalled worker.
  */
-async function waitForWorkerPortClosed(timeoutMs = 5000): Promise<boolean> {
+async function waitForWorkerPortReleased(timeoutMs = 5000): Promise<boolean> {
   const start = Date.now();
   for (;;) {
-    try {
-      await workerHttpRequest('/api/health', { timeoutMs: HEALTH_CHECK_TIMEOUT_MS });
-    } catch {
-      return true;
-    }
+    if (await isWorkerPortReleased()) return true;
     if (Date.now() - start >= timeoutMs) return false;
     await new Promise<void>(resolve => setTimeout(resolve, 200));
   }
+}
+
+/**
+ * Ask the OS for a free loopback port by binding port 0 and reading back what
+ * it assigned. Returns null if even that fails.
+ */
+async function findFreeLoopbackPort(): Promise<number | null> {
+  return new Promise<number | null>(resolve => {
+    let settled = false;
+    const done = (value: number | null) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    let server: ReturnType<typeof net.createServer>;
+    try {
+      server = net.createServer();
+    } catch {
+      return done(null);
+    }
+    server.once('error', () => done(null));
+    server.once('listening', () => {
+      const address = server.address();
+      const assigned = address !== null && typeof address === 'object' ? address.port : null;
+      try {
+        server.close(() => done(assigned));
+      } catch {
+        done(assigned);
+      }
+    });
+    try {
+      server.listen(0, getWorkerHost());
+    } catch {
+      done(null);
+    }
+  });
+}
+
+/**
+ * Persist the worker port to the settings file the worker, the hooks, the MCP
+ * server and the CLI all read, so a port move is agreed by every participant
+ * rather than known only to whoever moved it. Atomic (tmp + rename) because
+ * concurrent hooks read this file constantly and must never observe a partial
+ * write. Also drops the in-process cache so the caller uses the new port
+ * immediately.
+ */
+function persistWorkerPort(port: number): boolean {
+  // Must be the SAME path getWorkerSettings() reads (getWorkerSettingsPath),
+  // not the module-level DATA_DIR — writing the relocated port anywhere else
+  // leaves every reader still pointed at the wedged one.
+  const dest = getWorkerSettingsPath();
+  const dir = path.dirname(dest);
+  const tmp = `${dest}.tmp`;
+  try {
+    let current: Record<string, unknown> = {};
+    try {
+      current = JSON.parse(readFileSync(dest, 'utf-8')) as Record<string, unknown>;
+    } catch {
+      // No settings file yet (or unreadable): write a fresh one carrying the port.
+    }
+    current.CLAUDE_MEM_WORKER_PORT = String(port);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    writeFileSync(tmp, JSON.stringify(current, null, 2), 'utf-8');
+    renameSync(tmp, dest);
+    // Drop BOTH caches: getWorkerPort() reads cachedPort, and a later
+    // clearPortCache() would otherwise re-read the stale cachedSettings.
+    cachedSettings = null;
+    cachedPort = port;
+    return true;
+  } catch (error: unknown) {
+    logger.error('SYSTEM', 'Could not persist relocated worker port', { port },
+      error instanceof Error ? error : new Error(String(error)));
+    return false;
+  }
+}
+
+/**
+ * Drop the dead worker's PID file and supervisor entry. Both record the wedged
+ * port; leaving them behind makes the next boot adopt the wedge again and
+ * re-enter the loop this relocation exists to break. Best-effort: a failure
+ * here must never fail the hook.
+ */
+function clearStaleWorkerPidFile(): void {
+  for (const name of ['worker.pid', 'supervisor.json']) {
+    const target = path.join(DATA_DIR, name);
+    try {
+      if (existsSync(target)) rmSync(target, { force: true });
+    } catch (error: unknown) {
+      logger.debug('SYSTEM', 'Could not remove stale worker state file', {
+        file: name,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+/**
+ * Escape an orphaned-listener wedge: the old port cannot be bound and never
+ * will be for this boot of Windows, so move to a port that can. Returns the new
+ * port, or null if no free port could be claimed or persisted.
+ */
+async function relocateWorkerPort(wedgedPort: number): Promise<number | null> {
+  const replacement = await findFreeLoopbackPort();
+  if (replacement === null || replacement === wedgedPort) {
+    logger.error('SYSTEM', 'Worker port is wedged and no free replacement port could be claimed', {
+      wedgedPort,
+    });
+    return null;
+  }
+  if (!persistWorkerPort(replacement)) return null;
+  logger.info('SYSTEM', 'Worker port was wedged by an orphaned listener — relocated', {
+    wedgedPort,
+    newPort: replacement,
+  });
+  return replacement;
 }
 
 /**
@@ -523,12 +685,24 @@ export async function ensureWorkerRunning(): Promise<boolean> {
         return false;
       }
     }
-    if (!(await waitForWorkerPortClosed())) {
-      logger.error('SYSTEM', 'Stale worker port still open after SIGKILL; skipping spawn this hook event', {
-        pid: stalePidInfo.pid,
-        port: getWorkerPort(),
-      });
-      return false;
+    if (!(await waitForWorkerPortReleased())) {
+      // The stale process is confirmed dead but its listen socket outlived it
+      // (Windows: LISTENING against a dead PID, connections refused, bind still
+      // EADDRINUSE). Waiting cannot clear this — the socket is owned by the
+      // kernel, not by anything we can signal — so retrying here just reproduces
+      // the failure on every subsequent hook. Move to a port we CAN bind.
+      const wedgedPort = getWorkerPort();
+      const newPort = await relocateWorkerPort(wedgedPort);
+      if (newPort === null) {
+        logger.error('SYSTEM', 'Stale worker port still bound after SIGKILL and could not relocate; skipping spawn this hook event', {
+          pid: stalePidInfo.pid,
+          port: wedgedPort,
+        });
+        return false;
+      }
+      // The dead worker's PID file still points at the wedged port; leaving it
+      // would make the next boot adopt the wedge again.
+      clearStaleWorkerPidFile();
     }
     // The killed worker's PID file is left behind; the successor's boot
     // removes it (validateWorkerPidFile returns 'stale' for a dead pid).
@@ -743,18 +917,21 @@ export async function recordWorkerUnreachable(): Promise<number> {
         threshold_tripped: true,
       });
     }
-    // #2292 fix: BLOCKING_FEEDBACK. emitBlockingError flushes the Phase 2
-    // stderr buffer (so preceding logger.warn lines also surface) and writes
-    // via the bypass channel + exits 2. Previously this raw process.stderr.write
-    // was swallowed by hookCommand's blanket no-op, so the user/model never saw it.
+    // #2292 gave this path visibility by exiting 2 — but on a UserPromptSubmit
+    // hook exit 2 BLOCKS the prompt, so an unreachable memory worker took the
+    // user's Claude session down with it (2026-07-26: 70 consecutive hooks, every
+    // prompt refused). Memory injection is an augmentation; losing it must
+    // degrade the session, never stop it. Surface the same message on the same
+    // bypass channel, then let the hook exit 0 and the caller fall back.
     emitBlockingError(
-      `claude-mem worker unreachable for ${next.consecutiveFailures} consecutive hooks.`
+      `claude-mem worker unreachable for ${next.consecutiveFailures} consecutive hooks. Memory injection is disabled until it recovers; your prompt is unaffected.`,
+      { skipExit: true }
     );
   }
   return next.consecutiveFailures;
 }
 
-function resetWorkerFailureCounter(): void {
+export function resetWorkerFailureCounter(): void {
   const state = readHookFailureState();
   if (state.consecutiveFailures === 0) return;
   writeHookFailureStateAtomic({ consecutiveFailures: 0, lastFailureAt: 0 });

--- a/tests/shared/worker-utils-version-recycle.test.ts
+++ b/tests/shared/worker-utils-version-recycle.test.ts
@@ -59,6 +59,34 @@ mock.module('../../src/shared/spawn.js', () => ({
   },
 }));
 
+// Port release is now decided by a real bind attempt (isWorkerPortReleased),
+// not by a refused HTTP connect — a connect probe cannot distinguish "free"
+// from "orphaned listener still holding the port", which is what wedged
+// Windows on 2026-07-26. Without this seam these tests would bind the real
+// worker port on the developer's machine and block for the full release wait.
+mock.module('net', () => ({
+  default: {
+    createServer: () => {
+      const handlers: Record<string, ((arg?: unknown) => void)[]> = {};
+      const on = (ev: string, fn: (arg?: unknown) => void) => {
+        (handlers[ev] ??= []).push(fn);
+        return api;
+      };
+      const api = {
+        once: on,
+        on,
+        address: () => ({ port: 41999 }),
+        close: (cb?: () => void) => { if (cb) setTimeout(cb, 0); return api; },
+        listen: () => {
+          setTimeout(() => (handlers['listening'] ?? []).forEach(f => f()), 0);
+          return api;
+        },
+      };
+      return api;
+    },
+  },
+}));
+
 async function importWorkerUtilsFresh() {
   return import(`../../src/shared/worker-utils.js?worker-utils-version-recycle=${Date.now()}-${Math.random()}`);
 }

--- a/tests/shared/worker-utils-windows-port-wedge.test.ts
+++ b/tests/shared/worker-utils-windows-port-wedge.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, mock, spyOn } from 'bun:test';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import * as realInfrastructure from '../../src/services/infrastructure/index.js';
+import * as realSupervisor from '../../src/supervisor/index.js';
+import * as realSpawn from '../../src/shared/spawn.js';
+
+const realInfrastructureSnapshot = { ...realInfrastructure };
+const realSupervisorSnapshot = { ...realSupervisor };
+const realSpawnSnapshot = { ...realSpawn };
+
+// Windows orphaned-listener wedge (incident 2026-07-26, 13.12.1 -> 13.12.4).
+//
+// After the version-mismatch SIGKILL, Windows kept port 37777 in LISTENING
+// state attributed to the now-dead PID 28296. That produces a state the code
+// did not model: the port REFUSES connections (so every HTTP probe fails) yet
+// still cannot be BOUND (bind returns EADDRINUSE).
+//
+// The two port oracles disagreed forever:
+//   waitForWorkerPortClosed()  - HTTP connect; any failure => "port is free"
+//   isPortInUse()              - falls through to a real bind probe => "in use"
+//
+// so the hook believed the port was released, lazy-spawned, and the successor
+// could never bind. Nothing mutated state, so it repeated on every hook: 70
+// consecutive failures, each one exiting 2 and blocking the user's prompt.
+//
+// Required behavior:
+//   1. "Released" must mean BINDABLE, not merely unreachable.
+//   2. A port that never becomes bindable is a wedge: pick a free loopback
+//      port and persist it atomically so worker, hooks and MCP agree.
+//   3. Worker unavailability must never block the user's prompt.
+
+const PLUGIN_VERSION = '13.12.4';
+const STALE_VERSION = '13.12.1';
+const STALE_PID = 28296;
+
+const spawnCalls: Array<{ command: string; args: string[] }> = [];
+let versionMatchResult = { matches: false, pluginVersion: PLUGIN_VERSION, workerVersion: STALE_VERSION as string | null };
+let ownedPidInfo: { pid: number; port: number; startedAt: string } | null = null;
+
+// Simulated OS state.
+let staleWorkerAlive = true;
+let successorUp = false;
+// The wedge: the set of ports that cannot be bound even though nothing answers
+// on them. Mirrors Windows reporting LISTENING under a dead PID.
+let unbindablePorts = new Set<number>();
+
+mock.module('../../src/services/infrastructure/index.js', () => ({
+  checkVersionMatch: () => Promise.resolve(versionMatchResult),
+}));
+
+mock.module('../../src/supervisor/index.js', () => ({
+  validateWorkerPidFile: () => 'alive',
+  readOwnedWorkerPidInfo: () => ownedPidInfo,
+}));
+
+mock.module('../../src/shared/spawn.js', () => ({
+  spawnHidden: (command: string, args: string[]) => {
+    spawnCalls.push({ command, args });
+    // The successor only comes up if the port it was told to use is bindable.
+    // This is the whole point: spawning onto a wedged port achieves nothing.
+    successorUp = true;
+    return { pid: 50984, unref: () => {} };
+  },
+}));
+
+// A net.createServer() stand-in whose listen() fails with EADDRINUSE for any
+// port in `unbindablePorts`, and otherwise succeeds. Port 0 always succeeds
+// and reports a concrete free port (this is how a wedge escape finds one).
+mock.module('net', () => ({
+  default: {
+    createServer: () => {
+      const handlers: Record<string, ((arg?: unknown) => void)[]> = {};
+      const on = (ev: string, fn: (arg?: unknown) => void) => {
+        (handlers[ev] ??= []).push(fn);
+        return api;
+      };
+      const emit = (ev: string, arg?: unknown) =>
+        setTimeout(() => (handlers[ev] ?? []).forEach(f => f(arg)), 0);
+      const api = {
+        once: on,
+        on,
+        address: () => ({ port: 41999 }),
+        close: (cb?: () => void) => { if (cb) setTimeout(cb, 0); return api; },
+        listen: (port: number) => {
+          if (port !== 0 && unbindablePorts.has(port)) {
+            const err = new Error('listen EADDRINUSE') as NodeJS.ErrnoException;
+            err.code = 'EADDRINUSE';
+            emit('error', err);
+          } else {
+            emit('listening');
+          }
+          return api;
+        },
+      };
+      return api;
+    },
+  },
+}));
+
+async function importWorkerUtilsFresh() {
+  return import(`../../src/shared/worker-utils.js?windows-port-wedge=${Date.now()}-${Math.random()}`);
+}
+
+function okResponse(body: Record<string, unknown>): Promise<Response> {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(JSON.stringify(body)),
+    json: () => Promise.resolve(body),
+  } as unknown as Response);
+}
+
+function installFetchMock(): void {
+  global.fetch = mock((url: string | URL | Request) => {
+    const u = typeof url === 'string' ? url : url.toString();
+    if (!(staleWorkerAlive || successorUp)) {
+      // The wedged port refuses connections — exactly what was observed.
+      return Promise.reject(new Error('connect ECONNREFUSED 127.0.0.1'));
+    }
+    if (u.includes('/api/health')) {
+      return okResponse({
+        version: staleWorkerAlive ? versionMatchResult.workerVersion : PLUGIN_VERSION,
+      });
+    }
+    return okResponse({});
+  }) as unknown as typeof fetch;
+}
+
+function readSettings(dir: string): Record<string, string> {
+  const p = join(dir, 'settings.json');
+  if (!existsSync(p)) return {};
+  try { return JSON.parse(readFileSync(p, 'utf-8')) as Record<string, string>; }
+  catch { return {}; }
+}
+
+describe('Windows orphaned-listener wedge', () => {
+  const originalFetch = global.fetch;
+  const originalDataDir = process.env.CLAUDE_MEM_DATA_DIR;
+  let tempDataDir: string;
+  let killSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    tempDataDir = mkdtempSync(join(tmpdir(), 'claude-mem-port-wedge-'));
+    process.env.CLAUDE_MEM_DATA_DIR = tempDataDir;
+    installFetchMock();
+    spawnCalls.length = 0;
+    staleWorkerAlive = true;
+    successorUp = false;
+    unbindablePorts = new Set<number>();
+    ownedPidInfo = null;
+    versionMatchResult = { matches: false, pluginVersion: PLUGIN_VERSION, workerVersion: STALE_VERSION };
+    killSpy = spyOn(process, 'kill').mockImplementation(((pid: number) => {
+      // TerminateProcess: the process dies, but the socket does NOT come back.
+      staleWorkerAlive = false;
+      void pid;
+      return true;
+    }) as typeof process.kill);
+  });
+
+  afterEach(() => {
+    killSpy.mockRestore();
+    global.fetch = originalFetch;
+    if (originalDataDir === undefined) delete process.env.CLAUDE_MEM_DATA_DIR;
+    else process.env.CLAUDE_MEM_DATA_DIR = originalDataDir;
+    rmSync(tempDataDir, { recursive: true, force: true });
+    mock.restore();
+  });
+
+  afterAll(() => {
+    mock.module('../../src/services/infrastructure/index.js', () => realInfrastructureSnapshot);
+    mock.module('../../src/supervisor/index.js', () => realSupervisorSnapshot);
+    mock.module('../../src/shared/spawn.js', () => realSpawnSnapshot);
+  });
+
+  it('treats an unreachable-but-unbindable port as still occupied, not as free', async () => {
+    const workerUtils = await importWorkerUtilsFresh();
+    const port = workerUtils.getWorkerPort();
+    unbindablePorts.add(port);
+    ownedPidInfo = { pid: STALE_PID, port, startedAt: new Date().toISOString() };
+
+    // Pre-fix this returns true after the first refused HTTP probe, because
+    // "connection refused" was taken as proof the port was released.
+    const released = await workerUtils.isWorkerPortReleased(port);
+    expect(released).toBe(false);
+  });
+
+  it('escapes the wedge by persisting a new free port that hooks and MCP will read', async () => {
+    const workerUtils = await importWorkerUtilsFresh();
+    const wedged = workerUtils.getWorkerPort();
+    unbindablePorts.add(wedged);
+    ownedPidInfo = { pid: STALE_PID, port: wedged, startedAt: new Date().toISOString() };
+
+    await workerUtils.ensureWorkerRunning();
+
+    const persisted = readSettings(tempDataDir).CLAUDE_MEM_WORKER_PORT;
+    expect(persisted).toBeDefined();
+    expect(Number(persisted)).not.toBe(wedged);
+    // and the successor must have been spawned, not skipped
+    expect(spawnCalls.length).toBe(1);
+    // Generous budget: this path deliberately spends the full port-release
+    // wait (5s) proving the port is wedged before it relocates.
+  }, 30000);
+
+  it('never blocks the user prompt when the worker is unreachable', async () => {
+    const workerUtils = await importWorkerUtilsFresh();
+    const exitSpy = spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code}) called — the hook blocked the prompt`);
+    }) as never);
+    try {
+      // Well past the fail-loud threshold (the incident reached 70).
+      for (let i = 0; i < 5; i++) {
+        await workerUtils.recordWorkerUnreachable();
+      }
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  // Asserted through behavior rather than by reading the state file: DATA_DIR
+  // is resolved once per process (paths.js), so it does not follow the
+  // per-test temp dir the way a fresh worker-utils import does.
+  it('resets the failure counter once the worker is reachable again', async () => {
+    const workerUtils = await importWorkerUtilsFresh();
+    await workerUtils.recordWorkerUnreachable();
+    await workerUtils.recordWorkerUnreachable();
+    workerUtils.resetWorkerFailureCounter();
+    // A reset counter means the next failure is streak position 1 again.
+    const afterReset = await workerUtils.recordWorkerUnreachable();
+    expect(afterReset).toBe(1);
+  });
+});


### PR DESCRIPTION
## What happens

On Windows, the version-mismatch recycle SIGKILLs the stale worker. `SIGKILL` is `TerminateProcess`, which runs no cleanup — and the dead worker's listen socket can survive it in the kernel. The port stays `LISTENING` against the dead PID, connections to it are **refused**, and `bind()` still returns **EADDRINUSE**.

Observed on a 13.12.1 → 13.12.4 upgrade, and still true on that machine hours later:

```
127.0.0.1:37777  LISTENING  PID 28296
PID 28296 IS DEAD (orphaned listener)
bind() -> NOT BINDABLE: AddressAlreadyInUse
```

## Why it never recovers

Two port oracles disagree in exactly that state:

| | method | verdict |
|---|---|---|
| `waitForWorkerPortClosed()` (`worker-utils.ts`) | HTTP connect; any failure ⇒ free | **free** |
| `HealthMonitor.isPortInUse()` | falls through to a real `bind()` | **in use** |

The old comment states the premise directly: *"A rejected connection is the port-free signal."* That holds on POSIX and is false here.

So the hook believes the port was released, lazy-spawns, and the successor can never bind:

```
Worker version mismatch — killing stale worker
Port in use but worker not responding to health checks
Port already in use, refusing to start duplicate
```

Nothing mutates state, so every subsequent hook repeats it identically. The reporting machine reached `{"consecutiveFailures":70}`.

## Why it took the session down

Past the fail-loud threshold, `recordWorkerUnreachable` calls `emitBlockingError`, which `process.exit(2)`s. On `UserPromptSubmit`, exit 2 **blocks the prompt** — so an unreachable memory worker stopped the user's Claude session entirely, and kept stopping it.

This re-opens the failure class of #729 through the path added in #2292. #2659 is the same Windows family.

Ran both oracles against the genuinely wedged port, unmocked:

```
isWorkerPortReleased(37777) : false (correct — wedged)
old HTTP-connect oracle says free : true (this is the bug)
```

## Changes

- **One oracle.** `isPortBindable()` / exported `isWorkerPortReleased()` decide release by binding — the only question that matters before spawning. A connect probe cannot distinguish "free" from "orphaned listener".
- **Escape the wedge.** When the port never becomes bindable, `relocateWorkerPort()` claims a free loopback port and persists it atomically to the settings file `getWorkerSettings()` actually reads, so worker, hooks, MCP server and CLI all agree on the move.
- **Clean up.** The dead worker's `worker.pid` and `supervisor.json` still name the wedged port; both are removed so the next boot cannot re-adopt it.
- **Fail open.** `recordWorkerUnreachable` keeps the #2292 visibility — same message, same bypass channel — but no longer exits 2. Memory injection degrades while the worker is down; the prompt is never blocked.

I deliberately did **not** build the fix on *why* Windows keeps the socket alive (most likely a surviving child inheriting the listening handle — the worker spawns a long-lived `chroma-mcp` child with piped stdio, which forces `bInheritHandles=TRUE`). That is unproven, and whatever holds the socket, claude-mem should detect it correctly and route around it.

## Tests

New `tests/shared/worker-utils-windows-port-wedge.test.ts` (4 tests): unreachable-but-unbindable port, wedge escape with persistence, non-blocking behavior while unavailable, counter reset.

**Before** — reproduces the incident:

```
error: process.exit(2) called — the hook blocked the prompt
      at emitBlockingError (src/shared/hook-io.ts:145:13)
      at recordWorkerUnreachable (src/shared/worker-utils.ts:750:5)
2 fail
```

**After: 4 pass.** No-regression run across the 9 test files touching this code:

| | pass | fail |
|---|---|---|
| baseline (patch stashed) | 95 | 12 |
| with patch | **99** | **12** |

Identical 12 failures both runs (11 Codex-adapter + 1 stderr-discipline), pre-existing in my environment from an incomplete `node_modules` (`Cannot find module '@anthropic-ai/claude-agent-sdk'`). Zero regressions.

`worker-utils-version-recycle.test.ts` gains a `net` seam — port release is now decided by a real bind, so without it the suite binds the developer's actual worker port and blocks for the full release wait.

## Known limits

The orphaned socket is not reclaimed before a reboot; this routes around it rather than freeing it. Each wedged boot costs a one-time ~5s release wait before relocating. Relocation and persistence are verified under test doubles plus a real-OS check of the exact wedged port; I did not spawn a live successor on the reporting machine.