### PR TITLE
feat(install): offer CMEM Pro as the first memory provider option

### DIFF
--- a/src/npx-cli/cmem-pro-costs.ts
+++ b/src/npx-cli/cmem-pro-costs.ts
@@ -1,0 +1,100 @@
+/**
+ * Single source of truth for the cost-per-observation copy shown in the
+ * installer's provider prompt.
+ *
+ * Derivation — change ONE constant and every string below re-derives:
+ *
+ *   TOKENS_PER_OBSERVATION = 30_000        // tokens burned per observation
+ *   $/1k observations = ratePerM * TOKENS_PER_OBSERVATION / 1000
+ *                     = ratePerM * 30      (at 30k tokens/observation)
+ *
+ * Rates are blended $/M-token figures from the investor deck
+ * ("Claude-Mem Numbers"), mixed at claude-mem's real traffic shape
+ * (98.7% input / 1.3% output):
+ *
+ *   Anthropic Haiku 4.5             $0.297/M  ->  $8.91 / 1k observations
+ *   Gemini 2.5 Flash Lite           $0.113/M  ->  $3.39 / 1k observations
+ *   OpenRouter / DeepSeek V4 Flash  $0.091/M  ->  $2.73 / 1k observations
+ *
+ * CMEM Pro deliberately has NO $/1k figure. It is a flat subscription that does
+ * not bill the user's own tokens, so the honest (and stronger) framing is
+ * "$0/1k observations" from your plan plus the flat monthly price. Printing a
+ * computed $/1k for CMEM Pro would compare a retail subscription against
+ * wholesale token cost and is explicitly not what this prompt does.
+ */
+
+/** The one constant to tune. Everything else is derived from it. */
+export const TOKENS_PER_OBSERVATION = 30_000;
+
+/** Flat CMEM Pro subscription price, in USD per month. */
+export const CMEM_PRO_MONTHLY_USD = 30;
+
+/**
+ * Blended $/M-token rates. `geminiFlashLite` is the softest of the three — it is
+ * not sourced directly from the deck; verify before leaning on it.
+ */
+export const RATE_PER_MILLION_USD = {
+  anthropicHaiku45: 0.297,
+  geminiFlashLite25: 0.113,
+  openRouterDeepSeekV4Flash: 0.091,
+} as const;
+
+/** Dollars per 1,000 observations for a given $/M-token rate, e.g. 0.297 -> "8.91". */
+export function costPer1kObservations(ratePerMillionUsd: number): string {
+  return ((ratePerMillionUsd * TOKENS_PER_OBSERVATION) / 1000).toFixed(2);
+}
+
+const CLAUDE_PER_1K = costPer1kObservations(RATE_PER_MILLION_USD.anthropicHaiku45);
+const GEMINI_PER_1K = costPer1kObservations(RATE_PER_MILLION_USD.geminiFlashLite25);
+const OPENROUTER_PER_1K = costPer1kObservations(RATE_PER_MILLION_USD.openRouterDeepSeekV4Flash);
+
+/**
+ * Provider prompt labels. The leading text of each is padded so the
+ * parenthesised cost column lines up in the terminal.
+ */
+export const CMEM_PRO_OPTION_LABEL =
+  `CMEM Pro — observer model, off your plan  ($0/1k observations · $${CMEM_PRO_MONTHLY_USD}/mo, cloud sync included)`;
+
+export const CMEM_PRO_OPTION_HINT = 'Recommended';
+
+export const OPENROUTER_OPTION_LABEL =
+  `OpenRouter / any OpenAI-compatible key    (~$${OPENROUTER_PER_1K}/1k observations, billed to you)`;
+
+export const GEMINI_OPTION_LABEL =
+  `Gemini API key                            (~$${GEMINI_PER_1K}/1k observations, billed to you)`;
+
+export const CLAUDE_OPTION_LABEL =
+  `Use your Anthropic plan                   (~$${CLAUDE_PER_1K}/1k observations, billed to your Claude plan)`;
+
+/**
+ * Origin for the CMEM Pro funnel. Overridable so the whole flow can be walked
+ * against a dev server before it ships — same escape hatch the waitlist opt-in
+ * already uses (CLAUDE_MEM_SIGNUP_URL, see commands/install.ts). Production
+ * needs no env var set.
+ *
+ *   CMEM_PRO_ORIGIN=http://localhost:3005 node dist/npx-cli/index.js install
+ */
+const CMEM_PRO_ORIGIN = (process.env.CMEM_PRO_ORIGIN?.trim() || 'https://cmem.ai').replace(/\/+$/, '');
+
+/** Where the installer sends people to buy CMEM Pro. */
+export const CMEM_PRO_SIGNUP_URL = `${CMEM_PRO_ORIGIN}/pro?from=installer`;
+
+/**
+ * CMEM Pro settings, written as a plain `openrouter` provider config: the
+ * worker's OpenRouter client is a generic OpenAI-compatible client whose base
+ * URL and model are both settings-driven, so CMEM Pro needs no provider code.
+ * The worker only understands 'claude' | 'gemini' | 'openrouter' — 'cmem' is an
+ * installer-prompt-only value and must never reach settings.json.
+ */
+export const CMEM_PRO_BASE_URL = `${CMEM_PRO_ORIGIN}/api/inference/v1`;
+export const CMEM_PRO_MODEL = 'cmem-observer';
+
+/**
+ * Typo guard for the pasted key. Mirrors the server-side validator at
+ * `cmem-pro-mvp/src/lib/pro/mcp-token-format.ts:9`
+ * (`/^cm_pro_(?:[0-9a-f]{24}|[0-9a-f]{32})$/` — 24 or 32 hex chars, the two
+ * lengths ever issued). This range form is deliberately one notch looser so a
+ * future key length does not strand the installer; the server stays the real
+ * gate. Keep the two in sync if the issued shape changes.
+ */
+export const CMEM_PRO_KEY_PATTERN = /^cm_pro_[0-9a-f]{24,32}$/;

