### PR TITLE
fix(install): fetch model pricing live instead of hardcoding it

### DIFF
--- a/src/npx-cli/cmem-pro-costs.ts
+++ b/src/npx-cli/cmem-pro-costs.ts
@@ -1,76 +1,168 @@
 /**
- * Single source of truth for the cost-per-observation copy shown in the
- * installer's provider prompt.
+ * Cost-per-observation copy for the installer's provider prompt.
  *
- * Derivation — change ONE constant and every string below re-derives:
+ * Rates are fetched LIVE from OpenRouter and never hardcoded. Model pricing
+ * changes constantly and old models tend to get more expensive, so a constant
+ * baked into source is wrong the moment it is written. The first version of this
+ * file learned that the hard way: within weeks of shipping, its figures had
+ * drifted +56% for DeepSeek and +254% for Anthropic Haiku, which made the prompt
+ * understate every option that bills the user — i.e. it argued against CMEM Pro
+ * using CMEM Pro's own numbers.
  *
- *   TOKENS_PER_OBSERVATION = 30_000        // tokens burned per observation
- *   $/1k observations = ratePerM * TOKENS_PER_OBSERVATION / 1000
- *                     = ratePerM * 30      (at 30k tokens/observation)
+ * Derivation:
  *
- * Rates are blended $/M-token figures from the investor deck
- * ("Claude-Mem Numbers"), mixed at claude-mem's real traffic shape
- * (98.7% input / 1.3% output):
+ *   $/1k observations = blendedRatePerM × TOKENS_PER_OBSERVATION × 1000 / 1e6
+ *                     = blendedRatePerM × 56          (at 56k tokens/observation)
  *
- *   Anthropic Haiku 4.5             $0.297/M  ->  $8.91 / 1k observations
- *   Gemini 2.5 Flash Lite           $0.113/M  ->  $3.39 / 1k observations
- *   OpenRouter / DeepSeek V4 Flash  $0.091/M  ->  $2.73 / 1k observations
+ *   blendedRatePerM   = input$/M × 0.987 + output$/M × 0.013
  *
- * CMEM Pro deliberately has NO $/1k figure. It is a flat subscription that does
- * not bill the user's own tokens, so the honest (and stronger) framing is
- * "$0/1k observations" from your plan plus the flat monthly price. Printing a
- * computed $/1k for CMEM Pro would compare a retail subscription against
- * wholesale token cost and is explicitly not what this prompt does.
+ * The 98.7 / 1.3 split is claude-mem's real traffic shape: observation prompts
+ * are enormous and their summaries are small.
  */
 
-/** The one constant to tune. Everything else is derived from it. */
-export const TOKENS_PER_OBSERVATION = 30_000;
+/** OpenRouter's public model catalogue. No auth required. */
+const MODELS_URL = 'https://openrouter.ai/api/v1/models';
+
+/**
+ * The prompt is interactive, so pricing must never be what makes it feel slow.
+ * Three seconds is generous for a single GET; past that we fall back and move on.
+ */
+const FETCH_TIMEOUT_MS = 3_000;
+
+/**
+ * Tokens burned per observation — measured, not assumed.
+ *
+ * 55,960 across 201 real observations on 2026-08-08. The previous value of
+ * 30,000 was an estimate and was low by 1.87x, which understated every figure
+ * below on top of the pricing drift. Cost per observation climbs with context
+ * inside a session and resets between sessions, so this is a mean over a mixed
+ * workload rather than a per-call constant.
+ */
+export const TOKENS_PER_OBSERVATION = 56_000;
 
 /** Flat CMEM Pro subscription price, in USD per month. */
 export const CMEM_PRO_MONTHLY_USD = 30;
 
