### PR TITLE
fix(observer): preserve queued batch when a transport failure is returned as text

### DIFF
--- a/src/sdk/output-classifier.ts
+++ b/src/sdk/output-classifier.ts
@@ -72,6 +72,34 @@ export function isQuotaLimitedObserverOutput(raw: unknown): boolean {
 }
 
 /**
+ * Detect transport-level failure text surfaced as an assistant message rather
+ * than a structured SDK error — e.g. a connection dropped part-way through a
+ * response. Unlike ordinary observer prose, this represents *unfinished* work:
+ * the batch was never actually considered, so confirming it silently loses
+ * observations. Callers should preserve the claimed batch for retry instead.
+ */
+export function isTransportErrorObserverOutput(raw: unknown): boolean {
+  if (typeof raw !== 'string' || raw.trim() === '') {
+    return false;
+  }
+
+  if (/<(observation|summary)\b/i.test(raw) || /<skip_summary\b/i.test(raw)) {
+    return false;
+  }
+
+  const text = raw.toLowerCase().replace(/\s+/g, ' ').trim();
+
+  return (
+    /\bconnection closed\b.{0,40}\bmid-?response\b/.test(text) ||
+    /\bresponse\b.{0,40}\bmay be incomplete\b/.test(text) ||
+    /\b(?:stream|response|connection)\b.{0,20}\b(?:ended|terminated|closed)\b.{0,20}\bunexpectedly\b/.test(text) ||
+    /\bpremature (?:close|end of stream)\b/.test(text) ||
+    /\bsocket hang ?up\b/.test(text) ||
+    /\b(?:econnreset|epipe|etimedout)\b/.test(text)
+  );
+}
+
+/**
  * Detect provider authentication-failure prose so claimed work can be retried
  * after the user restores provider authentication.
  */

--- a/src/services/worker/agents/ResponseProcessor.ts
+++ b/src/services/worker/agents/ResponseProcessor.ts
@@ -5,6 +5,7 @@ import {
   classifyObserverOutput,
   isAuthFailureObserverOutput,
   isQuotaLimitedObserverOutput,
+  isTransportErrorObserverOutput,
   previewOutput,
 } from '../../../sdk/output-classifier.js';
 import { updateCursorContextForProject } from '../../integrations/CursorHooksInstaller.js';
@@ -341,6 +342,24 @@ export async function processAgentResponse(
         remediation: '/login',
         preview: previewOutput(text),
       });
+      return;
+    }
+
+    // A truncated/dropped connection surfaced as assistant text is unfinished
+    // work, not a no-op: the batch was never considered. Preserve it for the
+    // next round instead of confirming it away. Unlike the quota and auth
+    // cases the condition is transient, so the generator is left running.
+    if (isTransportErrorObserverOutput(text)) {
+      session.consecutiveInvalidOutputs = 0;
+
+      logger.warn('PARSER', `${agentName} returned transport-failure text — preserving queued batch for retry`, {
+        sessionId: session.sessionDbId,
+        outputClass: 'prose',
+        preview: previewOutput(text),
+      });
+
+      await sessionManager.resetProcessingToPending(session.sessionDbId);
+      session.earliestPendingTimestamp = null;
       return;
     }
 

--- a/tests/sdk/output-classifier.test.ts
+++ b/tests/sdk/output-classifier.test.ts
@@ -3,6 +3,7 @@ import {
   classifyObserverOutput,
   isAuthFailureObserverOutput,
   isQuotaLimitedObserverOutput,
+  isTransportErrorObserverOutput,
   previewOutput,
 } from '../../src/sdk/output-classifier.js';
 
