### PR TITLE
docs: update stale version badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
     <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License">
   </a>
   <a href="package.json">
-    <img src="https://img.shields.io/badge/version-13.4.0-green.svg" alt="Version">
+    <img src="https://img.shields.io/badge/version-13.12.4-green.svg" alt="Version">
   </a>
   <a href="package.json">
     <img src="https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg" alt="Node">


### PR DESCRIPTION
The version badge in README.md still showed 13.4.0, while package.json is at 13.12.4. This updates the badge to match the current published version.