### PR TITLE
fix(install): ship Claude marketplace manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "files": [
     "dist",
     ".agents/plugins/marketplace.json",
+    ".claude-plugin",
     ".codex-plugin",
     "plugin/.claude-plugin",
     "plugin/.codex-plugin",

--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -663,6 +663,7 @@ function copyPluginToMarketplace(): void {
 
   const allowedTopLevelEntries = [
     '.agents',
+    '.claude-plugin',
     '.codex-plugin',
     'plugin',
     'package.json',

--- a/tests/infrastructure/plugin-distribution.test.ts
+++ b/tests/infrastructure/plugin-distribution.test.ts
@@ -245,7 +245,7 @@ describe('Plugin Distribution - package.json Files Field', () => {
     expect(packageJson.files).toContain('plugin/sqlite');
   });
 
-  it('npm tarball includes sqlite runtime modules required by the worker', () => {
+  it('npm tarball includes runtime and Claude marketplace root manifests required by clean installs (#3424)', () => {
     const result = spawnSync('npm', ['pack', '--dry-run', '--json'], {
       cwd: projectRoot,
       encoding: 'utf-8',
@@ -257,6 +257,8 @@ describe('Plugin Distribution - package.json Files Field', () => {
 
     expect(filePaths.has('plugin/sqlite/SessionStore.js')).toBe(true);
     expect(filePaths.has('plugin/sqlite/observations/files.js')).toBe(true);
+    expect(filePaths.has('.claude-plugin/marketplace.json')).toBe(true);
+    expect(filePaths.has('.claude-plugin/plugin.json')).toBe(true);
   });
 });
 

--- a/tests/install-non-tty.test.ts
+++ b/tests/install-non-tty.test.ts
@@ -119,10 +119,17 @@ describe('Install Non-TTY Support', () => {
       );
       expect(copyRegion).toContain("'.agents'");
       expect(copyRegion).toContain("'.codex-plugin'");
+      expect(copyRegion).toContain("'.claude-plugin'");
       // Root .mcp.json was dropped in #2411; the MCP manifest now ships
       // exclusively as plugin/.mcp.json (bundled inside the 'plugin' entry).
       expect(copyRegion).toContain("'plugin'");
       expect(copyRegion).not.toContain("'.mcp.json'");
+    });
+
+    it('publishes the Claude marketplace root manifest in the npm package (#3424)', () => {
+      const packageJson = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8'));
+      expect(packageJson.files).toContain('.claude-plugin');
+      expect(packageJson.files).toContain('plugin/.claude-plugin');
     });
 
     it('validates the bundled plugin as the Codex marketplace source', () => {


### PR DESCRIPTION
Fix #3424

## Summary
- include the root `.claude-plugin` marketplace manifest in the npm package
- copy `.claude-plugin` into the durable marketplace install root
- cover the install/package allowlists so clean Claude Code installs do not cache-miss on marketplace load

## Tests
- RED: `bun test tests/install-non-tty.test.ts --timeout 30000` failed when the two implementation lines were temporarily reverted
- GREEN: `./run-ci.sh`
