### PR TITLE
fix(hooks): skip plugin cache sessions

### DIFF
--- a/src/shared/should-track-project.ts
+++ b/src/shared/should-track-project.ts
@@ -1,8 +1,27 @@
 
-import { relative, isAbsolute, normalize } from 'path';
+import { relative, isAbsolute, join, normalize } from 'path';
 import { isProjectExcluded } from '../utils/project-filter.js';
 import { loadFromFileOnce } from './hook-settings.js';
-import { OBSERVER_SESSIONS_DIR, OBSERVER_SESSIONS_PROJECT } from './paths.js';
+import {
+  CLAUDE_CONFIG_DIR,
+  MARKETPLACE_ROOT,
+  OBSERVER_SESSIONS_DIR,
+  OBSERVER_SESSIONS_PROJECT,
+} from './paths.js';
+
+const PLUGINS_DIR_NAME = 'plugins';
+const PLUGIN_CACHE_DIR_NAME = 'cache';
+const CLAUDE_MEM_PLUGIN_OWNER = 'thedotmack';
+const CLAUDE_MEM_PLUGIN_NAME = 'claude-mem';
+const PLUGIN_RUNTIME_DIR_NAME = 'plugin';
+const PLUGIN_CACHE_ROOT = join(
+  CLAUDE_CONFIG_DIR,
+  PLUGINS_DIR_NAME,
+  PLUGIN_CACHE_DIR_NAME,
+  CLAUDE_MEM_PLUGIN_OWNER,
+  CLAUDE_MEM_PLUGIN_NAME,
+);
+const PLUGIN_MARKETPLACE_PLUGIN_ROOT = join(MARKETPLACE_ROOT, PLUGIN_RUNTIME_DIR_NAME);
 
 function isWithin(child: string, parent: string): boolean {
   const normChild = normalize(child);
@@ -16,6 +35,9 @@ export function shouldTrackProject(cwd: string): boolean {
   if (process.env.CLAUDE_MEM_INTERNAL === '1') return false;
   if (!cwd) return true;
   if (isWithin(cwd, OBSERVER_SESSIONS_DIR)) {
+    return false;
+  }
+  if (isWithin(cwd, PLUGIN_CACHE_ROOT) || isWithin(cwd, PLUGIN_MARKETPLACE_PLUGIN_ROOT)) {
     return false;
   }
   const settings = loadFromFileOnce();

--- a/tests/cli/handlers/session-init-plugin-cache-skip.test.ts
+++ b/tests/cli/handlers/session-init-plugin-cache-skip.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'bun:test';
+
+const PLUGINS_DIR_NAME = 'plugins';
+const PLUGIN_CACHE_DIR_NAME = 'cache';
+const CLAUDE_MEM_PLUGIN_OWNER = 'thedotmack';
+const CLAUDE_MEM_PLUGIN_NAME = 'claude-mem';
+const PLUGIN_VERSION_DIR_NAME = '13.12.4';
+
+describe('sessionInitHandler plugin cache self-capture guard', () => {
+  it('skips session init when the SDK hook cwd is inside the installed plugin cache', async () => {
+    const env = { ...process.env };
+    delete env.CLAUDE_MEM_INTERNAL;
+
+    const script = `
+      const { join } = await import('path');
+      const { CLAUDE_CONFIG_DIR } = await import('./src/shared/paths.ts');
+      const { sessionInitHandler, setSessionInitDependenciesForTesting } = await import('./src/cli/handlers/session-init.ts');
+      const workerCalls = [];
+
+      setSessionInitDependenciesForTesting({
+        loadFromFileOnce: () => ({
+          CLAUDE_MEM_EXCLUDED_PROJECTS: '',
+          CLAUDE_MEM_RUNTIME: 'worker',
+          CLAUDE_MEM_SEMANTIC_INJECT: 'false',
+          CLAUDE_MEM_SEMANTIC_INJECT_LIMIT: '7',
+        }),
+        resolveRuntimeContext: () => ({ runtime: 'worker' }),
+        executeWithWorkerFallback: async (apiPath, method, body) => {
+          workerCalls.push({ apiPath, method, body });
+          return { sessionDbId: 42, promptNumber: 1 };
+        },
+        isWorkerFallback: () => false,
+      });
+
+      const cwd = join(
+        CLAUDE_CONFIG_DIR,
+        ${JSON.stringify(PLUGINS_DIR_NAME)},
+        ${JSON.stringify(PLUGIN_CACHE_DIR_NAME)},
+        ${JSON.stringify(CLAUDE_MEM_PLUGIN_OWNER)},
+        ${JSON.stringify(CLAUDE_MEM_PLUGIN_NAME)},
+        ${JSON.stringify(PLUGIN_VERSION_DIR_NAME)},
+      );
+      const result = await sessionInitHandler.execute({
+        sessionId: 'observer-sdk-session',
+        cwd,
+        platform: 'claude-code',
+        prompt: 'observer prompt',
+      });
+
+      if (!result.continue || !result.suppressOutput) {
+        throw new Error('unexpected result ' + JSON.stringify(result));
+      }
+      if (workerCalls.length !== 0) {
+        throw new Error('worker should not be called: ' + JSON.stringify(workerCalls));
+      }
+    `;
+
+    const result = Bun.spawnSync({
+      cmd: [process.execPath, '--eval', script],
+      cwd: process.cwd(),
+      env,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    expect(new TextDecoder().decode(result.stderr)).toBe('');
+    expect(new TextDecoder().decode(result.stdout)).toBe('');
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/tests/shared/should-track-project.test.ts
+++ b/tests/shared/should-track-project.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
-import { OBSERVER_SESSIONS_DIR } from '../../src/shared/paths.js';
-import { normalize } from 'path';
+import { CLAUDE_CONFIG_DIR, OBSERVER_SESSIONS_DIR } from '../../src/shared/paths.js';
+import { join, normalize } from 'path';
 
 // Snapshot the real module BEFORE mock.module mutates the live namespace, then
 // re-register it in afterAll. bun's mock.module is process-global and
@@ -20,6 +20,14 @@ afterAll(() => {
 
 // Import after mock so the module picks up the mocked dependency
 const { shouldTrackProject } = await import('../../src/shared/should-track-project.js');
+
+const PLUGINS_DIR_NAME = 'plugins';
+const PLUGIN_CACHE_DIR_NAME = 'cache';
+const CLAUDE_MEM_PLUGIN_OWNER = 'thedotmack';
+const CLAUDE_MEM_PLUGIN_NAME = 'claude-mem';
+const PLUGIN_VERSION_DIR_NAME = '13.12.4';
+const PLUGIN_RUNTIME_DIR_NAME = 'plugin';
+const PLUGIN_SCRIPTS_DIR_NAME = 'scripts';
 
 describe('shouldTrackProject — path normalization', () => {
   let savedInternal: string | undefined;
@@ -50,6 +58,20 @@ describe('shouldTrackProject — path normalization', () => {
 
   it('returns false when cwd matches OBSERVER_SESSIONS_DIR exactly (native separators)', () => {
     expect(shouldTrackProject(OBSERVER_SESSIONS_DIR)).toBe(false);
+  });
+
+  it('returns false when cwd is inside the installed plugin cache', () => {
+    const pluginVersionDir = join(
+      CLAUDE_CONFIG_DIR,
+      PLUGINS_DIR_NAME,
+      PLUGIN_CACHE_DIR_NAME,
+      CLAUDE_MEM_PLUGIN_OWNER,
+      CLAUDE_MEM_PLUGIN_NAME,
+      PLUGIN_VERSION_DIR_NAME,
+    );
+
+    expect(shouldTrackProject(pluginVersionDir)).toBe(false);
+    expect(shouldTrackProject(join(pluginVersionDir, PLUGIN_RUNTIME_DIR_NAME, PLUGIN_SCRIPTS_DIR_NAME))).toBe(false);
   });
 
   it('returns true for an unrelated project path', () => {

--- a/tests/shared/should-track-project.test.ts
+++ b/tests/shared/should-track-project.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
-import { CLAUDE_CONFIG_DIR, OBSERVER_SESSIONS_DIR } from '../../src/shared/paths.js';
+import { CLAUDE_CONFIG_DIR, MARKETPLACE_ROOT, OBSERVER_SESSIONS_DIR } from '../../src/shared/paths.js';
 import { join, normalize } from 'path';
 
 // Snapshot the real module BEFORE mock.module mutates the live namespace, then
@@ -72,6 +72,13 @@ describe('shouldTrackProject — path normalization', () => {
 
     expect(shouldTrackProject(pluginVersionDir)).toBe(false);
     expect(shouldTrackProject(join(pluginVersionDir, PLUGIN_RUNTIME_DIR_NAME, PLUGIN_SCRIPTS_DIR_NAME))).toBe(false);
+  });
+
+  it('returns false when cwd is inside the marketplace plugin runtime', () => {
+    const marketplacePluginDir = join(MARKETPLACE_ROOT, PLUGIN_RUNTIME_DIR_NAME);
+
+    expect(shouldTrackProject(marketplacePluginDir)).toBe(false);
+    expect(shouldTrackProject(join(marketplacePluginDir, PLUGIN_SCRIPTS_DIR_NAME))).toBe(false);
   });
 
   it('returns true for an unrelated project path', () => {


### PR DESCRIPTION
Fix #3425

## Summary

- Treat installed claude-mem plugin cache and marketplace runtime directories as internal paths that hooks must not track.
- Prevent SessionStart hooks running from a plugin version directory from creating a user project named after the plugin version.
- Add a regression test for the shared project-tracking guard and the SessionStart handler path.

## Validation

- RED: with the plugin-cache guard temporarily removed, `bun test tests/shared/should-track-project.test.ts tests/cli/handlers/session-init-plugin-cache-skip.test.ts` failed because the cache cwd was accepted and `/api/sessions/init` was called with `project:"13.12.4"`.
- GREEN: `bun test tests/shared/should-track-project.test.ts tests/cli/handlers/session-init-plugin-cache-skip.test.ts` (`7 pass / 0 fail`).
- GREEN: targeted hook handler suite (`13 pass / 0 fail`).
- GREEN: `npm run typecheck`.
- GREEN: `npm run build`.
- GREEN: `npm run lint:hook-io`.
- GREEN: `npm run lint:spawn-env`.
- GREEN: `git diff --check`.

## Baseline

`bun test tests` is not currently clean on `origin/main` in this checkout. Baseline on `origin/main` reported `2437 pass / 18 skip / 27 fail / 5 errors`; this branch reported `2439 pass / 18 skip / 27 fail / 5 errors`, with the same pre-existing failure families around `ProcessManager`, `HealthMonitor`, and server mode boot.
