### PR TITLE
fix(worker): wait for in-flight summarize before session finalize (closes #3419)

### DIFF
--- a/src/services/worker/SessionManager.ts
+++ b/src/services/worker/SessionManager.ts
@@ -9,6 +9,7 @@ import { telemetryBuffer } from '../telemetry/buffer.js';
 export class SessionManager {
   private dbManager: DatabaseManager;
   private sessions: Map<number, ActiveSession> = new Map();
+  private readonly summarizeRescues = new Set<number>();
   private onPendingMutate?: () => void;
   private readonly buffer = new SessionMessageBuffer(() => this.onPendingMutate?.());
 
@@ -214,6 +215,19 @@ export class SessionManager {
     }
   }
 
+  hasPendingSummarize(sessionDbId: number): boolean {
+    const types = this.buffer.peekTypes(sessionDbId);
+    return types.some(message => message.message_type === 'summarize');
+  }
+
+  claimSummarizeRescue(sessionDbId: number): boolean {
+    if (this.summarizeRescues.has(sessionDbId)) {
+      return false;
+    }
+    this.summarizeRescues.add(sessionDbId);
+    return true;
+  }
+
   async clearPendingForSession(sessionDbId: number): Promise<number> {
     return this.buffer.clear(sessionDbId);
   }
@@ -305,6 +319,7 @@ export class SessionManager {
     }
 
     this.buffer.dispose(sessionDbId);
+    this.summarizeRescues.delete(sessionDbId);
     this.sessions.delete(sessionDbId);
     logger.info('SESSION', 'Session deleted', {
       sessionId: sessionDbId,
@@ -328,6 +343,7 @@ export class SessionManager {
     }
 
     this.buffer.dispose(sessionDbId);
+    this.summarizeRescues.delete(sessionDbId);
     this.sessions.delete(sessionDbId);
     logger.info('SESSION', 'Session removed from active sessions', {
       sessionId: sessionDbId,

--- a/src/services/worker/http/routes/SessionRoutes.ts
+++ b/src/services/worker/http/routes/SessionRoutes.ts
@@ -17,7 +17,7 @@ import { PrivacyCheckValidator } from '../../validation/PrivacyCheckValidator.js
 import { SettingsDefaultsManager } from '../../../../shared/SettingsDefaultsManager.js';
 import { USER_SETTINGS_PATH } from '../../../../shared/paths.js';
 import { getProjectContext } from '../../../../utils/project-name.js';
-import { handleGeneratorExit } from '../../session/GeneratorExitHandler.js';
+import { handleGeneratorExit, type GeneratorExitOutcome } from '../../session/GeneratorExitHandler.js';
 import { telemetryBuffer } from '../../../telemetry/buffer.js';
 import { SessionCompletionHandler } from '../../session/SessionCompletionHandler.js';
 import { USER_PROMPT_DEDUPE_WINDOW_MS } from '../../../../shared/user-prompts.js';
@@ -66,6 +66,8 @@ export class SessionRoutes extends BaseRouteHandler {
     super();
   }
 
+  private readonly rescueCompletions = new Map<number, Promise<GeneratorExitOutcome>>();
+
   private getSelectedProvider(): 'claude' | 'gemini' | 'openrouter' {
     if (isOpenRouterSelected() && isOpenRouterAvailable()) {
       return 'openrouter';
@@ -73,9 +75,9 @@ export class SessionRoutes extends BaseRouteHandler {
     return (isGeminiSelected() && isGeminiAvailable()) ? 'gemini' : 'claude';
   }
 
-  public async ensureGeneratorRunning(sessionDbId: number, source: string): Promise<void> {
+  public async ensureGeneratorRunning(sessionDbId: number, source: string): Promise<boolean> {
     const session = this.sessionManager.getSession(sessionDbId);
-    if (!session) return;
+    if (!session) return false;
 
     const selectedProvider = this.getSelectedProvider();
 
@@ -91,7 +93,7 @@ export class SessionRoutes extends BaseRouteHandler {
               status: claudeStatus.kind,
               message: claudeStatus.message,
             });
-            return;
+            return false;
           }
 
           try {
@@ -112,13 +114,22 @@ export class SessionRoutes extends BaseRouteHandler {
               source,
               error: classified.message,
             }, err);
-            return;
+            return false;
           }
         }
       }
       await this.applyTierRouting(session);
+      if (source === 'summarize-rescue') {
+        let resolveRescueCompletion!: (outcome: GeneratorExitOutcome) => void;
+        const rescueCompletion = new Promise<GeneratorExitOutcome>(resolve => {
+          resolveRescueCompletion = resolve;
+        });
+        this.rescueCompletions.set(sessionDbId, rescueCompletion);
+        await this.startGeneratorWithProvider(session, selectedProvider, source, resolveRescueCompletion);
+        return true;
+      }
       await this.startGeneratorWithProvider(session, selectedProvider, source);
-      return;
+      return true;
     }
 
     if (session.currentProvider && session.currentProvider !== selectedProvider) {
@@ -131,12 +142,14 @@ export class SessionRoutes extends BaseRouteHandler {
       // Let current generator finish naturally, next one will use new provider
       // The shared conversationHistory ensures context is preserved
     }
+    return false;
   }
 
   private async startGeneratorWithProvider(
     session: ReturnType<typeof this.sessionManager.getSession>,
     provider: 'claude' | 'gemini' | 'openrouter',
-    source: string
+    source: string,
+    resolveRescueCompletion?: (outcome: GeneratorExitOutcome) => void,
   ): Promise<void> {
     if (!session) return;
 
@@ -232,11 +245,16 @@ export class SessionRoutes extends BaseRouteHandler {
           if (session.currentProvider === provider) {
             session.currentProvider = null;
           }
+          resolveRescueCompletion?.('not-started');
           return;
         }
 
         const reason = session.abortReason ?? null;
         session.abortReason = null;  // consume the reason
+        const abortCategory = (reason ?? '').split(':')[0];
+        const rescueOutcome = source === 'summarize-rescue'
+          ? (abortCategory === 'auth' || abortCategory === 'quota' ? 'preserved' : 'handled')
+          : undefined;
         if (reason !== null) {
           // Abort accounting lives HERE, where the reason is consumed — the
           // ONLY point every abort flow (idle / shutdown / overflow / quota)
@@ -254,7 +272,17 @@ export class SessionRoutes extends BaseRouteHandler {
         await handleGeneratorExit(session, reason, {
           sessionManager: this.sessionManager,
           completionHandler: this.completionHandler,
+          restartGenerator: async () => {
+            const launched = await this.ensureGeneratorRunning(session.sessionDbId, 'summarize-rescue');
+            if (!launched) return 'not-started';
+            const rescueCompletion = this.rescueCompletions.get(session.sessionDbId);
+            if (!rescueCompletion) return 'not-started';
+            const outcome = await rescueCompletion;
+            this.rescueCompletions.delete(session.sessionDbId);
+            return outcome;
+          },
         });
+        resolveRescueCompletion?.(rescueOutcome ?? 'handled');
       });
     session.generatorPromise = generatorPromise;
   }

--- a/src/services/worker/http/shared.ts
+++ b/src/services/worker/http/shared.ts
@@ -15,7 +15,7 @@ interface IngestContext {
   sessionManager: SessionManager;
   dbManager: DatabaseManager;
   eventBroadcaster: SessionEventBroadcaster;
-  ensureGeneratorRunning?: (sessionDbId: number, source: string) => void | Promise<void>;
+  ensureGeneratorRunning?: (sessionDbId: number, source: string) => boolean | Promise<boolean>;
 }
 
 let ctx: IngestContext | null = null;
@@ -25,7 +25,7 @@ export function setIngestContext(next: IngestContext): void {
 }
 
 export function attachIngestGeneratorStarter(
-  ensureGeneratorRunning: (sessionDbId: number, source: string) => void | Promise<void>,
+  ensureGeneratorRunning: (sessionDbId: number, source: string) => boolean | Promise<boolean>,
 ): void {
   requireContext().ensureGeneratorRunning = ensureGeneratorRunning;
 }

--- a/src/services/worker/session/GeneratorExitHandler.ts
+++ b/src/services/worker/session/GeneratorExitHandler.ts
@@ -4,9 +4,12 @@ import type { SessionCompletionHandler } from './SessionCompletionHandler.js';
 import { logger } from '../../../utils/logger.js';
 import { getSdkProcessForSession, ensureSdkProcessExit } from '../../../supervisor/process-registry.js';
 
+export type GeneratorExitOutcome = 'not-started' | 'preserved' | 'handled';
+
 export interface GeneratorExitDependencies {
   sessionManager: SessionManager;
   completionHandler: SessionCompletionHandler;
+  restartGenerator?: () => Promise<GeneratorExitOutcome>;
 }
 
 /**
@@ -30,7 +33,7 @@ export async function handleGeneratorExit(
   reason: ActiveSession['abortReason'],
   deps: GeneratorExitDependencies
 ): Promise<void> {
-  const { sessionManager, completionHandler } = deps;
+  const { sessionManager, completionHandler, restartGenerator } = deps;
   const sessionDbId = session.sessionDbId;
 
   const tracked = getSdkProcessForSession(sessionDbId);
@@ -48,6 +51,31 @@ export async function handleGeneratorExit(
       pendingCount: sessionManager.getMessageBuffer().getPendingCount(sessionDbId),
     });
     return;
+  }
+
+  const isOrdinaryExit = reason === null;
+  const hasPendingSummarize = typeof sessionManager.hasPendingSummarize === 'function'
+    && sessionManager.hasPendingSummarize(sessionDbId);
+  if (isOrdinaryExit && hasPendingSummarize) {
+    if (sessionManager.claimSummarizeRescue(sessionDbId)) {
+      await sessionManager.resetProcessingToPending(sessionDbId);
+      if (restartGenerator) {
+        logger.info('SESSION', 'Generator exited with summarize buffered; starting one rescue pass', {
+          sessionId: sessionDbId,
+        });
+        const rescueOutcome = await restartGenerator();
+        if (rescueOutcome !== 'not-started') {
+          return;
+        }
+        logger.warn('SESSION', 'Summarize rescue did not start a generator; finalizing session', {
+          sessionId: sessionDbId,
+        });
+      }
+    } else {
+      logger.warn('SESSION', 'Dropping summarize after bounded rescue attempt', {
+        sessionId: sessionDbId,
+      });
+    }
   }
 
   logger.info('SESSION', 'Generator exited — finalizing session', { sessionId: sessionDbId, reason });

--- a/tests/worker/claude-setup-gate.test.ts
+++ b/tests/worker/claude-setup-gate.test.ts
@@ -140,7 +140,9 @@ describe('Claude setup-required generator gate', () => {
     );
 
     await routes.ensureGeneratorRunning(session.sessionDbId, 'observation');
-    await session.generatorPromise;
+    const firstRun = session.generatorPromise;
+    expect(firstRun).not.toBeNull();
+    await firstRun;
 
     expect(starts).toBe(1);
     expect(getDependencyStatus('claude_cli')).toMatchObject({
@@ -191,5 +193,203 @@ describe('Claude setup-required generator gate', () => {
       kind: 'setup_required',
       remediation: expect.stringContaining('Claude Code CLI'),
     });
+  });
+
+  it('finalizes summarize when the rescue launch is skipped by setup gating', async () => {
+    const session = makeSession();
+    let activeSession: ActiveSession | undefined = session;
+    let starts = 0;
+    let finalizerCalls = 0;
+    let removeSessionImmediateCalls = 0;
+    let firstRunResolve: (() => void) | null = null;
+
+    const sessionManager = {
+      getSession: () => activeSession,
+      getMessageBuffer: () => ({
+        getPendingCount: () => 1,
+        peekTypes: () => [{ message_type: 'summarize', tool_name: null }],
+      }),
+      hasPendingSummarize: () => true,
+      claimSummarizeRescue: () => true,
+      resetProcessingToPending: async () => 1,
+      removeSessionImmediate: () => {
+        removeSessionImmediateCalls += 1;
+        activeSession = undefined;
+      },
+    };
+
+    const claudeProvider = {
+      startSession: async () => {
+        starts += 1;
+        if (starts === 1) {
+          await new Promise<void>(resolve => {
+            firstRunResolve = resolve;
+          });
+        } else {
+          throw new ClassifiedProviderError('Claude executable not found', {
+            kind: 'setup_required',
+            cause: new Error('Claude executable not found'),
+          });
+        }
+      },
+    };
+
+    const routes = new SessionRoutes(
+      sessionManager as any,
+      {} as any,
+      claudeProvider as any,
+      { startSession: async () => {} } as any,
+      { startSession: async () => {} } as any,
+      {} as any,
+      {} as any,
+      {
+        finalizeSession: async () => {
+          finalizerCalls += 1;
+        },
+      } as any,
+    );
+
+    await routes.ensureGeneratorRunning(session.sessionDbId, 'observation');
+    const firstRun = session.generatorPromise;
+    expect(firstRun).not.toBeNull();
+    firstRunResolve?.();
+    await firstRun;
+
+    expect(starts).toBe(2);
+    expect(finalizerCalls).toBe(1);
+    expect(removeSessionImmediateCalls).toBe(1);
+    expect(activeSession).toBeUndefined();
+    expect(session.generatorPromise).toBeNull();
+  });
+
+  it('preserves summarize when the rescue pass pauses for auth or quota', async () => {
+    for (const pauseReason of ['auth:rescue', 'quota:rescue'] as const) {
+      resetDependencyStatusesForTesting();
+      const session = makeSession();
+      let activeSession: ActiveSession | undefined = session;
+      let starts = 0;
+      let finalizerCalls = 0;
+      let removeSessionImmediateCalls = 0;
+      let firstRunResolve: (() => void) | null = null;
+
+      const sessionManager = {
+        getSession: () => activeSession,
+        getMessageBuffer: () => ({
+          getPendingCount: () => 1,
+          peekTypes: () => [{ message_type: 'summarize', tool_name: null }],
+        }),
+        hasPendingSummarize: () => true,
+        claimSummarizeRescue: () => true,
+        resetProcessingToPending: async () => 1,
+        removeSessionImmediate: () => {
+          removeSessionImmediateCalls += 1;
+          activeSession = undefined;
+        },
+      };
+
+      const claudeProvider = {
+        startSession: async () => {
+          starts += 1;
+          if (starts === 1) {
+            await new Promise<void>(resolve => {
+              firstRunResolve = resolve;
+            });
+            return;
+          }
+          session.abortReason = pauseReason;
+        },
+      };
+
+      const routes = new SessionRoutes(
+        sessionManager as any,
+        {} as any,
+        claudeProvider as any,
+        { startSession: async () => {} } as any,
+        { startSession: async () => {} } as any,
+        {} as any,
+        {} as any,
+        {
+          finalizeSession: async () => {
+            finalizerCalls += 1;
+          },
+        } as any,
+      );
+
+      await routes.ensureGeneratorRunning(session.sessionDbId, 'observation');
+      const firstRun = session.generatorPromise;
+      expect(firstRun).not.toBeNull();
+      firstRunResolve?.();
+      await firstRun;
+
+      expect(starts).toBe(2);
+      expect(finalizerCalls).toBe(0);
+      expect(removeSessionImmediateCalls).toBe(0);
+      expect(activeSession).toBe(session);
+      expect(sessionManager.hasPendingSummarize()).toBe(true);
+    }
+  });
+
+  it('finalizes once through the inner exit after a successful rescue', async () => {
+    const session = makeSession();
+    let activeSession: ActiveSession | undefined = session;
+    let summarizePending = true;
+    let starts = 0;
+    let finalizerCalls = 0;
+    let removeSessionImmediateCalls = 0;
+    let firstRunResolve: (() => void) | null = null;
+
+    const sessionManager = {
+      getSession: () => activeSession,
+      getMessageBuffer: () => ({
+        getPendingCount: () => summarizePending ? 1 : 0,
+        peekTypes: () => summarizePending ? [{ message_type: 'summarize', tool_name: null }] : [],
+      }),
+      hasPendingSummarize: () => summarizePending,
+      claimSummarizeRescue: () => true,
+      resetProcessingToPending: async () => 1,
+      removeSessionImmediate: () => {
+        removeSessionImmediateCalls += 1;
+        activeSession = undefined;
+      },
+    };
+
+    const claudeProvider = {
+      startSession: async () => {
+        starts += 1;
+        if (starts === 1) {
+          await new Promise<void>(resolve => {
+            firstRunResolve = resolve;
+          });
+        } else {
+          summarizePending = false;
+        }
+      },
+    };
+
+    const routes = new SessionRoutes(
+      sessionManager as any,
+      {} as any,
+      claudeProvider as any,
+      { startSession: async () => {} } as any,
+      { startSession: async () => {} } as any,
+      {} as any,
+      {} as any,
+      {
+        finalizeSession: async () => {
+          finalizerCalls += 1;
+        },
+      } as any,
+    );
+
+    await routes.ensureGeneratorRunning(session.sessionDbId, 'observation');
+    const firstRun = session.generatorPromise;
+    expect(firstRun).not.toBeNull();
+    firstRunResolve?.();
+    await firstRun;
+
+    expect(starts).toBe(2);
+    expect(finalizerCalls).toBe(1);
+    expect(removeSessionImmediateCalls).toBe(1);
+    expect(activeSession).toBeUndefined();
   });
 });

--- a/tests/worker/poison-respawn.test.ts
+++ b/tests/worker/poison-respawn.test.ts
@@ -307,6 +307,180 @@ describe('observer invalid-output handling (Phase 3 recovery)', () => {
     expect(sm.getMessageBuffer().getPendingCount(8)).toBe(1);
   });
 
+  it('rescues a claimed summarize once before finalizing', async () => {
+    const sm = new SessionManager(makeDbManager());
+    const session = sm.initializeSession(12, 'do the thing', 1);
+    await sm.queueSummarize(12, 'last answer');
+    const iterator = sm.getMessageIterator(12);
+    const claimed = await iterator.next();
+    expect(claimed.done).toBe(false);
+    await iterator.return?.();
+
+    const finalizeSession = mock(() => Promise.resolve());
+    const removeSpy = spyOn(sm, 'removeSessionImmediate');
+    const rescue = mock(async () => {
+      const rescueIterator = sm.getMessageIterator(12);
+      const rescued = await rescueIterator.next();
+      expect(rescued.done).toBe(false);
+      await sm.confirmClaimedMessages(12);
+      await rescueIterator.return?.();
+      return 'handled';
+    });
+
+    await handleGeneratorExit(session, null, {
+      sessionManager: sm,
+      completionHandler: { finalizeSession } as any,
+      restartGenerator: rescue,
+    });
+
+    expect(rescue).toHaveBeenCalledTimes(1);
+    expect(finalizeSession).not.toHaveBeenCalled();
+    expect(removeSpy).not.toHaveBeenCalled();
+    expect(sm.hasPendingSummarize(12)).toBe(false);
+  });
+
+  it('rescues a pending summarize and bounds a second ordinary exit', async () => {
+    const sm = new SessionManager(makeDbManager());
+    const session = sm.initializeSession(13, 'do the thing', 1);
+    await sm.queueSummarize(13, 'last answer');
+
+    const finalizeSession = mock(() => Promise.resolve());
+    const removeSpy = spyOn(sm, 'removeSessionImmediate');
+    const rescue = mock(async () => 'handled' as const);
+
+    await handleGeneratorExit(session, null, {
+      sessionManager: sm,
+      completionHandler: { finalizeSession } as any,
+      restartGenerator: rescue,
+    });
+    expect(rescue).toHaveBeenCalledTimes(1);
+    expect(finalizeSession).not.toHaveBeenCalled();
+
+    await handleGeneratorExit(session, null, {
+      sessionManager: sm,
+      completionHandler: { finalizeSession } as any,
+      restartGenerator: rescue,
+    });
+
+    expect(rescue).toHaveBeenCalledTimes(1);
+    expect(finalizeSession).toHaveBeenCalledTimes(1);
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith('SESSION', 'Dropping summarize after bounded rescue attempt', {
+      sessionId: 13,
+    });
+  });
+
+  it('finalizes when the summarize rescue launch is skipped', async () => {
+    const sm = new SessionManager(makeDbManager());
+    const session = sm.initializeSession(15, 'do the thing', 1);
+    await sm.queueSummarize(15, 'last answer');
+
+    const finalizeSession = mock(() => Promise.resolve());
+    const removeSpy = spyOn(sm, 'removeSessionImmediate');
+    const rescue = mock(async () => 'not-started' as const);
+
+    await handleGeneratorExit(session, null, {
+      sessionManager: sm,
+      completionHandler: { finalizeSession } as any,
+      restartGenerator: rescue,
+    });
+
+    expect(rescue).toHaveBeenCalledTimes(1);
+    expect(finalizeSession).toHaveBeenCalledTimes(1);
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+    expect(sm.getSession(15)).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith('SESSION', 'Summarize rescue did not start a generator; finalizing session', {
+      sessionId: 15,
+    });
+  });
+
+  it('finalizes observation-only ordinary exits immediately', async () => {
+    const sm = new SessionManager(makeDbManager());
+    const session = sm.initializeSession(14, 'do the thing', 1);
+    await sm.queueObservation(14, {
+      tool_name: 'Read',
+      tool_input: {},
+      tool_response: {},
+      prompt_number: 1,
+      toolUseId: 'tu-14',
+    });
+
+    const finalizeSession = mock(() => Promise.resolve());
+    const removeSpy = spyOn(sm, 'removeSessionImmediate');
+    const rescue = mock(async () => true);
+
+    await handleGeneratorExit(session, null, {
+      sessionManager: sm,
+      completionHandler: { finalizeSession } as any,
+      restartGenerator: rescue,
+    });
+
+    expect(rescue).not.toHaveBeenCalled();
+    expect(finalizeSession).toHaveBeenCalledTimes(1);
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+    expect(sm.getSession(14)).toBeUndefined();
+  });
+
+  it('rescues a mixed observation-plus-summarize buffer on ordinary exit', async () => {
+    const sm = new SessionManager(makeDbManager());
+    const session = sm.initializeSession(17, 'do the thing', 1);
+    await sm.queueObservation(17, {
+      tool_name: 'Read',
+      tool_input: {},
+      tool_response: {},
+      prompt_number: 1,
+      toolUseId: 'tu-17',
+    });
+    await sm.queueSummarize(17, 'last answer');
+
+    const finalizeSession = mock(() => Promise.resolve());
+    const removeSpy = spyOn(sm, 'removeSessionImmediate');
+    const rescue = mock(async () => {
+      const rescueIterator = sm.getMessageIterator(17);
+      const first = await rescueIterator.next();
+      const second = await rescueIterator.next();
+      expect(first.done).toBe(false);
+      expect(second.done).toBe(false);
+      expect(first.value.type).toBe('observation');
+      expect(second.value.type).toBe('summarize');
+      await sm.confirmClaimedMessages(17);
+      await rescueIterator.return?.();
+      return 'handled' as const;
+    });
+
+    await handleGeneratorExit(session, null, {
+      sessionManager: sm,
+      completionHandler: { finalizeSession } as any,
+      restartGenerator: rescue,
+    });
+
+    expect(rescue).toHaveBeenCalledTimes(1);
+    expect(finalizeSession).not.toHaveBeenCalled();
+    expect(removeSpy).not.toHaveBeenCalled();
+    expect(sm.hasPendingSummarize(17)).toBe(false);
+  });
+
+  it('does not rescue summarize during shutdown teardown', async () => {
+    const sm = new SessionManager(makeDbManager());
+    const session = sm.initializeSession(16, 'do the thing', 1);
+    await sm.queueSummarize(16, 'last answer');
+
+    const finalizeSession = mock(() => Promise.resolve());
+    const removeSpy = spyOn(sm, 'removeSessionImmediate');
+    const rescue = mock(async () => 'handled' as const);
+
+    await handleGeneratorExit(session, 'shutdown', {
+      sessionManager: sm,
+      completionHandler: { finalizeSession } as any,
+      restartGenerator: rescue,
+    });
+
+    expect(rescue).not.toHaveBeenCalled();
+    expect(finalizeSession).toHaveBeenCalledTimes(1);
+    expect(removeSpy).toHaveBeenCalledTimes(1);
+    expect(sm.getSession(16)).toBeUndefined();
+  });
+
   it('quota generator exit keeps the active session and in-memory buffer', async () => {
     const sm = new SessionManager(makeDbManager());
     const session = sm.initializeSession(6, 'do the thing', 1);


### PR DESCRIPTION
## Summary

Terminal session summaries can disappear when the generator exits after summarize has already been queued or claimed. This change keeps the session alive for one bounded terminal summarize rescue pass on ordinary exits whenever a terminal summarize is still buffered, even if an observation shares the queue, then finalizes only after that summarize is confirmed or the bounded guard gives up. Controlled aborts such as shutdown keep their existing teardown path and do not launch the rescue.

## Why

Current main queues summarize work only in the in-memory `SessionMessageBuffer`, but `handleGeneratorExit()` finalizes every ordinary generator exit and immediately calls `removeSessionImmediate()`, which disposes that buffer. The auth/quota branch already proves the worker can preserve buffered work by keeping the active session alive, so the fix is to extend that lifecycle seam for any ordinary-exit queue that still contains the terminal summarize instead of reviving the old durable retry queue.

## Scope

- Keeps auth and quota pause behavior unchanged.
- Keeps observation-only ordinary-exit replay out of scope; the only widened case is a mixed buffer that still contains the terminal summarize.
- Leaves the separate malformed summary-tag parser loss from issue 3419 on sibling target 3419-2.

## Risk

The only new lifecycle branch is the one-shot summarize rescue path on ordinary exit. The main risk is reopening the old respawn-on-pending retry loop or accidentally treating controlled aborts like shutdown as rescue candidates, so the implementation is bounded to summarize only, keys the rescue on `reason === null`, uses a session-local one-shot guard, and falls back to finalization after one failed rescue attempt.

## Verification

- [x] `bun test tests/worker/poison-respawn.test.ts` — 16 passing, including the claimed summarize rescue, mixed observation-plus-summarize rescue, bounded second exit, no-launch fallback, and shutdown teardown regression
- [x] `bun test tests/worker/claude-setup-gate.test.ts` — 5 passing, covering route-level `not-started`, `preserved`, and successful inner-exit handling
- [x] `npm run typecheck` — fixed the ingest starter callback contract so the worker-service wiring matches `ensureGeneratorRunning(): Promise<boolean>`
- [x] `npm run build` — bundle within size guardrail
- [x] `npm run lint:hook-io && npm run lint:spawn-env` — clean
- [ ] `npm run strip-comments:check` — existing repo-wide baseline still reports `Changed: 380 (check mode, no writes)` on this branch, matching the current repository baseline rather than a target-specific regression

Reported by @Vynorr in https://github.com/thedotmack/claude-mem/issues/3419 and clarified in https://github.com/thedotmack/claude-mem/issues/3419#issuecomment-5084380262

Closes #3419