--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -32,6 +32,17 @@ import {
   type InstallSummary,
 } from '../install/error-reporter.js';
 import { extractEresolveBlock, isEresolve, runNpmStrict } from '../install/npm-install-helper.js';
+import {
+  CLAUDE_OPTION_LABEL,
+  CMEM_PRO_BASE_URL,
+  CMEM_PRO_KEY_PATTERN,
+  CMEM_PRO_MODEL,
+  CMEM_PRO_OPTION_HINT,
+  CMEM_PRO_OPTION_LABEL,
+  CMEM_PRO_SIGNUP_URL,
+  GEMINI_OPTION_LABEL,
+  OPENROUTER_OPTION_LABEL,
+} from '../cmem-pro-costs.js';
 
 function getSetting<K extends keyof SettingsDefaults>(key: K): SettingsDefaults[K] {
   return SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH)[key];
@@ -808,6 +819,13 @@ function mergeSettings(updates: Record<string, string>): boolean {
 }
 
 type ProviderId = 'claude' | 'gemini' | 'openrouter';
+/**
+ * What the installer prompt may offer. `cmem` is a prompt-only sentinel: picking
+ * it configures the generic OpenAI-compatible path (base URL + model + key) and
+ * persists CLAUDE_MEM_PROVIDER='openrouter'. The worker only understands
+ * 'claude' | 'gemini' | 'openrouter', so 'cmem' must never reach settings.json.
+ */
+type ProviderChoice = ProviderId | 'cmem';
 type ClaudeAccessMode = 'subscription' | 'api-key';
 type ClaudeApiMode = 'direct' | 'gateway';
 // Phase 1d: Persisted DB literals (`server_beta_schema_migrations`, job_type
@@ -949,6 +967,27 @@ async function bootstrapAndPersistServerApiKey(): Promise<void> {
     `Provisioned local hook API key (project=${result.projectId.slice(0, 8)}…). `
       + 'Settings saved with mode 0600.',
   );
+}
+
+/**
+ * Best-effort "open this URL in the user's browser". Every failure mode is
+ * non-fatal — the caller has already printed the URL, so the worst case is the
+ * user clicks it themselves.
+ */
+function openBrowser(url: string): void {
+  try {
+    if (process.platform === 'darwin') {
+      spawnSync('open', [url], { stdio: 'ignore' });
+    } else if (process.platform === 'win32') {
+      spawnSync('cmd', ['/c', 'start', '', url], { stdio: 'ignore' });
+    } else {
+      spawnSync('xdg-open', [url], { stdio: 'ignore' });
+    }
+  } catch {
+    // [ANTI-PATTERN IGNORED]: opening a browser is a convenience, not a step of the
+    // install; the recovery is the URL already printed above this call, which the
+    // user can open by hand. A headless box legitimately has no opener at all.
+  }
 }
 
 async function promptProvider(options: InstallOptions): Promise<ProviderId> {
@@ -1124,24 +1163,63 @@ async function promptProvider(options: InstallOptions): Promise<ProviderId> {
     }
   };
 
