### PR TITLE
fix(chroma): prevent concurrent write storms

### DIFF
--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -29,6 +29,8 @@ const RECONNECT_BACKOFF_MS = 10_000;
 const CHROMA_WRITER_LOCK_FILENAME = '.claude-mem-chroma-writer.lock';
 const CHROMA_SUPERVISOR_ID = 'chroma-mcp';
 const CHROMA_OUTPUT_TAIL_MAX_CHARS = 2048;
+const DEFAULT_MAX_PENDING_MUTATIONS = 5_000;
+const CHROMA_MUTATION_TOOL_PATTERN = /^chroma_(?:add|create|delete|modify|update|upsert)_/;
 
 const CHROMA_MCP_PINNED_VERSION = '0.2.6';
 
@@ -88,9 +90,20 @@ export class ChromaMcpManager {
   private readonly chromaWriterOwnerId = `${process.pid}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
   private chromaWriterLock: { path: string; dataDir: string; ownerId: string } | null = null;
   private unexpectedCloseCleanup: Promise<void> | null = null;
+  private mutationTail: Promise<void> = Promise.resolve();
+  private pendingMutationCalls = 0;
+  private readonly maxPendingMutationCalls: number;
+  private readonly serializeMutations: boolean;
   private static uvxAvailabilityProbe: ((command: string, env: Record<string, string>, platform: NodeJS.Platform) => boolean) | null = null;
 
-  private constructor() {}
+  private constructor() {
+    const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
+    const configuredLimit = Number.parseInt(settings.CLAUDE_MEM_CHROMA_MAX_PENDING_MUTATIONS, 10);
+    this.maxPendingMutationCalls = Number.isInteger(configuredLimit) && configuredLimit > 0
+      ? configuredLimit
+      : DEFAULT_MAX_PENDING_MUTATIONS;
+    this.serializeMutations = (settings.CLAUDE_MEM_CHROMA_MODE || 'local') !== 'remote';
+  }
 
   static getInstance(): ChromaMcpManager {
     if (!ChromaMcpManager.instance) {
@@ -688,6 +701,15 @@ export class ChromaMcpManager {
   }
 
   async callTool(toolName: string, toolArguments: Record<string, unknown>): Promise<unknown> {
+    if (!this.serializeMutations || !ChromaMcpManager.isMutationTool(toolName)) {
+      return this.callToolUnqueued(toolName, toolArguments);
+    }
+
+    return this.enqueueMutation(() => this.callToolUnqueued(toolName, toolArguments), toolName);
+  }
+
+  private async callToolUnqueued(toolName: string, toolArguments: Record<string, unknown>): Promise<unknown> {
+    const callGeneration = this.connectionGeneration;
     await this.ensureConnected();
 
     logger.debug('CHROMA_MCP', `Calling tool: ${toolName}`, {
@@ -705,12 +727,19 @@ export class ChromaMcpManager {
         error: transportError instanceof Error ? transportError.message : String(transportError)
       });
 
+      if (callGeneration !== this.connectionGeneration) {
+        throw new ChromaMcpConnectionCancelledError('chroma-mcp call cancelled during shutdown');
+      }
+
       // Tree-kill the dying subprocess before reconnect. Previously this path
       // just nulled the handle, which on Linux leaks the uv/python/chroma-mcp
       // descendants every time a transport error happens (#2313).
       await this.disposeCurrentSubprocess();
 
       try {
+        if (callGeneration !== this.connectionGeneration) {
+          throw new ChromaMcpConnectionCancelledError('chroma-mcp call cancelled during shutdown');
+        }
         await this.ensureConnected();
         result = await this.client!.callTool({
           name: toolName,
@@ -749,6 +778,41 @@ export class ChromaMcpManager {
       }
       return null;
     }
+  }
+
+  private async enqueueMutation<T>(operation: () => Promise<T>, toolName: string): Promise<T> {
+    if (this.pendingMutationCalls >= this.maxPendingMutationCalls) {
+      const message = `Chroma mutation queue is full (${this.pendingMutationCalls}/${this.maxPendingMutationCalls}); deferring "${toolName}" to a later backfill`;
+      logger.warn('CHROMA_MCP', message, {
+        toolName,
+        pendingMutations: this.pendingMutationCalls,
+        maxPendingMutations: this.maxPendingMutationCalls
+      });
+      throw new ChromaUnavailableError(message);
+    }
+
+    this.pendingMutationCalls += 1;
+    const enqueuedGeneration = this.connectionGeneration;
+    const run = this.mutationTail
+      .catch(() => undefined)
+      .then(async () => {
+        if (enqueuedGeneration !== this.connectionGeneration) {
+          throw new ChromaMcpConnectionCancelledError('queued chroma-mcp mutation cancelled during shutdown');
+        }
+        return operation();
+      });
+
+    this.mutationTail = run.then(() => undefined, () => undefined);
+
+    try {
+      return await run;
+    } finally {
+      this.pendingMutationCalls -= 1;
+    }
+  }
+
+  private static isMutationTool(toolName: string): boolean {
+    return CHROMA_MUTATION_TOOL_PATTERN.test(toolName);
   }
 
   async isHealthy(): Promise<boolean> {

--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -94,6 +94,7 @@ export class ChromaMcpManager {
   private pendingMutationCalls = 0;
   private readonly maxPendingMutationCalls: number;
   private readonly serializeMutations: boolean;
+  private acceptingLocalMutations = true;
   private static uvxAvailabilityProbe: ((command: string, env: Record<string, string>, platform: NodeJS.Platform) => boolean) | null = null;
 
   private constructor() {
@@ -704,6 +705,9 @@ export class ChromaMcpManager {
     if (!this.serializeMutations || !ChromaMcpManager.isMutationTool(toolName)) {
       return this.callToolUnqueued(toolName, toolArguments);
     }
+    if (!this.acceptingLocalMutations) {
+      throw new ChromaUnavailableError('Local Chroma mutations are unavailable after shutdown begins');
+    }
 
     return this.enqueueMutation(() => this.callToolUnqueued(toolName, toolArguments), toolName);
   }
@@ -1002,6 +1006,7 @@ export class ChromaMcpManager {
    * pattern from shutdown.ts (Principle 5: OS-supervised teardown).
    */
   async stop(): Promise<void> {
+    this.acceptingLocalMutations = false;
     this.connectionGeneration += 1;
     await this.waitForUnexpectedCloseCleanup();
 

--- a/src/services/sync/ChromaSync.ts
+++ b/src/services/sync/ChromaSync.ts
@@ -99,6 +99,7 @@ export class ChromaSync {
   private project: string;
   private collectionName: string;
   private collectionCreated = false;
+  private collectionCreation: Promise<void> | null = null;
   private readonly BATCH_SIZE = 100;
 
   constructor(project: string) {
@@ -120,6 +121,15 @@ export class ChromaSync {
       return;
     }
 
+    if (!this.collectionCreation) {
+      this.collectionCreation = this.createCollection().finally(() => {
+        this.collectionCreation = null;
+      });
+    }
+    await this.collectionCreation;
+  }
+
+  private async createCollection(): Promise<void> {
     const chromaMcp = ChromaMcpManager.getInstance();
     try {
       await chromaMcp.callTool('chroma_create_collection', {

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -64,6 +64,7 @@ export interface SettingsDefaults {
   CLAUDE_MEM_CHROMA_TENANT: string;
   CLAUDE_MEM_CHROMA_DATABASE: string;
   CLAUDE_MEM_CHROMA_PREWARM_TIMEOUT_MS: string;
+  CLAUDE_MEM_CHROMA_MAX_PENDING_MUTATIONS: string;
   // Worker-native cloud sync. Active ⇔ TOKEN, USER_ID, and HUB_URL are all
   // non-empty — there is no separate enabled flag. HUB_URL points at the
   // two-lane sync hub (workers/sync-hub); while it is empty, sync is OFF
@@ -158,6 +159,7 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_CHROMA_TENANT: 'default_tenant',
     CLAUDE_MEM_CHROMA_DATABASE: 'default_database',
     CLAUDE_MEM_CHROMA_PREWARM_TIMEOUT_MS: '120000',
+    CLAUDE_MEM_CHROMA_MAX_PENDING_MUTATIONS: '5000', // Bound burst imports without changing normal live indexing
     // Worker-native cloud sync: credentials come from cmem.ai → Connect.
     CLAUDE_MEM_CLOUD_SYNC_TOKEN: '',
     CLAUDE_MEM_CLOUD_SYNC_USER_ID: '',

--- a/tests/services/sync/chroma-mcp-manager-singleton.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-singleton.test.ts
@@ -124,7 +124,7 @@ mock.module('@modelcontextprotocol/sdk/client/stdio.js', () => ({
 }));
 
 let connectImpl: (transport: FakeTransport) => Promise<void> = async () => {};
-let callToolImpl: () => Promise<unknown> = async () => ({
+let callToolImpl: (request?: { name: string; arguments?: Record<string, unknown> }) => Promise<unknown> = async () => ({
   content: [{ type: 'text', text: '{}' }],
 });
 
@@ -133,8 +133,8 @@ class FakeClient {
   async connect(transport: FakeTransport): Promise<void> {
     await connectImpl(transport);
   }
-  async callTool(): Promise<unknown> {
-    return await callToolImpl();
+  async callTool(request?: { name: string; arguments?: Record<string, unknown> }): Promise<unknown> {
+    return await callToolImpl(request);
   }
   async close(): Promise<void> {
     this.closed = true;
@@ -149,7 +149,10 @@ mock.module('../../../src/shared/SettingsDefaultsManager.js', () => ({
   SettingsDefaultsManager: {
     get: () => '',
     getInt: () => 0,
-    loadFromFile: () => ({ ...mockedSettings }),
+    loadFromFile: () => ({
+      CLAUDE_MEM_CHROMA_MAX_PENDING_MUTATIONS: '5000',
+      ...mockedSettings,
+    }),
   },
 }));
 
@@ -387,6 +390,64 @@ describe('ChromaMcpManager singleton enforcement (#2313)', () => {
     expect(prewarmSpawnCalls.length).toBe(1);
   });
 
+  it('serializes Chroma mutations while leaving read-only queries responsive', async () => {
+    const mgr = ChromaMcpManager.getInstance();
+    const mutationReleases: Array<() => void> = [];
+    let activeMutations = 0;
+    let maxActiveMutations = 0;
+
+    callToolImpl = async request => {
+      if (request?.name === 'chroma_add_documents') {
+        activeMutations += 1;
+        maxActiveMutations = Math.max(maxActiveMutations, activeMutations);
+        await new Promise<void>(resolve => mutationReleases.push(resolve));
+        activeMutations -= 1;
+      }
+      return { content: [{ type: 'text', text: '{}' }] };
+    };
+
+    const firstMutation = mgr.callTool('chroma_add_documents', { ids: ['one'] });
+    await waitForCondition(() => mutationReleases.length === 1);
+    const secondMutation = mgr.callTool('chroma_add_documents', { ids: ['two'] });
+    await Promise.resolve();
+
+    expect(mutationReleases.length).toBe(1);
+    await expect(mgr.callTool('chroma_query_documents', { query_texts: ['still responsive'] })).resolves.toEqual({});
+
+    mutationReleases[0]();
+    await waitForCondition(() => mutationReleases.length === 2);
+    mutationReleases[1]();
+    await Promise.all([firstMutation, secondMutation]);
+
+    expect(maxActiveMutations).toBe(1);
+  });
+
+  it('bounds the pending mutation queue and leaves rejected writes for backfill', async () => {
+    mockedSettings = {
+      CLAUDE_MEM_CHROMA_MAX_PENDING_MUTATIONS: '2',
+    };
+    const mgr = ChromaMcpManager.getInstance();
+    const mutationReleases: Array<() => void> = [];
+
+    callToolImpl = async request => {
+      if (request?.name === 'chroma_add_documents') {
+        await new Promise<void>(resolve => mutationReleases.push(resolve));
+      }
+      return { content: [{ type: 'text', text: '{}' }] };
+    };
+
+    const firstMutation = mgr.callTool('chroma_add_documents', { ids: ['one'] });
+    await waitForCondition(() => mutationReleases.length === 1);
+    const secondMutation = mgr.callTool('chroma_add_documents', { ids: ['two'] });
+
+    await expect(mgr.callTool('chroma_add_documents', { ids: ['three'] })).rejects.toThrow('mutation queue is full (2/2)');
+
+    mutationReleases[0]();
+    await waitForCondition(() => mutationReleases.length === 2);
+    mutationReleases[1]();
+    await Promise.all([firstMutation, secondMutation]);
+  });
+
   it('kills the prior subprocess tree before a reconnect spawn', async () => {
     const mgr = ChromaMcpManager.getInstance();
 
@@ -454,6 +515,28 @@ describe('ChromaMcpManager singleton enforcement (#2313)', () => {
     // a stale one).
     await mgr.callTool('chroma_list_collections', { limit: 1 });
     expect(transportInstances.length).toBe(2);
+  });
+
+  it('does not reconnect an active mutation after shutdown starts', async () => {
+    const mgr = ChromaMcpManager.getInstance();
+    let rejectMutation: ((error: Error) => void) | null = null;
+    callToolImpl = async request => {
+      if (request?.name === 'chroma_add_documents') {
+        return new Promise((_resolve, reject) => {
+          rejectMutation = reject;
+        });
+      }
+      return { content: [{ type: 'text', text: '{}' }] };
+    };
+
+    const pendingMutation = mgr.callTool('chroma_add_documents', { ids: ['one'] });
+    await waitForCondition(() => rejectMutation !== null && transportInstances.length === 1);
+
+    await mgr.stop();
+    rejectMutation?.(new Error('Connection closed'));
+
+    await expect(pendingMutation).rejects.toThrow('call cancelled during shutdown');
+    expect(transportInstances.length).toBe(1);
   });
 
   it('stop() ignores close-triggered onclose from an intentionally closed transport', async () => {
@@ -703,11 +786,25 @@ describe('ChromaMcpManager singleton enforcement (#2313)', () => {
     expect(transportInstances.length).toBe(1);
   });
 
-  it('does not acquire a local writer lock in remote Chroma mode', async () => {
-    mockedSettings = { CLAUDE_MEM_CHROMA_MODE: 'remote' };
+  it('preserves remote mutation concurrency', async () => {
+    mockedSettings = {
+      CLAUDE_MEM_CHROMA_MODE: 'remote',
+    };
     const mgr = ChromaMcpManager.getInstance();
+    const mutationReleases: Array<() => void> = [];
+    callToolImpl = async request => {
+      if (request?.name === 'chroma_add_documents') {
+        await new Promise<void>(resolve => mutationReleases.push(resolve));
+      }
+      return { content: [{ type: 'text', text: '{}' }] };
+    };
 
-    await mgr.callTool('chroma_list_collections', { limit: 1 });
+    const firstMutation = mgr.callTool('chroma_add_documents', { ids: ['one'] });
+    const secondMutation = mgr.callTool('chroma_add_documents', { ids: ['two'] });
+    await waitForCondition(() => mutationReleases.length === 2);
+
+    mutationReleases.forEach(release => release());
+    await Promise.all([firstMutation, secondMutation]);
 
     expect(existsSync(chromaWriterLockPath())).toBe(false);
     const connectLog = logEntries.find(entry => entry.message === 'Connecting to chroma-mcp via MCP stdio');

--- a/tests/services/sync/chroma-mcp-manager-singleton.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-singleton.test.ts
@@ -539,6 +539,17 @@ describe('ChromaMcpManager singleton enforcement (#2313)', () => {
     expect(transportInstances.length).toBe(1);
   });
 
+  it('rejects local mutations that arrive after shutdown without reconnecting', async () => {
+    const mgr = ChromaMcpManager.getInstance();
+
+    await mgr.stop();
+    await expect(mgr.callTool('chroma_add_documents', { ids: ['late'] }))
+      .rejects.toThrow('unavailable after shutdown begins');
+
+    expect(transportInstances.length).toBe(0);
+    expect(prewarmSpawnCalls.length).toBe(0);
+  });
+
   it('stop() ignores close-triggered onclose from an intentionally closed transport', async () => {
     transportCloseEmitsOnclose = true;
     const mgr = ChromaMcpManager.getInstance();

--- a/tests/services/sync/chroma-sync-reconcile.test.ts
+++ b/tests/services/sync/chroma-sync-reconcile.test.ts
@@ -4,6 +4,7 @@ import * as realChromaMcpManager from '../../../src/services/sync/ChromaMcpManag
 const realChromaMcpManagerSnapshot = { ...realChromaMcpManager };
 
 const calls: Array<{ tool: string; args: any }> = [];
+let createCollectionImpl: () => Promise<unknown> = async () => ({});
 // Stateful stand-in for a Chroma collection so the reconcile path exercises
 // real Chroma semantics: add rejects the whole batch on any existing ID,
 // update ignores absent IDs, get reports which of the requested IDs exist.
@@ -16,6 +17,8 @@ mock.module('../../../src/services/sync/ChromaMcpManager.js', () => ({
         calls.push({ tool, args });
         const ids: string[] = args?.ids ?? [];
         switch (tool) {
+          case 'chroma_create_collection':
+            return createCollectionImpl();
           case 'chroma_add_documents': {
             // Chroma rejects the entire batch if ANY id already exists.
             if (ids.some(id => stored.has(id))) {
@@ -47,6 +50,7 @@ afterAll(() => {
 beforeEach(() => {
   calls.length = 0;
   stored.clear();
+  createCollectionImpl = async () => ({});
 });
 
 function newSync(): ChromaSync {
@@ -57,6 +61,24 @@ function newSync(): ChromaSync {
 }
 
 describe('ChromaSync duplicate-ID reconcile', () => {
+  it('coalesces concurrent collection creation into one Chroma mutation', async () => {
+    const sync = new ChromaSync('project');
+    let releaseCreation: (() => void) | null = null;
+    createCollectionImpl = async () => new Promise<void>(resolve => {
+      releaseCreation = resolve;
+    });
+
+    const creations = Array.from({ length: 50 }, () => sync.ensureCollectionExists());
+    await Promise.resolve();
+
+    expect(calls.filter(call => call.tool === 'chroma_create_collection')).toHaveLength(1);
+    releaseCreation?.();
+    await Promise.all(creations);
+    await sync.ensureCollectionExists();
+
+    expect(calls.filter(call => call.tool === 'chroma_create_collection')).toHaveLength(1);
+  });
+
   it('reconciles a fully-duplicate batch with an in-place update, never delete+add', async () => {
     const sync = newSync();
     const docs = [{ id: 'obs_1_narrative', document: 'hello world', metadata: { sqlite_id: 1 } }];


### PR DESCRIPTION
## Summary

- coalesce concurrent collection creation into one Chroma call
- serialize and bound local Chroma mutations so timed-out imports cannot continue as thousands of concurrent writes
- keep read-only queries and remote Chroma mutation concurrency unchanged
- cancel queued or retrying mutations when worker shutdown begins

## Root cause

Historical imports could start many fire-and-forget Chroma writes at once. Callers timed out while the underlying writes remained active, so retries added more work and amplified local Chroma disk growth.

This change applies backpressure at the existing Chroma MCP boundary. The 5,000-call default preserves the observed import burst while preventing an unbounded queue; rejected writes remain unsynced for the existing backfill path.

## Scope

This intentionally does not add a filesystem watchdog, directory scanner, hard disk cap, or new process-killing circuit. Normal search remains concurrent, remote Chroma behavior is unchanged, and only local mutations are serialized.

## Validation

- `npm run typecheck`
- `npm run lint:hook-io`
- `npm run lint:spawn-env`
- `npm run build`
- `npm test` — 2,543 passed, 18 environment-gated skips, 0 failed
- focused Chroma regression tests — 23 passed, 0 failed
