### PR TITLE
Fix duplicate OpenAI-compatible conversation history entries

### DIFF
--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -170,7 +170,6 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     responseContext: ReturnType<typeof snapshotResponseContext>
   ): Promise<void> {
     if (initResponse.content) {
-      session.conversationHistory.push({ role: 'assistant', content: initResponse.content });
       const tokensUsed = initResponse.tokensUsed || 0;
       session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
       session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
@@ -219,7 +218,6 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
 
     let tokensUsed = 0;
     if (obsResponse.content) {
-      session.conversationHistory.push({ role: 'assistant', content: obsResponse.content });
       tokensUsed = obsResponse.tokensUsed || 0;
       session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
       session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
@@ -277,7 +275,6 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
 
     let tokensUsed = 0;
     if (summaryResponse.content) {
-      session.conversationHistory.push({ role: 'assistant', content: summaryResponse.content });
       tokensUsed = summaryResponse.tokensUsed || 0;
       session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
       session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);

--- a/tests/gemini_provider.test.ts
+++ b/tests/gemini_provider.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Test goal: verify GeminiProvider request formatting, lifecycle behavior, and error handling.
+ * Strategy: replace provider IO and worker persistence boundaries with deterministic test doubles,
+ * then exercise the public session API and inspect requests, stored results, and session state.
+ */
 import { describe, it, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test';
 import { writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
@@ -211,27 +216,82 @@ describe('GeminiProvider', () => {
 
   it('should add each provider response to conversation history exactly once', async () => {
     const session = makeSession();
-    const responseText = `
+    const initResponse = `
       <observation>
         <type>discovery</type>
-        <title>Test</title>
-        <narrative>Stored once</narrative>
+        <title>Init response</title>
+        <narrative>Initial context stored once</narrative>
         <facts></facts>
         <concepts></concepts>
         <files_read></files_read>
         <files_modified></files_modified>
       </observation>
     `;
+    const observationResponse = `
+      <observation>
+        <type>bugfix</type>
+        <title>Observation response</title>
+        <narrative>Tool result stored once</narrative>
+        <facts></facts>
+        <concepts></concepts>
+        <files_read></files_read>
+        <files_modified></files_modified>
+      </observation>
+    `;
+    const summaryResponse = `
+      <summary>
+        <request>Fix duplicate history entries</request>
+        <investigated>Init and message-loop responses</investigated>
+        <learned>ResponseProcessor owns assistant history writes</learned>
+        <completed>Added regression coverage</completed>
+        <next_steps>Run focused tests</next_steps>
+        <notes>Summary stored once</notes>
+      </summary>
+    `;
+    const providerResponses = [initResponse, observationResponse, summaryResponse];
 
-    global.fetch = mock(() => Promise.resolve(new Response(JSON.stringify({
-      candidates: [{ content: { parts: [{ text: responseText }] } }],
-      usageMetadata: { totalTokenCount: 50 }
-    }))));
+    mockSessionManager.getMessageIterator = async function* () {
+      yield {
+        type: 'observation',
+        tool_name: 'Read',
+        tool_input: { file_path: '/tmp/input.ts' },
+        tool_response: { content: 'file contents' },
+        prompt_number: 2,
+        cwd: '/tmp',
+        _persistentId: 1,
+        _originalTimestamp: 1_700_000_000_000,
+      };
+      yield {
+        type: 'summarize',
+        last_assistant_message: 'Regression test completed',
+        _persistentId: 2,
+        _originalTimestamp: 1_700_000_000_001,
+      };
+    };
+
+    global.fetch = mock(() => {
+      const responseText = providerResponses.shift();
+      if (!responseText) {
+        throw new Error('Unexpected Gemini request');
+      }
+      return Promise.resolve(new Response(JSON.stringify({
+        candidates: [{ content: { parts: [{ text: responseText }] } }],
+        usageMetadata: { totalTokenCount: 50 }
+      })));
+    });
 
     await agent.startSession(session);
 
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+    const requestBodies = (global.fetch as any).mock.calls.map((call: any[]) => JSON.parse(call[1].body));
+    expect(requestBodies[0].contents.at(-1).parts[0].text).toContain('<user_request>test prompt</user_request>');
+    expect(requestBodies[1].contents.at(-1).parts[0].text).toContain('<what_happened>Read</what_happened>');
+    expect(requestBodies[2].contents.at(-1).parts[0].text).toContain('MODE SWITCH: PROGRESS SUMMARY');
+    expect(mockStoreObservations).toHaveBeenCalledTimes(3);
     expect(session.conversationHistory.filter(message => message.role === 'assistant')).toEqual([
-      { role: 'assistant', content: responseText }
+      { role: 'assistant', content: initResponse },
+      { role: 'assistant', content: observationResponse },
+      { role: 'assistant', content: summaryResponse },
     ]);
   });
 

--- a/tests/gemini_provider.test.ts
+++ b/tests/gemini_provider.test.ts
@@ -209,6 +209,32 @@ describe('GeminiProvider', () => {
     expect(url).toContain('key=test-api-key');
   });
 
+  it('should add each provider response to conversation history exactly once', async () => {
+    const session = makeSession();
+    const responseText = `
+      <observation>
+        <type>discovery</type>
+        <title>Test</title>
+        <narrative>Stored once</narrative>
+        <facts></facts>
+        <concepts></concepts>
+        <files_read></files_read>
+        <files_modified></files_modified>
+      </observation>
+    `;
+
+    global.fetch = mock(() => Promise.resolve(new Response(JSON.stringify({
+      candidates: [{ content: { parts: [{ text: responseText }] } }],
+      usageMetadata: { totalTokenCount: 50 }
+    }))));
+
+    await agent.startSession(session);
+
+    expect(session.conversationHistory.filter(message => message.role === 'assistant')).toEqual([
+      { role: 'assistant', content: responseText }
+    ]);
+  });
+
   it('should handle multi-turn conversation', async () => {
     const session = {
       sessionDbId: 1,


### PR DESCRIPTION
## Summary

- Remove the OpenAI-compatible provider's duplicate assistant-history appends.
- Keep `ResponseProcessor` as the single shared owner of assistant response history updates.
- Add a Gemini provider regression test asserting one history entry per response.

## Root cause

`OpenAICompatibleProvider` appended init, observation, and summary responses before calling `processAgentResponse`, while `ResponseProcessor` appended the same response again. The Claude SDK path does not pre-append, so the shared processor remains the correct single write point.

## Impact

Gemini and OpenRouter sessions could retain duplicate assistant messages in `conversationHistory`, causing duplicated content to be sent in later requests and amplifying context growth.

## Validation

- `bun test tests/worker/agents/ tests/gemini_provider.test.ts tests/worker/openai-compatible-summary-tier.test.ts`
- 45 tests passed
- `bun run typecheck:root` passed

Fixes #3499