@@ -94,6 +95,56 @@ describe('isAuthFailureObserverOutput', () => {
     expect(isAuthFailureObserverOutput('No observations to record.')).toBe(false);
     expect(isAuthFailureObserverOutput('Please run /login in the observed project instructions.')).toBe(false);
     expect(isAuthFailureObserverOutput('The project authentication guide says to run /login before testing.')).toBe(false);
+  });
+});
+
+describe('isTransportErrorObserverOutput', () => {
+  it('detects a connection dropped mid-response', () => {
+    expect(
+      isTransportErrorObserverOutput(
+        'API Error: Connection closed mid-response. The response above may be incomplete.'
+      )
+    ).toBe(true);
+  });
+
+  it('detects other transport-failure phrasings', () => {
+    expect(isTransportErrorObserverOutput('The stream ended unexpectedly.')).toBe(true);
+    expect(isTransportErrorObserverOutput('Error: premature close')).toBe(true);
+    expect(isTransportErrorObserverOutput('socket hang up')).toBe(true);
+    expect(isTransportErrorObserverOutput('request failed: ECONNRESET')).toBe(true);
+  });
+
+  it('is insensitive to case and collapsed whitespace', () => {
+    expect(
+      isTransportErrorObserverOutput('API ERROR:   Connection   Closed\n  Mid-Response.')
+    ).toBe(true);
+  });
+
+  it('returns false for empty or non-string output', () => {
+    expect(isTransportErrorObserverOutput('')).toBe(false);
+    expect(isTransportErrorObserverOutput('   \n ')).toBe(false);
+    expect(isTransportErrorObserverOutput(undefined)).toBe(false);
+    expect(isTransportErrorObserverOutput(null)).toBe(false);
+  });
+
+  it('does not fire on XML, even when the content mentions a dropped connection', () => {
+    expect(
+      isTransportErrorObserverOutput(
+        '<observation><title>Connection closed mid-response in the retry path</title></observation>'
+      )
+    ).toBe(false);
+    expect(
+      isTransportErrorObserverOutput('<skip_summary reason="socket hang up in observed code"/>')
+    ).toBe(false);
+  });
+
+  it('does not fire on ordinary observer prose or on quota/auth text', () => {
+    expect(isTransportErrorObserverOutput('No observations to record.')).toBe(false);
+    expect(
+      isTransportErrorObserverOutput("I'm observing the primary session, but there's no work to record.")
+    ).toBe(false);
+    expect(isTransportErrorObserverOutput('Claude usage limit reached. Try again later.')).toBe(false);
+    expect(isTransportErrorObserverOutput('Authentication failed; run /login.')).toBe(false);
   });
 });
 


### PR DESCRIPTION
Fixes one of the defects reported in #3454.

## Problem

A dropped or truncated connection can surface as an assistant **message** rather than a structured SDK error:

```
API Error: Connection closed mid-response. The response above may be incomplete.
```

That text reaches `classifyObserverOutput()`, is classified as ordinary `prose`, and the claimed batch is confirmed away by `confirmClaimedMessages()`. Confirming is correct for genuine no-op prose — the observer looked and found nothing worth recording — but a truncated response means the batch was **never actually considered**. The observations are lost silently.

Observed on claude-mem 13.12.4 in normal use.

## Change

Adds `isTransportErrorObserverOutput()` to `src/sdk/output-classifier.ts`, deliberately mirroring the existing `isQuotaLimitedObserverOutput` and `isAuthFailureObserverOutput` detectors — same guard clauses, same XML bail-out, same whitespace/case normalisation, same regex-alternation shape.

`ResponseProcessor` checks it after the auth case and routes matches to `resetProcessingToPending()` so the batch is retried next round rather than dropped.

### Design note

Quota and auth both preserve the batch **and** abort the generator, because those conditions persist until the user intervenes. A truncated connection is transient, so this path preserves the batch but **leaves the generator running**.

That is a deliberate divergence from the two neighbouring handlers. Happy to align it with them instead if you'd prefer consistency — it's a one-line change.

The XML guard is what stops an observation *about* a dropped connection (`<observation><title>Connection closed mid-response in the retry path</title></observation>`) from being mistaken for an actual transport failure.

## Tests

12 new cases in `tests/sdk/output-classifier.test.ts`: the exact string seen in the wild, four other transport phrasings, case/whitespace insensitivity, empty and non-string input, XML containing transport wording, and negatives against ordinary observer prose plus quota/auth text so the detectors don't overlap.

| | |
|---|---|
| `tsc --noEmit` | clean |
| `bun test tests/sdk` | 60 pass / 0 fail |
| `bun test tests/worker` | 426 pass / 0 fail (3 consecutive runs) |
| `lint:hook-io` | OK |
| `lint:spawn-env` | OK |

Purely additive — 98 insertions, 0 deletions, no existing behaviour modified.

## Scope

This addresses only the transport-error defect from #3454. The primary finding in that issue — ~170 empty (`idle`) observer responses per day, a 63% discard rate — is **not** addressed here; its cause is upstream of this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
