### PR TITLE
fix(worker): prevent history amplification after auth failures

### DIFF
--- a/src/services/worker/http/routes/SessionRoutes.ts
+++ b/src/services/worker/http/routes/SessionRoutes.ts
@@ -165,6 +165,7 @@ export class SessionRoutes extends BaseRouteHandler {
     session.lastGeneratorSource = source;
 
     const myController = session.abortController;
+    const conversationHistoryCheckpoint = session.conversationHistory.length;
 
     let skipGeneratorExitFinalization = false;
     let generatorPromise: Promise<void>;
@@ -254,6 +255,7 @@ export class SessionRoutes extends BaseRouteHandler {
         await handleGeneratorExit(session, reason, {
           sessionManager: this.sessionManager,
           completionHandler: this.completionHandler,
+          conversationHistoryCheckpoint,
         });
       });
     session.generatorPromise = generatorPromise;

--- a/src/services/worker/session/GeneratorExitHandler.ts
+++ b/src/services/worker/session/GeneratorExitHandler.ts
@@ -7,15 +7,18 @@ import { getSdkProcessForSession, ensureSdkProcessExit } from '../../../supervis
 export interface GeneratorExitDependencies {
   sessionManager: SessionManager;
   completionHandler: SessionCompletionHandler;
+  conversationHistoryCheckpoint: number;
 }
 
 /**
  * Post-generator-exit handler.
  *
  * The generator's message iterator only ends on abort (idle / shutdown) or when
- * the SDK stream throws, so most exits mean this session is done. Quota exits
- * are different: claimed work has already been reset to pending, so leave the
- * session and in-RAM buffer alive for a later generator start.
+ * the SDK stream throws, so most exits mean this session is done. Quota/auth
+ * exits are different: claimed work has already been reset to pending, so
+ * leave the session and in-RAM buffer alive for a later generator start. A
+ * fresh Claude generator replays that buffer, so discard history appended by
+ * the failed attempt before it can accumulate across retries.
  *
  * For non-quota exits we do NOT respawn on remaining buffered work: the old
  * respawn-on-pending loop, driven by the durable pending_messages queue, was the
@@ -30,7 +33,7 @@ export async function handleGeneratorExit(
   reason: ActiveSession['abortReason'],
   deps: GeneratorExitDependencies
 ): Promise<void> {
-  const { sessionManager, completionHandler } = deps;
+  const { sessionManager, completionHandler, conversationHistoryCheckpoint } = deps;
   const sessionDbId = session.sessionDbId;
 
   const tracked = getSdkProcessForSession(sessionDbId);
@@ -39,13 +42,21 @@ export async function handleGeneratorExit(
   }
 
   session.generatorPromise = null;
+  const exitedProvider = session.currentProvider;
   session.currentProvider = null;
 
   const abortCategory = (reason ?? '').split(':')[0];
   if (abortCategory === 'quota' || abortCategory === 'auth') {
+    let rolledBackHistoryCount = 0;
+    if (exitedProvider === 'claude' && conversationHistoryCheckpoint < session.conversationHistory.length) {
+      rolledBackHistoryCount = session.conversationHistory.length - conversationHistoryCheckpoint;
+      session.conversationHistory.length = conversationHistoryCheckpoint;
+    }
+
     logger.warn('SESSION', `Generator paused for ${abortCategory}; preserving buffered work`, {
       sessionId: sessionDbId,
       pendingCount: sessionManager.getMessageBuffer().getPendingCount(sessionDbId),
+      rolledBackHistoryCount,
     });
     return;
   }

--- a/tests/worker/poison-respawn.test.ts
+++ b/tests/worker/poison-respawn.test.ts
@@ -280,6 +280,8 @@ describe('observer invalid-output handling (Phase 3 recovery)', () => {
     session.memorySessionId = 'mem-8';
     session.currentProvider = 'claude';
     session.generatorPromise = Promise.resolve();
+    session.conversationHistory.push({ role: 'assistant', content: 'previous successful response' });
+    const conversationHistoryCheckpoint = session.conversationHistory.length;
     await queueAndClaimOne(sm, 8);
 
     await processAgentResponse(
@@ -299,12 +301,55 @@ describe('observer invalid-output handling (Phase 3 recovery)', () => {
     await handleGeneratorExit(session, session.abortReason, {
       sessionManager: sm,
       completionHandler: { finalizeSession } as any,
+      conversationHistoryCheckpoint,
     });
 
     expect(finalizeSession).not.toHaveBeenCalled();
     expect(removeSpy).not.toHaveBeenCalled();
     expect(sm.getSession(8)).toBe(session);
     expect(sm.getMessageBuffer().getPendingCount(8)).toBe(1);
+    expect(session.conversationHistory).toEqual([
+      { role: 'assistant', content: 'previous successful response' },
+    ]);
+  });
+
+  it('auth retries do not accumulate replayed Claude history', async () => {
+    const sm = new SessionManager(makeDbManager());
+    const session = sm.initializeSession(12, 'do the thing', 1);
+    session.memorySessionId = 'mem-12';
+    session.conversationHistory.push({ role: 'assistant', content: 'previous successful response' });
+    await sm.queueObservation(12, {
+      tool_name: 'Read',
+      tool_input: {},
+      tool_response: {},
+      prompt_number: 1,
+      toolUseId: 'tu-12',
+    });
+
+    const finalizeSession = mock(() => Promise.resolve());
+    const conversationHistoryCheckpoint = session.conversationHistory.length;
+
+    for (let attempt = 0; attempt < 1_000; attempt++) {
+      session.currentProvider = 'claude';
+      session.generatorPromise = Promise.resolve();
+      session.conversationHistory.push(
+        { role: 'user', content: 'replayed init prompt' },
+        { role: 'user', content: 'replayed observation prompt' },
+        { role: 'assistant', content: '401 Unauthorized' },
+      );
+
+      await handleGeneratorExit(session, 'auth:observer_text', {
+        sessionManager: sm,
+        completionHandler: { finalizeSession } as any,
+        conversationHistoryCheckpoint,
+      });
+    }
+
+    expect(finalizeSession).not.toHaveBeenCalled();
+    expect(sm.getMessageBuffer().getPendingCount(12)).toBe(1);
+    expect(session.conversationHistory).toEqual([
+      { role: 'assistant', content: 'previous successful response' },
+    ]);
   });
 
   it('quota generator exit keeps the active session and in-memory buffer', async () => {
@@ -313,6 +358,7 @@ describe('observer invalid-output handling (Phase 3 recovery)', () => {
     session.memorySessionId = 'mem-6';
     session.currentProvider = 'claude';
     session.generatorPromise = Promise.resolve();
+    const conversationHistoryCheckpoint = session.conversationHistory.length;
     await queueAndClaimOne(sm, 6);
 
     await processAgentResponse(
@@ -332,6 +378,7 @@ describe('observer invalid-output handling (Phase 3 recovery)', () => {
     await handleGeneratorExit(session, session.abortReason, {
       sessionManager: sm,
       completionHandler: { finalizeSession } as any,
+      conversationHistoryCheckpoint,
     });
 
     expect(finalizeSession).not.toHaveBeenCalled();


### PR DESCRIPTION
## Problem

When Claude authentication expires or is revoked, the observer can return 401/authentication-failure prose instead of XML. The worker then:

1. resets the claimed batch to pending;
2. aborts the generator with an `auth:*` reason;
3. preserves the active session and its in-memory buffer; and
4. starts a fresh Claude generator on the next hook event.

The fresh generator replays the preserved buffer, appending the init prompt and every queued observation prompt to the same `conversationHistory`. The failed attempt's additions were never removed. Repeated auth failures therefore retained another copy of the replayed queue on every attempt (`O(retries * queue depth)`; near-quadratic growth while the queue also grows). A few thousand buffered tool events can become millions of retained history entries and drive the worker to multi-GB memory usage.

Quota pauses use the same preserve-and-replay path and had the same amplification risk.

## Fix

- Capture a conversation-history checkpoint before each provider attempt.
- When a Claude generator exits through the preserved `auth` or `quota` path, truncate only the history appended by that failed attempt.
- Keep the buffered work and all history from before the attempt intact.
- Leave Gemini/OpenRouter history behavior unchanged because those providers use the shared history as request context.
- Include the rollback count in the pause log for diagnosis.

The Claude retry already starts a fresh SDK process and uses the in-memory message buffer as the replay source, so retaining the failed attempt's duplicated history is unnecessary.

## Regression coverage

The new test simulates 1,000 consecutive Claude auth retries. Before this change, three replay entries per attempt would leave 3,001 history entries; after the change, history remains at the single pre-attempt entry while the pending batch is still preserved.

## Testing

- `bun run typecheck` — passed
- `bun test tests/worker/poison-respawn.test.ts tests/worker/agents/response-processor.test.ts` — 34 passed
- `bun test tests` — 2,544 passed, 18 skipped, 1 unrelated timeout: `mutation sites > adoptMergedWorktrees emits remap_project through its own connection` exceeded its 5,000 ms limit (5,043 ms; 5,034 ms when rerun alone)

Related historical report: #532 described unbounded `conversationHistory`, but this PR addresses the distinct auth/quota replay path introduced later.
