### PR TITLE
fix(chroma): tolerate CJK list backfill

### DIFF
--- a/src/services/sync/ChromaSync.ts
+++ b/src/services/sync/ChromaSync.ts
@@ -95,6 +95,39 @@ interface StoredUserPrompt {
   platform_source: string;
 }
 
+const MALFORMED_LIST_FIELD_PREVIEW_CHARS = 100;
+
+function parseStringListField(
+  rawValue: string | null | undefined,
+  fieldName: 'facts' | 'concepts',
+  rowId: number,
+): string[] {
+  if (!rawValue) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue);
+    if (!Array.isArray(parsed)) {
+      logger.warn('CHROMA_SYNC', 'Expected JSON array in observation list field, using plain string fallback', {
+        fieldName,
+        rowId,
+        parsedType: typeof parsed,
+      });
+      return typeof parsed === 'string' && parsed.trim() ? [parsed] : [];
+    }
+    return parsed.filter((value): value is string => typeof value === 'string' && value.trim().length > 0);
+  } catch (error) {
+    logger.warn('CHROMA_SYNC', 'Malformed observation list field, using plain string fallback', {
+      fieldName,
+      rowId,
+      preview: rawValue.slice(0, MALFORMED_LIST_FIELD_PREVIEW_CHARS),
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return rawValue.trim() ? [rawValue] : [];
+  }
+}
+
 export class ChromaSync {
   private project: string;
   private collectionName: string;
@@ -153,8 +186,8 @@ export class ChromaSync {
   private formatObservationDocs(obs: StoredObservation): ChromaDocument[] {
     const documents: ChromaDocument[] = [];
 
-    const facts = obs.facts ? JSON.parse(obs.facts) : [];
-    const concepts = obs.concepts ? JSON.parse(obs.concepts) : [];
+    const facts = parseStringListField(obs.facts, 'facts', obs.id);
+    const concepts = parseStringListField(obs.concepts, 'concepts', obs.id);
     // parseFileList is SQLite-shaped (`bun:sqlite` in the import chain) —
     // resolve it through the deferred loader so this method stays out of
     // the SDK bundle's import graph. Plan §3.

--- a/src/services/sync/ChromaSync.ts
+++ b/src/services/sync/ChromaSync.ts
@@ -95,8 +95,6 @@ interface StoredUserPrompt {
   platform_source: string;
 }
 
-const MALFORMED_LIST_FIELD_PREVIEW_CHARS = 100;
-
 function parseStringListField(
   rawValue: string | null | undefined,
   fieldName: 'facts' | 'concepts',
@@ -114,15 +112,14 @@ function parseStringListField(
         rowId,
         parsedType: typeof parsed,
       });
-      return typeof parsed === 'string' && parsed.trim() ? [parsed] : [];
+      return rawValue.trim() ? [rawValue] : [];
     }
     return parsed.filter((value): value is string => typeof value === 'string' && value.trim().length > 0);
   } catch (error) {
     logger.warn('CHROMA_SYNC', 'Malformed observation list field, using plain string fallback', {
       fieldName,
       rowId,
-      preview: rawValue.slice(0, MALFORMED_LIST_FIELD_PREVIEW_CHARS),
-      error: error instanceof Error ? error.message : String(error),
+      errorName: error instanceof Error ? error.name : 'NonError',
     });
     return rawValue.trim() ? [rawValue] : [];
   }

--- a/src/services/sync/ChromaSync.ts
+++ b/src/services/sync/ChromaSync.ts
@@ -112,6 +112,9 @@ function parseStringListField(
         rowId,
         parsedType: typeof parsed,
       });
+      if (typeof parsed === 'string') {
+        return parsed.trim() ? [parsed] : [];
+      }
       return rawValue.trim() ? [rawValue] : [];
     }
     return parsed.filter((value): value is string => typeof value === 'string' && value.trim().length > 0);

