### PR TITLE
fix(logging): roll log file path onto the current date (closes #3415)

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -79,16 +79,22 @@ class Logger {
   private level: LogLevel | null = null;
   private useColor: boolean;
   private logFilePath: string | null = null;
-  private logFileInitialized: boolean = false;
+  private logFileDate: string | null = null;
 
   constructor() {
     this.useColor = process.stdout.isTTY ?? false;
     // Don't initialize log file in constructor - do it lazily to avoid circular dependency
   }
 
+  // Re-resolves the log path whenever the date changes so long-running
+  // daemons roll onto the new day's file instead of appending to the file
+  // named for their start date forever (#3415). The date string doubles as
+  // the "already initialized for today" cache, so same-day calls stay a
+  // cheap comparison.
   private ensureLogFileInitialized(): void {
-    if (this.logFileInitialized) return;
-    this.logFileInitialized = true;
+    const date = new Date().toISOString().split('T')[0];
+    if (this.logFileDate === date) return;
+    this.logFileDate = date;
 
     try {
       const logsDir = paths.logsDir();
@@ -97,7 +103,6 @@ class Logger {
         mkdirSync(logsDir, { recursive: true });
       }
 
-      const date = new Date().toISOString().split('T')[0];
       this.logFilePath = join(logsDir, `claude-mem-${date}.log`);
     } catch (error: unknown) {
       console.error('[LOGGER] Failed to initialize log file:', error instanceof Error ? error.message : String(error));

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -94,7 +94,6 @@ class Logger {
   private ensureLogFileInitialized(): void {
     const date = new Date().toISOString().split('T')[0];
     if (this.logFileDate === date) return;
-    this.logFileDate = date;
 
     try {
       const logsDir = paths.logsDir();
@@ -104,6 +103,7 @@ class Logger {
       }
 
       this.logFilePath = join(logsDir, `claude-mem-${date}.log`);
+      this.logFileDate = date;
     } catch (error: unknown) {
       console.error('[LOGGER] Failed to initialize log file:', error instanceof Error ? error.message : String(error));
       this.logFilePath = null;

--- a/tests/utils/logger-log-path-rollover.test.ts
+++ b/tests/utils/logger-log-path-rollover.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { logger } from '../../src/utils/logger.js';
+import { paths } from '../../src/shared/paths.js';
+
+// Regression test for #3415: a long-running worker daemon resolved its log
+// file path once (lazily, on first log call) and kept appending to the file
+// named for its *start* date forever, even after the date rolled over.
+
+const RealDate = Date;
+
+function setFakeDate(iso: string): void {
+  class FixedDate extends RealDate {
+    constructor(...args: unknown[]) {
+      if (args.length === 0) {
+        super(iso);
+      } else {
+        // @ts-expect-error - forwarding constructor args to the real Date
+        super(...args);
+      }
+    }
+    static now(): number {
+      return new RealDate(iso).getTime();
+    }
+  }
+  (globalThis as { Date: typeof Date }).Date = FixedDate;
+}
+
+afterEach(() => {
+  (globalThis as { Date: typeof Date }).Date = RealDate;
+});
+
+describe('logger log file date rollover (#3415)', () => {
+  it('rolls the log file onto the new date instead of appending to the startup-date file forever', () => {
+    const logsDir = paths.logsDir();
+    if (!existsSync(logsDir)) mkdirSync(logsDir, { recursive: true });
+
+    const day1File = join(logsDir, 'claude-mem-2030-06-01.log');
+    const day2File = join(logsDir, 'claude-mem-2030-06-02.log');
+    rmSync(day1File, { force: true });
+    rmSync(day2File, { force: true });
+
+    setFakeDate('2030-06-01T23:59:00.000Z');
+    logger.info('SYSTEM', 'rollover-marker-day1');
+
+    setFakeDate('2030-06-02T00:05:00.000Z');
+    logger.info('SYSTEM', 'rollover-marker-day2');
+
+    expect(existsSync(day1File)).toBe(true);
+    expect(existsSync(day2File)).toBe(true);
+
+    const day1Content = readFileSync(day1File, 'utf8');
+    const day2Content = readFileSync(day2File, 'utf8');
+
+    expect(day1Content).toContain('rollover-marker-day1');
+    expect(day1Content).not.toContain('rollover-marker-day2');
+    expect(day2Content).toContain('rollover-marker-day2');
+
+    rmSync(day1File, { force: true });
+    rmSync(day2File, { force: true });
+  });
+});

--- a/tests/utils/logger-log-path-rollover.test.ts
+++ b/tests/utils/logger-log-path-rollover.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'bun:test';
+import { describe, it, expect, afterEach, spyOn } from 'bun:test';
 import { existsSync, mkdirSync, readFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { logger } from '../../src/utils/logger.js';
@@ -9,6 +9,13 @@ import { paths } from '../../src/shared/paths.js';
 // named for its *start* date forever, even after the date rolled over.
 
 const RealDate = Date;
+const logsDir = paths.logsDir();
+const generatedFiles = [
+  join(logsDir, 'claude-mem-2030-06-01.log'),
+  join(logsDir, 'claude-mem-2030-06-02.log'),
+  join(logsDir, 'claude-mem-2030-06-03.log'),
+];
+let logsDirSpy: ReturnType<typeof spyOn> | undefined;
 
 function setFakeDate(iso: string): void {
   class FixedDate extends RealDate {
@@ -28,16 +35,19 @@ function setFakeDate(iso: string): void {
 }
 
 afterEach(() => {
+  logsDirSpy?.mockRestore();
+  logsDirSpy = undefined;
   (globalThis as { Date: typeof Date }).Date = RealDate;
+  for (const file of generatedFiles) {
+    rmSync(file, { force: true });
+  }
 });
 
 describe('logger log file date rollover (#3415)', () => {
   it('rolls the log file onto the new date instead of appending to the startup-date file forever', () => {
-    const logsDir = paths.logsDir();
     if (!existsSync(logsDir)) mkdirSync(logsDir, { recursive: true });
 
-    const day1File = join(logsDir, 'claude-mem-2030-06-01.log');
-    const day2File = join(logsDir, 'claude-mem-2030-06-02.log');
+    const [day1File, day2File] = generatedFiles;
     rmSync(day1File, { force: true });
     rmSync(day2File, { force: true });
 
@@ -56,8 +66,26 @@ describe('logger log file date rollover (#3415)', () => {
     expect(day1Content).toContain('rollover-marker-day1');
     expect(day1Content).not.toContain('rollover-marker-day2');
     expect(day2Content).toContain('rollover-marker-day2');
+  });
 
-    rmSync(day1File, { force: true });
-    rmSync(day2File, { force: true });
+  it('retries same-day initialization after a transient path failure', () => {
+    if (!existsSync(logsDir)) mkdirSync(logsDir, { recursive: true });
+    const day3File = generatedFiles[2];
+    rmSync(day3File, { force: true });
+
+    let calls = 0;
+    logsDirSpy = spyOn(paths, 'logsDir').mockImplementation(() => {
+      calls += 1;
+      if (calls === 1) throw new Error('transient path failure');
+      return logsDir;
+    });
+
+    setFakeDate('2030-06-03T00:05:00.000Z');
+    logger.info('SYSTEM', 'first-attempt-fails');
+    logger.info('SYSTEM', 'same-day-retry-succeeds');
+
+    expect(calls).toBe(2);
+    expect(existsSync(day3File)).toBe(true);
+    expect(readFileSync(day3File, 'utf8')).toContain('same-day-retry-succeeds');
   });
 });


### PR DESCRIPTION
## Problem

`Logger.ensureLogFileInitialized()` resolved the dated log path only once, so long-running workers kept writing to the startup-day file after UTC midnight. The read path already selects today's file, which made logs appear empty after rollover.

## Fix

Cache the UTC date only after the dated path is initialized successfully. A date change selects the new file, while a transient path/filesystem failure remains retryable on the next same-day log call.

The regression test now cleans generated files in `afterEach` and covers both midnight rollover and same-day recovery after a transient initialization failure.

## Test

- `bun test tests/utils/logger-log-path-rollover.test.ts`: 2 pass / 0 fail
- `bun test tests/utils`: 223 pass / 0 fail
- `bunx tsc --noEmit --pretty false`: clean
- Earlier full-suite run: 2539 pass / 18 skip / 1 pre-existing timeout in `tests/worker/sync/mutation-sites.test.ts`, reproduced on clean `main`