### PR TITLE
fix: recognize Bun and undici connection-refused shapes in worker-down checks

### DIFF
--- a/src/integrations/opencode-plugin/index.ts
+++ b/src/integrations/opencode-plugin/index.ts
@@ -105,6 +105,20 @@ const MAX_TOOL_RESPONSE_LENGTH = 1000;
 
 const JSON_HEADERS: Record<string, string> = { "Content-Type": "application/json" };
 
+// A refused connection (worker simply not running) must stay quiet, but its
+// shape is runtime-dependent: Bun's fetch throws code 'ConnectionRefused'
+// ("Unable to connect..."), Node's undici throws TypeError 'fetch failed'
+// with ECONNREFUSED only on error.cause — a message.includes('ECONNREFUSED')
+// check matches neither. Local copy (not imported from HealthMonitor) to keep
+// worker-only modules out of the plugin bundle. Exported for the contract test.
+export function isConnectionRefusedError(error: unknown): boolean {
+  const err = error as { code?: unknown; cause?: { code?: unknown } };
+  if (err?.code === "ECONNREFUSED" || err?.code === "ConnectionRefused") return true;
+  if (err?.cause?.code === "ECONNREFUSED") return true;
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("ECONNREFUSED");
+}
+
 function workerPostFireAndForget(
   path: string,
   body: Record<string, unknown>,
@@ -114,8 +128,8 @@ function workerPostFireAndForget(
     headers: JSON_HEADERS,
     body: JSON.stringify(body),
   }).catch((error: unknown) => {
-    const message = error instanceof Error ? error.message : String(error);
-    if (!message.includes("ECONNREFUSED")) {
+    if (!isConnectionRefusedError(error)) {
+      const message = error instanceof Error ? error.message : String(error);
       console.warn(`[claude-mem] Worker POST ${path} failed: ${message}`);
     }
   });
@@ -130,8 +144,8 @@ async function workerGetText(path: string): Promise<string | null> {
     }
     return await response.text();
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    if (!message.includes("ECONNREFUSED")) {
+    if (!isConnectionRefusedError(error)) {
+      const message = error instanceof Error ? error.message : String(error);
       console.warn(`[claude-mem] Worker GET ${path} failed: ${message}`);
     }
     return null;

--- a/src/services/infrastructure/HealthMonitor.ts
+++ b/src/services/infrastructure/HealthMonitor.ts
@@ -15,6 +15,18 @@ function formatHostForUrl(host: string): string {
   return host.includes(':') ? `[${host}]` : host;
 }
 
+// A refused connection surfaces differently per runtime: Bun's fetch throws
+// code 'ConnectionRefused' ("Unable to connect..."), Node's undici throws
+// TypeError 'fetch failed' with the ECONNREFUSED only on error.cause — so a
+// message.includes('ECONNREFUSED') check matches neither.
+export function isConnectionRefusedError(error: unknown): boolean {
+  const err = error as { code?: unknown; cause?: { code?: unknown } };
+  if (err?.code === 'ECONNREFUSED' || err?.code === 'ConnectionRefused') return true;
+  if (err?.cause?.code === 'ECONNREFUSED') return true;
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes('ECONNREFUSED');
+}
+
 async function httpRequestToWorker(
   port: number,
   endpointPath: string,
@@ -136,7 +148,7 @@ export async function httpShutdown(port: number, reason: 'stop' | 'restart' = 's
     }
     return true;
   } catch (error) {
-    if (error instanceof Error && error.message?.includes('ECONNREFUSED')) {
+    if (error instanceof Error && isConnectionRefusedError(error)) {
       logger.debug('SYSTEM', 'Worker already stopped', {}, error);
       return false;
     }

--- a/tests/infrastructure/health-monitor.test.ts
+++ b/tests/infrastructure/health-monitor.test.ts
@@ -5,8 +5,10 @@ import {
   waitForHealth,
   waitForPortFree,
   getRunningWorkerVersion,
-  checkVersionMatch
+  checkVersionMatch,
+  httpShutdown
 } from '../../src/services/infrastructure/index.js';
+import { logger } from '../../src/utils/logger.js';
 
 describe('HealthMonitor', () => {
   const originalFetch = global.fetch;
@@ -172,6 +174,64 @@ describe('HealthMonitor', () => {
       } finally {
         Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
       }
+    });
+  });
+
+  describe('httpShutdown', () => {
+    // A refused connection means "worker already stopped" — expected during
+    // stop/restart flows — and must log at debug, not error. Its shape is
+    // runtime-dependent: Bun sets code 'ConnectionRefused' with an
+    // "Unable to connect..." message; Node's undici throws TypeError
+    // 'fetch failed' with ECONNREFUSED only on error.cause.
+    it('treats a Bun-shaped ConnectionRefused as worker-already-stopped, not an unexpected failure', async () => {
+      const bunRefusal = Object.assign(
+        new Error('Unable to connect. Is the computer able to access the url?'),
+        { code: 'ConnectionRefused' }
+      );
+      global.fetch = mock(() => Promise.reject(bunRefusal));
+      const errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
+      const debugSpy = spyOn(logger, 'debug').mockImplementation(() => {});
+
+      const result = await httpShutdown(39999);
+
+      expect(result).toBe(false);
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(debugSpy).toHaveBeenCalled();
+
+      errorSpy.mockRestore();
+      debugSpy.mockRestore();
+    });
+
+    it('treats an undici-shaped fetch failed with cause ECONNREFUSED as worker-already-stopped', async () => {
+      const undiciRefusal = new TypeError('fetch failed');
+      (undiciRefusal as { cause?: unknown }).cause = Object.assign(
+        new Error('connect ECONNREFUSED 127.0.0.1:39999'),
+        { code: 'ECONNREFUSED' }
+      );
+      global.fetch = mock(() => Promise.reject(undiciRefusal));
+      const errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
+      const debugSpy = spyOn(logger, 'debug').mockImplementation(() => {});
+
+      const result = await httpShutdown(39999);
+
+      expect(result).toBe(false);
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(debugSpy).toHaveBeenCalled();
+
+      errorSpy.mockRestore();
+      debugSpy.mockRestore();
+    });
+
+    it('still logs genuinely unexpected shutdown failures at error level', async () => {
+      global.fetch = mock(() => Promise.reject(new Error('TLS handshake exploded')));
+      const errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
+
+      const result = await httpShutdown(39999);
+
+      expect(result).toBe(false);
+      expect(errorSpy).toHaveBeenCalled();
+
+      errorSpy.mockRestore();
     });
   });
 

--- a/tests/infrastructure/health-monitor.test.ts
+++ b/tests/infrastructure/health-monitor.test.ts
@@ -183,23 +183,32 @@ describe('HealthMonitor', () => {
     // runtime-dependent: Bun sets code 'ConnectionRefused' with an
     // "Unable to connect..." message; Node's undici throws TypeError
     // 'fetch failed' with ECONNREFUSED only on error.cause.
+    let errorSpy: ReturnType<typeof spyOn> | null = null;
+    let debugSpy: ReturnType<typeof spyOn> | null = null;
+
+    // Restore in teardown so a failed assertion cannot leave the logger
+    // mocked for subsequent tests.
+    afterEach(() => {
+      errorSpy?.mockRestore();
+      debugSpy?.mockRestore();
+      errorSpy = null;
+      debugSpy = null;
+    });
+
     it('treats a Bun-shaped ConnectionRefused as worker-already-stopped, not an unexpected failure', async () => {
       const bunRefusal = Object.assign(
         new Error('Unable to connect. Is the computer able to access the url?'),
         { code: 'ConnectionRefused' }
       );
       global.fetch = mock(() => Promise.reject(bunRefusal));
-      const errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
-      const debugSpy = spyOn(logger, 'debug').mockImplementation(() => {});
+      errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
+      debugSpy = spyOn(logger, 'debug').mockImplementation(() => {});
 
       const result = await httpShutdown(39999);
 
       expect(result).toBe(false);
       expect(errorSpy).not.toHaveBeenCalled();
       expect(debugSpy).toHaveBeenCalled();
-
-      errorSpy.mockRestore();
-      debugSpy.mockRestore();
     });
 
     it('treats an undici-shaped fetch failed with cause ECONNREFUSED as worker-already-stopped', async () => {
@@ -209,29 +218,24 @@ describe('HealthMonitor', () => {
         { code: 'ECONNREFUSED' }
       );
       global.fetch = mock(() => Promise.reject(undiciRefusal));
-      const errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
-      const debugSpy = spyOn(logger, 'debug').mockImplementation(() => {});
+      errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
+      debugSpy = spyOn(logger, 'debug').mockImplementation(() => {});
 
       const result = await httpShutdown(39999);
 
       expect(result).toBe(false);
       expect(errorSpy).not.toHaveBeenCalled();
       expect(debugSpy).toHaveBeenCalled();
-
-      errorSpy.mockRestore();
-      debugSpy.mockRestore();
     });
 
     it('still logs genuinely unexpected shutdown failures at error level', async () => {
       global.fetch = mock(() => Promise.reject(new Error('TLS handshake exploded')));
-      const errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
+      errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
 
       const result = await httpShutdown(39999);
 
       expect(result).toBe(false);
       expect(errorSpy).toHaveBeenCalled();
-
-      errorSpy.mockRestore();
     });
   });
 

--- a/tests/integrations/opencode-plugin-contract.test.ts
+++ b/tests/integrations/opencode-plugin-contract.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "bun:test";
 import {
   ClaudeMemPlugin,
   parseSearchResponse,
+  isConnectionRefusedError,
   REGISTERED_OPENCODE_HOOKS,
   REAL_OPENCODE_EVENT_TYPES,
 } from "../../src/integrations/opencode-plugin/index";
@@ -161,5 +162,40 @@ describe("OpenCode search client response-shape contract", () => {
     });
     const rendered = parseSearchResponse(emptyResponse, "zzz");
     expect(rendered).toContain("No observations found");
+  });
+});
+
+describe("isConnectionRefusedError (worker-down warning suppression)", () => {
+  // The plugin stays quiet when the worker is simply not running. OpenCode
+  // hosts plugins under Bun, whose fetch rejects a refused connection with
+  // code 'ConnectionRefused' and no 'ECONNREFUSED' anywhere in the message;
+  // Node's undici puts ECONNREFUSED only on error.cause. A regression to
+  // message-only matching would spam a warning on every event while the
+  // worker is down.
+  it("recognizes Bun's ConnectionRefused shape", () => {
+    const bunRefusal = Object.assign(
+      new Error("Unable to connect. Is the computer able to access the url?"),
+      { code: "ConnectionRefused" }
+    );
+    expect(isConnectionRefusedError(bunRefusal)).toBe(true);
+  });
+
+  it("recognizes undici's fetch failed with cause ECONNREFUSED", () => {
+    const undiciRefusal = new TypeError("fetch failed");
+    (undiciRefusal as { cause?: unknown }).cause = Object.assign(
+      new Error("connect ECONNREFUSED 127.0.0.1:37777"),
+      { code: "ECONNREFUSED" }
+    );
+    expect(isConnectionRefusedError(undiciRefusal)).toBe(true);
+  });
+
+  it("recognizes a legacy message-embedded ECONNREFUSED", () => {
+    expect(isConnectionRefusedError(new Error("connect ECONNREFUSED 127.0.0.1:37777"))).toBe(true);
+  });
+
+  it("does not swallow unrelated failures", () => {
+    expect(isConnectionRefusedError(new Error("TLS handshake exploded"))).toBe(false);
+    expect(isConnectionRefusedError(new Error("Unable to connect. Is the computer able to access the url?"))).toBe(false);
+    expect(isConnectionRefusedError("string error")).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

Two places classify "the worker is simply not running" by checking `error.message.includes('ECONNREFUSED')`. That string never appears on either modern runtime:

- **Bun** (which runs the worker tooling, and hosts OpenCode plugins) rejects a refused `fetch` with `code: 'ConnectionRefused'` and the message *"Unable to connect. Is the computer able to access the url?"*
- **Node's undici** throws `TypeError: fetch failed` and buries `ECONNREFUSED` on `error.cause.code`.

So both branches are dead code in practice:

1. **`HealthMonitor.httpShutdown`** — the "worker already stopped" branch (debug log) never fires; instead every `stop`/`restart` against an already-dead worker logs
   `[ERROR] [SYSTEM] Shutdown request failed unexpectedly Unable to connect. Is the computer able to access the url?`
   Reproduced on Windows 11 / Bun 1.3.14 (log line captured verbatim). These spurious ERROR entries land in the logs the bug-report collector ships, polluting triage.
2. **OpenCode plugin `workerPostFireAndForget` / `workerGetText`** — the worker-down warning suppression never engages, so with the worker down every bus event prints `[claude-mem] Worker POST/GET … failed: Unable to connect…` into the OpenCode console — repeating warning spam for an expected condition.

## Fix

A small `isConnectionRefusedError(error)` predicate that checks `error.code` (`'ECONNREFUSED'` | Bun's `'ConnectionRefused'`), undici's `error.cause.code`, and keeps the legacy message match. Applied at both sites.

Deliberately **not** message-matching Bun's generic "Unable to connect" text on its own — Bun always sets `code: 'ConnectionRefused'` for refusals, and the generic text could cover non-refusal failures (a test pins this).

The predicate is duplicated locally in the OpenCode plugin rather than imported from `HealthMonitor`, keeping worker-only modules (`net`, logger) out of the plugin bundle — same pattern as `HealthMonitor`'s existing local `formatHostForUrl` copy.

## Before / after (Windows 11, Bun 1.3.14, `httpShutdown(39998)` with nothing listening)

| | log output |
|---|---|
| **before** | `[ERROR] [SYSTEM] Shutdown request failed unexpectedly Unable to connect. Is the computer able to access the url?` |
| **after** | *(nothing at INFO level — classified as debug "Worker already stopped")* |

Return values unchanged (`false` in both branches) — this fix is about correct classification, logging, and console noise, not control flow.

## Tests

- `tests/infrastructure/health-monitor.test.ts` — new `httpShutdown` block: Bun-shaped refusal → no error log; undici-shaped refusal → no error log; genuinely unexpected failure → still logs at error level.
- `tests/integrations/opencode-plugin-contract.test.ts` — predicate contract: Bun shape ✓, undici cause shape ✓, legacy message ✓, and unrelated failures (including a bare "Unable to connect" message with no code) are NOT swallowed.

Ran on Windows 11: `npm run typecheck` ✓ · `bun test tests/infrastructure/health-monitor.test.ts` 21 pass / 3 fail (the 3 are pre-existing on main on Windows, unchanged) · `bun test tests/integrations/opencode-plugin-contract.test.ts` 11/11 ✓.

Not changed (noted for completeness): `ChromaSync.ts:992` has the same message-matching pattern but carries an explicit `[ANTI-PATTERN IGNORED]` comment explaining the transport re-wrap, and `npx-cli/runtime.ts:177` already checks `cause?.code` (its Node path). Both left as-is to keep this PR scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
