### PR TITLE
fix(sdk): isolate observer session transcripts

### DIFF
--- a/src/sdk/hardened-options.ts
+++ b/src/sdk/hardened-options.ts
@@ -38,7 +38,10 @@
  */
 
 import type { Options } from '@anthropic-ai/claude-agent-sdk';
-import { OBSERVER_SESSIONS_DIR } from '../shared/paths.js';
+import {
+  OBSERVER_CLAUDE_CONFIG_DIR,
+  OBSERVER_SESSIONS_DIR,
+} from '../shared/paths.js';
 import { recordObserverToolAttempt } from '../utils/observer-audit.js';
 import { logger } from '../utils/logger.js';
 
@@ -115,7 +118,9 @@ export function buildHardenedSdkOptions(input: HardenedSdkOptionsInput): Options
   return {
     model: input.model,
     cwd: input.cwd ?? OBSERVER_SESSIONS_DIR,
-    env: input.env,
+    // Keep resume-capable SDK transcripts, but persist them under claude-mem's
+    // own data directory so Claude Desktop does not index them as user sessions.
+    env: { ...input.env, CLAUDE_CONFIG_DIR: OBSERVER_CLAUDE_CONFIG_DIR },
     pathToClaudeCodeExecutable: input.pathToClaudeCodeExecutable,
     ...(input.abortController ? { abortController: input.abortController } : {}),
     ...(input.resume ? { resume: input.resume } : {}),

--- a/src/shared/paths.ts
+++ b/src/shared/paths.ts
@@ -67,6 +67,7 @@ export const USER_SETTINGS_PATH = join(DATA_DIR, 'settings.json');
 export const DB_PATH = join(DATA_DIR, 'claude-mem.db');
 
 export const OBSERVER_SESSIONS_DIR = join(DATA_DIR, 'observer-sessions');
+export const OBSERVER_CLAUDE_CONFIG_DIR = join(DATA_DIR, 'observer-claude-config');
 
 export const OBSERVER_SESSIONS_PROJECT = basename(OBSERVER_SESSIONS_DIR);
 

--- a/tests/security/observer-tool-enforcement.test.ts
+++ b/tests/security/observer-tool-enforcement.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { readFileSync, existsSync, rmSync } from 'fs';
+import { join } from 'path';
 import {
   buildHardenedSdkOptions,
   OBSERVER_DISALLOWED_TOOLS,
@@ -8,7 +9,10 @@ import {
   recordObserverToolAttempt,
   getObserverAuditLogPath,
 } from '../../src/utils/observer-audit.js';
-import { OBSERVER_SESSIONS_DIR } from '../../src/shared/paths.js';
+import {
+  DATA_DIR,
+  OBSERVER_SESSIONS_DIR,
+} from '../../src/shared/paths.js';
 
 const BASE_INPUT = {
   source: 'Observer' as const,
@@ -73,6 +77,15 @@ describe('Observer/KnowledgeAgent SDK tool enforcement (hardened-options)', () =
       const opts = buildHardenedSdkOptions({ ...BASE_INPUT });
       expect(opts.cwd).toBe(OBSERVER_SESSIONS_DIR);
       expect(opts.cwd).not.toBe(process.cwd());
+    });
+
+    it('persists internal SDK sessions outside the user Claude config directory', () => {
+      const opts = buildHardenedSdkOptions({
+        ...BASE_INPUT,
+        env: { CLAUDE_CONFIG_DIR: '/user/claude-config' },
+      });
+      expect(opts.env?.CLAUDE_CONFIG_DIR).toBe(join(DATA_DIR, 'observer-claude-config'));
+      expect(opts.env?.CLAUDE_CONFIG_DIR).not.toBe('/user/claude-config');
     });
 
     it('exposes a canUseTool callback', () => {


### PR DESCRIPTION
## Summary

Store Observer and KnowledgeAgent SDK session transcripts under claude-mem's own data directory instead of the user's Claude config directory.

The Agent SDK persists resume-capable sessions under `CLAUDE_CONFIG_DIR/projects`. The observer already uses an isolated `cwd` (`OBSERVER_SESSIONS_DIR`), but without an isolated config directory those transcripts still land in `~/.claude/projects` and get indexed by Claude Desktop as user sessions.

This sets a dedicated internal `CLAUDE_CONFIG_DIR` (`<DATA_DIR>/observer-claude-config`) in the shared hardened SDK options. `resume` is still passed through unchanged, so resume behavior is preserved — this only isolates where the transcript lives.

## Tests

- Added a regression test in `tests/security/observer-tool-enforcement.test.ts` that is red on current `main` and green with the fix (verified locally by reverting just the production fix and re-running).
- `bun test tests/security`: 14 pass / 0 fail.
- `bun run typecheck:root`: clean.
- Full suite: 2539 pass / 18 skip / 1 pre-existing failure (unrelated timeout in `tests/worker/sync/mutation-sites.test.ts`, reproduces identically on clean `main`).

Closes #3417