### PR TITLE
fix(chroma): refuse to open a local store stamped by a newer writer epoch (refs #3012)

### DIFF
--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -13,7 +13,7 @@ import { getUvxBinDirs } from '../../shared/uvx-bin-dirs.js';
 import { sanitizeEnv } from '../../supervisor/env-sanitizer.js';
 import { getSupervisor } from '../../supervisor/index.js';
 import { captureProcessStartToken, isPidAlive } from '../../supervisor/process-registry.js';
-import { clearDependencyStatus, recordChromaVectorSearchUnavailable, recordUvxVectorSearchUnavailable, CHROMA_VECTOR_SEARCH_REMEDIATION } from '../../shared/dependency-health.js';
+import { clearDependencyStatus, recordChromaVectorSearchUnavailable, recordUvxVectorSearchUnavailable } from '../../shared/dependency-health.js';
 import { ChromaUnavailableError } from '../worker/search/errors.js';
 
 const execFileAsync = promisify(execFile);
@@ -32,6 +32,9 @@ const CHROMA_STORE_RECORD_FILENAME = '.claude-mem-chroma-store.json';
 // longer safely follow a newer one's store layout. Deliberately not tied to
 // the package version so routine releases do not trigger spurious refusals.
 const CHROMA_WRITER_EPOCH = 1;
+// Size cap for the store record. A legitimate record is a small JSON envelope;
+// anything larger is damaged or adversarially written and must fail open.
+const CHROMA_STORE_RECORD_MAX_BYTES = 64 * 1024;
 const CHROMA_SUPERVISOR_ID = 'chroma-mcp';
 const CHROMA_OUTPUT_TAIL_MAX_CHARS = 2048;
 const DEFAULT_MAX_PENDING_MUTATIONS = 5_000;
@@ -194,10 +197,14 @@ export class ChromaMcpManager {
           reason: stored.reason,
         });
       } else if (stored.kind === 'valid' && stored.record.writerEpoch > CHROMA_WRITER_EPOCH) {
+        const writerDesc = stored.record.claudeMemVersion
+          ? `claude-mem ${stored.record.claudeMemVersion}${stored.record.updatedAt ? ` at ${stored.record.updatedAt}` : ''}`
+          : stored.record.updatedAt || 'an unknown version';
         const message =
           `Chroma data dir ${path.resolve(localChromaDataDir)} was last written by epoch ` +
-          `${stored.record.writerEpoch}; this writer is epoch ${CHROMA_WRITER_EPOCH} and cannot ` +
-          `safely open a store written by a newer version. ${CHROMA_VECTOR_SEARCH_REMEDIATION}`;
+          `${stored.record.writerEpoch} (${writerDesc}); this writer is epoch ${CHROMA_WRITER_EPOCH}. ` +
+          `Upgrade claude-mem to match the version that last wrote this store, ` +
+          `or configure a distinct CLAUDE_MEM_DATA_DIR.`;
         recordChromaVectorSearchUnavailable(message);
         throw new ChromaUnavailableError(message);
       }
