### PR TITLE
fix(codex): detect desktop-bundled CLI on macOS

### DIFF
--- a/src/services/integrations/CodexCliInstaller.ts
+++ b/src/services/integrations/CodexCliInstaller.ts
@@ -5,7 +5,14 @@ import {
   spawnSync,
   type SpawnSyncReturns,
 } from 'child_process';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import {
+  accessSync,
+  constants,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'fs';
 import { fileURLToPath } from 'url';
 import { logger } from '../../utils/logger.js';
 import { paths } from '../../shared/paths.js';
@@ -32,8 +39,20 @@ const MACOS_CODEX_BUNDLE_PATHS = [
   '/Applications/Codex.app/Contents/Resources/codex',
 ];
 
+export function isExecutableFile(
+  candidate: string,
+  access: (path: string, mode: number) => void = accessSync,
+): boolean {
+  try {
+    access(candidate, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function commandExists(command: string): boolean {
-  if (path.isAbsolute(command)) return existsSync(command);
+  if (path.isAbsolute(command)) return isExecutableFile(command);
 
   try {
     if (process.platform === 'win32') {
@@ -118,10 +137,10 @@ function lookupCodexOnWindows(): string | null {
 
 export function lookupCodexOnMacOS(
   commandInPath: (command: string) => boolean = commandExists,
-  fileExists: (candidate: string) => boolean = existsSync,
+  candidateAvailable: (candidate: string) => boolean = isExecutableFile,
 ): string | null {
   if (commandInPath('codex')) return 'codex';
-  return MACOS_CODEX_BUNDLE_PATHS.find(fileExists) ?? null;
+  return MACOS_CODEX_BUNDLE_PATHS.find((candidate) => candidateAvailable(candidate)) ?? null;
 }
 
 export function resolveCodexCommand(

--- a/src/services/integrations/CodexCliInstaller.ts
+++ b/src/services/integrations/CodexCliInstaller.ts
@@ -51,10 +51,14 @@ export function isExecutableFile(
   }
 }
 
-function isUsableCodexBundle(candidate: string): boolean {
-  const result = spawnSync(candidate, ['--version'], {
+export function isUsableCodexBundle(
+  candidate: string,
+  probe: typeof spawnSync = spawnSync,
+): boolean {
+  const result = probe(candidate, ['--version'], {
     stdio: 'ignore',
     windowsHide: true,
+    timeout: 5_000,
   });
   return !result.error && result.status === 0;
 }

--- a/src/services/integrations/CodexCliInstaller.ts
+++ b/src/services/integrations/CodexCliInstaller.ts
@@ -27,8 +27,14 @@ const REQUIRED_MARKETPLACE_FILES = [
   path.join('plugin', 'skills', 'mem-search', 'SKILL.md'),
 ];
 const WINDOWS_CODEX_EXTENSIONS = new Set(['.cmd', '.exe', '.bat', '.com']);
+const MACOS_CODEX_BUNDLE_PATHS = [
+  '/Applications/ChatGPT.app/Contents/Resources/codex',
+  '/Applications/Codex.app/Contents/Resources/codex',
+];
 
 function commandExists(command: string): boolean {
+  if (path.isAbsolute(command)) return existsSync(command);
+
   try {
     if (process.platform === 'win32') {
       execFileSync('where.exe', [command], { stdio: 'ignore', windowsHide: true });
@@ -110,20 +116,31 @@ function lookupCodexOnWindows(): string | null {
     ?? null;
 }
 
+export function lookupCodexOnMacOS(
+  commandInPath: (command: string) => boolean = commandExists,
+  fileExists: (candidate: string) => boolean = existsSync,
+): string | null {
+  if (commandInPath('codex')) return 'codex';
+  return MACOS_CODEX_BUNDLE_PATHS.find(fileExists) ?? null;
+}
+
 export function resolveCodexCommand(
   platform: NodeJS.Platform = process.platform,
   windowsLookup: () => string | null = lookupCodexOnWindows,
+  macOSLookup: () => string | null = lookupCodexOnMacOS,
 ): string {
-  if (platform !== 'win32') return 'codex';
-  return windowsLookup() ?? 'codex.cmd';
+  if (platform === 'win32') return windowsLookup() ?? 'codex.cmd';
+  if (platform === 'darwin') return macOSLookup() ?? 'codex';
+  return 'codex';
 }
 
 export function resolveCodexSpawnInvocation(
   args: string[],
   platform: NodeJS.Platform = process.platform,
   windowsLookup: () => string | null = lookupCodexOnWindows,
+  macOSLookup: () => string | null = lookupCodexOnMacOS,
 ): SpawnSyncInvocation {
-  const resolvedCommand = resolveCodexCommand(platform, windowsLookup);
+  const resolvedCommand = resolveCodexCommand(platform, windowsLookup, macOSLookup);
   return buildSpawnSyncInvocation(resolvedCommand, args, {
     encoding: 'utf-8',
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -433,7 +450,7 @@ const cleanupLegacyCodexTranscriptAgentsContext = disableCodexTranscriptAgentsCo
 export async function installCodexCli(marketplaceRootOverride?: string): Promise<number> {
   console.log('\nInstalling Claude-Mem for Codex CLI (native hooks)...\n');
 
-  if (!commandExists('codex')) {
+  if (!commandExists(resolveCodexCommand())) {
     console.error('Codex CLI was not found on PATH.');
     console.error('Install Codex, then run: npx claude-mem@latest install');
     return 1;
@@ -494,7 +511,7 @@ export function uninstallCodexCli(): number {
   }
 
   try {
-    if (commandExists('codex')) {
+    if (commandExists(resolveCodexCommand())) {
       runCodex(['plugin', 'marketplace', 'remove', MARKETPLACE_NAME]);
     } else {
       console.log('  Codex CLI not found; skipping marketplace removal.');

--- a/src/services/integrations/CodexCliInstaller.ts
+++ b/src/services/integrations/CodexCliInstaller.ts
@@ -51,6 +51,14 @@ export function isExecutableFile(
   }
 }
 
+function isUsableCodexBundle(candidate: string): boolean {
+  const result = spawnSync(candidate, ['--version'], {
+    stdio: 'ignore',
+    windowsHide: true,
+  });
+  return !result.error && result.status === 0;
+}
+
 function commandExists(command: string): boolean {
   if (path.isAbsolute(command)) return isExecutableFile(command);
 
@@ -137,7 +145,7 @@ function lookupCodexOnWindows(): string | null {
 
 export function lookupCodexOnMacOS(
   commandInPath: (command: string) => boolean = commandExists,
-  candidateAvailable: (candidate: string) => boolean = isExecutableFile,
+  candidateAvailable: (candidate: string) => boolean = isUsableCodexBundle,
 ): string | null {
   if (commandInPath('codex')) return 'codex';
   return MACOS_CODEX_BUNDLE_PATHS.find((candidate) => candidateAvailable(candidate)) ?? null;

--- a/src/services/integrations/CodexCliInstaller.ts
+++ b/src/services/integrations/CodexCliInstaller.ts
@@ -59,6 +59,7 @@ export function isUsableCodexBundle(
     stdio: 'ignore',
     windowsHide: true,
     timeout: 5_000,
+    killSignal: 'SIGKILL',
   });
   return !result.error && result.status === 0;
 }

--- a/tests/services/integrations/spawn-contract-windows.test.ts
+++ b/tests/services/integrations/spawn-contract-windows.test.ts
@@ -3,6 +3,7 @@ import { ChromaMcpManager } from '../../../src/services/sync/ChromaMcpManager.js
 import {
   codexSpawn,
   isExecutableFile,
+  isUsableCodexBundle,
   lookupCodexOnMacOS,
   resolveCodexCommand,
   resolveCodexSpawnInvocation,
@@ -172,6 +173,15 @@ describe('macOS Codex Desktop bundle resolution', () => {
       },
     )).toBe(legacyBundledCodex);
     expect(probed).toEqual([chatGptBundledCodex, legacyBundledCodex]);
+  });
+
+  it('bounds the bundled CLI probe so a hung candidate cannot block fallback', () => {
+    const probe = ((_command: string, _args: string[], options: { timeout?: number }) => {
+      expect(options.timeout).toBe(5_000);
+      return { error: new Error('ETIMEDOUT'), status: null };
+    }) as typeof import('child_process').spawnSync;
+
+    expect(isUsableCodexBundle(chatGptBundledCodex, probe)).toBe(false);
   });
 
   it('passes the bundled CLI path through the shared spawn resolver', () => {

--- a/tests/services/integrations/spawn-contract-windows.test.ts
+++ b/tests/services/integrations/spawn-contract-windows.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'bun:test';
 import { ChromaMcpManager } from '../../../src/services/sync/ChromaMcpManager.js';
 import {
   codexSpawn,
+  isExecutableFile,
   lookupCodexOnMacOS,
   resolveCodexCommand,
   resolveCodexSpawnInvocation,
@@ -135,6 +136,13 @@ describe('Windows #2695 - codex spawn resolves the .cmd shim without a shell', (
 describe('macOS Codex Desktop bundle resolution', () => {
   const chatGptBundledCodex = '/Applications/ChatGPT.app/Contents/Resources/codex';
   const legacyBundledCodex = '/Applications/Codex.app/Contents/Resources/codex';
+
+  it('rejects bundle files that are not executable', () => {
+    expect(isExecutableFile(chatGptBundledCodex, () => {
+      throw new Error('EACCES');
+    })).toBe(false);
+    expect(isExecutableFile(chatGptBundledCodex, () => {})).toBe(true);
+  });
 
   it('keeps a standalone codex from PATH as the first choice', () => {
     expect(lookupCodexOnMacOS(() => true, () => true)).toBe('codex');

--- a/tests/services/integrations/spawn-contract-windows.test.ts
+++ b/tests/services/integrations/spawn-contract-windows.test.ts
@@ -162,6 +162,18 @@ describe('macOS Codex Desktop bundle resolution', () => {
     )).toBe(legacyBundledCodex);
   });
 
+  it('falls back to the legacy bundle when the ChatGPT bundled CLI probe fails', () => {
+    const probed: string[] = [];
+    expect(lookupCodexOnMacOS(
+      () => false,
+      (candidate) => {
+        probed.push(candidate);
+        return candidate === legacyBundledCodex;
+      },
+    )).toBe(legacyBundledCodex);
+    expect(probed).toEqual([chatGptBundledCodex, legacyBundledCodex]);
+  });
+
   it('passes the bundled CLI path through the shared spawn resolver', () => {
     const invocation = resolveCodexSpawnInvocation(
       ['--version'],

--- a/tests/services/integrations/spawn-contract-windows.test.ts
+++ b/tests/services/integrations/spawn-contract-windows.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'bun:test';
 import { ChromaMcpManager } from '../../../src/services/sync/ChromaMcpManager.js';
 import {
   codexSpawn,
+  lookupCodexOnMacOS,
   resolveCodexCommand,
   resolveCodexSpawnInvocation,
 } from '../../../src/services/integrations/CodexCliInstaller.js';
@@ -115,7 +116,7 @@ describe('Windows #2695 - codex spawn resolves the .cmd shim without a shell', (
 
   it('uses bare codex on non-Windows platforms', () => {
     expect(resolveCodexCommand('linux')).toBe('codex');
-    expect(resolveCodexCommand('darwin')).toBe('codex');
+    expect(resolveCodexCommand('darwin', () => null, () => null)).toBe('codex');
   });
 
   it('codexSpawn is exported and invokable (no crash on a bogus codex)', () => {
@@ -128,5 +129,40 @@ describe('Windows #2695 - codex spawn resolves the .cmd shim without a shell', (
     expect(result).toBeDefined();
     // status is a number when the binary ran; error is set when not found.
     expect(result.status !== undefined || result.error !== undefined).toBe(true);
+  });
+});
+
+describe('macOS Codex Desktop bundle resolution', () => {
+  const chatGptBundledCodex = '/Applications/ChatGPT.app/Contents/Resources/codex';
+  const legacyBundledCodex = '/Applications/Codex.app/Contents/Resources/codex';
+
+  it('keeps a standalone codex from PATH as the first choice', () => {
+    expect(lookupCodexOnMacOS(() => true, () => true)).toBe('codex');
+  });
+
+  it('prefers the current ChatGPT app bundle when both app bundles exist', () => {
+    expect(lookupCodexOnMacOS(
+      () => false,
+      () => true,
+    )).toBe(chatGptBundledCodex);
+  });
+
+  it('supports the legacy Codex app bundle when ChatGPT is absent', () => {
+    expect(lookupCodexOnMacOS(
+      () => false,
+      (candidate) => candidate === legacyBundledCodex,
+    )).toBe(legacyBundledCodex);
+  });
+
+  it('passes the bundled CLI path through the shared spawn resolver', () => {
+    const invocation = resolveCodexSpawnInvocation(
+      ['--version'],
+      'darwin',
+      () => null,
+      () => chatGptBundledCodex,
+    );
+
+    expect(invocation.command).toBe(chatGptBundledCodex);
+    expect(invocation.args).toEqual(['--version']);
   });
 });

--- a/tests/services/integrations/spawn-contract-windows.test.ts
+++ b/tests/services/integrations/spawn-contract-windows.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'bun:test';
+import { spawnSync } from 'child_process';
 import { ChromaMcpManager } from '../../../src/services/sync/ChromaMcpManager.js';
 import {
   codexSpawn,
@@ -175,13 +176,33 @@ describe('macOS Codex Desktop bundle resolution', () => {
     expect(probed).toEqual([chatGptBundledCodex, legacyBundledCodex]);
   });
 
-  it('bounds the bundled CLI probe so a hung candidate cannot block fallback', () => {
-    const probe = ((_command: string, _args: string[], options: { timeout?: number }) => {
+  it('bounds the bundled CLI probe and force-kills a hung candidate', () => {
+    const probe = ((_command: string, _args: string[], options: { timeout?: number; killSignal?: string }) => {
       expect(options.timeout).toBe(5_000);
+      expect(options.killSignal).toBe('SIGKILL');
       return { error: new Error('ETIMEDOUT'), status: null };
     }) as typeof import('child_process').spawnSync;
 
     expect(isUsableCodexBundle(chatGptBundledCodex, probe)).toBe(false);
+  });
+
+  it('returns after the deadline when the bundled CLI ignores SIGTERM', () => {
+    if (process.platform === 'win32') return;
+
+    const probe = ((_command: string, _args: string[], options: Parameters<typeof spawnSync>[2]) => (
+      spawnSync(process.execPath, ['-e', [
+        "process.on('SIGTERM', () => {});",
+        'setTimeout(() => process.exit(17), 3_000);',
+        'setInterval(() => {}, 1_000);',
+      ].join('')], {
+        ...options,
+        timeout: 200,
+      })
+    )) as typeof spawnSync;
+
+    const startedAt = Date.now();
+    expect(isUsableCodexBundle(chatGptBundledCodex, probe)).toBe(false);
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
   });
 
   it('passes the bundled CLI path through the shared spawn resolver', () => {


### PR DESCRIPTION
On macOS, Claude-Mem installation previously rejected Codex when it was available only through the ChatGPT or legacy Codex desktop app because the bundled CLI is not on `PATH`. The installer and uninstaller now prefer an existing standalone `codex`, then fall back to the current ChatGPT bundle and the legacy Codex bundle.

This preserves the user's selected standalone CLI and the existing minimum-version check while enabling Desktop-only setups. Validation covered 66 targeted tests, the spawn-environment lint, and a real restricted-`PATH` probe that resolved `/Applications/ChatGPT.app/Contents/Resources/codex` and ran `codex --version` successfully.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