--- a/tests/services/sync/chroma-sync-watermarks.test.ts
+++ b/tests/services/sync/chroma-sync-watermarks.test.ts
@@ -279,14 +279,23 @@ describe('ChromaSync watermark gap persistence', () => {
   it('preserves JSON-looking plain-string list fields without logging raw memory content', async () => {
     const secretFact = 'TREX_SECRET_OBSERVATION_TOKEN_9f3a7c_DO_NOT_LOG';
     const jsonLookingFact = `{"note":"${secretFact}"}`;
-    const jsonScalarConcept = '"数字化改造"';
+    const decodedJsonScalarConcept = '数字化改造';
+    const jsonScalarConcept = JSON.stringify(decodedJsonScalarConcept);
+    const malformedSecretFact = 'TREX_MALFORMED_SECRET_4b1e_DO_NOT_LOG';
+    const malformedJsonFact = `{"note":"${malformedSecretFact}"`;
     const warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
     const rowId = 1;
+    const malformedRowId = 2;
     const cjkRow = {
       ...makeObservationRow(rowId, project),
       facts: jsonLookingFact,
       concepts: jsonScalarConcept,
       narrative: 'json-looking fallback row',
+    };
+    const malformedRow = {
+      ...makeObservationRow(malformedRowId, project),
+      facts: malformedJsonFact,
+      narrative: 'malformed fallback row',
     };
     ChromaSyncState.replace(project, {
       observations: 0,
@@ -297,16 +306,18 @@ describe('ChromaSync watermark gap persistence', () => {
     const sync = new ChromaSync(project);
 
     try {
-      await sync.ensureBackfilled(project, makeStoreFromRows(project, [cjkRow]));
+      await sync.ensureBackfilled(project, makeStoreFromRows(project, [cjkRow, malformedRow]));
     } finally {
       warnSpy.mockRestore();
     }
 
     expect(addDocumentPayloads.flatMap(payload => payload.documents)).toContain(jsonLookingFact);
+    expect(addDocumentPayloads.flatMap(payload => payload.documents)).toContain(malformedJsonFact);
     expect(addDocumentPayloads.flatMap(payload => payload.metadatas).some(metadata => (
-      metadata.concepts === jsonScalarConcept
+      metadata.concepts === decodedJsonScalarConcept
     ))).toBe(true);
     expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(secretFact);
-    expect(ChromaSyncState.get(project).observations).toBe(rowId);
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(malformedSecretFact);
+    expect(ChromaSyncState.get(project).observations).toBe(malformedRowId);
   });
 });

--- a/tests/services/sync/chroma-sync-watermarks.test.ts
+++ b/tests/services/sync/chroma-sync-watermarks.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import { mkdtempSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -50,6 +50,7 @@ mock.module('../../../src/services/sync/ChromaMcpManager.js', () => ({
 
 import { ChromaSync } from '../../../src/services/sync/ChromaSync.js';
 import { ChromaSyncState } from '../../../src/services/sync/ChromaSyncState.js';
+import { logger } from '../../../src/utils/logger.js';
 
 afterAll(() => {
   mock.module('../../../src/services/sync/ChromaMcpManager.js', () => realChromaMcpManagerSnapshot);
@@ -273,5 +274,39 @@ describe('ChromaSync watermark gap persistence', () => {
     ))).toBe(true);
     expect(ChromaSyncState.get(project).observations).toBe(1);
     expect(ChromaSyncState.getPending(project, 'observations')).toEqual([]);
+  });
+
+  it('preserves JSON-looking plain-string list fields without logging raw memory content', async () => {
+    const secretFact = 'TREX_SECRET_OBSERVATION_TOKEN_9f3a7c_DO_NOT_LOG';
+    const jsonLookingFact = `{"note":"${secretFact}"}`;
+    const jsonScalarConcept = '"数字化改造"';
+    const warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
+    const rowId = 1;
+    const cjkRow = {
+      ...makeObservationRow(rowId, project),
+      facts: jsonLookingFact,
+      concepts: jsonScalarConcept,
+      narrative: 'json-looking fallback row',
+    };
+    ChromaSyncState.replace(project, {
+      observations: 0,
+      summaries: 0,
+      prompts: 0,
+      pending: {},
+    });
+    const sync = new ChromaSync(project);
+
+    try {
+      await sync.ensureBackfilled(project, makeStoreFromRows(project, [cjkRow]));
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    expect(addDocumentPayloads.flatMap(payload => payload.documents)).toContain(jsonLookingFact);
+    expect(addDocumentPayloads.flatMap(payload => payload.metadatas).some(metadata => (
+      metadata.concepts === jsonScalarConcept
+    ))).toBe(true);
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(secretFact);
+    expect(ChromaSyncState.get(project).observations).toBe(rowId);
   });
 });

--- a/tests/services/sync/chroma-sync-watermarks.test.ts
+++ b/tests/services/sync/chroma-sync-watermarks.test.ts
@@ -8,6 +8,7 @@ const realChromaMcpManagerSnapshot = { ...realChromaMcpManager };
 
 let existingObservationIds = new Set<number>();
 const addDocumentCalls: string[][] = [];
+const addDocumentPayloads: Array<{ ids: string[]; documents: string[]; metadatas: Array<Record<string, unknown>> }> = [];
 
 mock.module('../../../src/services/sync/ChromaMcpManager.js', () => ({
   ChromaMcpManager: {
@@ -33,6 +34,11 @@ mock.module('../../../src/services/sync/ChromaMcpManager.js', () => ({
 
         if (toolName === 'chroma_add_documents') {
           addDocumentCalls.push((args.ids as string[]) ?? []);
+          addDocumentPayloads.push({
+            ids: (args.ids as string[]) ?? [],
+            documents: (args.documents as string[]) ?? [],
+            metadatas: (args.metadatas as Array<Record<string, unknown>>) ?? [],
+          });
           return {};
         }
 
@@ -138,6 +144,7 @@ describe('ChromaSync watermark gap persistence', () => {
     process.env.CLAUDE_MEM_DATA_DIR = mkdtempSync(join(tmpdir(), 'claude-mem-watermarks-'));
     existingObservationIds = new Set<number>();
     addDocumentCalls.length = 0;
+    addDocumentPayloads.length = 0;
     ChromaSyncState.replace(project, { observations: 0, summaries: 0, prompts: 0, pending: {} });
   });
 
@@ -235,5 +242,36 @@ describe('ChromaSync watermark gap persistence', () => {
     expect(ChromaSyncState.get(project).observations).toBe(1);
     expect(ChromaSyncState.getPending(project, 'observations')).toEqual([]);
     expect(addDocumentCalls.some(batch => batch.includes('obs_1_fact_100'))).toBe(true);
+  });
+
+  it('backfills CJK plain-string facts and concepts without JSON parse failure', async () => {
+    const cjkFact = '用户身份定位——轻量数字化改造枢纽';
+    const cjkConcept = '数字化改造';
+    const cjkRow = {
+      ...makeObservationRow(1, project),
+      title: '观察: 用户身份定位',
+      facts: cjkFact,
+      concepts: cjkConcept,
+      narrative: '项目记录包含中文叙述',
+      text: '中文观察正文',
+    };
+    ChromaSyncState.replace(project, {
+      observations: 0,
+      summaries: 0,
+      prompts: 0,
+      pending: {},
+    });
+    const sync = new ChromaSync(project);
+
+    await sync.ensureBackfilled(project, makeStoreFromRows(project, [cjkRow]));
+
+    const writtenIds = addDocumentCalls.flat();
+    expect(writtenIds).toContain('obs_1_fact_0');
+    expect(addDocumentPayloads.flatMap(payload => payload.documents)).toContain(cjkFact);
+    expect(addDocumentPayloads.flatMap(payload => payload.metadatas).some(metadata => (
+      metadata.concepts === cjkConcept
+    ))).toBe(true);
+    expect(ChromaSyncState.get(project).observations).toBe(1);
+    expect(ChromaSyncState.getPending(project, 'observations')).toEqual([]);
   });
 });


### PR DESCRIPTION
Fix #3423

## Summary

- Make Chroma observation backfill tolerate legacy/plain-string `facts` and `concepts` fields instead of assuming every stored value is a JSON array.
- Decode valid JSON string scalars before indexing so their JSON quote delimiters are not retained.
- Preserve malformed and non-string scalar values as indexable Chroma content without logging stored memory text.
- Add regression coverage for CJK text, JSON string scalars, non-string scalars, and malformed JSON privacy.

## Test verification (RED → GREEN)

- RED: `bun test tests/services/sync/chroma-sync-watermarks.test.ts` failed because the Chroma metadata retained `"数字化改造"` instead of decoded `数字化改造`.
- GREEN: the focused Chroma watermark suite passed (`6 pass / 0 fail`).
- Local CI baseline (`origin/main`): `2554 pass / 18 skip / 22 fail / 3 errors`.
- Local CI final: `2556 pass / 18 skip / 22 fail / 3 errors`, with identical pre-existing failure identities.
- GREEN: typecheck, build, 100% changed-production-line coverage, OpenClaw (`44 pass / 0 fail`), hook-I/O lint, spawn-env lint, and `git diff --check`.
