### PR TITLE
feat(chroma): expose embedding function as a setting

### DIFF
--- a/src/services/sync/ChromaSync.ts
+++ b/src/services/sync/ChromaSync.ts
@@ -11,6 +11,8 @@ import { ParsedObservation, ParsedSummary } from '../../sdk/parser.js';
 import type { SessionStore as SessionStoreType } from '../sqlite/SessionStore.js';
 import { logger } from '../../utils/logger.js';
 import { ChromaUnavailableError } from '../worker/search/errors.js';
+import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js';
+import { USER_SETTINGS_PATH } from '../../shared/paths.js';
 import { normalizePlatformSource } from '../../shared/platform-source.js';
 import type * as SqliteFilesModule from '../sqlite/observations/files.js';
 
@@ -121,9 +123,13 @@ export class ChromaSync {
     }
 
     const chromaMcp = ChromaMcpManager.getInstance();
+    const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+    const embeddingFunction =
+      settings.CLAUDE_MEM_CHROMA_EMBEDDING_FUNCTION || 'default';
     try {
       await chromaMcp.callTool('chroma_create_collection', {
-        collection_name: this.collectionName
+        collection_name: this.collectionName,
+        embedding_function_name: embeddingFunction
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -64,6 +64,7 @@ export interface SettingsDefaults {
   CLAUDE_MEM_CHROMA_TENANT: string;
   CLAUDE_MEM_CHROMA_DATABASE: string;
   CLAUDE_MEM_CHROMA_PREWARM_TIMEOUT_MS: string;
+  CLAUDE_MEM_CHROMA_EMBEDDING_FUNCTION: string;  // chroma-mcp embedding function for new collections
   // Worker-native cloud sync. Active ⇔ TOKEN, USER_ID, and HUB_URL are all
   // non-empty — there is no separate enabled flag. HUB_URL points at the
   // two-lane sync hub (workers/sync-hub); while it is empty, sync is OFF
@@ -158,6 +159,11 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_CHROMA_TENANT: 'default_tenant',
     CLAUDE_MEM_CHROMA_DATABASE: 'default_database',
     CLAUDE_MEM_CHROMA_PREWARM_TIMEOUT_MS: '120000',
+    // Embedding function used when creating the Chroma collection. 'default' is
+    // all-MiniLM-L6-v2 (English-tuned). Non-English users can set 'multilingual'
+    // for markedly better recall at the same 384 dimensions. Applies to new
+    // collections only — changing it requires re-indexing.
+    CLAUDE_MEM_CHROMA_EMBEDDING_FUNCTION: 'default',
     // Worker-native cloud sync: credentials come from cmem.ai → Connect.
     CLAUDE_MEM_CLOUD_SYNC_TOKEN: '',
     CLAUDE_MEM_CLOUD_SYNC_USER_ID: '',


### PR DESCRIPTION
# feat(chroma): expose embedding function as a setting

## Problem

`ChromaSync.ensureCollectionExists()` creates the collection without passing `embedding_function_name`:

```ts
await chromaMcp.callTool('chroma_create_collection', {
  collection_name: this.collectionName
});
```

chroma-mcp then falls back to its `default` — `all-MiniLM-L6-v2`, which is tuned for English. Users whose observations are written in another language get noticeably weaker semantic search, and there is currently no way to change this short of patching the source.

## Change

Adds `CLAUDE_MEM_CHROMA_EMBEDDING_FUNCTION` (default `'default'`) and forwards it at collection creation. Behaviour is identical unless the setting is changed.

## Impact for non-English users

Measured on a real Korean-language observation corpus from this database (short summary as query, full narrative as document, 200 candidates, two independent samples):

| Embedding function | Dim | R@1 (A / B) | MRR (A / B) |
|---|---|---|---|
| `default` — all-MiniLM-L6-v2 | 384 | 12.0% / 10.0% | 0.166 / 0.148 |
| `multilingual` — paraphrase-multilingual-MiniLM-L12-v2 | 384 | **34.5% / 32.5%** | **0.462 / 0.457** |

R@1 improves by **+22.5pp in both samples**. Both models emit 384-dimensional vectors, so storage size and query latency are unchanged.

> Note: the `multilingual` value requires the corresponding option in chroma-mcp (PR filed separately). This change is still useful without it — it also unlocks the API-backed functions chroma-mcp already supports (`openai`, `cohere`, `jina`, `voyageai`) for users who want them.

## Notes

- Default is `'default'` — **no behaviour change** for existing installs.
- Embedding functions are fixed at collection creation time, so changing this setting only affects a **newly created** collection. Existing users must delete `~/.claude-mem/chroma/` and the sync watermark to re-index. This is documented in the setting's comment.
- Follows the existing settings pattern (`SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH)`) already used in `ChromaMcpManager`.

## Files changed

- `src/shared/SettingsDefaultsManager.ts` — interface field + default value
- `src/services/sync/ChromaSync.ts` — read setting, pass to `chroma_create_collection`
