### PR TITLE
fix(sqlite): populate session_summaries files_read and files_edited (#3517)

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -39,6 +39,31 @@ interface RecentSessionStatusRow {
   has_summary: boolean;
 }
 
+/** Roll observation file lists into session_summaries.files_read / files_edited. */
+export function rollupObservationFileLists(
+  observations: Array<{ files_read?: string[] | null; files_modified?: string[] | null }>
+): { files_read: string[]; files_edited: string[] } {
+  const filesRead: string[] = [];
+  const filesEdited: string[] = [];
+  const seenRead = new Set<string>();
+  const seenEdited = new Set<string>();
+
+  for (const observation of observations) {
+    for (const filePath of observation.files_read ?? []) {
+      if (!filePath || seenRead.has(filePath)) continue;
+      seenRead.add(filePath);
+      filesRead.push(filePath);
+    }
+    for (const filePath of observation.files_modified ?? []) {
+      if (!filePath || seenEdited.has(filePath)) continue;
+      seenEdited.add(filePath);
+      filesEdited.push(filePath);
+    }
+  }
+
+  return { files_read: filesRead, files_edited: filesEdited };
+}
+
 interface SessionObservationRow {
   title: string;
   subtitle: string;
@@ -2550,6 +2575,8 @@ export class SessionStore {
       completed: string;
       next_steps: string;
       notes: string | null;
+      files_read?: string[];
+      files_edited?: string[];
     },
     promptNumber?: number,
     discoveryTokens: number = 0,
@@ -2561,8 +2588,8 @@ export class SessionStore {
     const stmt = this.db.prepare(`
       INSERT INTO session_summaries
       (memory_session_id, project, request, investigated, learned, completed,
-       next_steps, notes, prompt_number, discovery_tokens, created_at, created_at_epoch)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       next_steps, files_read, files_edited, notes, prompt_number, discovery_tokens, created_at, created_at_epoch)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     const result = stmt.run(
@@ -2573,6 +2600,8 @@ export class SessionStore {
       summary.learned,
       summary.completed,
       summary.next_steps,
+      JSON.stringify(summary.files_read ?? []),
+      JSON.stringify(summary.files_edited ?? []),
       summary.notes,
       promptNumber || null,
       discoveryTokens,
@@ -2609,6 +2638,8 @@ export class SessionStore {
       completed: string;
       next_steps: string;
       notes: string | null;
+      files_read?: string[];
+      files_edited?: string[];
     } | null,
     promptNumber?: number,
     discoveryTokens: number = 0,
@@ -2674,11 +2705,14 @@ export class SessionStore {
 
       let summaryId: number | null = null;
       if (summary) {
+        const rolledUp = rollupObservationFileLists(observations);
+        const filesRead = summary.files_read ?? rolledUp.files_read;
+        const filesEdited = summary.files_edited ?? rolledUp.files_edited;
         const summaryStmt = this.db.prepare(`
           INSERT INTO session_summaries
           (memory_session_id, project, request, investigated, learned, completed,
-           next_steps, notes, prompt_number, discovery_tokens, created_at, created_at_epoch)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           next_steps, files_read, files_edited, notes, prompt_number, discovery_tokens, created_at, created_at_epoch)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `);
 
         const result = summaryStmt.run(
@@ -2689,6 +2723,8 @@ export class SessionStore {
           summary.learned,
           summary.completed,
           summary.next_steps,
+          JSON.stringify(filesRead),
+          JSON.stringify(filesEdited),
           summary.notes,
           promptNumber || null,
           discoveryTokens,

--- a/src/services/worker/agents/ResponseProcessor.ts
+++ b/src/services/worker/agents/ResponseProcessor.ts
@@ -385,9 +385,17 @@ export async function processAgentResponse(
   const claimedMessages = sessionManager.getClaimedMessages(session.sessionDbId);
   const fileEvidence = extractObservationFileEvidence(claimedMessages);
   const sanitizedObservations = sanitizeObservationFiles(observations, fileEvidence);
+  // Include claimed-message file evidence even for summary-only responses
+  // (no parsed observations), otherwise files_read/files_edited persist as [].
   const summaryForStore = attachObservationFilesToSummary(
     normalizeSummaryForStorage(summary),
-    sanitizedObservations
+    [
+      {
+        files_read: fileEvidence.files_read,
+        files_modified: fileEvidence.files_modified,
+      },
+      ...sanitizedObservations,
+    ]
   );
 
   const sessionStore = dbManager.getSessionStore();

--- a/src/services/worker/agents/ResponseProcessor.ts
+++ b/src/services/worker/agents/ResponseProcessor.ts
@@ -382,10 +382,13 @@ export async function processAgentResponse(
   }
 
   const { observations, summary } = parsed;
-  const summaryForStore = normalizeSummaryForStorage(summary);
   const claimedMessages = sessionManager.getClaimedMessages(session.sessionDbId);
   const fileEvidence = extractObservationFileEvidence(claimedMessages);
   const sanitizedObservations = sanitizeObservationFiles(observations, fileEvidence);
+  const summaryForStore = attachObservationFilesToSummary(
+    normalizeSummaryForStorage(summary),
+    sanitizedObservations
+  );
 
   const sessionStore = dbManager.getSessionStore();
   sessionStore.ensureMemorySessionIdRegistered(session.sessionDbId, session.memorySessionId, getWorkerPort());
@@ -532,6 +535,8 @@ function normalizeSummaryForStorage(summary: ParsedSummary | null): {
   completed: string;
   next_steps: string;
   notes: string | null;
+  files_read: string[];
+  files_edited: string[];
 } | null {
   if (!summary) return null;
   if (summary.skipped) return null;
@@ -542,7 +547,47 @@ function normalizeSummaryForStorage(summary: ParsedSummary | null): {
     learned: summary.learned || '',
     completed: summary.completed || '',
     next_steps: summary.next_steps || '',
-    notes: summary.notes
+    notes: summary.notes,
+    files_read: [],
+    files_edited: [],
+  };
+}
+
+export function attachObservationFilesToSummary(
+  summary: {
+    request: string;
+    investigated: string;
+    learned: string;
+    completed: string;
+    next_steps: string;
+    notes: string | null;
+    files_read?: string[];
+    files_edited?: string[];
+  } | null,
+  observations: Array<{ files_read?: string[] | null; files_modified?: string[] | null }>
+): {
+  request: string;
+  investigated: string;
+  learned: string;
+  completed: string;
+  next_steps: string;
+  notes: string | null;
+  files_read: string[];
+  files_edited: string[];
+} | null {
+  if (!summary) return null;
+  const filesRead = dedupeStable([
+    ...(summary.files_read ?? []),
+    ...observations.flatMap((obs) => obs.files_read ?? []),
+  ]);
+  const filesEdited = dedupeStable([
+    ...(summary.files_edited ?? []),
+    ...observations.flatMap((obs) => obs.files_modified ?? []),
+  ]);
+  return {
+    ...summary,
+    files_read: filesRead,
+    files_edited: filesEdited,
   };
 }
 

--- a/tests/sqlite/session-summary-files.test.ts
+++ b/tests/sqlite/session-summary-files.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { SessionStore, rollupObservationFileLists } from '../../src/services/sqlite/SessionStore.js';
+
+describe('session_summaries files_read / files_edited (#3517)', () => {
+  let store: SessionStore;
+
+  beforeEach(() => {
+    store = new SessionStore(':memory:');
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it('rollupObservationFileLists dedupes read and modified paths', () => {
+    expect(
+      rollupObservationFileLists([
+        { files_read: ['a.ts', 'b.ts'], files_modified: ['b.ts'] },
+        { files_read: ['a.ts', 'c.ts'], files_modified: ['d.ts'] },
+      ])
+    ).toEqual({
+      files_read: ['a.ts', 'b.ts', 'c.ts'],
+      files_edited: ['b.ts', 'd.ts'],
+    });
+  });
+
+  it('storeObservations writes rolled-up files_read and files_edited', () => {
+    const sessionDbId = store.createSDKSession('content-3517', 'proj-3517', 'prompt');
+    store.ensureMemorySessionIdRegistered(sessionDbId, 'mem-3517');
+
+    const result = store.storeObservations(
+      'mem-3517',
+      'proj-3517',
+      [
+        {
+          type: 'discovery',
+          title: 'Read auth',
+          subtitle: null,
+          facts: [],
+          narrative: 'read auth',
+          concepts: [],
+          files_read: ['src/auth.ts'],
+          files_modified: [],
+        },
+        {
+          type: 'change',
+          title: 'Edit auth',
+          subtitle: null,
+          facts: [],
+          narrative: 'edit auth',
+          concepts: [],
+          files_read: ['src/auth.ts'],
+          files_modified: ['src/auth.ts', 'src/login.ts'],
+        },
+      ],
+      {
+        request: 'fix login',
+        investigated: 'auth flow',
+        learned: 'token refresh',
+        completed: 'patched',
+        next_steps: 'ship',
+        notes: null,
+      },
+      1,
+      10
+    );
+
+    expect(result.summaryId).not.toBeNull();
+    const row = store.db
+      .prepare('SELECT files_read, files_edited FROM session_summaries WHERE id = ?')
+      .get(result.summaryId!) as { files_read: string; files_edited: string };
+
+    expect(JSON.parse(row.files_read)).toEqual(['src/auth.ts']);
+    expect(JSON.parse(row.files_edited)).toEqual(['src/auth.ts', 'src/login.ts']);
+  });
+
+  it('storeSummary writes empty JSON arrays instead of NULL', () => {
+    const sessionDbId = store.createSDKSession('content-3517b', 'proj-3517b', 'prompt');
+    store.ensureMemorySessionIdRegistered(sessionDbId, 'mem-3517b');
+
+    const { id } = store.storeSummary('mem-3517b', 'proj-3517b', {
+      request: 'r',
+      investigated: 'i',
+      learned: 'l',
+      completed: 'c',
+      next_steps: 'n',
+      notes: null,
+    });
+
+    const row = store.db
+      .prepare('SELECT files_read, files_edited FROM session_summaries WHERE id = ?')
+      .get(id) as { files_read: string; files_edited: string };
+
+    expect(row.files_read).toBe('[]');
+    expect(row.files_edited).toBe('[]');
+  });
+});

--- a/tests/sqlite/session-summary-files.test.ts
+++ b/tests/sqlite/session-summary-files.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { SessionStore, rollupObservationFileLists } from '../../src/services/sqlite/SessionStore.js';
+import { attachObservationFilesToSummary } from '../../src/services/worker/agents/ResponseProcessor.js';
 
 describe('session_summaries files_read / files_edited (#3517)', () => {
   let store: SessionStore;
@@ -22,6 +23,30 @@ describe('session_summaries files_read / files_edited (#3517)', () => {
       files_read: ['a.ts', 'b.ts', 'c.ts'],
       files_edited: ['b.ts', 'd.ts'],
     });
+  });
+
+  it('attachObservationFilesToSummary keeps claimed file evidence for summary-only responses', () => {
+    const summary = attachObservationFilesToSummary(
+      {
+        request: 'r',
+        investigated: 'i',
+        learned: 'l',
+        completed: 'c',
+        next_steps: 'n',
+        notes: null,
+        files_read: [],
+        files_edited: [],
+      },
+      [
+        {
+          files_read: ['src/verified.ts'],
+          files_modified: ['src/verified-edit.ts'],
+        },
+      ]
+    );
+
+    expect(summary?.files_read).toEqual(['src/verified.ts']);
+    expect(summary?.files_edited).toEqual(['src/verified-edit.ts']);
   });
 
   it('storeObservations writes rolled-up files_read and files_edited', () => {


### PR DESCRIPTION
## Summary

`session_summaries.files_read` / `files_edited` existed in the schema but the INSERT paths never wrote them, so every row stayed NULL (confident false negative for consumers).

## Fix

- `storeObservations` / `storeSummary` now write JSON arrays for both columns.
- When a summary is stored with observations, file lists are rolled up from `files_read` / `files_modified` (deduped).
- ResponseProcessor attaches the same rollup before store.

## Level of fix

Fixed at the SQLite write path (and the ResponseProcessor call site that builds the summary). Chroma summary docs stay text-only; search already reads the SQLite columns when present.

## Verification

```
bun test tests/sqlite/session-summary-files.test.ts
# 3 pass, 0 fail
```

## What was not tested

Live end-to-end Claude Code session writing a summary into a real user DB on this machine.

## AI assistance

Drafted with AI assistance; human (Stan Shih / stantheman0128) reviewed the diagnosis, scope, and Evidence.

Fixes #3517

Made with [Cursor](https://cursor.com)