-  let selectedProvider: ProviderId;
+  let selectedProvider: ProviderChoice;
   if (options.provider) {
     selectedProvider = options.provider;
   } else {
-    const providerResult = await p.select<ProviderId>({
+    const providerResult = await p.select<ProviderChoice>({
       message: 'Which memory provider do you want to use?',
       options: [
-        { value: 'claude', label: 'Claude Agent SDK (recommended)' },
-        { value: 'gemini', label: 'Gemini' },
-        { value: 'openrouter', label: 'OpenRouter' },
+        { value: 'cmem', label: CMEM_PRO_OPTION_LABEL, hint: CMEM_PRO_OPTION_HINT },
+        { value: 'openrouter', label: OPENROUTER_OPTION_LABEL },
+        { value: 'gemini', label: GEMINI_OPTION_LABEL },
+        { value: 'claude', label: CLAUDE_OPTION_LABEL },
       ],
-      initialValue: initialProvider,
+      initialValue: 'cmem',
     });
     if (p.isCancel(providerResult)) {
       p.cancel('Installation cancelled.');
       process.exit(0);
     }
     selectedProvider = providerResult;
+  }
+
+  // CMEM Pro: no new provider code. The worker's OpenRouter client is a generic
+  // OpenAI-compatible client whose endpoint and model both come from settings,
+  // so "use the CMEM observer model" is four settings writes and nothing else.
+  if (selectedProvider === 'cmem') {
+    p.note(
+      `Opening ${CMEM_PRO_SIGNUP_URL}\nSign in, subscribe, and copy the key you're shown.`,
+      'CMEM Pro',
+    );
+    openBrowser(CMEM_PRO_SIGNUP_URL);
+
+    const keyResult = await p.text({
+      message: 'Paste your CMEM Pro key (starts with cm_pro_):',
+      validate: (v?: string) =>
+        CMEM_PRO_KEY_PATTERN.test((v ?? '').trim())
+          ? undefined
+          : 'That does not look like a CMEM Pro key.',
+    });
+
+    if (p.isCancel(keyResult)) {
+      p.cancel('Installation cancelled.');
+      process.exit(0);
+    }
+
+    const wrote = mergeSettings({
+      CLAUDE_MEM_PROVIDER: 'openrouter',
+      CLAUDE_MEM_OPENROUTER_BASE_URL: CMEM_PRO_BASE_URL,
+      CLAUDE_MEM_OPENROUTER_MODEL: CMEM_PRO_MODEL,
+      CLAUDE_MEM_OPENROUTER_API_KEY: String(keyResult).trim(),
+    });
+    if (wrote) log.info('Saved CMEM Pro configuration to ~/.claude-mem/settings.json');
+
+    p.note(
+      'Next: finish cloud sync in the browser — press NEXT on the page.',
+      'CMEM Pro ready',
+    );
+    return 'openrouter';
   }
 
   if (selectedProvider === 'claude') {


### PR DESCRIPTION
Pairs with **thedotmack/claude-mem-pro#88** (`cmem.ai/pro` funnel). Both sides should land together — this PR sends people to `/pro`, that PR is the page they land on.

## What changes

The installer's provider prompt is reordered and repriced:

```
◆  Which memory provider do you want to use?
│  ● CMEM Pro — observer model, off your plan  ($0/1k observations · $30/mo, cloud sync included)  (Recommended)
│  ○ OpenRouter / any OpenAI-compatible key    (~$2.73/1k observations, billed to you)
│  ○ Gemini API key                            (~$3.39/1k observations, billed to you)
│  ○ Use your Anthropic plan                   (~$8.91/1k observations, billed to your Claude plan)
```

Picking CMEM Pro opens `cmem.ai/pro?from=installer`, waits for the `cm_pro_…` key the signup flow hands back, writes it to settings, and points the user at the browser to finish cloud sync.

## Why there is no new provider code

`OpenRouterProvider` is already a generic OpenAI-compatible client — base URL and model both come from settings (`src/shared/openrouter-base-url.ts` documents DeepSeek / LM Studio / "generic OpenAI-compatible endpoint" as supported). So CMEM Pro is four settings writes:

```json
{
  "CLAUDE_MEM_PROVIDER": "openrouter",
  "CLAUDE_MEM_OPENROUTER_BASE_URL": "https://cmem.ai/api/inference/v1",
  "CLAUDE_MEM_OPENROUTER_MODEL": "cmem-observer",
  "CLAUDE_MEM_OPENROUTER_API_KEY": "cm_pro_<hex>"
}
```

`'cmem'` is a **prompt-only sentinel** (`ProviderChoice = ProviderId | 'cmem'`). The worker only understands `claude | gemini | openrouter`, so it never reaches `settings.json` — `promptProvider` returns `'openrouter'`.

## Cost strings

New `src/npx-cli/cmem-pro-costs.ts` derives every label from one constant:

```
$/1k observations = ratePerM × TOKENS_PER_OBSERVATION / 1000
```

Re-pricing is a one-line edit. CMEM Pro deliberately carries **no** computed `$/1k` — it is a flat subscription that doesn't bill your tokens, so it shows `$0/1k observations · $30/mo` instead. The Gemini rate ($0.113/M) is the softest of the three and is flagged as such in the file's header comment.

`CMEM_PRO_ORIGIN=http://localhost:3005` overrides the origin so the whole funnel can be walked against a dev server.

## Notes for review

- `openBrowser()` is best-effort and non-fatal — the URL is printed by `p.note` before the call, so a headless box with no opener just falls through to a copy-pasteable link.
- The key regex `/^cm_pro_[0-9a-f]{24,32}$/` is a typo guard, deliberately one notch looser than the server-side validator (`24|32` exactly) so a future key length doesn't strand the installer. The server stays the real gate.
- No polling / device-code handshake — the key is pasted by hand, on purpose.

## Verification

- `npm run build` — clean
- `npm run typecheck:root` — clean
- `npm run lint:spawn-env` — OK
- `grep -rn "CmemProvider" src/` — empty (no new provider class)
- The four already-modified `plugin/` files in the working tree are unrelated in-flight work and are **not** included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)