### PR TITLE
feat: add OMP (Oh My Pi) hooks adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ Or install for Antigravity CLI ([setup guide](https://docs.claude-mem.ai/antigra
 npx claude-mem install --ide antigravity
 ```
 
+Or install for OMP (Oh My Pi):
+
+```bash
+npx claude-mem install --ide omp
+```
+
 Or install from the plugin marketplace inside Claude Code:
 
 ```bash

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -3,3 +3,5 @@
 Claude Code hook payloads are mapped through `src/adapters/claude-code/mapper.ts` into `AgentEvent` records. The mapper preserves legacy fields such as `contentSessionId`, `tool_name`, `tool_input`, `tool_response`, `cwd`, `agentId`, `agentType`, `platformSource`, and both `tool_use_id` and `toolUseId`.
 
 Generic agent examples live in `src/adapters/generic-rest/examples.ts` for Codex, OpenCode, and custom REST ingestion. New adapters should emit the REST V1 event shape instead of coupling their payloads to Claude Code internals.
+
+OMP (Oh My Pi) sessions are recorded via `omp/hooks/claude-mem.ts`, a hook module OMP loads from `~/.omp/agent/hooks/pre/`. It emits the REST V1 event shape (`contentSessionId`, `tool_name`, `tool_input`, `tool_response`, `cwd`, `platformSource: "omp"`) for init, observations, context injection, and summarize — the same contract the OpenClaw adapter uses.

--- a/omp/README.md
+++ b/omp/README.md
@@ -1,0 +1,91 @@
+# Claude-Mem for OMP (Oh My Pi)
+
+An [OMP](https://omp.sh) hook adapter that records OMP sessions into the same
+claude-mem store that Claude Code, Cursor, and OpenCode already write to —
+one shared memory across all your agents.
+
+OMP loads hook modules from `~/.omp/agent/hooks/pre/*.ts` (user-global) or
+`<cwd>/.omp/hooks/pre/*.ts` (per-project) on every session start. This hook
+translates OMP lifecycle events into claude-mem's REST V1 event shape, so no
+OMP-side plugin or modification is required.
+
+## How it works
+
+| OMP event | claude-mem endpoint | Purpose |
+|---|---|---|
+| `session_start` | — | Mint a process-stable `contentSessionId` |
+| `before_agent_start` | `POST /api/sessions/init` | Create/continue the claude-mem session (records the real user prompt) |
+| `tool_result` | `POST /api/sessions/observations` | Record each tool call (fire-and-forget) |
+| `context` | `GET /api/context/inject` | Inject memory from past sessions into the prompt (60s cache) |
+| `session_shutdown` | `POST /api/sessions/summarize` | Finalize the session summary |
+
+Behavioral notes (matching the OpenClaw adapter's conventions):
+
+- `contentSessionId` is stable for the lifetime of an OMP process and rotates on
+  compaction — never per user prompt, so observations stay grouped.
+- All POSTs are fire-and-forget detached chains; the hook never blocks tool
+  dispatch (the extension runner's 30s handler cap is never approached).
+- `memory_*` tool results are skipped to avoid recursion.
+- `tool_response` is capped at 1000 characters; `tool_input` is passed raw.
+- A circuit breaker opens for 30s after 3 consecutive worker failures.
+- The worker port resolves from `CLAUDE_MEM_WORKER_PORT` or the default
+  `37700 + (uid % 100)`.
+- The `context` handler always preserves the original conversation — it
+  re-spreads `event.messages` and appends exactly one system message.
+
+## Install
+
+Requires a running claude-mem worker (installed via `npx claude-mem install`).
+
+```bash
+npx claude-mem install --ide omp
+```
+
+This copies `omp/hooks/claude-mem.ts` to `~/.omp/agent/hooks/pre/claude-mem.ts`,
+where OMP auto-discovers it for every session. No restart of OMP is needed —
+the hook loads at the next session start.
+
+Manual install (no claude-mem CLI):
+
+```bash
+mkdir -p ~/.omp/agent/hooks/pre
+cp omp/hooks/claude-mem.ts ~/.omp/agent/hooks/pre/claude-mem.ts
+```
+
+## Uninstall
+
+```bash
+npx claude-mem uninstall   # removes the OMP hook along with all other integrations
+```
+
+Or manually:
+
+```bash
+rm ~/.omp/agent/hooks/pre/claude-mem.ts
+```
+
+## Verify
+
+Run a session in OMP, make at least one tool call, then:
+
+```bash
+npx claude-mem search "your project"
+```
+
+Observations from the OMP session appear alongside Claude Code / Cursor
+observations under the same project (platform source `omp`), and
+`~/.claude-mem/claude-mem.db` gains an `sdk_sessions` row with
+`platform_source = 'omp'`.
+
+## Development
+
+The hook is a single self-contained TypeScript module with no runtime
+dependencies (`import type` is erased at load). To test against a live OMP
+installation, copy the file into a project's `.omp/hooks/pre/` and run:
+
+```bash
+omp --print "Use the bash tool to run: pwd. Then finish."
+```
+
+Then confirm the observation landed in claude-mem's database:
+`SELECT * FROM sdk_sessions WHERE platform_source = 'omp';`

--- a/omp/hooks/claude-mem.ts
+++ b/omp/hooks/claude-mem.ts
@@ -286,15 +286,34 @@ export default function claudeMemBridge(pi: HookAPI): void {
   // reached /api/sessions/init makes the worker create an empty-project
   // sdk_sessions row for it (handleSummarizeByClaudeId calls createSDKSession
   // with an empty project).
+  //
+  // The summarize is chained onto the captured init promise, exactly like
+  // session_compact: `initialized` flips synchronously inside fireInit, before
+  // the init POST settles, so an unchained summarize can reach the worker
+  // first. It would then INSERT the sdk_sessions row itself with
+  // user_prompt='' — a column only that INSERT ever writes, so the later init
+  // repairs `project` but never the prompt — and would queue a summarize
+  // generator against a session with no prompts and no observations.
+  //
+  // id / pendingInit / previousAssistant are captured BEFORE the reset below:
+  // the detached chain runs after this handler has returned and cleared the
+  // module fields, so reading them inside the callback would send an empty
+  // last_assistant_message.
   pi.on("session_shutdown", async () => {
     const id = sid;
+    const pendingInit = initPromise;
+    const previousAssistant = lastAssistant;
+
     if (id && initialized) {
-      void post("/api/sessions/summarize", {
-        contentSessionId: id,
-        last_assistant_message: lastAssistant,
-        platformSource: "omp",
-      });
+      void (pendingInit ?? Promise.resolve()).then(() =>
+        post("/api/sessions/summarize", {
+          contentSessionId: id,
+          last_assistant_message: previousAssistant,
+          platformSource: "omp",
+        })
+      );
     }
+
     sid = undefined;
     initialized = false;
     initPromise = undefined;

--- a/omp/hooks/claude-mem.ts
+++ b/omp/hooks/claude-mem.ts
@@ -185,8 +185,9 @@ export default function claudeMemBridge(pi: HookAPI): void {
   });
 
   // Compaction starts a new logical session in claude-mem too (matches Claude
-  // Code's SessionStart clear/compact path): rotate id; the next
-  // before_agent_start re-inits with the post-compact prompt.
+  // Code's SessionStart clear/compact path): finalize the session that is
+  // ending, then rotate the id. The next before_agent_start re-inits with the
+  // post-compact prompt.
   pi.on("session_compact", async () => {
     const id = sid;
     const pendingInit = initPromise;
@@ -203,6 +204,11 @@ export default function claudeMemBridge(pi: HookAPI): void {
     }
 
     newSid();
+    // lastAssistant belongs to the logical session that just ended. newSid()
+    // resets sid/initialized/initPromise but not this field, so without the
+    // reset a compact followed directly by session_shutdown would attribute the
+    // pre-compaction response to the replacement id.
+    lastAssistant = "";
   });
 
   // before_agent_start fires once per user prompt — init for the current session
@@ -276,9 +282,13 @@ export default function claudeMemBridge(pi: HookAPI): void {
   });
 
   // session_shutdown: finalize the claude-mem session and drop in-memory state.
+  // Only an initialized session is finalized: summarizing an id that never
+  // reached /api/sessions/init makes the worker create an empty-project
+  // sdk_sessions row for it (handleSummarizeByClaudeId calls createSDKSession
+  // with an empty project).
   pi.on("session_shutdown", async () => {
     const id = sid;
-    if (id) {
+    if (id && initialized) {
       void post("/api/sessions/summarize", {
         contentSessionId: id,
         last_assistant_message: lastAssistant,

--- a/omp/hooks/claude-mem.ts
+++ b/omp/hooks/claude-mem.ts
@@ -188,6 +188,20 @@ export default function claudeMemBridge(pi: HookAPI): void {
   // Code's SessionStart clear/compact path): rotate id; the next
   // before_agent_start re-inits with the post-compact prompt.
   pi.on("session_compact", async () => {
+    const id = sid;
+    const pendingInit = initPromise;
+    const previousAssistant = lastAssistant;
+
+    if (id && initialized) {
+      void (pendingInit ?? Promise.resolve()).then(() =>
+        post("/api/sessions/summarize", {
+          contentSessionId: id,
+          last_assistant_message: previousAssistant,
+          platformSource: "omp",
+        })
+      );
+    }
+
     newSid();
   });
 

--- a/omp/hooks/claude-mem.ts
+++ b/omp/hooks/claude-mem.ts
@@ -1,0 +1,279 @@
+/**
+ * omp -> claude-mem observation bridge.
+ *
+ * Ports the claude-mem team's OpenClaw adapter (openclaw/src/index.ts, 1140 loc)
+ * to the omp hook event bus, so omp sessions are written into the same claude-mem
+ * store that Claude Code and Cursor already write to — one shared memory across
+ * all three agents.
+ *
+ * Discovery: omp auto-discovers `.omp/hooks/pre/*.ts` (project <cwd>/.omp and user
+ * ~/.omp/agent via getAgentDir()); the file loads as an extension module and
+ * `pi.on(...)` binds to the runtime event bus (oh-my-pi CHANGELOG #2796). The
+ * `tool` field derived from the filename is only the capability dedup key
+ * `${type}:${tool}:${name}`, NOT a runtime emission scope — emitToolResult
+ * (extensions/runner.ts) iterates handlers by event name with no tool filter, so
+ * this file receives tool_result for every tool.
+ *
+ * Advisor-signoff contract notes:
+ *  - context handler MAY return { messages }, but that REPLACES the conversation
+ *    (chained replacement). We spread the original messages back in and append
+ *    one system message — never return only injected text (would wipe the chat).
+ *  - contentSessionId is process-stable and regenerated only on session_compact
+ *    (one claude-mem session per omp session, not per prompt — before_agent_start
+ *    fires once per user prompt, so we never mint a new id there).
+ *  - init is fired exactly once per contentSessionId; observations await its
+ *    promise so the first observation never lands before the session row exists.
+ *  - All POSTs are fire-and-forget via detached chains; the handler returns
+ *    synchronously and never blocks the tool dispatch (30s handler cap).
+ */
+
+import type { HookAPI } from "@oh-my-pi/pi-coding-agent/extensibility/hooks";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const MAX_LEN = 1000; // tool_response hard cap (OpenClaw)
+const CTX_CACHE_MS = 60_000; // /api/context/inject cache TTL (OpenClaw)
+
+// ---------------------------------------------------------------------------
+// Worker endpoint
+// ---------------------------------------------------------------------------
+
+function port(): number {
+  // claude-mem default port derivation (docs/platform-integration.md).
+  const envP = Number(process.env.CLAUDE_MEM_WORKER_PORT);
+  if (Number.isFinite(envP) && envP > 0) return envP;
+  try {
+    const uid = typeof process.getuid === "function" ? process.getuid() : 0;
+    return 37700 + (uid % 100);
+  } catch {
+    return 37700;
+  }
+}
+
+const WORKER = `http://127.0.0.1:${port()}`;
+
+// ---------------------------------------------------------------------------
+// Circuit breaker (OpenClaw pattern) — 3 consecutive failures => 30s OPEN
+// ---------------------------------------------------------------------------
+
+let tripCount = 0;
+let openUntil = 0;
+
+function breakerOpen(): boolean {
+  return Date.now() < openUntil;
+}
+
+function onFail(): void {
+  tripCount++;
+  if (tripCount >= 3) {
+    openUntil = Date.now() + 30_000;
+    tripCount = 0;
+  }
+}
+
+function onOk(): void {
+  tripCount = 0;
+  openUntil = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Session state (process-stable contentSessionId)
+// ---------------------------------------------------------------------------
+
+let sid: string | undefined;
+let initialized = false;
+let initPromise: Promise<void> | undefined;
+let ctxCache: { at: number; md: string } | null = null; // single project per omp process
+let lastAssistant = ""; // captured on agent_end, sent at summarize
+
+function newSid(): string {
+  sid = `omp-${process.pid}-${Date.now().toString(36)}`;
+  initialized = false;
+  initPromise = undefined;
+  return sid;
+}
+
+function projectName(cwd: string | undefined): string {
+  // basename(cwd) — matches what Claude Code writes to claude-mem (verified in
+  // ~/.claude-mem/claude-mem.db: sdk_sessions.project = "maltpanel"). Cross-agent
+  // mem-search unifies on this exact key, so it must be basename, not the full path.
+  const parts = (cwd ?? "").split("/").filter(Boolean);
+  return parts[parts.length - 1] ?? "unknown";
+}
+
+function textFromContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map(c => (c && typeof c === "object" && "type" in c && c.type === "text" ? String(c.text ?? "") : ""))
+      .join("\n")
+      .trim();
+  }
+  return "";
+}
+
+// Find the last message of `role` and return its text. Handles string content or
+// [{type:"text",text}] chunks. Empty when the event carries no such message.
+function lastMessageText(messages: unknown[], role: string): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m && typeof m === "object" && "role" in m && m.role === role && "content" in m) {
+      return typeof m.content === "string" ? m.content : textFromContent(m.content);
+    }
+  }
+  return "";
+}
+
+// Fire /api/sessions/init exactly once per contentSessionId (observer awaits this).
+function fireInit(project: string, prompt?: string): Promise<void> {
+  if (breakerOpen()) return Promise.resolve();
+  if (sid === undefined) newSid();
+  if (initialized) return initPromise ?? Promise.resolve();
+  initialized = true;
+  const body = {
+    contentSessionId: sid,
+    project,
+    prompt: prompt ?? "",
+    platformSource: "omp",
+  };
+  // On any failure (network or HTTP) trip the breaker and release the init lock
+  // so the next before_agent_start/tool_result can retry; observers awaiting this
+  // promise proceed and the subsequent observation POST is gated by the breaker.
+  initPromise = fetch(`${WORKER}/api/sessions/init`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  })
+    .then(r => {
+      if (!r.ok) throw new Error(`init ${r.status}`);
+      onOk();
+    })
+    .catch(() => {
+      onFail();
+      initialized = false;
+      initPromise = undefined;
+    });
+  return initPromise;
+}
+
+function post(path: string, body: unknown): Promise<void> {
+  if (breakerOpen()) return Promise.resolve();
+  return fetch(`${WORKER}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  })
+    .then(r => {
+      if (!r.ok) throw new Error(`${path} ${r.status}`);
+      onOk();
+    })
+    .catch(() => onFail());
+}
+
+// ---------------------------------------------------------------------------
+// Hook factory
+// ---------------------------------------------------------------------------
+
+export default function claudeMemBridge(pi: HookAPI): void {
+  // session_start: mint the per-session contentSessionId. Init is deferred to
+  // before_agent_start so we can capture the real user prompt (the worker records
+  // and privacy-filters on it).
+  pi.on("session_start", async () => {
+    newSid();
+  });
+
+  // Compaction starts a new logical session in claude-mem too (matches Claude
+  // Code's SessionStart clear/compact path): rotate id; the next
+  // before_agent_start re-inits with the post-compact prompt.
+  pi.on("session_compact", async () => {
+    newSid();
+  });
+
+  // before_agent_start fires once per user prompt — init for the current session
+  // id (exactly once via the `initialized` lock) and send the latest user prompt.
+  // The prompt is a direct `event.prompt` string (BeforeAgentStartEvent in both
+  // hooks/types.ts:281 and extensions/types.ts:705) — NOT in event.messages.
+  // Never mint a new id here.
+  pi.on("before_agent_start", async (event, ctx) => {
+    fireInit(projectName(ctx?.cwd), event?.prompt);
+  });
+
+  // tool_result: the observation pipeline. Fire-and-forget; handler returns void
+  // immediately. Awaits init, then POSTs the observation on a detached chain.
+  pi.on("tool_result", async (event, ctx) => {
+    const toolName = String(event?.toolName ?? "");
+    if (!toolName || toolName.startsWith("memory_")) return; // avoid claude-mem recursion
+
+    const response = textFromContent(event?.content);
+    // isError rows are valuable — never skip them. tool_input is sent raw (the
+    // worker serializes it once); tool_response is capped to MAX_LEN.
+    const body: Record<string, unknown> = {
+      contentSessionId: sid ?? newSid(),
+      tool_name: toolName,
+      tool_input: event?.input,
+      tool_response: response.length > MAX_LEN ? response.slice(0, MAX_LEN) : response,
+      platformSource: "omp",
+    };
+    if (ctx?.cwd) body.cwd = ctx.cwd;
+
+    // Race-safe: wait for session init before the first observation lands.
+    const dep = initPromise ?? fireInit(projectName(ctx?.cwd));
+    void dep.then(() => post("/api/sessions/observations", body));
+  });
+
+  // agent_end: remember the last assistant message so summarize has an anchor.
+  // (fires every prompt loop; just overwrites — cheap)
+  pi.on("agent_end", async event => {
+    if (Array.isArray(event?.messages)) lastAssistant = lastMessageText(event.messages, "assistant");
+  });
+
+  // context: inject recent memory. MUST preserve the original conversation —
+  // returning { messages } replaces the chain, so we re-spread originals and
+  // append exactly one system message with the cached context markdown.
+  pi.on("context", async (event, ctx) => {
+    if (breakerOpen()) return;
+    const project = projectName(ctx?.cwd);
+    const now = Date.now();
+
+    if (!ctxCache || now - ctxCache.at > CTX_CACHE_MS) {
+      try {
+        const url = `${WORKER}/api/context/inject?projects=${encodeURIComponent(project)}`;
+        const r = await fetch(url);
+        if (!r.ok) throw new Error(`inject ${r.status}`);
+        const md = (await r.text()) ?? "";
+        onOk();
+        // Only cache non-empty — an empty result means "no memory yet", caching it
+        // would delay newly-arriving memory by CTX_CACHE_MS.
+        if (md.trim()) ctxCache = { at: now, md };
+        else ctxCache = null;
+      } catch {
+        onFail();
+        return; // leave conversation untouched
+      }
+    }
+
+    const injected = (ctxCache?.md ?? "").trim();
+    if (!injected) return; // no memory available this session — do not mutate
+
+    const original = Array.isArray(event?.messages) ? event.messages : [];
+    return { messages: [...original, { role: "system", content: injected }] };
+  });
+
+  // session_shutdown: finalize the claude-mem session and drop in-memory state.
+  pi.on("session_shutdown", async () => {
+    const id = sid;
+    if (id) {
+      void post("/api/sessions/summarize", {
+        contentSessionId: id,
+        last_assistant_message: lastAssistant,
+      });
+    }
+    sid = undefined;
+    initialized = false;
+    initPromise = undefined;
+    ctxCache = null;
+    lastAssistant = "";
+  });
+}

--- a/omp/hooks/claude-mem.ts
+++ b/omp/hooks/claude-mem.ts
@@ -268,6 +268,7 @@ export default function claudeMemBridge(pi: HookAPI): void {
       void post("/api/sessions/summarize", {
         contentSessionId: id,
         last_assistant_message: lastAssistant,
+        platformSource: "omp",
       });
     }
     sid = undefined;

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "plugin/sqlite",
     "plugin/skills",
     "plugin/ui",
-    "openclaw"
+    "openclaw",
+    "omp"
   ],
   "engines": {
     "node": ">=20.12.0",

--- a/src/npx-cli/commands/ide-detection.ts
+++ b/src/npx-cli/commands/ide-detection.ts
@@ -95,6 +95,12 @@ export function detectInstalledIDEs(): IDEInfo[] {
       hint: 'hooks + MCP integration',
     },
     {
+      id: 'omp',
+      label: 'OMP',
+      detected: isCommandInPath('omp') || existsSync(join(home, '.omp')),
+      hint: 'native hooks integration',
+    },
+    {
       id: 'goose',
       label: 'Goose',
       detected:

--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -354,6 +354,23 @@ function makeIDETask(ideId: string, summary: InstallSummary): TaskDescriptor | n
       };
     }
 
+    case 'omp': {
+      return {
+        title: 'OMP: installing hooks',
+        task: async (message) => {
+          message('Loading OMP installer…');
+          const { installOmpHooks } = await import('../../services/integrations/OmpHooksInstaller.js');
+          message('Installing OMP hooks…');
+          const { result, output } = await bufferConsole(() => installOmpHooks());
+          if (result !== 0) {
+            recordFailure('OMP: hook installation failed', output);
+            return `OMP: hook installation failed ${styleText('red', 'FAIL')}`;
+          }
+          return `OMP: hooks installed ${styleText('green', 'OK')}`;
+        },
+      };
+    }
+
     case 'windsurf': {
       return {
         title: 'Windsurf: installing hooks',

--- a/src/npx-cli/commands/uninstall.ts
+++ b/src/npx-cli/commands/uninstall.ts
@@ -376,6 +376,10 @@ export async function runUninstallCommand(): Promise<void> {
       const { uninstallAntigravityCliHooks } = await import('../../services/integrations/AntigravityCliHooksInstaller.js');
       return uninstallAntigravityCliHooks();
     }},
+    { label: 'OMP hooks', fn: async () => {
+      const { uninstallOmpHooks } = await import('../../services/integrations/OmpHooksInstaller.js');
+      return uninstallOmpHooks();
+    }},
   ];
 
   for (const { label, fn } of ideCleanups) {

--- a/src/npx-cli/index.ts
+++ b/src/npx-cli/index.ts
@@ -54,7 +54,7 @@ ${styleText('bold', 'Runtime Commands')} (requires Bun, delegates to installed p
   ${styleText('cyan', 'npx claude-mem antigravity-cli install|status|uninstall')}   Manage Antigravity CLI hooks + MCP config
 
 ${styleText('bold', 'IDE Identifiers')}:
-  claude-code, cursor, opencode, openclaw,
+  claude-code, cursor, opencode, openclaw, omp,
   windsurf, codex-cli, copilot-cli, antigravity, goose,
   roo-code, warp
 `);

--- a/src/services/integrations/OmpHooksInstaller.ts
+++ b/src/services/integrations/OmpHooksInstaller.ts
@@ -1,0 +1,82 @@
+import path from 'path';
+import { homedir } from 'os';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from 'fs';
+import { logger } from '../../utils/logger.js';
+import { MARKETPLACE_ROOT } from '../../shared/paths.js';
+
+/**
+ * OMP (Oh My Pi) hook installer.
+ *
+ * OMP auto-discovers hook modules at `<cwd>/.omp/hooks/pre/*.ts` and
+ * `~/.omp/agent/hooks/pre/*.ts` (user-global via getAgentDir(); see oh-my-pi
+ * builtin.ts loadHooks / getConfigDirs). Hooks are plain TypeScript modules
+ * loaded in-process by OMP's Bun runtime — no build step, no manifest, no
+ * shell-command wrapper (unlike Cursor/Windsurf/Antigravity, which exec the
+ * worker CLI per event).
+ *
+ * This installer copies the shipped hook bundle to
+ * `~/.omp/agent/hooks/pre/claude-mem.ts`, where OMP loads it for every session
+ * regardless of project. Uninstall removes that single file.
+ */
+
+const OMP_AGENT_HOOKS_PRE_DIR = path.join(homedir(), '.omp', 'agent', 'hooks', 'pre');
+const OMP_HOOK_FILENAME = 'claude-mem.ts';
+const OMP_HOOK_DESTINATION = path.join(OMP_AGENT_HOOKS_PRE_DIR, OMP_HOOK_FILENAME);
+
+/** Where the shipped hook lives: the installed marketplace root, or a repo/dev checkout. */
+const OMP_HOOK_SOURCE_ROOTS = [MARKETPLACE_ROOT, process.cwd()];
+
+export function findOmpHookSourcePath(): string | null {
+  for (const root of OMP_HOOK_SOURCE_ROOTS) {
+    const candidate = path.join(root, 'omp', 'hooks', OMP_HOOK_FILENAME);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+export async function installOmpHooks(): Promise<number> {
+  const source = findOmpHookSourcePath();
+  if (!source) {
+    console.error('Could not find the OMP hook bundle.');
+    console.error('  Expected at: omp/hooks/claude-mem.ts');
+    return 1;
+  }
+
+  try {
+    mkdirSync(OMP_AGENT_HOOKS_PRE_DIR, { recursive: true });
+    writeFileSync(OMP_HOOK_DESTINATION, readFileSync(source, 'utf-8'), 'utf-8');
+    console.log(`  OMP hook installed to: ${OMP_HOOK_DESTINATION}`);
+    logger.info('OMP', 'Hook installed', { destination: OMP_HOOK_DESTINATION });
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Failed to install OMP hook: ${message}`);
+    return 1;
+  }
+}
+
+export function uninstallOmpHooks(): number {
+  if (!existsSync(OMP_HOOK_DESTINATION)) {
+    console.log('  OMP hook not installed; nothing to remove.');
+    return 0;
+  }
+  try {
+    rmSync(OMP_HOOK_DESTINATION, { force: true });
+    console.log(`  Removed OMP hook: ${OMP_HOOK_DESTINATION}`);
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Failed to remove OMP hook: ${message}`);
+    return 1;
+  }
+}
+
+export function checkOmpStatus(): number {
+  console.log('\nClaude-Mem OMP Integration Status\n');
+  console.log(`Hooks directory: ${OMP_AGENT_HOOKS_PRE_DIR}`);
+  console.log(`  Exists: ${existsSync(OMP_AGENT_HOOKS_PRE_DIR) ? 'yes' : 'no'}`);
+  console.log(`Hook file: ${OMP_HOOK_DESTINATION}`);
+  console.log(`  Installed: ${existsSync(OMP_HOOK_DESTINATION) ? 'yes' : 'no'}`);
+  console.log('');
+  return 0;
+}

--- a/src/services/integrations/OmpHooksInstaller.ts
+++ b/src/services/integrations/OmpHooksInstaller.ts
@@ -23,11 +23,15 @@ const OMP_AGENT_HOOKS_PRE_DIR = path.join(homedir(), '.omp', 'agent', 'hooks', '
 const OMP_HOOK_FILENAME = 'claude-mem.ts';
 const OMP_HOOK_DESTINATION = path.join(OMP_AGENT_HOOKS_PRE_DIR, OMP_HOOK_FILENAME);
 
-/** Where the shipped hook lives: the installed marketplace root, or a repo/dev checkout. */
-const OMP_HOOK_SOURCE_ROOTS = [MARKETPLACE_ROOT, process.cwd()];
-
+/** Trusted locations for the shipped hook. The marketplace root is the
+ *  canonical, claude-mem-installed source. A repo/checkout source is honored
+ *  only behind an explicit dev opt-in — never by default: process.cwd() could
+ *  be an untrusted repository whose omp/hooks/ would then be installed as a
+ *  persistent user-global OMP hook (~/.omp/agent/hooks/pre/). (Greptile P1.) */
 export function findOmpHookSourcePath(): string | null {
-  for (const root of OMP_HOOK_SOURCE_ROOTS) {
+  const roots = [MARKETPLACE_ROOT];
+  if (process.env.CLAUDE_MEM_DEV_HOOK_SOURCE === '1') roots.push(process.cwd());
+  for (const root of roots) {
     const candidate = path.join(root, 'omp', 'hooks', OMP_HOOK_FILENAME);
     if (existsSync(candidate)) return candidate;
   }
@@ -37,8 +41,10 @@ export function findOmpHookSourcePath(): string | null {
 export async function installOmpHooks(): Promise<number> {
   const source = findOmpHookSourcePath();
   if (!source) {
-    console.error('Could not find the OMP hook bundle.');
-    console.error('  Expected at: omp/hooks/claude-mem.ts');
+    console.error('Could not find the OMP hook bundle shipped with claude-mem.');
+    console.error('  Expected at: <marketplace>/omp/hooks/claude-mem.ts');
+    console.error('  Re-run `npx claude-mem install` to populate the marketplace,');
+    console.error('  or set CLAUDE_MEM_DEV_HOOK_SOURCE=1 to resolve from the cwd (dev only).');
     return 1;
   }
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -34,6 +34,7 @@ export type Component =
   | 'IMPORT'
   | 'INGEST'
   | 'OAUTH'
+  | 'OMP'
   | 'OPENCLAW'
   | 'OPENCODE'
   | 'PARSER'

--- a/tests/omp-hook.test.ts
+++ b/tests/omp-hook.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import registerClaudeMemHook from '../omp/hooks/claude-mem.ts';
+
+type HookHandler = (...args: unknown[]) => unknown;
+
+type CapturedRequest = {
+  path: string;
+  body: Record<string, unknown>;
+};
+
+function installFetchCapture(requests: CapturedRequest[]): void {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    requests.push({
+      path: new URL(String(input)).pathname,
+      body: JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>,
+    });
+    return new Response('{}', { status: 200 });
+  }) as typeof fetch;
+}
+
+function registerHook(): Record<string, HookHandler> {
+  const handlers: Record<string, HookHandler> = {};
+  registerClaudeMemHook({
+    on(event, handler) {
+      handlers[event] = handler as HookHandler;
+    },
+  } as unknown as Parameters<typeof registerClaudeMemHook>[0]);
+  return handlers;
+}
+
+describe('OMP Claude Mem hook', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('includes omp platformSource in the session shutdown summarize request', async () => {
+    const requests: CapturedRequest[] = [];
+    installFetchCapture(requests);
+    const handlers = registerHook();
+
+    await handlers.session_start?.();
+    await handlers.before_agent_start?.(
+      { prompt: 'test OMP shutdown summary' },
+      { cwd: '/tmp/omp-hook-test' },
+    );
+    await handlers.session_shutdown?.();
+    await Promise.resolve();
+
+    const summarize = requests.find(request => request.path === '/api/sessions/summarize');
+    expect(summarize?.body).toMatchObject({
+      contentSessionId: expect.stringMatching(/^omp-/),
+      platformSource: 'omp',
+    });
+  });
+
+  it('summarizes the previous session before rotating on compaction', async () => {
+    const requests: CapturedRequest[] = [];
+    installFetchCapture(requests);
+    const handlers = registerHook();
+
+    await handlers.session_start?.();
+    await handlers.before_agent_start?.(
+      { prompt: 'before compaction' },
+      { cwd: '/tmp/omp-hook-compaction-test' },
+    );
+    await handlers.agent_end?.({
+      messages: [{ role: 'assistant', content: 'precompact answer' }],
+    });
+    await handlers.session_compact?.();
+    await handlers.before_agent_start?.(
+      { prompt: 'after compaction' },
+      { cwd: '/tmp/omp-hook-compaction-test' },
+    );
+    await handlers.session_shutdown?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const initSessions = requests
+      .filter(request => request.path === '/api/sessions/init')
+      .map(request => String(request.body.contentSessionId))
+      .sort();
+    const summaries = requests.filter(request => request.path === '/api/sessions/summarize');
+    const summarySessions = summaries
+      .map(request => String(request.body.contentSessionId))
+      .sort();
+
+    expect(initSessions).toHaveLength(2);
+    expect(summarySessions).toEqual(initSessions);
+    expect(summaries.find(request => request.body.contentSessionId === initSessions[0])?.body).toMatchObject({
+      last_assistant_message: 'precompact answer',
+      platformSource: 'omp',
+    });
+  });
+});

--- a/tests/omp-hook.test.ts
+++ b/tests/omp-hook.test.ts
@@ -18,6 +18,36 @@ function installFetchCapture(requests: CapturedRequest[]): void {
   }) as typeof fetch;
 }
 
+// Flush every pending microtask. The compact/shutdown summaries are detached
+// chains (void pendingInit.then(...) -> fetch -> .then), so counting individual
+// `await Promise.resolve()` calls is fragile; this suite uses no wall-clock
+// sleeps.
+async function drainMicrotasks(): Promise<void> {
+  for (let index = 0; index < 20; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+// Same capture as installFetchCapture, except /api/sessions/init hangs until
+// releaseInit() is called, so a test can observe exactly what the hook sends
+// while session init is still in flight.
+function installDeferredInitCapture(requests: CapturedRequest[]): { releaseInit: () => void } {
+  let releaseInit = (): void => {};
+  const initGate = new Promise<void>(resolve => {
+    releaseInit = resolve;
+  });
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const path = new URL(String(input)).pathname;
+    if (path === '/api/sessions/init') await initGate;
+    requests.push({
+      path,
+      body: JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>,
+    });
+    return new Response('{}', { status: 200 });
+  }) as typeof fetch;
+  return { releaseInit };
+}
+
 function registerHook(): Record<string, HookHandler> {
   const handlers: Record<string, HookHandler> = {};
   registerClaudeMemHook({
@@ -46,7 +76,7 @@ describe('OMP Claude Mem hook', () => {
       { cwd: '/tmp/omp-hook-test' },
     );
     await handlers.session_shutdown?.();
-    await Promise.resolve();
+    await drainMicrotasks();
 
     const summarize = requests.find(request => request.path === '/api/sessions/summarize');
     expect(summarize?.body).toMatchObject({
@@ -74,9 +104,7 @@ describe('OMP Claude Mem hook', () => {
       { cwd: '/tmp/omp-hook-compaction-test' },
     );
     await handlers.session_shutdown?.();
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await drainMicrotasks();
 
     const initSessions = requests
       .filter(request => request.path === '/api/sessions/init')
@@ -110,9 +138,7 @@ describe('OMP Claude Mem hook', () => {
     });
     await handlers.session_compact?.();
     await handlers.session_shutdown?.();
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    await drainMicrotasks();
 
     const initSession = String(
       requests.find(request => request.path === '/api/sessions/init')?.body.contentSessionId,
@@ -123,6 +149,41 @@ describe('OMP Claude Mem hook', () => {
     expect(summaries[0]?.body).toMatchObject({
       contentSessionId: initSession,
       last_assistant_message: 'precompact answer',
+      platformSource: 'omp',
+    });
+  });
+
+  it('defers the shutdown summarize until session init has completed', async () => {
+    const requests: CapturedRequest[] = [];
+    const { releaseInit } = installDeferredInitCapture(requests);
+    const handlers = registerHook();
+
+    await handlers.session_start?.();
+    await handlers.before_agent_start?.(
+      { prompt: 'prompt that must reach the worker first' },
+      { cwd: '/tmp/omp-hook-shutdown-init-race' },
+    );
+    await handlers.agent_end?.({
+      messages: [{ role: 'assistant', content: 'shutdown answer' }],
+    });
+    await handlers.session_shutdown?.();
+    await drainMicrotasks();
+
+    // Init is still in flight, so nothing may have been sent to the worker yet:
+    // a summarize arriving first makes the worker INSERT the sdk_sessions row
+    // with an empty user_prompt.
+    expect(requests.map(request => request.path)).toEqual([]);
+
+    releaseInit();
+    await drainMicrotasks();
+
+    expect(requests.map(request => request.path)).toEqual([
+      '/api/sessions/init',
+      '/api/sessions/summarize',
+    ]);
+    expect(requests[1]?.body).toMatchObject({
+      contentSessionId: String(requests[0]?.body.contentSessionId),
+      last_assistant_message: 'shutdown answer',
       platformSource: 'omp',
     });
   });

--- a/tests/omp-hook.test.ts
+++ b/tests/omp-hook.test.ts
@@ -94,4 +94,36 @@ describe('OMP Claude Mem hook', () => {
       platformSource: 'omp',
     });
   });
+
+  it('finalizes only the pre-compaction session when compaction is followed directly by shutdown', async () => {
+    const requests: CapturedRequest[] = [];
+    installFetchCapture(requests);
+    const handlers = registerHook();
+
+    await handlers.session_start?.();
+    await handlers.before_agent_start?.(
+      { prompt: 'before compaction' },
+      { cwd: '/tmp/omp-hook-compaction-shutdown-test' },
+    );
+    await handlers.agent_end?.({
+      messages: [{ role: 'assistant', content: 'precompact answer' }],
+    });
+    await handlers.session_compact?.();
+    await handlers.session_shutdown?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const initSession = String(
+      requests.find(request => request.path === '/api/sessions/init')?.body.contentSessionId,
+    );
+    const summaries = requests.filter(request => request.path === '/api/sessions/summarize');
+
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]?.body).toMatchObject({
+      contentSessionId: initSession,
+      last_assistant_message: 'precompact answer',
+      platformSource: 'omp',
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds a native OMP (Oh My Pi) hooks adapter so OMP sessions are captured into
claude-mem — closing the gap reported in #3355, where the MCP read path works
inside OMP but nothing is ever written ("zero observations captured").

The adapter is a single self-contained hook module (`omp/hooks/claude-mem.ts`)
that OMP auto-loads from `~/.omp/agent/hooks/pre/`. It translates OMP lifecycle
events into claude-mem's REST V1 event shape (init / observations / context
inject / summarize), mirroring the OpenClaw adapter's conventions: stable
process-scoped `contentSessionId`, fire-and-forget POSTs, `memory_*` skip,
1000-char `tool_response` cap, and a 30s circuit breaker.

Live-tested end-to-end: an OMP session's tool calls landed as observations
(`platform_source = 'omp'`, correct `project` from cwd basename, real prompt
text recorded) and surfaced alongside Claude Code observations in mem-search.

## Changes

- `omp/hooks/claude-mem.ts` — the hook adapter (no build step; OMP loads `.ts`
  directly via its Bun runtime)
- `omp/README.md` — integration docs
- `src/services/integrations/OmpHooksInstaller.ts` — `install/uninstall/status`
  (copies the hook to `~/.omp/agent/hooks/pre/claude-mem.ts`)
- `src/npx-cli/commands/install.ts` / `ide-detection.ts` / `uninstall.ts` /
  `index.ts` — `npx claude-mem install --ide omp` wiring
- `src/utils/logger.ts` — `'OMP'` component
- `package.json` — ship `omp/` in the npm package

## Verification

- `tsc --noEmit`: clean
- Hook file byte-identical to the version live-tested against a real OMP
  session (observations confirmed in `claude-mem.db`, `platform_source='omp'`)
- Installer: `installOmpHooks()` resolves and copies correctly

Resolves #3355