### PR TITLE
fix(supervisor): jail SDK subprocess cwd

### DIFF
--- a/src/supervisor/process-registry.ts
+++ b/src/supervisor/process-registry.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import path from 'path';
 import { logger } from '../utils/logger.js';
 import { sanitizeEnv } from './env-sanitizer.js';
-import { OBSERVER_SESSIONS_DIR, paths } from '../shared/paths.js';
+import { ensureDir, OBSERVER_SESSIONS_DIR, paths } from '../shared/paths.js';
 // Moved to shared/ so kill-process-tree.ts can use it without closing an
 // import cycle (process-registry already imports kill-process-tree). Re-exported
 // here so every existing caller keeps its import path.
@@ -586,6 +586,8 @@ export interface SpawnSdkOptions {
   command: string;
   args: string[];
   extraArgs?: string[];
+  // Part of the Claude SDK callback contract. Accepted at this trust boundary
+  // so callers remain compatible, but deliberately ignored for isolation.
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   signal?: AbortSignal;
@@ -615,8 +617,8 @@ export function normalizeSpawnSdkArgs(args: string[], extraArgs: string[] = []):
   return filteredArgs;
 }
 
-export function normalizeSpawnSdkCwd(_cwd: string | undefined): string {
-  return OBSERVER_SESSIONS_DIR;
+export function normalizeSpawnSdkCwd(sessionDbId: number): string {
+  return path.join(OBSERVER_SESSIONS_DIR, String(sessionDbId));
 }
 
 export function spawnSdkProcess(
@@ -628,7 +630,17 @@ export function spawnSdkProcess(
   const useCmdWrapper = process.platform === 'win32' && options.command.endsWith('.cmd');
   const env = sanitizeEnv(options.env ?? process.env);
   const filteredArgs = normalizeSpawnSdkArgs(options.args, options.extraArgs);
-  const cwd = normalizeSpawnSdkCwd(options.cwd);
+  const cwd = normalizeSpawnSdkCwd(sessionDbId);
+  try {
+    ensureDir(cwd);
+  } catch (error: unknown) {
+    const cause = error instanceof Error ? error : new Error(String(error));
+    logger.error('SDK_SPAWN', `[session-${sessionDbId}] failed to create observer session directory`, {
+      sessionDbId,
+      cwd,
+    }, cause);
+    return null;
+  }
 
   const isWin = process.platform === 'win32';
   const child = useCmdWrapper

--- a/src/supervisor/process-registry.ts
+++ b/src/supervisor/process-registry.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import path from 'path';
 import { logger } from '../utils/logger.js';
 import { sanitizeEnv } from './env-sanitizer.js';
-import { paths } from '../shared/paths.js';
+import { OBSERVER_SESSIONS_DIR, paths } from '../shared/paths.js';
 // Moved to shared/ so kill-process-tree.ts can use it without closing an
 // import cycle (process-registry already imports kill-process-tree). Re-exported
 // here so every existing caller keeps its import path.
@@ -615,6 +615,10 @@ export function normalizeSpawnSdkArgs(args: string[], extraArgs: string[] = []):
   return filteredArgs;
 }
 
+export function normalizeSpawnSdkCwd(_cwd: string | undefined): string {
+  return OBSERVER_SESSIONS_DIR;
+}
+
 export function spawnSdkProcess(
   sessionDbId: number,
   options: SpawnSdkOptions
@@ -624,11 +628,12 @@ export function spawnSdkProcess(
   const useCmdWrapper = process.platform === 'win32' && options.command.endsWith('.cmd');
   const env = sanitizeEnv(options.env ?? process.env);
   const filteredArgs = normalizeSpawnSdkArgs(options.args, options.extraArgs);
+  const cwd = normalizeSpawnSdkCwd(options.cwd);
 
   const isWin = process.platform === 'win32';
   const child = useCmdWrapper
     ? spawnHidden('cmd.exe', ['/d', '/c', options.command, ...filteredArgs], {
-        cwd: options.cwd,
+        cwd,
         env,
         detached: !isWin,
         stdio: ['pipe', 'pipe', 'pipe'],
@@ -636,7 +641,7 @@ export function spawnSdkProcess(
         windowsHide: true,
       })
     : spawnHidden(options.command, filteredArgs, {
-        cwd: options.cwd,
+        cwd,
         env,
         detached: !isWin,
         stdio: ['pipe', 'pipe', 'pipe'],

--- a/tests/supervisor/process-registry.test.ts
+++ b/tests/supervisor/process-registry.test.ts
@@ -1,9 +1,22 @@
 import { afterEach, describe, expect, it } from 'bun:test';
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import { OBSERVER_SESSIONS_DIR } from '../../src/shared/paths.js';
-import { createProcessRegistry, isPidAlive, normalizeSpawnSdkArgs, normalizeSpawnSdkCwd } from '../../src/supervisor/process-registry.js';
+import { createProcessRegistry, isPidAlive, normalizeSpawnSdkArgs, normalizeSpawnSdkCwd, spawnSdkProcess } from '../../src/supervisor/process-registry.js';
+
+const TEST_SESSION_ID = process.pid;
+const SDK_CWD_PROBE = 'console.log(process.cwd())';
+const EXPECTED_SDK_CWD = path.join(OBSERVER_SESSIONS_DIR, String(TEST_SESSION_ID));
+const PARENT_PATH = '..';
+const DIRECTORY_COLLISION = 'directory collision';
+
+function assertIsolatedObserverSessionsDir(): void {
+  const relativePath = path.relative(tmpdir(), OBSERVER_SESSIONS_DIR);
+  if (relativePath === PARENT_PATH || relativePath.startsWith(`${PARENT_PATH}${path.sep}`) || path.isAbsolute(relativePath)) {
+    throw new Error(`Refusing to mutate non-test observer directory: ${OBSERVER_SESSIONS_DIR}`);
+  }
+}
 
 function makeTempDir(): string {
   return path.join(tmpdir(), `claude-mem-supervisor-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -387,8 +400,37 @@ describe('supervisor ProcessRegistry', () => {
 
   describe('normalizeSpawnSdkCwd', () => {
     it('jails SDK subprocess cwd to the observer sessions directory (#3357)', () => {
-      expect(normalizeSpawnSdkCwd('/tmp/user-project')).toBe(OBSERVER_SESSIONS_DIR);
-      expect(normalizeSpawnSdkCwd(undefined)).toBe(OBSERVER_SESSIONS_DIR);
+      expect(normalizeSpawnSdkCwd(TEST_SESSION_ID)).toBe(EXPECTED_SDK_CWD);
+    });
+
+    it('applies the observer sessions cwd to direct SDK spawns', async () => {
+      assertIsolatedObserverSessionsDir();
+      tempDirs.push(EXPECTED_SDK_CWD);
+      const projectDir = makeTempDir();
+      tempDirs.push(projectDir);
+      mkdirSync(projectDir, { recursive: true });
+
+      const result = spawnSdkProcess(TEST_SESSION_ID, {
+        command: process.execPath,
+        args: ['--eval', SDK_CWD_PROBE],
+        cwd: projectDir,
+      });
+
+      expect(result).not.toBeNull();
+      const output = await new Response(result!.process.stdout).text();
+      expect(output.trim()).toBe(realpathSync(EXPECTED_SDK_CWD));
+    });
+
+    it('returns null when the observer session directory cannot be created', () => {
+      assertIsolatedObserverSessionsDir();
+      mkdirSync(OBSERVER_SESSIONS_DIR, { recursive: true });
+      tempDirs.push(EXPECTED_SDK_CWD);
+      writeFileSync(EXPECTED_SDK_CWD, DIRECTORY_COLLISION);
+
+      expect(spawnSdkProcess(TEST_SESSION_ID, {
+        command: process.execPath,
+        args: ['--eval', SDK_CWD_PROBE],
+      })).toBeNull();
     });
   });
 

--- a/tests/supervisor/process-registry.test.ts
+++ b/tests/supervisor/process-registry.test.ts
@@ -2,7 +2,8 @@ import { afterEach, describe, expect, it } from 'bun:test';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
-import { createProcessRegistry, isPidAlive, normalizeSpawnSdkArgs } from '../../src/supervisor/process-registry.js';
+import { OBSERVER_SESSIONS_DIR } from '../../src/shared/paths.js';
+import { createProcessRegistry, isPidAlive, normalizeSpawnSdkArgs, normalizeSpawnSdkCwd } from '../../src/supervisor/process-registry.js';
 
 function makeTempDir(): string {
   return path.join(tmpdir(), `claude-mem-supervisor-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -381,6 +382,13 @@ describe('supervisor ProcessRegistry', () => {
         'session-123',
         '--no-session-persistence',
       ]);
+    });
+  });
+
+  describe('normalizeSpawnSdkCwd', () => {
+    it('jails SDK subprocess cwd to the observer sessions directory (#3357)', () => {
+      expect(normalizeSpawnSdkCwd('/tmp/user-project')).toBe(OBSERVER_SESSIONS_DIR);
+      expect(normalizeSpawnSdkCwd(undefined)).toBe(OBSERVER_SESSIONS_DIR);
     });
   });
 


### PR DESCRIPTION
Fix 3357

## Summary
- Jail each supervised SDK subprocess in its own `~/.claude-mem/observer-sessions/<sessionDbId>` directory, never the user's project cwd.
- Create the session directory before both direct and Windows `.cmd` wrapper spawns; `spawnSdkProcess` returns `null` cleanly if it cannot be created.
- Keep the SDK callback `cwd` field for compatibility while deliberately ignoring it at the trust boundary.

Rebased onto the latest `main`: the observer-session path helpers (`OBSERVER_SESSIONS_DIR`, `ensureDir`) have since landed there, so this branch now carries only the supervisor cwd-jailing change in `src/supervisor/process-registry.ts` plus its tests.

## Test verification (RED → GREEN)

RED — unmodified `main` lacks the jailing (the focused probe cannot resolve `normalizeSpawnSdkCwd` / the child inherits the supplied project directory):

```text
Export named 'normalizeSpawnSdkCwd' not found in module '.../src/supervisor/process-registry.ts'
```

GREEN — with this change:

```text
bun test tests/supervisor/process-registry.test.ts  →  27 pass  0 fail
```

Full local suite `bun test tests` → 3053 pass / 0 fail / 27 skip, no regression. The `typecheck · build · test · bundle-size` job's `install.ts` errors are pre-existing on `main` (unrelated `@clack/prompts` symbol types) — identical set with and without this branch.
