### PR TITLE
fix(windows): hide worker daemon spawn instead of Node detached (#3521)

### DIFF
--- a/src/services/infrastructure/ProcessManager.ts
+++ b/src/services/infrastructure/ProcessManager.ts
@@ -369,6 +369,106 @@ export function buildWindowsDaemonStartCommand(runtimePath: string, scriptPath: 
   return `Start-Process -FilePath '${psSingleQuote(runtimePath)}' -ArgumentList @('"${psSingleQuote(scriptPath)}"','--daemon') -WindowStyle Hidden`;
 }
 
+/** Absolute powershell.exe when SystemRoot is set; otherwise PATH lookup. */
+export function resolveWindowsPowerShellPath(
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  const systemRoot = env.SystemRoot || env.SYSTEMROOT;
+  if (systemRoot) {
+    return `${systemRoot}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
+  }
+  return 'powershell.exe';
+}
+
+/**
+ * Argv for launching a hidden worker daemon via Start-Process.
+ * -WindowStyle Hidden on powershell.exe itself plus Start-Process
+ * -WindowStyle Hidden inside the encoded script (#3521). Never use
+ * Node `detached: true` for this on Windows — that allocates a console.
+ */
+export function buildWindowsHiddenDaemonPowerShellArgs(
+  runtimePath: string,
+  scriptPath: string
+): string[] {
+  const encodedCommand = Buffer.from(
+    buildWindowsDaemonStartCommand(runtimePath, scriptPath),
+    'utf16le'
+  ).toString('base64');
+  return ['-NoProfile', '-WindowStyle', 'Hidden', '-EncodedCommand', encodedCommand];
+}
+
+/**
+ * Spawn the worker as a background daemon without a visible console.
+ *
+ * Windows: Start-Process -WindowStyle Hidden via powershell argv (sync).
+ * Returns 0 as a success sentinel (Start-Process does not yield the child pid).
+ *
+ * Unix: setsid/detached spawnHidden; returns the child pid.
+ *
+ * Used by spawnDaemon (CLI/MCP) and hook lazy-spawn (ensureWorkerRunning).
+ */
+export function spawnDetachedWorkerDaemon(
+  runtimePath: string,
+  scriptPath: string,
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform = process.platform
+): number | undefined {
+  if (platform === 'win32') {
+    const powershell = resolveWindowsPowerShellPath(env);
+    const args = buildWindowsHiddenDaemonPowerShellArgs(runtimePath, scriptPath);
+    try {
+      // argv spawnSync — never `execSync('powershell ...')` shell string.
+      // A shell-string launch can allocate a console before windowsHide
+      // applies; argv + -WindowStyle Hidden keeps the flash off (#3521).
+      const result = spawnSync(powershell, args, {
+        stdio: 'ignore',
+        windowsHide: true,
+        env,
+      });
+      if (result.error) {
+        throw result.error;
+      }
+      if (result.status !== 0) {
+        throw new Error(
+          `powershell Start-Process exited ${result.status ?? 'null'}` +
+            (result.signal ? ` signal=${result.signal}` : '')
+        );
+      }
+      return 0;
+    } catch (error: unknown) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      logger.error(
+        'SYSTEM',
+        'Failed to spawn worker daemon on Windows',
+        { runtimePath, powershell },
+        err
+      );
+      return undefined;
+    }
+  }
+
+  const setsidPath = '/usr/bin/setsid';
+  const useSetsid = existsSync(setsidPath);
+
+  const execPath = useSetsid ? setsidPath : runtimePath;
+  const args = useSetsid
+    ? [runtimePath, scriptPath, '--daemon']
+    : [scriptPath, '--daemon'];
+
+  const child = spawnHidden(execPath, args, {
+    detached: true,
+    stdio: 'ignore',
+    env,
+  });
+
+  if (child.pid === undefined) {
+    return undefined;
+  }
+
+  child.unref();
+  return child.pid;
+}
+
 export function spawnDaemon(
   scriptPath: string,
   port: number,
@@ -391,49 +491,7 @@ export function spawnDaemon(
     return undefined;
   }
 
-  if (process.platform === 'win32') {
-    const psScript = buildWindowsDaemonStartCommand(runtimePath, scriptPath);
-    const encodedCommand = Buffer.from(psScript, 'utf16le').toString('base64');
-
-    try {
-      execSync(`powershell -NoProfile -EncodedCommand ${encodedCommand}`, {
-        stdio: 'ignore',
-        windowsHide: true,
-        env
-      });
-      return 0;
-    } catch (error: unknown) {
-      const err = error instanceof Error ? error : new Error(String(error));
-      logger.error(
-        'SYSTEM',
-        'Failed to spawn worker daemon on Windows',
-        { runtimePath },
-        err
-      );
-      return undefined;
-    }
-  }
-
-  const setsidPath = '/usr/bin/setsid';
-  const useSetsid = existsSync(setsidPath);
-
-  const execPath = useSetsid ? setsidPath : runtimePath;
-  const args = useSetsid
-    ? [runtimePath, scriptPath, '--daemon']
-    : [scriptPath, '--daemon'];
-
-  const child = spawnHidden(execPath, args, {
-    detached: true,
-    stdio: 'ignore',
-    env
-  });
-
-  if (child.pid === undefined) {
-    return undefined;
-  }
-
-  child.unref();
-  return child.pid;
+  return spawnDetachedWorkerDaemon(runtimePath, scriptPath, env);
 }
 
 export function isPidFileRecent(thresholdMs: number = 15000): boolean {

--- a/src/services/infrastructure/ProcessManager.ts
+++ b/src/services/infrastructure/ProcessManager.ts
@@ -10,6 +10,10 @@ import { removeOwnedPidFile } from '../../supervisor/shutdown.js';
 import { getSupervisor, validateWorkerPidFile, type ValidateWorkerPidStatus } from '../../supervisor/index.js';
 import { emitRemapProject, hasSyncLane } from '../sync/remap-outbox.js';
 import { paths } from '../../shared/paths.js';
+import { HOOK_TIMEOUTS, getTimeout } from '../../shared/hook-constants.js';
+
+/** Bound Windows PowerShell Start-Process so a stalled shell cannot hold the spawn lock forever (#3529 Greptile P1). */
+export const WINDOWS_HIDDEN_DAEMON_SPAWN_TIMEOUT_MS = getTimeout(HOOK_TIMEOUTS.POWERSHELL_COMMAND);
 
 const DATA_DIR = paths.dataDir();
 const PID_FILE = paths.workerPid();
@@ -424,9 +428,17 @@ export function spawnDetachedWorkerDaemon(
         stdio: 'ignore',
         windowsHide: true,
         env,
+        timeout: WINDOWS_HIDDEN_DAEMON_SPAWN_TIMEOUT_MS,
+        killSignal: 'SIGTERM',
       });
       if (result.error) {
         throw result.error;
+      }
+      if (result.signal) {
+        throw new Error(
+          `powershell Start-Process killed by signal=${result.signal}` +
+            ` after ${WINDOWS_HIDDEN_DAEMON_SPAWN_TIMEOUT_MS}ms`
+        );
       }
       if (result.status !== 0) {
         throw new Error(

--- a/src/shared/spawn.ts
+++ b/src/shared/spawn.ts
@@ -15,7 +15,11 @@ export function spawnHidden(
   args?: readonly string[],
   options?: SpawnOptions
 ): ChildProcess {
-  return spawn(command, args ?? [], { windowsHide: true, ...options });
+  // windowsHide MUST win over caller options. Node's `detached: true` on
+  // Windows still allocates a console for the child (#3521); callers that
+  // need a background daemon on win32 must use Start-Process -WindowStyle
+  // Hidden (see ProcessManager.spawnDetachedWorkerDaemon), not detached.
+  return spawn(command, args ?? [], { ...options, windowsHide: true });
 }
 
 export const WINDOWS_CMD_EXTENSIONS = new Set(['.cmd', '.bat']);
@@ -65,8 +69,9 @@ export function buildSpawnSyncInvocation(
   platform: NodeJS.Platform = process.platform,
 ): SpawnSyncInvocation {
   const invocationOptions: SpawnSyncOptionsWithStringEncoding = {
-    ...(platform === 'win32' ? { windowsHide: true } : {}),
     ...options,
+    // Force hide on Windows last so callers cannot override it off (#3521).
+    ...(platform === 'win32' ? { windowsHide: true } : {}),
   };
 
   if (platform === 'win32' && WINDOWS_CMD_EXTENSIONS.has(extname(command).toLowerCase())) {

--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -1,6 +1,5 @@
 import path from "path";
 import { readFileSync, existsSync, writeFileSync, renameSync, mkdirSync, readdirSync, statSync } from "fs";
-import { spawnHidden } from "./spawn.js";
 import { logger } from "../utils/logger.js";
 import { HOOK_TIMEOUTS, getTimeout } from "./hook-constants.js";
 import { SettingsDefaultsManager, type SettingsDefaults } from "./SettingsDefaultsManager.js";
@@ -13,8 +12,12 @@ import { checkVersionMatch } from "../services/infrastructure/index.js";
 // Imported from ProcessManager.js directly (not the infrastructure barrel):
 // tests mock the barrel module wholesale, and the resolver must stay real.
 // ProcessManager imports nothing from worker-utils, so no cycle.
-import { resolveWorkerRuntimePath } from "../services/infrastructure/ProcessManager.js";
+import {
+  resolveWorkerRuntimePath,
+  spawnDetachedWorkerDaemon,
+} from "../services/infrastructure/ProcessManager.js";
 import { acquireSpawnLock, releaseSpawnLock } from "./worker-spawn-gate.js";
+import { sanitizeEnv } from "../supervisor/env-sanitizer.js";
 
 function readTimeoutEnv(
   envName: string,
@@ -563,11 +566,20 @@ export async function ensureWorkerRunning(): Promise<boolean> {
       logger.info('SYSTEM', 'Worker not running — lazy-spawning', { runtimePath, scriptPath });
 
       try {
-        const proc = spawnHidden(runtimePath, [scriptPath, '--daemon'], {
-          detached: true,
-          stdio: ['ignore', 'ignore', 'ignore'],
-        });
-        proc.unref();
+        // Windows: Start-Process -WindowStyle Hidden (never Node detached —
+        // detached allocates its own console on win32, #3521). Unix: setsid /
+        // detached via spawnDetachedWorkerDaemon.
+        const spawned = spawnDetachedWorkerDaemon(
+          runtimePath,
+          scriptPath,
+          sanitizeEnv({
+            ...process.env,
+            CLAUDE_MEM_WORKER_PORT: String(getWorkerPort()),
+          }),
+        );
+        if (spawned === undefined) {
+          return false;
+        }
       } catch (error: unknown) {
         if (error instanceof Error) {
           logger.error('SYSTEM', 'Lazy-spawn of worker failed', { runtimePath, scriptPath }, error);

--- a/tests/shared/windows-hidden-daemon-spawn.test.ts
+++ b/tests/shared/windows-hidden-daemon-spawn.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  buildWindowsDaemonStartCommand,
+  buildWindowsHiddenDaemonPowerShellArgs,
+  resolveWindowsPowerShellPath,
+} from '../../src/services/infrastructure/ProcessManager.js';
+import { buildSpawnSyncInvocation } from '../../src/shared/spawn.js';
+
+/**
+ * #3521 — Windows console flash from detached / shell-string daemon spawns.
+ * Contract: Windows daemon launch must go through Start-Process -WindowStyle
+ * Hidden via powershell argv (never Node detached:true, never
+ * execSync('powershell ...') shell string).
+ */
+describe('Windows #3521 — hidden daemon spawn contract', () => {
+  it('Start-Process script keeps -WindowStyle Hidden', () => {
+    const command = buildWindowsDaemonStartCommand(
+      String.raw`C:\bun\bun.exe`,
+      String.raw`C:\plugin\worker-service.cjs`,
+    );
+    expect(command).toContain('-WindowStyle Hidden');
+    expect(command).toContain('Start-Process');
+  });
+
+  it('powershell argv includes -WindowStyle Hidden and -EncodedCommand (no shell string)', () => {
+    const args = buildWindowsHiddenDaemonPowerShellArgs(
+      String.raw`C:\Users\Test\.bun\bin\bun.exe`,
+      String.raw`C:\Users\Test\plugin\scripts\worker-service.cjs`,
+    );
+
+    expect(args[0]).toBe('-NoProfile');
+    expect(args[1]).toBe('-WindowStyle');
+    expect(args[2]).toBe('Hidden');
+    expect(args[3]).toBe('-EncodedCommand');
+    expect(args[4]).toMatch(/^[A-Za-z0-9+/=]+$/);
+
+    const decoded = Buffer.from(args[4], 'base64').toString('utf16le');
+    expect(decoded).toBe(
+      buildWindowsDaemonStartCommand(
+        String.raw`C:\Users\Test\.bun\bin\bun.exe`,
+        String.raw`C:\Users\Test\plugin\scripts\worker-service.cjs`,
+      ),
+    );
+  });
+
+  it('resolves System32 powershell when SystemRoot is set', () => {
+    expect(
+      resolveWindowsPowerShellPath({ SystemRoot: 'C:\\Windows' }),
+    ).toBe(String.raw`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`);
+  });
+
+  it('buildSpawnSyncInvocation forces windowsHide even when options try to disable it', () => {
+    const invocation = buildSpawnSyncInvocation(
+      String.raw`C:\Tools\bin\tool.exe`,
+      ['run'],
+      { encoding: 'utf-8', stdio: 'ignore', windowsHide: false },
+      'win32',
+    );
+    expect(invocation.options.windowsHide).toBe(true);
+  });
+});

--- a/tests/shared/windows-hidden-daemon-spawn.test.ts
+++ b/tests/shared/windows-hidden-daemon-spawn.test.ts
@@ -3,8 +3,11 @@ import {
   buildWindowsDaemonStartCommand,
   buildWindowsHiddenDaemonPowerShellArgs,
   resolveWindowsPowerShellPath,
+  WINDOWS_HIDDEN_DAEMON_SPAWN_TIMEOUT_MS,
 } from '../../src/services/infrastructure/ProcessManager.js';
 import { buildSpawnSyncInvocation } from '../../src/shared/spawn.js';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 /**
  * #3521 — Windows console flash from detached / shell-string daemon spawns.
@@ -57,5 +60,14 @@ describe('Windows #3521 — hidden daemon spawn contract', () => {
       'win32',
     );
     expect(invocation.options.windowsHide).toBe(true);
+  });
+
+  it('Windows daemon spawnSync uses a bounded timeout (Greptile P1)', () => {
+    expect(WINDOWS_HIDDEN_DAEMON_SPAWN_TIMEOUT_MS).toBeGreaterThan(0);
+    const source = readFileSync(
+      join(import.meta.dir, '../../src/services/infrastructure/ProcessManager.ts'),
+      'utf8',
+    );
+    expect(source).toContain('timeout: WINDOWS_HIDDEN_DAEMON_SPAWN_TIMEOUT_MS');
   });
 });

--- a/tests/shared/worker-utils-version-recycle.test.ts
+++ b/tests/shared/worker-utils-version-recycle.test.ts
@@ -4,11 +4,11 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import * as realInfrastructure from '../../src/services/infrastructure/index.js';
 import * as realSupervisor from '../../src/supervisor/index.js';
-import * as realSpawn from '../../src/shared/spawn.js';
+import * as realProcessManager from '../../src/services/infrastructure/ProcessManager.js';
 
 const realInfrastructureSnapshot = { ...realInfrastructure };
 const realSupervisorSnapshot = { ...realSupervisor };
-const realSpawnSnapshot = { ...realSpawn };
+const realProcessManagerSnapshot = { ...realProcessManager };
 
 // On version mismatch the hook must NOT delegate the recycle to the running
 // worker (the old design POSTed /api/admin/restart and the dying worker
@@ -35,11 +35,11 @@ let versionMatchResult: { matches: boolean; pluginVersion: string; workerVersion
 let ownedPidInfo: { pid: number; port: number; startedAt: string } | null = null;
 
 // Simulated process states driving the fetch mock: the stale worker serves
-// the port until it is killed; the successor serves it after spawnHidden.
+// the port until it is killed; the successor serves it after spawn.
 let staleWorkerAlive = true;
 let successorUp = false;
 
-// Records every spawn attempt (the lazy-spawn seam, spawnHidden in spawn.ts).
+// Records every spawn attempt (lazy-spawn seam: spawnDetachedWorkerDaemon).
 const spawnCalls: Array<{ command: string; args: string[] }> = [];
 
 mock.module('../../src/services/infrastructure/index.js', () => ({
@@ -51,11 +51,12 @@ mock.module('../../src/supervisor/index.js', () => ({
   readOwnedWorkerPidInfo: () => ownedPidInfo,
 }));
 
-mock.module('../../src/shared/spawn.js', () => ({
-  spawnHidden: (command: string, args: string[]) => {
-    spawnCalls.push({ command, args });
+mock.module('../../src/services/infrastructure/ProcessManager.js', () => ({
+  ...realProcessManagerSnapshot,
+  spawnDetachedWorkerDaemon: (runtimePath: string, scriptPath: string) => {
+    spawnCalls.push({ command: runtimePath, args: [scriptPath, '--daemon'] });
     successorUp = true;
-    return { pid: 5151, unref: () => {} };
+    return 0;
   },
 }));
 
@@ -136,7 +137,7 @@ describe('ensureWorkerRunning — stale-worker recycle on version mismatch', () 
   afterAll(() => {
     mock.module('../../src/services/infrastructure/index.js', () => realInfrastructureSnapshot);
     mock.module('../../src/supervisor/index.js', () => realSupervisorSnapshot);
-    mock.module('../../src/shared/spawn.js', () => realSpawnSnapshot);
+    mock.module('../../src/services/infrastructure/ProcessManager.js', () => realProcessManagerSnapshot);
   });
 
   it('SIGKILLs the stale worker and lazy-spawns the resolved script — never POSTs /api/admin/restart', async () => {


### PR DESCRIPTION
## Summary

- On Windows, Node `detached: true` gives the child its own console even when `windowsHide` is set. Hook lazy-spawn used that path, which matches the visible-window report in #3521 (about one flash when the worker starts).
- Route both CLI/MCP `spawnDaemon` and hook lazy-spawn through `spawnDetachedWorkerDaemon`: Windows uses `Start-Process -WindowStyle Hidden` via powershell argv (`-NoProfile -WindowStyle Hidden -EncodedCommand`), never a shell-string `execSync('powershell ...')` and never Node detached.
- Force `windowsHide: true` last in `spawnHidden` / `buildSpawnSyncInvocation` so callers cannot override it off.

## Level of fix

Class: Windows background daemon spawn that can allocate a console.
Fixed at the shared daemon spawn helper so hook lazy-spawn and CLI restart/spawn share one Windows path. Rejected leaving hook lazy-spawn on `detached: true` with only `windowsHide` (Node still opens a console).

## Evidence

```text
bun test tests/shared/windows-hidden-daemon-spawn.test.ts tests/shared/worker-utils-version-recycle.test.ts
8 pass, 0 fail
```

Contract tests assert Start-Process keeps `-WindowStyle Hidden`, powershell argv includes `-WindowStyle Hidden` + `-EncodedCommand`, and sync spawn helpers force `windowsHide`.

## What was not tested

Live Claude Code click-through counting console flashes on this box. The reporter already ruled out `$SHELL -lc` and `bun-runner` `shell: true`; residual per-tool-call flashes (if any remain after the daemon path is hidden) would be a separate spawn site and should be filed against that path.

## AI assistance

Implemented with Cursor (Grok). Human review and Windows niche framing by Stan Shih (@stantheman0128).

Fixes #3521