### PR TITLE
fix(shutdown): reap chroma and the registry when the graceful deadline cuts teardown short

### DIFF
--- a/src/services/infrastructure/GracefulShutdown.ts
+++ b/src/services/infrastructure/GracefulShutdown.ts
@@ -31,6 +31,19 @@ export interface GracefulShutdownConfig {
   mcpClient?: CloseableClient;
   dbManager?: CloseableDatabase;
   chromaMcpManager?: StoppableService;
+  /**
+   * Restart only: skip the supervisor cascade here and leave it to
+   * runShutdownSequence, which runs it AFTER the successor handoff.
+   *
+   * This sequence runs under a hard deadline that does not cancel it — on
+   * expiry the caller proceeds while this promise keeps going. Reaching
+   * getSupervisor().stop() at any point around that boundary sets stopPromise,
+   * and assertCanSpawn() then refuses the successor spawn, turning a restart
+   * into a worker that never comes back. Deferring makes that unreachable by
+   * construction rather than by timing: on a restart this function never takes
+   * the spawn gate, whether it finishes early, late, or is abandoned mid-drain.
+   */
+  deferSupervisorStop?: boolean;
 }
 
 export async function performGracefulShutdown(config: GracefulShutdownConfig): Promise<void> {
@@ -58,7 +71,9 @@ export async function performGracefulShutdown(config: GracefulShutdownConfig): P
     await config.dbManager.close();
   }
 
-  await getSupervisor().stop();
+  if (!config.deferSupervisorStop) {
+    await getSupervisor().stop();
+  }
 
   logger.info('SYSTEM', 'Worker shutdown complete');
 }

