### PR TITLE
fix(sqlite): repair stamped discovery_tokens drift (refs #3446)

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -1323,23 +1323,36 @@ export class SessionStore {
   }
 
   private ensureDiscoveryTokensColumn(): void {
-    const applied = this.db.prepare('SELECT version FROM schema_versions WHERE version = ?').get(11) as SchemaVersion | undefined;
-    if (applied) return;
+    // Not gated on schema_versions row 11: a pre-13.12.0 v7 rebuild can drop
+    // the column while leaving row 11 intact (#3446), so affected DBs have that
+    // version row but not the column. The PRAGMA checks are the real guard;
+    // version 11 is recorded for bookkeeping only.
+    const alreadyStamped = !!(this.db.prepare('SELECT version FROM schema_versions WHERE version = ?').get(11) as SchemaVersion | undefined);
 
     const observationsInfo = this.db.query('PRAGMA table_info(observations)').all() as TableColumnInfo[];
-    const obsHasDiscoveryTokens = observationsInfo.some(col => col.name === 'discovery_tokens');
-
-    if (!obsHasDiscoveryTokens) {
-      this.db.run('ALTER TABLE observations ADD COLUMN discovery_tokens INTEGER DEFAULT 0');
-      logger.debug('DB', 'Added discovery_tokens column to observations table');
+    if (observationsInfo.length > 0) {
+      const obsHasDiscoveryTokens = observationsInfo.some(col => col.name === 'discovery_tokens');
+      if (!obsHasDiscoveryTokens) {
+        this.db.run('ALTER TABLE observations ADD COLUMN discovery_tokens INTEGER DEFAULT 0');
+        if (alreadyStamped) {
+          logger.warn('DB', 'Repaired missing discovery_tokens column on observations (v11 stamp present, column absent — #3446)');
+        } else {
+          logger.debug('DB', 'Added discovery_tokens column to observations table');
+        }
+      }
     }
 
     const summariesInfo = this.db.query('PRAGMA table_info(session_summaries)').all() as TableColumnInfo[];
-    const sumHasDiscoveryTokens = summariesInfo.some(col => col.name === 'discovery_tokens');
-
-    if (!sumHasDiscoveryTokens) {
-      this.db.run('ALTER TABLE session_summaries ADD COLUMN discovery_tokens INTEGER DEFAULT 0');
-      logger.debug('DB', 'Added discovery_tokens column to session_summaries table');
+    if (summariesInfo.length > 0) {
+      const sumHasDiscoveryTokens = summariesInfo.some(col => col.name === 'discovery_tokens');
+      if (!sumHasDiscoveryTokens) {
+        this.db.run('ALTER TABLE session_summaries ADD COLUMN discovery_tokens INTEGER DEFAULT 0');
+        if (alreadyStamped) {
+          logger.warn('DB', 'Repaired missing discovery_tokens column on session_summaries (v11 stamp present, column absent — #3446)');
+        } else {
+          logger.debug('DB', 'Added discovery_tokens column to session_summaries table');
+        }
+      }
     }
 
     this.db.prepare('INSERT OR IGNORE INTO schema_versions (version, applied_at) VALUES (?, ?)').run(11, new Date().toISOString());

--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -1335,7 +1335,7 @@ export class SessionStore {
       if (!obsHasDiscoveryTokens) {
         this.db.run('ALTER TABLE observations ADD COLUMN discovery_tokens INTEGER DEFAULT 0');
         if (alreadyStamped) {
-          logger.warn('DB', 'Repaired missing discovery_tokens column on observations (v11 stamp present, column absent — #3446); observations written while drifted were not recorded and cannot be recovered');
+          logger.warn('DB', 'Repaired missing discovery_tokens column on observations (v11 stamp present, column absent — #3446); observations written while drifted were not stored, so transcript replay may be required');
         } else {
           logger.debug('DB', 'Added discovery_tokens column to observations table');
         }
@@ -1348,7 +1348,7 @@ export class SessionStore {
       if (!sumHasDiscoveryTokens) {
         this.db.run('ALTER TABLE session_summaries ADD COLUMN discovery_tokens INTEGER DEFAULT 0');
         if (alreadyStamped) {
-          logger.warn('DB', 'Repaired missing discovery_tokens column on session_summaries (v11 stamp present, column absent — #3446); summaries written while drifted were not recorded and cannot be recovered');
+          logger.warn('DB', 'Repaired missing discovery_tokens column on session_summaries (v11 stamp present, column absent — #3446); summaries written while drifted were not stored, so transcript replay may be required');
         } else {
           logger.debug('DB', 'Added discovery_tokens column to session_summaries table');
         }

--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -1335,7 +1335,7 @@ export class SessionStore {
       if (!obsHasDiscoveryTokens) {
         this.db.run('ALTER TABLE observations ADD COLUMN discovery_tokens INTEGER DEFAULT 0');
         if (alreadyStamped) {
-          logger.warn('DB', 'Repaired missing discovery_tokens column on observations (v11 stamp present, column absent — #3446)');
+          logger.warn('DB', 'Repaired missing discovery_tokens column on observations (v11 stamp present, column absent — #3446); observations written while drifted were not recorded and cannot be recovered');
         } else {
           logger.debug('DB', 'Added discovery_tokens column to observations table');
         }
@@ -1348,7 +1348,7 @@ export class SessionStore {
       if (!sumHasDiscoveryTokens) {
         this.db.run('ALTER TABLE session_summaries ADD COLUMN discovery_tokens INTEGER DEFAULT 0');
         if (alreadyStamped) {
-          logger.warn('DB', 'Repaired missing discovery_tokens column on session_summaries (v11 stamp present, column absent — #3446)');
+          logger.warn('DB', 'Repaired missing discovery_tokens column on session_summaries (v11 stamp present, column absent — #3446); summaries written while drifted were not recorded and cannot be recovered');
         } else {
           logger.debug('DB', 'Added discovery_tokens column to session_summaries table');
         }

--- a/tests/fixtures/session-store-v7-fixture.ts
+++ b/tests/fixtures/session-store-v7-fixture.ts
@@ -1,8 +1,5 @@
 import { Database } from 'bun:sqlite';
 
-// Replays the pre-13.12.0 v7 rebuild against session_summaries, producing the
-// damaged state from issue #3446: discovery_tokens absent, schema_versions row
-// 11 still stamped. Uses the same 14-column literal as SessionStore.ts:1101-1131.
 export function replayV7RebuildOnSummaries(db: Database): void {
   db.run('BEGIN');
   db.run(`

--- a/tests/fixtures/session-store-v7-fixture.ts
+++ b/tests/fixtures/session-store-v7-fixture.ts
@@ -1,0 +1,40 @@
+import { Database } from 'bun:sqlite';
+
+// Replays the pre-13.12.0 v7 rebuild against session_summaries, producing the
+// damaged state from issue #3446: discovery_tokens absent, schema_versions row
+// 11 still stamped. Uses the same 14-column literal as SessionStore.ts:1101-1131.
+export function replayV7RebuildOnSummaries(db: Database): void {
+  db.run('BEGIN');
+  db.run(`
+    CREATE TABLE session_summaries_new (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      memory_session_id TEXT NOT NULL,
+      project TEXT NOT NULL,
+      request TEXT,
+      investigated TEXT,
+      learned TEXT,
+      completed TEXT,
+      next_steps TEXT,
+      files_read TEXT,
+      files_edited TEXT,
+      notes TEXT,
+      prompt_number INTEGER,
+      created_at TEXT NOT NULL,
+      created_at_epoch INTEGER NOT NULL,
+      FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE
+    )
+  `);
+  db.run(`
+    INSERT INTO session_summaries_new
+    SELECT id, memory_session_id, project, request, investigated, learned,
+           completed, next_steps, files_read, files_edited, notes,
+           prompt_number, created_at, created_at_epoch
+    FROM session_summaries
+  `);
+  db.run('DROP TABLE session_summaries');
+  db.run('ALTER TABLE session_summaries_new RENAME TO session_summaries');
+  db.run(`CREATE INDEX idx_session_summaries_sdk_session ON session_summaries(memory_session_id)`);
+  db.run(`CREATE INDEX idx_session_summaries_project ON session_summaries(project)`);
+  db.run(`CREATE INDEX idx_session_summaries_created ON session_summaries(created_at_epoch DESC)`);
+  db.run('COMMIT');
+}

--- a/tests/infrastructure/worker-built-schema-repair.test.ts
+++ b/tests/infrastructure/worker-built-schema-repair.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import net from 'net';
+import { Database } from 'bun:sqlite';
+import { SessionStore } from '../../src/services/sqlite/SessionStore.js';
+
+const REPO_ROOT = path.resolve(import.meta.dir, '../..');
+const WORKER_SOURCE = path.join(REPO_ROOT, 'src/services/worker-service.ts');
+
+function bunInPath(): boolean {
+  const result = Bun.spawnSync(
+    [process.platform === 'win32' ? 'where.exe' : 'which', 'bun'],
+    { stderr: 'ignore', stdout: 'ignore' },
+  );
+  return result.exitCode === 0;
+}
+
+let esbuildModule: typeof import('esbuild') | null = null;
+let esbuildLoadError: string | null = null;
+try {
+  esbuildModule = await import('esbuild');
+} catch (err) {
+  esbuildLoadError = err instanceof Error ? err.message : String(err);
+}
+
+const BUN_AVAILABLE = bunInPath();
+const SKIP_REASON: string | null =
+  !BUN_AVAILABLE ? 'bun not found in PATH — built-worker test requires bun runtime' :
+  !esbuildModule ? `esbuild not available: ${esbuildLoadError}` :
+  null;
+
+async function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, '127.0.0.1', () => {
+      const { port } = srv.address() as net.AddressInfo;
+      srv.close(() => resolve(port));
+    });
+    srv.on('error', reject);
+  });
+}
+
+function seedDamagedDb(dbPath: string): void {
+  const db = new Database(dbPath);
+  try {
+    new SessionStore(db);
+
+    db.run('BEGIN');
+    db.run(`
+      CREATE TABLE session_summaries_new (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        memory_session_id TEXT NOT NULL,
+        project TEXT NOT NULL,
+        request TEXT,
+        investigated TEXT,
+        learned TEXT,
+        completed TEXT,
+        next_steps TEXT,
+        files_read TEXT,
+        files_edited TEXT,
+        notes TEXT,
+        prompt_number INTEGER,
+        created_at TEXT NOT NULL,
+        created_at_epoch INTEGER NOT NULL,
+        FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE
+      )
+    `);
+    db.run(`
+      INSERT INTO session_summaries_new
+      SELECT id, memory_session_id, project, request, investigated, learned,
+             completed, next_steps, files_read, files_edited, notes,
+             prompt_number, created_at, created_at_epoch
+      FROM session_summaries
+    `);
+    db.run('DROP TABLE session_summaries');
+    db.run('ALTER TABLE session_summaries_new RENAME TO session_summaries');
+    db.run(`CREATE INDEX idx_session_summaries_sdk_session ON session_summaries(memory_session_id)`);
+    db.run(`CREATE INDEX idx_session_summaries_project ON session_summaries(project)`);
+    db.run(`CREATE INDEX idx_session_summaries_created ON session_summaries(created_at_epoch DESC)`);
+    db.run('COMMIT');
+  } finally {
+    db.close();
+  }
+}
+
+async function pollHealth(port: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/api/health`, {
+        signal: AbortSignal.timeout(2000),
+      });
+      if (res.status === 200 || res.status === 503) {
+        return true;
+      }
+    } catch {
+      // connection refused or timeout — keep polling
+    }
+    await new Promise<void>(r => setTimeout(r, 300));
+  }
+  return false;
+}
+
+async function pollReadiness(port: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/api/readiness`, {
+        signal: AbortSignal.timeout(2000),
+      });
+      if (res.status === 200) {
+        return true;
+      }
+    } catch {
+      // connection refused or still initializing — keep polling
+    }
+    await new Promise<void>(r => setTimeout(r, 300));
+  }
+  return false;
+}
+
+describe('worker-built-schema-repair (#3446)', () => {
+  it('a worker bundled from head source boots against a damaged DB and repairs discovery_tokens', async () => {
+    if (SKIP_REASON) {
+      console.log(`DIAGNOSTIC SKIP: ${SKIP_REASON}`);
+      expect(SKIP_REASON).toBeString();
+      return;
+    }
+
+    const bundleDir = mkdtempSync(path.join(tmpdir(), 'claude-mem-wbundle-'));
+    const dataDir = mkdtempSync(path.join(tmpdir(), 'claude-mem-wdata-'));
+    const bundlePath = path.join(bundleDir, 'worker-service.cjs');
+    const dbPath = path.join(dataDir, 'claude-mem.db');
+    const port = await findFreePort();
+    let proc: ReturnType<typeof Bun.spawn> | null = null;
+    let assertionError: unknown = null;
+
+    try {
+      await esbuildModule!.build({
+        entryPoints: [WORKER_SOURCE],
+        bundle: true,
+        platform: 'node',
+        target: 'node18',
+        format: 'cjs',
+        outfile: bundlePath,
+        logLevel: 'error',
+        external: [
+          'bun:sqlite',
+          'zod',
+          'cohere-ai',
+          'ollama',
+          '@chroma-core/default-embed',
+          'onnxruntime-node',
+          'better-auth',
+          'better-auth/node',
+          'better-auth/plugins',
+          '@better-auth/api-key',
+        ],
+        define: {
+          '__DEFAULT_PACKAGE_VERSION__': '"0.0.0-test"',
+          'import.meta.url': '__IMPORT_META_URL__',
+        },
+        banner: {
+          js: [
+            'var __filename = __filename || require("node:path").resolve(process.argv[1] || "");',
+            'var __dirname = __dirname || require("node:path").dirname(__filename);',
+            'var __IMPORT_META_URL__ = require("node:url").pathToFileURL(__filename).href;',
+          ].join('\n'),
+        },
+      });
+
+      writeFileSync(
+        path.join(dataDir, 'settings.json'),
+        JSON.stringify({ CLAUDE_MEM_WORKER_PORT: String(port), CLAUDE_MEM_CHROMA_ENABLED: 'false' }),
+      );
+
+      seedDamagedDb(dbPath);
+      {
+        const check = new Database(dbPath, { readonly: true, create: false });
+        try {
+          const colNames = (check.query('PRAGMA table_info(session_summaries)').all() as Array<{ name: string }>).map(c => c.name);
+          const v11Row = check.prepare('SELECT version FROM schema_versions WHERE version = 11').get();
+          expect(colNames).not.toContain('discovery_tokens');
+          expect(v11Row).not.toBeNull();
+        } finally {
+          check.close();
+        }
+      }
+
+      const logFile = Bun.file(path.join(dataDir, 'worker.log'));
+      const logWriter = logFile.writer();
+
+      proc = Bun.spawn(
+        ['bun', bundlePath, '--daemon'],
+        {
+          env: {
+            ...process.env,
+            CLAUDE_MEM_DATA_DIR: dataDir,
+            CLAUDE_CONFIG_DIR: dataDir,
+            CLAUDE_MEM_WORKER_PORT: String(port),
+            CLAUDE_MEM_CHROMA_ENABLED: 'false',
+            CLAUDE_MEM_MODES_DIR: path.join(REPO_ROOT, 'plugin', 'modes'),
+          },
+          stdout: 'ignore',
+          stderr: 'pipe',
+        },
+      );
+
+      if (proc.stderr) {
+        const reader = proc.stderr.getReader();
+        const drainStderr = async () => {
+          try {
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              logWriter.write(value);
+            }
+          } catch { /* pipe closed */ } finally {
+            try { logWriter.flush(); } catch {}
+          }
+        };
+        drainStderr().catch(() => {});
+      }
+
+      const healthy = await pollHealth(port, 30000);
+      const ready = healthy && await pollReadiness(port, 45000);
+
+      try {
+        if (!healthy || !ready) {
+          try {
+            const logsDir = path.join(dataDir, 'logs');
+            const { readdirSync: readdir } = await import('fs');
+            const logFiles = readdir(logsDir).filter(f => f.startsWith('claude-mem-'));
+            if (logFiles.length > 0) {
+              const logPath = path.join(logsDir, logFiles[logFiles.length - 1]);
+              const logContent = await Bun.file(logPath).text().catch(() => '(no log)');
+              console.error('[DEBUG] Worker log (last 3000):', logContent.slice(-3000));
+            } else {
+              console.error('[DEBUG] No log files found in', logsDir);
+            }
+          } catch (err) {
+            console.error('[DEBUG] Could not read log dir:', err);
+          }
+        }
+        expect(healthy).toBe(true);
+        expect(ready).toBe(true);
+
+        try {
+          await fetch(`http://127.0.0.1:${port}/api/admin/shutdown`, {
+            method: 'POST',
+            signal: AbortSignal.timeout(3000),
+          });
+        } catch {
+          // connection closed before response is valid
+        }
+
+        await Promise.race([
+          proc.exited,
+          new Promise<void>(r => setTimeout(r, 5000)),
+        ]);
+
+        const postBoot = new Database(dbPath, { readonly: true, create: false });
+        try {
+          const colNames = (postBoot.query('PRAGMA table_info(session_summaries)').all() as Array<{ name: string }>).map(c => c.name);
+          expect(colNames).toContain('discovery_tokens');
+        } finally {
+          postBoot.close();
+        }
+      } catch (err) {
+        assertionError = err;
+      }
+    } finally {
+      try { proc?.kill(); } catch {}
+      if (proc) {
+        await Promise.race([
+          proc.exited,
+          new Promise<void>(r => setTimeout(r, 3000)),
+        ]);
+      }
+      rmSync(bundleDir, { recursive: true, force: true });
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+
+    if (assertionError !== null) {
+      throw assertionError;
+    }
+  }, 90000);
+});

--- a/tests/infrastructure/worker-built-schema-repair.test.ts
+++ b/tests/infrastructure/worker-built-schema-repair.test.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import net from 'net';
 import { Database } from 'bun:sqlite';
 import { SessionStore } from '../../src/services/sqlite/SessionStore.js';
+import { replayV7RebuildOnSummaries } from '../fixtures/session-store-v7-fixture.js';
 
 const REPO_ROOT = path.resolve(import.meta.dir, '../..');
 const WORKER_SOURCE = path.join(REPO_ROOT, 'src/services/worker-service.ts');
@@ -31,6 +32,10 @@ const SKIP_REASON: string | null =
   !esbuildModule ? `esbuild not available: ${esbuildLoadError}` :
   null;
 
+if (SKIP_REASON) {
+  console.log(`[worker-built-schema-repair] SKIP: ${SKIP_REASON}`);
+}
+
 async function findFreePort(): Promise<number> {
   return new Promise((resolve, reject) => {
     const srv = net.createServer();
@@ -46,40 +51,7 @@ function seedDamagedDb(dbPath: string): void {
   const db = new Database(dbPath);
   try {
     new SessionStore(db);
-
-    db.run('BEGIN');
-    db.run(`
-      CREATE TABLE session_summaries_new (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        memory_session_id TEXT NOT NULL,
-        project TEXT NOT NULL,
-        request TEXT,
-        investigated TEXT,
-        learned TEXT,
-        completed TEXT,
-        next_steps TEXT,
-        files_read TEXT,
-        files_edited TEXT,
-        notes TEXT,
-        prompt_number INTEGER,
-        created_at TEXT NOT NULL,
-        created_at_epoch INTEGER NOT NULL,
-        FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE
-      )
-    `);
-    db.run(`
-      INSERT INTO session_summaries_new
-      SELECT id, memory_session_id, project, request, investigated, learned,
-             completed, next_steps, files_read, files_edited, notes,
-             prompt_number, created_at, created_at_epoch
-      FROM session_summaries
-    `);
-    db.run('DROP TABLE session_summaries');
-    db.run('ALTER TABLE session_summaries_new RENAME TO session_summaries');
-    db.run(`CREATE INDEX idx_session_summaries_sdk_session ON session_summaries(memory_session_id)`);
-    db.run(`CREATE INDEX idx_session_summaries_project ON session_summaries(project)`);
-    db.run(`CREATE INDEX idx_session_summaries_created ON session_summaries(created_at_epoch DESC)`);
-    db.run('COMMIT');
+    replayV7RebuildOnSummaries(db);
   } finally {
     db.close();
   }
@@ -122,13 +94,7 @@ async function pollReadiness(port: number, timeoutMs: number): Promise<boolean> 
 }
 
 describe('worker-built-schema-repair (#3446)', () => {
-  it('a worker bundled from head source boots against a damaged DB and repairs discovery_tokens', async () => {
-    if (SKIP_REASON) {
-      console.log(`DIAGNOSTIC SKIP: ${SKIP_REASON}`);
-      expect(SKIP_REASON).toBeString();
-      return;
-    }
-
+  it.skipIf(SKIP_REASON !== null)('a worker bundled from head source boots against a damaged DB and repairs discovery_tokens', async () => {
     const bundleDir = mkdtempSync(path.join(tmpdir(), 'claude-mem-wbundle-'));
     const dataDir = mkdtempSync(path.join(tmpdir(), 'claude-mem-wdata-'));
     const bundlePath = path.join(bundleDir, 'worker-service.cjs');

--- a/tests/infrastructure/worker-built-schema-repair.test.ts
+++ b/tests/infrastructure/worker-built-schema-repair.test.ts
@@ -119,6 +119,7 @@ describe('worker-built-schema-repair (#3446)', () => {
     let closeLogWriter: (() => Promise<void>) | null = null;
     let drainPromise: Promise<void> | null = null;
     let assertionError: unknown = null;
+    let cleanupError: unknown = null;
 
     try {
       await esbuildModule!.build({
@@ -314,12 +315,23 @@ describe('worker-built-schema-repair (#3446)', () => {
       try {
         if (closeLogWriter !== null) await closeLogWriter();
       } catch {}
-      await removeTempDir(bundleDir);
-      await removeTempDir(dataDir);
+      try {
+        await removeTempDir(bundleDir);
+      } catch (err) {
+        cleanupError ??= err;
+      }
+      try {
+        await removeTempDir(dataDir);
+      } catch (err) {
+        cleanupError ??= err;
+      }
     }
 
     if (assertionError !== null) {
       throw assertionError;
+    }
+    if (cleanupError !== null) {
+      throw cleanupError;
     }
   }, 90000);
 });

--- a/tests/infrastructure/worker-built-schema-repair.test.ts
+++ b/tests/infrastructure/worker-built-schema-repair.test.ts
@@ -93,6 +93,21 @@ async function pollReadiness(port: number, timeoutMs: number): Promise<boolean> 
   return false;
 }
 
+async function removeTempDir(dirPath: string): Promise<void> {
+  const deadline = Date.now() + 5000;
+  while (true) {
+    try {
+      rmSync(dirPath, { recursive: true, force: true });
+      return;
+    } catch (err) {
+      if (Date.now() >= deadline || !(err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'EBUSY')) {
+        throw err;
+      }
+      await new Promise<void>(resolve => setTimeout(resolve, 100));
+    }
+  }
+}
+
 describe('worker-built-schema-repair (#3446)', () => {
   it.skipIf(SKIP_REASON !== null)('a worker bundled from head source boots against a damaged DB and repairs discovery_tokens', async () => {
     const bundleDir = mkdtempSync(path.join(tmpdir(), 'claude-mem-wbundle-'));
@@ -101,6 +116,8 @@ describe('worker-built-schema-repair (#3446)', () => {
     const dbPath = path.join(dataDir, 'claude-mem.db');
     const port = await findFreePort();
     let proc: ReturnType<typeof Bun.spawn> | null = null;
+    let closeLogWriter: (() => Promise<void>) | null = null;
+    let drainPromise: Promise<void> | null = null;
     let assertionError: unknown = null;
 
     try {
@@ -157,6 +174,7 @@ describe('worker-built-schema-repair (#3446)', () => {
 
       const logFile = Bun.file(path.join(dataDir, 'worker.log'));
       const logWriter = logFile.writer();
+      closeLogWriter = async () => { await logWriter.end(); };
 
       proc = Bun.spawn(
         ['bun', bundlePath, '--daemon'],
@@ -187,7 +205,8 @@ describe('worker-built-schema-repair (#3446)', () => {
             try { logWriter.flush(); } catch {}
           }
         };
-        drainStderr().catch(() => {});
+        drainPromise = drainStderr();
+        drainPromise.catch(() => {});
       }
 
       const healthy = await pollHealth(port, 30000);
@@ -213,6 +232,48 @@ describe('worker-built-schema-repair (#3446)', () => {
         expect(healthy).toBe(true);
         expect(ready).toBe(true);
 
+        const importResponse = await fetch(`http://127.0.0.1:${port}/api/import`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            sessions: [{
+              content_session_id: 'built-worker-content',
+              memory_session_id: 'built-worker-schema-repair',
+              project: dataDir,
+              platform_source: 'claude',
+              user_prompt: 'schema repair',
+              started_at: new Date().toISOString(),
+              started_at_epoch: Date.now(),
+              completed_at: null,
+              completed_at_epoch: null,
+              status: 'completed',
+            }],
+            summaries: [{
+              memory_session_id: 'built-worker-schema-repair',
+              project: dataDir,
+              request: 'built worker summary insert',
+              investigated: 'schema repair',
+              learned: 'the repaired column is writable',
+              completed: 'worker boot',
+              next_steps: null,
+              files_read: null,
+              files_edited: null,
+              notes: null,
+              prompt_number: 1,
+              discovery_tokens: 7,
+              created_at: new Date().toISOString(),
+              created_at_epoch: Date.now(),
+            }],
+          }),
+        });
+        const importBodyText = await importResponse.text();
+        if (!importResponse.ok) {
+          throw new Error(`Built worker summary import failed (${importResponse.status}): ${importBodyText}`);
+        }
+        const importBody = JSON.parse(importBodyText) as { success: boolean; stats: { summariesImported: number } };
+        expect(importBody.success).toBe(true);
+        expect(importBody.stats.summariesImported).toBe(1);
+
         try {
           await fetch(`http://127.0.0.1:${port}/api/admin/shutdown`, {
             method: 'POST',
@@ -231,6 +292,8 @@ describe('worker-built-schema-repair (#3446)', () => {
         try {
           const colNames = (postBoot.query('PRAGMA table_info(session_summaries)').all() as Array<{ name: string }>).map(c => c.name);
           expect(colNames).toContain('discovery_tokens');
+          const summary = postBoot.prepare('SELECT request, discovery_tokens FROM session_summaries WHERE memory_session_id = ?').get('built-worker-schema-repair') as { request: string; discovery_tokens: number } | undefined;
+          expect(summary).toEqual({ request: 'built worker summary insert', discovery_tokens: 7 });
         } finally {
           postBoot.close();
         }
@@ -245,8 +308,14 @@ describe('worker-built-schema-repair (#3446)', () => {
           new Promise<void>(r => setTimeout(r, 3000)),
         ]);
       }
-      rmSync(bundleDir, { recursive: true, force: true });
-      rmSync(dataDir, { recursive: true, force: true });
+      try {
+        if (drainPromise !== null) await drainPromise;
+      } catch {}
+      try {
+        if (closeLogWriter !== null) await closeLogWriter();
+      } catch {}
+      await removeTempDir(bundleDir);
+      await removeTempDir(dataDir);
     }
 
     if (assertionError !== null) {

--- a/tests/sqlite/session-store-migrations.test.ts
+++ b/tests/sqlite/session-store-migrations.test.ts
@@ -978,6 +978,217 @@ describe('SessionStore migrations', () => {
     }
   });
 
+  describe('v11 discovery_tokens column repair (#3446)', () => {
+    // Replay the pre-13.12.0 v7 rebuild against session_summaries, reproducing
+    // the damage from issue #3446 (issue Step 4 of the five-step sweep).
+    // Uses the same 14-column literal as SessionStore.ts:1101-1131.
+    // Leaves schema_versions untouched so row 11 stays stamped.
+    function replayV7RebuildOnSummaries(db: Database): void {
+      db.run('BEGIN');
+      db.run(`
+        CREATE TABLE session_summaries_new (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          memory_session_id TEXT NOT NULL,
+          project TEXT NOT NULL,
+          request TEXT,
+          investigated TEXT,
+          learned TEXT,
+          completed TEXT,
+          next_steps TEXT,
+          files_read TEXT,
+          files_edited TEXT,
+          notes TEXT,
+          prompt_number INTEGER,
+          created_at TEXT NOT NULL,
+          created_at_epoch INTEGER NOT NULL,
+          FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE
+        )
+      `);
+      db.run(`
+        INSERT INTO session_summaries_new
+        SELECT id, memory_session_id, project, request, investigated, learned,
+               completed, next_steps, files_read, files_edited, notes,
+               prompt_number, created_at, created_at_epoch
+        FROM session_summaries
+      `);
+      db.run('DROP TABLE session_summaries');
+      db.run('ALTER TABLE session_summaries_new RENAME TO session_summaries');
+      db.run(`
+        CREATE INDEX idx_session_summaries_sdk_session ON session_summaries(memory_session_id)
+      `);
+      db.run(`
+        CREATE INDEX idx_session_summaries_project ON session_summaries(project)
+      `);
+      db.run(`
+        CREATE INDEX idx_session_summaries_created ON session_summaries(created_at_epoch DESC)
+      `);
+      db.run('COMMIT');
+    }
+
+    it('repairs drifted session_summaries.discovery_tokens on next construction so storeSummary succeeds', () => {
+      const db = new Database(':memory:');
+      try {
+        new SessionStore(db);
+        const memId = 'mem-3446-ss';
+        db.prepare(`
+          INSERT INTO sdk_sessions (content_session_id, memory_session_id, project, started_at, started_at_epoch, status)
+          VALUES ('content-3446-ss', ?, 'proj-3446', ?, 1751234567000, 'active')
+        `).run(memId, new Date().toISOString());
+
+        // Reproduce issue Step 4: rebuild session_summaries from the 14-col literal
+        replayV7RebuildOnSummaries(db);
+
+        // Confirm damage: row 11 present, discovery_tokens absent (issue Step 4)
+        expect(db.prepare('SELECT version FROM schema_versions WHERE version = 11').get()).not.toBeNull();
+        const damagedCols = (db.query('PRAGMA table_info(session_summaries)').all() as Array<{ name: string }>).map(c => c.name);
+        expect(damagedCols).not.toContain('discovery_tokens');
+        // ux_session_summaries_origin dropped with the table, confirming Step 5 territory
+        const damagedIndexes = (db.query('PRAGMA index_list(session_summaries)').all() as Array<{ name: string }>).map(i => i.name);
+        expect(damagedIndexes).not.toContain('ux_session_summaries_origin');
+
+        // Head: re-run migration chain — must repair discovery_tokens
+        new SessionStore(db);
+
+        const repairedCols = (db.query('PRAGMA table_info(session_summaries)').all() as Array<{ name: string }>).map(c => c.name);
+        expect(repairedCols).toContain('discovery_tokens');
+        // v41 also restored ux_session_summaries_origin (issue Step 5)
+        const repairedIndexes = (db.query('PRAGMA index_list(session_summaries)').all() as Array<{ name: string }>).map(i => i.name);
+        expect(repairedIndexes).toContain('ux_session_summaries_origin');
+
+        // storeSummary must now succeed (it names discovery_tokens in its INSERT)
+        const result = new SessionStore(db).storeSummary(memId, 'proj-3446', {
+          request: 'req', investigated: 'inv', learned: 'learned',
+          completed: 'done', next_steps: 'next', notes: null,
+        });
+        expect(typeof result.id).toBe('number');
+        expect(result.id).toBeGreaterThan(0);
+      } finally {
+        db.close();
+      }
+    });
+
+    it('repairs drifted observations.discovery_tokens on next construction', () => {
+      const db = new Database(':memory:');
+      try {
+        new SessionStore(db);
+
+        // Drop discovery_tokens from observations while leaving row 11 stamped
+        db.run('ALTER TABLE observations DROP COLUMN discovery_tokens');
+        expect(db.prepare('SELECT version FROM schema_versions WHERE version = 11').get()).not.toBeNull();
+        const damagedCols = (db.query('PRAGMA table_info(observations)').all() as Array<{ name: string }>).map(c => c.name);
+        expect(damagedCols).not.toContain('discovery_tokens');
+
+        new SessionStore(db);
+
+        const repairedCols = (db.query('PRAGMA table_info(observations)').all() as Array<{ name: string }>).map(c => c.name);
+        expect(repairedCols).toContain('discovery_tokens');
+      } finally {
+        db.close();
+      }
+    });
+
+    it('healthy post-v11 DB: construction emits no DDL against either table (negative space)', () => {
+      const db = new Database(':memory:');
+      try {
+        new SessionStore(db);
+
+        const ddlSnapshot = () => (db.prepare(`
+          SELECT type, name, tbl_name, sql
+          FROM sqlite_master
+          WHERE tbl_name IN ('observations', 'session_summaries')
+            AND type IN ('table', 'index', 'trigger')
+          ORDER BY type, name
+        `).all() as Array<{ type: string; name: string; tbl_name: string; sql: string }>);
+        const versionSnapshot = () => (db.prepare('SELECT version FROM schema_versions ORDER BY version').all() as Array<{ version: number }>);
+
+        const ddlBefore = ddlSnapshot();
+        const versionsBefore = versionSnapshot();
+
+        new SessionStore(db);
+
+        expect(ddlSnapshot()).toEqual(ddlBefore);
+        expect(versionSnapshot()).toEqual(versionsBefore);
+      } finally {
+        db.close();
+      }
+    });
+
+    it('repair preserves all existing summary rows and observations.discovery_tokens values', () => {
+      const db = new Database(':memory:');
+      try {
+        const store = new SessionStore(db);
+        const memId = 'mem-3446-pres';
+        db.prepare(`
+          INSERT INTO sdk_sessions (content_session_id, memory_session_id, project, started_at, started_at_epoch, status)
+          VALUES ('content-3446-pres', ?, 'proj-3446-pres', ?, 1751234567000, 'active')
+        `).run(memId, new Date().toISOString());
+
+        store.storeSummary(memId, 'proj-3446-pres', {
+          request: 'preserve-req', investigated: 'inv', learned: 'learned',
+          completed: 'done', next_steps: 'next', notes: 'preserve-note',
+        }, 1, 42);
+
+        // Observation with a non-default discovery_tokens value to preserve
+        db.prepare(`
+          INSERT INTO observations (memory_session_id, project, type, title, created_at, created_at_epoch, discovery_tokens)
+          VALUES (?, 'proj-3446-pres', 'discovery', 'obs-preserve', ?, ?, 99)
+        `).run(memId, new Date().toISOString(), Date.now());
+
+        replayV7RebuildOnSummaries(db);
+
+        new SessionStore(db);
+
+        const summaryCount = (db.prepare('SELECT COUNT(*) AS n FROM session_summaries').get() as { n: number }).n;
+        expect(summaryCount).toBe(1);
+
+        const summary = db.prepare("SELECT notes FROM session_summaries WHERE request = 'preserve-req'").get() as { notes: string } | undefined;
+        expect(summary?.notes).toBe('preserve-note');
+
+        const obs = db.prepare("SELECT discovery_tokens FROM observations WHERE title = 'obs-preserve'").get() as { discovery_tokens: number } | undefined;
+        expect(obs?.discovery_tokens).toBe(99);
+
+        // No index dropped on observations
+        const obsIndexes = (db.query('PRAGMA index_list(observations)').all() as Array<{ name: string }>).map(i => i.name);
+        expect(obsIndexes).toContain('ux_observations_session_hash');
+      } finally {
+        db.close();
+      }
+    });
+
+    it('repair is idempotent: two consecutive constructions over a damaged DB yield one ALTER and identical DDL', () => {
+      const db = new Database(':memory:');
+      try {
+        new SessionStore(db);
+        replayV7RebuildOnSummaries(db);
+
+        new SessionStore(db);
+        const ddlAfterFirst = (db.prepare(`
+          SELECT type, name, tbl_name, sql FROM sqlite_master
+          WHERE tbl_name IN ('observations', 'session_summaries')
+            AND type IN ('table', 'index', 'trigger')
+          ORDER BY type, name
+        `).all() as Array<{ type: string; name: string; tbl_name: string; sql: string }>);
+        const v11CountAfterFirst = (db.prepare('SELECT COUNT(*) AS n FROM schema_versions WHERE version = 11').get() as { n: number }).n;
+        expect((db.query('PRAGMA table_info(session_summaries)').all() as Array<{ name: string }>).map(c => c.name)).toContain('discovery_tokens');
+
+        new SessionStore(db);
+        const ddlAfterSecond = (db.prepare(`
+          SELECT type, name, tbl_name, sql FROM sqlite_master
+          WHERE tbl_name IN ('observations', 'session_summaries')
+            AND type IN ('table', 'index', 'trigger')
+          ORDER BY type, name
+        `).all() as Array<{ type: string; name: string; tbl_name: string; sql: string }>);
+        const v11CountAfterSecond = (db.prepare('SELECT COUNT(*) AS n FROM schema_versions WHERE version = 11').get() as { n: number }).n;
+
+        expect(ddlAfterSecond).toEqual(ddlAfterFirst);
+        expect(v11CountAfterSecond).toBe(v11CountAfterFirst);
+        expect(v11CountAfterFirst).toBe(1);
+      } finally {
+        db.close();
+      }
+    });
+  });
+
   it('v49 requeues corrected native rows for sync and leaves replicas and invalid JSON untouched', () => {
     const db = new Database(':memory:');
     try {

--- a/tests/sqlite/session-store-migrations.test.ts
+++ b/tests/sqlite/session-store-migrations.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect, afterEach } from 'bun:test';
+import { describe, it, expect, afterEach, spyOn } from 'bun:test';
 import { Database } from 'bun:sqlite';
 import { SessionStore } from '../../src/services/sqlite/SessionStore.js';
+import { logger } from '../../src/utils/logger.js';
+import { replayV7RebuildOnSummaries } from '../fixtures/session-store-v7-fixture.js';
 import { SessionSearch } from '../../src/services/sqlite/SessionSearch.js';
 import { SQLITE_BUSY_TIMEOUT_MS, SQLITE_JOURNAL_SIZE_LIMIT_BYTES } from '../../src/services/sqlite/connection.js';
 import { queryObservationsMulti } from '../../src/services/context/ObservationCompiler.js';
@@ -979,52 +981,6 @@ describe('SessionStore migrations', () => {
   });
 
   describe('v11 discovery_tokens column repair (#3446)', () => {
-    // Replay the pre-13.12.0 v7 rebuild against session_summaries, reproducing
-    // the damage from issue #3446 (issue Step 4 of the five-step sweep).
-    // Uses the same 14-column literal as SessionStore.ts:1101-1131.
-    // Leaves schema_versions untouched so row 11 stays stamped.
-    function replayV7RebuildOnSummaries(db: Database): void {
-      db.run('BEGIN');
-      db.run(`
-        CREATE TABLE session_summaries_new (
-          id INTEGER PRIMARY KEY AUTOINCREMENT,
-          memory_session_id TEXT NOT NULL,
-          project TEXT NOT NULL,
-          request TEXT,
-          investigated TEXT,
-          learned TEXT,
-          completed TEXT,
-          next_steps TEXT,
-          files_read TEXT,
-          files_edited TEXT,
-          notes TEXT,
-          prompt_number INTEGER,
-          created_at TEXT NOT NULL,
-          created_at_epoch INTEGER NOT NULL,
-          FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE
-        )
-      `);
-      db.run(`
-        INSERT INTO session_summaries_new
-        SELECT id, memory_session_id, project, request, investigated, learned,
-               completed, next_steps, files_read, files_edited, notes,
-               prompt_number, created_at, created_at_epoch
-        FROM session_summaries
-      `);
-      db.run('DROP TABLE session_summaries');
-      db.run('ALTER TABLE session_summaries_new RENAME TO session_summaries');
-      db.run(`
-        CREATE INDEX idx_session_summaries_sdk_session ON session_summaries(memory_session_id)
-      `);
-      db.run(`
-        CREATE INDEX idx_session_summaries_project ON session_summaries(project)
-      `);
-      db.run(`
-        CREATE INDEX idx_session_summaries_created ON session_summaries(created_at_epoch DESC)
-      `);
-      db.run('COMMIT');
-    }
-
     it('repairs drifted session_summaries.discovery_tokens on next construction so storeSummary succeeds', () => {
       const db = new Database(':memory:');
       try {
@@ -1184,6 +1140,54 @@ describe('SessionStore migrations', () => {
         expect(v11CountAfterSecond).toBe(v11CountAfterFirst);
         expect(v11CountAfterFirst).toBe(1);
       } finally {
+        db.close();
+      }
+    });
+
+    it('logger.warn fires for drift (v11 stamp present, column absent); logger.debug does not', () => {
+      const db = new Database(':memory:');
+      const warnSpy = spyOn(logger, 'warn');
+      const debugSpy = spyOn(logger, 'debug');
+      try {
+        new SessionStore(db);
+        replayV7RebuildOnSummaries(db);
+        warnSpy.mockClear();
+        debugSpy.mockClear();
+
+        new SessionStore(db);
+
+        const warnCalls = warnSpy.mock.calls.filter(c => String(c[1]).includes('#3446'));
+        expect(warnCalls.length).toBeGreaterThan(0);
+        const debugCalls = debugSpy.mock.calls.filter(c => String(c[1]).includes('discovery_tokens'));
+        expect(debugCalls.length).toBe(0);
+      } finally {
+        warnSpy.mockRestore();
+        debugSpy.mockRestore();
+        db.close();
+      }
+    });
+
+    it('logger.debug fires (no warn) on first-time v11 application on legacy pre-v11 DB', () => {
+      const db = new Database(':memory:');
+      const warnSpy = spyOn(logger, 'warn');
+      const debugSpy = spyOn(logger, 'debug');
+      try {
+        new SessionStore(db);
+        db.run('ALTER TABLE observations DROP COLUMN discovery_tokens');
+        db.run('ALTER TABLE session_summaries DROP COLUMN discovery_tokens');
+        db.run('DELETE FROM schema_versions WHERE version = 11');
+        warnSpy.mockClear();
+        debugSpy.mockClear();
+
+        new SessionStore(db);
+
+        const warnCalls = warnSpy.mock.calls.filter(c => String(c[1]).includes('#3446'));
+        expect(warnCalls.length).toBe(0);
+        const debugCalls = debugSpy.mock.calls.filter(c => String(c[1]).includes('discovery_tokens'));
+        expect(debugCalls.length).toBeGreaterThan(0);
+      } finally {
+        warnSpy.mockRestore();
+        debugSpy.mockRestore();
         db.close();
       }
     });


### PR DESCRIPTION
## Summary

A database damaged by a worker launched from a pre-13.12.0 plugin directory can never repair itself — not by upgrading, not by restarting, not on any shipped version. The old worker's v7 rebuild drops `session_summaries.discovery_tokens` but leaves `schema_versions` row 11 in place, and `ensureDiscoveryTokensColumn()` checks that row instead of the table, so the repair path early-exits forever while every session-summary INSERT fails with `table session_summaries has no column named discovery_tokens`. This change makes `PRAGMA table_info` the authoritative guard for that migration and keeps version 11 as bookkeeping, matching the shape `ensureSyncedAtColumns` (v39) and `ensureSyncOriginColumns` (v41) already use in the same file. A drifted database now heals on its next worker boot with upstream's own DDL, instead of requiring hand-written SQL.

## Why

`ensureDiscoveryTokensColumn()` opens with `SELECT version FROM schema_versions WHERE version = 11` and returns if the row exists (`src/services/sqlite/SessionStore.ts:1325-1327`). That guard is sound only if nothing can remove the column after v11 is stamped, and two migrations break that assumption. `removeSessionSummariesUniqueConstraint()` (v7, `src/services/sqlite/SessionStore.ts:1075-1143`) rebuilds `session_summaries` from a hard-coded 14-column list frozen before v11 existed, and until 13.12.0 its probe matched any non-primary-key unique index. `ensureSyncOriginColumns()` (v41, `src/services/sqlite/SessionStore.ts:512-516`) unconditionally creates `ux_session_summaries_origin` with `unique=1, origin='c'`, which that older probe treats as a constraint to strip. The rebuild then silently drops every post-v7 column.

Current main's strict predicate (`idx.unique === 1 && idx.origin === 'u'`, `src/services/sqlite/SessionStore.ts:1082`) prevents new damage and is already locked by `tests/sqlite/session-store-migrations.test.ts:498-539`. It cannot help a database already drifted, because the drift never touched `schema_versions` — the version row outlived the column it certifies. v41 then recreates the origin index on the next boot, so the broken database presents as freshly migrated. Because `storeSummary()` names `discovery_tokens` in its INSERT column list (`src/services/sqlite/SessionStore.ts:2560-2566`), the result is a hard failure on every summary write, caught per summary and visible only as a single `[ERROR] [SESSION] Generator failed` line.

The fix is the demotion the repo already performs elsewhere. `ensureSyncedAtColumns()` carries the comment *"affected DBs have those version rows but not the columns. The PRAGMA checks are the real guard; version 39 is recorded for bookkeeping only"* (`src/services/sqlite/SessionStore.ts:459-463`) — v11 is the same population and was never converted.

## Scope

This PR takes only the self-healing half of #3446.

- **Not addressed: refusing migrations from an older binary.** No writer-version epoch is stamped into the database (issue suggestion #1). An old worker can still run migrations; this PR only makes the reported v11 `discovery_tokens` drift repairable. The five named sibling stamp-only migrations remain outside this change.
- **Not addressed: stale plugin-directory resolution.** Nothing changes about how `$CLAUDE_PLUGIN_ROOT` resolves or how version-mismatched workers are recycled.

## Risk

One migration function changes and the DDL it emits is unchanged — the same `ALTER TABLE … ADD COLUMN discovery_tokens INTEGER DEFAULT 0` that both reporters applied by hand and confirmed survives the full 13.12.4 chain. The real risk is the removed early return: the probe now runs on every `SessionStore` construction, so it must emit nothing when the invariant already holds. That is asserted directly — a healthy database's complete `sqlite_master` DDL snapshot and `schema_versions` row set must be byte-identical across construction. The repair is additive only: no table is rebuilt, no index or foreign key is touched, no existing value is overwritten, and version row 11 is still written exactly once. Cost is two `PRAGMA table_info` reads per boot. Because it re-checks every boot rather than once, the recovery is also durable against any future migration that drops the column again.

## Verification

- [x] `bun test tests/sqlite/session-store-migrations.test.ts` — 26 passing (includes drifted-summaries reproduction, observations-side variant, healthy-DB negative space, value/row preservation, idempotence across two boots, v7 strict-probe regression, and two log-discrimination tests)
- [x] `bun test tests/sqlite/session-store-summaries.test.ts` — 8 passing, summary write path unchanged
- [x] `bun test tests/infrastructure/worker-built-schema-repair.test.ts` — 1 passing; a worker bundled with the repo's own esbuild flags boots `--daemon` against an isolated damaged database, repairs the column, and accepts a full-column summary INSERT
- [x] `npm run typecheck` — clean
- [x] `npm run build` — bundle within the advisory guardrail; all regenerated artifacts (`plugin/scripts/*.cjs`, `plugin/scripts/*.js`, `plugin/ui/viewer-bundle.js`, `plugin/sqlite/SessionStore.js`, `plugin/sqlite/observations/files.js`) restored, so the diff carries no build output
- [x] `npm run lint:hook-io && npm run lint:spawn-env` — clean; the new test's process spawns use array-based args
- [x] `npm run strip-comments:check` — Changed: 380, unchanged from base
- [x] The v7 drift fixture covers the stamped missing-column state and the head repair restores both tables before a summary write.

Verified on Windows / Bun 1.3.14; the reporters' Linux and macOS environments were not re-run.

Reported in https://github.com/thedotmack/claude-mem/issues/3446 and independently confirmed on macOS with Node in https://github.com/thedotmack/claude-mem/issues/3446#issuecomment-5138829316 , whose 8-day / 951-dropped-summary outage is attributed specifically to the version-stamp guard fixed here. The same stamp-only guard pattern exists at `SessionStore.ts:1146` (v8), `:1244` (v10), `:1362` (v16), `:1449` (v20), and `:1464` (v21); this PR repairs only v11.

Refs #3446
