### PR TITLE
fix(settings): normalize a 'localhost' worker host to 127.0.0.1 — closes #2992

### DIFF
--- a/scripts/bug-report/collector.ts
+++ b/scripts/bug-report/collector.ts
@@ -247,7 +247,9 @@ export async function collectDiagnostics(
 
   const pidInfo = await readPidFile(dataDir);
   const workerSettings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
-  const workerHost = process.env.CLAUDE_MEM_WORKER_HOST || workerSettings.CLAUDE_MEM_WORKER_HOST;
+  // loadFromFile already applies env overrides and normalizes 'localhost' to
+  // 127.0.0.1 (#2992); a raw process.env read here would bypass both.
+  const workerHost = workerSettings.CLAUDE_MEM_WORKER_HOST;
   const configuredWorkerPort = process.env.CLAUDE_MEM_WORKER_PORT || workerSettings.CLAUDE_MEM_WORKER_PORT;
   const workerPort = typeof pidInfo?.port === "number"
     ? pidInfo.port

--- a/scripts/check-pending-queue.ts
+++ b/scripts/check-pending-queue.ts
@@ -8,7 +8,9 @@ const DEFAULT_WORKER_HOST = workerSettings.CLAUDE_MEM_WORKER_HOST;
 const DEFAULT_WORKER_PORT = workerSettings.CLAUDE_MEM_WORKER_PORT;
 
 function resolveWorkerHost(): string {
-  return process.env.CLAUDE_MEM_WORKER_HOST || DEFAULT_WORKER_HOST;
+  // loadFromFile already applies env overrides and normalizes 'localhost'
+  // to 127.0.0.1 (#2992); a raw process.env read here would bypass both.
+  return DEFAULT_WORKER_HOST;
 }
 
 function resolveWorkerPort(): string {

--- a/scripts/export-memories.ts
+++ b/scripts/export-memories.ts
@@ -50,7 +50,7 @@ async function fetchWithTimeout(url: string, init?: RequestInit): Promise<Respon
 export async function exportMemories(query: string, outputFile: string, project?: string) {
   const settings = SettingsDefaultsManager.loadFromFile(join(resolveDataDir(), 'settings.json'));
   const port = parseWorkerPort(settings.CLAUDE_MEM_WORKER_PORT);
-  const baseUrl = `http://localhost:${port}`;
+  const baseUrl = `http://${settings.CLAUDE_MEM_WORKER_HOST}:${port}`;
 
   console.log(`🔍 Searching for: "${query}"${project ? ` (project: ${project})` : ' (all projects)'}`);
 

--- a/scripts/import-memories.ts
+++ b/scripts/import-memories.ts
@@ -5,7 +5,9 @@ import { SettingsDefaultsManager } from '../src/shared/SettingsDefaultsManager.j
 import { USER_SETTINGS_PATH } from '../src/shared/paths.js';
 
 const workerSettings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
-const WORKER_HOST = process.env.CLAUDE_MEM_WORKER_HOST || workerSettings.CLAUDE_MEM_WORKER_HOST;
+// loadFromFile already applies env overrides and normalizes 'localhost' to
+// 127.0.0.1 (#2992); a raw process.env read here would bypass both.
+const WORKER_HOST = workerSettings.CLAUDE_MEM_WORKER_HOST;
 const WORKER_PORT = process.env.CLAUDE_MEM_WORKER_PORT || workerSettings.CLAUDE_MEM_WORKER_PORT;
 const WORKER_URL = `http://${WORKER_HOST}:${WORKER_PORT}`;
 

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -194,7 +194,25 @@ export class SettingsDefaultsManager {
   }
 
   static get(key: keyof SettingsDefaults): string {
-    return process.env[key] ?? this.DEFAULTS[key];
+    const value = process.env[key] ?? this.DEFAULTS[key];
+    if (key === 'CLAUDE_MEM_WORKER_HOST') {
+      return this.normalizeWorkerHost(value);
+    }
+    return value;
+  }
+
+  // 'localhost' resolves IPv6-first on modern Windows resolvers while
+  // server.listen(port, 'localhost') binds ::1 only, so the hook client and
+  // the worker can land on different loopback families (#2992). Pin the
+  // documented IPv4 loopback so every consumer of the setting agrees.
+  private static normalizeWorkerHost(host: string): string {
+    return host === 'localhost' ? '127.0.0.1' : host;
+  }
+
+  private static finalizeSettings(settings: SettingsDefaults, applyEnvOverrides: boolean): SettingsDefaults {
+    const result = applyEnvOverrides ? this.applyEnvOverrides(settings) : settings;
+    result.CLAUDE_MEM_WORKER_HOST = this.normalizeWorkerHost(result.CLAUDE_MEM_WORKER_HOST);
+    return result;
   }
 
   static getInt(key: keyof SettingsDefaults): number {
@@ -225,7 +243,7 @@ export class SettingsDefaultsManager {
         } catch (error: unknown) {
           console.warn('[SETTINGS] Failed to create settings file, using in-memory defaults:', settingsPath, error instanceof Error ? error.message : String(error));
         }
-        return applyEnvOverrides ? this.applyEnvOverrides(defaults) : defaults;
+        return this.finalizeSettings(defaults, applyEnvOverrides);
       }
 
       const settingsData = readFileSync(settingsPath, 'utf-8');
@@ -252,11 +270,11 @@ export class SettingsDefaultsManager {
         }
       }
 
-      return applyEnvOverrides ? this.applyEnvOverrides(result) : result;
+      return this.finalizeSettings(result, applyEnvOverrides);
     } catch (error: unknown) {
       console.warn('[SETTINGS] Failed to load settings, using defaults:', settingsPath, error instanceof Error ? error.message : String(error));
       const defaults = this.getAllDefaults();
-      return applyEnvOverrides ? this.applyEnvOverrides(defaults) : defaults;
+      return this.finalizeSettings(defaults, applyEnvOverrides);
     }
   }
 }

