### PR TITLE
Bound scheduled projection repair work

### DIFF
--- a/workers/sync-hub/src/index.ts
+++ b/workers/sync-hub/src/index.ts
@@ -866,7 +866,13 @@ async function handleRepairDrain(request: Request, env: Env): Promise<Response> 
 			projected_through_seq: finalState.projected_seq,
 		});
 	}
-	return json(200, {
+	// A bounded repair that checkpointed one page is successful progress, but it
+	// is not a completed request until the original target has been reached.
+	// HTTP 202 preserves the existing JSON schema while giving the Pro caller an
+	// explicit continuation signal. Explicit through_seq callers are complete
+	// once their requested target is reached even if newer ops arrived meanwhile.
+	const complete = decimalAtLeast(finalState.projected_seq, target);
+	return json(complete ? 200 : 202, {
 		protocol_version: 1,
 		user_id: record.user_id,
 		epoch: finalState.epoch,

--- a/workers/sync-hub/src/index.ts
+++ b/workers/sync-hub/src/index.ts
@@ -81,6 +81,10 @@ const DEFAULT_CACHE_TTL_SECONDS = 60;
 const MAX_OPS_PER_PUSH = 500; // mirrors the getChanges page cap
 const MAX_PUSH_BODY_BYTES = 8_000_000;
 const CANONICAL_DECIMAL = /^(?:0|[1-9][0-9]*)$/;
+// Scheduled repair is deliberately incremental. One page is at most 100 ops or
+// 4 MB, so a deeply lagging user cannot monopolize a cron request or keep the
+// per-user projection lease busy while every other user waits.
+const REPAIR_DRAIN_MAX_PAGES = 1;
 
 /**
  * Pro declares a 60-second maximum duration. Abort the complete response-body
@@ -591,6 +595,8 @@ export interface ProjectionDrainDependencies {
 	fetchImpl?: ProjectionFetch;
 	/** Test seam for deterministic Durable Object lease timestamps. */
 	now?: () => number;
+	/** Optional page budget. Omitted client-triggered drains still reach target. */
+	maxPages?: number;
 }
 
 function projectionNow(dependencies: ProjectionDrainDependencies): number | undefined {
@@ -607,6 +613,12 @@ export async function drainProjection(
 	targetSeq: string,
 	dependencies: ProjectionDrainDependencies = {},
 ): Promise<DrainResult> {
+	if (
+		dependencies.maxPages !== undefined
+		&& (!Number.isSafeInteger(dependencies.maxPages) || dependencies.maxPages < 1)
+	) {
+		throw new Error("projection maxPages must be a positive safe integer");
+	}
 	const stub = env.SYNC_HUB.getByName(userId);
 	let state = await stub.getProjectionState();
 	if (decimalAtLeast(state.projected_seq, targetSeq)) {
@@ -641,6 +653,7 @@ export async function drainProjection(
 
 	const token = lease.lease_token;
 	let releaseLeaseEarly = false;
+	let projectedPages = 0;
 	try {
 		for (;;) {
 			state = await stub.getProjectionState();
@@ -774,10 +787,10 @@ export async function drainProjection(
 					httpStatus: 503,
 					retryable: true,
 				};
-			}
-			const checkpointAt = projectionNow(dependencies);
-			state = checkpointAt === undefined
-				? await stub.advanceProjectionCheckpoint(
+				}
+				const checkpointAt = projectionNow(dependencies);
+				state = checkpointAt === undefined
+					? await stub.advanceProjectionCheckpoint(
 					token,
 					page.epoch,
 					page.from_seq_exclusive,
@@ -787,11 +800,19 @@ export async function drainProjection(
 					token,
 					page.epoch,
 					page.from_seq_exclusive,
-					page.through_seq,
-					checkpointAt,
-				);
-			releaseLeaseEarly = true;
-		}
+						page.through_seq,
+						checkpointAt,
+					);
+				releaseLeaseEarly = true;
+				projectedPages++;
+				if (
+					dependencies.maxPages !== undefined
+					&& projectedPages >= dependencies.maxPages
+					&& !decimalAtLeast(state.projected_seq, targetSeq)
+				) {
+					return { ok: true, projectedSeq: state.projected_seq };
+				}
+			}
 	} catch (error) {
 		return {
 			ok: false,
@@ -831,7 +852,9 @@ async function handleRepairDrain(request: Request, env: Env): Promise<Response> 
 	if (decimalAtLeast(target, state.head_seq) && target !== state.head_seq) {
 		return errorResponse(400, "through_seq exceeds Hub head_seq");
 	}
-	const drained = await drainProjection(env, record.user_id, target);
+	const drained = await drainProjection(env, record.user_id, target, {
+		maxPages: REPAIR_DRAIN_MAX_PAGES,
+	});
 	const finalState = await stub.getProjectionState();
 	if (!drained.ok) {
 		return json(drained.httpStatus, {

--- a/workers/sync-hub/test/sync-hub.test.ts
+++ b/workers/sync-hub/test/sync-hub.test.ts
@@ -825,6 +825,34 @@ describe("front Worker durability and repair", () => {
 		expect(body.projected_through_seq).toBe(body.head_seq);
 	});
 
+	it("returns 202 until a bounded scheduled repair reaches its target", async () => {
+		const repairUser = "66666666-6666-4666-8666-666666666667";
+		const stub = hub(repairUser);
+		const ops = await Promise.all(
+			Array.from({ length: 101 }, (_, index) => observationOp(String(index + 1))),
+		);
+		ok(await stub.pushOps("dev-a", ops));
+		const request = () => SELF.fetch(`${base}/internal/v1/projection/drain`, {
+			method: "POST",
+			headers: { Authorization: "Bearer test-projector-secret", "Content-Type": "application/json" },
+			body: JSON.stringify({ protocol_version: 1, user_id: repairUser }),
+		});
+
+		const partial = await request();
+		expect(partial.status).toBe(202);
+		expect(await partial.json()).toMatchObject({
+			head_seq: "101",
+			projected_through_seq: "100",
+		});
+
+		const complete = await request();
+		expect(complete.status).toBe(200);
+		expect(await complete.json()).toMatchObject({
+			head_seq: "101",
+			projected_through_seq: "101",
+		});
+	});
+
 	it("surfaces deterministic Pro document rejection as nonretryable 409", async () => {
 		const rejectedUser = "77777777-7777-4777-8777-777777777777";
 		const response = await SELF.fetch(`${base}/v1/sync/ops`, {

--- a/workers/sync-hub/test/sync-hub.test.ts
+++ b/workers/sync-hub/test/sync-hub.test.ts
@@ -709,6 +709,37 @@ describe("projection checkpoint, lease fencing, and launch log retention", () =>
 		)).acquired).toBe(true);
 		expect(releaseCalls).toBe(0);
 	});
+
+	it("bounds scheduled repair work and releases the lease after safe progress", async () => {
+		const userId = "projection-bounded-repair";
+		const stub = hub(userId);
+		const ops = await Promise.all(
+			Array.from({ length: 101 }, (_, index) => observationOp(String(index + 1))),
+		);
+		const pushed = ok(await stub.pushOps("dev-a", ops));
+
+		const partial = await drainProjection(projectionEnv("success"), userId, pushed.head_seq, {
+			maxPages: 1,
+			fetchTimeoutMs: 100,
+		});
+		expect(partial).toEqual({ ok: true, projectedSeq: "100" });
+		expect((await stub.getProjectionState()).projected_seq).toBe("100");
+
+		// The bounded success is deterministic and checkpointed, so the lease is
+		// released immediately and the next cron can finish the same user.
+		const finished = await drainProjection(projectionEnv("success"), userId, pushed.head_seq, {
+			maxPages: 1,
+			fetchTimeoutMs: 100,
+		});
+		expect(finished).toEqual({ ok: true, projectedSeq: "101" });
+		expect((await stub.getProjectionState()).projected_seq).toBe("101");
+	});
+
+	it("rejects invalid projection page budgets before acquiring a lease", async () => {
+		await expect(drainProjection(projectionEnv("success"), "projection-bad-budget", "1", {
+			maxPages: 0,
+		})).rejects.toThrow(/positive safe integer/);
+	});
 });
 
 describe("large cursor pagination", () => {


### PR DESCRIPTION
## What changed

- Bound the secret-gated scheduled projection repair endpoint to one projection page per user and invocation.
- Release the fencing lease after that page is durably checkpointed so the next cron can continue immediately.
- Return HTTP `202 Accepted` with the existing result schema while the captured repair target remains ahead of the durable checkpoint, and HTTP 200 once the target is reached.
- Keep client-triggered projection unchanged: calls that omit a page budget still drain through their requested target.
- Reject invalid page budgets before acquiring a lease.

## Why

The repair endpoint previously tried to drain an arbitrarily large backlog in one HTTP request. In production this produced timeouts and prolonged lease contention even though individual projection pages were succeeding. One page is already bounded to 100 operations or 4 MB, so scheduled repair can make deterministic progress without monopolizing the request or the per-user lease.

## Impact

Lagging users recover incrementally through successive bounded requests during the selected cron attempt. The paired Pro caller in [claude-mem-pro #99](https://github.com/thedotmack/claude-mem-pro/pull/99) ([exact scheduler commit](https://github.com/thedotmack/claude-mem-pro/blob/ce66fc0b3043eb496871ab3ea4026b48b1114a1b/src/lib/cmem/content-v2-repair.ts)) pins the first returned head, requeues incomplete users fairly, and stops starting pages early enough to preserve Vercel's route-response margin. The unchanged JSON schema keeps either deployment order compatible. Ordinary sync and client-triggered projection semantics do not change.

## Deployment

Merging this repository does not deploy the Cloudflare Worker. After merge, an authorized operator must run the documented `workers/sync-hub` Wrangler deployment and then verify the next Pro repair cron reports bounded progress.

## Validation

- `npm run lint` in `workers/sync-hub`
- `npm test` in `workers/sync-hub` — 116 tests passed
- `npm run typecheck:root`
- Added regression coverage for the 202-to-200 continuation contract, partial checkpoint progress, immediate lease release, continuation on the next repair call, and invalid budgets