--- a/src/services/infrastructure/GracefulShutdown.ts
+++ b/src/services/infrastructure/GracefulShutdown.ts
@@ -16,7 +16,13 @@ export interface CloseableDatabase {
 }
 
 export interface StoppableService {
-  stop(): Promise<void>;
+  /**
+   * `terminal` marks this as a process-exit teardown: the service must not
+   * rebuild itself afterwards. ChromaMcpManager uses it to stop its
+   * transport-error retry from spawning a replacement subprocess tree that the
+   * imminent process.exit() would orphan.
+   */
+  stop(options?: { terminal?: boolean }): Promise<void>;
 }
 
 export interface GracefulShutdownConfig {
@@ -44,7 +50,7 @@ export async function performGracefulShutdown(config: GracefulShutdownConfig): P
 
   if (config.chromaMcpManager) {
     logger.info('SHUTDOWN', 'Stopping Chroma MCP connection...');
-    await config.chromaMcpManager.stop();
+    await config.chromaMcpManager.stop({ terminal: true });
     logger.info('SHUTDOWN', 'Chroma MCP connection stopped');
   }
 

--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -95,6 +95,15 @@ export class ChromaMcpManager {
   private readonly maxPendingMutationCalls: number;
   private readonly serializeMutations: boolean;
   private acceptingLocalMutations = true;
+  /**
+   * Terminal latch set by stop({ terminal: true }). Those callers are abandoning
+   * this instance for good (worker shutdown, or reset() which then nulls the
+   * singleton), so once it is set, ensureConnected() must refuse rather than
+   * spawn a replacement tree — see the note on stop().
+   */
+  private stopped: boolean = false;
+  /** Memoized stop() run, so concurrent callers share one teardown. */
+  private stopPromise: Promise<void> | null = null;
   private static uvxAvailabilityProbe: ((command: string, env: Record<string, string>, platform: NodeJS.Platform) => boolean) | null = null;
 
   private constructor() {
@@ -114,6 +123,14 @@ export class ChromaMcpManager {
   }
 
   private async ensureConnected(): Promise<void> {
+    // Refuse once stop() has latched: this instance is being torn down and the
+    // process is about to exit, so spawning a replacement tree here would leak
+    // it to init. Reached via callTool()'s transport-error retry when session
+    // work is still draining as chroma goes away. Throwing (rather than
+    // returning) keeps the existing ChromaUnavailableError contract that
+    // callers already handle as "chroma is not usable right now".
+    this.assertNotStopped();
+
     await this.waitForUnexpectedCloseCleanup();
 
     if (this.connected && this.client) {
@@ -129,6 +146,15 @@ export class ChromaMcpManager {
       await this.connecting;
       return;
     }
+
+    // Re-check immediately before the spawn. The check at the top of this method
+    // is separated from here by at least one await, and stop({ terminal: true })
+    // can land inside that window — the call would then resume with a stale
+    // "not stopped" reading and connectInternal() would capture the POST-bump
+    // generation, so #3462's cancellation guards see nothing wrong either. This
+    // is the last latch check before connectInternal() starts; from there the
+    // generation guards cover its own awaits, including the two spawn sites.
+    this.assertNotStopped();
 
     this.connecting = this.connectInternal();
     try {
@@ -147,6 +173,20 @@ export class ChromaMcpManager {
       throw error;
     } finally {
       this.connecting = null;
+    }
+  }
+
+  /**
+   * Refuse work once stop({ terminal: true }) has latched: this instance is
+   * permanently abandoned — the worker is exiting, or reset() has dropped the
+   * singleton — so spawning a replacement tree here would leak it (to init, on
+   * the shutdown path). Throwing (rather than returning) keeps the existing
+   * ChromaUnavailableError contract that callers already handle as "chroma is
+   * not usable right now" — see the note on stop().
+   */
+  private assertNotStopped(): void {
+    if (this.stopped) {
+      throw new ChromaUnavailableError('chroma-mcp is shutting down');
     }
   }
 
@@ -1005,9 +1045,61 @@ export class ChromaMcpManager {
    * accumulate across reconnects or worker restarts. Matches the tree-kill
    * pattern from shutdown.ts (Principle 5: OS-supervised teardown).
    */
-  async stop(): Promise<void> {
+  async stop(options: { terminal?: boolean } = {}): Promise<void> {
     this.acceptingLocalMutations = false;
+
+    // Two properties the worker's shutdown path depends on:
+    //
+    // 1. `terminal: true` latches so ensureConnected() refuses afterwards.
+    //    The connectionGeneration guards added in #3462 cancel calls that were
+    //    already in flight when stop() bumped the generation, but a call that
+    //    ARRIVES after the bump captures the new generation and passes every
+    //    one of them; acceptingLocalMutations catches only mutation tools in
+    //    local mode. So a read (or isHealthy()'s chroma_list_collections) still
+    //    reaches connectInternal() and spawns a REPLACEMENT tree, which the
+    //    imminent process.exit() orphans — stopping chroma would create the very
+    //    leak it is meant to prevent. ensureConnected() therefore checks the
+    //    latch both on entry and again immediately before it spawns, since those
+    //    two points are separated by an await the latch can land inside.
+    // 2. The run is memoized so concurrent callers share one teardown. The
+    //    worker's shutdown backstop can call stop() while the abandoned
+    //    performGracefulShutdown reaches the same call; without this, two
+    //    disposers interleave over the same client/transport/lock fields and an
+    //    older one can clear state the newer one just established.
+    //
+    // The latch is OPT-IN because a plain stop() must stay reusable for reads:
+    // ensureConnected() after stop() must spawn a fresh transport (pinned by
+    // "stop() disposes state including any pending connecting promise" in
+    // tests/services/sync/chroma-mcp-manager-singleton.test.ts). Note that only
+    // reads recover: local mutations stay rejected either way, since #3462
+    // clears acceptingLocalMutations above and never restores it.
+    //
+    // Only callers abandoning this instance for good pass terminal: true — the worker's
+    // shutdown paths, which exit the process immediately after, and reset(),
+    // which drops the singleton so a retained reference must not reconnect.
+    if (options.terminal) {
+      this.stopped = true;
+    }
+
+    // Bump on EVERY call, not only the one that owns the teardown. A plain
+    // stop() is reusable, so a connection can be established while an earlier
+    // teardown is still in flight; that connection captured the generation the
+    // first stop() set, and a later caller returning the memoized promise below
+    // would otherwise never invalidate it. Bumping here also cancels sooner than
+    // stopInternal() could, since it happens before any await.
     this.connectionGeneration += 1;
+
+    if (this.stopPromise) {
+      return this.stopPromise;
+    }
+    this.stopPromise = this.stopInternal().finally(() => {
+      this.stopPromise = null;
+    });
+    return this.stopPromise;
+  }
+
+  private async stopInternal(): Promise<void> {
+    // connectionGeneration is bumped by stop() before this runs.
     await this.waitForUnexpectedCloseCleanup();
 
     if (!this.client && !this.transport && !this.activePrewarmChild) {
@@ -1159,7 +1251,10 @@ export class ChromaMcpManager {
    */
   static async reset(): Promise<void> {
     if (ChromaMcpManager.instance) {
-      await ChromaMcpManager.instance.stop();
+      // Terminal: the singleton is dropped on the next line, so any caller
+      // still holding this reference must not be able to reconnect it into a
+      // subprocess tree nothing owns any more.
+      await ChromaMcpManager.instance.stop({ terminal: true });
     }
     ChromaMcpManager.instance = null;
   }

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -823,6 +823,41 @@ export class WorkerService implements WorkerRef {
         chromaMcpManager: this.chromaMcpManager || undefined
       }),
       gracefulDeadlineMs: getPlatformTimeout(10000),
+      // Backstop for the chroma-mcp tree-kill that performGracefulShutdown runs
+      // second-to-last, behind the session drain. Idempotent, so it is safe to
+      // run while the abandoned graceful promise is still in flight on the
+      // deadline path: ChromaMcpManager.stop() memoizes, so a concurrent caller
+      // joins the teardown already running rather than starting a second one,
+      // and once no client/transport/prewarm child is left it early-returns.
+      //
+      // Chroma only, and deliberately so: this hook runs BEFORE the restart
+      // handoff (the successor must not race a live predecessor chroma for the
+      // writer lock), and the supervisor cascade cannot safely run there —
+      // it holds the spawn gate for its whole duration. That half is
+      // reapProcessRegistry below.
+      reapSubprocesses: async () => {
+        if (this.chromaMcpManager) {
+          await this.chromaMcpManager.stop({ terminal: true });
+        }
+      },
+      // The rest of the managed children (SDK trees, mcp servers), reaped after
+      // the handoff. Idempotent: Supervisor.stop() memoizes via stopPromise, so
+      // this is safe even while the abandoned performGracefulShutdown is still
+      // in flight toward the same call.
+      reapProcessRegistry: () => getSupervisor().stop(),
+      reapDeadlineMs: getPlatformTimeout(5000),
+      // Must clear the cascade's own waits or the reap truncates mid-kill and
+      // skips its unregister/persist pass. POSIX needs ~6s (waitForExit 5s +
+      // 1s). Windows is worse and not fixed-boundable: signalProcess shells out
+      // to taskkill per child with a 10s timeout (HOOK_TIMEOUTS.
+      // POWERSHELL_COMMAND), sequentially, so worst case scales with the number
+      // of stubborn children. 10s here (20s on Windows via getPlatformTimeout)
+      // covers the realistic case — taskkill typically returns in <1s — and
+      // costs nothing when the cascade finishes early, since this is a ceiling
+      // rather than a sleep. A pathological Windows cascade is deliberately
+      // truncated: the children have already been signaled by then, and the
+      // successor's startup pruneDeadEntries() repairs the registry.
+      reapRegistryDeadlineMs: getPlatformTimeout(10000),
       restartHandoff: {
         port: getWorkerPort(),
         portFreeTimeoutMs: getPlatformTimeout(5000),

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -820,7 +820,12 @@ export class WorkerService implements WorkerRef {
         sessionManager: this.sessionManager,
         mcpClient: this.mcpClient,
         dbManager: this.dbManager,
-        chromaMcpManager: this.chromaMcpManager || undefined
+        chromaMcpManager: this.chromaMcpManager || undefined,
+        // On a restart the cascade belongs after the successor handoff — see
+        // reapProcessRegistry below. Deferring also keeps this sequence off the
+        // supervisor spawn gate, which it could otherwise take on either side
+        // of the deadline and refuse the successor.
+        deferSupervisorStop: reason === 'restart'
       }),
       gracefulDeadlineMs: getPlatformTimeout(10000),
       // Backstop for the chroma-mcp tree-kill that performGracefulShutdown runs
@@ -841,10 +846,22 @@ export class WorkerService implements WorkerRef {
         }
       },
       // The rest of the managed children (SDK trees, mcp servers), reaped after
-      // the handoff. Idempotent: Supervisor.stop() memoizes via stopPromise, so
-      // this is safe even while the abandoned performGracefulShutdown is still
-      // in flight toward the same call.
-      reapProcessRegistry: () => getSupervisor().stop(),
+      // the handoff. Idempotent: Supervisor.stop() memoizes via stopPromise.
+      //
+      // preserveRegistryForSuccessor once a successor has been launched: it may
+      // register itself in the shared supervisor.json at any point, and this
+      // cascade's registry writes rewrite that file wholesale from this dying
+      // worker's boot-time snapshot — erasing the successor's record. Passed
+      // through from the handoff result rather than from `reason`, so a restart
+      // whose spawn failed still cleans up after itself.
+      //
+      // In the normal restart path this is the first stop() caller, because
+      // deferSupervisorStop keeps the graceful sequence away from it — which
+      // matters, since stop() memoizes and a second caller's options are
+      // ignored.
+      reapProcessRegistry: (successorSpawned: boolean) => getSupervisor().stop({
+        preserveRegistryForSuccessor: successorSpawned
+      }),
       reapDeadlineMs: getPlatformTimeout(5000),
       // Must clear the cascade's own waits or the reap truncates mid-kill and
       // skips its unregister/persist pass. POSIX needs ~6s (waitForExit 5s +

--- a/src/services/worker-shutdown.ts
+++ b/src/services/worker-shutdown.ts
@@ -83,8 +83,13 @@ export interface ShutdownSequenceOptions {
    * chroma. Split from reapSubprocesses because it must run AFTER the restart
    * handoff: it holds the supervisor's spawn gate for its duration, so running
    * it first can make the successor spawn fail. See the call site.
+   *
+   * `successorSpawned` reports whether the handoff attempt successfully
+   * launched a successor process. Once it has, that successor may register
+   * itself in supervisor.json at any point, so this cascade must not write to
+   * the file. If the launch failed, normal cleanup applies.
    */
-  reapProcessRegistry: () => Promise<void>;
+  reapProcessRegistry: (successorSpawned: boolean) => Promise<void>;
   /**
    * Budget for reapSubprocesses — a chroma tree-kill is ~200ms, not 40s. Kept
    * tight because this one runs BEFORE the handoff and so delays the successor.
@@ -198,14 +203,23 @@ export async function runShutdownSequence(options: ShutdownSequenceOptions): Pro
   // stale install would respawn its own version forever (#3378). This runs
   // inside flushResponseThen's flushed action, so it completes before that
   // helper's process.exit(0).
+  // Whether spawnDaemon() returned a pid for a successor process. NOT proof
+  // that the successor is live, registered, or has touched supervisor.json —
+  // only that a launch happened, after which it may register at any moment.
+  // That is the point at which this worker must stop writing. If the launch
+  // failed, it remains the sole known writer and cleans up as it always did.
+  let successorSpawned = false;
+
   if (options.reason === 'restart') {
     const handoff = options.restartHandoff;
     try {
-      await spawnRestartSuccessor(handoff);
+      successorSpawned = await spawnRestartSuccessor(handoff);
     } catch (error: unknown) {
-      // spawnDaemon can throw (supervisor assertCanSpawn refuses while its stop
-      // cascade is still in flight after a deadline); the handoff must never
-      // turn the dying worker's exit into an unhandled rejection.
+      // spawnDaemon can still throw if something else concurrently started a
+      // supervisor stop (assertCanSpawn refuses while stopPromise is set); the
+      // handoff must never turn the dying worker's exit into an unhandled
+      // rejection. deferSupervisorStop rules out this sequence's own graceful
+      // path as that "something else".
       logger.error(
         'SYSTEM',
         'Restart successor handoff threw — the next hook lazy-spawn is the safety net',
@@ -226,21 +240,42 @@ export async function runShutdownSequence(options: ShutdownSequenceOptions): Pro
   // iterates only this worker's own children and cannot signal its replacement.
   // ProcessRegistry.getAll() is in-memory after a once-guarded initialize()
   // (process-registry.ts), so the successor's own records — written to the
-  // shared supervisor.json on its boot — are invisible here and cannot be
-  // killed by this cascade either.
+  // shared supervisor.json on its boot — are invisible here and are not
+  // signalled by this cascade. (Not an absolute guarantee: a stale child record
+  // whose pid the OS has since recycled onto the successor would still be
+  // signalled. That hazard predates this ordering and applies to any pid-based
+  // teardown here.)
   //
-  // Known trade-off: because this now runs after the successor has started,
-  // the cascade's unregister/persist writes can clobber supervisor.json with
-  // this dying worker's stale view, including erasing the successor's own
-  // freshly-written 'worker' record. It does NOT kill the successor (whose
-  // registry is a separate process-local map), and the file is corrected on
-  // the successor's next registry write — but that is not guaranteed to be
-  // prompt if the successor sits idle, so supervisor.json can under-report for
-  // a while. Accepted as the lesser evil: the alternative ordering can refuse
-  // the successor spawn outright, which loses the worker entirely.
-  if (outcome !== 'graceful') {
+  // On a restart this is the ONLY cascade: performGracefulShutdown defers its
+  // own (deferSupervisorStop), so ownership of the restart-path cascade lives
+  // here and it always runs after the handoff — including on the fully graceful
+  // outcome, where it is not a backstop but the sequence's own teardown step.
+  //
+  // That single invariant is what keeps the successor spawnable. The deadline
+  // does not cancel the graceful promise, so if that promise could still reach
+  // getSupervisor().stop() it would set stopPromise on either side of the
+  // boundary — finishing just before expiry, or resuming just after — and
+  // assertCanSpawn() would refuse the handoff. Deferring removes the race
+  // instead of trying to out-time it.
+  //
+  // Preserve mode is gated on a successor process having been LAUNCHED, not
+  // merely on this being a restart. All three handoff failure paths (port never
+  // freed, spawnDaemon returned undefined, spawnDaemon threw) leave this worker
+  // as the sole known writer, so suppressing writes there would strand its own
+  // records with nothing to prune them — a regression against the pre-existing
+  // behavior, where the graceful path cleaned up before exit.
+  //
+  // Once a successor is launched, the cascade signals this worker's children
+  // without writing to a file that successor may claim at any moment. What it
+  // leaves behind is normally pruned by the successor's 30s health check —
+  // normally, not always: that repair needs a successor which stayed up, and
+  // pid reuse can make a dead record look alive, so the file can over-report
+  // stale processes for a while. Accepted direction of error, against erasing a
+  // live worker's record.
+  if (options.reason === 'restart' || outcome !== 'graceful') {
     await reapUnderDeadline(
-      options.reapProcessRegistry, 'registry cascade', options.reapRegistryDeadlineMs, options, outcome
+      () => options.reapProcessRegistry(successorSpawned),
+      'registry cascade', options.reapRegistryDeadlineMs, options, outcome
     );
   }
 }
@@ -259,13 +294,23 @@ async function reapUnderDeadline(
   label: string,
   deadlineMs: number,
   options: ShutdownSequenceOptions,
-  outcome: 'graceful-error' | 'deadline'
+  outcome: 'graceful' | 'graceful-error' | 'deadline'
 ): Promise<void> {
-  logger.warn('SYSTEM', `Graceful shutdown did not reach ${label} — reaping directly`, {
-    outcome,
-    reason: options.reason,
-    reapDeadlineMs: deadlineMs,
-  });
+  // On a graceful restart this is not a backstop: the graceful sequence deferred
+  // the cascade to here on purpose, so "did not reach" would be a false alarm.
+  if (outcome === 'graceful') {
+    logger.info('SYSTEM', `Running ${label} after the restart handoff`, {
+      outcome,
+      reason: options.reason,
+      reapDeadlineMs: deadlineMs,
+    });
+  } else {
+    logger.warn('SYSTEM', `Graceful shutdown did not reach ${label} — reaping directly`, {
+      outcome,
+      reason: options.reason,
+      reapDeadlineMs: deadlineMs,
+    });
+  }
 
   let reapTimer: ReturnType<typeof setTimeout> | undefined;
   const reapDeadline = new Promise<'deadline'>((resolve) => {
@@ -310,7 +355,7 @@ async function reapUnderDeadline(
  * runShutdownSequence so its caller's try wraps a single call; every failure
  * path logs and returns (the next hook lazy-spawn is the safety net).
  */
-async function spawnRestartSuccessor(handoff: RestartHandoffDeps): Promise<void> {
+async function spawnRestartSuccessor(handoff: RestartHandoffDeps): Promise<boolean> {
   const successorScript = handoff.resolveSuccessorScript();
   const portFree = await handoff.waitForPortFree(handoff.port, handoff.portFreeTimeoutMs);
   if (!portFree) {
@@ -318,7 +363,7 @@ async function spawnRestartSuccessor(handoff: RestartHandoffDeps): Promise<void>
       port: handoff.port,
       timeoutMs: handoff.portFreeTimeoutMs,
     });
-    return;
+    return false;
   }
   // Same ordering as the CLI restart path (worker-service.ts `restart`
   // case): port free → remove the now-ownerless PID file → spawn. Without
@@ -334,11 +379,12 @@ async function spawnRestartSuccessor(handoff: RestartHandoffDeps): Promise<void>
       port: handoff.port,
       script: successorScript,
     });
-    return;
+    return false;
   }
   logger.info('SYSTEM', 'Restart successor spawned', {
     pid: successorPid,
     script: successorScript,
     port: handoff.port,
   });
+  return true;
 }

--- a/src/services/worker-shutdown.ts
+++ b/src/services/worker-shutdown.ts
@@ -58,6 +58,52 @@ export interface ShutdownSequenceOptions {
   beforeGracefulShutdown: () => Promise<void>;
   performGracefulShutdown: () => Promise<void>;
   gracefulDeadlineMs: number;
+  /**
+   * Bounded teardown of the OS subprocess tree that leaks when the graceful
+   * sequence is cut short — in production, chroma-mcp. performGracefulShutdown
+   * already stops it, but only as its second-to-last step, behind a session
+   * drain observed at 35-40s (see the deadline note above). When the deadline
+   * wins that race the process exits with that step unreached, orphaning the
+   * tree to init. This runs it again on its own budget so subprocess teardown
+   * is never collateral of a slow drain.
+   *
+   * Must be idempotent: on the deadline path the abandoned
+   * performGracefulShutdown is still in flight and may reach the same teardown
+   * concurrently.
+   *
+   * Must not hold state that the restart handoff depends on — it runs to
+   * completion (or times out) BEFORE spawnRestartSuccessor. The supervisor
+   * cascade is therefore NOT part of this hook; it is reapProcessRegistry
+   * below, on the far side of the handoff.
+   */
+  reapSubprocesses: () => Promise<void>;
+  /**
+   * The supervisor's registry cascade — the OTHER teardown step the deadline
+   * skips, covering every managed child (SDK trees, mcp servers), not just
+   * chroma. Split from reapSubprocesses because it must run AFTER the restart
+   * handoff: it holds the supervisor's spawn gate for its duration, so running
+   * it first can make the successor spawn fail. See the call site.
+   */
+  reapProcessRegistry: () => Promise<void>;
+  /**
+   * Budget for reapSubprocesses — a chroma tree-kill is ~200ms, not 40s. Kept
+   * tight because this one runs BEFORE the handoff and so delays the successor.
+   */
+  reapDeadlineMs: number;
+  /**
+   * Budget for reapProcessRegistry, which needs a bigger one: the cascade is
+   * SIGTERM -> waitForExit(5s) -> SIGKILL -> waitForExit(1s) -> unregister, so
+   * anything under ~6s truncates it mid-SIGKILL and skips the unregister pass,
+   * leaving stubborn children alive at process.exit(). On Windows each signal
+   * additionally shells out to taskkill with its own 10s timeout, per child, so
+   * the true worst case is unbounded by any fixed number — see the production
+   * value for how that is sized and why truncation is acceptable there.
+   *
+   * Affordable because this runs AFTER the handoff: it delays only this dying
+   * process, not the successor, which is already up. And it is a ceiling, not a
+   * sleep — a fast cascade returns immediately.
+   */
+  reapRegistryDeadlineMs: number;
   restartHandoff: RestartHandoffDeps;
 }
 
@@ -93,8 +139,9 @@ export async function runShutdownSequence(options: ShutdownSequenceOptions): Pro
     deadlineTimer = setTimeout(() => resolve('deadline'), options.gracefulDeadlineMs);
     deadlineTimer.unref?.();
   });
+  let outcome: 'graceful' | 'graceful-error' | 'deadline';
   try {
-    const outcome = await Promise.race([
+    outcome = await Promise.race([
       options.performGracefulShutdown().then(
         () => 'graceful' as const,
         (error: unknown) => {
@@ -121,6 +168,26 @@ export async function runShutdownSequence(options: ShutdownSequenceOptions): Pro
     if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
   }
 
+  // Subprocess teardown backstop. performGracefulShutdown stops the chroma-mcp
+  // tree second-to-last, behind the session drain, so on the deadline path it
+  // has definitely not run; on the error path it may not have (steps fail fast,
+  // so an early failure skips it). Either way the caller — flushResponseThen or
+  // the supervisor signal handler — is about to process.exit(), abandoning the
+  // in-flight promise and reparenting the tree (uvx -> uv -> python) to init,
+  // where it survives indefinitely because chroma-mcp does not terminate on
+  // stdin EOF.
+  //
+  // Nothing downstream catches it either: the supervisor's registry cascade is
+  // the LAST step of the same sequence, and the signal handler's
+  // Supervisor.stop() fallback fires only when the handler *throws* — a
+  // deadline-expired shutdown returns normally. So this is the last point at
+  // which a leaked tree can still be reaped in-process.
+  if (outcome !== 'graceful') {
+    await reapUnderDeadline(
+      options.reapSubprocesses, 'subprocess teardown', options.reapDeadlineMs, options, outcome
+    );
+  }
+
   // Successor handoff — ONLY for restart; 'stop' and signal shutdowns stay
   // kill-only. The old worker spawns its replacement as its final act, after
   // its port is confirmed free, so the successor never races the corpse for
@@ -131,21 +198,109 @@ export async function runShutdownSequence(options: ShutdownSequenceOptions): Pro
   // stale install would respawn its own version forever (#3378). This runs
   // inside flushResponseThen's flushed action, so it completes before that
   // helper's process.exit(0).
-  if (options.reason !== 'restart') return;
+  if (options.reason === 'restart') {
+    const handoff = options.restartHandoff;
+    try {
+      await spawnRestartSuccessor(handoff);
+    } catch (error: unknown) {
+      // spawnDaemon can throw (supervisor assertCanSpawn refuses while its stop
+      // cascade is still in flight after a deadline); the handoff must never
+      // turn the dying worker's exit into an unhandled rejection.
+      logger.error(
+        'SYSTEM',
+        'Restart successor handoff threw — the next hook lazy-spawn is the safety net',
+        { port: handoff.port },
+        error instanceof Error ? error : new Error(String(error))
+      );
+    }
+  }
 
-  const handoff = options.restartHandoff;
-  try {
-    await spawnRestartSuccessor(handoff);
-  } catch (error: unknown) {
-    // spawnDaemon can throw (supervisor assertCanSpawn refuses while its stop
-    // cascade is still in flight after a deadline); the handoff must never
-    // turn the dying worker's exit into an unhandled rejection.
-    logger.error(
-      'SYSTEM',
-      'Restart successor handoff threw — the next hook lazy-spawn is the safety net',
-      { port: handoff.port },
-      error instanceof Error ? error : new Error(String(error))
+  // Registry cascade, AFTER the handoff — deliberately, and this ordering is
+  // load-bearing. Supervisor.stop() holds its stopPromise for the whole cascade
+  // (SIGTERM -> waitForExit(5s) -> SIGKILL), and assertCanSpawn() refuses any
+  // spawn while that is set. Run before the handoff and a cascade still in
+  // flight makes spawnDaemon throw, trading a leaked subprocess for a worker
+  // that never comes back. Running it after is safe in both directions: the
+  // spawn gate has already been passed, and spawnDaemon spawns the successor
+  // detached WITHOUT registering it (ProcessManager.ts), so the cascade
+  // iterates only this worker's own children and cannot signal its replacement.
+  // ProcessRegistry.getAll() is in-memory after a once-guarded initialize()
+  // (process-registry.ts), so the successor's own records — written to the
+  // shared supervisor.json on its boot — are invisible here and cannot be
+  // killed by this cascade either.
+  //
+  // Known trade-off: because this now runs after the successor has started,
+  // the cascade's unregister/persist writes can clobber supervisor.json with
+  // this dying worker's stale view, including erasing the successor's own
+  // freshly-written 'worker' record. It does NOT kill the successor (whose
+  // registry is a separate process-local map), and the file is corrected on
+  // the successor's next registry write — but that is not guaranteed to be
+  // prompt if the successor sits idle, so supervisor.json can under-report for
+  // a while. Accepted as the lesser evil: the alternative ordering can refuse
+  // the successor spawn outright, which loses the worker entirely.
+  if (outcome !== 'graceful') {
+    await reapUnderDeadline(
+      options.reapProcessRegistry, 'registry cascade', options.reapRegistryDeadlineMs, options, outcome
     );
+  }
+}
+
+/**
+ * Run the subprocess teardown under its own short deadline, never throwing.
+ *
+ * Bounded for the same reason the graceful sequence is: the dying worker must
+ * not hang. But this budget is sized for a tree-kill (~200ms), not a session
+ * drain, so it cannot be starved by the work that overran the outer deadline.
+ * On expiry we proceed anyway — a boot-time reaper in the successor is the
+ * remaining backstop for whatever survives.
+ */
+async function reapUnderDeadline(
+  reap: () => Promise<void>,
+  label: string,
+  deadlineMs: number,
+  options: ShutdownSequenceOptions,
+  outcome: 'graceful-error' | 'deadline'
+): Promise<void> {
+  logger.warn('SYSTEM', `Graceful shutdown did not reach ${label} — reaping directly`, {
+    outcome,
+    reason: options.reason,
+    reapDeadlineMs: deadlineMs,
+  });
+
+  let reapTimer: ReturnType<typeof setTimeout> | undefined;
+  const reapDeadline = new Promise<'deadline'>((resolve) => {
+    reapTimer = setTimeout(() => resolve('deadline'), deadlineMs);
+    reapTimer.unref?.();
+  });
+
+  try {
+    const reapOutcome = await Promise.race([
+      reap().then(
+        () => 'reaped' as const,
+        (error: unknown) => {
+          logger.error(
+            'SYSTEM',
+            `Reap of ${label} failed — proceeding to exit`,
+            { reason: options.reason },
+            error instanceof Error ? error : new Error(String(error))
+          );
+          return 'reap-error' as const;
+        }
+      ),
+      reapDeadline,
+    ]);
+    if (reapOutcome === 'deadline') {
+      logger.error('SYSTEM', `Reap of ${label} exceeded its deadline — processes may be orphaned`, {
+        reapDeadlineMs: deadlineMs,
+        reason: options.reason,
+      });
+    } else if (reapOutcome === 'reaped') {
+      logger.info('SYSTEM', `Reaped ${label} via shutdown backstop`, {
+        reason: options.reason,
+      });
+    }
+  } finally {
+    if (reapTimer !== undefined) clearTimeout(reapTimer);
   }
 }
 

--- a/src/supervisor/index.ts
+++ b/src/supervisor/index.ts
@@ -101,7 +101,19 @@ class Supervisor {
     }
   }
 
-  async stop(): Promise<void> {
+  /**
+   * `preserveRegistryForSuccessor` is for a restart that actually handed off:
+   * the successor may already have registered itself in supervisor.json, so
+   * this cascade signals its children but makes no registry writes. See
+   * ShutdownCascadeOptions for why.
+   *
+   * Note this is memoized — a second caller joins the in-flight cascade and its
+   * options do NOT apply. In the normal restart path that is not a problem,
+   * because performGracefulShutdown defers its own supervisor stop
+   * (deferSupervisorStop), leaving the post-handoff backstop as the first
+   * caller.
+   */
+  async stop(options: { preserveRegistryForSuccessor?: boolean } = {}): Promise<void> {
     if (this.stopPromise) {
       await this.stopPromise;
       return;
@@ -110,7 +122,8 @@ class Supervisor {
     stopHealthChecker();
     this.stopPromise = runShutdownCascade({
       registry: this.registry,
-      currentPid: process.pid
+      currentPid: process.pid,
+      preserveRegistryForSuccessor: options.preserveRegistryForSuccessor
     }).finally(() => {
       this.started = false;
       this.stopPromise = null;

--- a/src/supervisor/process-registry.ts
+++ b/src/supervisor/process-registry.ts
@@ -188,6 +188,7 @@ export class ProcessRegistry {
   private readonly entries = new Map<string, ManagedProcessInfo>();
   private readonly runtimeProcesses = new Map<string, ChildProcess>();
   private initialized = false;
+  private writesSuspended = false;
 
   constructor(registryPath: string = DEFAULT_REGISTRY_PATH) {
     this.registryPath = registryPath;
@@ -397,7 +398,30 @@ export class ProcessRegistry {
     return sessionRecords.length;
   }
 
+  /**
+   * Stop this instance from writing supervisor.json, permanently.
+   *
+   * For the restart handoff: once the successor has registered itself in the
+   * shared file, this (dying) process must not write to it again. Its map is a
+   * process-local snapshot frozen at boot, and persist() rewrites the file in
+   * full, so any write erases the successor's record.
+   *
+   * The latch lives here rather than at the cascade's call sites because the
+   * writes are not all synchronous or enumerable: SIGTERM'ing a tracked child
+   * makes its own 'exit' handler call unregister() (see spawnSdkProcess and
+   * ChromaMcpManager's chromaProcess 'exit' hook), which persists from outside
+   * the cascade entirely. Suppressing at the single write chokepoint covers
+   * those callbacks and any future writer.
+   *
+   * In-memory bookkeeping continues as normal — only the file write stops.
+   */
+  suspendWrites(): void {
+    this.writesSuspended = true;
+  }
+
   private persist(): void {
+    if (this.writesSuspended) return;
+
     const payload: PersistedRegistry = {
       processes: Object.fromEntries(this.entries.entries())
     };

--- a/src/supervisor/shutdown.ts
+++ b/src/supervisor/shutdown.ts
@@ -13,11 +13,38 @@ export interface ShutdownCascadeOptions {
   registry: ProcessRegistry;
   currentPid?: number;
   pidFilePath?: string;
+  /**
+   * Restart-safety latch: put this process's registry into read-only mode for
+   * the rest of its life, keeping the kill side intact.
+   *
+   * This registry is process-local after a once-guarded initialize(), so its
+   * map is a snapshot frozen at boot, and persist() rewrites supervisor.json in
+   * full from that snapshot. Once a restart has handed off, the successor may
+   * already have written its OWN 'worker' record to the shared file, so any
+   * write from here can erase it.
+   *
+   * Implemented via registry.suspendWrites() rather than by skipping call sites
+   * here, because signalling a child makes that child's 'exit' handler call
+   * unregister() asynchronously, from outside this function.
+   *
+   * Same posture as removeOwnedPidFile() below: a dying process does not touch
+   * what its successor now owns. The predecessor's stale records are left
+   * behind, and the successor's periodic health check prunes them on a later
+   * pass (pruneDeadEntries only persists when it removes something, and the
+   * abandoned records supply exactly that trigger).
+   */
+  preserveRegistryForSuccessor?: boolean;
 }
 
 export async function runShutdownCascade(options: ShutdownCascadeOptions): Promise<void> {
   const currentPid = options.currentPid ?? process.pid;
   const pidFilePath = options.pidFilePath ?? PID_FILE;
+
+  // Before the first read: getAll() can trigger initialize(), which persists.
+  if (options.preserveRegistryForSuccessor) {
+    options.registry.suspendWrites();
+  }
+
   const allRecords = options.registry.getAll();
   const childRecords = [...allRecords]
     .filter(record => record.pid !== currentPid)
@@ -75,6 +102,9 @@ export async function runShutdownCascade(options: ShutdownCascadeOptions): Promi
 
   await waitForExit(survivors, 1000);
 
+  // These still run under preserveRegistryForSuccessor — suspendWrites() has
+  // made them in-memory only, so the bookkeeping stays consistent while the
+  // successor's file is left untouched.
   for (const record of childRecords) {
     options.registry.unregister(record.id);
   }
@@ -82,6 +112,8 @@ export async function runShutdownCascade(options: ShutdownCascadeOptions): Promi
     options.registry.unregister(record.id);
   }
 
+  // Owner-guarded, so it is safe on both paths: it deletes only a PID file this
+  // process actually owns and leaves a successor's file alone.
   removeOwnedPidFile(pidFilePath, currentPid);
 
   options.registry.pruneDeadEntries();

--- a/tests/infrastructure/graceful-shutdown.test.ts
+++ b/tests/infrastructure/graceful-shutdown.test.ts
@@ -344,6 +344,43 @@ describe('GracefulShutdown', () => {
       }
     }, 15000);
 
+    // The deadline in runShutdownSequence does not cancel this promise. If this
+    // sequence could reach getSupervisor().stop() on a restart — finishing just
+    // before expiry, or resuming just after — stopPromise would be set and
+    // assertCanSpawn() would refuse the successor spawn, turning a restart into
+    // a worker that never comes back. deferSupervisorStop removes the race by
+    // construction: runShutdownSequence owns the cascade, after the handoff.
+    it('defers the supervisor cascade so a restart can never take the spawn gate', async () => {
+      const mockServer = {
+        closeAllConnections: mock(() => {}),
+        close: mock((cb: (err?: Error) => void) => { cb(); })
+      } as unknown as http.Server;
+      const mockSessionManager: ShutdownableService = {
+        shutdownAll: mock(async () => {})
+      };
+      const mockChromaMcpManager = {
+        stop: mock(async () => {})
+      };
+
+      const supervisorStopSpy = spyOn(getSupervisor(), 'stop');
+
+      try {
+        await expect(performGracefulShutdown({
+          server: mockServer,
+          sessionManager: mockSessionManager,
+          chromaMcpManager: mockChromaMcpManager,
+          deferSupervisorStop: true
+        })).resolves.toBeUndefined();
+
+        // Every other teardown step still ran — only the cascade is deferred.
+        expect(mockSessionManager.shutdownAll).toHaveBeenCalledTimes(1);
+        expect(mockChromaMcpManager.stop).toHaveBeenCalledWith({ terminal: true });
+        expect(supervisorStopSpy).not.toHaveBeenCalled();
+      } finally {
+        supervisorStopSpy.mockRestore();
+      }
+    }, 15000);
+
     it('still rejects when server.close reports any other error code', async () => {
       const mockServer = {
         closeAllConnections: mock(() => {}),

--- a/tests/infrastructure/graceful-shutdown.test.ts
+++ b/tests/infrastructure/graceful-shutdown.test.ts
@@ -159,6 +159,13 @@ describe('GracefulShutdown', () => {
       expect(callOrder.indexOf('mcpClient.close')).toBeLessThan(callOrder.indexOf('dbManager.close'));
 
       expect(callOrder.indexOf('chromaMcpManager.stop')).toBeLessThan(callOrder.indexOf('dbManager.close'));
+
+      // Production wiring, not just the seam: this is a process-exit teardown,
+      // so chroma must be stopped TERMINALLY. Without the flag,
+      // ChromaMcpManager's transport-error retry can reconnect during the
+      // remaining teardown and spawn a replacement subprocess tree that the
+      // imminent process.exit() orphans to init.
+      expect(mockChromaMcpManager.stop).toHaveBeenCalledWith({ terminal: true });
     }, 15000);
 
     it('should remove its OWN PID file during shutdown (owner guard)', async () => {

--- a/tests/services/sync/chroma-mcp-manager-singleton.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-singleton.test.ts
@@ -550,6 +550,103 @@ describe('ChromaMcpManager singleton enforcement (#2313)', () => {
     expect(prewarmSpawnCalls.length).toBe(0);
   });
 
+  // The worker's shutdown paths exit the process moments after stopping chroma.
+  // #3462's connectionGeneration guards cancel calls that were already in flight
+  // when stop() bumped the generation, and acceptingLocalMutations rejects late
+  // mutations in local mode — but a READ arriving after the bump captures the new
+  // generation, so it passes every guard and reaches connectInternal(), spawning a
+  // REPLACEMENT tree that process.exit() then orphans to init. The terminal latch
+  // closes that remaining path.
+  it('stop({ terminal: true }) refuses to spawn a replacement tree afterwards', async () => {
+    const mgr = ChromaMcpManager.getInstance();
+
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+    expect(transportInstances.length).toBe(1);
+
+    await mgr.stop({ terminal: true });
+
+    await expect(mgr.callTool('chroma_list_collections', { limit: 1 })).rejects.toThrow(
+      /shutting down/
+    );
+    // The critical assertion: no second subprocess tree was spawned.
+    expect(transportInstances.length).toBe(1);
+  });
+
+  // The latch check on entry to ensureConnected() is separated from the spawn by
+  // `await waitForUnexpectedCloseCleanup()`. A terminal stop landing inside that
+  // window leaves the call resuming with a stale "not stopped" reading, and
+  // connectInternal() then captures the POST-bump generation, so #3462's
+  // cancellation guards pass too — a replacement tree gets spawned for
+  // process.exit() to orphan. Parking the cleanup makes that race deterministic.
+  it('stop({ terminal: true }) landing mid-ensureConnected still blocks the spawn', async () => {
+    const managerForTesting = ChromaMcpManager as unknown as typeof ChromaMcpManager & {
+      killProcessTree: (pid: number) => Promise<void>;
+    };
+    const originalKillProcessTree = managerForTesting.killProcessTree;
+    const cleanupStartedForPids: number[] = [];
+    let finishCleanup: (() => void) | null = null;
+
+    managerForTesting.killProcessTree = async (pid: number) => {
+      cleanupStartedForPids.push(pid);
+      await new Promise<void>(resolve => {
+        finishCleanup = resolve;
+      });
+    };
+
+    try {
+      const mgr = ChromaMcpManager.getInstance();
+
+      await mgr.callTool('chroma_list_collections', { limit: 1 });
+      expect(transportInstances.length).toBe(1);
+
+      // Unexpected close parks a cleanup promise that ensureConnected() awaits.
+      const firstPid = transportInstances[0]._process.pid;
+      transportInstances[0].onclose?.();
+      await waitForCondition(() => cleanupStartedForPids.includes(firstPid));
+
+      // This call passes the entry check (nothing has latched yet), then blocks
+      // on the parked cleanup.
+      const reconnecting = mgr.callTool('chroma_list_collections', { limit: 1 });
+
+      // Teardown lands while it is parked. stop() latches synchronously, so
+      // firing it un-awaited models the race without deadlocking on the same
+      // parked cleanup.
+      void mgr.stop({ terminal: true });
+
+      // The unexpected close also armed the 10s reconnect backoff, which would
+      // reject the resumed call before it ever reaches the spawn guard under
+      // test. Clearing it simulates that backoff having expired, without making
+      // the test sleep for 10s — a reachable state, since a session drain
+      // outlasts the backoff several times over.
+      (mgr as unknown as { lastConnectionFailureTimestamp: number }).lastConnectionFailureTimestamp = 0;
+
+      finishCleanup?.();
+
+      await expect(reconnecting).rejects.toThrow(/shutting down/);
+      // The critical assertion: the resumed call spawned no replacement tree.
+      expect(transportInstances.length).toBe(1);
+    } finally {
+      finishCleanup?.();
+      managerForTesting.killProcessTree = originalKillProcessTree;
+    }
+  });
+
+  it('concurrent stop() calls share a single teardown', async () => {
+    const mgr = ChromaMcpManager.getInstance();
+
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+    logEntries.length = 0;
+
+    // The worker's shutdown backstop can call stop() while the abandoned
+    // performGracefulShutdown reaches the same call. Unmemoized, two disposers
+    // interleave over the same client/transport/writer-lock fields.
+    await Promise.all([mgr.stop(), mgr.stop(), mgr.stop()]);
+
+    expect(
+      logEntries.filter(entry => entry.message === 'Stopping chroma-mcp MCP connection').length
+    ).toBe(1);
+  });
+
   it('stop() ignores close-triggered onclose from an intentionally closed transport', async () => {
     transportCloseEmitsOnclose = true;
     const mgr = ChromaMcpManager.getInstance();

--- a/tests/services/worker-shutdown-sequence.test.ts
+++ b/tests/services/worker-shutdown-sequence.test.ts
@@ -25,6 +25,8 @@ interface Harness {
     spawnDaemon: number;
   };
   spawnArgs: Array<{ scriptPath: string; port: number }>;
+  /** successorSpawned as seen by each reapProcessRegistry call. */
+  preserveFlags: boolean[];
 }
 
 function makeHarness(overrides: {
@@ -42,6 +44,7 @@ function makeHarness(overrides: {
 } = {}): Harness {
   const guard = { shuttingDown: false };
   const calls: string[] = [];
+  const preserveFlags: boolean[] = [];
   const counters = {
     beforeGraceful: 0,
     graceful: 0,
@@ -77,9 +80,10 @@ function makeHarness(overrides: {
     },
     reapDeadlineMs: overrides.reapDeadlineMs ?? 1000,
     reapRegistryDeadlineMs: overrides.reapRegistryDeadlineMs ?? 1000,
-    reapProcessRegistry: () => {
+    reapProcessRegistry: (successorSpawned: boolean) => {
       counters.reapProcessRegistry++;
       calls.push('reapProcessRegistry');
+      preserveFlags.push(successorSpawned);
       return overrides.reapProcessRegistry ? overrides.reapProcessRegistry() : Promise.resolve();
     },
     restartHandoff: {
@@ -107,7 +111,7 @@ function makeHarness(overrides: {
     },
   };
 
-  return { options, guard, calls, counters, spawnArgs };
+  return { options, guard, calls, counters, spawnArgs, preserveFlags };
 }
 
 describe('runShutdownSequence — re-entrancy guard', () => {
@@ -306,12 +310,64 @@ describe('runShutdownSequence — registry cascade backstop', () => {
     expect(h.counters.spawnDaemon).toBe(0);
   });
 
-  it('does NOT reap the registry when the graceful sequence completed', async () => {
-    const h = makeHarness({ reason: 'restart' });
+  // Non-restart shutdowns still own their cascade inside performGracefulShutdown
+  // (deferSupervisorStop is restart-only), so a completed graceful sequence has
+  // already reaped and this must stay a pure backstop.
+  it('does NOT reap the registry when a non-restart graceful sequence completed', async () => {
+    const h = makeHarness({ reason: 'stop' });
 
     await runShutdownSequence(h.options);
 
     expect(h.counters.reapProcessRegistry).toBe(0);
+  });
+
+  // Restart is the exception: the graceful sequence defers its cascade so this
+  // one always runs, after the handoff, even on the graceful outcome. Keeping
+  // it off the spawn gate is the whole point — see deferSupervisorStop.
+  it('DOES reap the registry on a graceful restart, after the handoff', async () => {
+    const h = makeHarness({ reason: 'restart' });
+
+    await runShutdownSequence(h.options);
+
+    expect(h.counters.reapProcessRegistry).toBe(1);
+    expect(h.calls.indexOf('reapProcessRegistry')).toBeGreaterThan(h.calls.indexOf('spawnDaemon'));
+  });
+
+  // Registry preservation is gated on a successor process having been launched.
+  // Every handoff failure path leaves this worker as the sole known writer, so
+  // suppressing its writes there would strand its own records with nothing left
+  // to prune them.
+  it('preserves the registry once a successor process is launched', async () => {
+    const h = makeHarness({ reason: 'restart' });
+
+    await runShutdownSequence(h.options);
+
+    expect(h.preserveFlags).toEqual([true]);
+  });
+
+  it('does NOT preserve the registry when the port never freed', async () => {
+    const h = makeHarness({ reason: 'restart', portFree: false });
+
+    await runShutdownSequence(h.options);
+
+    expect(h.counters.spawnDaemon).toBe(0);
+    expect(h.preserveFlags).toEqual([false]);
+  });
+
+  it('does NOT preserve the registry when spawnDaemon returns no pid', async () => {
+    const h = makeHarness({ reason: 'restart', spawnResult: undefined });
+
+    await runShutdownSequence(h.options);
+
+    expect(h.preserveFlags).toEqual([false]);
+  });
+
+  it('does NOT preserve the registry when the successor spawn throws', async () => {
+    const h = makeHarness({ reason: 'restart', spawnThrows: true });
+
+    await runShutdownSequence(h.options);
+
+    expect(h.preserveFlags).toEqual([false]);
   });
 
   it('still reaps the registry when the successor spawn throws', async () => {

--- a/tests/services/worker-shutdown-sequence.test.ts
+++ b/tests/services/worker-shutdown-sequence.test.ts
@@ -18,6 +18,8 @@ interface Harness {
   counters: {
     beforeGraceful: number;
     graceful: number;
+    reapSubprocesses: number;
+    reapProcessRegistry: number;
     waitForPortFree: number;
     removePidFile: number;
     spawnDaemon: number;
@@ -30,6 +32,10 @@ function makeHarness(overrides: {
   gracefulDeadlineMs?: number;
   beforeGracefulThrows?: boolean;
   graceful?: () => Promise<void>;
+  reapSubprocesses?: () => Promise<void>;
+  reapProcessRegistry?: () => Promise<void>;
+  reapDeadlineMs?: number;
+  reapRegistryDeadlineMs?: number;
   portFree?: boolean;
   spawnResult?: number | undefined;
   spawnThrows?: boolean;
@@ -39,6 +45,8 @@ function makeHarness(overrides: {
   const counters = {
     beforeGraceful: 0,
     graceful: 0,
+    reapSubprocesses: 0,
+    reapProcessRegistry: 0,
     waitForPortFree: 0,
     removePidFile: 0,
     spawnDaemon: 0,
@@ -62,6 +70,18 @@ function makeHarness(overrides: {
       return overrides.graceful ? overrides.graceful() : Promise.resolve();
     },
     gracefulDeadlineMs: overrides.gracefulDeadlineMs ?? 1000,
+    reapSubprocesses: () => {
+      counters.reapSubprocesses++;
+      calls.push('reapSubprocesses');
+      return overrides.reapSubprocesses ? overrides.reapSubprocesses() : Promise.resolve();
+    },
+    reapDeadlineMs: overrides.reapDeadlineMs ?? 1000,
+    reapRegistryDeadlineMs: overrides.reapRegistryDeadlineMs ?? 1000,
+    reapProcessRegistry: () => {
+      counters.reapProcessRegistry++;
+      calls.push('reapProcessRegistry');
+      return overrides.reapProcessRegistry ? overrides.reapProcessRegistry() : Promise.resolve();
+    },
     restartHandoff: {
       port: PORT,
       portFreeTimeoutMs: 1000,
@@ -160,6 +180,192 @@ describe('runShutdownSequence — graceful-shutdown deadline', () => {
 
     await runShutdownSequence(h.options); // must not throw
 
+    expect(h.counters.spawnDaemon).toBe(1);
+  });
+});
+
+// performGracefulShutdown stops the chroma-mcp subprocess tree and runs the
+// supervisor registry cascade as its LAST steps, behind a session drain the
+// module header records at 35-40s — well past the 10s production deadline. When
+// the deadline wins, the caller process.exit()s and the abandoned promise never
+// reaches that teardown, orphaning the chroma-mcp tree (uvx -> uv -> python) to
+// init, where it never exits because chroma-mcp ignores stdin EOF. These tests
+// pin the backstop that guarantees teardown is still reached.
+describe('runShutdownSequence — subprocess reap backstop', () => {
+  it('reaps subprocesses when the graceful deadline expires mid-drain', async () => {
+    const h = makeHarness({
+      reason: 'restart',
+      gracefulDeadlineMs: 50,
+      graceful: () => new Promise<void>(() => { /* hangs forever — unbounded session drain */ }),
+    });
+
+    await runShutdownSequence(h.options);
+
+    expect(h.counters.reapSubprocesses).toBe(1);
+    // ...and it happens BEFORE the successor is spawned, so the replacement
+    // worker never races a still-live predecessor chroma for the writer lock.
+    expect(h.calls.indexOf('reapSubprocesses')).toBeLessThan(h.calls.indexOf('spawnDaemon'));
+  });
+
+  it('reaps subprocesses when performGracefulShutdown rejects', async () => {
+    const h = makeHarness({
+      reason: 'restart',
+      graceful: () => Promise.reject(new Error('db close failed')),
+    });
+
+    await runShutdownSequence(h.options);
+
+    expect(h.counters.reapSubprocesses).toBe(1);
+  });
+
+  it('does NOT reap when the graceful sequence completed (it already tore down)', async () => {
+    const h = makeHarness({ reason: 'restart' });
+
+    await runShutdownSequence(h.options);
+
+    expect(h.counters.graceful).toBe(1);
+    expect(h.counters.reapSubprocesses).toBe(0);
+  });
+
+  it('bounds a hanging reap on its own deadline and still completes the handoff', async () => {
+    const h = makeHarness({
+      reason: 'restart',
+      gracefulDeadlineMs: 50,
+      graceful: () => new Promise<void>(() => { /* hangs */ }),
+      reapDeadlineMs: 50,
+      reapSubprocesses: () => new Promise<void>(() => { /* tree-kill wedged */ }),
+    });
+
+    const start = Date.now();
+    await runShutdownSequence(h.options);
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(2000);
+    expect(h.counters.spawnDaemon).toBe(1);
+  });
+
+  it('proceeds (and does not reject) when the reap itself throws', async () => {
+    const h = makeHarness({
+      reason: 'restart',
+      gracefulDeadlineMs: 50,
+      graceful: () => new Promise<void>(() => { /* hangs */ }),
+      reapSubprocesses: () => Promise.reject(new Error('pkill unavailable')),
+    });
+
+    await runShutdownSequence(h.options); // must not throw
+
+    expect(h.counters.spawnDaemon).toBe(1);
+  });
+
+  it("reaps on a 'stop' shutdown too, where there is no successor handoff", async () => {
+    const h = makeHarness({
+      reason: 'stop',
+      gracefulDeadlineMs: 50,
+      graceful: () => new Promise<void>(() => { /* hangs */ }),
+    });
+
+    await runShutdownSequence(h.options);
+
+    expect(h.counters.reapSubprocesses).toBe(1);
+    expect(h.counters.spawnDaemon).toBe(0);
+  });
+});
+
+// The registry cascade (Supervisor.stop()) is the OTHER teardown step the
+// deadline skips, and it covers every managed child — SDK trees, mcp servers —
+// not just chroma. It has to run on the far side of the handoff: it holds the
+// supervisor's spawn gate (assertCanSpawn) for its whole duration, so running
+// it first can make the successor spawn throw.
+describe('runShutdownSequence — registry cascade backstop', () => {
+  it('reaps the process registry AFTER spawning the successor, never before', async () => {
+    const h = makeHarness({
+      reason: 'restart',
+      gracefulDeadlineMs: 50,
+      graceful: () => new Promise<void>(() => { /* hangs */ }),
+    });
+
+    await runShutdownSequence(h.options);
+
+    expect(h.counters.reapProcessRegistry).toBe(1);
+    expect(h.calls.indexOf('reapProcessRegistry')).toBeGreaterThan(h.calls.indexOf('spawnDaemon'));
+    // ...and the chroma reap stays on the near side, so the successor never
+    // races a live predecessor for the chroma writer lock.
+    expect(h.calls.indexOf('reapSubprocesses')).toBeLessThan(h.calls.indexOf('spawnDaemon'));
+  });
+
+  it("reaps the registry on a 'stop' shutdown, where no handoff happens", async () => {
+    const h = makeHarness({
+      reason: 'stop',
+      gracefulDeadlineMs: 50,
+      graceful: () => new Promise<void>(() => { /* hangs */ }),
+    });
+
+    await runShutdownSequence(h.options);
+
+    expect(h.counters.reapProcessRegistry).toBe(1);
+    expect(h.counters.spawnDaemon).toBe(0);
+  });
+
+  it('does NOT reap the registry when the graceful sequence completed', async () => {
+    const h = makeHarness({ reason: 'restart' });
+
+    await runShutdownSequence(h.options);
+
+    expect(h.counters.reapProcessRegistry).toBe(0);
+  });
+
+  it('still reaps the registry when the successor spawn throws', async () => {
+    const h = makeHarness({
+      reason: 'restart',
+      gracefulDeadlineMs: 50,
+      graceful: () => new Promise<void>(() => { /* hangs */ }),
+      spawnThrows: true,
+    });
+
+    await runShutdownSequence(h.options); // must not throw
+
+    expect(h.counters.reapProcessRegistry).toBe(1);
+  });
+
+  // The cascade is SIGTERM -> waitForExit(5s) -> SIGKILL -> waitForExit(1s) ->
+  // unregister, so it legitimately needs ~6s. Sharing the chroma reap's tight
+  // budget would truncate it mid-SIGKILL and skip the unregister pass, leaving
+  // stubborn children alive at exit. The two budgets must be independent.
+  it('gives the registry cascade a budget independent of the chroma reap', async () => {
+    let cascadeCompleted = false;
+    const h = makeHarness({
+      reason: 'restart',
+      gracefulDeadlineMs: 50,
+      graceful: () => new Promise<void>(() => { /* hangs */ }),
+      // Chroma's budget is deliberately shorter than the cascade takes.
+      reapDeadlineMs: 30,
+      reapRegistryDeadlineMs: 500,
+      reapProcessRegistry: async () => {
+        await new Promise(resolve => setTimeout(resolve, 120));
+        cascadeCompleted = true;
+      },
+    });
+
+    await runShutdownSequence(h.options);
+
+    // Ran to completion rather than being cut off by the 30ms chroma budget.
+    expect(cascadeCompleted).toBe(true);
+  });
+
+  it('bounds a hanging registry cascade on its own deadline', async () => {
+    const h = makeHarness({
+      reason: 'restart',
+      gracefulDeadlineMs: 50,
+      graceful: () => new Promise<void>(() => { /* hangs */ }),
+      reapDeadlineMs: 50,
+      reapProcessRegistry: () => new Promise<void>(() => { /* cascade wedged */ }),
+    });
+
+    const start = Date.now();
+    await runShutdownSequence(h.options); // must not hang the dying worker
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(2000);
     expect(h.counters.spawnDaemon).toBe(1);
   });
 });

--- a/tests/supervisor/shutdown.test.ts
+++ b/tests/supervisor/shutdown.test.ts
@@ -58,6 +58,137 @@ describe('supervisor shutdown cascade', () => {
     expect(() => readFileSync(pidFilePath, 'utf-8')).toThrow();
   });
 
+  // Restart handoff (greptile review, PR #3465): the successor self-registers
+  // into the SHARED supervisor.json before the predecessor's post-handoff
+  // cascade runs. The predecessor's registry is process-local and frozen at its
+  // boot, and every unregister()/pruneDeadEntries() rewrites the whole file from
+  // that stale snapshot — erasing the successor's record.
+  it('preserves a successor record written after this registry was initialized', async () => {
+    const tempDir = makeTempDir();
+    tempDirs.push(tempDir);
+    mkdirSync(tempDir, { recursive: true });
+
+    const registryPath = path.join(tempDir, 'supervisor.json');
+
+    // Predecessor: its own worker record plus a child that is already dead, so
+    // the in-loop unregister path is exercised too.
+    const predecessor = createProcessRegistry(registryPath);
+    predecessor.register('worker', {
+      pid: process.pid,
+      type: 'worker',
+      startedAt: '2026-03-15T00:00:00.000Z'
+    });
+    predecessor.register('dead-child', {
+      pid: 2147483647,
+      type: 'mcp',
+      startedAt: '2026-03-15T00:00:01.000Z'
+    });
+
+    // Successor boots and claims the same 'worker' id in the shared file. A
+    // separate registry instance is the point: the predecessor cannot see this.
+    const successor = createProcessRegistry(registryPath);
+    successor.register('worker', {
+      pid: process.ppid,
+      type: 'worker',
+      startedAt: '2026-03-15T00:00:02.000Z'
+    });
+
+    await runShutdownCascade({
+      registry: predecessor,
+      currentPid: process.pid,
+      pidFilePath: path.join(tempDir, 'worker.pid'),
+      preserveRegistryForSuccessor: true
+    });
+
+    const persisted = JSON.parse(readFileSync(registryPath, 'utf-8'));
+    expect(persisted.processes.worker).toBeDefined();
+    expect(persisted.processes.worker.pid).toBe(process.ppid);
+  });
+
+  // The cascade signals children, and each child's own 'exit' handler calls
+  // registry.unregister() (spawnSdkProcess; ChromaMcpManager's chromaProcess
+  // 'exit' hook) — asynchronously, from outside the cascade. Gating only the
+  // cascade's own call sites left that path writing the stale snapshot, so the
+  // latch has to live on the registry and outlive the cascade.
+  it('keeps suppressing writes after the cascade returns (child exit callbacks)', async () => {
+    const tempDir = makeTempDir();
+    tempDirs.push(tempDir);
+    mkdirSync(tempDir, { recursive: true });
+
+    const registryPath = path.join(tempDir, 'supervisor.json');
+
+    const predecessor = createProcessRegistry(registryPath);
+    predecessor.register('worker', {
+      pid: process.pid,
+      type: 'worker',
+      startedAt: '2026-03-15T00:00:00.000Z'
+    });
+    predecessor.register('sdk:1:41001', {
+      pid: 41001,
+      type: 'sdk',
+      startedAt: '2026-03-15T00:00:01.000Z'
+    });
+
+    const successor = createProcessRegistry(registryPath);
+    successor.register('worker', {
+      pid: process.ppid,
+      type: 'worker',
+      startedAt: '2026-03-15T00:00:02.000Z'
+    });
+
+    await runShutdownCascade({
+      registry: predecessor,
+      currentPid: process.pid,
+      pidFilePath: path.join(tempDir, 'worker.pid'),
+      preserveRegistryForSuccessor: true
+    });
+
+    // What a child's exit handler does once the cascade has already returned.
+    predecessor.unregister('sdk:1:41001');
+    predecessor.register('late', {
+      pid: 41002,
+      type: 'mcp',
+      startedAt: '2026-03-15T00:00:03.000Z'
+    });
+
+    const persisted = JSON.parse(readFileSync(registryPath, 'utf-8'));
+    expect(persisted.processes.worker?.pid).toBe(process.ppid);
+    expect(persisted.processes.late).toBeUndefined();
+  });
+
+  it('erases that successor record without the preserve flag (the bug)', async () => {
+    const tempDir = makeTempDir();
+    tempDirs.push(tempDir);
+    mkdirSync(tempDir, { recursive: true });
+
+    const registryPath = path.join(tempDir, 'supervisor.json');
+
+    const predecessor = createProcessRegistry(registryPath);
+    predecessor.register('worker', {
+      pid: process.pid,
+      type: 'worker',
+      startedAt: '2026-03-15T00:00:00.000Z'
+    });
+
+    const successor = createProcessRegistry(registryPath);
+    successor.register('worker', {
+      pid: process.ppid,
+      type: 'worker',
+      startedAt: '2026-03-15T00:00:02.000Z'
+    });
+
+    await runShutdownCascade({
+      registry: predecessor,
+      currentPid: process.pid,
+      pidFilePath: path.join(tempDir, 'worker.pid')
+    });
+
+    // Pins the behavior the flag exists to avoid: the successor's live record
+    // is gone from the shared file.
+    const persisted = JSON.parse(readFileSync(registryPath, 'utf-8'));
+    expect(persisted.processes.worker).toBeUndefined();
+  });
+
   it('terminates tracked children in reverse spawn order', async () => {
     const tempDir = makeTempDir();
     tempDirs.push(tempDir);


### PR DESCRIPTION

Closes #3459.

## The bug

`performGracefulShutdown` (`GracefulShutdown.ts:30`) runs six steps. The chroma tree-kill is **4th**, the supervisor registry cascade is **6th**, and step **2** — `sessionManager.shutdownAll()` — is documented *in this repo* (`worker-shutdown.ts:20`) as **35–40s**. The whole sequence is raced against a **10s** hard deadline (`worker-service.ts`, `gracefulDeadlineMs`).

On expiry the deadline branch logs and **returns normally**, so `flushResponseThen`'s `finally { process.exit(0) }` fires and the still-pending `performGracefulShutdown()` dies with the process. Steps 4–6 never run and the chroma tree reparents to init, where the pinned `chroma-mcp==0.2.6` never self-terminates (all three stdio fds are socketpairs with `->(none)` peers; observed still sleeping 8 days later).

Both existing safety nets are behind the same deadline: the registry cascade *is* step 6, and the signal-path fallback in `supervisor/index.ts:66-77` calls `this.stop()` only in a `catch` — a deadline-expired shutdown returns successfully, so it is skipped.

**This fires on an ordinary `worker:restart`.** Every prior report (#3301, #3153, #3382, #3413, #3230, #3218, #3216, #3205) attributes chroma orphans to *ungraceful* death, so the proposed boot-time reapers don't cover this pump. Evidence here: 30 orphaned pairs, all `PPID 1`, spawned in bursts during a session of repeated `build-and-sync` — i.e. repeated *graceful* restarts while sessions were live.

## Relationship to #3462

Rebased onto `a90066f9`. That PR is complementary, not overlapping — it bounds *write* concurrency, and its `connectionGeneration` guards cancel calls that were **already in flight** when `stop()` bumped the generation. That genuinely closes part of the respawn hole described in #3459, and this branch drops the test that covered it.

One path remains open on top of #3462, and it is the one shutdown actually hits. A call that **arrives after** `stop()` captures the *post-bump* generation in `callToolUnqueued` (`ChromaMcpManager.ts:738`), so every generation guard passes; `acceptingLocalMutations` rejects only mutation tools in local mode. A read — or `isHealthy()`'s `chroma_list_collections` — therefore reaches `ensureConnected()` → `connectInternal()` and **spawns a replacement tree** for `process.exit()` to orphan.

Verified by disabling only the new latch and re-running: the post-`stop()` read *resolves* instead of rejecting, i.e. it reconnected.

## The change

Deliberately **additive rather than a reordering** — #3387 established that reordering `performGracefulShutdown` is out of scope for a targeted fix, and a reorder would make this *worse* by widening the window in which drain work can trigger the respawn above.

**1. A bounded reap backstop in `runShutdownSequence`**, on the `deadline` / `graceful-error` outcomes only — exactly the cases where teardown was not reached. Two hooks, because the ordering is load-bearing:

- `reapSubprocesses` (chroma) runs **before** the successor handoff, so the replacement worker never races a live predecessor for the chroma writer lock.
- `reapProcessRegistry` (`getSupervisor().stop()`) runs **after** it.

The cascade **cannot** precede the handoff: `Supervisor.stop()` holds `stopPromise` for its full duration — including a built-in `waitForExit(children, 5000)` between SIGTERM and SIGKILL — and `assertCanSpawn()` refuses any spawn while that is set (`supervisor/index.ts:122-126`). Putting it first makes `spawnDaemon` throw, trading a leaked subprocess for a worker that never comes back.

Running it after is safe in both directions: `spawnDaemon` spawns the successor detached without registering it, and `ProcessRegistry.getAll()` is in-memory after a once-guarded `initialize()` — so the cascade iterates only the dying worker's own children and cannot reach its replacement.

Budgets are separate (5s chroma / 10s cascade) and sized for a tree-kill, not a drain. The cascade needs ~6s (`SIGTERM → waitForExit(5s) → SIGKILL → waitForExit(1s) → unregister`); sharing chroma's tight budget truncates it mid-SIGKILL and skips the unregister pass. The longer budget is affordable precisely because it sits after the handoff — the response is already flushed, the port already released, the successor already up, so the extra seconds delay only a portless dying process. A deadline is a ceiling, not a sleep.

**2. An opt-in terminal latch on `ChromaMcpManager`** for the remaining respawn path above. `stop({ terminal: true })` latches; `ensureConnected()` then throws `ChromaUnavailableError` rather than spawning.

The latch is checked **twice** — on entry *and* again immediately before `connectInternal()` — because those two points are separated by `await waitForUnexpectedCloseCleanup()`. A terminal stop landing inside that window would otherwise leave the call resuming on a stale reading, and since `connectInternal()` then captures the *post-bump* generation, #3462's guards would pass too: both protections defeated by the same window. Covered by `stop({ terminal: true }) landing mid-ensureConnected still blocks the spawn`, which parks the cleanup to make the race deterministic.

It **must** be opt-in: `chroma-mcp-manager-singleton.test.ts` pins that a plain `stop()` stays reusable for reads. Only callers abandoning the instance for good opt in — the worker's shutdown paths and `reset()`.

**3. Memoized `stop()`**, so concurrent callers share one teardown instead of interleaving disposers over the same `client`/`transport`/writer-lock fields. `connectionGeneration` is bumped in `stop()` itself rather than inside the memoized run, so a caller that *joins* an in-flight teardown still invalidates any connection established since it started — and the bump lands before any await.

## Known trade-off

The post-handoff cascade's `persist()` can clobber `supervisor.json` with the dying worker's stale view, including erasing the successor's freshly-written `worker` record. It does **not** kill the successor — that registry is a separate process-local map — and the file is corrected on the successor's next registry write, though that isn't guaranteed to be prompt if it sits idle. Accepted as the lesser evil against refusing the successor spawn outright.

On Windows the cascade can't be bounded by any fixed number — `signalProcess` shells to `taskkill` per child with its own 10s timeout, sequentially. The budget covers the realistic case (taskkill typically returns in <1s) and accepts truncation in the pathological one, where the children have already been signaled and the successor's `pruneDeadEntries()` repairs the registry.

## Testing

- `npx tsc --noEmit` clean.
- Full suite: **2604 pass**, 18 skip. The 7 failures are pre-existing and environmental (1 npm-tarball test, 6 `workers/sync-hub` tests requiring the uninstalled `cloudflare:test`) — identical before and after this change.
- Focused suites (`worker-shutdown-sequence`, `chroma-mcp-manager-singleton`, `graceful-shutdown`, `chroma-sync-reconcile`): **61 pass / 0 fail**.
- Every new test red→green verified by reverting the fix in place and confirming failure.

## Explicitly not covered

- **Boot-time reaper** (#3301 / #3382 / #3153) — still needed for genuinely ungraceful deaths (SIGKILL/OOM) that no in-process fix can reach.
- **The hook-driven stale-version recycle**, which SIGKILLs the worker deliberately (`worker-utils.ts:495-514`, citing #3378's "2,424 recycles in one machine-day") and so bypasses every graceful path including this one — likely the dominant pump per #3413.
- Optionally making the `supervisor/index.ts:66-77` fallback unconditional rather than `catch`-only.

