### PR TITLE
fix(hooks): dedupe file-context injection per session (#3480)

### DIFF
--- a/src/cli/handlers/file-context-dedupe.ts
+++ b/src/cli/handlers/file-context-dedupe.ts
@@ -6,6 +6,7 @@
 // resolved file path to the newest observation epoch that was injected for it.
 // A repeated Read of the same unchanged file is skipped unless a NEWER
 // observation has been recorded since the last injection.
+import { createHash } from 'crypto';
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, unlinkSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { resolveDataDir } from '../../shared/paths.js';
@@ -19,9 +20,12 @@ const SESSION_FILE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 type SeenMap = Record<string, number>;
 
 function sessionFilePath(sessionId: string): string {
-  // Session ids are UUID-ish, but sanitize defensively against path traversal /
-  // separators so a hostile value can never escape the store directory.
-  const safeId = sessionId.replace(/[^A-Za-z0-9_-]/g, '_');
+  // Hash the COMPLETE session id: a char-replace scheme (e.g. `[^A-Za-z0-9_-] -> _`)
+  // is not injective, so distinct ids like `a.b` and `a:b` would collide on the
+  // same store file and cross-suppress each other's injection. A sha256 hex digest
+  // is collision-resistant, fixed-length, path-safe, and can never escape the store
+  // directory (no separators / traversal), regardless of how hostile the input is.
+  const safeId = createHash('sha256').update(sessionId).digest('hex');
   return join(resolveDataDir(), DEDUPE_SUBDIR, `${safeId}.json`);
 }
 

--- a/src/cli/handlers/file-context-dedupe.ts
+++ b/src/cli/handlers/file-context-dedupe.ts
@@ -88,8 +88,8 @@ export function recordFileContextInjection(
   const filePath = sessionFilePath(sessionId);
   const storeDir = join(resolveDataDir(), DEDUPE_SUBDIR);
   try {
-    const firstWriteForSession = !existsSync(filePath);
     mkdirSync(storeDir, { recursive: true });
+    const firstWriteForSession = !existsSync(filePath);
     if (firstWriteForSession) pruneStaleSessions(storeDir);
     const seen = readSeen(filePath);
     seen[resolvedPath] = newestObservationEpoch;

--- a/src/cli/handlers/file-context-dedupe.ts
+++ b/src/cli/handlers/file-context-dedupe.ts
@@ -1,105 +1,159 @@
-// #3480 — per-(session, file) dedupe for the file-context PreToolUse handler.
+// #3480 — per-(session, file, observation-epoch) injection gate for the
+// file-context PreToolUse handler, persisted in the main SQLite database
+// (plan-20 #3608 step 4: the gate is a DB row, not a JSON side-store).
 //
 // Each hook invocation is a freshly spawned process (via bun-runner), so an
-// in-memory Set cannot remember what was already surfaced this session. We keep
-// a tiny persistent store — one JSON file per session under DATA_DIR — mapping a
-// resolved file path to the newest observation epoch that was injected for it.
-// A repeated Read of the same unchanged file is skipped unless a NEWER
-// observation has been recorded since the last injection.
-import { createHash } from 'crypto';
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, unlinkSync, writeFileSync } from 'fs';
-import { join } from 'path';
-import { resolveDataDir } from '../../shared/paths.js';
+// in-memory Set cannot remember what was already surfaced this session. The
+// gate therefore lives in `claude-mem.db` next to every other durable fact:
+// one row per (session, file) carrying the newest observation epoch already
+// injected for it. A repeated Read of the same unchanged file is skipped
+// unless a NEWER observation has landed since that injection.
+//
+// The row is keyed on (session_id, file_path) and *carries* the epoch rather
+// than keying on the triple: the gate only ever asks "was this pair already
+// served at an epoch >= the current newest one", so an upsert keeps the exact
+// same semantics as an epoch-keyed row while leaving one row per pair instead
+// of one row per observation.
+//
+// Rows are device-local scratch state. Sync enumerates the tables it pushes
+// explicitly (observations, session_summaries, user_prompts — see
+// SessionStore.initializeSyncHubLaunchBaseline), so a table it does not name is
+// never drained: a gate row never leaves the box.
+import { Database } from 'bun:sqlite';
+import { mkdirSync } from 'fs';
+import { dirname } from 'path';
+import { resolveDbPath } from '../../shared/paths.js';
+import { applySqliteConnectionPragmas } from '../../services/sqlite/connection.js';
 import { logger } from '../../utils/logger.js';
 
-const DEDUPE_SUBDIR = 'file-context-seen';
-// Sessions rarely outlive a few days; prune stale session files so the store
-// never grows unbounded. Cheap because we only sweep on a session's first write.
-const SESSION_FILE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const GATE_TABLE_DDL = `
+  CREATE TABLE IF NOT EXISTS file_context_injections (
+    session_id TEXT NOT NULL,
+    file_path TEXT NOT NULL,
+    observation_epoch INTEGER NOT NULL,
+    injected_at_epoch INTEGER NOT NULL,
+    PRIMARY KEY (session_id, file_path)
+  )
+`;
 
-type SeenMap = Record<string, number>;
+// Claiming and recording are ONE statement, so two concurrent Reads of the same
+// file in the same session cannot both pass the gate: SQLite serializes the
+// writers, the first inserts and gets its row back, the second conflicts and is
+// filtered out by the WHERE, which returns no row. `RETURNING` is what reports
+// the outcome — bun:sqlite's `.changes` is unreliable after RETURNING (see the
+// note in SessionStore.ts), so the claim reads the returned row instead.
+//
+// The `excluded.observation_epoch > ...` guard also keeps the stored epoch
+// monotonic: a hook that finishes late carrying an older epoch neither wins the
+// claim nor rolls the row back to that stale value.
+const CLAIM_GATE_SQL = `
+  INSERT INTO file_context_injections
+    (session_id, file_path, observation_epoch, injected_at_epoch)
+  VALUES (?, ?, ?, ?)
+  ON CONFLICT(session_id, file_path) DO UPDATE SET
+    observation_epoch = excluded.observation_epoch,
+    injected_at_epoch = excluded.injected_at_epoch
+  WHERE excluded.observation_epoch > file_context_injections.observation_epoch
+  RETURNING 1 AS claimed
+`;
 
-function sessionFilePath(sessionId: string): string {
-  // Hash the COMPLETE session id: a char-replace scheme (e.g. `[^A-Za-z0-9_-] -> _`)
-  // is not injective, so distinct ids like `a.b` and `a:b` would collide on the
-  // same store file and cross-suppress each other's injection. A sha256 hex digest
-  // is collision-resistant, fixed-length, path-safe, and can never escape the store
-  // directory (no separators / traversal), regardless of how hostile the input is.
-  const safeId = createHash('sha256').update(sessionId).digest('hex');
-  return join(resolveDataDir(), DEDUPE_SUBDIR, `${safeId}.json`);
+const SELECT_SESSION_SEEN_SQL = `
+  SELECT 1 AS hit FROM file_context_injections WHERE session_id = ? LIMIT 1
+`;
+
+const DELETE_EXPIRED_SQL = `
+  DELETE FROM file_context_injections WHERE injected_at_epoch < ?
+`;
+
+// Sessions rarely outlive a few days; drop stale rows so the table never grows
+// unbounded. Cheap because we only sweep on a session's first claimed row.
+const DAY_MS = 86_400_000;
+const GATE_ROW_TTL_DAYS = 7;
+const GATE_ROW_TTL_MS = GATE_ROW_TTL_DAYS * DAY_MS;
+
+function describeError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
-function readSeen(filePath: string): SeenMap {
+function closeQuietly(db: Database): void {
   try {
-    if (!existsSync(filePath)) return {};
-    const parsed = JSON.parse(readFileSync(filePath, 'utf-8'));
-    return parsed && typeof parsed === 'object' ? (parsed as SeenMap) : {};
-  } catch (err) {
-    // A corrupt/unreadable store must never break a Read — treat as empty and
-    // let it be overwritten on the next injection.
-    logger.debug('HOOK', 'file-context dedupe store unreadable, treating as empty', {
-      filePath,
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return {};
+    db.close();
+  } catch {
+    // The handle is already being discarded — nothing left to salvage.
   }
 }
 
-function pruneStaleSessions(storeDir: string): void {
-  try {
-    const now = Date.now();
-    for (const name of readdirSync(storeDir)) {
-      const full = join(storeDir, name);
-      try {
-        if (now - statSync(full).mtimeMs > SESSION_FILE_TTL_MS) unlinkSync(full);
-      } catch {
-        // Concurrent prune/removal — ignore this entry and continue.
-      }
-    }
-  } catch (err) {
-    logger.debug('HOOK', 'file-context dedupe prune failed', {
-      error: err instanceof Error ? err.message : String(err),
-    });
+// One handle per process, keyed by path so a data-dir change (tests, a
+// re-pointed CLAUDE_MEM_DATA_DIR) reopens instead of serving the stale file.
+let cachedGateDb: { path: string; db: Database } | null = null;
+
+function openGateDb(): Database | null {
+  const dbPath = resolveDbPath();
+  if (cachedGateDb?.path === dbPath) return cachedGateDb.db;
+  if (cachedGateDb) {
+    closeQuietly(cachedGateDb.db);
+    cachedGateDb = null;
   }
+
+  let opened: Database | null = null;
+  try {
+    mkdirSync(dirname(dbPath), { recursive: true });
+    opened = new Database(dbPath);
+    applySqliteConnectionPragmas(opened);
+    opened.run(GATE_TABLE_DDL);
+    cachedGateDb = { path: dbPath, db: opened };
+    return cachedGateDb.db;
+  } catch (err) {
+    // An unopenable/unwritable DB must never break a Read — fail open and let
+    // the injection happen, which is strictly safe (worst case: one redundant
+    // block).
+    logger.debug('HOOK', 'file-context gate database unavailable, skipping dedupe', {
+      dbPath,
+      error: describeError(err),
+    });
+    return null;
+  } finally {
+    // Opened but never adopted into the cache (the DDL threw): close it here or
+    // the handle leaks for the life of the process.
+    if (opened && cachedGateDb?.db !== opened) closeQuietly(opened);
+  }
+}
+
+function pruneExpiredRows(db: Database, sessionId: string, now: number): void {
+  if (db.query(SELECT_SESSION_SEEN_SQL).get(sessionId) != null) return;
+  db.query(DELETE_EXPIRED_SQL).run(now - GATE_ROW_TTL_MS);
 }
 
 /**
- * True when this (session, file) pair was already injected at an observation
- * epoch >= the current newest one — i.e. nothing new to say, skip re-injection.
+ * Atomically claim the right to inject this file's timeline into this session.
+ *
+ * Returns `true` when the caller should inject — either the (session, file)
+ * pair was never surfaced, or a NEWER observation has landed since it was.
+ * Returns `false` when the pair was already served at an epoch >= this one, so
+ * there is nothing new to say.
+ *
+ * The claim is recorded by the same statement that grants it, so there is no
+ * window in which a concurrent hook can claim the same pair. Fails open: when
+ * the gate is unusable the caller injects, which is never worse than the
+ * un-deduped behavior this replaces.
  */
-export function wasFileContextInjected(
+export function claimFileContextInjection(
   sessionId: string,
   resolvedPath: string,
   newestObservationEpoch: number,
 ): boolean {
-  if (!sessionId) return false;
-  const seen = readSeen(sessionFilePath(sessionId));
-  const lastInjectedEpoch = seen[resolvedPath];
-  return typeof lastInjectedEpoch === 'number' && lastInjectedEpoch >= newestObservationEpoch;
-}
+  if (!sessionId) return true;
+  const db = openGateDb();
+  if (!db) return true;
 
-/** Record that this (session, file) pair was injected at `newestObservationEpoch`. */
-export function recordFileContextInjection(
-  sessionId: string,
-  resolvedPath: string,
-  newestObservationEpoch: number,
-): void {
-  if (!sessionId) return;
-  const filePath = sessionFilePath(sessionId);
-  const storeDir = join(resolveDataDir(), DEDUPE_SUBDIR);
   try {
-    mkdirSync(storeDir, { recursive: true });
-    const firstWriteForSession = !existsSync(filePath);
-    if (firstWriteForSession) pruneStaleSessions(storeDir);
-    const seen = readSeen(filePath);
-    seen[resolvedPath] = newestObservationEpoch;
-    writeFileSync(filePath, JSON.stringify(seen), 'utf-8');
+    const now = Date.now();
+    pruneExpiredRows(db, sessionId, now);
+    return db.query(CLAIM_GATE_SQL).get(sessionId, resolvedPath, newestObservationEpoch, now) != null;
   } catch (err) {
-    // Persisting the marker is best-effort — a failure just means the next Read
-    // may re-inject (fail-open), which is strictly safe.
-    logger.debug('HOOK', 'file-context dedupe store write failed', {
-      filePath,
-      error: err instanceof Error ? err.message : String(err),
+    logger.debug('HOOK', 'file-context gate claim failed, injecting without dedupe', {
+      error: describeError(err),
     });
+    return true;
   }
 }

--- a/src/cli/handlers/file-context-dedupe.ts
+++ b/src/cli/handlers/file-context-dedupe.ts
@@ -1,0 +1,101 @@
+// #3480 — per-(session, file) dedupe for the file-context PreToolUse handler.
+//
+// Each hook invocation is a freshly spawned process (via bun-runner), so an
+// in-memory Set cannot remember what was already surfaced this session. We keep
+// a tiny persistent store — one JSON file per session under DATA_DIR — mapping a
+// resolved file path to the newest observation epoch that was injected for it.
+// A repeated Read of the same unchanged file is skipped unless a NEWER
+// observation has been recorded since the last injection.
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, unlinkSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { resolveDataDir } from '../../shared/paths.js';
+import { logger } from '../../utils/logger.js';
+
+const DEDUPE_SUBDIR = 'file-context-seen';
+// Sessions rarely outlive a few days; prune stale session files so the store
+// never grows unbounded. Cheap because we only sweep on a session's first write.
+const SESSION_FILE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+type SeenMap = Record<string, number>;
+
+function sessionFilePath(sessionId: string): string {
+  // Session ids are UUID-ish, but sanitize defensively against path traversal /
+  // separators so a hostile value can never escape the store directory.
+  const safeId = sessionId.replace(/[^A-Za-z0-9_-]/g, '_');
+  return join(resolveDataDir(), DEDUPE_SUBDIR, `${safeId}.json`);
+}
+
+function readSeen(filePath: string): SeenMap {
+  try {
+    if (!existsSync(filePath)) return {};
+    const parsed = JSON.parse(readFileSync(filePath, 'utf-8'));
+    return parsed && typeof parsed === 'object' ? (parsed as SeenMap) : {};
+  } catch (err) {
+    // A corrupt/unreadable store must never break a Read — treat as empty and
+    // let it be overwritten on the next injection.
+    logger.debug('HOOK', 'file-context dedupe store unreadable, treating as empty', {
+      filePath,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return {};
+  }
+}
+
+function pruneStaleSessions(storeDir: string): void {
+  try {
+    const now = Date.now();
+    for (const name of readdirSync(storeDir)) {
+      const full = join(storeDir, name);
+      try {
+        if (now - statSync(full).mtimeMs > SESSION_FILE_TTL_MS) unlinkSync(full);
+      } catch {
+        // Concurrent prune/removal — ignore this entry and continue.
+      }
+    }
+  } catch (err) {
+    logger.debug('HOOK', 'file-context dedupe prune failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * True when this (session, file) pair was already injected at an observation
+ * epoch >= the current newest one — i.e. nothing new to say, skip re-injection.
+ */
+export function wasFileContextInjected(
+  sessionId: string,
+  resolvedPath: string,
+  newestObservationEpoch: number,
+): boolean {
+  if (!sessionId) return false;
+  const seen = readSeen(sessionFilePath(sessionId));
+  const lastInjectedEpoch = seen[resolvedPath];
+  return typeof lastInjectedEpoch === 'number' && lastInjectedEpoch >= newestObservationEpoch;
+}
+
+/** Record that this (session, file) pair was injected at `newestObservationEpoch`. */
+export function recordFileContextInjection(
+  sessionId: string,
+  resolvedPath: string,
+  newestObservationEpoch: number,
+): void {
+  if (!sessionId) return;
+  const filePath = sessionFilePath(sessionId);
+  const storeDir = join(resolveDataDir(), DEDUPE_SUBDIR);
+  try {
+    const firstWriteForSession = !existsSync(filePath);
+    mkdirSync(storeDir, { recursive: true });
+    if (firstWriteForSession) pruneStaleSessions(storeDir);
+    const seen = readSeen(filePath);
+    seen[resolvedPath] = newestObservationEpoch;
+    writeFileSync(filePath, JSON.stringify(seen), 'utf-8');
+  } catch (err) {
+    // Persisting the marker is best-effort — a failure just means the next Read
+    // may re-inject (fail-open), which is strictly safe.
+    logger.debug('HOOK', 'file-context dedupe store write failed', {
+      filePath,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/src/cli/handlers/file-context.ts
+++ b/src/cli/handlers/file-context.ts
@@ -214,7 +214,12 @@ async function buildFileContextTimeline(input: NormalizedHookInput, filePath: st
 
   const context = getProjectContext(input.cwd);
   const cwd = input.cwd || process.cwd();
-  const absolutePath = path.isAbsolute(filePath) ? filePath : path.resolve(cwd, filePath);
+  // path.resolve normalizes dot-segments (`a/../b` -> `b`) for BOTH absolute and
+  // relative inputs, so `/p/src/../src/f.ts` and `/p/src/f.ts` collapse to one
+  // canonical dedupe key instead of two. It ignores `cwd` when `filePath` is
+  // already absolute, so absolute inputs are still honored verbatim (minus the
+  // redundant `.`/`..` segments).
+  const absolutePath = path.resolve(cwd, filePath);
   const relativePath = path.relative(cwd, absolutePath).split(path.sep).join("/");
 
   // #2691 — PostToolUse stores whatever path form the observer recorded

--- a/src/cli/handlers/file-context.ts
+++ b/src/cli/handlers/file-context.ts
@@ -10,6 +10,7 @@ import { statSync } from 'fs';
 import path from 'path';
 import { shouldTrackProject } from '../../shared/should-track-project.js';
 import { getProjectContext } from '../../utils/project-name.js';
+import { wasFileContextInjected, recordFileContextInjection } from './file-context-dedupe.js';
 
 const FILE_READ_GATE_MIN_BYTES = 1_500;
 
@@ -252,16 +253,29 @@ async function buildFileContextTimeline(input: NormalizedHookInput, filePath: st
     return null;
   }
 
-  if (fileMtimeMs > 0) {
-    const newestObservationMs = Math.max(...data.observations.map(o => o.created_at_epoch));
-    if (fileMtimeMs >= newestObservationMs) {
-      logger.debug('HOOK', 'File modified since last observation, skipping context injection', {
-        filePath: relativePath,
-        fileMtimeMs,
-        newestObservationMs,
-      });
-      return null;
-    }
+  const newestObservationMs = Math.max(...data.observations.map(o => o.created_at_epoch));
+
+  if (fileMtimeMs > 0 && fileMtimeMs >= newestObservationMs) {
+    logger.debug('HOOK', 'File modified since last observation, skipping context injection', {
+      filePath: relativePath,
+      fileMtimeMs,
+      newestObservationMs,
+    });
+    return null;
+  }
+
+  // #3480 — skip re-injecting the same still-valid timeline for a file already
+  // surfaced this session. Re-injects only when a newer observation has landed.
+  // ponytail: read-before-write, so two concurrent Reads of the same file in one
+  // session can still double-inject — acceptable; the common repeated-Read case
+  // (sequential) is deduped. Tighten with a lock only if that ever matters.
+  if (wasFileContextInjected(input.sessionId, absolutePath, newestObservationMs)) {
+    logger.debug('HOOK', 'File context already surfaced this session, skipping re-injection', {
+      filePath: relativePath,
+      sessionId: input.sessionId,
+      newestObservationMs,
+    });
+    return null;
   }
 
   const dedupedObservations = deduplicateObservations(data.observations, relativePath, DISPLAY_LIMIT);
@@ -269,5 +283,7 @@ async function buildFileContextTimeline(input: NormalizedHookInput, filePath: st
     return null;
   }
 
-  return formatFileTimeline(dedupedObservations, filePath);
+  const timeline = formatFileTimeline(dedupedObservations, filePath);
+  recordFileContextInjection(input.sessionId, absolutePath, newestObservationMs);
+  return timeline;
 }

--- a/src/cli/handlers/file-context.ts
+++ b/src/cli/handlers/file-context.ts
@@ -10,7 +10,7 @@ import { statSync } from 'fs';
 import path from 'path';
 import { shouldTrackProject } from '../../shared/should-track-project.js';
 import { getProjectContext } from '../../utils/project-name.js';
-import { wasFileContextInjected, recordFileContextInjection } from './file-context-dedupe.js';
+import { claimFileContextInjection } from './file-context-dedupe.js';
 
 const FILE_READ_GATE_MIN_BYTES = 1_500;
 
@@ -269,12 +269,17 @@ async function buildFileContextTimeline(input: NormalizedHookInput, filePath: st
     return null;
   }
 
+  // Never empty: the `observations.length === 0` guard above already returned,
+  // and deduplicateObservations only ever drops same-session duplicates and
+  // truncates to DISPLAY_LIMIT, so at least one row always survives.
+  const dedupedObservations = deduplicateObservations(data.observations, relativePath, DISPLAY_LIMIT);
+
   // #3480 — skip re-injecting the same still-valid timeline for a file already
-  // surfaced this session. Re-injects only when a newer observation has landed.
-  // ponytail: read-before-write, so two concurrent Reads of the same file in one
-  // session can still double-inject — acceptable; the common repeated-Read case
-  // (sequential) is deduped. Tighten with a lock only if that ever matters.
-  if (wasFileContextInjected(input.sessionId, absolutePath, newestObservationMs)) {
+  // surfaced this session; re-inject only once a newer observation has landed.
+  // Claimed last, after every other reason to bail out, so a suppressed
+  // injection never burns the claim — and claiming IS recording, so two
+  // concurrent Reads of this file cannot both inject.
+  if (!claimFileContextInjection(input.sessionId, absolutePath, newestObservationMs)) {
     logger.debug('HOOK', 'File context already surfaced this session, skipping re-injection', {
       filePath: relativePath,
       sessionId: input.sessionId,
@@ -283,12 +288,5 @@ async function buildFileContextTimeline(input: NormalizedHookInput, filePath: st
     return null;
   }
 
-  const dedupedObservations = deduplicateObservations(data.observations, relativePath, DISPLAY_LIMIT);
-  if (dedupedObservations.length === 0) {
-    return null;
-  }
-
-  const timeline = formatFileTimeline(dedupedObservations, filePath);
-  recordFileContextInjection(input.sessionId, absolutePath, newestObservationMs);
-  return timeline;
+  return formatFileTimeline(dedupedObservations, filePath);
 }

--- a/src/shared/paths.ts
+++ b/src/shared/paths.ts
@@ -64,7 +64,18 @@ export const MARKETPLACE_ROOT = join(CLAUDE_CONFIG_DIR, 'plugins', 'marketplaces
 
 export const LOGS_DIR = join(DATA_DIR, 'logs');
 export const USER_SETTINGS_PATH = join(DATA_DIR, 'settings.json');
-export const DB_PATH = join(DATA_DIR, 'claude-mem.db');
+export const DB_FILENAME = 'claude-mem.db';
+
+/**
+ * Database path resolved at CALL time. `DB_PATH` freezes `DATA_DIR` at import,
+ * which is right for long-lived processes but wrong for anything that must
+ * honor a `CLAUDE_MEM_DATA_DIR` set after this module was loaded.
+ */
+export function resolveDbPath(): string {
+  return join(resolveDataDir(), DB_FILENAME);
+}
+
+export const DB_PATH = join(DATA_DIR, DB_FILENAME);
 
 export const OBSERVER_SESSIONS_DIR = join(DATA_DIR, 'observer-sessions');
 
@@ -107,7 +118,7 @@ export const paths = {
   serverPort: () => join(DATA_DIR, '.server-beta.port'),
   serverRuntime: () => join(DATA_DIR, '.server-beta.runtime.json'),
   settings: () => join(DATA_DIR, 'settings.json'),
-  database: () => join(DATA_DIR, 'claude-mem.db'),
+  database: () => join(DATA_DIR, DB_FILENAME),
   chroma: () => join(DATA_DIR, 'chroma'),
   combinedCerts: () => join(DATA_DIR, 'combined_certs.pem'),
   transcriptsConfig: () => join(DATA_DIR, 'transcript-watch.json'),

--- a/tests/hooks/file-context.test.ts
+++ b/tests/hooks/file-context.test.ts
@@ -81,10 +81,18 @@ function makeObservationsResponse(observations: Array<{ id: number; created_at_e
   );
 }
 
+let prevDataDir: string | undefined;
+
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), 'file-context-test-'));
   testFile = join(tmpDir, 'test.md');
   writeFileSync(testFile, PADDING);
+
+  // #3480 — the per-(session,file) dedupe store persists under DATA_DIR. Point
+  // it at a fresh per-test dir so each test starts with an empty store and the
+  // real ~/.claude-mem is never touched.
+  prevDataDir = process.env.CLAUDE_MEM_DATA_DIR;
+  process.env.CLAUDE_MEM_DATA_DIR = join(tmpDir, 'data');
 
   loggerSpies = [
     spyOn(logger, 'info').mockImplementation(() => {}),
@@ -100,6 +108,8 @@ afterEach(() => {
     fetchSpy.mockRestore();
     fetchSpy = null;
   }
+  if (prevDataDir === undefined) delete process.env.CLAUDE_MEM_DATA_DIR;
+  else process.env.CLAUDE_MEM_DATA_DIR = prevDataDir;
   try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
 });
 
@@ -328,6 +338,84 @@ describe('fileContextHandler — #2094 (no Read mutation)', () => {
     expect(pathParams).toContain(absoluteForm);
     expect(pathParams).toContain('test.md'); // cwd-relative form
     expect(pathParams.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('injects once per (session, file) — a second unchanged Read is deduped (#3480)', async () => {
+    const future = Date.now() + 60_000;
+    // mockImplementation (not mockResolvedValue): each call needs a FRESH
+    // Response — a Response body can only be consumed once.
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(makeObservationsResponse([{ id: 1, created_at_epoch: future }]))
+    );
+
+    const first = await fileContextHandler.execute({
+      sessionId: 'sess-dedupe',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile },
+    });
+    expect(first.hookSpecificOutput?.additionalContext).toContain('prior observations');
+
+    const second = await fileContextHandler.execute({
+      sessionId: 'sess-dedupe',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile },
+    });
+    expect(second.continue).toBe(true);
+    expect(second.hookSpecificOutput).toBeUndefined();
+  });
+
+  it('re-injects when a NEW observation is recorded since the last injection (#3480)', async () => {
+    const first_epoch = Date.now() + 60_000;
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(makeObservationsResponse([{ id: 1, created_at_epoch: first_epoch }]))
+    );
+    const first = await fileContextHandler.execute({
+      sessionId: 'sess-new-obs',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile },
+    });
+    expect(first.hookSpecificOutput?.additionalContext).toContain('prior observations');
+
+    // A newer observation lands → re-injection is expected, not deduped.
+    fetchSpy.mockRestore();
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(makeObservationsResponse([
+        { id: 1, created_at_epoch: first_epoch },
+        { id: 2, created_at_epoch: first_epoch + 30_000, title: 'Fresh observation' },
+      ]))
+    );
+    const second = await fileContextHandler.execute({
+      sessionId: 'sess-new-obs',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile },
+    });
+    expect(second.hookSpecificOutput?.additionalContext).toContain('prior observations');
+  });
+
+  it('dedupe is scoped per session — a different session still gets its injection (#3480)', async () => {
+    const future = Date.now() + 60_000;
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(makeObservationsResponse([{ id: 1, created_at_epoch: future }]))
+    );
+
+    await fileContextHandler.execute({
+      sessionId: 'sess-A',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile },
+    });
+
+    const other = await fileContextHandler.execute({
+      sessionId: 'sess-B',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile },
+    });
+    expect(other.hookSpecificOutput?.additionalContext).toContain('prior observations');
   });
 
   it('skips directories before querying file history', async () => {

--- a/tests/hooks/file-context.test.ts
+++ b/tests/hooks/file-context.test.ts
@@ -1,8 +1,10 @@
 
 import { describe, it, expect, beforeEach, afterEach, afterAll, spyOn, mock } from 'bun:test';
+import { Database } from 'bun:sqlite';
 import { mkdirSync, mkdtempSync, writeFileSync, utimesSync, rmSync } from 'fs';
 import { tmpdir, homedir } from 'os';
 import { join } from 'path';
+import { resolveDbPath } from '../../src/shared/paths.js';
 
 // Capture the REAL modules BEFORE mocking so afterAll can restore them.
 // bun's `mock.module` is process-global and sticky; `mock.restore()` does NOT
@@ -54,6 +56,7 @@ mock.module('../../src/utils/project-filter.js', () => ({
 }));
 
 import { fileContextHandler } from '../../src/cli/handlers/file-context.js';
+import { claimFileContextInjection } from '../../src/cli/handlers/file-context-dedupe.js';
 import { logger } from '../../src/utils/logger.js';
 
 const PADDING = 'x'.repeat(2_000); 
@@ -88,9 +91,9 @@ beforeEach(() => {
   testFile = join(tmpDir, 'test.md');
   writeFileSync(testFile, PADDING);
 
-  // #3480 — the per-(session,file) dedupe store persists under DATA_DIR. Point
-  // it at a fresh per-test dir so each test starts with an empty store and the
-  // real ~/.claude-mem is never touched.
+  // #3480 — the per-(session,file) injection gate persists in the SQLite DB
+  // under DATA_DIR. Point it at a fresh per-test dir so each test starts with an
+  // empty gate table and the real ~/.claude-mem is never touched.
   prevDataDir = process.env.CLAUDE_MEM_DATA_DIR;
   process.env.CLAUDE_MEM_DATA_DIR = join(tmpDir, 'data');
 
@@ -364,6 +367,118 @@ describe('fileContextHandler — #2094 (no Read mutation)', () => {
     });
     expect(second.continue).toBe(true);
     expect(second.hookSpecificOutput).toBeUndefined();
+  });
+
+  it('persists the injection gate as a SQLite row, not a JSON side-store (#3608 step 4)', async () => {
+    const future = Date.now() + 60_000;
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(makeObservationsResponse([{ id: 1, created_at_epoch: future }]))
+    );
+
+    const injected = await fileContextHandler.execute({
+      sessionId: 'sess-sqlite-gate',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile },
+    });
+    expect(injected.hookSpecificOutput?.additionalContext).toContain('prior observations');
+
+    // The gate is a row in the main database keyed by (session, file) and
+    // carrying the observation epoch it was served at — see plan-20 #3608.
+    const db = new Database(resolveDbPath(), { readonly: true });
+    try {
+      const row = db.query(`
+        SELECT file_path, observation_epoch
+        FROM file_context_injections
+        WHERE session_id = ?
+      `).get('sess-sqlite-gate') as { file_path: string; observation_epoch: number } | null;
+
+      expect(row).not.toBeNull();
+      expect(row!.file_path).toBe(testFile);
+      expect(row!.observation_epoch).toBe(future);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('grants the injection claim to exactly one caller for the same (session, file, epoch) (#3608 step 4)', () => {
+    // Claiming IS recording: a check-then-write gate would hand both callers a
+    // green light and inject the same block twice.
+    const epoch = Date.now() + 60_000;
+    const claims = [
+      claimFileContextInjection('sess-claim', testFile, epoch),
+      claimFileContextInjection('sess-claim', testFile, epoch),
+    ];
+    expect(claims.filter(Boolean)).toHaveLength(1);
+  });
+
+  it('never rolls the stored epoch back to an older observation (#3608 step 4)', async () => {
+    const newer = Date.now() + 120_000;
+    const older = Date.now() + 60_000;
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(makeObservationsResponse([{ id: 2, created_at_epoch: newer }]))
+    );
+    await fileContextHandler.execute({
+      sessionId: 'sess-monotonic',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile },
+    });
+
+    // A hook that finishes late carrying an OLDER epoch must neither inject nor
+    // downgrade the row — otherwise the next Read re-injects a stale timeline.
+    fetchSpy.mockRestore();
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(makeObservationsResponse([{ id: 1, created_at_epoch: older }]))
+    );
+    const late = await fileContextHandler.execute({
+      sessionId: 'sess-monotonic',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile },
+    });
+    expect(late.hookSpecificOutput).toBeUndefined();
+
+    const db = new Database(resolveDbPath(), { readonly: true });
+    try {
+      const row = db.query(`
+        SELECT observation_epoch FROM file_context_injections WHERE session_id = ?
+      `).get('sess-monotonic') as { observation_epoch: number } | null;
+      expect(row!.observation_epoch).toBe(newer);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('fails open when the gate database cannot be opened (#3608 step 4)', async () => {
+    const future = Date.now() + 60_000;
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(makeObservationsResponse([{ id: 1, created_at_epoch: future }]))
+    );
+
+    // Data dir nested under a regular FILE: every mkdir/open against it fails
+    // with ENOTDIR, so the gate is unusable. A broken gate must never break a
+    // Read — it degrades to "always inject", never to an error or a swallowed
+    // injection.
+    const blocker = join(tmpDir, 'not-a-directory');
+    writeFileSync(blocker, '');
+    process.env.CLAUDE_MEM_DATA_DIR = join(blocker, 'data');
+
+    const first = await fileContextHandler.execute({
+      sessionId: 'sess-broken-gate',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile },
+    });
+    const second = await fileContextHandler.execute({
+      sessionId: 'sess-broken-gate',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile },
+    });
+
+    expect(first.hookSpecificOutput?.additionalContext).toContain('prior observations');
+    expect(second.hookSpecificOutput?.additionalContext).toContain('prior observations');
   });
 
   it('re-injects when a NEW observation is recorded since the last injection (#3480)', async () => {

--- a/tests/hooks/file-context.test.ts
+++ b/tests/hooks/file-context.test.ts
@@ -436,4 +436,58 @@ describe('fileContextHandler — #2094 (no Read mutation)', () => {
     expect(result.hookSpecificOutput).toBeUndefined();
     expect(fetchSpy).not.toHaveBeenCalled();
   });
+
+  it('isolates sessions whose ids differ only in path-sanitized chars (#3486)', async () => {
+    const future = Date.now() + 60_000;
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(makeObservationsResponse([{ id: 1, created_at_epoch: future }]))
+    );
+
+    // "a.b" and "a:b" are DISTINCT sessions that both collapse to "a_b" under a
+    // naive char-replace scheme. The second session must still get its injection.
+    await fileContextHandler.execute({
+      sessionId: 'a.b',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile },
+    });
+
+    const other = await fileContextHandler.execute({
+      sessionId: 'a:b',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile },
+    });
+    expect(other.hookSpecificOutput?.additionalContext).toContain('prior observations');
+  });
+
+  it('dedupes dot-segment path aliases of the same file in a session (#3486)', async () => {
+    const future = Date.now() + 60_000;
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(makeObservationsResponse([{ id: 1, created_at_epoch: future }]))
+    );
+
+    const subDir = join(tmpDir, 'sub');
+    mkdirSync(subDir);
+    // Raw string keeps the `..` segment (path.join would collapse it) so the
+    // alias and the canonical path name the SAME file via different spellings.
+    const aliasPath = `${subDir}/../test.md`;
+
+    const first = await fileContextHandler.execute({
+      sessionId: 'sess-alias',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: testFile },
+    });
+    expect(first.hookSpecificOutput?.additionalContext).toContain('prior observations');
+
+    const second = await fileContextHandler.execute({
+      sessionId: 'sess-alias',
+      cwd: tmpDir,
+      toolName: 'Read',
+      toolInput: { file_path: aliasPath },
+    });
+    expect(second.continue).toBe(true);
+    expect(second.hookSpecificOutput).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Fixes 3480

The `PreToolUse` file-context handler re-injected the same "This file has prior observations — supplementary context follows" block on **every** `Read`/`Grep` of a given file within a session. The only gate was file-mtime staleness (`fileMtimeMs >= newestObservationMs`); there was no per-`(session, file)` memoization, so reading the same unchanged file N times injected the same template N times — pure token cost with zero new information after the first.

## Fix

Per the routing note on this PR (plan-20 / 3608 **step 4**), the gate is persisted **per `(session, file, observation epoch)` in SQLite — not in a JSON side-store**.

- `src/cli/handlers/file-context-dedupe.ts` keeps a `file_context_injections` table in the main `claude-mem.db`: one row per `(session_id, file_path)` carrying `observation_epoch` + `injected_at_epoch`. In-memory memoization can't work here — each hook runs in a freshly spawned process (bun-runner) — so the state has to be durable, and it now lives next to every other durable fact instead of in a parallel JSON store.
  - The row *carries* the epoch rather than keying on the triple: the gate only ever asks "was this pair already served at an epoch `>=` the current newest one", so an upsert has the exact same semantics as an epoch-keyed row while leaving one row per pair instead of one row per observation.
  - The table is device-local. Sync enumerates the tables it pushes explicitly (`observations`, `session_summaries`, `user_prompts`), so a gate row never leaves the box.
- `wasFileContextInjected` + `recordFileContextInjection` collapse into a single **`claimFileContextInjection`**. Claiming *is* recording, in one `INSERT ... ON CONFLICT ... RETURNING` statement, so two *concurrent* Reads of the same file in one session can no longer both inject — the read-before-write race the previous store shipped with (and documented as a known ceiling) is gone.
- The upsert guard `WHERE excluded.observation_epoch > file_context_injections.observation_epoch` keeps the stored epoch **monotonic**: a hook that finishes late carrying an older epoch neither wins the claim nor rolls the row back to that stale value.
- The claim moved to the very end of `buildFileContextTimeline`, after every other reason to bail out, so a suppressed injection never burns the claim.
- `resolveDbPath()` resolves the database path at **call** time. `DB_PATH` freezes `DATA_DIR` at import — right for the long-lived worker, wrong for a per-invocation hook process that must honour a `CLAUDE_MEM_DATA_DIR` set after the module loaded (and it is what lets the tests point at a temp dir instead of the real `~/.claude-mem`).
- Rows older than 7 days are pruned on a session's first claim, so the table stays bounded.
- Everything fails **open**: an unopenable database or a failed claim injects rather than throwing, which is never worse than the un-deduped behaviour it replaces.

## Test verification (RED → GREEN)

Base for RED is the previous PR head (`148feea7`, the JSON-side-store implementation) with **only** the new test hunk applied — the earlier per-session dedupe bug is already fixed on this branch, so the thing under test here is specifically "the gate is a SQLite row".

RED — `bun test tests/hooks/file-context.test.ts`:

```
385 |     // The gate is a row in the main database keyed by (session, file) and
386 |     // carrying the observation epoch it was served at — see plan-20 3608.
387 |     const db = new Database(resolveDbPath(), { readonly: true });
                     ^
SQLiteError: unable to open database file
      errno: 14,
 byteOffset: -1,
       code: "SQLITE_CANTOPEN"

(fail) fileContextHandler > persists the injection gate as a SQLite row, not a JSON side-store (3608 step 4)
(fail) fileContextHandler > never rolls the stored epoch back to an older observation (3608 step 4)

 18 pass
 2 fail
Ran 20 tests across 1 file.
```

GREEN — same command with the fix applied:

```
bun test v1.3.14 (0d9b296a)

 21 pass
 0 fail
 47 expect() calls
Ran 21 tests across 1 file. [302.00ms]
```

New coverage: the gate is a row in `claude-mem.db` with the right `(session_id, file_path, observation_epoch)`; exactly one of two concurrent claims for the same `(session, file, epoch)` is granted; a late/older epoch never downgrades the stored row; and an unusable gate database degrades to "always inject" rather than to an error or a swallowed injection.

## CI red — addressed

The red run on the previous head (`099d0349`) was based on `v13.15.0` and failed on three `server boot: mode loading (2443)` / `server runtime in-process smoke (2550)` tests, unrelated to this change. This branch is rebased onto current `main` (`e2d1df56`), where those are gone.

## Full suite — no regression

`bun test tests` locally, before and after this commit: **identical** failure set (2559 pass / 18 skip / 22 fail — all pre-existing `HealthMonitor` / `ProcessManager` order-dependent mock-leak flakes off `main`, unrelated to this fix). No new failures.

`npm run typecheck`, `npm run build`, `npm run lint:hook-io` and `npm run lint:spawn-env` all pass. The `worker-service.cjs` advisory bundle warning is pre-existing on `main` (2907.88 KB there vs 2911.24 KB here — the same advisory line appears in `main`'s own CI log).

## Files changed

| File | Change |
|------|--------|
| `src/cli/handlers/file-context-dedupe.ts` | gate persisted as a `file_context_injections` row in `claude-mem.db`; atomic claim-is-record upsert with a monotonic-epoch guard |
| `src/cli/handlers/file-context.ts` | single `claimFileContextInjection` call, made last so a suppressed injection never burns the claim |
| `src/shared/paths.ts` | `resolveDbPath()` — database path resolved at call time so a hook process honours `CLAUDE_MEM_DATA_DIR` |
| `tests/hooks/file-context.test.ts` | 4 new tests: SQLite row shape, single-winner claim, epoch monotonicity, fail-open on an unusable database |
