### PR TITLE
feat(npx-cli): add setup command; make update keep existing settings

### DIFF
--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -986,7 +986,7 @@ function openBrowser(url: string): void {
   }
 }
 
-async function promptProvider(options: InstallOptions): Promise<ProviderId> {
+export async function promptProvider(options: InstallOptions): Promise<ProviderId> {
   const initialProvider = (getSetting('CLAUDE_MEM_PROVIDER') as ProviderId) || 'claude';
 
   const persistClaudeProvider = (authMethod?: 'subscription' | 'api-key' | 'gateway') => {
@@ -1263,7 +1263,7 @@ async function promptProvider(options: InstallOptions): Promise<ProviderId> {
   return selectedProvider;
 }
 
-async function promptClaudeModel(options: InstallOptions): Promise<void> {
+export async function promptClaudeModel(options: InstallOptions): Promise<void> {
   const allowed = new Set([
     'claude-haiku-4-5-20251001',
     'claude-sonnet-5',
@@ -1522,6 +1522,12 @@ export interface InstallOptions {
   runtime?: 'worker' | 'server' | 'server-beta';
   // Base URL the server runtime (and the injected IDE MCP config) targets.
   serverUrl?: string;
+  // `update` re-runs the file install (plugin cache, marketplace, runtime,
+  // hooks) on the latest version while keeping the stored configuration:
+  // the overwrite confirm and the runtime/provider/model prompts are skipped
+  // when settings already exist and no overriding flags were passed.
+  // Settings-only changes belong to `npx claude-mem setup`.
+  mode?: 'install' | 'update';
 }
 
 export async function runInstallCommand(options: InstallOptions = {}): Promise<void> {
@@ -1599,7 +1605,9 @@ async function runInstallCommandInner(options: InstallOptions, summary: InstallS
   await promptCmemOnlineOptIn(version);
 
   if (alreadyInstalled) {
-    if (process.stdin.isTTY) {
+    if (options.mode === 'update') {
+      log.info('Updating existing installation in place.');
+    } else if (process.stdin.isTTY) {
       const shouldContinue = await p.confirm({
         message: 'Overwrite existing installation?',
         initialValue: true,
@@ -1628,10 +1636,33 @@ async function runInstallCommandInner(options: InstallOptions, summary: InstallS
     selectedIDEs = ['claude-code'];
   }
 
-  const selectedRuntime = await promptRuntime(options);
-  const selectedProvider = await promptProvider(options);
-  if (selectedProvider === 'claude') {
-    await promptClaudeModel(options);
+  // `update` keeps the stored configuration instead of re-prompting: users
+  // updating versions have already answered these questions, and re-asking
+  // made "update" indistinguishable from a fresh install. Explicit flags
+  // (--provider/--model/--runtime) still win and route through the normal
+  // prompt flows, which handle them non-interactively.
+  const storedProvider = getSetting('CLAUDE_MEM_PROVIDER') as ProviderId | '';
+  const keepStoredConfig =
+    options.mode === 'update' &&
+    alreadyInstalled &&
+    storedProvider !== '' &&
+    options.provider === undefined &&
+    options.model === undefined &&
+    options.runtime === undefined;
+
+  let selectedRuntime: RuntimeId;
+  let selectedProvider: ProviderId;
+  if (keepStoredConfig) {
+    const storedRuntime = String(getSetting('CLAUDE_MEM_RUNTIME') || 'worker');
+    selectedRuntime = storedRuntime === 'server' || storedRuntime === 'server-beta' ? 'server' : 'worker';
+    selectedProvider = storedProvider;
+    log.info(`Keeping existing configuration (provider=${selectedProvider}, runtime=${selectedRuntime}). Run ${styleText('cyan', 'npx claude-mem setup')} to change settings.`);
+  } else {
+    selectedRuntime = await promptRuntime(options);
+    selectedProvider = await promptProvider(options);
+    if (selectedProvider === 'claude') {
+      await promptClaudeModel(options);
+    }
   }
 
   let workerStartResult: WorkerStartResult = 'dead';

--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -1641,11 +1641,17 @@ async function runInstallCommandInner(options: InstallOptions, summary: InstallS
   // made "update" indistinguishable from a fresh install. Explicit flags
   // (--provider/--model/--runtime) still win and route through the normal
   // prompt flows, which handle them non-interactively.
-  const storedProvider = getSetting('CLAUDE_MEM_PROVIDER') as ProviderId | '';
+  // `loadFromFile` merges the built-in defaults, so a missing key reads back as
+  // 'claude' rather than ''. Validate the literal instead: an unrecognized
+  // provider (hand-edited or corrupt settings.json) falls through to the normal
+  // prompts rather than being carried forward as-is.
+  const storedProvider = String(getSetting('CLAUDE_MEM_PROVIDER') || '');
+  const hasUsableProvider =
+    storedProvider === 'claude' || storedProvider === 'gemini' || storedProvider === 'openrouter';
   const keepStoredConfig =
     options.mode === 'update' &&
     alreadyInstalled &&
-    storedProvider !== '' &&
+    hasUsableProvider &&
     options.provider === undefined &&
     options.model === undefined &&
     options.runtime === undefined;
@@ -1655,7 +1661,7 @@ async function runInstallCommandInner(options: InstallOptions, summary: InstallS
   if (keepStoredConfig) {
     const storedRuntime = String(getSetting('CLAUDE_MEM_RUNTIME') || 'worker');
     selectedRuntime = storedRuntime === 'server' || storedRuntime === 'server-beta' ? 'server' : 'worker';
-    selectedProvider = storedProvider;
+    selectedProvider = storedProvider as ProviderId;
     log.info(`Keeping existing configuration (provider=${selectedProvider}, runtime=${selectedRuntime}). Run ${styleText('cyan', 'npx claude-mem setup')} to change settings.`);
   } else {
     selectedRuntime = await promptRuntime(options);

--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -815,6 +815,17 @@ function mergeSettings(updates: Record<string, string>): boolean {
 }
 
 type ProviderId = 'claude' | 'gemini' | 'openrouter';
+
+/**
+ * Whether a stored/hand-edited CLAUDE_MEM_PROVIDER value is one the worker can
+ * actually use. `SettingsDefaultsManager.loadFromFile` merges the built-in
+ * defaults but does not validate them, so anything can come back from a
+ * hand-edited settings.json — an emptiness check is not enough.
+ */
+export function isKnownProvider(value: unknown): value is ProviderId {
+  return value === 'claude' || value === 'gemini' || value === 'openrouter';
+}
+
 /**
  * What the installer prompt may offer. `cmem` is a prompt-only sentinel: picking
  * it configures the generic OpenAI-compatible path (base URL + model + key) and
@@ -987,7 +998,8 @@ function openBrowser(url: string): void {
 }
 
 export async function promptProvider(options: InstallOptions): Promise<ProviderId> {
-  const initialProvider = (getSetting('CLAUDE_MEM_PROVIDER') as ProviderId) || 'claude';
+  const storedProviderSetting = getSetting('CLAUDE_MEM_PROVIDER');
+  const initialProvider: ProviderId = isKnownProvider(storedProviderSetting) ? storedProviderSetting : 'claude';
 
   const persistClaudeProvider = (authMethod?: 'subscription' | 'api-key' | 'gateway') => {
     const resolvedAuthMethod = authMethod ?? resolveClaudeAuthMethod();
@@ -1111,6 +1123,16 @@ export async function promptProvider(options: InstallOptions): Promise<ProviderI
       if (wrote) log.info(`Saved provider=${options.provider} to ~/.claude-mem/settings.json`);
       log.warn(`Provider=${options.provider} requested non-interactively. API key prompt skipped — set CLAUDE_MEM_${options.provider.toUpperCase()}_API_KEY and CLAUDE_MEM_PROVIDER in settings.json or env manually if not already set.`);
       return options.provider;
+    }
+    // A hand-edited or corrupt CLAUDE_MEM_PROVIDER has no prompt to fall back
+    // on here, and returning it would let the install complete against a
+    // provider the worker cannot use. Repair the setting rather than only
+    // returning a safe value: the worker reads settings.json at startup, so
+    // leaving the bad literal in place would keep it broken.
+    if (!isKnownProvider(storedProviderSetting)) {
+      log.warn(`Stored CLAUDE_MEM_PROVIDER="${String(storedProviderSetting)}" is not a supported provider — falling back to claude.`);
+      persistClaudeProvider();
+      return 'claude';
     }
     return initialProvider;
   }
@@ -1645,13 +1667,11 @@ async function runInstallCommandInner(options: InstallOptions, summary: InstallS
   // 'claude' rather than ''. Validate the literal instead: an unrecognized
   // provider (hand-edited or corrupt settings.json) falls through to the normal
   // prompts rather than being carried forward as-is.
-  const storedProvider = String(getSetting('CLAUDE_MEM_PROVIDER') || '');
-  const hasUsableProvider =
-    storedProvider === 'claude' || storedProvider === 'gemini' || storedProvider === 'openrouter';
+  const storedProvider = getSetting('CLAUDE_MEM_PROVIDER');
   const keepStoredConfig =
     options.mode === 'update' &&
     alreadyInstalled &&
-    hasUsableProvider &&
+    isKnownProvider(storedProvider) &&
     options.provider === undefined &&
     options.model === undefined &&
     options.runtime === undefined;
@@ -1661,7 +1681,7 @@ async function runInstallCommandInner(options: InstallOptions, summary: InstallS
   if (keepStoredConfig) {
     const storedRuntime = String(getSetting('CLAUDE_MEM_RUNTIME') || 'worker');
     selectedRuntime = storedRuntime === 'server' || storedRuntime === 'server-beta' ? 'server' : 'worker';
-    selectedProvider = storedProvider as ProviderId;
+    selectedProvider = storedProvider;
     log.info(`Keeping existing configuration (provider=${selectedProvider}, runtime=${selectedRuntime}). Run ${styleText('cyan', 'npx claude-mem setup')} to change settings.`);
   } else {
     selectedRuntime = await promptRuntime(options);

--- a/src/npx-cli/commands/setup.ts
+++ b/src/npx-cli/commands/setup.ts
@@ -73,6 +73,18 @@ export function formatCurrentConfig(settings: Record<string, unknown>): string[]
   return lines;
 }
 
+/**
+ * First candidate worker script that actually exists, or `undefined` when none
+ * do. Pure over the existence check so the "no script → don't touch the running
+ * worker" guarantee is testable without a real plugin tree.
+ */
+export function selectWorkerScriptPath(
+  candidates: string[],
+  exists: (path: string) => boolean,
+): string | undefined {
+  return candidates.find((candidate) => exists(candidate));
+}
+
 export async function runSetupCommand(options: InstallOptions = {}): Promise<void> {
   const version = readPluginVersion();
 
@@ -122,30 +134,40 @@ export async function runSetupCommand(options: InstallOptions = {}): Promise<voi
     restartNote = `Run ${styleText('cyan', 'npx claude-mem restart')} for the new settings to take effect.`;
   } else {
     const port = Number(getSetting('CLAUDE_MEM_WORKER_PORT'));
-    const marketplaceScriptPath = join(marketplaceDirectory(), 'plugin', 'scripts', 'worker-service.cjs');
-    const cacheScriptPath = join(pluginCacheDirectory(version), 'scripts', 'worker-service.cjs');
-    const scriptPath = existsSync(marketplaceScriptPath) ? marketplaceScriptPath : cacheScriptPath;
+    // Resolve the script BEFORE stopping anything. `ensureWorkerStarted` only
+    // rejects a missing script *after* the shutdown has already landed, so
+    // picking an unchecked fallback path would turn a settings-only `setup`
+    // into an outage: the healthy worker gets killed with nothing to replace it.
+    const scriptPath = selectWorkerScriptPath([
+      join(marketplaceDirectory(), 'plugin', 'scripts', 'worker-service.cjs'),
+      join(pluginCacheDirectory(version), 'scripts', 'worker-service.cjs'),
+    ], existsSync);
 
-    const spinner = p.spinner();
-    spinner.start('Restarting worker so the new settings take effect…');
-    try {
-      await shutdownWorkerAndWait(port, 10000);
-      const startResult = await ensureWorkerStarted(port, scriptPath);
-      switch (startResult) {
-        case 'ready':
-          spinner.stop(`Worker restarted at http://localhost:${port} ${styleText('green', 'OK')}`);
-          break;
-        case 'warming':
-          spinner.stop(`Worker restarting on port ${port} — finishing in background ${styleText('yellow', '⏳')}`);
-          break;
-        case 'dead':
-          spinner.stop(`Worker did not come back — run ${styleText('cyan', 'npx claude-mem start')} manually ${styleText('yellow', '!')}`);
-          break;
+    if (!scriptPath) {
+      log.warn('Worker script missing from both the marketplace and the plugin cache — leaving the running worker alone.');
+      restartNote = `Settings are saved. Run ${styleText('cyan', 'npx claude-mem repair')} to restore the runtime, then ${styleText('cyan', 'npx claude-mem restart')}.`;
+    } else {
+      const spinner = p.spinner();
+      spinner.start('Restarting worker so the new settings take effect…');
+      try {
+        await shutdownWorkerAndWait(port, 10000);
+        const startResult = await ensureWorkerStarted(port, scriptPath);
+        switch (startResult) {
+          case 'ready':
+            spinner.stop(`Worker restarted at http://localhost:${port} ${styleText('green', 'OK')}`);
+            break;
+          case 'warming':
+            spinner.stop(`Worker restarting on port ${port} — finishing in background ${styleText('yellow', '⏳')}`);
+            break;
+          case 'dead':
+            spinner.stop(`Worker did not come back — run ${styleText('cyan', 'npx claude-mem start')} manually ${styleText('yellow', '!')}`);
+            break;
+        }
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        spinner.stop(`Worker restart failed: ${message}`);
+        restartNote = `Run ${styleText('cyan', 'npx claude-mem restart')} for the new settings to take effect.`;
       }
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      spinner.stop(`Worker restart failed: ${message}`);
-      restartNote = `Run ${styleText('cyan', 'npx claude-mem restart')} for the new settings to take effect.`;
     }
   }
 

--- a/src/npx-cli/commands/setup.ts
+++ b/src/npx-cli/commands/setup.ts
@@ -15,7 +15,7 @@ import { existsSync } from 'fs';
 import { join } from 'path';
 import { SettingsDefaultsManager, type SettingsDefaults } from '../../shared/SettingsDefaultsManager.js';
 import { USER_SETTINGS_PATH } from '../../shared/paths.js';
-import { ensureWorkerStarted } from '../../services/worker-spawner.js';
+import { ensureWorkerStarted, type WorkerStartResult } from '../../services/worker-spawner.js';
 import { shutdownWorkerAndWait } from '../../services/install/shutdown-helper.js';
 import { captureCliEvent } from '../../services/telemetry/cli-telemetry.js';
 import {
@@ -32,6 +32,15 @@ import {
 } from './install.js';
 
 const isInteractive = process.stdin.isTTY === true;
+
+// Bounds on the post-shutdown restart retry. `install`/`update` replace the
+// plugin tree with rmSync + cpSync; the copy is the slow half, so a couple of
+// seconds between attempts is enough to outlast a typical replacement without
+// making a genuinely broken install sit on a spinner.
+const WORKER_RESTART_ATTEMPTS = 3;
+const WORKER_RESTART_RETRY_DELAY_MS = 2000;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 const log = {
   info: (msg: string) => isInteractive ? p.log.info(msg) : console.log(`  ${msg}`),
@@ -151,29 +160,41 @@ export async function runSetupCommand(options: InstallOptions = {}): Promise<voi
       spinner.start('Restarting worker so the new settings take effect…');
       try {
         await shutdownWorkerAndWait(port, 10000);
-        // Re-resolve after the shutdown rather than reusing the path from
-        // above: `install`/`update` replace these directories with rmSync +
-        // cpSync, so a concurrent run can delete the chosen script while we
-        // wait. Re-resolving starts from whichever copy exists *now*, and an
-        // empty result means the tree is mid-replacement — say so instead of
-        // handing ensureWorkerStarted a path that has since vanished.
-        const scriptPath = selectWorkerScriptPath(workerScriptCandidates, existsSync);
-        if (!scriptPath) {
-          spinner.stop(`Worker script vanished mid-restart — a concurrent ${styleText('cyan', 'install')}/${styleText('cyan', 'update')} is likely replacing it ${styleText('yellow', '!')}`);
-          restartNote = `Run ${styleText('cyan', 'npx claude-mem start')} once that finishes.`;
-        } else {
-          const startResult = await ensureWorkerStarted(port, scriptPath);
-          switch (startResult) {
-            case 'ready':
-              spinner.stop(`Worker restarted at http://localhost:${port} ${styleText('green', 'OK')}`);
-              break;
-            case 'warming':
-              spinner.stop(`Worker restarting on port ${port} — finishing in background ${styleText('yellow', '⏳')}`);
-              break;
-            case 'dead':
-              spinner.stop(`Worker did not come back — run ${styleText('cyan', 'npx claude-mem start')} manually ${styleText('yellow', '!')}`);
-              break;
+
+        // The worker is down at this point, so the restart has to keep trying
+        // rather than give up on the first miss. `install`/`update` replace
+        // these directories with rmSync + cpSync, and neither resolving the
+        // path nor spawning from it is atomic against that: the script can go
+        // missing before we resolve it, or between our existsSync and the
+        // spawner's. Both failures look the same from here and both are
+        // transient — the replacement copy lands moments later — so re-resolve
+        // and retry a bounded number of times before declaring failure.
+        let startResult: WorkerStartResult | 'missing' = 'missing';
+        for (let attempt = 1; attempt <= WORKER_RESTART_ATTEMPTS; attempt++) {
+          const scriptPath = selectWorkerScriptPath(workerScriptCandidates, existsSync);
+          startResult = scriptPath ? await ensureWorkerStarted(port, scriptPath) : 'missing';
+          if (startResult === 'ready' || startResult === 'warming') break;
+
+          if (attempt < WORKER_RESTART_ATTEMPTS) {
+            spinner.message(`Worker script is being replaced — retrying (${attempt}/${WORKER_RESTART_ATTEMPTS - 1})…`);
+            await sleep(WORKER_RESTART_RETRY_DELAY_MS);
           }
+        }
+
+        switch (startResult) {
+          case 'ready':
+            spinner.stop(`Worker restarted at http://localhost:${port} ${styleText('green', 'OK')}`);
+            break;
+          case 'warming':
+            spinner.stop(`Worker restarting on port ${port} — finishing in background ${styleText('yellow', '⏳')}`);
+            break;
+          case 'missing':
+            spinner.stop(`Worker script still missing after ${WORKER_RESTART_ATTEMPTS} attempts — a concurrent ${styleText('cyan', 'install')}/${styleText('cyan', 'update')} may still be running ${styleText('yellow', '!')}`);
+            restartNote = `Run ${styleText('cyan', 'npx claude-mem start')} once that finishes.`;
+            break;
+          case 'dead':
+            spinner.stop(`Worker did not come back — run ${styleText('cyan', 'npx claude-mem start')} manually ${styleText('yellow', '!')}`);
+            break;
         }
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/npx-cli/commands/setup.ts
+++ b/src/npx-cli/commands/setup.ts
@@ -1,0 +1,162 @@
+/**
+ * `npx claude-mem setup` — change configuration (LLM provider, observation
+ * model, Claude Code auto-memory) on an existing installation without
+ * re-running the full installer. Reuses the exact prompt flows from
+ * `install`, so the two paths can never drift, then restarts the worker so
+ * the new settings take effect immediately.
+ *
+ * Full (re)installs remain the path for anything that touches installed
+ * files: IDE hook setup, runtime switching (worker ⇄ server), and version
+ * updates (`npx claude-mem update`).
+ */
+import * as p from '@clack/prompts';
+import { styleText } from 'node:util';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { SettingsDefaultsManager, type SettingsDefaults } from '../../shared/SettingsDefaultsManager.js';
+import { USER_SETTINGS_PATH } from '../../shared/paths.js';
+import { ensureWorkerStarted } from '../../services/worker-spawner.js';
+import { shutdownWorkerAndWait } from '../../services/install/shutdown-helper.js';
+import { captureCliEvent } from '../../services/telemetry/cli-telemetry.js';
+import {
+  isPluginInstalled,
+  marketplaceDirectory,
+  pluginCacheDirectory,
+  readPluginVersion,
+} from '../utils/paths.js';
+import {
+  disableClaudeAutoMemory,
+  promptClaudeModel,
+  promptProvider,
+  type InstallOptions,
+} from './install.js';
+
+const isInteractive = process.stdin.isTTY === true;
+
+const log = {
+  info: (msg: string) => isInteractive ? p.log.info(msg) : console.log(`  ${msg}`),
+  success: (msg: string) => isInteractive ? p.log.success(msg) : console.log(`  ${msg}`),
+  warn: (msg: string) => isInteractive ? p.log.warn(msg) : console.warn(`  ${msg}`),
+  error: (msg: string) => isInteractive ? p.log.error(msg) : console.error(`  ${msg}`),
+};
+
+function getSetting<K extends keyof SettingsDefaults>(key: K): SettingsDefaults[K] {
+  return SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH)[key];
+}
+
+/**
+ * Render the currently stored configuration as display lines. Pure over the
+ * flat settings record so it stays unit-testable without a TTY or a real
+ * ~/.claude-mem/settings.json.
+ */
+export function formatCurrentConfig(settings: Record<string, unknown>): string[] {
+  const read = (key: string): string => {
+    const value = settings[key];
+    return typeof value === 'string' ? value.trim() : '';
+  };
+
+  const provider = read('CLAUDE_MEM_PROVIDER') || 'claude';
+  // Phase 1d dual-accept: stored `server-beta` displays as the canonical `server`.
+  const storedRuntime = read('CLAUDE_MEM_RUNTIME') || 'worker';
+  const runtime = storedRuntime === 'server-beta' ? 'server' : storedRuntime;
+
+  const lines = [`provider  ${provider}`];
+  if (provider === 'claude') {
+    const authMethod = read('CLAUDE_MEM_CLAUDE_AUTH_METHOD');
+    if (authMethod) {
+      lines[0] = `provider  ${provider} (${authMethod})`;
+    }
+    const model = read('CLAUDE_MEM_MODEL');
+    lines.push(`model     ${model || '(default)'}`);
+  }
+  lines.push(`runtime   ${runtime}`);
+  return lines;
+}
+
+export async function runSetupCommand(options: InstallOptions = {}): Promise<void> {
+  const version = readPluginVersion();
+
+  if (!isPluginInstalled()) {
+    log.error('claude-mem is not installed yet — nothing to configure.');
+    log.info(`Run ${styleText('cyan', 'npx claude-mem install')} first.`);
+    process.exit(1);
+  }
+
+  if (isInteractive) {
+    p.intro(styleText(['bgCyan', 'black'], ' claude-mem setup '));
+  } else {
+    console.log('claude-mem setup');
+  }
+  log.info(`${styleText('bold', 'claude-mem')} ${styleText('cyan', `v${version}`)} ${styleText('dim', '·')} editing ~/.claude-mem/settings.json in place`);
+
+  const current = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH) as unknown as Record<string, unknown>;
+  for (const line of formatCurrentConfig(current)) {
+    log.info(styleText('dim', line));
+  }
+
+  const selectedProvider = await promptProvider(options);
+  if (selectedProvider === 'claude') {
+    await promptClaudeModel(options);
+  }
+
+  if (options.disableAutoMemory) {
+    const wrote = disableClaudeAutoMemory();
+    if (wrote) {
+      log.success('Claude Code: auto-memory disabled (CLAUDE_CODE_DISABLE_AUTO_MEMORY=1).');
+    } else {
+      log.info('Claude Code: auto-memory already disabled, leaving settings.json untouched.');
+    }
+  }
+
+  // Apply the change. The worker reads settings at startup, so a saved
+  // provider/model only takes effect after a restart. The server runtime has
+  // its own daemon lifecycle — point at `server restart` instead of touching
+  // the worker path.
+  const storedRuntime = String(getSetting('CLAUDE_MEM_RUNTIME') || 'worker');
+  const isServerRuntime = storedRuntime === 'server' || storedRuntime === 'server-beta';
+
+  let restartNote = '';
+  if (isServerRuntime) {
+    restartNote = `Run ${styleText('cyan', 'npx claude-mem server restart')} for the new settings to take effect.`;
+  } else if (options.noAutoStart || !isInteractive) {
+    restartNote = `Run ${styleText('cyan', 'npx claude-mem restart')} for the new settings to take effect.`;
+  } else {
+    const port = Number(getSetting('CLAUDE_MEM_WORKER_PORT'));
+    const marketplaceScriptPath = join(marketplaceDirectory(), 'plugin', 'scripts', 'worker-service.cjs');
+    const cacheScriptPath = join(pluginCacheDirectory(version), 'scripts', 'worker-service.cjs');
+    const scriptPath = existsSync(marketplaceScriptPath) ? marketplaceScriptPath : cacheScriptPath;
+
+    const spinner = p.spinner();
+    spinner.start('Restarting worker so the new settings take effect…');
+    try {
+      await shutdownWorkerAndWait(port, 10000);
+      const startResult = await ensureWorkerStarted(port, scriptPath);
+      switch (startResult) {
+        case 'ready':
+          spinner.stop(`Worker restarted at http://localhost:${port} ${styleText('green', 'OK')}`);
+          break;
+        case 'warming':
+          spinner.stop(`Worker restarting on port ${port} — finishing in background ${styleText('yellow', '⏳')}`);
+          break;
+        case 'dead':
+          spinner.stop(`Worker did not come back — run ${styleText('cyan', 'npx claude-mem start')} manually ${styleText('yellow', '!')}`);
+          break;
+      }
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      spinner.stop(`Worker restart failed: ${message}`);
+      restartNote = `Run ${styleText('cyan', 'npx claude-mem restart')} for the new settings to take effect.`;
+    }
+  }
+
+  await captureCliEvent('setup_completed', {
+    provider: selectedProvider,
+    cli_version: version,
+  });
+
+  if (isInteractive) {
+    p.outro(styleText('green', 'Settings saved.') + (restartNote ? ` ${restartNote}` : ''));
+  } else {
+    console.log(`Settings saved.${restartNote ? ` ${restartNote}` : ''}`);
+  }
+}

--- a/src/npx-cli/commands/setup.ts
+++ b/src/npx-cli/commands/setup.ts
@@ -138,12 +138,12 @@ export async function runSetupCommand(options: InstallOptions = {}): Promise<voi
     // rejects a missing script *after* the shutdown has already landed, so
     // picking an unchecked fallback path would turn a settings-only `setup`
     // into an outage: the healthy worker gets killed with nothing to replace it.
-    const scriptPath = selectWorkerScriptPath([
+    const workerScriptCandidates = [
       join(marketplaceDirectory(), 'plugin', 'scripts', 'worker-service.cjs'),
       join(pluginCacheDirectory(version), 'scripts', 'worker-service.cjs'),
-    ], existsSync);
+    ];
 
-    if (!scriptPath) {
+    if (!selectWorkerScriptPath(workerScriptCandidates, existsSync)) {
       log.warn('Worker script missing from both the marketplace and the plugin cache — leaving the running worker alone.');
       restartNote = `Settings are saved. Run ${styleText('cyan', 'npx claude-mem repair')} to restore the runtime, then ${styleText('cyan', 'npx claude-mem restart')}.`;
     } else {
@@ -151,17 +151,29 @@ export async function runSetupCommand(options: InstallOptions = {}): Promise<voi
       spinner.start('Restarting worker so the new settings take effect…');
       try {
         await shutdownWorkerAndWait(port, 10000);
-        const startResult = await ensureWorkerStarted(port, scriptPath);
-        switch (startResult) {
-          case 'ready':
-            spinner.stop(`Worker restarted at http://localhost:${port} ${styleText('green', 'OK')}`);
-            break;
-          case 'warming':
-            spinner.stop(`Worker restarting on port ${port} — finishing in background ${styleText('yellow', '⏳')}`);
-            break;
-          case 'dead':
-            spinner.stop(`Worker did not come back — run ${styleText('cyan', 'npx claude-mem start')} manually ${styleText('yellow', '!')}`);
-            break;
+        // Re-resolve after the shutdown rather than reusing the path from
+        // above: `install`/`update` replace these directories with rmSync +
+        // cpSync, so a concurrent run can delete the chosen script while we
+        // wait. Re-resolving starts from whichever copy exists *now*, and an
+        // empty result means the tree is mid-replacement — say so instead of
+        // handing ensureWorkerStarted a path that has since vanished.
+        const scriptPath = selectWorkerScriptPath(workerScriptCandidates, existsSync);
+        if (!scriptPath) {
+          spinner.stop(`Worker script vanished mid-restart — a concurrent ${styleText('cyan', 'install')}/${styleText('cyan', 'update')} is likely replacing it ${styleText('yellow', '!')}`);
+          restartNote = `Run ${styleText('cyan', 'npx claude-mem start')} once that finishes.`;
+        } else {
+          const startResult = await ensureWorkerStarted(port, scriptPath);
+          switch (startResult) {
+            case 'ready':
+              spinner.stop(`Worker restarted at http://localhost:${port} ${styleText('green', 'OK')}`);
+              break;
+            case 'warming':
+              spinner.stop(`Worker restarting on port ${port} — finishing in background ${styleText('yellow', '⏳')}`);
+              break;
+            case 'dead':
+              spinner.stop(`Worker did not come back — run ${styleText('cyan', 'npx claude-mem start')} manually ${styleText('yellow', '!')}`);
+              break;
+          }
         }
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/npx-cli/index.ts
+++ b/src/npx-cli/index.ts
@@ -29,8 +29,11 @@ ${styleText('bold', 'Install Commands')} (no Bun required):
   ${styleText('cyan', 'npx claude-mem install --disable-auto-memory')}   Explicitly disable Claude Code native auto-memory
   ${styleText('cyan', 'npx claude-mem install --runtime worker|server')}   Select runtime non-interactively (server brings up Docker pg+redis, generates an API key, injects the IDE MCP config)
   ${styleText('cyan', 'npx claude-mem install --runtime server --server-url <url>')}   Point the server runtime at a specific base URL
+  ${styleText('cyan', 'npx claude-mem setup')}                Change settings (provider, model) without reinstalling
+  ${styleText('cyan', 'npx claude-mem setup --provider claude|gemini|openrouter')}   Change provider non-interactively
+  ${styleText('cyan', 'npx claude-mem setup --model <id>')}   Change model non-interactively
   ${styleText('cyan', 'npx claude-mem repair')}                Repair runtime (re-runs Bun/uv setup and bun install in plugin cache)
-  ${styleText('cyan', 'npx claude-mem update')}               Update to latest version
+  ${styleText('cyan', 'npx claude-mem update')}               Update to latest version (keeps your settings)
   ${styleText('cyan', 'npx claude-mem uninstall')}            Remove plugin and configs
   ${styleText('cyan', 'npx claude-mem version')}              Print version
 
@@ -116,7 +119,16 @@ async function main(): Promise<void> {
     case 'update':
     case 'upgrade': {
       const { runInstallCommand } = await import('./commands/install.js');
-      await runInstallCommand();
+      await runInstallCommand({ ...parseInstallOptions(args.slice(1)), mode: 'update' });
+      break;
+    }
+
+    case 'setup':
+    case 'settings':
+    case 'config':
+    case 'configure': {
+      const { runSetupCommand } = await import('./commands/setup.js');
+      await runSetupCommand(parseInstallOptions(args.slice(1)));
       break;
     }
 

--- a/tests/npx-cli/provider-validation.test.ts
+++ b/tests/npx-cli/provider-validation.test.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'bun:test';
+import { isKnownProvider } from '../../src/npx-cli/commands/install.js';
+
+describe('isKnownProvider', () => {
+  it('accepts every provider the worker understands', () => {
+    expect(isKnownProvider('claude')).toBe(true);
+    expect(isKnownProvider('gemini')).toBe(true);
+    expect(isKnownProvider('openrouter')).toBe(true);
+  });
+
+  // `cmem` is a prompt-only sentinel — picking it persists 'openrouter', so it
+  // must never be treated as a stored provider.
+  it('rejects the cmem prompt sentinel', () => {
+    expect(isKnownProvider('cmem')).toBe(false);
+  });
+
+  // Regression: `loadFromFile` merges defaults but never validates them, so a
+  // hand-edited settings.json can hand back anything. An emptiness check let a
+  // malformed provider ride through `update` and the non-TTY promptProvider
+  // fallback as though it were selected.
+  it('rejects hand-edited and corrupt values', () => {
+    expect(isKnownProvider('malformed-provider')).toBe(false);
+    expect(isKnownProvider('Claude')).toBe(false);
+    expect(isKnownProvider(' claude ')).toBe(false);
+    expect(isKnownProvider('')).toBe(false);
+  });
+
+  it('rejects non-string values', () => {
+    expect(isKnownProvider(undefined)).toBe(false);
+    expect(isKnownProvider(null)).toBe(false);
+    expect(isKnownProvider(42)).toBe(false);
+    expect(isKnownProvider({ provider: 'claude' })).toBe(false);
+  });
+});

--- a/tests/npx-cli/setup-command.test.ts
+++ b/tests/npx-cli/setup-command.test.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'bun:test';
+import { formatCurrentConfig } from '../../src/npx-cli/commands/setup.js';
+
+describe('setup — current-config summary', () => {
+  it('falls back to claude/worker defaults on an empty settings record', () => {
+    const lines = formatCurrentConfig({});
+    expect(lines).toContain('provider  claude');
+    expect(lines).toContain('model     (default)');
+    expect(lines).toContain('runtime   worker');
+  });
+
+  it('renders stored provider, auth method, and model for the claude path', () => {
+    const lines = formatCurrentConfig({
+      CLAUDE_MEM_PROVIDER: 'claude',
+      CLAUDE_MEM_CLAUDE_AUTH_METHOD: 'subscription',
+      CLAUDE_MEM_MODEL: 'claude-haiku-4-5-20251001',
+      CLAUDE_MEM_RUNTIME: 'worker',
+    });
+    expect(lines).toContain('provider  claude (subscription)');
+    expect(lines).toContain('model     claude-haiku-4-5-20251001');
+    expect(lines).toContain('runtime   worker');
+  });
+
+  it('omits the model line for non-claude providers', () => {
+    const lines = formatCurrentConfig({ CLAUDE_MEM_PROVIDER: 'openrouter' });
+    expect(lines).toContain('provider  openrouter');
+    expect(lines.some((line) => line.startsWith('model'))).toBe(false);
+  });
+
+  it('displays the legacy server-beta runtime literal as canonical server', () => {
+    // Phase 1d dual-accept: stored `server-beta` must render as `server`.
+    const lines = formatCurrentConfig({ CLAUDE_MEM_RUNTIME: 'server-beta' });
+    expect(lines).toContain('runtime   server');
+  });
+
+  it('treats non-string and whitespace-only values as unset', () => {
+    const lines = formatCurrentConfig({
+      CLAUDE_MEM_PROVIDER: '   ',
+      CLAUDE_MEM_MODEL: 42,
+      CLAUDE_MEM_RUNTIME: undefined,
+    });
+    expect(lines).toContain('provider  claude');
+    expect(lines).toContain('model     (default)');
+    expect(lines).toContain('runtime   worker');
+  });
+});

--- a/tests/npx-cli/setup-command.test.ts
+++ b/tests/npx-cli/setup-command.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from 'bun:test';
-import { formatCurrentConfig } from '../../src/npx-cli/commands/setup.js';
+import { formatCurrentConfig, selectWorkerScriptPath } from '../../src/npx-cli/commands/setup.js';
 
 describe('setup — current-config summary', () => {
   it('falls back to claude/worker defaults on an empty settings record', () => {
@@ -44,5 +44,29 @@ describe('setup — current-config summary', () => {
     expect(lines).toContain('provider  claude');
     expect(lines).toContain('model     (default)');
     expect(lines).toContain('runtime   worker');
+  });
+});
+
+describe('setup — worker script selection', () => {
+  const marketplace = '/mkt/plugin/scripts/worker-service.cjs';
+  const cache = '/cache/scripts/worker-service.cjs';
+
+  it('prefers the marketplace script when it exists', () => {
+    const picked = selectWorkerScriptPath([marketplace, cache], (p) => p === marketplace);
+    expect(picked).toBe(marketplace);
+  });
+
+  it('falls back to the plugin cache script when only that one exists', () => {
+    const picked = selectWorkerScriptPath([marketplace, cache], (p) => p === cache);
+    expect(picked).toBe(cache);
+  });
+
+  // Regression: setup must not shut the worker down when there is nothing to
+  // restart it with. `ensureWorkerStarted` only rejects a missing script after
+  // the shutdown has landed, so an unchecked fallback path turned a
+  // settings-only `setup` into an outage.
+  it('returns undefined when neither candidate exists, so the running worker is left alone', () => {
+    const picked = selectWorkerScriptPath([marketplace, cache], () => false);
+    expect(picked).toBeUndefined();
   });
 });


### PR DESCRIPTION
### What

**New: `npx claude-mem setup`** (aliases: `settings`, `config`, `configure`)

Change configuration on an existing install without re-running the installer:

- Shows the currently stored config (provider, auth method, model, runtime), then re-runs the exact `promptProvider` / `promptClaudeModel` flows from `install` — those two functions are now exported and shared, so the install and setup paths can never drift.
- Honors the same flags non-interactively: `--provider claude|gemini|openrouter`, `--model <id>`, `--disable-auto-memory`, `--no-auto-start`.
- Restarts the worker at the end so the new settings actually take effect (settings are read at worker startup). On the server runtime it prints a `npx claude-mem server restart` hint instead of touching the worker path.
- Guards against no-install: exits 1 with a pointer to `npx claude-mem install`.

**Changed: `npx claude-mem update` keeps your settings**

`update`/`upgrade` previously aliased straight to the interactive installer — it re-asked runtime/provider/model and the "Overwrite existing installation?" confirm on every version bump. Now, when run on an existing install whose stored provider is a known id and no overriding flags were passed:

- the overwrite confirm is skipped ("Updating existing installation in place."),
- the runtime/provider/model prompts are skipped ("Keeping existing configuration (provider=…, runtime=…). Run `npx claude-mem setup` to change settings."),
- the file-install phase (plugin cache, marketplace, Bun/uv runtime, hooks, IDE config) runs as before.

Explicit flags still win: `npx claude-mem update --model claude-sonnet-5` routes through the normal prompt flows, which already handle flags non-interactively. Fresh installs and `install` itself are unchanged.

**Division of labor after this PR:** `setup` = settings only, no file changes · `update` = files only, settings preserved · `install` = both (unchanged, still the full interactive path).

### Why

Changing the provider or model previously required the full reinstall flow, and `update` was indistinguishable from a fresh install. Settings tweaks and version updates are the two most common day-2 operations; they now each have a dedicated, minimal path.

### Hardening on top of the original change

**1. The `update` skip guard validates the provider (`c438720`).** `SettingsDefaultsManager.loadFromFile` merges the built-in defaults, so a missing `CLAUDE_MEM_PROVIDER` reads back as `'claude'`, never `''` — an emptiness test could never be false. The guard validates the stored literal instead.

**2. Provider validation is shared, and repairs rather than adopts (`9abe7e8`).** `promptProvider` built `initialProvider` from the raw setting and, in its non-TTY / no-`--provider` branch, returned it unvalidated — so a hand-edited `settings.json` let an unsupported provider ride through. This predates the PR (`update` previously aliased straight into `runInstallCommand()` and reached the same return); the new keep-settings guard is what routes malformed values into that branch. Added `isKnownProvider`, used in all three places that were each validating differently. When the stored value is unusable the fallback now **persists** `claude` — returning a safe value while leaving the bad literal on disk would not have helped, since the worker re-reads `settings.json` at startup.

**3. `setup` no longer stops a worker it cannot restart (`46f638e`).** The restart path picked the plugin-cache script as an *unchecked* fallback and then called `shutdownWorkerAndWait`. `ensureWorkerStarted` does its `existsSync` check at `worker-spawner.ts:80-87` — after the shutdown has already landed — so with both script locations absent, a settings-only `setup` took a healthy worker offline and returned `dead`. The script is now resolved *before* anything is stopped; when no candidate exists the shutdown is skipped entirely.

**4. The restart retries while the plugin tree is being replaced (`6b8963d`, `15412f4b`).** `install`/`update` replace the marketplace and cache directories with `rmSync` + `cpSync`, and neither resolving the path nor spawning from it is atomic against that — the script can vanish before the resolve, or between our `existsSync` and the spawner's. Since the worker is already stopped by then, the restart re-resolves and retries (3 attempts, 2s apart) rather than giving up on the first miss. A still-missing script is reported distinctly from a worker that failed to come up.

Not done deliberately: a shared install/runtime lock. `install`, `update`, and `repair` race with each other today for the same reason and independently of this PR, so a lock only `setup` participates in would be a false guarantee — it belongs with the replacement logic, not in a settings command.

### Validation

Run against this branch:

- `tsc --noEmit` (root) and `tsc --noEmit -p src/ui/viewer/tsconfig.json` — both clean
- `npm run build` — succeeds, bundle-size guardrails pass
- `bun test tests` — 2539 pass / 18 skip / 2 fail; the 2 failures are `tests/sdk/parse-summary.test.ts` and `tests/sdk/parser.test.ts` (a pre-existing `ModeManager` stub leak between test files). Verified identical on the base commit `4702c33` via a clean worktree — not introduced here.
- `bun test openclaw` — 44 pass
- `bun test tests/npx-cli/` — 13 pass
- `bun test tests/install-disable-auto-memory.test.ts` — 18 pass
- `check-hook-io-discipline` and `check-spawn-env-discipline` pass

**Not exercised in this environment:** the full `update` file-install to completion, the interactive TTY prompt paths (unchanged code, exercised daily via `install`), and worker restart against a live worker.

### Files

- `src/npx-cli/commands/setup.ts` — new command
- `src/npx-cli/commands/install.ts` — export the two prompt flows; `isKnownProvider`; `mode: 'update'` handling
- `src/npx-cli/index.ts` — routing + help text
- `tests/npx-cli/setup-command.test.ts`, `tests/npx-cli/provider-validation.test.ts` — new