### PR TITLE
fix(worktree): reconcile orphaned worktree and submodule observations

### DIFF
--- a/src/services/infrastructure/WorktreeAdoption.ts
+++ b/src/services/infrastructure/WorktreeAdoption.ts
@@ -16,6 +16,12 @@ export interface AdoptionResult {
   parentProject: string;
   scannedWorktrees: number;
   mergedBranches: string[];
+  /**
+   * #2864 — composite project keys adopted because their worktree directory is
+   * gone, regardless of merge status. Reported separately from mergedBranches
+   * so a run never silently widens what it folded into the parent.
+   */
+  orphanedWorktrees: string[];
   adoptedObservations: number;
   adoptedSummaries: number;
   chromaUpdates: number;
@@ -86,6 +92,21 @@ function resolveMainRepoPath(cwd: string): string | null {
   ]);
   if (!commonDir) return null;
 
+  // #2842 — inside a submodule, --git-common-dir is `<super>/.git/modules/<name>`
+  // (nested submodules append further `/modules/<name>` segments). Neither
+  // branch below matches that shape, so discovery used to hand back the
+  // gitdir itself: a path that exists, is not a working tree, and resolves to
+  // the wrong project. Walk back past `/.git/modules/` to the superproject
+  // root — the same anchor detectWorktree uses for the composite key, so
+  // discovery and key derivation agree.
+  const modulesMarker = `${path.sep}.git${path.sep}modules${path.sep}`;
+  const normalized = commonDir.split('/').join(path.sep);
+  const modulesIndex = normalized.indexOf(modulesMarker);
+  if (modulesIndex !== -1) {
+    const superprojectRoot = normalized.slice(0, modulesIndex);
+    return existsSync(superprojectRoot) ? superprojectRoot : null;
+  }
+
   const mainRoot = commonDir.endsWith('/.git')
     ? path.dirname(commonDir)
     : commonDir.replace(/\.git$/, '');
@@ -114,6 +135,80 @@ function listWorktrees(mainRepo: string): WorktreeEntry[] {
   }
   if (current.path) entries.push({ path: current.path, branch: current.branch ?? null });
   return entries;
