### PR TITLE
fix: accept camelCase dateStart/dateEnd in build_corpus and warn on empty corpus

### DIFF
--- a/src/services/worker/http/routes/CorpusRoutes.ts
+++ b/src/services/worker/http/routes/CorpusRoutes.ts
@@ -36,7 +36,18 @@ const positiveIntegerLike = z.preprocess((value) => {
   return value;
 }, z.number().int().positive().optional());
 
-const buildCorpusSchema = z.object({
+// The MCP tool schema and the search endpoints use camelCase (dateStart/dateEnd)
+// while the corpus filter uses snake_case. Normalize before validation so a
+// camelCase date filter is never silently dropped at the HTTP boundary.
+const buildCorpusSchema = z.preprocess((value) => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return value;
+  const body = value as Record<string, unknown>;
+  return {
+    ...body,
+    date_start: body.date_start ?? body.dateStart,
+    date_end: body.date_end ?? body.dateEnd,
+  };
+}, z.object({
   // Validate the raw name — do NOT .trim() first, or a padded name like
   // " bad " would be silently normalized to "bad" and accepted instead of
   // rejected. CORPUS_NAME_PATTERN already disallows whitespace, so surrounding
@@ -54,7 +65,7 @@ const buildCorpusSchema = z.object({
   date_start: z.string().optional(),
   date_end: z.string().optional(),
   limit: positiveIntegerLike,
-}).passthrough();
+}).passthrough());
 
 const queryCorpusSchema = z.object({
   question: z.string().trim().min(1),
@@ -105,7 +116,16 @@ export class CorpusRoutes extends BaseRouteHandler {
     logger.info('SEARCH', 'Building corpus', { name, project, filterKeys: Object.keys(filter) });
     const corpus = await this.corpusBuilder.build(name, description || '', filter);
 
+    // An empty corpus is a valid response but almost always means a filter
+    // mismatch, so surface a warning instead of a clean success.
     const { observations, ...metadata } = corpus;
+    if (metadata.stats.observation_count === 0) {
+      res.json({
+        ...metadata,
+        warning: 'Corpus created with 0 observations: no filter matched. Check dateStart/dateEnd, project, types and query.'
+      });
+      return;
+    }
     res.json(metadata);
   });
 
@@ -152,7 +172,16 @@ export class CorpusRoutes extends BaseRouteHandler {
 
     const corpus = await this.corpusBuilder.build(name, existingCorpus.description, existingCorpus.filter);
 
+    // Same empty-corpus warning as handleBuildCorpus: a rebuild that matches
+    // nothing must not look like a clean success.
     const { observations, ...metadata } = corpus;
+    if (metadata.stats.observation_count === 0) {
+      res.json({
+        ...metadata,
+        warning: 'Corpus rebuilt with 0 observations: no filter matched. Check the stored filter (dateStart/dateEnd, project, types, query).'
+      });
+      return;
+    }
     res.json(metadata);
   });
 

--- a/tests/worker/http/routes/corpus-routes-coercion.test.ts
+++ b/tests/worker/http/routes/corpus-routes-coercion.test.ts
@@ -211,4 +211,68 @@ describe('CorpusRoutes Type Coercion', () => {
     expect(statusSpy).toHaveBeenCalledWith(400);
     expect(mockBuild).not.toHaveBeenCalled();
   });
+
+  it('accepts camelCase dateStart/dateEnd and maps them to the snake_case filter', async () => {
+    const { req, res } = createMockReqRes({
+      name: 'camel-dates',
+      dateStart: '2026-07-31',
+      dateEnd: '2026-08-01',
+    });
+
+    handler(req as Request, res as Response);
+    await flushPromises();
+
+    expect(mockBuild).toHaveBeenCalledWith('camel-dates', '', {
+      date_start: '2026-07-31',
+      date_end: '2026-08-01',
+    });
+  });
+
+  it('prefers snake_case date_start when both conventions are sent', async () => {
+    const { req, res } = createMockReqRes({
+      name: 'snake-dates',
+      date_start: '2026-01-01',
+      dateStart: '2026-07-31',
+    });
+
+    handler(req as Request, res as Response);
+    await flushPromises();
+
+    expect(mockBuild).toHaveBeenCalledWith('snake-dates', '', {
+      date_start: '2026-01-01',
+    });
+  });
+
+  it('adds a warning when the built corpus matched 0 observations', async () => {
+    const { req, res, jsonSpy } = createMockReqRes({
+      name: 'empty-corpus',
+      dateStart: '2099-01-01',
+    });
+
+    handler(req as Request, res as Response);
+    await flushPromises();
+
+    const payload = jsonSpy.mock.calls[0][0] as { warning?: string; observations?: unknown };
+    expect(payload.warning).toContain('0 observations');
+    expect(payload.observations).toBeUndefined();
+  });
+
+  it('omits the warning when observations matched', async () => {
+    mockBuild.mockImplementation((name: string, _description: string, filter: unknown) => {
+      const corpus = createCorpus(name, filter);
+      corpus.stats.observation_count = 3;
+      return Promise.resolve(corpus);
+    });
+
+    const { req, res, jsonSpy } = createMockReqRes({
+      name: 'non-empty-corpus',
+      query: 'hooks',
+    });
+
+    handler(req as Request, res as Response);
+    await flushPromises();
+
+    const payload = jsonSpy.mock.calls[0][0] as { warning?: string };
+    expect(payload.warning).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

The `build_corpus` MCP tool declares `dateStart`/`dateEnd` (camelCase) in its input schema (`src/servers/mcp-server.ts`), but the worker corpus route only reads `date_start`/`date_end` (snake_case). Since `buildCorpusSchema` uses `.passthrough()`, a camelCase date filter passes validation and is then silently dropped by the destructuring — the corpus is built with no date filter, returns `observation_count: 0`, and the response looks like a clean success.

Measured reproduction (2026-07-31, plugin 13.12.4): `build_corpus` with `dateStart: "2026-07-31", limit: 500` returned `"filter": {"limit": 500}` and `observation_count: 0`, with no error, warning, or log. The same call with `query` instead of a date worked, because every other parameter has the same name on both sides of the boundary — only `dateStart`/`dateEnd` diverge.

## Changes

- **Name bridge at the HTTP boundary**: `buildCorpusSchema` now normalizes `dateStart`/`dateEnd` to `date_start`/`date_end` in a `z.preprocess` step, mirroring the `dateStart ?? date_start ?? date_from` convention the search endpoints already use. snake_case wins when both conventions are sent, so existing clients are unaffected. Fixing the route (rather than the MCP server) means any HTTP client gets the fix. `handleRebuildCorpus` needs no bridge — it reuses the persisted snake_case filter.
- **Empty corpus can no longer read as clean success**: build and rebuild responses gain a non-breaking `warning` field when `observation_count` is 0, pointing at the filters to check. This closes the defect class: any future filter-name mismatch will be visible immediately instead of producing a silently empty corpus.

## Test plan

- [x] Added coverage in `tests/worker/http/routes/corpus-routes-coercion.test.ts`:
  - camelCase `dateStart`/`dateEnd` map to the snake_case filter
  - snake_case wins when both conventions are sent
  - `warning` present when the corpus matched 0 observations
  - `warning` absent when observations matched
- [x] Verified end-to-end against a live worker (13.12.4 with this patch applied): `build_corpus` with `dateStart: "2026-07-31"` now echoes the date in `filter` and returned 265 observations; an impossible date (`2027-01-01`) returned 0 observations **with** the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dYTvpBchC6w4vF72cm5fc