--- a/tests/infrastructure/health-monitor.test.ts
+++ b/tests/infrastructure/health-monitor.test.ts
@@ -239,6 +239,23 @@ describe('HealthMonitor', () => {
     });
 
     it('should honor configured worker host when polling health', async () => {
+      process.env.CLAUDE_MEM_WORKER_HOST = '127.0.0.2';
+      const fetchMock = mock(() => Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve('')
+      } as unknown as Response));
+      global.fetch = fetchMock;
+
+      await waitForHealth(37777, 1000);
+
+      expect(fetchMock.mock.calls[0][0]).toBe('http://127.0.0.2:37777/api/health');
+    });
+
+    it('should normalize a localhost worker host to 127.0.0.1 when polling health', async () => {
+      // 'localhost' resolves IPv6-first on modern Windows while the worker
+      // binds a single family, so SettingsDefaultsManager pins it to the
+      // IPv4 loopback (#2992) — the poll URL must reflect that.
       process.env.CLAUDE_MEM_WORKER_HOST = 'localhost';
       const fetchMock = mock(() => Promise.resolve({
         ok: true,
@@ -249,7 +266,7 @@ describe('HealthMonitor', () => {
 
       await waitForHealth(37777, 1000);
 
-      expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:37777/api/health');
+      expect(fetchMock.mock.calls[0][0]).toBe('http://127.0.0.1:37777/api/health');
     });
 
     it('should use default timeout when not specified', async () => {

--- a/tests/shared/settings-defaults-manager.test.ts
+++ b/tests/shared/settings-defaults-manager.test.ts
@@ -471,4 +471,72 @@ describe('SettingsDefaultsManager', () => {
       expect(result.CLAUDE_MEM_WORKER_PORT).toBe('33333'); 
     });
   });
+
+  describe('CLAUDE_MEM_WORKER_HOST localhost normalization (#2992)', () => {
+    // On modern Windows resolvers 'localhost' resolves IPv6-first while
+    // server.listen(port, 'localhost') binds ::1 only, so a 'localhost'
+    // host value can put the hook client and the worker on different
+    // loopback families. The manager pins it to the IPv4 loopback.
+    let originalHostEnv: string | undefined;
+
+    beforeEach(() => {
+      originalHostEnv = process.env.CLAUDE_MEM_WORKER_HOST;
+      delete process.env.CLAUDE_MEM_WORKER_HOST;
+    });
+
+    afterEach(() => {
+      if (originalHostEnv === undefined) {
+        delete process.env.CLAUDE_MEM_WORKER_HOST;
+      } else {
+        process.env.CLAUDE_MEM_WORKER_HOST = originalHostEnv;
+      }
+    });
+
+    it('should normalize a file value of localhost to 127.0.0.1', () => {
+      writeFileSync(settingsPath, JSON.stringify({ CLAUDE_MEM_WORKER_HOST: 'localhost' }));
+
+      const result = SettingsDefaultsManager.loadFromFile(settingsPath);
+
+      expect(result.CLAUDE_MEM_WORKER_HOST).toBe('127.0.0.1');
+    });
+
+    it('should normalize an env override of localhost to 127.0.0.1', () => {
+      process.env.CLAUDE_MEM_WORKER_HOST = 'localhost';
+
+      const result = SettingsDefaultsManager.loadFromFile(settingsPath);
+
+      expect(result.CLAUDE_MEM_WORKER_HOST).toBe('127.0.0.1');
+    });
+
+    it('should normalize localhost through get() when set via env', () => {
+      process.env.CLAUDE_MEM_WORKER_HOST = 'localhost';
+
+      expect(SettingsDefaultsManager.get('CLAUDE_MEM_WORKER_HOST')).toBe('127.0.0.1');
+    });
+
+    it('should normalize when env overrides are skipped', () => {
+      writeFileSync(settingsPath, JSON.stringify({ CLAUDE_MEM_WORKER_HOST: 'localhost' }));
+
+      const result = SettingsDefaultsManager.loadFromFile(settingsPath, false);
+
+      expect(result.CLAUDE_MEM_WORKER_HOST).toBe('127.0.0.1');
+    });
+
+    it('should pass through non-localhost hosts unchanged', () => {
+      writeFileSync(settingsPath, JSON.stringify({ CLAUDE_MEM_WORKER_HOST: '0.0.0.0' }));
+
+      const result = SettingsDefaultsManager.loadFromFile(settingsPath);
+
+      expect(result.CLAUDE_MEM_WORKER_HOST).toBe('0.0.0.0');
+    });
+
+    it('should not rewrite the settings file when normalizing', () => {
+      const content = JSON.stringify({ CLAUDE_MEM_WORKER_HOST: 'localhost' }, null, 2);
+      writeFileSync(settingsPath, content);
+
+      SettingsDefaultsManager.loadFromFile(settingsPath);
+
+      expect(readFileSync(settingsPath, 'utf-8')).toBe(content);
+    });
+  });
 });


### PR DESCRIPTION
## Problem

#2992 reports hooks timing out after ~29s on Windows, attributing it to hook code using `localhost` (which resolves IPv6-first) while the worker listens on `127.0.0.1` only.

Investigating on Windows 11 (10.0.26200, claude-mem 13.12.4, Bun 1.3.14, Node 22.19.0), the issue **as filed doesn't reproduce**: the hook→worker path hasn't used `localhost` since `b8a9f366` (v7.1.1) — client URL (`buildWorkerUrl`) and worker bind read the same `CLAUDE_MEM_WORKER_HOST` setting, default `127.0.0.1`. With the default config, `session-init` hooks complete in ~1s. (Full measurements in [my comment on the issue](https://github.com/thedotmack/claude-mem/issues/2992#issuecomment-5108733134).)

But the *mechanism* behind the report is real, and there is still one supported path into it:

- The settings validator **accepts** `CLAUDE_MEM_WORKER_HOST=localhost` (`SettingsRoutes.ts` `validHostPattern`) — while its own error message says "must be a valid IP address" — and the value can also arrive via env.
- With that value, `server.listen(port, 'localhost')` binds **`::1` only** on Windows (verified under both Bun and Node), so the worker becomes invisible to anything IPv4 — e.g. the install-time shutdown helper, which hardcodes `127.0.0.1`.
- The `isPortInUse` bind-probe goes cross-family blind: probing `localhost` binds `::1` and reports the port free while `127.0.0.1` is occupied (and inversely), defeating the duplicate-daemon gate.
- On machines where `::1` loopback SYNs are silently dropped instead of refused (VPN/endpoint-security filtering — consistent with the reporter's `Test-NetConnection ::1` failure), every hook fetch then hangs until the 30s `CLAUDE_MEM_API_TIMEOUT_MS` abort. The reporter's `hook_duration_ms=29,947` matches that timeout, not any DNS behavior. On stock Windows the OS refuses instantly and Bun's fetch falls back to IPv4 in ~13ms, which is why most machines never see the stall.

## Fix

Normalize `'localhost'` → `'127.0.0.1'` at the single source every consumer already reads — `SettingsDefaultsManager` (`loadFromFile`'s three exits via a `finalizeSettings` helper, and static `get`). Both `getWorkerHost()` implementations (`worker-utils.ts` and `HealthMonitor.ts`'s local copy), the npx CLI (`doctor`/`runtime`/`install`), and the OpenCode plugin all sit above this choke point, so client URL, worker bind, health probes, and the port probe can no longer disagree about the loopback family.

This implements the #3138 Phase 1 directive: *"Fix host selection so getWorkerHost() is used consistently and Windows IPv6 localhost does not block IPv4-only worker listeners."*

**Approaches considered and rejected:**
- *Hardcode `127.0.0.1` in the client* (the issue's proposal): breaks `0.0.0.0`/custom-host configs and contradicts #3138's configured-host direction (the earlier hardcoded-host cleanup, #2998-era, moved the other way).
- *Dual-bind the worker on both families*: a second listener is a second system — more lifecycle surface for the port-reclaim/orphan work tracked in #2963, for zero benefit once the families agree.
- *Reject `localhost` in the validator*: turns a working (post-fix) config into an error; normalization keeps user intent ("bind loopback") and makes it correct. The value stays as the user wrote it in `settings.json` — normalization is read-side only; `/api/settings` reports the effective (normalized) host.

## Before / after (Windows 11, same command: worker started with `CLAUDE_MEM_WORKER_HOST=localhost`, isolated data dir)

| | bind result (`Get-NetTCPConnection`) | reachable at `http://127.0.0.1:<port>/api/health` |
|---|---|---|
| **before (13.12.4)** | `::1 : 37800 LISTEN` | ✗ |
| **after (this fix)** | `127.0.0.1 : 37800 LISTEN` | ✓ `{status: ok}` |

Client side, measured against an IPv4-only worker with `localhost` resolving `::1`-first (`dns.lookup` order verified): real `session-init` hook round-trips are ~1s both before and after on stock Windows — the fix removes the family mismatch that turns into 30s stalls on SYN-dropping environments and the port-probe blindness everywhere.

## Tests

- `tests/shared/settings-defaults-manager.test.ts` — new `#2992` describe block: normalization from file value, from env override, through `get()`, with env overrides skipped; non-`localhost` hosts pass through; the settings file on disk is never rewritten.
- `tests/infrastructure/health-monitor.test.ts` — "honor configured worker host when polling health" now uses `127.0.0.2` (still guards against hardcoding; `localhost` is intentionally normalized now), plus a new companion test pinning `localhost` → `http://127.0.0.1:.../api/health`.

Ran on Windows 11: `npm run typecheck` ✓ · `npm run build` ✓ (bundle guardrail) · `bun test tests/shared` 135 pass / 4 fail · `bun test tests/infrastructure` 203 pass / 12 fail · `bun test tests/bun-runner.test.ts` 15/15 ✓ · `bun test openclaw` 44/44 ✓ · `lint:hook-io` + `lint:spawn-env` ✓. The 4 + 12 failures are pre-existing on current `main` on Windows (identical list before/after this change; primarily path-shape and live-daemon-sensitive tests that Windows CI does not run).

Generated `plugin/scripts/*.cjs` intentionally not committed (edit-source-and-rebuild guard); behavior above was demonstrated on a locally rebuilt artifact.

Closes #2992

🤖 Generated with [Claude Code](https://claude.com/claude-code)