@@ -572,6 +579,10 @@ export class ChromaMcpManager {
     const recordPath = path.join(path.resolve(dataDir), CHROMA_STORE_RECORD_FILENAME);
     let raw: string;
     try {
+      const stat = fs.statSync(recordPath);
+      if (stat.size > CHROMA_STORE_RECORD_MAX_BYTES) {
+        return { kind: 'damaged', reason: `record size ${stat.size} exceeds limit ${CHROMA_STORE_RECORD_MAX_BYTES}` };
+      }
       raw = fs.readFileSync(recordPath, 'utf-8');
     } catch (error) {
       const errno = error instanceof Error ? (error as NodeJS.ErrnoException).code : undefined;

--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -191,29 +191,7 @@ export class ChromaMcpManager {
     // last written by a newer epoch than this runtime.  The reader never
     // creates the data dir — acquireChromaWriterLock() retains that right.
     if (localChromaDataDir) {
-      const stored = ChromaMcpManager.readChromaStoreRecord(localChromaDataDir);
-      if (stored.kind === 'damaged') {
-        logger.warn('CHROMA_MCP', 'Chroma store record is damaged; connecting anyway', {
-          dataDir: localChromaDataDir,
-          reason: stored.reason,
-        });
-      } else if (stored.kind === 'valid' && stored.record.writerEpoch > CHROMA_WRITER_EPOCH) {
-        // Strip non-printables and cap each field so injected control characters
-        // or outsized strings cannot propagate through the health map to API responses.
-        const sanitizeField = (s: string) => s.replace(/[^\x20-\x7E]/g, '').slice(0, 80);
-        const version = sanitizeField(stored.record.claudeMemVersion);
-        const ts = sanitizeField(stored.record.updatedAt);
-        const writerDesc = version
-          ? `claude-mem ${version}${ts ? ` at ${ts}` : ''}`
-          : ts || 'an unknown version';
-        const message =
-          `Chroma data dir ${path.resolve(localChromaDataDir)} was last written by epoch ` +
-          `${stored.record.writerEpoch} (${writerDesc}); this writer is epoch ${CHROMA_WRITER_EPOCH}. ` +
-          `Upgrade claude-mem to match the version that last wrote this store, ` +
-          `or configure a distinct CLAUDE_MEM_DATA_DIR.`;
-        recordChromaVectorSearchUnavailable(message);
-        throw new ChromaUnavailableError(message);
-      }
+      ChromaMcpManager.assertChromaStoreCompatible(localChromaDataDir);
     }
 
     const commandArgs = this.buildCommandArgs(localChromaDataDir);
@@ -249,7 +227,7 @@ export class ChromaMcpManager {
     try {
       if (localChromaDataDir) {
         this.acquireChromaWriterLock(localChromaDataDir);
-        ChromaMcpManager.writeChromaStoreRecord(localChromaDataDir);
+        ChromaMcpManager.assertChromaStoreCompatible(localChromaDataDir);
       }
 
       this.transport = new StdioClientTransport({
@@ -310,6 +288,10 @@ export class ChromaMcpManager {
       throw connectionError;
     }
     clearTimeout(timeoutId!);
+
+    if (localChromaDataDir) {
+      ChromaMcpManager.writeChromaStoreRecord(localChromaDataDir);
+    }
 
     this.connected = true;
     this.registerManagedProcess();
@@ -624,6 +606,36 @@ export class ChromaMcpManager {
         updatedAt: typeof candidate.updatedAt === 'string' ? candidate.updatedAt : '',
       },
     };
+  }
+
+  private static assertChromaStoreCompatible(dataDir: string): void {
+    const stored = ChromaMcpManager.readChromaStoreRecord(dataDir);
+    if (stored.kind === 'damaged') {
+      logger.warn('CHROMA_MCP', 'Chroma store record is damaged; connecting anyway', {
+        dataDir,
+        reason: stored.reason,
+      });
+      return;
+    }
+    if (stored.kind !== 'valid' || stored.record.writerEpoch <= CHROMA_WRITER_EPOCH) {
+      return;
+    }
+
+    // Strip non-printables and cap each field so injected control characters
+    // or outsized strings cannot propagate through the health map to API responses.
+    const sanitizeField = (s: string) => s.replace(/[^\x20-\x7E]/g, '').slice(0, 80);
+    const version = sanitizeField(stored.record.claudeMemVersion);
+    const ts = sanitizeField(stored.record.updatedAt);
+    const writerDesc = version
+      ? `claude-mem ${version}${ts ? ` at ${ts}` : ''}`
+      : ts || 'an unknown version';
+    const message =
+      `Chroma data dir ${path.resolve(dataDir)} was last written by epoch ` +
+      `${stored.record.writerEpoch} (${writerDesc}); this writer is epoch ${CHROMA_WRITER_EPOCH}. ` +
+      `Upgrade claude-mem to match the version that last wrote this store, ` +
+      `or configure a distinct CLAUDE_MEM_DATA_DIR.`;
+    recordChromaVectorSearchUnavailable(message);
+    throw new ChromaUnavailableError(message);
   }
 
   private static writeChromaStoreRecord(dataDir: string): void {

--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -13,7 +13,7 @@ import { getUvxBinDirs } from '../../shared/uvx-bin-dirs.js';
 import { sanitizeEnv } from '../../supervisor/env-sanitizer.js';
 import { getSupervisor } from '../../supervisor/index.js';
 import { captureProcessStartToken, isPidAlive } from '../../supervisor/process-registry.js';
-import { clearDependencyStatus, recordChromaVectorSearchUnavailable, recordUvxVectorSearchUnavailable } from '../../shared/dependency-health.js';
+import { clearDependencyStatus, recordChromaVectorSearchUnavailable, recordUvxVectorSearchUnavailable, CHROMA_VECTOR_SEARCH_REMEDIATION } from '../../shared/dependency-health.js';
 import { ChromaUnavailableError } from '../worker/search/errors.js';
 
 const execFileAsync = promisify(execFile);
@@ -27,6 +27,11 @@ const CHROMA_PREWARM_TIMEOUT_BOUNDS = { min: 1, max: 600_000 } as const;
 const CHROMA_PREWARM_REAP_TIMEOUT_MS = 1_000;
 const RECONNECT_BACKOFF_MS = 10_000;
 const CHROMA_WRITER_LOCK_FILENAME = '.claude-mem-chroma-writer.lock';
+const CHROMA_STORE_RECORD_FILENAME = '.claude-mem-chroma-store.json';
+// Writer epoch — monotonic integer, bumped only when an older writer can no
+// longer safely follow a newer one's store layout. Deliberately not tied to
+// the package version so routine releases do not trigger spurious refusals.
+const CHROMA_WRITER_EPOCH = 1;
 const CHROMA_SUPERVISOR_ID = 'chroma-mcp';
 const CHROMA_OUTPUT_TAIL_MAX_CHARS = 2048;
 const DEFAULT_MAX_PENDING_MUTATIONS = 5_000;
@@ -76,6 +81,18 @@ interface ChromaWriterLockPayload {
   acquiredAt: string;
   startToken?: string | null;
 }
+
+interface ChromaStoreRecord {
+  writerEpoch: number;
+  chromaMcpVersion: string;
+  depOverrides: string[];
+  clientType: string;
+  claudeMemVersion: string;
+  updatedAt: string;
+}
+
+declare const __DEFAULT_PACKAGE_VERSION__: string;
+const claudeMemVersion = typeof __DEFAULT_PACKAGE_VERSION__ !== 'undefined' ? __DEFAULT_PACKAGE_VERSION__ : '0.0.0-dev';
 
 export class ChromaMcpManager {
   private static instance: ChromaMcpManager | null = null;
@@ -164,6 +181,28 @@ export class ChromaMcpManager {
     this.assertConnectionNotCancelled(connectionGeneration);
 
     const localChromaDataDir = this.getLocalPersistentChromaDataDir();
+
+    // Pre-spawn compatibility check (refs #3012): refuse before prewarm and
+    // before lock acquisition when the on-disk record proves this store was
+    // last written by a newer epoch than this runtime.  The reader never
+    // creates the data dir — acquireChromaWriterLock() retains that right.
+    if (localChromaDataDir) {
+      const stored = ChromaMcpManager.readChromaStoreRecord(localChromaDataDir);
+      if (stored.kind === 'damaged') {
+        logger.warn('CHROMA_MCP', 'Chroma store record is damaged; connecting anyway', {
+          dataDir: localChromaDataDir,
+          reason: stored.reason,
+        });
+      } else if (stored.kind === 'valid' && stored.record.writerEpoch > CHROMA_WRITER_EPOCH) {
+        const message =
+          `Chroma data dir ${path.resolve(localChromaDataDir)} was last written by epoch ` +
+          `${stored.record.writerEpoch}; this writer is epoch ${CHROMA_WRITER_EPOCH} and cannot ` +
+          `safely open a store written by a newer version. ${CHROMA_VECTOR_SEARCH_REMEDIATION}`;
+        recordChromaVectorSearchUnavailable(message);
+        throw new ChromaUnavailableError(message);
+      }
+    }
+
     const commandArgs = this.buildCommandArgs(localChromaDataDir);
     const uvxPreflightEnv = ChromaMcpManager.getUvxPreflightEnv();
     getSupervisor().assertCanSpawn('chroma mcp');
@@ -197,6 +236,7 @@ export class ChromaMcpManager {
     try {
       if (localChromaDataDir) {
         this.acquireChromaWriterLock(localChromaDataDir);
+        ChromaMcpManager.writeChromaStoreRecord(localChromaDataDir);
       }
 
       this.transport = new StdioClientTransport({
@@ -524,6 +564,69 @@ export class ChromaMcpManager {
     }
     const currentStartToken = captureProcessStartToken(lock.pid);
     return currentStartToken === null || currentStartToken === lock.startToken;
+  }
+
+  private static readChromaStoreRecord(
+    dataDir: string,
+  ): { kind: 'absent' } | { kind: 'damaged'; reason: string } | { kind: 'valid'; record: ChromaStoreRecord } {
+    const recordPath = path.join(path.resolve(dataDir), CHROMA_STORE_RECORD_FILENAME);
+    let raw: string;
+    try {
+      raw = fs.readFileSync(recordPath, 'utf-8');
+    } catch (error) {
+      const errno = error instanceof Error ? (error as NodeJS.ErrnoException).code : undefined;
+      if (errno === 'ENOENT') {
+        return { kind: 'absent' };
+      }
+      return { kind: 'damaged', reason: error instanceof Error ? error.message : String(error) };
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { kind: 'damaged', reason: 'JSON parse error' };
+    }
+    if (typeof parsed !== 'object' || parsed === null) {
+      return { kind: 'damaged', reason: 'record is not an object' };
+    }
+    const candidate = parsed as Record<string, unknown>;
+    if (!Number.isInteger(candidate.writerEpoch)) {
+      return { kind: 'damaged', reason: `writerEpoch is ${typeof candidate.writerEpoch}, expected integer` };
+    }
+    return {
+      kind: 'valid',
+      record: {
+        writerEpoch: candidate.writerEpoch as number,
+        chromaMcpVersion: typeof candidate.chromaMcpVersion === 'string' ? candidate.chromaMcpVersion : '',
+        depOverrides: Array.isArray(candidate.depOverrides) ? candidate.depOverrides as string[] : [],
+        clientType: typeof candidate.clientType === 'string' ? candidate.clientType : '',
+        claudeMemVersion: typeof candidate.claudeMemVersion === 'string' ? candidate.claudeMemVersion : '',
+        updatedAt: typeof candidate.updatedAt === 'string' ? candidate.updatedAt : '',
+      },
+    };
+  }
+
+  private static writeChromaStoreRecord(dataDir: string): void {
+    const normalizedDataDir = path.resolve(dataDir);
+    const recordPath = path.join(normalizedDataDir, CHROMA_STORE_RECORD_FILENAME);
+    const tmp = `${recordPath}.tmp`;
+    const record: ChromaStoreRecord = {
+      writerEpoch: CHROMA_WRITER_EPOCH,
+      chromaMcpVersion: CHROMA_MCP_PINNED_VERSION,
+      depOverrides: [...CHROMA_MCP_DEP_OVERRIDES],
+      clientType: 'persistent',
+      claudeMemVersion,
+      updatedAt: new Date().toISOString(),
+    };
+    try {
+      fs.writeFileSync(tmp, JSON.stringify(record, null, 2), 'utf-8');
+      fs.renameSync(tmp, recordPath);
+    } catch (error) {
+      logger.warn('CHROMA_MCP', 'Failed to write Chroma store record; connecting anyway', {
+        recordPath,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   private static buildLauncherPrefix(pythonVersion: string): string[] {

--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -88,7 +88,8 @@ interface ChromaWriterLockPayload {
 interface ChromaStoreRecord {
   writerEpoch: number;
   chromaMcpVersion: string;
-  depOverrides: string[];
+  // depOverrides is written for diagnostic provenance but not parsed back —
+  // element types are unchecked and the field never participates in any predicate.
   clientType: string;
   claudeMemVersion: string;
   updatedAt: string;
@@ -197,9 +198,14 @@ export class ChromaMcpManager {
           reason: stored.reason,
         });
       } else if (stored.kind === 'valid' && stored.record.writerEpoch > CHROMA_WRITER_EPOCH) {
-        const writerDesc = stored.record.claudeMemVersion
-          ? `claude-mem ${stored.record.claudeMemVersion}${stored.record.updatedAt ? ` at ${stored.record.updatedAt}` : ''}`
-          : stored.record.updatedAt || 'an unknown version';
+        // Strip non-printables and cap each field so injected control characters
+        // or outsized strings cannot propagate through the health map to API responses.
+        const sanitizeField = (s: string) => s.replace(/[^\x20-\x7E]/g, '').slice(0, 80);
+        const version = sanitizeField(stored.record.claudeMemVersion);
+        const ts = sanitizeField(stored.record.updatedAt);
+        const writerDesc = version
+          ? `claude-mem ${version}${ts ? ` at ${ts}` : ''}`
+          : ts || 'an unknown version';
         const message =
           `Chroma data dir ${path.resolve(localChromaDataDir)} was last written by epoch ` +
           `${stored.record.writerEpoch} (${writerDesc}); this writer is epoch ${CHROMA_WRITER_EPOCH}. ` +
@@ -541,6 +547,7 @@ export class ChromaMcpManager {
 
   private static readChromaWriterLock(lockPath: string): ChromaWriterLockPayload | null {
     try {
+      if (!fs.statSync(lockPath).isFile()) return null;
       const raw = JSON.parse(fs.readFileSync(lockPath, 'utf-8')) as Partial<ChromaWriterLockPayload>;
       if (
         typeof raw.pid !== 'number' ||
@@ -580,6 +587,9 @@ export class ChromaMcpManager {
     let raw: string;
     try {
       const stat = fs.statSync(recordPath);
+      if (!stat.isFile()) {
+        return { kind: 'damaged', reason: 'record path is not a regular file' };
+      }
       if (stat.size > CHROMA_STORE_RECORD_MAX_BYTES) {
         return { kind: 'damaged', reason: `record size ${stat.size} exceeds limit ${CHROMA_STORE_RECORD_MAX_BYTES}` };
       }
@@ -609,7 +619,6 @@ export class ChromaMcpManager {
       record: {
         writerEpoch: candidate.writerEpoch as number,
         chromaMcpVersion: typeof candidate.chromaMcpVersion === 'string' ? candidate.chromaMcpVersion : '',
-        depOverrides: Array.isArray(candidate.depOverrides) ? candidate.depOverrides as string[] : [],
         clientType: typeof candidate.clientType === 'string' ? candidate.clientType : '',
         claudeMemVersion: typeof candidate.claudeMemVersion === 'string' ? candidate.claudeMemVersion : '',
         updatedAt: typeof candidate.updatedAt === 'string' ? candidate.updatedAt : '',
@@ -621,7 +630,9 @@ export class ChromaMcpManager {
     const normalizedDataDir = path.resolve(dataDir);
     const recordPath = path.join(normalizedDataDir, CHROMA_STORE_RECORD_FILENAME);
     const tmp = `${recordPath}.tmp`;
-    const record: ChromaStoreRecord = {
+    // depOverrides is written for diagnostic provenance but not typed on ChromaStoreRecord
+    // (see interface comment) — the write payload intentionally extends beyond the read type.
+    const record = {
       writerEpoch: CHROMA_WRITER_EPOCH,
       chromaMcpVersion: CHROMA_MCP_PINNED_VERSION,
       depOverrides: [...CHROMA_MCP_DEP_OVERRIDES],

--- a/tests/services/sync/chroma-mcp-manager-singleton.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-singleton.test.ts
@@ -197,9 +197,10 @@ const killTreeCalls: number[] = [];
 const deadPids = new Set<number>();
 let execSyncCalls = 0;
 const prewarmSpawnCalls: Array<{ command: string; args: string[]; child: FakeChildProcess }> = [];
-let prewarmSpawnBehavior: 'success' | 'timeout' | 'failure' = 'success';
+let prewarmSpawnBehavior: 'success' | 'timeout' | 'failure' | 'pending' = 'success';
 let prewarmStdout = '';
 let prewarmStderr = '';
+let releasePendingPrewarm: (() => void) | null = null;
 
 mock.module('../../../src/supervisor/index.ts', () => ({
   getSupervisor: () => ({
@@ -230,6 +231,8 @@ mock.module('child_process', () => {
           child.finish(0);
         } else if (prewarmSpawnBehavior === 'failure') {
           child.finish(1);
+        } else if (prewarmSpawnBehavior === 'pending') {
+          releasePendingPrewarm = () => child.finish(0);
         }
       });
       return child;
@@ -323,6 +326,7 @@ function resetState(): void {
   prewarmSpawnBehavior = 'success';
   prewarmStdout = '';
   prewarmStderr = '';
+  releasePendingPrewarm = null;
   prewarmKillEmitsClose = true;
   transportCloseEmitsOnclose = false;
   transportKillEmitsOnclose = false;
@@ -640,6 +644,61 @@ describe('ChromaMcpManager singleton enforcement (#2313)', () => {
     await mgr.callTool('chroma_list_collections', { limit: 1 });
 
     expect(transportInstances.length).toBe(2);
+  });
+
+  it('[reproduction] Rechecks newer provenance after prewarm while holding the writer lock', async () => {
+    prewarmSpawnBehavior = 'pending';
+    const mgr = ChromaMcpManager.getInstance();
+
+    const pendingCall = mgr.callTool('chroma_list_collections', { limit: 1 });
+    await waitForCondition(() => prewarmSpawnCalls.length === 1 && releasePendingPrewarm !== null);
+
+    writeChromaStoreRecord({ writerEpoch: 2, claudeMemVersion: '13.99.0' });
+    releasePendingPrewarm?.();
+
+    await expect(pendingCall).rejects.toThrow(/epoch 2.*epoch 1/);
+    expect(transportInstances.length).toBe(0);
+    expect(existsSync(chromaWriterLockPath())).toBe(false);
+    expect(getDependencyStatus('chroma')).toMatchObject({
+      dependency: 'chroma',
+      kind: 'vector_search_unavailable',
+      message: expect.stringContaining('epoch 2'),
+    });
+    expect(JSON.parse(readFileSync(chromaStoreRecordPath(), 'utf-8')).writerEpoch).toBe(2);
+  });
+
+  it('Failed MCP handshake preserves the previous store record', async () => {
+    writeChromaStoreRecord({ writerEpoch: 0, updatedAt: '2026-01-01T00:00:00.000Z' });
+    const before = readFileSync(chromaStoreRecordPath(), 'utf-8');
+    connectImpl = async () => {
+      throw new Error('handshake failed');
+    };
+    const mgr = ChromaMcpManager.getInstance();
+
+    await expect(mgr.callTool('chroma_list_collections', { limit: 1 })).rejects.toThrow('handshake failed');
+    expect(existsSync(chromaWriterLockPath())).toBe(false);
+    expect(readFileSync(chromaStoreRecordPath(), 'utf-8')).toBe(before);
+  });
+
+  it('Cancelled MCP handshake preserves the previous store record byte-for-byte', async () => {
+    writeChromaStoreRecord({ writerEpoch: 0, updatedAt: '2026-01-01T00:00:00.000Z' });
+    const before = readFileSync(chromaStoreRecordPath(), 'utf-8');
+    rejectPendingConnectOnTransportClose = true;
+    let connectStarted = false;
+    connectImpl = async () => new Promise<void>((_resolve, reject) => {
+      connectStarted = true;
+      pendingConnectReject = reject;
+    });
+    const mgr = ChromaMcpManager.getInstance();
+
+    const pendingCall = mgr.callTool('chroma_list_collections', { limit: 1 });
+    await waitForCondition(() => connectStarted && pendingConnectReject !== null && transportInstances.length === 1);
+    const stopPromise = mgr.stop();
+
+    await expect(pendingCall).rejects.toThrow('connection cancelled during shutdown');
+    await stopPromise;
+    expect(existsSync(chromaWriterLockPath())).toBe(false);
+    expect(readFileSync(chromaStoreRecordPath(), 'utf-8')).toBe(before);
   });
 
   it('classifies missing uvx before spawning chroma-mcp transport', async () => {

--- a/tests/services/sync/chroma-mcp-manager-singleton.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-singleton.test.ts
@@ -849,12 +849,12 @@ describe('ChromaMcpManager store record (refs #3012)', () => {
 
   it('[reproduction] Newer-epoch store record refuses the local writer', async () => {
     // Seed a record stamped with epoch 2 (strictly above the shipped CHROMA_WRITER_EPOCH = 1).
-    // Record JSON: {"writerEpoch":2,...}
-    writeChromaStoreRecord({ writerEpoch: 2 });
+    // Record JSON: {"writerEpoch":2,"claudeMemVersion":"13.99.0",...}
+    writeChromaStoreRecord({ writerEpoch: 2, claudeMemVersion: '13.99.0' });
     const mgr = ChromaMcpManager.getInstance();
 
     await expect(mgr.callTool('chroma_list_collections', { limit: 1 }))
-      .rejects.toThrow(/epoch 2.*epoch 1|epoch 1.*epoch 2/);
+      .rejects.toThrow(/epoch 2.*epoch 1/);
 
     expect(transportInstances.length).toBe(0);
     expect(existsSync(chromaWriterLockPath())).toBe(false);
@@ -862,8 +862,12 @@ describe('ChromaMcpManager store record (refs #3012)', () => {
     expect(chromaStatus).not.toBeNull();
     expect(chromaStatus?.dependency).toBe('chroma');
     expect(chromaStatus?.kind).toBe('vector_search_unavailable');
+    // Message must name both epochs and the recorded writer identity.
     expect(chromaStatus?.message ?? '').toContain('epoch 2');
     expect(chromaStatus?.message ?? '').toContain('epoch 1');
+    expect(chromaStatus?.message ?? '').toContain('13.99.0');
+    // Remediation is attached separately; not concatenated into the message.
+    expect(chromaStatus?.message ?? '').not.toContain('Stop the other');
   });
 
   it('Equal-epoch store record connects and refreshes provenance', async () => {
@@ -905,6 +909,44 @@ describe('ChromaMcpManager store record (refs #3012)', () => {
     expect(existsSync(chromaStoreRecordPath())).toBe(true);
     const record = JSON.parse(readFileSync(chromaStoreRecordPath(), 'utf-8'));
     expect(record.writerEpoch).toBe(1);
+  });
+
+  it('Store record with non-integer writerEpoch fails open and is rewritten', async () => {
+    writeChromaStoreRecord({ writerEpoch: 'two' });
+    const mgr = ChromaMcpManager.getInstance();
+
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+
+    expect(transportInstances.length).toBe(1);
+    const warn = logEntries.find(e => e.message === 'Chroma store record is damaged; connecting anyway');
+    expect(warn).toBeDefined();
+    const record = JSON.parse(readFileSync(chromaStoreRecordPath(), 'utf-8'));
+    expect(record.writerEpoch).toBe(1);
+  });
+
+  it('Oversized store record fails open without parsing', async () => {
+    mkdirSync(mockedChromaDir, { recursive: true });
+    writeFileSync(chromaStoreRecordPath(), 'x'.repeat(65 * 1024));
+    const mgr = ChromaMcpManager.getInstance();
+
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+
+    expect(transportInstances.length).toBe(1);
+    const warn = logEntries.find(e => e.message === 'Chroma store record is damaged; connecting anyway');
+    expect(warn).toBeDefined();
+    expect(warn?.meta?.reason).toContain('exceeds');
+  });
+
+  it('Record write failure logs and continues without aborting the connection', async () => {
+    // Block the temp-file path so writeFileSync throws EISDIR.
+    mkdirSync(path.join(mockedChromaDir, '.claude-mem-chroma-store.json.tmp'), { recursive: true });
+    const mgr = ChromaMcpManager.getInstance();
+
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+
+    expect(transportInstances.length).toBe(1);
+    const warn = logEntries.find(e => e.message === 'Failed to write Chroma store record; connecting anyway');
+    expect(warn).toBeDefined();
   });
 
   it('Older-epoch store record connects and upgrades the epoch', async () => {
@@ -950,7 +992,10 @@ describe('ChromaMcpManager store record (refs #3012)', () => {
     const stalePid = 999_998_312;
     deadPids.add(stalePid);
     writeChromaWriterLock(stalePid, 'dead-worker-owner');
-    writeChromaStoreRecord({ writerEpoch: 1 });
+    // Seed a record with an old updatedAt so we can confirm the record was
+    // refreshed after the reap, not just left at the seeded value.
+    const staleUpdatedAt = new Date(Date.now() - 5000).toISOString();
+    writeChromaStoreRecord({ writerEpoch: 1, updatedAt: staleUpdatedAt });
     const mgr = ChromaMcpManager.getInstance();
 
     await mgr.callTool('chroma_list_collections', { limit: 1 });
@@ -961,6 +1006,8 @@ describe('ChromaMcpManager store record (refs #3012)', () => {
     expect(transportInstances.length).toBe(1);
     const record = JSON.parse(readFileSync(chromaStoreRecordPath(), 'utf-8'));
     expect(record.writerEpoch).toBe(1);
+    // Confirm the record was actually written after the reap, not just left at the seed.
+    expect(record.updatedAt > staleUpdatedAt).toBe(true);
   });
 
   it('stop() releases the lock and preserves the store record', async () => {

--- a/tests/services/sync/chroma-mcp-manager-singleton.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-singleton.test.ts
@@ -937,6 +937,21 @@ describe('ChromaMcpManager store record (refs #3012)', () => {
     expect(warn?.meta?.reason).toContain('exceeds');
   });
 
+  it('Store record at a non-file path fails open (POSIX only)', async () => {
+    // FIFOs don't exist on Windows; statSync().isFile() is the guard being tested.
+    if (process.platform === 'win32') return;
+    mkdirSync(mockedChromaDir, { recursive: true });
+    realChildProcess.execSync(`mkfifo '${chromaStoreRecordPath()}'`);
+    const mgr = ChromaMcpManager.getInstance();
+
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+
+    expect(transportInstances.length).toBe(1);
+    const warn = logEntries.find(e => e.message === 'Chroma store record is damaged; connecting anyway');
+    expect(warn).toBeDefined();
+    expect(warn?.meta?.reason).toContain('not a regular file');
+  });
+
   it('Record write failure logs and continues without aborting the connection', async () => {
     // Block the temp-file path so writeFileSync throws EISDIR.
     mkdirSync(path.join(mockedChromaDir, '.claude-mem-chroma-store.json.tmp'), { recursive: true });

--- a/tests/services/sync/chroma-mcp-manager-singleton.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-singleton.test.ts
@@ -369,6 +369,23 @@ function writeChromaWriterLock(pid: number, ownerId: string): void {
   }, null, 2));
 }
 
+function chromaStoreRecordPath(): string {
+  return path.join(mockedChromaDir, '.claude-mem-chroma-store.json');
+}
+
+function writeChromaStoreRecord(partial: Record<string, unknown>): void {
+  mkdirSync(mockedChromaDir, { recursive: true });
+  writeFileSync(chromaStoreRecordPath(), JSON.stringify({
+    writerEpoch: 1,
+    chromaMcpVersion: '0.2.6',
+    depOverrides: ['onnxruntime>=1.20', 'protobuf<7'],
+    clientType: 'persistent',
+    claudeMemVersion: '0.0.0-dev',
+    updatedAt: new Date().toISOString(),
+    ...partial,
+  }, null, 2));
+}
+
 describe('ChromaMcpManager singleton enforcement (#2313)', () => {
   beforeEach(async () => {
     await ChromaMcpManager.reset();
@@ -821,6 +838,157 @@ describe('ChromaMcpManager singleton enforcement (#2313)', () => {
     const connectLog = logEntries.find(entry => entry.message === 'Connecting to chroma-mcp via MCP stdio');
     expect(connectLog?.meta?.args).toContain('--client-type http');
     expect(connectLog?.meta?.args).not.toContain('--data-dir');
+  });
+});
+
+describe('ChromaMcpManager store record (refs #3012)', () => {
+  beforeEach(async () => {
+    await ChromaMcpManager.reset();
+    resetState();
+  });
+
+  it('[reproduction] Newer-epoch store record refuses the local writer', async () => {
+    // Seed a record stamped with epoch 2 (strictly above the shipped CHROMA_WRITER_EPOCH = 1).
+    // Record JSON: {"writerEpoch":2,...}
+    writeChromaStoreRecord({ writerEpoch: 2 });
+    const mgr = ChromaMcpManager.getInstance();
+
+    await expect(mgr.callTool('chroma_list_collections', { limit: 1 }))
+      .rejects.toThrow(/epoch 2.*epoch 1|epoch 1.*epoch 2/);
+
+    expect(transportInstances.length).toBe(0);
+    expect(existsSync(chromaWriterLockPath())).toBe(false);
+    const chromaStatus = getDependencyStatus('chroma');
+    expect(chromaStatus).not.toBeNull();
+    expect(chromaStatus?.dependency).toBe('chroma');
+    expect(chromaStatus?.kind).toBe('vector_search_unavailable');
+    expect(chromaStatus?.message ?? '').toContain('epoch 2');
+    expect(chromaStatus?.message ?? '').toContain('epoch 1');
+  });
+
+  it('Equal-epoch store record connects and refreshes provenance', async () => {
+    const before = new Date(Date.now() - 1000).toISOString();
+    writeChromaStoreRecord({ writerEpoch: 1, updatedAt: before });
+    const mgr = ChromaMcpManager.getInstance();
+
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+
+    expect(transportInstances.length).toBe(1);
+    expect(existsSync(chromaStoreRecordPath())).toBe(true);
+    const record = JSON.parse(readFileSync(chromaStoreRecordPath(), 'utf-8'));
+    expect(record.writerEpoch).toBe(1);
+    expect(record.updatedAt > before).toBe(true);
+  });
+
+  it('Missing store record on an existing installation connects and stamps', async () => {
+    expect(existsSync(chromaStoreRecordPath())).toBe(false);
+    const mgr = ChromaMcpManager.getInstance();
+
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+
+    expect(transportInstances.length).toBe(1);
+    expect(existsSync(chromaStoreRecordPath())).toBe(true);
+    const record = JSON.parse(readFileSync(chromaStoreRecordPath(), 'utf-8'));
+    expect(record.writerEpoch).toBe(1);
+  });
+
+  it('Malformed store record fails open and is rewritten', async () => {
+    mkdirSync(mockedChromaDir, { recursive: true });
+    writeFileSync(chromaStoreRecordPath(), 'not-json-{{{{');
+    const mgr = ChromaMcpManager.getInstance();
+
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+
+    expect(transportInstances.length).toBe(1);
+    const warn = logEntries.find(e => e.message === 'Chroma store record is damaged; connecting anyway');
+    expect(warn).toBeDefined();
+    expect(existsSync(chromaStoreRecordPath())).toBe(true);
+    const record = JSON.parse(readFileSync(chromaStoreRecordPath(), 'utf-8'));
+    expect(record.writerEpoch).toBe(1);
+  });
+
+  it('Older-epoch store record connects and upgrades the epoch', async () => {
+    writeChromaStoreRecord({ writerEpoch: 0 });
+    const mgr = ChromaMcpManager.getInstance();
+
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+
+    expect(transportInstances.length).toBe(1);
+    const record = JSON.parse(readFileSync(chromaStoreRecordPath(), 'utf-8'));
+    expect(record.writerEpoch).toBe(1);
+  });
+
+  it('Remote Chroma mode writes and reads no store record', async () => {
+    mockedSettings = { CLAUDE_MEM_CHROMA_MODE: 'remote' };
+    const mgr = ChromaMcpManager.getInstance();
+
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+
+    expect(existsSync(chromaStoreRecordPath())).toBe(false);
+    expect(existsSync(chromaWriterLockPath())).toBe(false);
+    const connectLog = logEntries.find(entry => entry.message === 'Connecting to chroma-mcp via MCP stdio');
+    expect(connectLog?.meta?.args).toContain('--client-type http');
+    expect(connectLog?.meta?.args).not.toContain('--data-dir');
+  });
+
+  it('Writer lock live-owner refusal unchanged', async () => {
+    writeChromaWriterLock(process.pid, 'other-worker-owner');
+    writeChromaStoreRecord({ writerEpoch: 1 });
+    const mgr = ChromaMcpManager.getInstance();
+
+    await expect(mgr.callTool('chroma_list_collections', { limit: 1 })).rejects.toThrow('already owned by PID');
+
+    expect(transportInstances.length).toBe(0);
+    expect(getDependencyStatus('chroma')).toMatchObject({
+      dependency: 'chroma',
+      kind: 'vector_search_unavailable',
+      message: expect.stringContaining('already owned by PID'),
+    });
+  });
+
+  it('Writer lock stale reap unchanged', async () => {
+    const stalePid = 999_998_312;
+    deadPids.add(stalePid);
+    writeChromaWriterLock(stalePid, 'dead-worker-owner');
+    writeChromaStoreRecord({ writerEpoch: 1 });
+    const mgr = ChromaMcpManager.getInstance();
+
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+
+    const lock = JSON.parse(readFileSync(chromaWriterLockPath(), 'utf-8'));
+    expect(lock.pid).toBe(process.pid);
+    expect(lock.ownerId).not.toBe('dead-worker-owner');
+    expect(transportInstances.length).toBe(1);
+    const record = JSON.parse(readFileSync(chromaStoreRecordPath(), 'utf-8'));
+    expect(record.writerEpoch).toBe(1);
+  });
+
+  it('stop() releases the lock and preserves the store record', async () => {
+    const mgr = ChromaMcpManager.getInstance();
+
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+    expect(existsSync(chromaStoreRecordPath())).toBe(true);
+
+    await mgr.stop();
+
+    expect(existsSync(chromaWriterLockPath())).toBe(false);
+    expect(existsSync(chromaStoreRecordPath())).toBe(true);
+    const record = JSON.parse(readFileSync(chromaStoreRecordPath(), 'utf-8'));
+    expect(record.writerEpoch).toBe(1);
+  });
+
+  it('Store record carries launcher provenance', async () => {
+    const mgr = ChromaMcpManager.getInstance();
+
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+
+    expect(existsSync(chromaStoreRecordPath())).toBe(true);
+    const record = JSON.parse(readFileSync(chromaStoreRecordPath(), 'utf-8'));
+    expect(record.chromaMcpVersion).toBe('0.2.6');
+    expect(record.depOverrides).toEqual(['onnxruntime>=1.20', 'protobuf<7']);
+    expect(record.clientType).toBe('persistent');
+    expect(typeof record.claudeMemVersion).toBe('string');
+    expect(record.claudeMemVersion.length).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
## Summary

A local persistent Chroma store carries no record of which claude-mem writer generation last wrote it, so a runtime opens it blind. `ChromaMcpManager` now stamps `.claude-mem-chroma-store.json` in the data dir while holding the existing writer lock, checks that record before prewarm and again after acquiring the lock, and refuses to open the store when it names a writer epoch strictly newer than its own. Provenance is published only after the MCP connection succeeds and the cancellation check passes.

This does **not** close the corruption reported in #3012. The writers in that report, 13.11.0 and 13.12.2, are already published and will never read this record. What it adds is the enforceable half: a downgrade-safe boundary going forward, and durable machine-readable writer provenance in the data dir so the next report of this class carries evidence instead of `ps` output and bundle diffs.

## Why

`acquireChromaWriterLock()` (`src/services/sync/ChromaMcpManager.ts:385-457`) already refuses a live foreign writer and reaps a dead one, but it only models *concurrent* exclusion. The lock payload records `pid`, `ownerId`, `dataDir`, `acquiredAt`, `startToken` and nothing about writer identity, and `releaseChromaWriterLock()` deletes the lock file on clean release (`:460-493`). The durable store record remains after release so the next startup can inspect provenance.

The first compatibility read runs before prewarm, so a known-incompatible store is rejected without paying the prewarm cost. After prewarm, the manager acquires the writer lock and repeats the same compatibility check before constructing `StdioClientTransport`. The locked read is authoritative for the interval through provenance publication, so an older writer cannot overwrite a newer record that appeared during prewarm.

The record is written only after `Client.connect()` completes and `assertConnectionNotCancelled()` succeeds. Rejected, timed-out, and cancelled startups release the lock without creating or advancing provenance. The record remains atomic via temp-file-plus-rename, following the pattern already used at `src/services/sync/ChromaSyncState.ts:74-83`.

The refusal is deliberately asymmetric. Only `recorded > current` refuses. A missing record is an existing installation and must connect; an *older* record is the safe direction and must connect; an unparseable record must connect rather than let one corrupt byte remove semantic search. Refusal degrades through the existing `ChromaUnavailableError` + `recordChromaVectorSearchUnavailable` contract, so search falls back to FTS5 exactly as the current lock refusal does.

The predicate keys only on `writerEpoch`. `claudeMemVersion`, `chromaMcpVersion`, `depOverrides`, and `clientType` ride in the record as diagnostics and never participate, so ordinary upgrades never trip the guard and a future chromadb pin shows up in the record without changing behavior.

## Scope

Explicitly not addressed:

- **The corruption in #3012 itself.** Reporter forensics in https://github.com/thedotmack/claude-mem/issues/3012#issuecomment-5144394853 show the divergence was claude-mem's own mutation strategy, `chroma_delete_documents` present in 13.11.0, replaced by `chroma_update_documents` in 13.12.3/13.12.4 per #3266. Both writers launched identical `chroma-mcp==0.2.6` with identical dep overrides, so this is not a store-format divergence and no guard keyed on format would have fired. Old binaries also cannot honor a record introduced after they shipped.
- **Why stale versions linger at all**, open issues #3205 and #3216.
- **Index growth bounding, compaction, size caps, and the `link_lists.bin` ratio heuristic**, requests 1 and 4 of #3012. Those depend on chromadb internals not verifiable here.
- **Uninstall and marketplace `autoUpdate`**, request 3 of #3012.
- Shutdown/teardown deadlines (#3465), corrupt-collection drop-and-derive (#3203), and the chromadb pin (#3384) are untouched.

`CHROMA_WRITER_EPOCH` ships at 1 and is not bumped here. The guard is inert until a future write-path change bumps it; that bump is the maintainer's call.

## Risk

Writer-lock semantics are unchanged in every direction: live-owner refusal, dead-PID reap, start-token liveness, same-owner re-entry, and deletion on `stop()` keep their current behavior, and the existing tests cover them with a record present. Remote mode reads and writes nothing. The record survives release, `stop()`, and `reset()` by design, and a failed record write logs and continues rather than aborting an otherwise successful connection. Failed, timed-out, and cancelled MCP startups leave the prior record absent or unchanged. The one new failure mode is refusal to open a store stamped by a newer epoch, which degrades to FTS5 rather than failing the worker.

Everything here is proven in-process against the existing fake-transport harness. No real `uvx`, `chroma-mcp`, `chromadb`, or persistent store is exercised, and no claim is made about chromadb's on-disk behavior.

## Verification

- [x] `bun test tests/services/sync/chroma-mcp-manager-singleton.test.ts`
- [x] `bun test tests/services/sync/chroma-mcp-manager-ssl.test.ts tests/services/sync/chroma-sync-unavailable.test.ts`
- [x] `npm run build`
- [x] `npm run lint:hook-io`
- [x] `npm run lint:spawn-env`
- [ ] `npm run strip-comments:check`

Refs #3012