-/**
- * Blended $/M-token rates. `geminiFlashLite` is the softest of the three — it is
- * not sourced directly from the deck; verify before leaning on it.
- */
-export const RATE_PER_MILLION_USD = {
-  anthropicHaiku45: 0.297,
-  geminiFlashLite25: 0.113,
-  openRouterDeepSeekV4Flash: 0.091,
+/** claude-mem's measured input/output mix. */
+const INPUT_SHARE = 0.987;
+const OUTPUT_SHARE = 0.013;
+
+/** The models each prompt option actually runs on. */
+const MODEL_IDS = {
+  openrouter: 'deepseek/deepseek-v4-flash',
+  gemini: 'google/gemini-2.5-flash-lite',
+  claude: 'anthropic/claude-haiku-4.5',
 } as const;
 
-/** Dollars per 1,000 observations for a given $/M-token rate, e.g. 0.297 -> "8.91". */
-export function costPer1kObservations(ratePerMillionUsd: number): string {
-  return ((ratePerMillionUsd * TOKENS_PER_OBSERVATION) / 1000).toFixed(2);
-}
-
-const CLAUDE_PER_1K = costPer1kObservations(RATE_PER_MILLION_USD.anthropicHaiku45);
-const GEMINI_PER_1K = costPer1kObservations(RATE_PER_MILLION_USD.geminiFlashLite25);
-const OPENROUTER_PER_1K = costPer1kObservations(RATE_PER_MILLION_USD.openRouterDeepSeekV4Flash);
+type OptionKey = keyof typeof MODEL_IDS;
+type Rates = Record<OptionKey, number>;
 
 /**
- * Provider prompt labels. The leading text of each is padded so the
- * parenthesised cost column lines up in the terminal.
+ * Last-resort rates, in blended $/M.
+ *
+ * Only used when OpenRouter is unreachable. Captured live on 2026-08-08 — they
+ * are a floor for graceful degradation, NOT a source of truth, and they will
+ * drift exactly like their predecessors did. If you are tempted to "just update
+ * these," fix the fetch instead.
  */
-export const CMEM_PRO_OPTION_LABEL =
-  `CMEM Pro — observer model, off your plan  ($0/1k observations · $${CMEM_PRO_MONTHLY_USD}/mo, cloud sync included)`;
+const FALLBACK_BLENDED_PER_M: Rates = {
+  openrouter: 0.1418,
+  gemini: 0.1039,
+  claude: 1.052,
+};
 
-export const CMEM_PRO_OPTION_HINT = 'Recommended';
+function blend(promptPerToken: string, completionPerToken: string): number {
+  const input = Number(promptPerToken) * 1e6;
+  const output = Number(completionPerToken) * 1e6;
+  if (!Number.isFinite(input) || !Number.isFinite(output)) return NaN;
+  return input * INPUT_SHARE + output * OUTPUT_SHARE;
+}
 
-export const OPENROUTER_OPTION_LABEL =
-  `OpenRouter / any OpenAI-compatible key    (~$${OPENROUTER_PER_1K}/1k observations, billed to you)`;
+/**
+ * Pull live blended rates. Returns the fallback for any model the catalogue does
+ * not describe, so one renamed or retired model id cannot blank the whole prompt.
+ */
+export async function fetchBlendedRates(): Promise<{ rates: Rates; live: boolean }> {
+  try {
+    const response = await fetch(MODELS_URL, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) return { rates: FALLBACK_BLENDED_PER_M, live: false };
 
-export const GEMINI_OPTION_LABEL =
-  `Gemini API key                            (~$${GEMINI_PER_1K}/1k observations, billed to you)`;
+    const payload = (await response.json()) as {
+      data?: Array<{ id?: string; pricing?: { prompt?: string; completion?: string } }>;
+    };
+    const byId = new Map(
+      (payload.data ?? []).filter((m) => m?.id).map((m) => [m.id as string, m])
+    );
 
-export const CLAUDE_OPTION_LABEL =
-  `Use your Anthropic plan                   (~$${CLAUDE_PER_1K}/1k observations, billed to your Claude plan)`;
+    const rates = { ...FALLBACK_BLENDED_PER_M };
+    let matched = 0;
+    for (const key of Object.keys(MODEL_IDS) as OptionKey[]) {
+      const pricing = byId.get(MODEL_IDS[key])?.pricing;
+      if (!pricing?.prompt || !pricing?.completion) continue;
+      const value = blend(pricing.prompt, pricing.completion);
+      if (Number.isFinite(value) && value > 0) {
+        rates[key] = value;
+        matched++;
+      }
+    }
+    // "live" only if the catalogue actually priced everything we ask about;
+    // a partial answer is a fallback wearing a live badge.
+    return { rates, live: matched === Object.keys(MODEL_IDS).length };
+  } catch {
+    // Offline installs are normal and must not be blocked by a pricing lookup.
+    return { rates: FALLBACK_BLENDED_PER_M, live: false };
+  }
+}
+
+/** Dollars per 1,000 observations for a blended $/M rate, e.g. 0.1418 -> "7.94". */
+export function costPer1kObservations(blendedPerM: number): string {
+  return ((blendedPerM * TOKENS_PER_OBSERVATION) / 1000).toFixed(2);
+}
+
+export interface ProviderLabels {
+  cmem: string;
+  cmemHint: string;
+  openrouter: string;
+  gemini: string;
+  claude: string;
+  /** False when any rate came from the fallback table. */
+  live: boolean;
+}
+
+/**
+ * Build the four option labels.
+ *
+ * CMEM Pro deliberately carries no computed $/1k figure. It is a flat
+ * subscription that does not bill the user's own tokens, so the honest framing
+ * is "$0/1k from your plan" plus the monthly price. Printing a derived $/1k for
+ * it would compare a retail subscription against wholesale token cost.
+ *
+ * The leading text of each label is padded so the parenthesised cost column
+ * lines up in the terminal.
+ */
+export async function buildProviderLabels(): Promise<ProviderLabels> {
+  const { rates, live } = await fetchBlendedRates();
+
+  return {
+    cmem:
+      `CMEM Pro — observer model, off your plan  ($0/1k observations · $${CMEM_PRO_MONTHLY_USD}/mo, cloud sync included)`,
+    cmemHint: 'Recommended',
+    openrouter:
+      `OpenRouter / any OpenAI-compatible key    (~$${costPer1kObservations(rates.openrouter)}/1k observations, billed to you)`,
+    gemini:
+      `Gemini API key                            (~$${costPer1kObservations(rates.gemini)}/1k observations, billed to you)`,
+    claude:
+      `Use your Anthropic plan                   (~$${costPer1kObservations(rates.claude)}/1k observations, from your Claude plan)`,
+    live,
+  };
+}
 
 /**
  * Origin for the CMEM Pro funnel. Overridable so the whole flow can be walked
- * against a dev server before it ships — same escape hatch the waitlist opt-in
- * already uses (CLAUDE_MEM_SIGNUP_URL, see commands/install.ts). Production
- * needs no env var set.
+ * against a dev server before it ships.
  *
  *   CMEM_PRO_ORIGIN=http://localhost:3005 node dist/npx-cli/index.js install
  */
@@ -92,9 +184,8 @@ export const CMEM_PRO_MODEL = 'cmem-observer';
 /**
  * Typo guard for the pasted key. Mirrors the server-side validator at
  * `cmem-pro-mvp/src/lib/pro/mcp-token-format.ts:9`
- * (`/^cm_pro_(?:[0-9a-f]{24}|[0-9a-f]{32})$/` — 24 or 32 hex chars, the two
- * lengths ever issued). This range form is deliberately one notch looser so a
- * future key length does not strand the installer; the server stays the real
- * gate. Keep the two in sync if the issued shape changes.
+ * (`/^cm_pro_(?:[0-9a-f]{24}|[0-9a-f]{32})$/`). This range form is deliberately
+ * one notch looser so a future key length does not strand the installer; the
+ * server stays the real gate.
  */
 export const CMEM_PRO_KEY_PATTERN = /^cm_pro_[0-9a-f]{24,32}$/;

--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -33,15 +33,11 @@ import {
 } from '../install/error-reporter.js';
 import { extractEresolveBlock, isEresolve, runNpmStrict } from '../install/npm-install-helper.js';
 import {
-  CLAUDE_OPTION_LABEL,
+  buildProviderLabels,
   CMEM_PRO_BASE_URL,
   CMEM_PRO_KEY_PATTERN,
   CMEM_PRO_MODEL,
-  CMEM_PRO_OPTION_HINT,
-  CMEM_PRO_OPTION_LABEL,
   CMEM_PRO_SIGNUP_URL,
-  GEMINI_OPTION_LABEL,
-  OPENROUTER_OPTION_LABEL,
 } from '../cmem-pro-costs.js';
 
 function getSetting<K extends keyof SettingsDefaults>(key: K): SettingsDefaults[K] {
@@ -1167,13 +1163,18 @@ async function promptProvider(options: InstallOptions): Promise<ProviderId> {
   if (options.provider) {
     selectedProvider = options.provider;
   } else {
+    // Rates are looked up live so the prompt never quotes a stale price. The
+    // lookup is timeout-bounded and falls back silently, so an offline install
+    // still gets a working prompt — just with last-known figures.
+    const labels = await buildProviderLabels();
+
     const providerResult = await p.select<ProviderChoice>({
       message: 'Which memory provider do you want to use?',
       options: [
-        { value: 'cmem', label: CMEM_PRO_OPTION_LABEL, hint: CMEM_PRO_OPTION_HINT },
-        { value: 'openrouter', label: OPENROUTER_OPTION_LABEL },
-        { value: 'gemini', label: GEMINI_OPTION_LABEL },
-        { value: 'claude', label: CLAUDE_OPTION_LABEL },
+        { value: 'cmem', label: labels.cmem, hint: labels.cmemHint },
+        { value: 'openrouter', label: labels.openrouter },
+        { value: 'gemini', label: labels.gemini },
+        { value: 'claude', label: labels.claude },
       ],
       initialValue: 'cmem',
     });


### PR DESCRIPTION
The provider prompt quoted constants derived from a deck. Model pricing changes constantly and old models tend to get *more* expensive, so those numbers were wrong within weeks of shipping:

| model | hardcoded | live blended | drift |
|---|---:|---:|---:|
| `deepseek/deepseek-v4-flash` | $0.091/M | $0.1418/M | **+56%** |
| `anthropic/claude-haiku-4.5` | $0.297/M | $1.0520/M | **+254%** |
| `google/gemini-2.5-flash-lite` | $0.113/M | $0.1039/M | −8% |

## Two errors, compounding

**Pricing** now comes from OpenRouter's public model catalogue at prompt time, blended at claude-mem's real 98.7/1.3 input-output split. Bounded to 3s, falls back to last-known figures so offline installs still work. A partial catalogue response counts as fallback rather than reporting itself live.

**`TOKENS_PER_OBSERVATION`** goes from an assumed `30_000` to a measured `56_000` — 55,960 across 201 real observations. The old value was low by **1.87×**, and since every figure derives from it, the errors stacked.

## What the prompt now says

```
◆  Which memory provider do you want to use?
│  ● CMEM Pro — observer model, off your plan  ($0/1k observations · $30/mo, cloud sync included)  Recommended
│  ○ OpenRouter / any OpenAI-compatible key    (~$7.94/1k observations, billed to you)
│  ○ Gemini API key                            (~$5.82/1k observations, billed to you)
│  ○ Use your Anthropic plan                   (~$58.91/1k observations, from your Claude plan)
```

Previously $2.73 / $3.40 / $8.91.

## Why this mattered commercially

The old numbers understated every option that bills the user — so the prompt **argued against CMEM Pro using CMEM Pro's own figures**. At the advertised 75M tokens/mo allowance, the quoted Anthropic rate came to **$22.28/mo** against CMEM Pro's flat **$30**. A reader doing the arithmetic would have concluded Anthropic was cheaper and skipped Pro. At the live rate that same comparison is **$78.90 vs $30**.

## One copy change

Anthropic's suffix goes from "billed to your Claude plan" to "**from** your Claude plan". Most people picking that option are on a Claude subscription and spend quota, not cash — the old wording implied a bill they never receive. The $58.91/1k is the API rate; for subscription users it is opportunity cost, and the honest pitch there is "off your plan", which the CMEM Pro label already makes.

## Verification

- `npm run typecheck:root` clean, `npm run build` clean, `lint:spawn-env` OK
- Live fetch exercised end to end: `live rates? true`, blended `{openrouter: 0.1418, gemini: 0.1039, claude: 1.052}`, labels render with correct column alignment
- Note: adds one unauthenticated public GET during install. No credentials, no user data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)