### PR TITLE
fix(observer): skip textless assistant frames before batch confirm (Fixes #3492)

### DIFF
--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -273,6 +273,10 @@ export class ClaudeProvider {
       // Textless frames are not dispatched (see below), so their usage rolls
       // into the next dispatch instead of going unattributed.
       let discoveryTokenBaseline = session.cumulativeInputTokens + session.cumulativeOutputTokens;
+      // Whether the current turn has dispatched any text yet. A turn that ends
+      // without one still needs the idle hand-off, otherwise the claimed batch
+      // is left dangling for session teardown to discard.
+      let turnDispatchedText = false;
 
       for await (const message of queryResult) {
         // Quota-aware wall-clock guard (#2234): the SDK pushes `system` events
@@ -339,7 +343,9 @@ export class ClaudeProvider {
           // confirm-and-drop the claimed batch before the real XML frame
           // arrives (#3492). A frame that does contain a text block still goes
           // through even when that text is empty: that is the provider saying
-          // it had nothing to record, which stays a confirmed no-op batch.
+          // it had nothing to record, which stays a confirmed no-op batch. A
+          // turn that never produces a text frame gets the same idle hand-off
+          // once, from the `result` branch below.
           const hasTextBlock = Array.isArray(content)
             ? content.some((c: any) => c?.type === 'text')
             : typeof content === 'string';
@@ -422,6 +428,7 @@ export class ClaudeProvider {
           );
 
           discoveryTokenBaseline = session.cumulativeInputTokens + session.cumulativeOutputTokens;
+          turnDispatchedText = true;
         }
 
         if (message.type === 'result') {
@@ -467,6 +474,30 @@ export class ClaudeProvider {
                   : undefined,
             });
           }
+
+          if (!turnDispatchedText) {
+            // The whole turn carried no text, so no frame handed the claimed
+            // batch to the parser. Do it once here with the empty response the
+            // turn actually produced: the batch is classified idle and
+            // confirmed, exactly as before #3492's frame-level skip. Skipping
+            // this would leave the batch claimed until session teardown
+            // disposes the in-RAM buffer, which drops it with no hand-off.
+            await processAgentResponse(
+              '',
+              session,
+              this.dbManager,
+              this.sessionManager,
+              worker,
+              (session.cumulativeInputTokens + session.cumulativeOutputTokens) - discoveryTokenBaseline,
+              session.earliestPendingTimestamp,
+              'SDK',
+              cwdTracker.lastCwd,
+              modelId,
+              activeResponseContext.current
+            );
+            discoveryTokenBaseline = session.cumulativeInputTokens + session.cumulativeOutputTokens;
+          }
+          turnDispatchedText = false;
         }
       }
     } finally {

--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -269,6 +269,11 @@ export class ClaudeProvider {
         }),
       });
 