+}
+
+/**
+ * #2864 — composite `parent/leaf` keys in the DB that have no corresponding
+ * live worktree. Once the worktree directory is gone, the parent↔worktree
+ * association cannot be recomputed from disk, so these rows are unreachable by
+ * every read path: `getProjectContext` on the parent yields only `[parent]`,
+ * and `merged_into_project` was never stamped. They are orphaned by definition,
+ * which is why they are adopted regardless of merge status — the alternative is
+ * not "kept separate", it is "lost".
+ *
+ * Matched with a half-open range rather than `LIKE 'parent/%' ESCAPE`, because
+ * comparing exact bytes removes the LIKE-wildcard hazard at the source: `_` is
+ * a single-character wildcard and is very common in repo names, so an
+ * unescaped `my_app/%` also matches `myXapp/...` — a different repo's
+ * worktree. (Both forms plan the same way today: SQLite drives off
+ * `idx_observations_merged_into` for the `IS NULL` term rather than the
+ * project prefix, so this is a correctness choice, not a speed one.)
+ */
+function listOrphanProjectKeys(
+  db: import('bun:sqlite').Database,
+  parentProject: string,
+  liveWorktreeProjects: Set<string>
+): string[] {
+  const prefix = `${parentProject}/`;
+  // '0' is the byte immediately after '/', so [prefix, upperBound) is exactly
+  // the set of keys beginning with `${parentProject}/`.
+  const upperBound = `${parentProject}0`;
+  const rows = db.prepare(
+    `SELECT DISTINCT project FROM observations
+      WHERE project >= ? AND project < ? AND merged_into_project IS NULL
+     UNION
+     SELECT DISTINCT project FROM session_summaries
+      WHERE project >= ? AND project < ? AND merged_into_project IS NULL`
+  ).all(prefix, upperBound, prefix, upperBound) as Array<{ project: string }>;
+
+  return rows
+    .map(r => r.project)
+    .filter(project => {
+      if (liveWorktreeProjects.has(project)) return false;
+      // Composite keys are exactly one level deep (`${parent}/${leaf}`); anything
+      // deeper is not a key this resolver produces.
+      const leaf = project.slice(prefix.length);
+      return leaf.length > 0 && !leaf.includes('/');
+    });
+}
+
+/**
+ * #2842 — absolute paths of this repo's submodule checkouts. Submodules share
+ * the `parent/leaf` composite key with worktrees (getProjectContext) but are
+ * NOT reported by `git worktree list`, so without this an actively-used
+ * submodule looks exactly like a worktree whose directory was deleted and the
+ * orphan sweep would fold it into the superproject.
+ *
+ * Only paths that still exist are returned: a submodule checkout that is gone
+ * strands its observations the same way a removed worktree does, and should be
+ * adopted rather than protected.
+ */
+function listSubmodulePaths(mainRepo: string): string[] {
+  const raw = gitCapture(mainRepo, ['submodule', 'status', '--recursive']);
+  if (!raw) return [];
+
+  const paths: string[] = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    // ` <sha> <path> (<describe>)`, where a leading -/+/U flags an
+    // uninitialized/out-of-sync/conflicted submodule and the trailing
+    // describe-suffix is optional. Paths may contain spaces.
+    const match = line.match(/^[\s+\-U]*[0-9a-f]{7,40}\s+(.+?)(?:\s+\([^)]*\))?$/);
+    if (!match) continue;
+    const absolute = path.resolve(mainRepo, match[1]);
+    if (existsSync(absolute)) paths.push(absolute);
+  }
+  return paths;
 }
 
 function listMergedBranches(mainRepo: string): Set<string> {
@@ -147,6 +242,7 @@ export async function adoptMergedWorktrees(opts: {
     parentProject,
     scannedWorktrees: 0,
     mergedBranches: [],
+    orphanedWorktrees: [],
     adoptedObservations: 0,
     adoptedSummaries: 0,
     chromaUpdates: 0,
@@ -170,10 +266,6 @@ export async function adoptMergedWorktrees(opts: {
   const childWorktrees = allWorktrees.filter(w => w.path !== mainRepo);
   result.scannedWorktrees = childWorktrees.length;
 
-  if (childWorktrees.length === 0) {
-    return result;
-  }
-
   let targets: WorktreeEntry[];
   if (opts.onlyBranch) {
     targets = childWorktrees.filter(w => w.branch === opts.onlyBranch);
@@ -185,10 +277,6 @@ export async function adoptMergedWorktrees(opts: {
   result.mergedBranches = targets
     .map(t => t.branch)
     .filter((b): b is string => b !== null);
-
-  if (targets.length === 0) {
-    return result;
-  }
 
   const adoptedChromaTargets: MergedIntoProjectTarget[] = [];
 
@@ -239,8 +327,7 @@ export async function adoptMergedWorktrees(opts: {
     // plain-UPDATE path.
     const syncLane = hasSyncLane(db);
 
-    const adoptWorktreeInTransaction = (wt: WorktreeEntry) => {
-      const worktreeProject = getProjectContext(wt.path).primary;
+    const adoptWorktreeInTransaction = (worktreeProject: string) => {
       const rows = selectObsForPatch.all(
         worktreeProject,
         parentProject
@@ -274,18 +361,37 @@ export async function adoptMergedWorktrees(opts: {
       result.adoptedSummaries += sumChanges;
     };
 
+    // Every nested checkout still on disk — worktrees (merged or in-flight) and
+    // submodules alike. Both share the parent/leaf composite key, and neither
+    // is an orphan while its directory exists.
+    const liveWorktreeProjects = new Set([
+      ...childWorktrees.map(w => getProjectContext(w.path).primary),
+      ...listSubmodulePaths(mainRepo).map(p => getProjectContext(p).primary),
+    ]);
+
+    // `--branch` is a targeted escape hatch for squash-merges; keep it precise
+    // and leave the orphan sweep to the default run.
+    const orphanProjects = opts.onlyBranch
+      ? []
+      : listOrphanProjectKeys(db, parentProject, liveWorktreeProjects);
+    result.orphanedWorktrees = orphanProjects;
+
+    const adoptionTargets: Array<{ project: string; label: string }> = [
+      ...targets.map(wt => ({ project: getProjectContext(wt.path).primary, label: wt.path })),
+      ...orphanProjects.map(project => ({ project, label: `${project} (worktree removed)` })),
+    ];
+
     const tx = db.transaction(() => {
-      for (const wt of targets) {
+      for (const target of adoptionTargets) {
         try {
-          adoptWorktreeInTransaction(wt);
+          adoptWorktreeInTransaction(target.project);
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           logger.warn('SYSTEM', 'Worktree adoption skipped branch', {
-            worktree: wt.path,
-            branch: wt.branch,
+            worktree: target.label,
             error: message
           });
-          result.errors.push({ worktree: wt.path, error: message });
+          result.errors.push({ worktree: target.label, error: message });
         }
       }
       if (dryRun) {
@@ -345,6 +451,7 @@ export async function adoptMergedWorktrees(opts: {
       dryRun,
       scannedWorktrees: result.scannedWorktrees,
       mergedBranches: result.mergedBranches,
+      orphanedWorktrees: result.orphanedWorktrees,
       adoptedObservations: result.adoptedObservations,
       adoptedSummaries: result.adoptedSummaries,
       chromaUpdates: result.chromaUpdates,
@@ -375,19 +482,36 @@ export async function adoptMergedWorktreesForAllKnownRepos(opts: {
     const { Database } = require('bun:sqlite') as typeof import('bun:sqlite');
     db = new Database(dbPath, { readonly: true });
 
-    const hasPending = db.prepare(
-      "SELECT name FROM sqlite_master WHERE type='table' AND name='pending_messages'"
-    ).get() as { name: string } | undefined;
-    if (!hasPending) {
-      logger.debug('SYSTEM', 'Worktree adoption skipped (pending_messages table missing)');
+    // #2864 — repo discovery reads sdk_sessions.cwd. It used to read
+    // pending_messages.cwd, but that queue was replaced by an in-RAM buffer
+    // (61fe70a2, v13.10.0) and the table stopped receiving writes, so this
+    // sweep found zero repos on every startup and adoption only ever ran via a
+    // manual `npx claude-mem adopt`. pending_messages is still UNIONed in so
+    // installs that upgrade with pre-13.10 rows still on disk keep their
+    // history of known repos until sessions re-populate sdk_sessions.cwd.
+    const sessionCols = db
+      .prepare('PRAGMA table_info(sdk_sessions)')
+      .all() as Array<{ name: string }>;
+    if (!sessionCols.some(c => c.name === 'cwd')) {
+      logger.debug(
+        'SYSTEM',
+        'Worktree adoption skipped (sdk_sessions.cwd missing; will run after migration)'
+      );
       return results;
     }
 
-    const cwdRows = db.prepare(`
-      SELECT cwd FROM pending_messages
-      WHERE cwd IS NOT NULL AND cwd != ''
-      GROUP BY cwd
-    `).all() as Array<{ cwd: string }>;
+    const hasPending = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='pending_messages'"
+    ).get() as { name: string } | undefined;
+
+    const cwdSources = ['SELECT cwd FROM sdk_sessions WHERE cwd IS NOT NULL AND cwd != \'\''];
+    if (hasPending) {
+      cwdSources.push('SELECT cwd FROM pending_messages WHERE cwd IS NOT NULL AND cwd != \'\'');
+    }
+
+    const cwdRows = db.prepare(
+      `SELECT DISTINCT cwd FROM (${cwdSources.join(' UNION ')})`
+    ).all() as Array<{ cwd: string }>;
 
     for (const { cwd } of cwdRows) {
       const mainRepo = resolveMainRepoPath(cwd);

--- a/src/services/infrastructure/WorktreeAdoption.ts
+++ b/src/services/infrastructure/WorktreeAdoption.ts
@@ -16,11 +16,7 @@ export interface AdoptionResult {
   parentProject: string;
   scannedWorktrees: number;
   mergedBranches: string[];
-  /**
-   * #2864 — composite project keys adopted because their worktree directory is
-   * gone, regardless of merge status. Reported separately from mergedBranches
-   * so a run never silently widens what it folded into the parent.
-   */
+  /** Keys adopted because their checkout is gone, merged or not (#2864). */
   orphanedWorktrees: string[];
   adoptedObservations: number;
   adoptedSummaries: number;
@@ -92,13 +88,10 @@ function resolveMainRepoPath(cwd: string): string | null {
   ]);
   if (!commonDir) return null;
 
-  // #2842 — inside a submodule, --git-common-dir is `<super>/.git/modules/<name>`
-  // (nested submodules append further `/modules/<name>` segments). Neither
-  // branch below matches that shape, so discovery used to hand back the
-  // gitdir itself: a path that exists, is not a working tree, and resolves to
-  // the wrong project. Walk back past `/.git/modules/` to the superproject
-  // root — the same anchor detectWorktree uses for the composite key, so
-  // discovery and key derivation agree.
+  // A submodule's --git-common-dir is `<super>/.git/modules/<name>`, which
+  // neither branch below matches — discovery used to return the gitdir itself.
+  // Anchor on the same marker detectWorktree uses, so discovery and key
+  // derivation agree (#2842).
   const modulesMarker = `${path.sep}.git${path.sep}modules${path.sep}`;
   const normalized = commonDir.split('/').join(path.sep);
   const modulesIndex = normalized.indexOf(modulesMarker);
@@ -138,45 +131,28 @@ function listWorktrees(mainRepo: string): WorktreeEntry[] {
 }
 
 /**
- * #2864 — composite `parent/leaf` keys in the DB that have no corresponding
- * live worktree. Once the worktree directory is gone, the parent↔worktree
- * association cannot be recomputed from disk, so these rows are unreachable by
- * every read path: `getProjectContext` on the parent yields only `[parent]`,
- * and `merged_into_project` was never stamped. They are orphaned by definition,
- * which is why they are adopted regardless of merge status — the alternative is
- * not "kept separate", it is "lost".
+ * Composite keys with no live checkout. Their parent association can no longer
+ * be recomputed from disk, so they are unreachable by every read path and are
+ * adopted regardless of merge status — the alternative to adopting is not
+ * "kept separate", it is "lost" (#2864).
  *
- * Matched with a half-open range rather than `LIKE 'parent/%' ESCAPE`, because
- * comparing exact bytes removes the LIKE-wildcard hazard at the source: `_` is
- * a single-character wildcard and is very common in repo names, so an
- * unescaped `my_app/%` also matches `myXapp/...` — a different repo's
- * worktree. (Both forms plan the same way today: SQLite drives off
- * `idx_observations_merged_into` for the `IS NULL` term rather than the
- * project prefix, so this is a correctness choice, not a speed one.)
+ * Range-matched rather than `LIKE 'parent/%'`: `_` is a LIKE wildcard and
+ * common in repo names, so `my_app/%` would also match another repo's
+ * `myXapp/...`.
  */
 function listOrphanProjectKeys(
   db: import('bun:sqlite').Database,
   parentProject: string,
   liveWorktreeProjects: Set<string>,
-  /**
-   * When false, only keys with rows still awaiting adoption are returned —
-   * used for reporting, so a run's output is a changelog of what it folded in
-   * rather than a running tally of everything ever adopted.
-   */
+  /** False narrows to keys still awaiting adoption, for reporting. */
   includeAlreadyAdopted: boolean
 ): string[] {
   const prefix = `${parentProject}/`;
-  // '0' is the byte immediately after '/', so [prefix, upperBound) is exactly
-  // the set of keys beginning with `${parentProject}/`.
+  // '0' is the byte after '/', so [prefix, upperBound) is exactly the children.
   const upperBound = `${parentProject}0`;
-  // `merged_into_project IS NULL OR = parent` mirrors selectObsForPatch. The
-  // SQL update is a no-op for rows already stamped (emitRemapProject only
-  // touches NULLs), so re-runs neither double-count nor bump sync revs — but
-  // the rows stay eligible for the Chroma patch, which commits separately and
-  // can fail on its own (single-writer data dir). Filtering on NULL alone
-  // would drop an adopted key out of the target set permanently and strand
-  // its vector metadata, contradicting the "will retry on next run" the CLI
-  // reports.
+  // Mirrors selectObsForPatch: already-adopted rows stay eligible so a Chroma
+  // patch that failed after the SQL commit can retry. The update itself is a
+  // no-op for them, so re-runs neither double-count nor bump sync revs.
   const adoptedClause = includeAlreadyAdopted
     ? 'AND (merged_into_project IS NULL OR merged_into_project = ?)'
     : 'AND merged_into_project IS NULL';
@@ -196,23 +172,17 @@ function listOrphanProjectKeys(
     .map(r => r.project)
     .filter(project => {
       if (liveWorktreeProjects.has(project)) return false;
-      // Composite keys are exactly one level deep (`${parent}/${leaf}`); anything
-      // deeper is not a key this resolver produces.
+      // Composite keys are exactly one level deep.
       const leaf = project.slice(prefix.length);
       return leaf.length > 0 && !leaf.includes('/');
     });
 }
 
 /**
- * #2842 — absolute paths of this repo's submodule checkouts. Submodules share
- * the `parent/leaf` composite key with worktrees (getProjectContext) but are
- * NOT reported by `git worktree list`, so without this an actively-used
- * submodule looks exactly like a worktree whose directory was deleted and the
- * orphan sweep would fold it into the superproject.
- *
- * Only paths that still exist are returned: a submodule checkout that is gone
- * strands its observations the same way a removed worktree does, and should be
- * adopted rather than protected.
+ * Submodule checkouts, which share the composite key with worktrees but are not
+ * reported by `git worktree list` — without them a live submodule looks exactly
+ * like a deleted worktree to the orphan sweep. Existence-filtered, so a deleted
+ * submodule is still adopted (#2842).
  */
 function listSubmodulePaths(mainRepo: string): string[] {
   const raw = gitCapture(mainRepo, ['submodule', 'status', '--recursive']);
@@ -221,9 +191,7 @@ function listSubmodulePaths(mainRepo: string): string[] {
   const paths: string[] = [];
   for (const line of raw.split('\n')) {
     if (!line.trim()) continue;
-    // ` <sha> <path> (<describe>)`, where a leading -/+/U flags an
-    // uninitialized/out-of-sync/conflicted submodule and the trailing
-    // describe-suffix is optional. Paths may contain spaces.
+    // ` <sha> <path> (<describe>)`; paths may contain spaces.
     const match = line.match(/^[\s+\-U]*[0-9a-f]{7,40}\s+(.+?)(?:\s+\([^)]*\))?$/);
     if (!match) continue;
     const absolute = path.resolve(mainRepo, match[1]);
@@ -382,18 +350,12 @@ export async function adoptMergedWorktrees(opts: {
       result.adoptedSummaries += sumChanges;
     };
 
-    // Every nested checkout still on disk — worktrees (merged or in-flight) and
-    // submodules alike. Both share the parent/leaf composite key, and neither
-    // is an orphan while its directory exists.
     const liveWorktreeProjects = new Set([
       ...childWorktrees.map(w => getProjectContext(w.path).primary),
       ...listSubmodulePaths(mainRepo).map(p => getProjectContext(p).primary),
     ]);
 
-    // `--branch` is a targeted escape hatch for squash-merges; keep it precise
-    // and leave the orphan sweep to the default run.
-    // Targets include already-adopted keys so a previously-failed Chroma patch
-    // can recover; reporting lists only what this run actually folds in.
+    // `--branch` is a targeted squash-merge escape hatch; no orphan sweep.
     const orphanProjects = opts.onlyBranch
       ? []
       : listOrphanProjectKeys(db, parentProject, liveWorktreeProjects, true);
@@ -507,13 +469,8 @@ export async function adoptMergedWorktreesForAllKnownRepos(opts: {
     const { Database } = require('bun:sqlite') as typeof import('bun:sqlite');
     db = new Database(dbPath, { readonly: true });
 
-    // #2864 — repo discovery reads sdk_sessions.cwd. It used to read
-    // pending_messages.cwd, but that queue was replaced by an in-RAM buffer
-    // (61fe70a2, v13.10.0) and the table stopped receiving writes, so this
-    // sweep found zero repos on every startup and adoption only ever ran via a
-    // manual `npx claude-mem adopt`. pending_messages is still UNIONed in so
-    // installs that upgrade with pre-13.10 rows still on disk keep their
-    // history of known repos until sessions re-populate sdk_sessions.cwd.
+    // Discovery reads sdk_sessions.cwd; pending_messages stopped receiving
+    // writes in v13.10.0 and is UNIONed only for rows still on disk (#2864).
     const sessionCols = db
       .prepare('PRAGMA table_info(sdk_sessions)')
       .all() as Array<{ name: string }>;

--- a/src/services/infrastructure/WorktreeAdoption.ts
+++ b/src/services/infrastructure/WorktreeAdoption.ts
@@ -172,9 +172,9 @@ function listOrphanProjectKeys(
     .map(r => r.project)
     .filter(project => {
       if (liveWorktreeProjects.has(project)) return false;
-      // Composite keys are exactly one level deep.
-      const leaf = project.slice(prefix.length);
-      return leaf.length > 0 && !leaf.includes('/');
+      // Nested submodules key on their path under the superproject, so a
+      // composite is not always one level deep (#2842).
+      return project.length > prefix.length;
     });
 }
 

--- a/src/services/infrastructure/WorktreeAdoption.ts
+++ b/src/services/infrastructure/WorktreeAdoption.ts
@@ -157,19 +157,40 @@ function listWorktrees(mainRepo: string): WorktreeEntry[] {
 function listOrphanProjectKeys(
   db: import('bun:sqlite').Database,
   parentProject: string,
-  liveWorktreeProjects: Set<string>
+  liveWorktreeProjects: Set<string>,
+  /**
+   * When false, only keys with rows still awaiting adoption are returned —
+   * used for reporting, so a run's output is a changelog of what it folded in
+   * rather than a running tally of everything ever adopted.
+   */
+  includeAlreadyAdopted: boolean
 ): string[] {
   const prefix = `${parentProject}/`;
   // '0' is the byte immediately after '/', so [prefix, upperBound) is exactly
   // the set of keys beginning with `${parentProject}/`.
   const upperBound = `${parentProject}0`;
+  // `merged_into_project IS NULL OR = parent` mirrors selectObsForPatch. The
+  // SQL update is a no-op for rows already stamped (emitRemapProject only
+  // touches NULLs), so re-runs neither double-count nor bump sync revs — but
+  // the rows stay eligible for the Chroma patch, which commits separately and
+  // can fail on its own (single-writer data dir). Filtering on NULL alone
+  // would drop an adopted key out of the target set permanently and strand
+  // its vector metadata, contradicting the "will retry on next run" the CLI
+  // reports.
+  const adoptedClause = includeAlreadyAdopted
+    ? 'AND (merged_into_project IS NULL OR merged_into_project = ?)'
+    : 'AND merged_into_project IS NULL';
+  const params = includeAlreadyAdopted
+    ? [prefix, upperBound, parentProject, prefix, upperBound, parentProject]
+    : [prefix, upperBound, prefix, upperBound];
+
   const rows = db.prepare(
     `SELECT DISTINCT project FROM observations
-      WHERE project >= ? AND project < ? AND merged_into_project IS NULL
+      WHERE project >= ? AND project < ? ${adoptedClause}
      UNION
      SELECT DISTINCT project FROM session_summaries
-      WHERE project >= ? AND project < ? AND merged_into_project IS NULL`
-  ).all(prefix, upperBound, prefix, upperBound) as Array<{ project: string }>;
+      WHERE project >= ? AND project < ? ${adoptedClause}`
+  ).all(...params) as Array<{ project: string }>;
 
   return rows
     .map(r => r.project)
@@ -371,10 +392,14 @@ export async function adoptMergedWorktrees(opts: {
 
     // `--branch` is a targeted escape hatch for squash-merges; keep it precise
     // and leave the orphan sweep to the default run.
+    // Targets include already-adopted keys so a previously-failed Chroma patch
+    // can recover; reporting lists only what this run actually folds in.
     const orphanProjects = opts.onlyBranch
       ? []
-      : listOrphanProjectKeys(db, parentProject, liveWorktreeProjects);
-    result.orphanedWorktrees = orphanProjects;
+      : listOrphanProjectKeys(db, parentProject, liveWorktreeProjects, true);
+    result.orphanedWorktrees = opts.onlyBranch
+      ? []
+      : listOrphanProjectKeys(db, parentProject, liveWorktreeProjects, false);
 
     const adoptionTargets: Array<{ project: string; label: string }> = [
       ...targets.map(wt => ({ project: getProjectContext(wt.path).primary, label: wt.path })),

--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -1725,14 +1725,8 @@ export class SessionStore {
     );
   }
 
-  /**
-   * #2864 — sessions persist the cwd they were captured in. The worktree
-   * adoption sweep used to discover repos from `pending_messages.cwd`, but that
-   * queue was replaced by an in-RAM buffer (61fe70a2, v13.10.0) and the table
-   * stopped receiving writes, so the sweep silently found nothing on every
-   * startup. `sdk_sessions` is local-only (sync knows observation/summary/prompt
-   * — see CanonicalContent.ts), so this column needs no sync-lane plumbing.
-   */
+  // Worktree adoption discovers repos from this; sdk_sessions is local-only,
+  // so no sync-lane plumbing (#2864).
   private ensureSessionCwdColumn(): void {
     const cols = this.db
       .query('PRAGMA table_info(sdk_sessions)')
@@ -2459,13 +2453,8 @@ export class SessionStore {
     return Number(result.lastInsertRowid);
   }
 
-  /**
-   * #2864 — record the directory a session was captured in, so the worktree
-   * adoption sweep can find the repos this install actually works in. First
-   * write wins: a session's cwd can drift mid-session (the agent may `cd` into
-   * a submodule or subdirectory), and the launch directory is the one that
-   * identifies the repo.
-   */
+  // First write wins: cwd drifts when the agent `cd`s into a subdirectory, and
+  // the launch directory is the one that identifies the repo.
   setSessionCwd(sessionDbId: number, cwd: string): void {
     if (!cwd.trim()) return;
     this.db.prepare(

--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -1733,10 +1733,13 @@ export class SessionStore {
       .all() as TableColumnInfo[];
     if (!cols.some(c => c.name === 'cwd')) {
       this.db.run('ALTER TABLE sdk_sessions ADD COLUMN cwd TEXT');
+      logger.debug('DB', 'Added cwd column to sdk_sessions table (#2864)');
     }
     this.db.run(
       'CREATE INDEX IF NOT EXISTS idx_sdk_sessions_cwd ON sdk_sessions(cwd)'
     );
+
+    this.db.prepare('INSERT OR IGNORE INTO schema_versions (version, applied_at) VALUES (?, ?)').run(50, new Date().toISOString());
   }
 
   private addObservationSubagentColumns(): void {

--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -104,6 +104,7 @@ export class SessionStore {
     this.addSessionPlatformSourceColumn();
     this.addObservationModelColumns();
     this.ensureMergedIntoProjectColumns();
+    this.ensureSessionCwdColumn();
     this.addObservationSubagentColumns();
     this.addObservationsUniqueContentHashIndex();
     this.addObservationsMetadataColumn();
@@ -1724,6 +1725,26 @@ export class SessionStore {
     );
   }
 
+  /**
+   * #2864 — sessions persist the cwd they were captured in. The worktree
+   * adoption sweep used to discover repos from `pending_messages.cwd`, but that
+   * queue was replaced by an in-RAM buffer (61fe70a2, v13.10.0) and the table
+   * stopped receiving writes, so the sweep silently found nothing on every
+   * startup. `sdk_sessions` is local-only (sync knows observation/summary/prompt
+   * — see CanonicalContent.ts), so this column needs no sync-lane plumbing.
+   */
+  private ensureSessionCwdColumn(): void {
+    const cols = this.db
+      .query('PRAGMA table_info(sdk_sessions)')
+      .all() as TableColumnInfo[];
+    if (!cols.some(c => c.name === 'cwd')) {
+      this.db.run('ALTER TABLE sdk_sessions ADD COLUMN cwd TEXT');
+    }
+    this.db.run(
+      'CREATE INDEX IF NOT EXISTS idx_sdk_sessions_cwd ON sdk_sessions(cwd)'
+    );
+  }
+
   private addObservationSubagentColumns(): void {
     const applied = this.db.prepare('SELECT version FROM schema_versions WHERE version = ?').get(27) as SchemaVersion | undefined;
 
@@ -2436,6 +2457,20 @@ export class SessionStore {
     }
 
     return Number(result.lastInsertRowid);
+  }
+
+  /**
+   * #2864 — record the directory a session was captured in, so the worktree
+   * adoption sweep can find the repos this install actually works in. First
+   * write wins: a session's cwd can drift mid-session (the agent may `cd` into
+   * a submodule or subdirectory), and the launch directory is the one that
+   * identifies the repo.
+   */
+  setSessionCwd(sessionDbId: number, cwd: string): void {
+    if (!cwd.trim()) return;
+    this.db.prepare(
+      'UPDATE sdk_sessions SET cwd = ? WHERE id = ? AND cwd IS NULL'
+    ).run(cwd, sessionDbId);
   }
 
   /**

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -1390,6 +1390,7 @@ async function main() {
       console.log(`  Repo:                 ${result.repoPath}`);
       console.log(`  Worktrees scanned:    ${result.scannedWorktrees}`);
       console.log(`  Merged branches:      ${result.mergedBranches.join(', ') || '(none)'}`);
+      console.log(`  Orphaned worktrees:   ${result.orphanedWorktrees.join(', ') || '(none)'}`);
       console.log(`  Observations adopted: ${result.adoptedObservations}`);
       console.log(`  Summaries adopted:    ${result.adoptedSummaries}`);
       console.log(`  Chroma docs updated:  ${result.chromaUpdates}`);

--- a/src/services/worker/http/shared.ts
+++ b/src/services/worker/http/shared.ts
@@ -89,8 +89,6 @@ export async function ingestObservation(payload: ObservationPayload): Promise<In
   let promptNumber: number;
   try {
     sessionDbId = store.createSDKSession(payload.contentSessionId, project, '', undefined, platformSource);
-    // #2864 — persist cwd so the worktree adoption sweep can discover the repos
-    // this install works in. First write wins (see SessionStore.setSessionCwd).
     if (cwd) store.setSessionCwd(sessionDbId, cwd);
     promptNumber = store.getPromptNumberFromUserPrompts(payload.contentSessionId, sessionDbId);
   } catch (error) {

--- a/src/services/worker/http/shared.ts
+++ b/src/services/worker/http/shared.ts
@@ -89,6 +89,9 @@ export async function ingestObservation(payload: ObservationPayload): Promise<In
   let promptNumber: number;
   try {
     sessionDbId = store.createSDKSession(payload.contentSessionId, project, '', undefined, platformSource);
+    // #2864 — persist cwd so the worktree adoption sweep can discover the repos
+    // this install works in. First write wins (see SessionStore.setSessionCwd).
+    if (cwd) store.setSessionCwd(sessionDbId, cwd);
     promptNumber = store.getPromptNumberFromUserPrompts(payload.contentSessionId, sessionDbId);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/utils/project-name.ts
+++ b/src/utils/project-name.ts
@@ -73,6 +73,8 @@ export interface ProjectContext {
   primary: string;
   parent: string | null;
   isWorktree: boolean;
+  /** #2842 — set when `primary` is a composite key for a git submodule. */
+  isSubmodule: boolean;
   allProjects: string[];
 }
 
@@ -80,7 +82,7 @@ export function getProjectContext(cwd: string | null | undefined): ProjectContex
   const cwdProjectName = getProjectName(cwd);
 
   if (!cwd) {
-    return { primary: cwdProjectName, parent: null, isWorktree: false, allProjects: [cwdProjectName] };
+    return { primary: cwdProjectName, parent: null, isWorktree: false, isSubmodule: false, allProjects: [cwdProjectName] };
   }
 
   const expandedCwd = expandTilde(cwd);
@@ -90,15 +92,18 @@ export function getProjectContext(cwd: string | null | undefined): ProjectContex
   // the parent/worktree compound key.
   const worktreeInfo = detectWorktree(findGitRepoRoot(expandedCwd) ?? expandedCwd);
 
-  if (worktreeInfo.isWorktree && worktreeInfo.parentProjectName) {
+  // #2842 — submodules nest under a superproject exactly like worktrees nest
+  // under a parent repo, and get the same composite key.
+  if ((worktreeInfo.isWorktree || worktreeInfo.isSubmodule) && worktreeInfo.parentProjectName) {
     const composite = `${worktreeInfo.parentProjectName}/${cwdProjectName}`;
     return {
       primary: composite,
       parent: worktreeInfo.parentProjectName,
-      isWorktree: true,
+      isWorktree: worktreeInfo.isWorktree,
+      isSubmodule: worktreeInfo.isSubmodule,
       allProjects: [worktreeInfo.parentProjectName, composite]
     };
   }
 
-  return { primary: cwdProjectName, parent: null, isWorktree: false, allProjects: [cwdProjectName] };
+  return { primary: cwdProjectName, parent: null, isWorktree: false, isSubmodule: false, allProjects: [cwdProjectName] };
 }

--- a/src/utils/project-name.ts
+++ b/src/utils/project-name.ts
@@ -73,7 +73,7 @@ export interface ProjectContext {
   primary: string;
   parent: string | null;
   isWorktree: boolean;
-  /** #2842 — set when `primary` is a composite key for a git submodule. */
+  /** Set when `primary` is a composite key for a submodule (#2842). */
   isSubmodule: boolean;
   allProjects: string[];
 }
@@ -92,8 +92,6 @@ export function getProjectContext(cwd: string | null | undefined): ProjectContex
   // the parent/worktree compound key.
   const worktreeInfo = detectWorktree(findGitRepoRoot(expandedCwd) ?? expandedCwd);
 
-  // #2842 — submodules nest under a superproject exactly like worktrees nest
-  // under a parent repo, and get the same composite key.
   if ((worktreeInfo.isWorktree || worktreeInfo.isSubmodule) && worktreeInfo.parentProjectName) {
     const composite = `${worktreeInfo.parentProjectName}/${cwdProjectName}`;
     return {

--- a/src/utils/project-name.ts
+++ b/src/utils/project-name.ts
@@ -2,7 +2,7 @@ import { homedir } from 'os'
 import path from 'path';
 import { execFileSync } from 'child_process';
 import { logger } from './logger.js';
-import { detectWorktree } from './worktree.js';
+import { detectWorktree, type WorktreeInfo } from './worktree.js';
 
 function expandTilde(p: string): string {
   if (p === '~' || p.startsWith('~/')) {
@@ -78,6 +78,21 @@ export interface ProjectContext {
   allProjects: string[];
 }
 
+/**
+ * A submodule's key component is its path under the superproject, not its
+ * basename: two nested submodules can share a leaf repo name
+ * (`outer/alpha/shared` and `outer/beta/shared`), and keying on the basename
+ * alone collapses them into one project whose observations overwrite each
+ * other. Worktrees keep the basename — they usually live outside the parent
+ * tree, where a relative path is meaningless.
+ */
+function submoduleLeaf(info: WorktreeInfo, repoRoot: string): string | null {
+  if (!info.isSubmodule || !info.parentRepoPath) return null;
+  const relative = path.relative(info.parentRepoPath, repoRoot);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+  return relative.split(path.sep).join('/');
+}
+
 export function getProjectContext(cwd: string | null | undefined): ProjectContext {
   const cwdProjectName = getProjectName(cwd);
 
@@ -90,10 +105,11 @@ export function getProjectContext(cwd: string | null | undefined): ProjectContex
   // worktree root. Resolve the git working-tree root first (same pattern as
   // getProjectName / #2663) so sessions started in a subdirectory still get
   // the parent/worktree compound key.
-  const worktreeInfo = detectWorktree(findGitRepoRoot(expandedCwd) ?? expandedCwd);
+  const repoRoot = findGitRepoRoot(expandedCwd) ?? expandedCwd;
+  const worktreeInfo = detectWorktree(repoRoot);
 
   if ((worktreeInfo.isWorktree || worktreeInfo.isSubmodule) && worktreeInfo.parentProjectName) {
-    const composite = `${worktreeInfo.parentProjectName}/${cwdProjectName}`;
+    const composite = `${worktreeInfo.parentProjectName}/${submoduleLeaf(worktreeInfo, repoRoot) ?? cwdProjectName}`;
     return {
       primary: composite,
       parent: worktreeInfo.parentProjectName,

--- a/src/utils/worktree.ts
+++ b/src/utils/worktree.ts
@@ -5,13 +5,21 @@ import { logger } from './logger.js';
 
 export interface WorktreeInfo {
   isWorktree: boolean;
-  worktreeName: string | null;     
-  parentRepoPath: string | null;   
-  parentProjectName: string | null; 
+  /**
+   * #2842 — a git submodule is a nested checkout that folds into its
+   * superproject the same way a worktree folds into its parent. Callers that
+   * only care "does this nest under a parent repo?" should test
+   * `isWorktree || isSubmodule`.
+   */
+  isSubmodule: boolean;
+  worktreeName: string | null;
+  parentRepoPath: string | null;
+  parentProjectName: string | null;
 }
 
 const NOT_A_WORKTREE: WorktreeInfo = {
   isWorktree: false,
+  isSubmodule: false,
   worktreeName: null,
   parentRepoPath: null,
   parentProjectName: null
@@ -50,18 +58,34 @@ export function detectWorktree(cwd: string): WorktreeInfo {
   const gitdirPath = path.resolve(path.dirname(gitPath), match[1]);
 
   const worktreesMatch = gitdirPath.match(/^(.+)[/\\]\.git[/\\]worktrees[/\\]([^/\\]+)$/);
-  if (!worktreesMatch) {
-    return NOT_A_WORKTREE;
+  if (worktreesMatch) {
+    const parentRepoPath = worktreesMatch[1];
+    return {
+      isWorktree: true,
+      isSubmodule: false,
+      worktreeName: path.basename(cwd),
+      parentRepoPath,
+      parentProjectName: path.basename(parentRepoPath)
+    };
   }
 
-  const parentRepoPath = worktreesMatch[1];
-  const worktreeName = path.basename(cwd);
-  const parentProjectName = path.basename(parentRepoPath);
+  // #2842 — a submodule's .git file points at `<super>/.git/modules/<name>`
+  // (nested submodules extend that with further `/modules/` segments), which
+  // the worktrees pattern above never matched. Without this branch a submodule
+  // session resolved to its own leaf name: a brand-new, empty project, so
+  // context injection reported "no memory yet" despite a rich superproject
+  // history.
+  const submoduleMatch = gitdirPath.match(/^(.+)[/\\]\.git[/\\]modules[/\\](.+)$/);
+  if (submoduleMatch) {
+    const parentRepoPath = submoduleMatch[1];
+    return {
+      isWorktree: false,
+      isSubmodule: true,
+      worktreeName: path.basename(cwd),
+      parentRepoPath,
+      parentProjectName: path.basename(parentRepoPath)
+    };
+  }
 
-  return {
-    isWorktree: true,
-    worktreeName,
-    parentRepoPath,
-    parentProjectName
-  };
+  return NOT_A_WORKTREE;
 }

--- a/src/utils/worktree.ts
+++ b/src/utils/worktree.ts
@@ -5,12 +5,7 @@ import { logger } from './logger.js';
 
 export interface WorktreeInfo {
   isWorktree: boolean;
-  /**
-   * #2842 — a git submodule is a nested checkout that folds into its
-   * superproject the same way a worktree folds into its parent. Callers that
-   * only care "does this nest under a parent repo?" should test
-   * `isWorktree || isSubmodule`.
-   */
+  /** Nests under a superproject like a worktree nests under its parent (#2842). */
   isSubmodule: boolean;
   worktreeName: string | null;
   parentRepoPath: string | null;
@@ -69,12 +64,9 @@ export function detectWorktree(cwd: string): WorktreeInfo {
     };
   }
 
-  // #2842 — a submodule's .git file points at `<super>/.git/modules/<name>`
-  // (nested submodules extend that with further `/modules/` segments), which
-  // the worktrees pattern above never matched. Without this branch a submodule
-  // session resolved to its own leaf name: a brand-new, empty project, so
-  // context injection reported "no memory yet" despite a rich superproject
-  // history.
+  // Submodules point at `<super>/.git/modules/<name>`, which the worktrees
+  // pattern never matched — they resolved to their own leaf name, a new empty
+  // project, so context injection reported "no memory yet" (#2842).
   const submoduleMatch = gitdirPath.match(/^(.+)[/\\]\.git[/\\]modules[/\\](.+)$/);
   if (submoduleMatch) {
     const parentRepoPath = submoduleMatch[1];

--- a/tests/services/infrastructure/worktree-adoption-orphans.test.ts
+++ b/tests/services/infrastructure/worktree-adoption-orphans.test.ts
@@ -140,6 +140,45 @@ describe('orphaned worktree adoption (#2864)', () => {
     expect(result.orphanedWorktrees).toEqual(['parent-repo/reported-wt']);
   });
 
+  // The Chroma patch runs after the SQL commits and can fail on its own (the
+  // data dir allows a single writer, so a CLI run loses to the live worker).
+  // selectObsForPatch matches `merged_into_project IS NULL OR = parent`
+  // precisely so a later run can re-patch. Orphan detection has to admit
+  // already-adopted keys too, or the retry it promises never happens and the
+  // vector metadata stays stale forever.
+  it('still collects Chroma targets for an already-adopted orphan', async () => {
+    tempRoot = mkdtempSync(path.join(tmpdir(), 'claude-mem-2864-orphan-'));
+    const mainRepo = path.join(tempRoot, 'parent-repo');
+    const worktree = path.join(tempRoot, 'retry-wt');
+    const dataDirectory = path.join(tempRoot, 'data');
+    mkdirSync(dataDirectory, { recursive: true });
+    initRepo(mainRepo);
+
+    git(mainRepo, 'worktree', 'add', '-b', 'retry', worktree);
+    const dbPath = path.join(dataDirectory, 'claude-mem.db');
+    const store = new SessionStore(dbPath);
+    seedSession(store, 'content-retry', 'parent-repo/retry-wt', 'memory-retry');
+    seedObservation(store, 'memory-retry', 'parent-repo/retry-wt');
+    store.close();
+
+    git(mainRepo, 'worktree', 'remove', '--force', worktree);
+    git(mainRepo, 'worktree', 'prune');
+
+    const first = await adoptMergedWorktrees({ repoPath: mainRepo, dataDirectory });
+    expect(first.adoptedObservations).toBe(1);
+    expect(first.chromaUpdates).toBe(1);
+    expect(first.orphanedWorktrees).toEqual(['parent-repo/retry-wt']);
+
+    const second = await adoptMergedWorktrees({ repoPath: mainRepo, dataDirectory });
+    // SQL is a no-op the second time — no double counting, no spurious revs.
+    expect(second.adoptedObservations).toBe(0);
+    // ...but the row is still offered to Chroma so a failed patch can recover.
+    expect(second.chromaUpdates).toBe(1);
+    // Reporting stays a changelog of what this run folded in, not a running
+    // tally of everything ever adopted.
+    expect(second.orphanedWorktrees).toEqual([]);
+  });
+
   it('adopts an orphan even when its branch was never merged', async () => {
     tempRoot = mkdtempSync(path.join(tmpdir(), 'claude-mem-2864-orphan-'));
     const mainRepo = path.join(tempRoot, 'parent-repo');

--- a/tests/services/infrastructure/worktree-adoption-orphans.test.ts
+++ b/tests/services/infrastructure/worktree-adoption-orphans.test.ts
@@ -207,6 +207,27 @@ describe('orphaned worktree adoption (#2864)', () => {
     expect(mergedInto(dbPath, obsId)).toBe('parent-repo');
   });
 
+  // Nested submodules key on their path under the superproject
+  // (`outer/alpha/shared`), so a composite key is not always one level deep.
+  it('adopts a deeper composite key whose checkout is gone', async () => {
+    tempRoot = mkdtempSync(path.join(tmpdir(), 'claude-mem-2864-orphan-'));
+    const mainRepo = path.join(tempRoot, 'parent-repo');
+    const dataDirectory = path.join(tempRoot, 'data');
+    mkdirSync(dataDirectory, { recursive: true });
+    initRepo(mainRepo);
+
+    const dbPath = path.join(dataDirectory, 'claude-mem.db');
+    const store = new SessionStore(dbPath);
+    seedSession(store, 'content-nested', 'parent-repo/vendor/shared', 'memory-nested');
+    const obsId = seedObservation(store, 'memory-nested', 'parent-repo/vendor/shared');
+    store.close();
+
+    const result = await adoptMergedWorktrees({ repoPath: mainRepo, dataDirectory });
+
+    expect(result.orphanedWorktrees).toEqual(['parent-repo/vendor/shared']);
+    expect(mergedInto(dbPath, obsId)).toBe('parent-repo');
+  });
+
   it('leaves a live worktree with an unmerged branch alone', async () => {
     tempRoot = mkdtempSync(path.join(tmpdir(), 'claude-mem-2864-orphan-'));
     const mainRepo = path.join(tempRoot, 'parent-repo');

--- a/tests/services/infrastructure/worktree-adoption-orphans.test.ts
+++ b/tests/services/infrastructure/worktree-adoption-orphans.test.ts
@@ -1,0 +1,216 @@
+// #2864 / #2967: observations captured in a worktree keep the composite
+// `parent/leaf` project key. Adoption only ever folded them into the parent
+// when the worktree was still listed by `git worktree list` AND its branch was
+// merged. Delete the worktree after merging — routine cleanup — and the rows
+// were stranded: `merged_into_project` stayed NULL and no read path could reach
+// them, because the parent↔worktree association was only recomputable from the
+// live directory.
+//
+// A composite key whose worktree is gone is orphaned by definition, so adoption
+// folds it into the parent regardless of merge status. Leaving it unreachable
+// forever is strictly worse than adopting work from an abandoned branch.
+import { afterAll, afterEach, describe, expect, it, mock } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import * as realChromaMcpManager from '../../../src/services/sync/ChromaMcpManager.js';
+
+const realChromaMcpManagerSnapshot = { ...realChromaMcpManager };
+
+mock.module('../../../src/services/sync/ChromaMcpManager.js', () => ({
+  ChromaMcpManager: {
+    getInstance: () => ({
+      callTool: async () => ({})
+    })
+  }
+}));
+
+import { adoptMergedWorktrees } from '../../../src/services/infrastructure/WorktreeAdoption.js';
+import { SessionStore } from '../../../src/services/sqlite/SessionStore.js';
+
+let tempRoot: string | undefined;
+
+afterEach(() => {
+  if (tempRoot) {
+    try { rmSync(tempRoot, { recursive: true, force: true }); } catch {}
+  }
+  tempRoot = undefined;
+});
+
+afterAll(() => {
+  mock.module('../../../src/services/sync/ChromaMcpManager.js', () => realChromaMcpManagerSnapshot);
+});
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync('git', ['-C', cwd, ...args], { stdio: 'ignore' });
+}
+
+function initRepo(repo: string): void {
+  mkdirSync(repo, { recursive: true });
+  git(repo, 'init', '-b', 'main');
+  git(repo, 'config', 'user.email', 'test@example.com');
+  git(repo, 'config', 'user.name', 'Test');
+  writeFileSync(path.join(repo, 'README.md'), 'base\n');
+  git(repo, 'add', 'README.md');
+  git(repo, 'commit', '-m', 'base');
+}
+
+function seedObservation(store: SessionStore, memorySessionId: string, project: string): number {
+  const result = store.importObservation({
+    memory_session_id: memorySessionId,
+    project,
+    text: 'worktree work',
+    type: 'discovery',
+    title: `work in ${project}`,
+    subtitle: null,
+    facts: null,
+    narrative: null,
+    concepts: null,
+    files_read: null,
+    files_modified: null,
+    prompt_number: 1,
+    discovery_tokens: 0,
+    created_at: new Date(1_700_000_000_000).toISOString(),
+    created_at_epoch: 1_700_000_000_000,
+  });
+  return result.id;
+}
+
+function seedSession(store: SessionStore, contentId: string, project: string, memoryId: string): void {
+  const sessionDbId = store.createSDKSession(contentId, project, 'prompt');
+  store.ensureMemorySessionIdRegistered(sessionDbId, memoryId);
+}
+
+function mergedInto(dbPath: string, obsId: number): string | null {
+  const verify = new SessionStore(dbPath);
+  const row = verify.db.prepare(
+    'SELECT merged_into_project FROM observations WHERE id = ?'
+  ).get(obsId) as { merged_into_project: string | null };
+  verify.close();
+  return row.merged_into_project;
+}
+
+describe('orphaned worktree adoption (#2864)', () => {
+  it('adopts observations whose worktree directory no longer exists', async () => {
+    tempRoot = mkdtempSync(path.join(tmpdir(), 'claude-mem-2864-orphan-'));
+    const mainRepo = path.join(tempRoot, 'parent-repo');
+    const worktree = path.join(tempRoot, 'gone-wt');
+    const dataDirectory = path.join(tempRoot, 'data');
+    mkdirSync(dataDirectory, { recursive: true });
+    initRepo(mainRepo);
+
+    // A worktree that did real work, then was cleaned up after its branch merged.
+    git(mainRepo, 'worktree', 'add', '-b', 'gone', worktree);
+    const dbPath = path.join(dataDirectory, 'claude-mem.db');
+    const store = new SessionStore(dbPath);
+    seedSession(store, 'content-gone', 'parent-repo/gone-wt', 'memory-gone');
+    const obsId = seedObservation(store, 'memory-gone', 'parent-repo/gone-wt');
+    store.close();
+
+    git(mainRepo, 'worktree', 'remove', '--force', worktree);
+    git(mainRepo, 'worktree', 'prune');
+
+    const result = await adoptMergedWorktrees({ repoPath: mainRepo, dataDirectory });
+
+    expect(result.adoptedObservations).toBe(1);
+    expect(mergedInto(dbPath, obsId)).toBe('parent-repo');
+  });
+
+  it('reports which orphans it adopted rather than folding them silently', async () => {
+    tempRoot = mkdtempSync(path.join(tmpdir(), 'claude-mem-2864-orphan-'));
+    const mainRepo = path.join(tempRoot, 'parent-repo');
+    const worktree = path.join(tempRoot, 'reported-wt');
+    const dataDirectory = path.join(tempRoot, 'data');
+    mkdirSync(dataDirectory, { recursive: true });
+    initRepo(mainRepo);
+
+    git(mainRepo, 'worktree', 'add', '-b', 'reported', worktree);
+    const dbPath = path.join(dataDirectory, 'claude-mem.db');
+    const store = new SessionStore(dbPath);
+    seedSession(store, 'content-reported', 'parent-repo/reported-wt', 'memory-reported');
+    seedObservation(store, 'memory-reported', 'parent-repo/reported-wt');
+    store.close();
+
+    git(mainRepo, 'worktree', 'remove', '--force', worktree);
+    git(mainRepo, 'worktree', 'prune');
+
+    const result = await adoptMergedWorktrees({ repoPath: mainRepo, dataDirectory });
+
+    expect(result.orphanedWorktrees).toEqual(['parent-repo/reported-wt']);
+  });
+
+  it('adopts an orphan even when its branch was never merged', async () => {
+    tempRoot = mkdtempSync(path.join(tmpdir(), 'claude-mem-2864-orphan-'));
+    const mainRepo = path.join(tempRoot, 'parent-repo');
+    const worktree = path.join(tempRoot, 'abandoned-wt');
+    const dataDirectory = path.join(tempRoot, 'data');
+    mkdirSync(dataDirectory, { recursive: true });
+    initRepo(mainRepo);
+
+    git(mainRepo, 'worktree', 'add', '-b', 'abandoned', worktree);
+    writeFileSync(path.join(worktree, 'unmerged.txt'), 'never merged\n');
+    git(worktree, 'add', 'unmerged.txt');
+    git(worktree, 'commit', '-m', 'unmerged work');
+
+    const dbPath = path.join(dataDirectory, 'claude-mem.db');
+    const store = new SessionStore(dbPath);
+    seedSession(store, 'content-abandoned', 'parent-repo/abandoned-wt', 'memory-abandoned');
+    const obsId = seedObservation(store, 'memory-abandoned', 'parent-repo/abandoned-wt');
+    store.close();
+
+    git(mainRepo, 'worktree', 'remove', '--force', worktree);
+    git(mainRepo, 'worktree', 'prune');
+
+    const result = await adoptMergedWorktrees({ repoPath: mainRepo, dataDirectory });
+
+    expect(result.adoptedObservations).toBe(1);
+    expect(mergedInto(dbPath, obsId)).toBe('parent-repo');
+  });
+
+  it('leaves a live worktree with an unmerged branch alone', async () => {
+    tempRoot = mkdtempSync(path.join(tmpdir(), 'claude-mem-2864-orphan-'));
+    const mainRepo = path.join(tempRoot, 'parent-repo');
+    const worktree = path.join(tempRoot, 'live-wt');
+    const dataDirectory = path.join(tempRoot, 'data');
+    mkdirSync(dataDirectory, { recursive: true });
+    initRepo(mainRepo);
+
+    git(mainRepo, 'worktree', 'add', '-b', 'in-flight', worktree);
+    writeFileSync(path.join(worktree, 'wip.txt'), 'work in progress\n');
+    git(worktree, 'add', 'wip.txt');
+    git(worktree, 'commit', '-m', 'wip');
+
+    const dbPath = path.join(dataDirectory, 'claude-mem.db');
+    const store = new SessionStore(dbPath);
+    seedSession(store, 'content-live', 'parent-repo/live-wt', 'memory-live');
+    const obsId = seedObservation(store, 'memory-live', 'parent-repo/live-wt');
+    store.close();
+
+    const result = await adoptMergedWorktrees({ repoPath: mainRepo, dataDirectory });
+
+    expect(result.adoptedObservations).toBe(0);
+    expect(mergedInto(dbPath, obsId)).toBeNull();
+  });
+
+  it('does not treat a same-prefix sibling project as an orphan of the parent', async () => {
+    tempRoot = mkdtempSync(path.join(tmpdir(), 'claude-mem-2864-orphan-'));
+    const mainRepo = path.join(tempRoot, 'my_app');
+    const dataDirectory = path.join(tempRoot, 'data');
+    mkdirSync(dataDirectory, { recursive: true });
+    initRepo(mainRepo);
+
+    const dbPath = path.join(dataDirectory, 'claude-mem.db');
+    const store = new SessionStore(dbPath);
+    // `_` is a LIKE wildcard: an unescaped `my_app/%` pattern also matches
+    // `myXapp/...`, which belongs to a different repo entirely.
+    seedSession(store, 'content-other', 'myXapp/some-wt', 'memory-other');
+    const foreignObsId = seedObservation(store, 'memory-other', 'myXapp/some-wt');
+    store.close();
+
+    const result = await adoptMergedWorktrees({ repoPath: mainRepo, dataDirectory });
+
+    expect(result.adoptedObservations).toBe(0);
+    expect(mergedInto(dbPath, foreignObsId)).toBeNull();
+  });
+});

--- a/tests/services/infrastructure/worktree-adoption-submodule.test.ts
+++ b/tests/services/infrastructure/worktree-adoption-submodule.test.ts
@@ -1,0 +1,187 @@
+// #2842 + #2864 interaction: submodules get the same `parent/leaf` composite
+// key as worktrees, but they are NOT listed by `git worktree list`. The orphan
+// sweep treats any composite key with no live worktree as orphaned, so a live,
+// actively-used submodule must not be mistaken for a removed worktree and
+// folded into its superproject.
+import { afterAll, afterEach, describe, expect, it, mock } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, realpathSync } from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import * as realChromaMcpManager from '../../../src/services/sync/ChromaMcpManager.js';
+
+const realChromaMcpManagerSnapshot = { ...realChromaMcpManager };
+
+mock.module('../../../src/services/sync/ChromaMcpManager.js', () => ({
+  ChromaMcpManager: {
+    getInstance: () => ({ callTool: async () => ({}) })
+  }
+}));
+
+import {
+  adoptMergedWorktrees,
+  adoptMergedWorktreesForAllKnownRepos
+} from '../../../src/services/infrastructure/WorktreeAdoption.js';
+import { SessionStore } from '../../../src/services/sqlite/SessionStore.js';
+
+let tempRoot: string | undefined;
+
+afterEach(() => {
+  if (tempRoot) {
+    try { rmSync(tempRoot, { recursive: true, force: true }); } catch {}
+  }
+  tempRoot = undefined;
+});
+
+afterAll(() => {
+  mock.module('../../../src/services/sync/ChromaMcpManager.js', () => realChromaMcpManagerSnapshot);
+});
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync('git', ['-C', cwd, ...args], { stdio: 'ignore' });
+}
+
+function initRepo(repo: string): void {
+  mkdirSync(repo, { recursive: true });
+  git(repo, 'init', '-b', 'main');
+  git(repo, 'config', 'user.email', 'test@example.com');
+  git(repo, 'config', 'user.name', 'Test');
+  writeFileSync(path.join(repo, 'README.md'), 'base\n');
+  git(repo, 'add', 'README.md');
+  git(repo, 'commit', '-m', 'base');
+}
+
+function seedObservation(store: SessionStore, memoryId: string, project: string): number {
+  return store.importObservation({
+    memory_session_id: memoryId,
+    project,
+    text: 'submodule work',
+    type: 'discovery',
+    title: `work in ${project}`,
+    subtitle: null,
+    facts: null,
+    narrative: null,
+    concepts: null,
+    files_read: null,
+    files_modified: null,
+    prompt_number: 1,
+    discovery_tokens: 0,
+    created_at: new Date(1_700_000_000_000).toISOString(),
+    created_at_epoch: 1_700_000_000_000,
+  }).id;
+}
+
+function mergedInto(dbPath: string, obsId: number): string | null {
+  const verify = new SessionStore(dbPath);
+  const row = verify.db.prepare(
+    'SELECT merged_into_project FROM observations WHERE id = ?'
+  ).get(obsId) as { merged_into_project: string | null };
+  verify.close();
+  return row.merged_into_project;
+}
+
+interface Fixture {
+  superproject: string;
+  submodule: string;
+  dataDirectory: string;
+  dbPath: string;
+  obsId: number;
+}
+
+function buildFixture(): Fixture {
+  tempRoot = realpathSync(mkdtempSync(path.join(tmpdir(), 'claude-mem-2842-adopt-')));
+  const superproject = path.join(tempRoot, 'react');
+  const child = path.join(tempRoot, 'peerless-origin');
+  const dataDirectory = path.join(tempRoot, 'data');
+  mkdirSync(dataDirectory, { recursive: true });
+
+  initRepo(superproject);
+  initRepo(child);
+  execFileSync(
+    'git',
+    ['-C', superproject, '-c', 'protocol.file.allow=always', 'submodule', 'add', child, 'peerless'],
+    { stdio: 'ignore' }
+  );
+  git(superproject, 'commit', '-m', 'add submodule');
+
+  const submodule = path.join(superproject, 'peerless');
+  const dbPath = path.join(dataDirectory, 'claude-mem.db');
+  const store = new SessionStore(dbPath);
+  const sessionDbId = store.createSDKSession('content-sub', 'react/peerless', 'prompt');
+  store.ensureMemorySessionIdRegistered(sessionDbId, 'memory-sub');
+  store.setSessionCwd(sessionDbId, submodule);
+  const obsId = seedObservation(store, 'memory-sub', 'react/peerless');
+  store.close();
+
+  return { superproject, submodule, dataDirectory, dbPath, obsId };
+}
+
+describe('live submodules are not orphans (#2842 + #2864)', () => {
+  it('does not adopt a live submodule when adopting the superproject', async () => {
+    const fx = buildFixture();
+
+    const result = await adoptMergedWorktrees({
+      repoPath: fx.superproject,
+      dataDirectory: fx.dataDirectory
+    });
+
+    expect(result.orphanedWorktrees).toEqual([]);
+    expect(result.adoptedObservations).toBe(0);
+    expect(mergedInto(fx.dbPath, fx.obsId)).toBeNull();
+  });
+
+  it('does adopt a submodule whose checkout has been deleted', async () => {
+    const fx = buildFixture();
+    rmSync(fx.submodule, { recursive: true, force: true });
+
+    const result = await adoptMergedWorktrees({
+      repoPath: fx.superproject,
+      dataDirectory: fx.dataDirectory
+    });
+
+    expect(result.orphanedWorktrees).toEqual(['react/peerless']);
+    expect(mergedInto(fx.dbPath, fx.obsId)).toBe('react');
+  });
+
+  it('does not adopt a live submodule during the startup sweep', async () => {
+    const fx = buildFixture();
+
+    await adoptMergedWorktreesForAllKnownRepos({ dataDirectory: fx.dataDirectory });
+
+    expect(mergedInto(fx.dbPath, fx.obsId)).toBeNull();
+  });
+
+  // A submodule's --git-common-dir is `<super>/.git/modules/<name>`, not
+  // `<super>/.git`, so repo discovery has to walk back past `/.git/modules/`
+  // to reach the superproject root. Without that, a session that only ever ran
+  // inside a submodule contributes no discoverable repo and the superproject's
+  // own orphans are never swept.
+  it('discovers the superproject from a submodule-only session cwd', async () => {
+    const fx = buildFixture();
+
+    // An orphaned worktree of the SUPERPROJECT — only reachable if discovery
+    // resolves `react` from the submodule cwd recorded above.
+    const goneWorktree = path.join(tempRoot!, 'gone-wt');
+    git(fx.superproject, 'worktree', 'add', '-b', 'gone', goneWorktree);
+    const store = new SessionStore(fx.dbPath);
+    const sessionDbId = store.createSDKSession('content-gone', 'react/gone-wt', 'prompt');
+    store.ensureMemorySessionIdRegistered(sessionDbId, 'memory-gone');
+    const orphanObsId = seedObservation(store, 'memory-gone', 'react/gone-wt');
+    store.close();
+    git(fx.superproject, 'worktree', 'remove', '--force', goneWorktree);
+    git(fx.superproject, 'worktree', 'prune');
+
+    // Only the submodule cwd is on record — no session ever ran in `react`.
+    const check = new SessionStore(fx.dbPath);
+    const cwds = (check.db.prepare(
+      "SELECT DISTINCT cwd FROM sdk_sessions WHERE cwd IS NOT NULL AND cwd != ''"
+    ).all() as Array<{ cwd: string }>).map(r => r.cwd);
+    check.close();
+    expect(cwds).toEqual([fx.submodule]);
+
+    await adoptMergedWorktreesForAllKnownRepos({ dataDirectory: fx.dataDirectory });
+
+    expect(mergedInto(fx.dbPath, orphanObsId)).toBe('react');
+    expect(mergedInto(fx.dbPath, fx.obsId)).toBeNull();
+  });
+});

--- a/tests/services/infrastructure/worktree-adoption-sweep.test.ts
+++ b/tests/services/infrastructure/worktree-adoption-sweep.test.ts
@@ -1,0 +1,88 @@
+// #2864 / #2967: the startup adoption sweep discovered parent repos by reading
+// distinct `cwd` values out of `pending_messages`. That table stopped being
+// written in 61fe70a2 ("remove retry/observation queue, replace with
+// SessionMessageBuffer", v13.10.0), so the sweep found zero repos on every
+// startup and adoption only ever ran when a user invoked `npx claude-mem adopt`
+// by hand. Sessions now persist their cwd on `sdk_sessions`, and the sweep
+// reads from there.
+import { afterEach, describe, expect, it } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { adoptMergedWorktreesForAllKnownRepos } from '../../../src/services/infrastructure/WorktreeAdoption.js';
+import { SessionStore } from '../../../src/services/sqlite/SessionStore.js';
+
+let tempRoot: string | undefined;
+
+afterEach(() => {
+  if (tempRoot) {
+    try { rmSync(tempRoot, { recursive: true, force: true }); } catch {}
+  }
+  tempRoot = undefined;
+});
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync('git', ['-C', cwd, ...args], { stdio: 'ignore' });
+}
+
+function seedObservation(store: SessionStore, memorySessionId: string, project: string): void {
+  store.importObservation({
+    memory_session_id: memorySessionId,
+    project,
+    text: 'worktree work',
+    type: 'discovery',
+    title: 'worktree work',
+    subtitle: null,
+    facts: null,
+    narrative: null,
+    concepts: null,
+    files_read: null,
+    files_modified: null,
+    prompt_number: 1,
+    discovery_tokens: 0,
+    created_at: new Date(1_700_000_000_000).toISOString(),
+    created_at_epoch: 1_700_000_000_000,
+  });
+}
+
+describe('adoption sweep repo discovery (#2864)', () => {
+  it('discovers parent repos from sdk_sessions.cwd when pending_messages is empty', async () => {
+    tempRoot = mkdtempSync(path.join(tmpdir(), 'claude-mem-2864-sweep-'));
+    const mainRepo = path.join(tempRoot, 'parent-repo');
+    const worktree = path.join(tempRoot, 'feature-wt');
+    const dataDirectory = path.join(tempRoot, 'data');
+    mkdirSync(mainRepo, { recursive: true });
+    mkdirSync(dataDirectory);
+
+    git(mainRepo, 'init', '-b', 'main');
+    git(mainRepo, 'config', 'user.email', 'test@example.com');
+    git(mainRepo, 'config', 'user.name', 'Test');
+    writeFileSync(path.join(mainRepo, 'README.md'), 'base\n');
+    git(mainRepo, 'add', 'README.md');
+    git(mainRepo, 'commit', '-m', 'base');
+    git(mainRepo, 'worktree', 'add', '-b', 'feature', worktree);
+
+    const dbPath = path.join(dataDirectory, 'claude-mem.db');
+    const store = new SessionStore(dbPath);
+    const sessionDbId = store.createSDKSession('content-1', 'parent-repo/feature-wt', 'prompt');
+    store.ensureMemorySessionIdRegistered(sessionDbId, 'memory-1');
+    store.setSessionCwd(sessionDbId, worktree);
+    seedObservation(store, 'memory-1', 'parent-repo/feature-wt');
+
+    const pendingCount = (store.db.prepare(
+      'SELECT COUNT(*) AS n FROM pending_messages'
+    ).get() as { n: number }).n;
+    store.close();
+
+    // Guard the premise: the sweep must not be relying on the dead table.
+    expect(pendingCount).toBe(0);
+
+    const results = await adoptMergedWorktreesForAllKnownRepos({ dataDirectory, dryRun: true });
+
+    const parent = results.find(r => r.parentProject === 'parent-repo');
+    expect(parent).toBeDefined();
+    expect(parent!.adoptedObservations).toBe(1);
+  });
+});

--- a/tests/services/worker/ingest-session-cwd.test.ts
+++ b/tests/services/worker/ingest-session-cwd.test.ts
@@ -1,0 +1,86 @@
+// #2864 / #2967: the adoption sweep needs to know which directories this
+// install actually works in. cwd arrives on every observation ingest but was
+// never persisted after the pending_messages queue was removed (61fe70a2,
+// v13.10.0), leaving the sweep with no repos to scan. Ingest now stamps it on
+// the session row.
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { ingestObservation, setIngestContext } from '../../../src/services/worker/http/shared.js';
+import { SessionStore } from '../../../src/services/sqlite/SessionStore.js';
+
+let tempRoot: string | undefined;
+let store: SessionStore | undefined;
+
+afterEach(() => {
+  try { store?.close(); } catch {}
+  store = undefined;
+  if (tempRoot) {
+    try { rmSync(tempRoot, { recursive: true, force: true }); } catch {}
+  }
+  tempRoot = undefined;
+});
+
+function wireIngest(sessionStore: SessionStore): void {
+  setIngestContext({
+    sessionManager: { queueObservation: async () => {} } as never,
+    dbManager: { getSessionStore: () => sessionStore } as never,
+    eventBroadcaster: { broadcastObservationQueued: () => {} } as never,
+  });
+}
+
+describe('ingest persists session cwd (#2864)', () => {
+  it('stamps the ingest cwd onto the session row', async () => {
+    tempRoot = mkdtempSync(path.join(tmpdir(), 'claude-mem-2864-ingest-'));
+    const dataDirectory = path.join(tempRoot, 'data');
+    mkdirSync(dataDirectory, { recursive: true });
+    store = new SessionStore(path.join(dataDirectory, 'claude-mem.db'));
+    wireIngest(store);
+
+    const result = await ingestObservation({
+      contentSessionId: 'content-cwd-1',
+      toolName: 'Bash',
+      toolInput: { command: 'ls' },
+      toolResponse: { stdout: '' },
+      cwd: tempRoot,
+    });
+
+    expect(result.ok).toBe(true);
+    const row = store.db.prepare(
+      'SELECT cwd FROM sdk_sessions WHERE content_session_id = ?'
+    ).get('content-cwd-1') as { cwd: string | null };
+    expect(row.cwd).toBe(tempRoot);
+  });
+
+  it('keeps the launch cwd when a later observation arrives from a subdirectory', async () => {
+    tempRoot = mkdtempSync(path.join(tmpdir(), 'claude-mem-2864-ingest-'));
+    const dataDirectory = path.join(tempRoot, 'data');
+    const subdir = path.join(tempRoot, 'packages', 'api');
+    mkdirSync(dataDirectory, { recursive: true });
+    mkdirSync(subdir, { recursive: true });
+    store = new SessionStore(path.join(dataDirectory, 'claude-mem.db'));
+    wireIngest(store);
+
+    await ingestObservation({
+      contentSessionId: 'content-cwd-2',
+      toolName: 'Bash',
+      toolInput: { command: 'ls' },
+      toolResponse: { stdout: '' },
+      cwd: tempRoot,
+    });
+    await ingestObservation({
+      contentSessionId: 'content-cwd-2',
+      toolName: 'Bash',
+      toolInput: { command: 'ls' },
+      toolResponse: { stdout: '' },
+      cwd: subdir,
+    });
+
+    const row = store.db.prepare(
+      'SELECT cwd FROM sdk_sessions WHERE content_session_id = ?'
+    ).get('content-cwd-2') as { cwd: string | null };
+    expect(row.cwd).toBe(tempRoot);
+  });
+});

--- a/tests/sqlite/session-store-cwd-migration.test.ts
+++ b/tests/sqlite/session-store-cwd-migration.test.ts
@@ -1,0 +1,61 @@
+// #2864: sdk_sessions.cwd is added by a PRAGMA-guarded migration. The guard
+// makes it idempotent on its own, but the schema ledger is how this codebase
+// records that a change was applied, so the version has to land too.
+import { describe, it, expect, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { SessionStore } from '../../src/services/sqlite/SessionStore.js';
+
+const SESSION_CWD_SCHEMA_VERSION = 50;
+
+let tempRoot: string | undefined;
+
+afterEach(() => {
+  if (tempRoot) {
+    try { rmSync(tempRoot, { recursive: true, force: true }); } catch {}
+  }
+  tempRoot = undefined;
+});
+
+function open(): { store: SessionStore; dbPath: string } {
+  tempRoot = mkdtempSync(path.join(tmpdir(), 'claude-mem-cwd-migration-'));
+  const dbPath = path.join(tempRoot, 'claude-mem.db');
+  return { store: new SessionStore(dbPath), dbPath };
+}
+
+describe('sdk_sessions.cwd migration (#2864)', () => {
+  it('records its schema version in the ledger', () => {
+    const { store } = open();
+    const row = store.db
+      .prepare('SELECT version FROM schema_versions WHERE version = ?')
+      .get(SESSION_CWD_SCHEMA_VERSION) as { version: number } | undefined;
+    store.close();
+
+    expect(row?.version).toBe(SESSION_CWD_SCHEMA_VERSION);
+  });
+
+  it('adds the column and index', () => {
+    const { store } = open();
+    const cols = store.db.prepare('PRAGMA table_info(sdk_sessions)').all() as Array<{ name: string }>;
+    const idx = store.db
+      .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_sdk_sessions_cwd'")
+      .get() as { name: string } | undefined;
+    store.close();
+
+    expect(cols.some(c => c.name === 'cwd')).toBe(true);
+    expect(idx?.name).toBe('idx_sdk_sessions_cwd');
+  });
+
+  it('reopens cleanly without duplicating the ledger entry', () => {
+    const { store, dbPath } = open();
+    store.close();
+    const reopened = new SessionStore(dbPath);
+    const count = (reopened.db
+      .prepare('SELECT COUNT(*) AS n FROM schema_versions WHERE version = ?')
+      .get(SESSION_CWD_SCHEMA_VERSION) as { n: number }).n;
+    reopened.close();
+
+    expect(count).toBe(1);
+  });
+});

--- a/tests/utils/project-name-submodule.test.ts
+++ b/tests/utils/project-name-submodule.test.ts
@@ -1,0 +1,94 @@
+// #2842 / #2967: a session whose cwd is inside a git submodule resolved to the
+// submodule's own leaf name — a brand-new, empty project — so context injection
+// showed "This project has no memory yet" even though the superproject had a
+// full history. detectWorktree() only matched `.git/worktrees/<name>` gitdir
+// pointers; a submodule's `.git` file points at `.git/modules/<name>`, so it
+// fell through to the standalone-project branch.
+//
+// A submodule folds into its superproject the same way a worktree does.
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { realpathSync } from 'node:fs';
+
+import { getProjectContext } from '../../src/utils/project-name.js';
+
+let tempRoot: string;
+let superproject: string;
+let submodule: string;
+let submoduleSubdir: string;
+
+function git(cwd: string, ...args: string[]): void {
+  execFileSync('git', ['-C', cwd, ...args], {
+    stdio: 'ignore',
+    env: { ...process.env, GIT_ALLOW_PROTOCOL: 'file' },
+  });
+}
+
+function initRepo(repo: string, branch: string): void {
+  mkdirSync(repo, { recursive: true });
+  git(repo, 'init', '-b', branch);
+  git(repo, 'config', 'user.email', 'test@example.com');
+  git(repo, 'config', 'user.name', 'Test');
+  writeFileSync(path.join(repo, 'README.md'), 'base\n');
+  git(repo, 'add', 'README.md');
+  git(repo, 'commit', '-m', 'base');
+}
+
+beforeAll(() => {
+  tempRoot = realpathSync(mkdtempSync(path.join(tmpdir(), 'claude-mem-2842-')));
+  superproject = path.join(tempRoot, 'react');
+  const child = path.join(tempRoot, 'peerless-origin');
+
+  initRepo(superproject, 'main');
+  initRepo(child, 'main');
+
+  git(superproject, '-c', 'protocol.file.allow=always', 'submodule', 'add', child, 'peerless');
+  git(superproject, 'commit', '-m', 'add submodule');
+
+  submodule = path.join(superproject, 'peerless');
+  submoduleSubdir = path.join(submodule, 'src', 'nested');
+  mkdirSync(submoduleSubdir, { recursive: true });
+});
+
+afterAll(() => {
+  if (tempRoot) {
+    try { rmSync(tempRoot, { recursive: true, force: true }); } catch {}
+  }
+});
+
+describe('#2842 — submodule folds into the superproject', () => {
+  it('submodule root resolves to the superproject composite key', () => {
+    const ctx = getProjectContext(submodule);
+    expect(ctx.parent).toBe('react');
+    expect(ctx.primary).toBe('react/peerless');
+  });
+
+  it('reads the superproject history alongside the submodule key', () => {
+    const ctx = getProjectContext(submodule);
+    expect(ctx.allProjects).toEqual(['react', 'react/peerless']);
+  });
+
+  it('does not claim a submodule is a worktree', () => {
+    const ctx = getProjectContext(submodule);
+    expect(ctx.isWorktree).toBe(false);
+    expect(ctx.isSubmodule).toBe(true);
+  });
+
+  it('subdirectory of a submodule yields the same key as its root', () => {
+    const atRoot = getProjectContext(submodule).primary;
+    const inSubdir = getProjectContext(submoduleSubdir).primary;
+    expect(inSubdir).toBe(atRoot);
+    expect(inSubdir).not.toBe('peerless');
+    expect(inSubdir).not.toBe('nested');
+  });
+
+  it('leaves the superproject itself a plain top-level project', () => {
+    const ctx = getProjectContext(superproject);
+    expect(ctx.primary).toBe('react');
+    expect(ctx.parent).toBeNull();
+    expect(ctx.allProjects).toEqual(['react']);
+  });
+});

--- a/tests/utils/project-name-submodule.test.ts
+++ b/tests/utils/project-name-submodule.test.ts
@@ -57,7 +57,34 @@ afterAll(() => {
   if (tempRoot) {
     try { rmSync(tempRoot, { recursive: true, force: true }); } catch {}
   }
+  for (const root of nestedRoots) {
+    try { rmSync(root, { recursive: true, force: true }); } catch {}
+  }
 });
+
+function buildNestedFixture(): { outer: string } {
+  const root = realpathSync(mkdtempSync(path.join(tmpdir(), 'claude-mem-2842-nested-')));
+  const shared = path.join(root, 'shared-origin');
+  const alpha = path.join(root, 'alpha-origin');
+  const beta = path.join(root, 'beta-origin');
+  const outer = path.join(root, 'outer');
+
+  for (const repo of [shared, alpha, beta, outer]) initRepo(repo, 'main');
+
+  for (const parent of [alpha, beta]) {
+    git(parent, '-c', 'protocol.file.allow=always', 'submodule', 'add', shared, 'shared');
+    git(parent, 'commit', '-m', 'add shared');
+  }
+  git(outer, '-c', 'protocol.file.allow=always', 'submodule', 'add', alpha, 'alpha');
+  git(outer, '-c', 'protocol.file.allow=always', 'submodule', 'add', beta, 'beta');
+  git(outer, 'commit', '-m', 'add alpha+beta');
+  git(outer, '-c', 'protocol.file.allow=always', 'submodule', 'update', '--init', '--recursive');
+
+  nestedRoots.push(root);
+  return { outer };
+}
+
+const nestedRoots: string[] = [];
 
 describe('#2842 — submodule folds into the superproject', () => {
   it('submodule root resolves to the superproject composite key', () => {
@@ -83,6 +110,23 @@ describe('#2842 — submodule folds into the superproject', () => {
     expect(inSubdir).toBe(atRoot);
     expect(inSubdir).not.toBe('peerless');
     expect(inSubdir).not.toBe('nested');
+  });
+
+  // Two nested submodules can share a leaf repo name under one superproject.
+  // Keying on the superproject + leaf basename alone collapses them into one
+  // project, so each checkout's observations would overwrite and read back as
+  // the other's. The key has to carry the path that distinguishes them.
+  it('keeps same-named nested submodules under distinct project keys', () => {
+    const nested = buildNestedFixture();
+
+    const alpha = getProjectContext(path.join(nested.outer, 'alpha', 'shared'));
+    const beta = getProjectContext(path.join(nested.outer, 'beta', 'shared'));
+
+    expect(alpha.primary).toBe('outer/alpha/shared');
+    expect(beta.primary).toBe('outer/beta/shared');
+    expect(alpha.primary).not.toBe(beta.primary);
+    expect(alpha.parent).toBe('outer');
+    expect(beta.parent).toBe('outer');
   });
 
   it('leaves the superproject itself a plain top-level project', () => {


### PR DESCRIPTION
## Summary

Two failures under tracking issue #2967, fixed together because they interact (see Assumptions).

**#2864 — worktree observations orphaned.** `adoptMergedWorktreesForAllKnownRepos` discovered repos by reading distinct `cwd` values from `pending_messages`. That table stopped receiving writes in 61fe70a2 ("remove retry/observation queue, replace with SessionMessageBuffer", v13.10.0) — the only remaining `INSERT INTO pending_messages` statements are in tests. The startup sweep therefore found zero repos on every boot, and adoption only ever ran when a user invoked `npx claude-mem adopt` by hand. Worktree rows kept their `parent/leaf` key with `merged_into_project = NULL`; once the worktree directory was deleted, the parent↔worktree association could no longer be recomputed from disk and no read path could reach them.

`cwd` was not lost, only unrecorded: it still arrives on every ingest (`SessionRoutes.ts` → `ingestObservation`), and `cwd TEXT` existed in exactly one schema — `pending_messages`.

**#2842 — submodule sessions see no memory.** `detectWorktree` only matched `.git/worktrees/<name>` gitdir pointers. A submodule's `.git` file points at `.git/modules/<name>`, so it fell through to the standalone-project branch and resolved to the submodule's own leaf name — a new, empty project — producing the "no memory yet" banner despite a full superproject history.

## Changes

| Area | Change |
|---|---|
| `SessionStore.ts` | `ensureSessionCwdColumn()` (PRAGMA-guarded) + `setSessionCwd()`, first-write-wins |
| `worker/http/shared.ts` | Stamp cwd at ingest |
| `WorktreeAdoption.ts` | Sweep reads `sdk_sessions.cwd`; orphan adoption; live-submodule exclusion; `resolveMainRepoPath` walks `.git/modules` |
| `worktree.ts` / `project-name.ts` | Submodule detection → superproject composite key; `isSubmodule` added |
| `worker-service.ts` | CLI reports orphans |

Notable details for review:

- **`sdk_sessions.cwd` is local-only.** Sync entities are `observation | summary | prompt` (`CanonicalContent.ts:9`); `sdk_sessions` is joined for reads but never pushed, so no `CanonicalContent`/`SyncApply`/`CloudSync` changes are needed. `SessionStore.ts` already documents this ("sdk_sessions rows do not sync").
- **First-write-wins on cwd** — a session's cwd drifts when the agent `cd`s into a subdirectory; the launch directory is the one that identifies the repo.
- **Discovery UNIONs `pending_messages`** so installs upgrading with pre-13.10 rows still on disk keep their known-repo history until sessions repopulate `sdk_sessions.cwd`.
- **Orphan matching uses a half-open range, not `LIKE`.** `_` is a single-character LIKE wildcard and common in repo names, so `my_app/%` would also match `myXapp/...`. Range comparison removes the hazard at the source. It is *not* a perf change — `EXPLAIN QUERY PLAN` shows both forms drive off `idx_observations_merged_into` for the `IS NULL` term.
- **Two early returns removed** (`childWorktrees.length === 0`, `targets.length === 0`) — orphans exist precisely when there are no live worktrees left.
- **`--branch` skips the orphan sweep**, staying a precise escape hatch for squash-merges.

## Assumptions / decisions

1. **Deleted worktrees are adopted regardless of merge status.** Existing adoption required the branch to be merged into HEAD. A worktree can be deleted with unmerged or abandoned work, and for those rows the alternative to adopting is not "kept separate" — it is unreachable forever. Widening the rule is deliberate; it is surfaced through `AdoptionResult.orphanedWorktrees`, the applied-adoption log line, and the CLI so a run never widens silently. Live worktrees, merged or in-flight, are untouched.

2. **#2882 is excluded.** The third item under #2967 asks for project names derived from the subdirectory again, reversing the git-root behavior of #2663 (closed COMPLETED) / #2665. That is a product decision about what a "project" means, not a technical one, and it touches `getProjectName` — far hotter than anything here. **#2967 will not auto-close on merge**; it needs the #2882 decision.

3. **The two fixes had to land together.** Submodules now share the `parent/leaf` composite key but are *not* reported by `git worktree list`, so the orphan sweep initially classified a live, actively-used submodule as a removed worktree and folded it into the superproject. Caught by test, fixed by enumerating `git submodule status --recursive` into the live set (existence-filtered, so a *deleted* submodule checkout is still adopted). Shipping either issue alone would not have produced this bug — which is the argument for one PR.

4. **Pre-existing submodule rows are not repaired.** Observations captured in a submodule *before* this change are keyed with the bare leaf (e.g. `peerless`); after it, sessions key `react/peerless`, so the old flat key goes dark. Historical rows have no cwd to resolve against (the column is new), so precise repair is impossible. Adding the bare leaf to `allProjects` would recover them but risks silently merging an unrelated top-level project of the same name. New submodule data is correctly keyed from the first session and needs no reconciliation. Structurally identical to the #2882 legacy-key gap; one explicit user-invoked remap could serve both.

## Verification

- `bun test tests/` — **2574 pass, 18 skip, 0 fail** (18 new tests across 5 files)
- `npm run typecheck` — clean
- `npm run lint:hook-io`, `npm run lint:spawn-env` — clean
- `npm run build` — clean (rebuilt `plugin/` artifacts reverted to keep the diff source-only)

Every fix was written test-first and the failing state observed before implementing; the orphan-reporting field and the `isWorktree`-for-submodules correction were each reverted to confirm RED before being restored.

Known-failing, **not** caused by this branch (both verified by stashing and re-running on clean `main`):

- `workers/sync-hub` — 6 failures, `Cannot find package 'cloudflare:test'` (needs vitest-pool-workers, not bun). Identical on `main`.
- `npm run strip-comments:check` — exits 1 with 384 changed files; **381 on clean `main`**. The 3 added are source files where this branch added issue-referencing comments, matching the surrounding house style.

## Test coverage

| File | Covers |
|---|---|
| `worktree-adoption-sweep.test.ts` | Discovery from `sdk_sessions.cwd` with `pending_messages` empty |
| `ingest-session-cwd.test.ts` | cwd stamped at ingest; launch cwd survives a subdirectory observation |
| `worktree-adoption-orphans.test.ts` | Removed worktree adopted; unmerged orphan adopted; live unmerged worktree untouched; `_`-wildcard sibling not swept; orphans reported |
| `worktree-adoption-submodule.test.ts` | Live submodule not adopted (repo + sweep); deleted submodule adopted; superproject resolved from a submodule-only cwd |
| `project-name-submodule.test.ts` | Composite key, `allProjects`, subdirectory parity, superproject unaffected, `isWorktree` not claimed |

https://claude.ai/code/session_01LshL8n6PcqmStKHBpamv1j
