### PR TITLE
fix(openrouter): never send an empty messages array to the API (Fixes #3491)

### DIFF
--- a/src/services/worker/OpenRouterProvider.ts
+++ b/src/services/worker/OpenRouterProvider.ts
@@ -95,6 +95,7 @@ export function classifyOpenRouterError(input: {
 }
 
 const CHARS_PER_TOKEN_ESTIMATE = 4;
+const OPENROUTER_EMPTY_HISTORY_FALLBACK = '(context unavailable)';
 
 interface OpenAIMessage {
   role: 'user' | 'assistant' | 'system';
@@ -180,10 +181,42 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
   }
 
   private conversationToOpenAIMessages(history: ConversationMessage[]): OpenAIMessage[] {
-    return history.map(msg => ({
-      role: msg.role === 'assistant' ? 'assistant' : 'user',
-      content: msg.content
-    }));
+    let newestNonEmptyContent: string | null = null;
+    for (const msg of history) {
+      const trimmed = msg.content.trim();
+      if (trimmed.length > 0) {
+        newestNonEmptyContent = trimmed;
+      }
+    }
+
+    const messages: OpenAIMessage[] = [];
+    for (const msg of history) {
+      const trimmed = msg.content.trim();
+      if (!trimmed) {
+        continue;
+      }
+
+      const role = msg.role === 'assistant' ? 'assistant' : 'user';
+      if (messages.length === 0 && role === 'assistant') {
+        continue;
+      }
+
+      const previous = messages[messages.length - 1];
+      if (previous?.role === role) {
+        previous.content = `${previous.content}\n\n${msg.content}`;
+      } else {
+        messages.push({ role, content: msg.content });
+      }
+    }
+
+    if (messages.length === 0) {
+      return [{
+        role: 'user',
+        content: newestNonEmptyContent ?? OPENROUTER_EMPTY_HISTORY_FALLBACK,
+      }];
+    }
+
+    return messages;
   }
 
   protected async query(history: ConversationMessage[], config: OpenRouterConfig): Promise<ProviderQueryResult> {
@@ -234,7 +267,7 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
   ): Promise<ProviderQueryResult> {
     const messages = this.conversationToOpenAIMessages(history);
     const totalChars = history.reduce((sum, m) => sum + m.content.length, 0);
-    const estimatedTokens = this.estimateTokens(history.map(m => m.content).join(''));
+    const estimatedTokens = this.estimateTokens(messages.map(m => m.content).join(''));
 
     logger.debug('SDK', `Querying OpenRouter multi-turn (${model})`, {
       turns: history.length,

--- a/tests/worker/openrouter-messages.test.ts
+++ b/tests/worker/openrouter-messages.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, spyOn, mock } from 'bun:test';
+import { OpenRouterProvider } from '../../src/services/worker/OpenRouterProvider.js';
+import { DatabaseManager } from '../../src/services/worker/DatabaseManager.js';
+import { SessionManager } from '../../src/services/worker/SessionManager.js';
+import { SettingsDefaultsManager } from '../../src/shared/SettingsDefaultsManager.js';
+import type { ConversationMessage } from '../../src/services/worker-types.js';
+
+class TestOpenRouterProvider extends OpenRouterProvider {
+  buildMessages(history: ConversationMessage[]) {
+    return (this as unknown as { conversationToOpenAIMessages(history: ConversationMessage[]): unknown })
+      .conversationToOpenAIMessages(history);
+  }
+}
+
+describe('OpenRouterProvider conversation normalization', () => {
+  let provider: TestOpenRouterProvider;
+
+  beforeEach(() => {
+    spyOn(SettingsDefaultsManager, 'loadFromFile').mockImplementation(() => ({
+      ...SettingsDefaultsManager.getAllDefaults(),
+      CLAUDE_MEM_OPENROUTER_API_KEY: 'test-api-key',
+      CLAUDE_MEM_OPENROUTER_MODEL: 'xiaomi/mimo-v2-flash:free',
+    }));
+
+    provider = new TestOpenRouterProvider({} as DatabaseManager, {} as SessionManager);
+  });
+
+  it('drops empty history entries instead of sending an empty messages array', () => {
+    const messages = provider.buildMessages([
+      { role: 'user', content: '   ' },
+      { role: 'assistant', content: '' },
+    ]);
+
+    expect(messages).toEqual([{ role: 'user', content: '(context unavailable)' }]);
+  });
+
+  it('keeps the newest non-empty message as the fallback when everything else is blank', () => {
+    const messages = provider.buildMessages([
+      { role: 'user', content: 'keep me' },
+      { role: 'assistant', content: '   ' },
+    ]);
+
+    expect(messages).toEqual([{ role: 'user', content: 'keep me' }]);
+  });
+
+  it('never returns an empty messages array for oversized single-message histories', () => {
+    const oversized = 'x'.repeat(500_000);
+    const messages = provider.buildMessages([{ role: 'user', content: oversized }]);
+
+    expect(messages.length).toBe(1);
+    expect(messages[0]?.content).toBe(oversized);
+  });
+});
+
+describe('OpenRouterProvider request guard', () => {
+  it('posts at least one message even when history is blank', async () => {
+    spyOn(SettingsDefaultsManager, 'loadFromFile').mockImplementation(() => ({
+      ...SettingsDefaultsManager.getAllDefaults(),
+      CLAUDE_MEM_OPENROUTER_API_KEY: 'test-api-key',
+      CLAUDE_MEM_OPENROUTER_MODEL: 'xiaomi/mimo-v2-flash:free',
+    }));
+
+    const provider = new TestOpenRouterProvider({} as DatabaseManager, {} as SessionManager);
+    const fetchMock = mock(() => Promise.resolve(new Response(JSON.stringify({
+      choices: [{ message: { content: 'ok' } }],
+    }))));
+
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await (provider as unknown as {
+      queryOpenRouterMultiTurn(
+        history: ConversationMessage[],
+        apiKey: string,
+        model: string,
+        apiUrl: string,
+        siteUrl?: string,
+        appName?: string,
+      ): Promise<unknown>;
+    }).queryOpenRouterMultiTurn(
+      [{ role: 'user', content: '   ' }],
+      'test-api-key',
+      'xiaomi/mimo-v2-flash:free',
+      'https://openrouter.ai/api/v1/chat/completions',
+    );
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+    expect(body.messages.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/worker/openrouter-messages.test.ts
+++ b/tests/worker/openrouter-messages.test.ts
@@ -14,15 +14,20 @@ class TestOpenRouterProvider extends OpenRouterProvider {
 
 describe('OpenRouterProvider conversation normalization', () => {
   let provider: TestOpenRouterProvider;
+  let settingsSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
-    spyOn(SettingsDefaultsManager, 'loadFromFile').mockImplementation(() => ({
+    settingsSpy = spyOn(SettingsDefaultsManager, 'loadFromFile').mockImplementation(() => ({
       ...SettingsDefaultsManager.getAllDefaults(),
       CLAUDE_MEM_OPENROUTER_API_KEY: 'test-api-key',
       CLAUDE_MEM_OPENROUTER_MODEL: 'xiaomi/mimo-v2-flash:free',
     }));
 
     provider = new TestOpenRouterProvider({} as DatabaseManager, {} as SessionManager);
+  });
+
+  afterEach(() => {
+    settingsSpy.mockRestore();
   });
 
   it('drops empty history entries instead of sending an empty messages array', () => {
@@ -54,6 +59,7 @@ describe('OpenRouterProvider conversation normalization', () => {
 
 describe('OpenRouterProvider request guard', () => {
   let originalFetch: typeof fetch;
+  let settingsSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     originalFetch = global.fetch;
@@ -61,10 +67,11 @@ describe('OpenRouterProvider request guard', () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
+    settingsSpy?.mockRestore();
   });
 
   it('posts at least one message even when history is blank', async () => {
-    spyOn(SettingsDefaultsManager, 'loadFromFile').mockImplementation(() => ({
+    settingsSpy = spyOn(SettingsDefaultsManager, 'loadFromFile').mockImplementation(() => ({
       ...SettingsDefaultsManager.getAllDefaults(),
       CLAUDE_MEM_OPENROUTER_API_KEY: 'test-api-key',
       CLAUDE_MEM_OPENROUTER_MODEL: 'xiaomi/mimo-v2-flash:free',

--- a/tests/worker/openrouter-messages.test.ts
+++ b/tests/worker/openrouter-messages.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, spyOn, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test';
 import { OpenRouterProvider } from '../../src/services/worker/OpenRouterProvider.js';
 import { DatabaseManager } from '../../src/services/worker/DatabaseManager.js';
 import { SessionManager } from '../../src/services/worker/SessionManager.js';
@@ -53,6 +53,16 @@ describe('OpenRouterProvider conversation normalization', () => {
 });
 
 describe('OpenRouterProvider request guard', () => {
+  let originalFetch: typeof fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
   it('posts at least one message even when history is blank', async () => {
     spyOn(SettingsDefaultsManager, 'loadFromFile').mockImplementation(() => ({
       ...SettingsDefaultsManager.getAllDefaults(),


### PR DESCRIPTION
## Summary

- Normalize OpenRouter conversation history the same way Gemini already does: skip blank turns, merge adjacent same-role messages, and fall back to the newest non-empty prompt.
- Prevents OpenRouter requests with messages: [], which returned HTTP 400 and dropped observations.

## Context

v13.9.2 removed centralized 	runcateHistory(), which was the original source of the empty-array bug on 12.4.7. This patch closes the remaining provider gap: OpenRouter still forwarded blank history verbatim while Gemini filtered it.

## Verification

\\\
cd claude-mem-wt/3491-openrouter-truncate-guard
bun test ./tests/worker/openrouter-messages.test.ts
# 4 pass
\\\

## AI assistance

AI-assisted (Cursor). Stan Shih reviewed the diff.

Fixes #3491

Made with [Cursor](https://cursor.com)