+      // Baseline for the next dispatched response's discovery-token delta.
+      // Textless frames are not dispatched (see below), so their usage rolls
+      // into the next dispatch instead of going unattributed.
+      let discoveryTokenBaseline = session.cumulativeInputTokens + session.cumulativeOutputTokens;
+
       for await (const message of queryResult) {
         // Quota-aware wall-clock guard (#2234): the SDK pushes `system` events
         // with subtype `rate_limit` carrying live subscription quota state.
@@ -327,13 +332,22 @@ export class ClaudeProvider {
 
         if (message.type === 'assistant') {
           const content = message.message.content;
+          // A turn can arrive as several assistant messages, and a frame that
+          // holds only thinking or tool_use blocks carries no text at all.
+          // Flattening such a frame to '' and handing it to
+          // processAgentResponse makes the parser read the turn as idle and
+          // confirm-and-drop the claimed batch before the real XML frame
+          // arrives (#3492). A frame that does contain a text block still goes
+          // through even when that text is empty: that is the provider saying
+          // it had nothing to record, which stays a confirmed no-op batch.
+          const hasTextBlock = Array.isArray(content)
+            ? content.some((c: any) => c?.type === 'text')
+            : typeof content === 'string';
           const textContent = Array.isArray(content)
             ? content.filter((c: any) => c.type === 'text').map((c: any) => c.text).join('\n')
             : typeof content === 'string' ? content : '';
 
           const responseSize = textContent.length;
-
-          const tokensBeforeResponse = session.cumulativeInputTokens + session.cumulativeOutputTokens;
 
           const usage = message.message.usage;
           if (usage) {
@@ -364,7 +378,18 @@ export class ClaudeProvider {
             });
           }
 
-          const discoveryTokens = (session.cumulativeInputTokens + session.cumulativeOutputTokens) - tokensBeforeResponse;
+          if (!hasTextBlock) {
+            logger.debug('SDK', 'Assistant frame carried no text block, leaving queued batch intact', {
+              sessionId: session.sessionDbId,
+              promptNumber: session.lastPromptNumber,
+              blockTypes: Array.isArray(content)
+                ? [...new Set(content.map((c: any) => String(c?.type)))].join(',')
+                : typeof content,
+            });
+            continue;
+          }
+
+          const discoveryTokens = (session.cumulativeInputTokens + session.cumulativeOutputTokens) - discoveryTokenBaseline;
 
           const originalTimestamp = session.earliestPendingTimestamp;
 
@@ -395,6 +420,8 @@ export class ClaudeProvider {
             modelId,
             activeResponseContext.current
           );
+
+          discoveryTokenBaseline = session.cumulativeInputTokens + session.cumulativeOutputTokens;
         }
 
         if (message.type === 'result') {

--- a/tests/worker/claude-provider-assistant-frames.test.ts
+++ b/tests/worker/claude-provider-assistant-frames.test.ts
@@ -274,7 +274,7 @@ describe('ClaudeProvider assistant frame dispatch (#3492)', () => {
     expect(harness.confirmClaimedMessages).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps the batch claimed when the whole turn produced no text frame', async () => {
+  it('confirms the batch once at the end of a turn that produced no text frame', async () => {
     const session = createSession();
     const harness = createHarness(session);
 
@@ -285,11 +285,46 @@ describe('ClaudeProvider assistant frame dispatch (#3492)', () => {
 
     await harness.provider.startSession(session);
 
-    // Nothing was answered, so nothing is confirmed. The next generator pass
-    // re-yields the batch (SessionManager.getMessageIterator resets claimed
-    // messages back to pending before draining).
-    expect(harness.confirmClaimedMessages).not.toHaveBeenCalled();
-    expect(harness.remainingClaimed()).toHaveLength(1);
-    expect(session.earliestPendingTimestamp).toBe(QUEUED_TIMESTAMP);
+    // The turn said nothing at all, so the batch still gets the idle hand-off,
+    // just once and at turn granularity. Leaving it claimed would hand it to
+    // session teardown, which disposes the in-RAM buffer without a hand-off.
+    expect(harness.storeObservations).not.toHaveBeenCalled();
+    expect(harness.confirmClaimedMessages).toHaveBeenCalledTimes(1);
+    expect(harness.remainingClaimed()).toEqual([]);
+    expect(session.claimedMessageIds).toEqual([]);
+  });
+
+  it('does not re-confirm at the result when the turn already dispatched text', async () => {
+    const session = createSession();
+    const harness = createHarness(session);
+
+    scriptedMessages = [
+      assistantFrame([{ type: 'text', text: OBSERVATION_XML }]),
+      resultFrame(),
+    ];
+
+    await harness.provider.startSession(session);
+
+    expect(harness.storeObservations).toHaveBeenCalledTimes(1);
+    expect(harness.confirmClaimedMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracks text dispatch per turn across consecutive turns', async () => {
+    const session = createSession();
+    const harness = createHarness(session);
+
+    scriptedMessages = [
+      assistantFrame([{ type: 'text', text: OBSERVATION_XML }]),
+      resultFrame(),
+      assistantFrame([{ type: 'tool_use', id: 'toolu_1', name: 'Read', input: {} }]),
+      resultFrame(),
+    ];
+
+    await harness.provider.startSession(session);
+
+    // Turn one stored, turn two produced no text and took the idle hand-off:
+    // the flag must not stay latched from the first turn.
+    expect(harness.storeObservations).toHaveBeenCalledTimes(1);
+    expect(harness.confirmClaimedMessages).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/worker/claude-provider-assistant-frames.test.ts
+++ b/tests/worker/claude-provider-assistant-frames.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, beforeEach, afterAll, mock } from 'bun:test';
+import type { ActiveSession } from '../../src/services/worker-types.js';
+
+// bun's mock.module is process-global and sticky: it is never auto-unregistered
+// and leaks into every file that runs afterwards. Snapshot each real module
+// before mocking and re-register the snapshot in afterAll so the stubs below
+// cannot break later suites that drive the real implementations.
+const actualAgentSdk = { ...(await import('@anthropic-ai/claude-agent-sdk')) };
+const actualFindClaude = { ...(await import('../../src/shared/find-claude-executable.js')) };
+const actualEnvManager = { ...(await import('../../src/shared/EnvManager.js')) };
+const actualProcessRegistry = { ...(await import('../../src/supervisor/process-registry.js')) };
+const actualModeManager = { ...(await import('../../src/services/domain/ModeManager.js')) };
+
+let scriptedMessages: unknown[] = [];
+
+mock.module('@anthropic-ai/claude-agent-sdk', () => ({
+  ...actualAgentSdk,
+  query: () => (async function* () {
+    for (const message of scriptedMessages) {
+      yield message;
+    }
+  })(),
+}));
+
+mock.module('../../src/shared/find-claude-executable.js', () => ({
+  ...actualFindClaude,
+  findClaudeExecutable: () => '/mock/claude',
+}));
+
+mock.module('../../src/shared/EnvManager.js', () => ({
+  ...actualEnvManager,
+  buildIsolatedEnvWithFreshOAuth: async () => ({ PATH: process.env.PATH ?? '' }),
+  getAuthMethodDescription: () => 'test-auth',
+}));
+
+mock.module('../../src/supervisor/process-registry.js', () => ({
+  ...actualProcessRegistry,
+  waitForSlot: async () => ({ release: () => {} }),
+  createSdkSpawnFactory: () => () => {
+    throw new Error('spawn factory must not run in this test');
+  },
+  getSdkProcessForSession: () => undefined,
+  ensureSdkProcessExit: async () => {},
+}));
+
+mock.module('../../src/services/domain/ModeManager.js', () => ({
+  ...actualModeManager,
+  ModeManager: {
+    getInstance: () => ({
+      getActiveMode: () => ({
+        name: 'code',
+        prompts: { init: 'init prompt', observation: 'obs prompt', summary: 'summary prompt' },
+        observation_types: [{ id: 'discovery' }, { id: 'bugfix' }, { id: 'refactor' }],
+        observation_concepts: [],
+      }),
+    }),
+  },
+}));
+
+afterAll(() => {
+  mock.module('../../src/services/domain/ModeManager.js', () => actualModeManager);
+  mock.module('@anthropic-ai/claude-agent-sdk', () => actualAgentSdk);
+  mock.module('../../src/shared/find-claude-executable.js', () => actualFindClaude);
+  mock.module('../../src/shared/EnvManager.js', () => actualEnvManager);
+  mock.module('../../src/supervisor/process-registry.js', () => actualProcessRegistry);
+});
+
+const { ClaudeProvider } = await import('../../src/services/worker/ClaudeProvider.js');
+
+const MEMORY_SESSION_ID = 'memory-session-3492';
+const QUEUED_TIMESTAMP = 1700000000000;
+
+const OBSERVATION_XML = `
+<observation>
+  <type>discovery</type>
+  <title>Observed the queued tool call</title>
+  <narrative>The queued batch reached the parser.</narrative>
+  <facts><fact>Batch survived the textless frame</fact></facts>
+  <concepts><concept>observer</concept></concepts>
+  <files_read></files_read>
+  <files_modified></files_modified>
+</observation>
+`;
+
+function assistantFrame(content: unknown) {
+  return {
+    type: 'assistant',
+    session_id: MEMORY_SESSION_ID,
+    message: {
+      content,
+      usage: { input_tokens: 120, output_tokens: 4 },
+    },
+  };
+}
+
+function resultFrame() {
+  return {
+    type: 'result',
+    session_id: MEMORY_SESSION_ID,
+    usage: { input_tokens: 120, output_tokens: 40 },
+    total_cost_usd: 0.001,
+  };
+}
+
+function createSession(): ActiveSession {
+  return {
+    sessionDbId: 3492,
+    contentSessionId: 'content-3492',
+    memorySessionId: null,
+    project: 'observer-project',
+    platformSource: 'claude',
+    userPrompt: 'run the project',
+    abortController: new AbortController(),
+    generatorPromise: null,
+    lastPromptNumber: 2,
+    startTime: Date.now(),
+    cumulativeInputTokens: 0,
+    cumulativeOutputTokens: 0,
+    earliestPendingTimestamp: QUEUED_TIMESTAMP,
+    claimedMessageIds: [1],
+    conversationHistory: [],
+    currentProvider: null,
+    consecutiveRestarts: 0,
+    consecutiveInvalidOutputs: 0,
+    lastGeneratorActivity: Date.now(),
+  } as ActiveSession;
+}
+
+function createHarness(session: ActiveSession) {
+  // Mirrors SessionManager.confirmClaimedMessages: the claimed batch and the
+  // batch's original timestamp are both released on confirm, so a later
+  // dispatch in the same turn sees an empty batch.
+  let claimedMessages: Array<{ type: string; tool_name?: string; tool_input?: unknown }> = [
+    { type: 'observation', tool_name: 'Read', tool_input: { file_path: 'src/queued.ts' } },
+  ];
+
+  const confirmClaimedMessages = mock(async () => {
+    const confirmed = claimedMessages.length;
+    claimedMessages = [];
+    session.claimedMessageIds = [];
+    session.earliestPendingTimestamp = null;
+    return confirmed;
+  });
+  const resetProcessingToPending = mock(async () => 0);
+  const storeObservations = mock(() => ({
+    observationIds: [7],
+    summaryId: null,
+    createdAtEpoch: QUEUED_TIMESTAMP,
+  }));
+
+  const sessionManager = {
+    confirmClaimedMessages,
+    resetProcessingToPending,
+    getClaimedMessages: () => claimedMessages,
+    getMessageIterator: async function* () {},
+  };
+
+  const dbManager = {
+    getSessionStore: () => ({
+      updateMemorySessionId: () => {},
+      ensureMemorySessionIdRegistered: () => {},
+      getSessionById: () => ({ memory_session_id: MEMORY_SESSION_ID }),
+      storeObservations,
+    }),
+    getChromaSync: () => null,
+    getCloudSync: () => null,
+  };
+
+  return {
+    confirmClaimedMessages,
+    resetProcessingToPending,
+    storeObservations,
+    remainingClaimed: () => claimedMessages,
+    provider: new ClaudeProvider(dbManager as never, sessionManager as never),
+  };
+}
+
+describe('ClaudeProvider assistant frame dispatch (#3492)', () => {
+  beforeEach(() => {
+    scriptedMessages = [];
+  });
+
+  it('leaves the claimed batch intact when a frame carries no text block', async () => {
+    const session = createSession();
+    const harness = createHarness(session);
+
+    scriptedMessages = [
+      assistantFrame([{ type: 'tool_use', id: 'toolu_1', name: 'Read', input: {} }]),
+      assistantFrame([{ type: 'text', text: OBSERVATION_XML }]),
+      resultFrame(),
+    ];
+
+    await harness.provider.startSession(session);
+
+    expect(harness.storeObservations).toHaveBeenCalledTimes(1);
+    const [memorySessionId, project, observations, , , , originalTimestamp] =
+      harness.storeObservations.mock.calls[0] as unknown[] as [
+        string, string, Array<{ files_read: string[] }>, unknown, number, number, number | undefined,
+      ];
+
+    expect(memorySessionId).toBe(MEMORY_SESSION_ID);
+    expect(project).toBe('observer-project');
+    // The tool_use frame must not have confirmed the batch away: the XML frame
+    // still sees the queued Read as file evidence, and still carries the
+    // batch's original timestamp.
+    expect(observations[0].files_read).toEqual(['src/queued.ts']);
+    expect(originalTimestamp).toBe(QUEUED_TIMESTAMP);
+    expect(harness.confirmClaimedMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the claimed batch intact when a frame carries only thinking blocks', async () => {
+    const session = createSession();
+    const harness = createHarness(session);
+
+    scriptedMessages = [
+      assistantFrame([{ type: 'thinking', thinking: 'considering the batch', signature: 'sig' }]),
+      assistantFrame([{ type: 'text', text: OBSERVATION_XML }]),
+      resultFrame(),
+    ];
+
+    await harness.provider.startSession(session);
+
+    expect(harness.storeObservations).toHaveBeenCalledTimes(1);
+    const [, , observations] = harness.storeObservations.mock.calls[0] as unknown[] as [
+      string, string, Array<{ files_read: string[] }>,
+    ];
+    expect(observations[0].files_read).toEqual(['src/queued.ts']);
+    expect(harness.confirmClaimedMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it('still confirms and drops the batch when the frame carries an empty text block', async () => {
+    const session = createSession();
+    const harness = createHarness(session);
+
+    scriptedMessages = [
+      assistantFrame([{ type: 'text', text: '   ' }]),
+      resultFrame(),
+    ];
+
+    await harness.provider.startSession(session);
+
+    expect(harness.storeObservations).not.toHaveBeenCalled();
+    expect(harness.confirmClaimedMessages).toHaveBeenCalledTimes(1);
+    expect(harness.remainingClaimed()).toEqual([]);
+  });
+
+  it('still confirms and drops the batch for idle prose', async () => {
+    const session = createSession();
+    const harness = createHarness(session);
+
+    scriptedMessages = [
+      assistantFrame([
+        { type: 'text', text: 'No observations to record yet - waiting for tool executions and results.' },
+      ]),
+      resultFrame(),
+    ];
+
+    await harness.provider.startSession(session);
+
+    expect(harness.storeObservations).not.toHaveBeenCalled();
+    expect(harness.confirmClaimedMessages).toHaveBeenCalledTimes(1);
+    expect(harness.remainingClaimed()).toEqual([]);
+  });
+
+  it('dispatches string content as text', async () => {
+    const session = createSession();
+    const harness = createHarness(session);
+
+    scriptedMessages = [assistantFrame(OBSERVATION_XML), resultFrame()];
+
+    await harness.provider.startSession(session);
+
+    expect(harness.storeObservations).toHaveBeenCalledTimes(1);
+    expect(harness.confirmClaimedMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the batch claimed when the whole turn produced no text frame', async () => {
+    const session = createSession();
+    const harness = createHarness(session);
+
+    scriptedMessages = [
+      assistantFrame([{ type: 'tool_use', id: 'toolu_1', name: 'Read', input: {} }]),
+      resultFrame(),
+    ];
+
+    await harness.provider.startSession(session);
+
+    // Nothing was answered, so nothing is confirmed. The next generator pass
+    // re-yields the batch (SessionManager.getMessageIterator resets claimed
+    // messages back to pending before draining).
+    expect(harness.confirmClaimedMessages).not.toHaveBeenCalled();
+    expect(harness.remainingClaimed()).toHaveLength(1);
+    expect(session.earliestPendingTimestamp).toBe(QUEUED_TIMESTAMP);
+  });
+});


### PR DESCRIPTION
## Summary

- Skip `processAgentResponse` when a Claude assistant frame has no `text` content block (thinking-only or tool_use-only frames).
- Prevents `ResponseProcessor` from classifying the flattened `''` as idle and calling `confirmClaimedMessages()` before the real observation XML frame arrives.

## Context

Fixes #3492. Reporter logs showed `idle` with an empty preview immediately before a 258-char XML response; observations stayed at 0 while summaries still stored.

**Level of fix:** `ClaudeProvider` only (Gemini already skips empty responses; OpenRouter uses `forwardEmptyMessageResponse`). Frames that include a `text` block still flow through, including empty or idle prose, so the existing confirm-and-drop path for true idle answers is unchanged.

**Bot / edge-case checks**

| Path | Before | After |
| --- | --- | --- |
| tool_use-only frame then XML frame | `''` classified idle, batch dropped | batch kept, XML stores observation |
| empty `text` block frame | confirm-and-drop | unchanged |
| idle prose text frame | confirm-and-drop | unchanged |

## Verification

```
cd claude-mem-wt/3492-observer-init-loop
bun test tests/worker/claude-provider-assistant-frames.test.ts
# 6 pass
bun test tests/worker/agents/response-processor.test.ts
# 23 pass
bun run typecheck
```

## AI assistance

AI-assisted (Cursor). Stan Shih reviewed the diff.

Fixes #3492
