### PR TITLE
fix(viewer): surface settings-save error details (refs #3457)

### DIFF
--- a/src/ui/viewer/components/ContextSettingsModal.tsx
+++ b/src/ui/viewer/components/ContextSettingsModal.tsx
@@ -13,6 +13,10 @@ interface ContextSettingsModalProps {
   saveStatus: string;
 }
 
+export function saveStatusClass(saveStatus: string): string {
+  return saveStatus.includes('✗') ? 'error' : saveStatus.includes('✓') ? 'success' : '';
+}
+
 function CollapsibleSection({
   title,
   description,
@@ -485,7 +489,7 @@ export function ContextSettingsModal({
         {/* Footer with Save button */}
         <div className="modal-footer">
           <div className="save-status">
-            {saveStatus && <span className={saveStatus.includes('✗') ? 'error' : saveStatus.includes('✓') ? 'success' : ''}>{saveStatus}</span>}
+            {saveStatus && <span className={saveStatusClass(saveStatus)}>{saveStatus}</span>}
           </div>
           <button
             className="save-btn"

--- a/src/ui/viewer/components/ContextSettingsModal.tsx
+++ b/src/ui/viewer/components/ContextSettingsModal.tsx
@@ -485,7 +485,7 @@ export function ContextSettingsModal({
         {/* Footer with Save button */}
         <div className="modal-footer">
           <div className="save-status">
-            {saveStatus && <span className={saveStatus.includes('✓') ? 'success' : saveStatus.includes('✗') ? 'error' : ''}>{saveStatus}</span>}
+            {saveStatus && <span className={saveStatus.includes('✗') ? 'error' : saveStatus.includes('✓') ? 'success' : ''}>{saveStatus}</span>}
           </div>
           <button
             className="save-btn"

--- a/src/ui/viewer/hooks/useSettings.ts
+++ b/src/ui/viewer/hooks/useSettings.ts
@@ -3,6 +3,7 @@ import { Settings } from '../types';
 import { DEFAULT_SETTINGS } from '../constants/settings';
 import { API_ENDPOINTS } from '../constants/api';
 import { TIMING } from '../constants/timing';
+import { describeSaveFailure } from '../utils/save-error';
 
 export function useSettings() {
   const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
@@ -33,7 +34,7 @@ export function useSettings() {
     });
 
     if (!response.ok) {
-      setSaveStatus(`✗ Error: ${response.status === 401 ? 'Unauthorized' : response.statusText}`);
+      setSaveStatus(await describeSaveFailure(response));
       setIsSaving(false);
       return;
     }

--- a/src/ui/viewer/hooks/useSettings.ts
+++ b/src/ui/viewer/hooks/useSettings.ts
@@ -5,6 +5,40 @@ import { API_ENDPOINTS } from '../constants/api';
 import { TIMING } from '../constants/timing';
 import { describeSaveFailure } from '../utils/save-error';
 
+export interface SubmitSettingsDependencies {
+  fetchImpl: typeof fetch;
+  setSettings: (settings: Settings) => void;
+  setSaveStatus: (status: string) => void;
+  setIsSaving: (isSaving: boolean) => void;
+}
+
+export async function submitSettings(
+  newSettings: Settings,
+  deps: SubmitSettingsDependencies,
+): Promise<void> {
+  const response = await deps.fetchImpl(API_ENDPOINTS.SETTINGS, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(newSettings)
+  });
+
+  if (!response.ok) {
+    deps.setSaveStatus(await describeSaveFailure(response));
+    deps.setIsSaving(false);
+    return;
+  }
+
+  const result = await response.json();
+
+  if (result.success) {
+    deps.setSettings(newSettings);
+    deps.setSaveStatus('✓ Saved');
+    setTimeout(() => deps.setSaveStatus(''), TIMING.SAVE_STATUS_DISPLAY_DURATION_MS);
+  } else {
+    deps.setSaveStatus(`✗ Error: ${result.error}`);
+  }
+}
+
 export function useSettings() {
   const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
   const [isSaving, setIsSaving] = useState(false);
@@ -26,36 +60,17 @@ export function useSettings() {
       });
   }, []);
 
-  const submitSettings = async (newSettings: Settings) => {
-    const response = await fetch(API_ENDPOINTS.SETTINGS, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(newSettings)
-    });
-
-    if (!response.ok) {
-      setSaveStatus(await describeSaveFailure(response));
-      setIsSaving(false);
-      return;
-    }
-
-    const result = await response.json();
-
-    if (result.success) {
-      setSettings(newSettings);
-      setSaveStatus('✓ Saved');
-      setTimeout(() => setSaveStatus(''), TIMING.SAVE_STATUS_DISPLAY_DURATION_MS);
-    } else {
-      setSaveStatus(`✗ Error: ${result.error}`);
-    }
-  };
-
   const saveSettings = async (newSettings: Settings) => {
     setIsSaving(true);
     setSaveStatus('Saving...');
 
     try {
-      await submitSettings(newSettings);
+      await submitSettings(newSettings, {
+        fetchImpl: fetch,
+        setSettings,
+        setSaveStatus,
+        setIsSaving,
+      });
     } catch (error) {
       console.error('Failed to save settings:', error);
       setSaveStatus(`✗ Error: ${error instanceof Error ? error.message : 'Network error'}`);

--- a/src/ui/viewer/hooks/useSettings.ts
+++ b/src/ui/viewer/hooks/useSettings.ts
@@ -10,6 +10,7 @@ export interface SubmitSettingsDependencies {
   setSettings: (settings: Settings) => void;
   setSaveStatus: (status: string) => void;
   setIsSaving: (isSaving: boolean) => void;
+  setStatusTimeout?: (callback: () => void, delay: number) => void;
 }
 
 export async function submitSettings(
@@ -33,10 +34,30 @@ export async function submitSettings(
   if (result.success) {
     deps.setSettings(newSettings);
     deps.setSaveStatus('✓ Saved');
-    setTimeout(() => deps.setSaveStatus(''), TIMING.SAVE_STATUS_DISPLAY_DURATION_MS);
+    (deps.setStatusTimeout ?? setTimeout)(
+      () => deps.setSaveStatus(''),
+      TIMING.SAVE_STATUS_DISPLAY_DURATION_MS,
+    );
   } else {
     deps.setSaveStatus(`✗ Error: ${result.error}`);
   }
+}
+
+export async function saveSettings(
+  newSettings: Settings,
+  deps: SubmitSettingsDependencies,
+): Promise<void> {
+  deps.setIsSaving(true);
+  deps.setSaveStatus('Saving...');
+
+  try {
+    await submitSettings(newSettings, deps);
+  } catch (error) {
+    console.error('Failed to save settings:', error);
+    deps.setSaveStatus(`✗ Error: ${error instanceof Error ? error.message : 'Network error'}`);
+  }
+
+  deps.setIsSaving(false);
 }
 
 export function useSettings() {
@@ -60,24 +81,15 @@ export function useSettings() {
       });
   }, []);
 
-  const saveSettings = async (newSettings: Settings) => {
-    setIsSaving(true);
-    setSaveStatus('Saving...');
-
-    try {
-      await submitSettings(newSettings, {
-        fetchImpl: fetch,
-        setSettings,
-        setSaveStatus,
-        setIsSaving,
-      });
-    } catch (error) {
-      console.error('Failed to save settings:', error);
-      setSaveStatus(`✗ Error: ${error instanceof Error ? error.message : 'Network error'}`);
-    }
-
-    setIsSaving(false);
+  return {
+    settings,
+    saveSettings: (newSettings: Settings) => saveSettings(newSettings, {
+      fetchImpl: fetch,
+      setSettings,
+      setSaveStatus,
+      setIsSaving,
+    }),
+    isSaving,
+    saveStatus,
   };
-
-  return { settings, saveSettings, isSaving, saveStatus };
 }

--- a/src/ui/viewer/hooks/useSettings.ts
+++ b/src/ui/viewer/hooks/useSettings.ts
@@ -84,7 +84,7 @@ export function useSettings() {
   return {
     settings,
     saveSettings: (newSettings: Settings) => saveSettings(newSettings, {
-      fetchImpl: fetch,
+      fetchImpl: fetch.bind(globalThis) as typeof fetch,
       setSettings,
       setSaveStatus,
       setIsSaving,

--- a/src/ui/viewer/utils/save-error.ts
+++ b/src/ui/viewer/utils/save-error.ts
@@ -156,11 +156,13 @@ export async function describeSaveFailure(response: SaveErrorResponse): Promise<
   let normalized = normalize(message);
 
   if (normalized.length === 0) {
-    if (response.statusText.length > 0) {
+    if (response.status === 401) {
+      normalized = 'Unauthorized';
+    } else if (response.statusText.length > 0) {
       normalized = normalize(response.statusText);
     }
     if (normalized.length === 0) {
-      normalized = response.status === 401 ? 'Unauthorized' : `HTTP ${response.status}`;
+      normalized = `HTTP ${response.status}`;
     }
   }
 

--- a/src/ui/viewer/utils/save-error.ts
+++ b/src/ui/viewer/utils/save-error.ts
@@ -174,7 +174,7 @@ export async function describeSaveFailure(response: SaveErrorResponse): Promise<
     normalized = [...normalized].slice(0, SAVE_ERROR_MAX_CHARS - 1).join('') + '\u2026';
   }
 
-  console.error('Settings save failed:', response.status, raw);
+  console.error('Settings save failed:', response.status, normalized);
 
   return `\u2717 Error: ${normalized}`;
 }

--- a/src/ui/viewer/utils/save-error.ts
+++ b/src/ui/viewer/utils/save-error.ts
@@ -11,7 +11,17 @@ export interface SaveErrorResponse {
 
 async function readResponseText(response: SaveErrorResponse): Promise<string> {
   if (!response.body) {
-    return response.text();
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        response.text(),
+        new Promise<string>(resolve => {
+          timeoutId = setTimeout(() => resolve(''), SAVE_ERROR_BODY_READ_TIMEOUT_MS);
+        }),
+      ]);
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+    }
   }
 
   const reader = response.body.getReader();
@@ -19,33 +29,48 @@ async function readResponseText(response: SaveErrorResponse): Promise<string> {
   let bytesRead = 0;
   let raw = '';
 
-  while (bytesRead < SAVE_ERROR_MAX_BODY_BYTES) {
-    let timedOut = false;
-    const timeout = new Promise<{ done: true; value: undefined }>(resolve => {
-      setTimeout(() => {
-        timedOut = true;
-        resolve({ done: true, value: undefined });
-      }, SAVE_ERROR_BODY_READ_TIMEOUT_MS);
-    });
-    const next = await Promise.race([reader.read(), timeout]);
-    if (next.done || next.value === undefined) {
-      if (timedOut) {
-        void reader.cancel().catch(() => {});
+  try {
+    while (bytesRead < SAVE_ERROR_MAX_BODY_BYTES) {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      const next = await Promise.race([
+        reader.read(),
+        new Promise<null>(resolve => {
+          timeoutId = setTimeout(() => resolve(null), SAVE_ERROR_BODY_READ_TIMEOUT_MS);
+        }),
+      ]);
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+      if (next === null) {
+        await reader.cancel().catch(() => {});
+        break;
       }
-      break;
-    }
+      if (next.done || next.value === undefined) {
+        break;
+      }
 
-    const remaining = SAVE_ERROR_MAX_BODY_BYTES - bytesRead;
-    const chunk = next.value.subarray(0, remaining);
-    bytesRead += chunk.byteLength;
-    raw += decoder.decode(chunk, { stream: bytesRead < SAVE_ERROR_MAX_BODY_BYTES });
-    if (chunk.byteLength < next.value.byteLength) {
-      void reader.cancel().catch(() => {});
-      break;
+      const remaining = SAVE_ERROR_MAX_BODY_BYTES - bytesRead;
+      const chunk = next.value.subarray(0, remaining);
+      bytesRead += chunk.byteLength;
+      raw += decoder.decode(chunk, { stream: bytesRead < SAVE_ERROR_MAX_BODY_BYTES });
+      if (chunk.byteLength < next.value.byteLength) {
+        await reader.cancel().catch(() => {});
+        break;
+      }
     }
+  } finally {
+    reader.releaseLock();
   }
 
   return raw + decoder.decode();
+}
+
+function extractTruncatedStringField(raw: string, field: 'error' | 'message'): string | null {
+  const match = raw.match(new RegExp(`"${field}"\\s*:\\s*"((?:\\\\.|[^"\\\\])*)`, 's'));
+  if (!match) return null;
+  try {
+    return JSON.parse(`"${match[1]}"`) as string;
+  } catch {
+    return null;
+  }
 }
 
 export async function describeSaveFailure(response: SaveErrorResponse): Promise<string> {
@@ -64,6 +89,14 @@ export async function describeSaveFailure(response: SaveErrorResponse): Promise<
     }
   } catch {
     parsed = null;
+  }
+
+  if (parsed === null && raw.length >= SAVE_ERROR_MAX_BODY_BYTES) {
+    const truncatedError = extractTruncatedStringField(raw, 'error');
+    const truncatedMessage = extractTruncatedStringField(raw, 'message');
+    if (truncatedError !== null || truncatedMessage !== null) {
+      parsed = { error: truncatedError, message: truncatedMessage };
+    }
   }
 
   let message: string | null = null;

--- a/src/ui/viewer/utils/save-error.ts
+++ b/src/ui/viewer/utils/save-error.ts
@@ -63,9 +63,13 @@ async function readResponseText(response: SaveErrorResponse): Promise<string> {
 
       const remaining = SAVE_ERROR_MAX_BODY_BYTES - bytesRead;
       const chunk = next.value.subarray(0, remaining);
+      if (chunk.byteLength === 0) {
+        await cancelReader(reader);
+        break;
+      }
       bytesRead += chunk.byteLength;
       raw += decoder.decode(chunk, { stream: bytesRead < SAVE_ERROR_MAX_BODY_BYTES });
-      if (chunk.byteLength < next.value.byteLength) {
+      if (bytesRead >= SAVE_ERROR_MAX_BODY_BYTES || chunk.byteLength < next.value.byteLength) {
         await cancelReader(reader);
         break;
       }
@@ -115,8 +119,8 @@ export async function describeSaveFailure(response: SaveErrorResponse): Promise<
 
   let message: string | null = null;
   if (parsed !== null) {
-    const err = typeof parsed.error === 'string' && parsed.error.length > 0 ? parsed.error : null;
-    const msg = typeof parsed.message === 'string' && parsed.message.length > 0 ? parsed.message : null;
+    const err = typeof parsed.error === 'string' && parsed.error.trim().length > 0 ? parsed.error : null;
+    const msg = typeof parsed.message === 'string' && parsed.message.trim().length > 0 ? parsed.message : null;
     const issues = parsed.issues;
 
     if (err !== null && msg !== null && err !== msg) {

--- a/src/ui/viewer/utils/save-error.ts
+++ b/src/ui/viewer/utils/save-error.ts
@@ -1,0 +1,80 @@
+﻿export const SAVE_ERROR_MAX_CHARS = 240;
+
+export interface SaveErrorResponse {
+  status: number;
+  statusText: string;
+  text: () => Promise<string>;
+}
+
+export async function describeSaveFailure(response: SaveErrorResponse): Promise<string> {
+  let raw = '';
+  try {
+    raw = await response.text();
+  } catch {
+    raw = '';
+  }
+
+  let parsed: Record<string, unknown> | null = null;
+  try {
+    const p = JSON.parse(raw);
+    if (p !== null && typeof p === 'object' && !Array.isArray(p)) {
+      parsed = p as Record<string, unknown>;
+    }
+  } catch {
+    parsed = null;
+  }
+
+  let message: string | null = null;
+  if (parsed !== null) {
+    const err = typeof parsed.error === 'string' && parsed.error.length > 0 ? parsed.error : null;
+    const msg = typeof parsed.message === 'string' && parsed.message.length > 0 ? parsed.message : null;
+    const issues = parsed.issues;
+
+    if (err !== null && msg !== null && err !== msg) {
+      message = `${err}: ${msg}`;
+    } else if (err !== null && Array.isArray(issues)) {
+      const issueStr = (issues as Array<Record<string, unknown>>)
+        .map(i => [
+          Array.isArray(i.path) ? (i.path as unknown[]).join('.') : '',
+          typeof i.message === 'string' ? i.message : ''
+        ].filter(Boolean).join(': '))
+        .join('; ');
+      message = `${err}: ${issueStr}`;
+    } else if (err !== null) {
+      message = err;
+    } else if (msg !== null) {
+      message = msg;
+    }
+  }
+
+  if (message === null) {
+    if (response.statusText.length > 0) {
+      message = response.statusText;
+    } else if (response.status === 401) {
+      message = 'Unauthorized';
+    } else {
+      message = `HTTP ${response.status}`;
+    }
+  }
+
+  const ctrlChars = /[\s\u0000-\u001f\u007f]+/g;
+  const normalize = (s: string) => s.replace(ctrlChars, ' ').trim();
+  let normalized = normalize(message);
+
+  if (normalized.length === 0) {
+    if (response.statusText.length > 0) {
+      normalized = normalize(response.statusText);
+    }
+    if (normalized.length === 0) {
+      normalized = response.status === 401 ? 'Unauthorized' : `HTTP ${response.status}`;
+    }
+  }
+
+  if (normalized.length > SAVE_ERROR_MAX_CHARS) {
+    normalized = normalized.slice(0, SAVE_ERROR_MAX_CHARS - 1) + '\u2026';
+  }
+
+  console.error('Settings save failed:', response.status, raw);
+
+  return `\u2717 Error: ${normalized}`;
+}

--- a/src/ui/viewer/utils/save-error.ts
+++ b/src/ui/viewer/utils/save-error.ts
@@ -142,10 +142,10 @@ export async function describeSaveFailure(response: SaveErrorResponse): Promise<
   }
 
   if (message === null) {
-    if (response.statusText.length > 0) {
-      message = response.statusText;
-    } else if (response.status === 401) {
+    if (response.status === 401) {
       message = 'Unauthorized';
+    } else if (response.statusText.length > 0) {
+      message = response.statusText;
     } else {
       message = `HTTP ${response.status}`;
     }

--- a/src/ui/viewer/utils/save-error.ts
+++ b/src/ui/viewer/utils/save-error.ts
@@ -1,4 +1,4 @@
-﻿export const SAVE_ERROR_MAX_CHARS = 240;
+export const SAVE_ERROR_MAX_CHARS = 240;
 
 export interface SaveErrorResponse {
   status: number;
@@ -57,7 +57,7 @@ export async function describeSaveFailure(response: SaveErrorResponse): Promise<
     }
   }
 
-  const ctrlChars = /[\s\u0000-\u001f\u007f]+/g;
+  const ctrlChars = /[\s\u0000-\u001f\u007f\u2713\u2717]+/g;
   const normalize = (s: string) => s.replace(ctrlChars, ' ').trim();
   let normalized = normalize(message);
 
@@ -70,8 +70,8 @@ export async function describeSaveFailure(response: SaveErrorResponse): Promise<
     }
   }
 
-  if (normalized.length > SAVE_ERROR_MAX_CHARS) {
-    normalized = normalized.slice(0, SAVE_ERROR_MAX_CHARS - 1) + '\u2026';
+  if ([...normalized].length > SAVE_ERROR_MAX_CHARS) {
+    normalized = [...normalized].slice(0, SAVE_ERROR_MAX_CHARS - 1).join('') + '\u2026';
   }
 
   console.error('Settings save failed:', response.status, raw);

--- a/src/ui/viewer/utils/save-error.ts
+++ b/src/ui/viewer/utils/save-error.ts
@@ -9,6 +9,20 @@ export interface SaveErrorResponse {
   body?: ReadableStream<Uint8Array> | null;
 }
 
+async function cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      reader.cancel().catch(() => {}),
+      new Promise<void>(resolve => {
+        timeoutId = setTimeout(resolve, SAVE_ERROR_BODY_READ_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
+}
+
 async function readResponseText(response: SaveErrorResponse): Promise<string> {
   if (!response.body) {
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -40,7 +54,7 @@ async function readResponseText(response: SaveErrorResponse): Promise<string> {
       ]);
       if (timeoutId !== undefined) clearTimeout(timeoutId);
       if (next === null) {
-        await reader.cancel().catch(() => {});
+        await cancelReader(reader);
         break;
       }
       if (next.done || next.value === undefined) {
@@ -52,12 +66,12 @@ async function readResponseText(response: SaveErrorResponse): Promise<string> {
       bytesRead += chunk.byteLength;
       raw += decoder.decode(chunk, { stream: bytesRead < SAVE_ERROR_MAX_BODY_BYTES });
       if (chunk.byteLength < next.value.byteLength) {
-        await reader.cancel().catch(() => {});
+        await cancelReader(reader);
         break;
       }
     }
   } finally {
-    reader.releaseLock();
+    try { reader.releaseLock(); } catch {}
   }
 
   return raw + decoder.decode();
@@ -91,7 +105,7 @@ export async function describeSaveFailure(response: SaveErrorResponse): Promise<
     parsed = null;
   }
 
-  if (parsed === null && raw.length >= SAVE_ERROR_MAX_BODY_BYTES) {
+  if (parsed === null && new TextEncoder().encode(raw).byteLength >= SAVE_ERROR_MAX_BODY_BYTES) {
     const truncatedError = extractTruncatedStringField(raw, 'error');
     const truncatedMessage = extractTruncatedStringField(raw, 'message');
     if (truncatedError !== null || truncatedMessage !== null) {

--- a/src/ui/viewer/utils/save-error.ts
+++ b/src/ui/viewer/utils/save-error.ts
@@ -1,15 +1,57 @@
 export const SAVE_ERROR_MAX_CHARS = 240;
+const SAVE_ERROR_MAX_BODY_BYTES = 64 * 1024;
+const SAVE_ERROR_BODY_READ_TIMEOUT_MS = 1000;
 
 export interface SaveErrorResponse {
   status: number;
   statusText: string;
   text: () => Promise<string>;
+  body?: ReadableStream<Uint8Array> | null;
+}
+
+async function readResponseText(response: SaveErrorResponse): Promise<string> {
+  if (!response.body) {
+    return response.text();
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let bytesRead = 0;
+  let raw = '';
+
+  while (bytesRead < SAVE_ERROR_MAX_BODY_BYTES) {
+    let timedOut = false;
+    const timeout = new Promise<{ done: true; value: undefined }>(resolve => {
+      setTimeout(() => {
+        timedOut = true;
+        resolve({ done: true, value: undefined });
+      }, SAVE_ERROR_BODY_READ_TIMEOUT_MS);
+    });
+    const next = await Promise.race([reader.read(), timeout]);
+    if (next.done || next.value === undefined) {
+      if (timedOut) {
+        void reader.cancel().catch(() => {});
+      }
+      break;
+    }
+
+    const remaining = SAVE_ERROR_MAX_BODY_BYTES - bytesRead;
+    const chunk = next.value.subarray(0, remaining);
+    bytesRead += chunk.byteLength;
+    raw += decoder.decode(chunk, { stream: bytesRead < SAVE_ERROR_MAX_BODY_BYTES });
+    if (chunk.byteLength < next.value.byteLength) {
+      void reader.cancel().catch(() => {});
+      break;
+    }
+  }
+
+  return raw + decoder.decode();
 }
 
 export async function describeSaveFailure(response: SaveErrorResponse): Promise<string> {
   let raw = '';
   try {
-    raw = await response.text();
+    raw = await readResponseText(response);
   } catch {
     raw = '';
   }
@@ -33,13 +75,18 @@ export async function describeSaveFailure(response: SaveErrorResponse): Promise<
     if (err !== null && msg !== null && err !== msg) {
       message = `${err}: ${msg}`;
     } else if (err !== null && Array.isArray(issues)) {
-      const issueStr = (issues as Array<Record<string, unknown>>)
-        .map(i => [
-          Array.isArray(i.path) ? (i.path as unknown[]).join('.') : '',
-          typeof i.message === 'string' ? i.message : ''
-        ].filter(Boolean).join(': '))
+      const issueStr = (issues as unknown[])
+        .map(i => {
+          if (i === null || typeof i !== 'object' || Array.isArray(i)) return '';
+          const issue = i as Record<string, unknown>;
+          return [
+            Array.isArray(issue.path) ? (issue.path as unknown[]).join('.') : '',
+            typeof issue.message === 'string' ? issue.message : ''
+          ].filter(Boolean).join(': ');
+        })
+        .filter(Boolean)
         .join('; ');
-      message = `${err}: ${issueStr}`;
+      message = issueStr.length > 0 ? `${err}: ${issueStr}` : err;
     } else if (err !== null) {
       message = err;
     } else if (msg !== null) {

--- a/src/ui/viewer/utils/save-error.ts
+++ b/src/ui/viewer/utils/save-error.ts
@@ -57,7 +57,7 @@ export async function describeSaveFailure(response: SaveErrorResponse): Promise<
     }
   }
 
-  const ctrlChars = /[\s\u0000-\u001f\u007f\u2713\u2717]+/g;
+  const ctrlChars = /[\s\u0000-\u001f\u007f]+/g;
   const normalize = (s: string) => s.replace(ctrlChars, ' ').trim();
   let normalized = normalize(message);
 

--- a/tests/fixtures/settings-save-error-repro.json
+++ b/tests/fixtures/settings-save-error-repro.json
@@ -1,0 +1,1 @@
+﻿{"success":false,"error":"CLAUDE_MEM_GEMINI_MODEL must be one of: gemini-flash-latest, gemini-flash-lite-latest, gemini-3.5-flash, gemini-3.1-flash-lite, gemini-3-flash-preview"}

--- a/tests/fixtures/settings-save-error-repro.json
+++ b/tests/fixtures/settings-save-error-repro.json
@@ -1,1 +1,1 @@
-﻿{"success":false,"error":"CLAUDE_MEM_GEMINI_MODEL must be one of: gemini-flash-latest, gemini-flash-lite-latest, gemini-3.5-flash, gemini-3.1-flash-lite, gemini-3-flash-preview"}
+{"success":false,"error":"CLAUDE_MEM_GEMINI_MODEL must be one of: gemini-flash-latest, gemini-flash-lite-latest, gemini-3.5-flash, gemini-3.1-flash-lite, gemini-3-flash-preview"}

--- a/tests/viewer/settings-save-error.test.ts
+++ b/tests/viewer/settings-save-error.test.ts
@@ -1,0 +1,141 @@
+﻿import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describeSaveFailure, SAVE_ERROR_MAX_CHARS } from '../../src/ui/viewer/utils/save-error';
+
+const REPRO_PATH = join(import.meta.dir, '../fixtures/settings-save-error-repro.json');
+const reproRaw = readFileSync(REPRO_PATH, 'utf-8').trim();
+
+describe('describeSaveFailure', () => {
+  describe('base-fails/head-passes: captured 400 validator body from the issue fixture', () => {
+    it('returns the server error message from the fixture', async () => {
+      const response = new Response(reproRaw, {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: { 'Content-Type': 'application/json' }
+      });
+      const result = await describeSaveFailure(response);
+      expect(result).toBe(
+        '\u2717 Error: CLAUDE_MEM_GEMINI_MODEL must be one of: gemini-flash-latest, gemini-flash-lite-latest, gemini-3.5-flash, gemini-3.1-flash-lite, gemini-3-flash-preview'
+      );
+    });
+
+    it('base formula from useSettings.ts:36 yields generic status, not the server message', () => {
+      const res = { status: 400, statusText: 'Bad Request' };
+      const baseStatus = `\u2717 Error: ${res.status === 401 ? 'Unauthorized' : res.statusText}`;
+      expect(baseStatus).toBe('\u2717 Error: Bad Request');
+      expect(baseStatus).not.toContain('CLAUDE_MEM_GEMINI_MODEL');
+    });
+  });
+
+  it('401 with body "not json" returns exactly \u2717 Error: Unauthorized (invariant 3)', async () => {
+    const response = new Response('not json', {
+      status: 401,
+      statusText: 'Unauthorized'
+    });
+    const result = await describeSaveFailure(response);
+    expect(result).toBe('\u2717 Error: Unauthorized');
+  });
+
+  it('401 with {error:"Unauthorized",message:"Missing API key (...)"} includes both parts', async () => {
+    const body = JSON.stringify({
+      error: 'Unauthorized',
+      message: 'Missing API key (Authorization: Bearer <key> or X-Api-Key: <key>)'
+    });
+    const response = new Response(body, {
+      status: 401,
+      statusText: 'Unauthorized',
+      headers: { 'Content-Type': 'application/json' }
+    });
+    const result = await describeSaveFailure(response);
+    expect(result).toBe(
+      '\u2717 Error: Unauthorized: Missing API key (Authorization: Bearer <key> or X-Api-Key: <key>)'
+    );
+  });
+
+  it('400 {error:"CLAUDE_MEM_WORKER_PORT must be between 1024 and 65535"} surfaces error (invariants 1-2)', async () => {
+    const body = JSON.stringify({ error: 'CLAUDE_MEM_WORKER_PORT must be between 1024 and 65535' });
+    const response = new Response(body, {
+      status: 400,
+      statusText: 'Bad Request',
+      headers: { 'Content-Type': 'application/json' }
+    });
+    const result = await describeSaveFailure(response);
+    expect(result).toBe('\u2717 Error: CLAUDE_MEM_WORKER_PORT must be between 1024 and 65535');
+  });
+
+  it('400 {error:"ValidationError",issues:[...]} formats path and message', async () => {
+    const body = JSON.stringify({
+      error: 'ValidationError',
+      issues: [{ path: ['enabled'], message: 'Required', code: 'invalid_type' }]
+    });
+    const response = new Response(body, {
+      status: 400,
+      statusText: 'Bad Request',
+      headers: { 'Content-Type': 'application/json' }
+    });
+    const result = await describeSaveFailure(response);
+    expect(result).toBe('\u2717 Error: ValidationError: enabled: Required');
+  });
+
+  it('502 HTML body falls back to statusText (invariants 1-2)', async () => {
+    const response = new Response('<html><body>Bad Gateway</body></html>', {
+      status: 502,
+      statusText: 'Bad Gateway'
+    });
+    const result = await describeSaveFailure(response);
+    expect(result).toBe('\u2717 Error: Bad Gateway');
+  });
+
+  it('502 empty body with empty statusText falls back to HTTP 502 (invariants 1-2)', async () => {
+    const response = new Response('', {
+      status: 502,
+      statusText: ''
+    });
+    const result = await describeSaveFailure(response);
+    expect(result).toBe('\u2717 Error: HTTP 502');
+  });
+
+  it('response whose text() rejects still resolves without throwing (invariant 6)', async () => {
+    const fakeResponse = {
+      status: 503,
+      statusText: 'Service Unavailable',
+      text: () => Promise.reject(new Error('body stream error'))
+    };
+    const result = await describeSaveFailure(fakeResponse);
+    expect(result).toStartWith('\u2717 Error: ');
+    expect(result).toBe('\u2717 Error: Service Unavailable');
+  });
+
+  it('600-char body with \\n and \\u0007 is clamped to SAVE_ERROR_MAX_CHARS and ends with \u2026', async () => {
+    const long = 'A'.repeat(100) + '\n' + '\u0007' + 'B'.repeat(500);
+    const body = JSON.stringify({ error: long });
+    const response = new Response(body, {
+      status: 400,
+      statusText: 'Bad Request',
+      headers: { 'Content-Type': 'application/json' }
+    });
+    const result = await describeSaveFailure(response);
+    expect(SAVE_ERROR_MAX_CHARS).toBe(240);
+    const msgPart = result.slice('\u2717 Error: '.length);
+    expect(msgPart).not.toMatch(/[\u0000-\u001f\u007f]/);
+    expect(msgPart.length).toBe(SAVE_ERROR_MAX_CHARS);
+    expect(msgPart.endsWith('\u2026')).toBe(true);
+  });
+
+  it('200 response.ok is true so !response.ok guard does not fire (invariant 5 witness)', () => {
+    const response = new Response(JSON.stringify({ success: false, error: 'boom' }), {
+      status: 200,
+      statusText: 'OK',
+      headers: { 'Content-Type': 'application/json' }
+    });
+    expect(response.ok).toBe(true);
+  });
+});
+
+describe('tests/viewer/ regression baseline', () => {
+  it('describeSaveFailure module loads without errors', () => {
+    expect(typeof describeSaveFailure).toBe('function');
+    expect(SAVE_ERROR_MAX_CHARS).toBe(240);
+  });
+});

--- a/tests/viewer/settings-save-error.test.ts
+++ b/tests/viewer/settings-save-error.test.ts
@@ -1,4 +1,4 @@
-﻿import { describe, it, expect } from 'bun:test';
+import { describe, it, expect } from 'bun:test';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { describeSaveFailure, SAVE_ERROR_MAX_CHARS } from '../../src/ui/viewer/utils/save-error';
@@ -20,11 +20,13 @@ describe('describeSaveFailure', () => {
       );
     });
 
-    it('base formula from useSettings.ts:36 yields generic status, not the server message', () => {
-      const res = { status: 400, statusText: 'Bad Request' };
-      const baseStatus = `\u2717 Error: ${res.status === 401 ? 'Unauthorized' : res.statusText}`;
-      expect(baseStatus).toBe('\u2717 Error: Bad Request');
-      expect(baseStatus).not.toContain('CLAUDE_MEM_GEMINI_MODEL');
+    it('head wires useSettings.ts to describeSaveFailure (regression guard)', () => {
+      const source = readFileSync(
+        join(import.meta.dir, '../../src/ui/viewer/hooks/useSettings.ts'),
+        'utf-8'
+      );
+      expect(source).not.toContain("response.status === 401 ? 'Unauthorized' : response.statusText");
+      expect(source).toContain('describeSaveFailure');
     });
   });
 
@@ -107,7 +109,7 @@ describe('describeSaveFailure', () => {
     expect(result).toBe('\u2717 Error: Service Unavailable');
   });
 
-  it('600-char body with \\n and \\u0007 is clamped to SAVE_ERROR_MAX_CHARS and ends with \u2026', async () => {
+  it('600-char body with \\n and \\u0007 is clamped to SAVE_ERROR_MAX_CHARS code points and ends with \u2026', async () => {
     const long = 'A'.repeat(100) + '\n' + '\u0007' + 'B'.repeat(500);
     const body = JSON.stringify({ error: long });
     const response = new Response(body, {
@@ -119,17 +121,128 @@ describe('describeSaveFailure', () => {
     expect(SAVE_ERROR_MAX_CHARS).toBe(240);
     const msgPart = result.slice('\u2717 Error: '.length);
     expect(msgPart).not.toMatch(/[\u0000-\u001f\u007f]/);
-    expect(msgPart.length).toBe(SAVE_ERROR_MAX_CHARS);
+    expect([...msgPart].length).toBe(SAVE_ERROR_MAX_CHARS);
     expect(msgPart.endsWith('\u2026')).toBe(true);
   });
 
-  it('200 response.ok is true so !response.ok guard does not fire (invariant 5 witness)', () => {
-    const response = new Response(JSON.stringify({ success: false, error: 'boom' }), {
+  it('structural proof: 200 response.ok guard prevents describeSaveFailure (invariant 5)', async () => {
+    const response200 = new Response(JSON.stringify({ success: false, error: 'boom' }), {
       status: 200,
       statusText: 'OK',
       headers: { 'Content-Type': 'application/json' }
     });
-    expect(response.ok).toBe(true);
+    expect(response200.ok).toBe(true);
+    const wouldBeWrong = await describeSaveFailure({
+      status: 200,
+      statusText: 'OK',
+      text: async () => JSON.stringify({ success: true })
+    });
+    expect(wouldBeWrong).toStartWith('\u2717 Error:');
+  });
+
+  it('{message:"rate limit exceeded"} uses message field when error is absent', async () => {
+    const body = JSON.stringify({ message: 'rate limit exceeded' });
+    const response = new Response(body, {
+      status: 429,
+      statusText: 'Too Many Requests',
+      headers: { 'Content-Type': 'application/json' }
+    });
+    const result = await describeSaveFailure(response);
+    expect(result).toBe('\u2717 Error: rate limit exceeded');
+  });
+
+  it('{error:"Duplicate key",message:"Duplicate key"} uses error field when err === msg', async () => {
+    const body = JSON.stringify({ error: 'Duplicate key', message: 'Duplicate key' });
+    const response = new Response(body, {
+      status: 409,
+      statusText: 'Conflict',
+      headers: { 'Content-Type': 'application/json' }
+    });
+    const result = await describeSaveFailure(response);
+    expect(result).toBe('\u2717 Error: Duplicate key');
+  });
+
+  it('{success:false,foo:1} (JSON object with no error/message) falls back to statusText', async () => {
+    const body = JSON.stringify({ success: false, foo: 1 });
+    const response = new Response(body, {
+      status: 400,
+      statusText: 'Bad Request',
+      headers: { 'Content-Type': 'application/json' }
+    });
+    const result = await describeSaveFailure(response);
+    expect(result).toBe('\u2717 Error: Bad Request');
+  });
+
+  it('[{error:"nope"}] (array body) is not a plain object and falls back to statusText', async () => {
+    const body = JSON.stringify([{ error: 'nope' }]);
+    const response = new Response(body, {
+      status: 400,
+      statusText: 'Bad Request',
+      headers: { 'Content-Type': 'application/json' }
+    });
+    const result = await describeSaveFailure(response);
+    expect(result).toBe('\u2717 Error: Bad Request');
+  });
+
+  it('{error:"\\n\\t  "} (whitespace-only error) enters recovery block and uses statusText', async () => {
+    const body = JSON.stringify({ error: '\n\t  ' });
+    const response = new Response(body, {
+      status: 400,
+      statusText: 'Bad Request',
+      headers: { 'Content-Type': 'application/json' }
+    });
+    const result = await describeSaveFailure(response);
+    expect(result).toBe('\u2717 Error: Bad Request');
+  });
+
+  it('{error:"\\u0007"} at 401 with empty statusText uses Unauthorized from recovery', async () => {
+    const body = JSON.stringify({ error: '\u0007' });
+    const response = new Response(body, {
+      status: 401,
+      statusText: '',
+      headers: { 'Content-Type': 'application/json' }
+    });
+    const result = await describeSaveFailure(response);
+    expect(result).toBe('\u2717 Error: Unauthorized');
+  });
+
+  it('{issues:[...]} without error field falls back to statusText', async () => {
+    const body = JSON.stringify({ issues: [{ path: ['x'], message: 'invalid' }] });
+    const response = new Response(body, {
+      status: 400,
+      statusText: 'Bad Request',
+      headers: { 'Content-Type': 'application/json' }
+    });
+    const result = await describeSaveFailure(response);
+    expect(result).toBe('\u2717 Error: Bad Request');
+  });
+
+  it('{error:"value \u2713 rejected"} strips \u2713 from server message to prevent styling conflict', async () => {
+    const body = JSON.stringify({ error: 'value \u2713 rejected' });
+    const response = new Response(body, {
+      status: 400,
+      statusText: 'Bad Request',
+      headers: { 'Content-Type': 'application/json' }
+    });
+    const result = await describeSaveFailure(response);
+    expect(result).toBe('\u2717 Error: value rejected');
+  });
+
+  it('clamps on code points not code units: surrogate pair at boundary is not split', async () => {
+    const astral = '\u{1F4A9}';
+    const body = JSON.stringify({ error: 'A'.repeat(238) + astral + 'B'.repeat(10) });
+    const response = new Response(body, {
+      status: 400,
+      statusText: 'Bad Request',
+      headers: { 'Content-Type': 'application/json' }
+    });
+    const result = await describeSaveFailure(response);
+    const msgPart = result.slice('\u2717 Error: '.length);
+    expect([...msgPart].length).toBe(SAVE_ERROR_MAX_CHARS);
+    expect(msgPart.endsWith('\u2026')).toBe(true);
+    const encoded = new TextEncoder().encode(msgPart);
+    const decoded = new TextDecoder().decode(encoded);
+    expect(decoded).toBe(msgPart);
   });
 });
 

--- a/tests/viewer/settings-save-error.test.ts
+++ b/tests/viewer/settings-save-error.test.ts
@@ -50,6 +50,16 @@ describe('describeSaveFailure', () => {
     expect(result).toBe('\u2717 Error: Unauthorized');
   });
 
+  it('401 with a blank body and custom statusText still uses the stable Unauthorized fallback', async () => {
+    const response = new Response(JSON.stringify({ error: '   ' }), {
+      status: 401,
+      statusText: 'Proxy Unauthorized',
+      headers: { 'Content-Type': 'application/json' }
+    });
+    const result = await describeSaveFailure(response);
+    expect(result).toBe('\u2717 Error: Unauthorized');
+  });
+
   it('401 with {error:"Unauthorized",message:"Missing API key (...)"} includes both parts', async () => {
     const body = JSON.stringify({
       error: 'Unauthorized',

--- a/tests/viewer/settings-save-error.test.ts
+++ b/tests/viewer/settings-save-error.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'bun:test';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { saveStatusClass } from '../../src/ui/viewer/components/ContextSettingsModal';
-import { submitSettings } from '../../src/ui/viewer/hooks/useSettings';
+import { saveSettings, submitSettings } from '../../src/ui/viewer/hooks/useSettings';
 import { describeSaveFailure, SAVE_ERROR_MAX_CHARS } from '../../src/ui/viewer/utils/save-error';
 
 const REPRO_PATH = join(import.meta.dir, '../fixtures/settings-save-error-repro.json');
@@ -208,14 +208,34 @@ describe('describeSaveFailure', () => {
     const statuses: string[] = [];
     let saved = false;
     const deps = {
-      fetchImpl: async () => new Response(JSON.stringify({ success: false, error: 'boom' }), { status: 200 }),
+      fetchImpl: async () => new Response(JSON.stringify({ success: true }), { status: 200 }),
       setSettings: () => { saved = true; },
       setSaveStatus: (status: string) => statuses.push(status),
       setIsSaving: () => {},
+      setStatusTimeout: (callback: () => void) => callback(),
     };
     await submitSettings({} as never, deps);
-    expect(statuses).toEqual(['\u2717 Error: boom']);
-    expect(saved).toBe(false);
+    expect(statuses).toEqual(['\u2713 Saved', '']);
+    expect(saved).toBe(true);
+
+    await submitSettings({} as never, {
+      ...deps,
+      fetchImpl: async () => new Response(JSON.stringify({ success: false, error: 'boom' }), { status: 200 }),
+    });
+    expect(statuses).toEqual(['\u2713 Saved', '', '\u2717 Error: boom']);
+  });
+
+  it('keeps a rejected production fetch inside the outer saveSettings catch', async () => {
+    const statuses: string[] = [];
+    let saving = false;
+    await saveSettings({} as never, {
+      fetchImpl: async () => { throw new Error('network down'); },
+      setSettings: () => {},
+      setSaveStatus: status => statuses.push(status),
+      setIsSaving: value => { saving = value; },
+    });
+    expect(statuses).toEqual(['Saving...', '✗ Error: network down']);
+    expect(saving).toBe(false);
   });
 
   it('{message:"rate limit exceeded"} uses message field when error is absent', async () => {

--- a/tests/viewer/settings-save-error.test.ts
+++ b/tests/viewer/settings-save-error.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'bun:test';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { saveStatusClass } from '../../src/ui/viewer/components/ContextSettingsModal';
+import { submitSettings } from '../../src/ui/viewer/hooks/useSettings';
 import { describeSaveFailure, SAVE_ERROR_MAX_CHARS } from '../../src/ui/viewer/utils/save-error';
 
 const REPRO_PATH = join(import.meta.dir, '../fixtures/settings-save-error-repro.json');
@@ -186,6 +187,35 @@ describe('describeSaveFailure', () => {
       text: async () => JSON.stringify({ success: true })
     });
     expect(wouldBeWrong).toStartWith('\u2717 Error:');
+  });
+
+  it('runs the production submitSettings failure branch with a mocked fetch', async () => {
+    const statuses: string[] = [];
+    let saving = true;
+    await submitSettings({} as never, {
+      fetchImpl: async () => new Response(reproRaw, { status: 400, statusText: 'Bad Request' }),
+      setSettings: () => {},
+      setSaveStatus: status => statuses.push(status),
+      setIsSaving: value => { saving = value; },
+    });
+    expect(statuses).toEqual([
+      '\u2717 Error: CLAUDE_MEM_GEMINI_MODEL must be one of: gemini-flash-latest, gemini-flash-lite-latest, gemini-3.5-flash, gemini-3.1-flash-lite, gemini-3-flash-preview',
+    ]);
+    expect(saving).toBe(false);
+  });
+
+  it('keeps the production success and 2xx-error branches separate from the extractor', async () => {
+    const statuses: string[] = [];
+    let saved = false;
+    const deps = {
+      fetchImpl: async () => new Response(JSON.stringify({ success: false, error: 'boom' }), { status: 200 }),
+      setSettings: () => { saved = true; },
+      setSaveStatus: (status: string) => statuses.push(status),
+      setIsSaving: () => {},
+    };
+    await submitSettings({} as never, deps);
+    expect(statuses).toEqual(['\u2717 Error: boom']);
+    expect(saved).toBe(false);
   });
 
   it('{message:"rate limit exceeded"} uses message field when error is absent', async () => {

--- a/tests/viewer/settings-save-error.test.ts
+++ b/tests/viewer/settings-save-error.test.ts
@@ -217,7 +217,7 @@ describe('describeSaveFailure', () => {
     expect(result).toBe('\u2717 Error: Bad Request');
   });
 
-  it('{error:"value \u2713 rejected"} strips \u2713 from server message to prevent styling conflict', async () => {
+  it('{error:"value \u2713 rejected"} preserves \u2713 in output; styling fix is at ContextSettingsModal:488', async () => {
     const body = JSON.stringify({ error: 'value \u2713 rejected' });
     const response = new Response(body, {
       status: 400,
@@ -225,7 +225,7 @@ describe('describeSaveFailure', () => {
       headers: { 'Content-Type': 'application/json' }
     });
     const result = await describeSaveFailure(response);
-    expect(result).toBe('\u2717 Error: value rejected');
+    expect(result).toBe('\u2717 Error: value \u2713 rejected');
   });
 
   it('clamps on code points not code units: surrogate pair at boundary is not split', async () => {

--- a/tests/viewer/settings-save-error.test.ts
+++ b/tests/viewer/settings-save-error.test.ts
@@ -16,6 +16,10 @@ describe('describeSaveFailure', () => {
         statusText: 'Bad Request',
         headers: { 'Content-Type': 'application/json' }
       });
+      const baseMessage = response.status === 401 ? 'Unauthorized' : response.statusText;
+      expect(baseMessage).toBe('Bad Request');
+      expect(reproRaw).toContain('CLAUDE_MEM_GEMINI_MODEL');
+      expect(baseMessage).not.toContain('CLAUDE_MEM_GEMINI_MODEL');
       const result = await describeSaveFailure(response);
       expect(result).toBe(
         '\u2717 Error: CLAUDE_MEM_GEMINI_MODEL must be one of: gemini-flash-latest, gemini-flash-lite-latest, gemini-3.5-flash, gemini-3.1-flash-lite, gemini-3-flash-preview'
@@ -146,6 +150,44 @@ describe('describeSaveFailure', () => {
 
     expect(result).toBe('\u2717 Error: partial body');
     expect(Date.now() - startedAt).toBeLessThan(2000);
+  });
+
+  it('cancels a response stream that reaches the exact byte cap', async () => {
+    let cancelled = false;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(64 * 1024));
+      },
+      cancel() {
+        cancelled = true;
+      }
+    });
+    await expect(describeSaveFailure({
+      status: 502,
+      statusText: 'Bad Gateway',
+      body: stream,
+      text: async () => 'unreachable'
+    })).resolves.toBe('\u2717 Error: Bad Gateway');
+    expect(cancelled).toBe(true);
+  });
+
+  it('cancels a response stream that yields an empty chunk forever', async () => {
+    let cancelled = false;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(new Uint8Array());
+      },
+      cancel() {
+        cancelled = true;
+      }
+    });
+    await expect(describeSaveFailure({
+      status: 502,
+      statusText: 'Bad Gateway',
+      body: stream,
+      text: async () => 'unreachable'
+    })).resolves.toBe('\u2717 Error: Bad Gateway');
+    expect(cancelled).toBe(true);
   });
 
   it('malformed validation issues cannot reject the failure formatter', async () => {
@@ -301,8 +343,8 @@ describe('describeSaveFailure', () => {
     expect(result).toBe('\u2717 Error: Bad Request');
   });
 
-  it('{error:"\\n\\t  "} (whitespace-only error) enters recovery block and uses statusText', async () => {
-    const body = JSON.stringify({ error: '\n\t  ' });
+  it('{error,message: whitespace-only} enters recovery block and uses statusText', async () => {
+    const body = JSON.stringify({ error: '\n\t  ', message: ' \t ' });
     const response = new Response(body, {
       status: 400,
       statusText: 'Bad Request',

--- a/tests/viewer/settings-save-error.test.ts
+++ b/tests/viewer/settings-save-error.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect, spyOn } from 'bun:test';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { saveStatusClass } from '../../src/ui/viewer/components/ContextSettingsModal';
@@ -233,6 +233,27 @@ describe('describeSaveFailure', () => {
     expect(msgPart).not.toMatch(/[\u0000-\u001f\u007f]/);
     expect([...msgPart].length).toBe(SAVE_ERROR_MAX_CHARS);
     expect(msgPart.endsWith('\u2026')).toBe(true);
+  });
+
+  it('logs only the bounded diagnostic instead of the raw response body', async () => {
+    const consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const rawSecret = 'internal-secret-' + 'x'.repeat(70000);
+      const result = await describeSaveFailure(new Response(JSON.stringify({ error: 'short diagnostic', details: rawSecret }), {
+        status: 400,
+        statusText: 'Bad Request',
+        headers: { 'Content-Type': 'application/json' },
+      }));
+
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      const logged = consoleErrorSpy.mock.calls[0] as unknown[];
+      expect(logged[1]).toBe(400);
+      expect(logged[2]).toBe('short diagnostic');
+      expect(logged.join(' ')).not.toContain('internal-secret-');
+      expect(result).toContain('\u2717 Error:');
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   it('structural proof: 200 response.ok guard prevents describeSaveFailure (invariant 5)', async () => {

--- a/tests/viewer/settings-save-error.test.ts
+++ b/tests/viewer/settings-save-error.test.ts
@@ -41,6 +41,15 @@ describe('describeSaveFailure', () => {
     expect(result).toBe('\u2717 Error: Unauthorized');
   });
 
+  it('401 with a custom statusText still uses the stable Unauthorized fallback', async () => {
+    const response = new Response('not json', {
+      status: 401,
+      statusText: 'Proxy Unauthorized'
+    });
+    const result = await describeSaveFailure(response);
+    expect(result).toBe('\u2717 Error: Unauthorized');
+  });
+
   it('401 with {error:"Unauthorized",message:"Missing API key (...)"} includes both parts', async () => {
     const body = JSON.stringify({
       error: 'Unauthorized',

--- a/tests/viewer/settings-save-error.test.ts
+++ b/tests/viewer/settings-save-error.test.ts
@@ -136,6 +136,27 @@ describe('describeSaveFailure', () => {
     await expect(describeSaveFailure(response)).resolves.toBe('\u2717 Error: ValidationError');
   });
 
+  it('extracts and clamps an error field when the JSON body exceeds the read cap', async () => {
+    const response = new Response(JSON.stringify({ error: 'X'.repeat(70000) }), {
+      status: 400,
+      statusText: 'Bad Request',
+      headers: { 'Content-Type': 'application/json' }
+    });
+    const result = await describeSaveFailure(response);
+    const msgPart = result.slice('\u2717 Error: '.length);
+    expect([...msgPart].length).toBe(SAVE_ERROR_MAX_CHARS);
+    expect(msgPart).toBe(`${'X'.repeat(SAVE_ERROR_MAX_CHARS - 1)}\u2026`);
+  });
+
+  it('times out a response without a readable body', async () => {
+    const result = await describeSaveFailure({
+      status: 502,
+      statusText: 'Bad Gateway',
+      text: () => new Promise<string>(() => {})
+    });
+    expect(result).toBe('\u2717 Error: Bad Gateway');
+  });
+
   it('600-char body with \\n and \\u0007 is clamped to SAVE_ERROR_MAX_CHARS code points and ends with \u2026', async () => {
     const long = 'A'.repeat(100) + '\n' + '\u0007' + 'B'.repeat(500);
     const body = JSON.stringify({ error: long });

--- a/tests/viewer/settings-save-error.test.ts
+++ b/tests/viewer/settings-save-error.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'bun:test';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { saveStatusClass } from '../../src/ui/viewer/components/ContextSettingsModal';
 import { describeSaveFailure, SAVE_ERROR_MAX_CHARS } from '../../src/ui/viewer/utils/save-error';
 
 const REPRO_PATH = join(import.meta.dir, '../fixtures/settings-save-error-repro.json');
@@ -107,6 +108,32 @@ describe('describeSaveFailure', () => {
     const result = await describeSaveFailure(fakeResponse);
     expect(result).toStartWith('\u2717 Error: ');
     expect(result).toBe('\u2717 Error: Service Unavailable');
+  });
+
+  it('bounded body read returns a partial JSON body when the stream never closes', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(JSON.stringify({ error: 'partial body' })));
+      }
+    });
+    const startedAt = Date.now();
+    const result = await describeSaveFailure({
+      status: 502,
+      statusText: 'Bad Gateway',
+      body: stream,
+      text: async () => 'unreachable'
+    });
+
+    expect(result).toBe('\u2717 Error: partial body');
+    expect(Date.now() - startedAt).toBeLessThan(2000);
+  });
+
+  it('malformed validation issues cannot reject the failure formatter', async () => {
+    const response = new Response(JSON.stringify({ error: 'ValidationError', issues: [null] }), {
+      status: 400,
+      statusText: 'Bad Request'
+    });
+    await expect(describeSaveFailure(response)).resolves.toBe('\u2717 Error: ValidationError');
   });
 
   it('600-char body with \\n and \\u0007 is clamped to SAVE_ERROR_MAX_CHARS code points and ends with \u2026', async () => {
@@ -226,6 +253,11 @@ describe('describeSaveFailure', () => {
     });
     const result = await describeSaveFailure(response);
     expect(result).toBe('\u2717 Error: value \u2713 rejected');
+  });
+
+  it('error styling wins when an error message contains the success glyph', () => {
+    expect(saveStatusClass('\u2717 Error: value \u2713 rejected')).toBe('error');
+    expect(saveStatusClass('\u2713 Saved')).toBe('success');
   });
 
   it('clamps on code points not code units: surrogate pair at boundary is not split', async () => {


### PR DESCRIPTION
## Summary

`submitSettings` in `src/ui/viewer/hooks/useSettings.ts` returns on `!response.ok` using only `response.statusText`, so every failed save renders `✗ Error: Bad Request` regardless of what the server sent. The response body — which carries the actionable error sentence — is never read.

This PR adds `describeSaveFailure` in `src/ui/viewer/utils/save-error.ts`, calls it from the single `!response.ok` branch, and pins the production submitter plus the formatter with a browserless harness loaded from the reporter's captured fixture.

Refs #3457

## Why

`submitSettings` (`useSettings.ts:35-39` at `a90066f9`) awaits `fetch`, then on `!response.ok` builds its status string from `response.statusText` and returns before reading the body:

```ts
if (!response.ok) {
  setSaveStatus(`✗ Error: ${response.status === 401 ? 'Unauthorized' : response.statusText}`);
  setIsSaving(false);
  return;
}
```

`response.statusText` for an express `res.status(400)` is the generic reason phrase `Bad Request`. The body — in the reporter's case `{"success":false,"error":"CLAUDE_MEM_GEMINI_MODEL must be one of: …"}` — is never read. The same function reads the body eleven lines later and renders `result.error` for a 2xx `{success:false}` (`:41-49`), so the machinery already exists; it's simply not reached on the non-2xx path.

PR #3119 (`39dd77d9`) extracted `submitSettings` during a broad error-handling change and carried the line through unchanged.

## Scope

This PR changes the failed-save branch and the single viewer status-class resolver. Failed responses are bounded before parsing, and error styling takes precedence when server text contains the success glyph.

Not in this PR:
- `src/services/worker/http/routes/SettingsRoutes.ts` — server-side validation remains unchanged by this viewer-only change.
- Retired-model normalization at settings load — separate mechanism.
- The settings **load** path (`useSettings.ts:12-26`) — its `throw new Error(...)` behavior is untouched.
- `usePagination.ts:55`, `LogsModal.tsx:124,148` — the same statusText-only pattern exists there; widening the diff past the reported symptom is out of scope.

## Risk

The `submitSettings` behavior is extracted into a dependency-injected helper for production-path tests; its 2xx behavior and `saveSettings` outer catch remain unchanged. `ContextSettingsModal.tsx` now resolves the footer class with error precedence. `usePagination`, `useSSE`, `useContextPreview`, `LogsModal`, and other viewer fetches remain unchanged.

The new path bounds stream reads at 64 KiB with a one-second per-read timeout, extracts a bounded `error` or `message` field when the cap cuts through JSON, and falls back through a deterministic chain to `statusText`, then `HTTP ${status}`. It never rejects, never returns an empty string, and never surfaces raw body text.

`describeSaveFailure` normalizes control characters and clamps to 240 characters before returning. The value is returned as a React text child, never through `dangerouslySetInnerHTML`.

## Verification / Test plan

- [x] `bun test tests/viewer/settings-save-error.test.ts`
- [x] `bun test tests/viewer/`
- [x] `npm run typecheck`
- [x] `npm run build` succeeds; no generated bundle is in the diff
- [x] `npm run lint:hook-io && npm run lint:spawn-env`

Refs #3457
