### PR TITLE
fix(observer): surface cumulative token usage on session completion (Related to #3497)

### DIFF
--- a/src/services/worker-types.ts
+++ b/src/services/worker-types.ts
@@ -58,6 +58,14 @@ export interface ActiveSession {
   pendingCompressionEvent?: Record<string, unknown> | null;
   /** Cumulative total_cost_usd from the SDK's latest result message — per-compression cost is the delta between results. */
   lastResultTotalCostUsd?: number | null;
+  /**
+   * Cumulative cache_read_input_tokens across the session. Kept apart from
+   * cumulativeInputTokens because discovery_tokens is the delta of that
+   * counter; on a long observer session this is where most of the context the
+   * model re-reads shows up, so it is the number that makes resend growth
+   * visible.
+   */
+  cumulativeCacheReadTokens?: number;
 }
 
 export interface PendingMessage {

--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -28,6 +28,7 @@ import { query } from '@anthropic-ai/claude-agent-sdk';
 import { buildHardenedSdkOptions } from '../../sdk/hardened-options.js';
 import { ClassifiedProviderError } from './provider-errors.js';
 import { resolveTierAlias } from './model-aliases.js';
+import { accumulateClaudeUsage, observerUsageLogFields } from './observer-usage.js';
 import { telemetryBuffer } from '../telemetry/buffer.js';
 import { clearDependencyStatus, recordClaudeCliSetupRequired } from '../../shared/dependency-health.js';
 
@@ -337,12 +338,7 @@ export class ClaudeProvider {
 
           const usage = message.message.usage;
           if (usage) {
-            session.cumulativeInputTokens += usage.input_tokens || 0;
-            session.cumulativeOutputTokens += usage.output_tokens || 0;
-
-            if (usage.cache_creation_input_tokens) {
-              session.cumulativeInputTokens += usage.cache_creation_input_tokens;
-            }
+            accumulateClaudeUsage(session, usage);
 
             // Real per-response usage for telemetry (tokens_input includes the
             // full context the model read: fresh + cache writes + cache reads).
@@ -462,7 +458,8 @@ export class ClaudeProvider {
     const sessionDuration = Date.now() - session.startTime;
     logger.success('SDK', 'Agent completed', {
       sessionId: session.sessionDbId,
-      duration: `${(sessionDuration / 1000).toFixed(1)}s`
+      duration: `${(sessionDuration / 1000).toFixed(1)}s`,
+      ...observerUsageLogFields(session)
     });
   }
 

--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -171,11 +171,12 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     model: string,
     responseContext: ReturnType<typeof snapshotResponseContext>
   ): Promise<void> {
+    accumulateObserverUsage(session, initResponse);
+    session.lastUsage = this.buildLastUsage(initResponse);
+    const tokensUsed = initResponse.tokensUsed || 0;
+
     if (initResponse.content) {
       session.conversationHistory.push({ role: 'assistant', content: initResponse.content });
-      const tokensUsed = initResponse.tokensUsed || 0;
-      accumulateObserverUsage(session, initResponse);
-      session.lastUsage = this.buildLastUsage(initResponse);
       await processAgentResponse(
         initResponse.content, session, this.dbManager, this.sessionManager,
         worker, tokensUsed, null, this.providerName, undefined, initResponse.servedModel ?? model, responseContext
@@ -218,14 +219,12 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     session.lastGeneratorSource = 'ingest';
     const obsResponse = await this.query(session.conversationHistory, config);
 
-    let tokensUsed = 0;
+    accumulateObserverUsage(session, obsResponse);
+    session.lastUsage = this.buildLastUsage(obsResponse);
+    const tokensUsed = obsResponse.tokensUsed || 0;
+
     if (obsResponse.content) {
       session.conversationHistory.push({ role: 'assistant', content: obsResponse.content });
-      tokensUsed = obsResponse.tokensUsed || 0;
-      accumulateObserverUsage(session, obsResponse);
-      // Both sides or nothing: a backend reporting only one of the two counts
-      // must not produce a half-real event (input=0 → compression_ratio 0.0).
-      session.lastUsage = this.buildLastUsage(obsResponse);
     }
 
     if (obsResponse.content || this.forwardEmptyMessageResponse) {
@@ -275,12 +274,12 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     }
     const summaryResponse = await this.query(session.conversationHistory, summaryConfig);
 
-    let tokensUsed = 0;
+    accumulateObserverUsage(session, summaryResponse);
+    session.lastUsage = this.buildLastUsage(summaryResponse);
+    const tokensUsed = summaryResponse.tokensUsed || 0;
+
     if (summaryResponse.content) {
       session.conversationHistory.push({ role: 'assistant', content: summaryResponse.content });
-      tokensUsed = summaryResponse.tokensUsed || 0;
-      accumulateObserverUsage(session, summaryResponse);
-      session.lastUsage = this.buildLastUsage(summaryResponse);
     }
 
     if (summaryResponse.content || this.forwardEmptyMessageResponse) {

--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -8,6 +8,7 @@ import type { ActiveSession, ConversationMessage } from '../worker-types.js';
 import { ModeManager } from '../domain/ModeManager.js';
 import type { ModeConfig } from '../domain/types.js';
 import { resolveSummaryTierModel } from './model-aliases.js';
+import { accumulateObserverUsage, observerUsageLogFields } from './observer-usage.js';
 import {
   processAgentResponse,
   snapshotResponseContext,
@@ -133,7 +134,8 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     logger.success('SDK', `${this.providerName} agent completed`, {
       sessionId: session.sessionDbId,
       duration: `${(sessionDuration / 1000).toFixed(1)}s`,
-      historyLength: session.conversationHistory.length
+      historyLength: session.conversationHistory.length,
+      ...observerUsageLogFields(session)
     });
   }
 
@@ -172,8 +174,7 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     if (initResponse.content) {
       session.conversationHistory.push({ role: 'assistant', content: initResponse.content });
       const tokensUsed = initResponse.tokensUsed || 0;
-      session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
-      session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
+      accumulateObserverUsage(session, initResponse);
       session.lastUsage = this.buildLastUsage(initResponse);
       await processAgentResponse(
         initResponse.content, session, this.dbManager, this.sessionManager,
@@ -221,8 +222,7 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     if (obsResponse.content) {
       session.conversationHistory.push({ role: 'assistant', content: obsResponse.content });
       tokensUsed = obsResponse.tokensUsed || 0;
-      session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
-      session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
+      accumulateObserverUsage(session, obsResponse);
       // Both sides or nothing: a backend reporting only one of the two counts
       // must not produce a half-real event (input=0 → compression_ratio 0.0).
       session.lastUsage = this.buildLastUsage(obsResponse);
@@ -279,8 +279,7 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     if (summaryResponse.content) {
       session.conversationHistory.push({ role: 'assistant', content: summaryResponse.content });
       tokensUsed = summaryResponse.tokensUsed || 0;
-      session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
-      session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
+      accumulateObserverUsage(session, summaryResponse);
       session.lastUsage = this.buildLastUsage(summaryResponse);
     }
 
@@ -298,11 +297,17 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
 
   protected handleSessionError(error: unknown, session: ActiveSession, _worker?: WorkerRef): never {
     if (isAbortError(error)) {
-      logger.warn('SDK', `${this.providerName} agent aborted`, { sessionId: session.sessionDbId });
+      logger.warn('SDK', `${this.providerName} agent aborted`, {
+        sessionId: session.sessionDbId,
+        ...observerUsageLogFields(session)
+      });
       throw error;
     }
 
-    logger.failure('SDK', `${this.providerName} agent error`, { sessionDbId: session.sessionDbId }, error instanceof Error ? error : new Error(String(error)));
+    logger.failure('SDK', `${this.providerName} agent error`, {
+      sessionDbId: session.sessionDbId,
+      ...observerUsageLogFields(session)
+    }, error instanceof Error ? error : new Error(String(error)));
     throw error;
   }
 

--- a/src/services/worker/http/routes/SessionRoutes.ts
+++ b/src/services/worker/http/routes/SessionRoutes.ts
@@ -20,6 +20,7 @@ import { getProjectContext } from '../../../../utils/project-name.js';
 import { handleGeneratorExit } from '../../session/GeneratorExitHandler.js';
 import { telemetryBuffer } from '../../../telemetry/buffer.js';
 import { SessionCompletionHandler } from '../../session/SessionCompletionHandler.js';
+import { observerUsageLogFields } from '../../observer-usage.js';
 import { USER_PROMPT_DEDUPE_WINDOW_MS } from '../../../../shared/user-prompts.js';
 import {
   CLAUDE_CLI_SETUP_RECHECK_COOLDOWN_MS,
@@ -212,6 +213,7 @@ export class SessionRoutes extends BaseRouteHandler {
           sessionId: session.sessionDbId,
           provider,
           error: errorMsg,
+          ...observerUsageLogFields(session),
         }, error);
         telemetryBuffer.record('session_compressed', session.sessionDbId, {
           outcome: 'error',

--- a/src/services/worker/observer-usage.ts
+++ b/src/services/worker/observer-usage.ts
@@ -1,0 +1,84 @@
+import type { ActiveSession } from '../worker-types.js';
+
+/**
+ * Applied only when a gateway reports a bare total with no prompt/completion
+ * breakdown. openrouter.ai and Gemini both report the split, so this is the
+ * custom-gateway fallback, not the normal path.
+ */
+const FALLBACK_INPUT_SHARE = 0.7;
+const FALLBACK_OUTPUT_SHARE = 0.3;
+
+/** The usage fields an OpenAI-compatible provider response can carry. */
+export interface ObserverUsageSample {
+  tokensUsed?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+/** The subset of the Claude SDK's usage block that feeds the session counters. */
+export interface ClaudeUsageSample {
+  input_tokens?: number | null;
+  output_tokens?: number | null;
+  cache_creation_input_tokens?: number | null;
+  cache_read_input_tokens?: number | null;
+}
+
+/**
+ * Fold one OpenAI-compatible response into the session's cumulative counters.
+ *
+ * Gemini (promptTokenCount/candidatesTokenCount) and OpenRouter
+ * (prompt_tokens/completion_tokens) both report the real split, so the
+ * estimate must not win when real counts exist: the observer resends its whole
+ * conversation on every turn, which makes its traffic overwhelmingly
+ * input-heavy, and a fixed 70/30 assumption understates input on exactly the
+ * long sessions worth noticing. Both sides or nothing, matching buildLastUsage:
+ * a gateway reporting only one of the two must not produce a half-real number.
+ */
+export function accumulateObserverUsage(session: ActiveSession, sample: ObserverUsageSample): void {
+  if (typeof sample.inputTokens === 'number' && typeof sample.outputTokens === 'number') {
+    session.cumulativeInputTokens += sample.inputTokens;
+    session.cumulativeOutputTokens += sample.outputTokens;
+    return;
+  }
+
+  const total = sample.tokensUsed || 0;
+  session.cumulativeInputTokens += Math.floor(total * FALLBACK_INPUT_SHARE);
+  session.cumulativeOutputTokens += Math.floor(total * FALLBACK_OUTPUT_SHARE);
+}
+
+/**
+ * Fold one Claude SDK assistant-message usage block into the session counters.
+ *
+ * Cache reads are tracked in their own counter rather than added to
+ * cumulativeInputTokens: discovery_tokens is derived from the delta of
+ * (cumulativeInput + cumulativeOutput) across a response, so widening those two
+ * would silently redefine a value already persisted on every observation.
+ */
+export function accumulateClaudeUsage(session: ActiveSession, usage: ClaudeUsageSample): void {
+  session.cumulativeInputTokens += usage.input_tokens || 0;
+  session.cumulativeOutputTokens += usage.output_tokens || 0;
+
+  if (usage.cache_creation_input_tokens) {
+    session.cumulativeInputTokens += usage.cache_creation_input_tokens;
+  }
+
+  if (usage.cache_read_input_tokens) {
+    session.cumulativeCacheReadTokens =
+      (session.cumulativeCacheReadTokens ?? 0) + usage.cache_read_input_tokens;
+  }
+}
+
+/**
+ * Log context for the once-per-session lines that report what the observer
+ * spent. Cache reads are omitted when the provider never reported any, so
+ * HTTP-provider logs do not carry a permanent zero.
+ */
+export function observerUsageLogFields(session: ActiveSession): Record<string, number> {
+  return {
+    cumulativeInputTokens: session.cumulativeInputTokens,
+    cumulativeOutputTokens: session.cumulativeOutputTokens,
+    ...(session.cumulativeCacheReadTokens
+      ? { cumulativeCacheReadTokens: session.cumulativeCacheReadTokens }
+      : {}),
+  };
+}

--- a/tests/logger-usage-standards.test.ts
+++ b/tests/logger-usage-standards.test.ts
@@ -44,6 +44,7 @@ const EXCLUDED_PATTERNS = [
   /sdk\/output-classifier\.ts$/,  // Pure, side-effect-free output classifier; logging happens at the ResponseProcessor call site with full session context
   /build\/hook-shell-template\.ts$/,  // Pure build-time shell-string generator (no runtime/observability surface); drift is enforced by build-hooks.js + plugin-distribution.test.ts
   /worker\/model-aliases\.ts$/,  // Pure $TIER alias resolver (#2289); side-effect-free passthrough, logging happens at the request-time call site
+  /worker\/observer-usage\.ts$/,  // Pure observer token accumulation helpers; logging happens at provider/session completion call sites (#3508)
   /worker\/TimelineService\.ts$/,  // Pure filterByDepth helper after dead-code removal; no side effects (mirrors FallbackErrorHandler)
 ];
 

--- a/tests/worker/observer-usage-visibility.test.ts
+++ b/tests/worker/observer-usage-visibility.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import { ModeManager } from '../../src/services/domain/ModeManager.js';
+import { OpenAICompatibleProvider, type ProviderQueryResult } from '../../src/services/worker/OpenAICompatibleProvider.js';
+import {
+  accumulateClaudeUsage,
+  accumulateObserverUsage,
+  observerUsageLogFields,
+} from '../../src/services/worker/observer-usage.js';
+import { SettingsDefaultsManager } from '../../src/shared/SettingsDefaultsManager.js';
+import { logger } from '../../src/utils/logger.js';
+import type { ActiveSession, ConversationMessage } from '../../src/services/worker-types.js';
+
+const mockMode = {
+  name: 'code',
+  prompts: {
+    init: 'init prompt',
+    observation: 'obs prompt',
+    summary: 'summary prompt',
+  },
+  observation_types: [{ id: 'discovery' }],
+  observation_concepts: [],
+};
+
+function makeSession(overrides: Partial<ActiveSession> = {}): ActiveSession {
+  return {
+    sessionDbId: 1,
+    contentSessionId: 'test-session',
+    memorySessionId: 'mem-session-123',
+    project: 'test-project',
+    platformSource: 'claude',
+    userPrompt: 'test prompt',
+    abortController: new AbortController(),
+    generatorPromise: null,
+    lastPromptNumber: 1,
+    startTime: Date.now(),
+    cumulativeInputTokens: 0,
+    cumulativeOutputTokens: 0,
+    earliestPendingTimestamp: null,
+    claimedMessageIds: [],
+    conversationHistory: [],
+    currentProvider: null,
+    consecutiveRestarts: 0,
+    consecutiveInvalidOutputs: 0,
+    lastGeneratorActivity: Date.now(),
+    ...overrides,
+  };
+}
+
+/**
+ * Every query reports the real prompt/completion split that Gemini
+ * (promptTokenCount/candidatesTokenCount) and OpenRouter
+ * (prompt_tokens/completion_tokens) both return.
+ */
+class RealUsageProvider extends OpenAICompatibleProvider<{ apiKey: string; model: string }> {
+  protected readonly providerName = 'TestProvider';
+  protected readonly syntheticIdPrefix = 'test';
+  protected readonly forwardEmptyMessageResponse = false;
+
+  constructor(dbManager: any, sessionManager: any, private readonly failOnQuery = false) {
+    super(dbManager, sessionManager);
+  }
+
+  protected getConfig() {
+    return { apiKey: 'test-api-key', model: 'session-model' };
+  }
+
+  protected missingApiKeyError(): Error {
+    return new Error('missing key');
+  }
+
+  protected async query(_history: ConversationMessage[]): Promise<ProviderQueryResult> {
+    if (this.failOnQuery) {
+      throw new Error('gateway exploded');
+    }
+    return { content: 'ok', tokensUsed: 1000, inputTokens: 990, outputTokens: 10 };
+  }
+
+  protected estimateTokens(): number {
+    return 0;
+  }
+
+  protected buildLastUsage(): ActiveSession['lastUsage'] {
+    return null;
+  }
+}
+
+describe('accumulateObserverUsage', () => {
+  it('accumulates the real input/output split instead of a 70/30 estimate', () => {
+    const session = makeSession();
+
+    accumulateObserverUsage(session, { tokensUsed: 1000, inputTokens: 990, outputTokens: 10 });
+
+    expect(session.cumulativeInputTokens).toBe(990);
+    expect(session.cumulativeOutputTokens).toBe(10);
+  });
+
+  it('accumulates zero-valued real counts as reported', () => {
+    const session = makeSession();
+
+    accumulateObserverUsage(session, { tokensUsed: 40, inputTokens: 40, outputTokens: 0 });
+
+    expect(session.cumulativeInputTokens).toBe(40);
+    expect(session.cumulativeOutputTokens).toBe(0);
+  });
+
+  it('falls back to the 70/30 split when a gateway reports only a bare total', () => {
+    const session = makeSession();
+
+    accumulateObserverUsage(session, { tokensUsed: 1000 });
+
+    expect(session.cumulativeInputTokens).toBe(700);
+    expect(session.cumulativeOutputTokens).toBe(300);
+  });
+
+  it('falls back when only one side of the split is reported (both sides or nothing)', () => {
+    const session = makeSession();
+
+    accumulateObserverUsage(session, { tokensUsed: 1000, outputTokens: 10 });
+
+    expect(session.cumulativeInputTokens).toBe(700);
+    expect(session.cumulativeOutputTokens).toBe(300);
+  });
+
+  it('leaves the counters untouched when the response carries no usage at all', () => {
+    const session = makeSession({ cumulativeInputTokens: 5, cumulativeOutputTokens: 2 });
+
+    accumulateObserverUsage(session, {});
+
+    expect(session.cumulativeInputTokens).toBe(5);
+    expect(session.cumulativeOutputTokens).toBe(2);
+  });
+});
+
+describe('accumulateClaudeUsage', () => {
+  it('keeps fresh input plus cache creation in cumulativeInputTokens', () => {
+    const session = makeSession();
+
+    accumulateClaudeUsage(session, {
+      input_tokens: 12,
+      output_tokens: 300,
+      cache_creation_input_tokens: 88,
+    });
+
+    expect(session.cumulativeInputTokens).toBe(100);
+    expect(session.cumulativeOutputTokens).toBe(300);
+  });
+
+  it('tracks cache reads separately so discovery_tokens keeps its meaning', () => {
+    const session = makeSession();
+
+    accumulateClaudeUsage(session, {
+      input_tokens: 12,
+      output_tokens: 300,
+      cache_read_input_tokens: 84_000,
+    });
+    accumulateClaudeUsage(session, {
+      input_tokens: 12,
+      output_tokens: 300,
+      cache_read_input_tokens: 86_000,
+    });
+
+    expect(session.cumulativeCacheReadTokens).toBe(170_000);
+    expect(session.cumulativeInputTokens).toBe(24);
+  });
+});
+
+describe('observerUsageLogFields', () => {
+  it('reports both cumulative counters', () => {
+    const session = makeSession({ cumulativeInputTokens: 64_400_000, cumulativeOutputTokens: 120_000 });
+
+    expect(observerUsageLogFields(session)).toEqual({
+      cumulativeInputTokens: 64_400_000,
+      cumulativeOutputTokens: 120_000,
+    });
+  });
+
+  it('adds cumulative cache reads when the provider reported any', () => {
+    const session = makeSession({
+      cumulativeInputTokens: 900,
+      cumulativeOutputTokens: 120,
+      cumulativeCacheReadTokens: 21_000_000,
+    });
+
+    expect(observerUsageLogFields(session)).toEqual({
+      cumulativeInputTokens: 900,
+      cumulativeOutputTokens: 120,
+      cumulativeCacheReadTokens: 21_000_000,
+    });
+  });
+});
+
+describe('OpenAICompatibleProvider observer cost visibility', () => {
+  let modeManagerSpy: ReturnType<typeof spyOn>;
+  let loadFromFileSpy: ReturnType<typeof spyOn>;
+  let successSpy: ReturnType<typeof spyOn>;
+  let failureSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    modeManagerSpy = spyOn(ModeManager, 'getInstance').mockImplementation(() => ({
+      getActiveMode: () => mockMode,
+      loadMode: () => {},
+    } as any));
+    loadFromFileSpy = spyOn(SettingsDefaultsManager, 'loadFromFile').mockImplementation(() => ({
+      ...SettingsDefaultsManager.getAllDefaults(),
+    }));
+    successSpy = spyOn(logger, 'success').mockImplementation(() => {});
+    failureSpy = spyOn(logger, 'failure').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    modeManagerSpy.mockRestore();
+    loadFromFileSpy.mockRestore();
+    successSpy.mockRestore();
+    failureSpy.mockRestore();
+    mock.restore();
+  });
+
+  it('reports cumulative observer tokens on the session completion line', async () => {
+    const provider = new RealUsageProvider({} as any, {
+      confirmClaimedMessages: async () => 0,
+      resetProcessingToPending: async () => 0,
+      getMessageIterator: async function* () {
+        yield { type: 'observation', tool_name: 'Read', tool_input: {}, tool_response: {}, prompt_number: 2 };
+      },
+    } as any);
+    const session = makeSession();
+
+    await provider.startSession(session);
+
+    // init query + observation query, each 990 in / 10 out.
+    expect(session.cumulativeInputTokens).toBe(1980);
+    expect(session.cumulativeOutputTokens).toBe(20);
+
+    const completion = successSpy.mock.calls.find(call => String(call[1]).includes('agent completed'));
+    expect(completion).toBeDefined();
+    expect(completion![2]).toMatchObject({
+      cumulativeInputTokens: 1980,
+      cumulativeOutputTokens: 20,
+    });
+  });
+
+  it('reports cumulative observer tokens when the session dies mid-flight', async () => {
+    const provider = new RealUsageProvider({} as any, {
+      getMessageIterator: async function* () {},
+    } as any, true);
+    const session = makeSession({ cumulativeInputTokens: 4_100_000, cumulativeOutputTokens: 9_000 });
+
+    await expect(provider.startSession(session)).rejects.toThrow('gateway exploded');
+
+    expect(failureSpy).toHaveBeenCalled();
+    const failure = failureSpy.mock.calls.find(call => String(call[1]).includes('agent error'));
+    expect(failure).toBeDefined();
+    expect(failure![2]).toMatchObject({
+      cumulativeInputTokens: 4_100_000,
+      cumulativeOutputTokens: 9_000,
+    });
+  });
+});

--- a/tests/worker/observer-usage-visibility.test.ts
+++ b/tests/worker/observer-usage-visibility.test.ts
@@ -187,6 +187,27 @@ describe('observerUsageLogFields', () => {
       cumulativeCacheReadTokens: 21_000_000,
     });
   });
+
+  it('matches the fields SessionRoutes spreads into Generator failed logs', () => {
+    const session = makeSession({
+      cumulativeInputTokens: 12_000,
+      cumulativeOutputTokens: 40,
+      cumulativeCacheReadTokens: 84_000,
+    });
+
+    const failureContext = {
+      sessionId: session.sessionDbId,
+      provider: 'claude',
+      error: 'stream died',
+      ...observerUsageLogFields(session),
+    };
+
+    expect(failureContext).toMatchObject({
+      cumulativeInputTokens: 12_000,
+      cumulativeOutputTokens: 40,
+      cumulativeCacheReadTokens: 84_000,
+    });
+  });
 });
 
 describe('OpenAICompatibleProvider observer cost visibility', () => {

--- a/tests/worker/observer-usage-visibility.test.ts
+++ b/tests/worker/observer-usage-visibility.test.ts
@@ -84,6 +84,43 @@ class RealUsageProvider extends OpenAICompatibleProvider<{ apiKey: string; model
   }
 }
 
+/** Init returns content; the observation turn is billed but empty-bodied (Gemini path). */
+class EmptyObservationUsageProvider extends OpenAICompatibleProvider<{ apiKey: string; model: string }> {
+  protected readonly providerName = 'TestProvider';
+  protected readonly syntheticIdPrefix = 'test';
+  protected readonly forwardEmptyMessageResponse = false;
+
+  private queryCount = 0;
+
+  constructor(dbManager: any, sessionManager: any) {
+    super(dbManager, sessionManager);
+  }
+
+  protected getConfig() {
+    return { apiKey: 'test-api-key', model: 'session-model' };
+  }
+
+  protected missingApiKeyError(): Error {
+    return new Error('missing key');
+  }
+
+  protected async query(_history: ConversationMessage[]): Promise<ProviderQueryResult> {
+    this.queryCount += 1;
+    if (this.queryCount === 1) {
+      return { content: 'init ok', tokensUsed: 100, inputTokens: 90, outputTokens: 10 };
+    }
+    return { content: '', tokensUsed: 1000, inputTokens: 990, outputTokens: 10 };
+  }
+
+  protected estimateTokens(): number {
+    return 0;
+  }
+
+  protected buildLastUsage(): ActiveSession['lastUsage'] {
+    return null;
+  }
+}
+
 describe('accumulateObserverUsage', () => {
   it('accumulates the real input/output split instead of a 70/30 estimate', () => {
     const session = makeSession();
@@ -274,6 +311,29 @@ describe('OpenAICompatibleProvider observer cost visibility', () => {
     expect(failure![2]).toMatchObject({
       cumulativeInputTokens: 4_100_000,
       cumulativeOutputTokens: 9_000,
+    });
+  });
+
+  it('accumulates billed usage from an empty-bodied observation response', async () => {
+    const provider = new EmptyObservationUsageProvider({} as any, {
+      confirmClaimedMessages: async () => 0,
+      resetProcessingToPending: async () => 0,
+      getMessageIterator: async function* () {
+        yield { type: 'observation', tool_name: 'Read', tool_input: {}, tool_response: {}, prompt_number: 2 };
+      },
+    } as any);
+    const session = makeSession();
+
+    await provider.startSession(session);
+
+    // init 90/10 + empty observation 990/10
+    expect(session.cumulativeInputTokens).toBe(1080);
+    expect(session.cumulativeOutputTokens).toBe(20);
+
+    const completion = successSpy.mock.calls.find(call => String(call[1]).includes('agent completed'));
+    expect(completion![2]).toMatchObject({
+      cumulativeInputTokens: 1080,
+      cumulativeOutputTokens: 20,
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add shared `observer-usage` helpers so OpenAI-compatible providers accumulate **real** `inputTokens`/`outputTokens` when reported (Gemini, OpenRouter) instead of always applying a 70/30 split on `tokensUsed`.
- Track Claude `cache_read_input_tokens` in `cumulativeCacheReadTokens` (separate from `cumulativeInputTokens` so `discovery_tokens` semantics stay intact).
- Attach cumulative observer token fields to the once-per-session **completion** and **error** log lines at INFO for Claude and OpenAI-compatible providers.

## Context

Related to #3497. The reporter's ~10x amplification on the **default Claude subscription path** comes from the persistent `claude` CLI child context, not from trimming `conversationHistory` (that array is write-only on the Claude path). Maintainer removed client-side history caps in `29af0284` ("second system" anti-pattern), so this PR does **not** reintroduce truncation.

What it does address from the issue: cost was invisible because cumulative counters were DEBUG-only (Claude) or never logged (OpenAI-compatible), and HTTP providers used a 70/30 estimate that understates input on history-resend sessions.

**Level of fix:** shared `observer-usage.ts` + session completion boundaries. Rejected: sliding window / `CLAUDE_MEM_MAX_HISTORY_TOKENS` (reverted upstream; competing PRs #3151/#2957 on community-edge).

## Verification

```
cd claude-mem-wt/3497-trim-conversation-history
bun test tests/worker/observer-usage-visibility.test.ts
# 11 pass
bun run typecheck
```

## AI assistance

AI-assisted (Cursor). Stan Shih reviewed the diff.

Related to #3497
