### PR TITLE
fix(chroma): isolate uvx children from foreign Python venvs (#3552)

### DIFF
--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -10,7 +10,7 @@ import { logger } from '../../utils/logger.js';
 import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js';
 import { USER_SETTINGS_PATH, paths } from '../../shared/paths.js';
 import { getUvxBinDirs } from '../../shared/uvx-bin-dirs.js';
-import { sanitizeEnv } from '../../supervisor/env-sanitizer.js';
+import { sanitizeEnv, stripForeignPythonEnv } from '../../supervisor/env-sanitizer.js';
 import { getSupervisor } from '../../supervisor/index.js';
 import { captureProcessStartToken, isPidAlive } from '../../supervisor/process-registry.js';
 import { clearDependencyStatus, recordChromaVectorSearchUnavailable, recordUvxVectorSearchUnavailable } from '../../shared/dependency-health.js';
@@ -671,6 +671,11 @@ export class ChromaMcpManager {
         timeoutMs,
         ...(pid ? { pid } : {}),
         error: errorMessage,
+        // Parent contamination signals (#3552): child env is scrubbed, but these
+        // tell operators why a prior unclean spawn may have failed.
+        parentHadVirtualEnv: Boolean(process.env.VIRTUAL_ENV),
+        parentHadPythonPath: Boolean(process.env.PYTHONPATH),
+        parentHadPythonHome: Boolean(process.env.PYTHONHOME),
         ...(stdout ? { stdoutTail: stdout } : {}),
         ...(stderr ? { stderrTail: stderr } : {})
       });
@@ -1371,7 +1376,12 @@ export class ChromaMcpManager {
 
   private static getUvxPreflightEnv(): Record<string, string> {
     const baseEnv: Record<string, string> = {};
-    for (const [key, value] of Object.entries(sanitizeEnv(process.env))) {
+    // sanitizeEnv strips host Claude Code vars; stripForeignPythonEnv then
+    // removes activated-venv / conda leakage so uvx --python stays hermetic
+    // even when the worker was started from a foreign virtualenv (#3552).
+    for (const [key, value] of Object.entries(
+      stripForeignPythonEnv(sanitizeEnv(process.env)),
+    )) {
       if (value !== undefined) {
         baseEnv[key] = value;
       }

--- a/src/supervisor/env-sanitizer.ts
+++ b/src/supervisor/env-sanitizer.ts
@@ -59,3 +59,88 @@ export function sanitizeEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.Proces
 
   return sanitized;
 }
+
+/**
+ * Python / venv keys that poison hermetic `uvx --python …` children when the
+ * worker itself was launched from an activated virtualenv (#3552).
+ *
+ * `uvx` installs chromadb into its own cache, but CPython still honours
+ * `VIRTUAL_ENV` / `PYTHONPATH` / `PYTHONHOME` from the parent, so a foreign
+ * `numpy` (wrong ABI) can win and chroma-mcp prewarm fails silently.
+ */
+export const FOREIGN_PYTHON_ENV_KEYS = [
+  'VIRTUAL_ENV',
+  'VIRTUAL_ENV_PROMPT',
+  'PYTHONHOME',
+  'PYTHONPATH',
+  'PYTHONUSERBASE',
+  'PYTHONSTARTUP',
+  '__PYVENV_LAUNCHER__',
+  'CONDA_PREFIX',
+  'CONDA_DEFAULT_ENV',
+  'CONDA_PROMPT_MODIFIER',
+  'CONDA_PYTHON_EXE',
+  'CONDA_SHLVL',
+] as const;
+
+const FOREIGN_PYTHON_ENV_KEY_SET = new Set<string>(FOREIGN_PYTHON_ENV_KEYS);
+
+function normalizePathForCompare(value: string): string {
+  return value.replace(/[\\/]+$/, '').replace(/\\/g, '/').toLowerCase();
+}
+
+function isForeignPythonPathEntry(entry: string, roots: string[]): boolean {
+  const normalized = normalizePathForCompare(entry);
+  if (!normalized) return false;
+
+  for (const root of roots) {
+    const normalizedRoot = normalizePathForCompare(root);
+    if (
+      normalized === normalizedRoot
+      || normalized.startsWith(`${normalizedRoot}/`)
+    ) {
+      return true;
+    }
+  }
+
+  // Heuristic for shells that put venv Scripts/bin on PATH without VIRTUAL_ENV.
+  return /(^|\/)(\.?venv|virtualenv)(\/.*)?\/(scripts|bin)$/i.test(normalized)
+    || /(^|\/)(\.?venv|virtualenv)$/i.test(normalized);
+}
+
+/**
+ * Strip foreign Python / conda activation state and matching PATH prefixes so
+ * `uvx --python N` children resolve packages from uv's cache only (#3552).
+ *
+ * Does not touch UV_* cache/config vars — those belong to the hermetic tool.
+ */
+export function stripForeignPythonEnv(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform = process.platform,
+): NodeJS.ProcessEnv {
+  const cleaned: NodeJS.ProcessEnv = { ...env };
+  const roots: string[] = [];
+
+  for (const key of ['VIRTUAL_ENV', 'CONDA_PREFIX'] as const) {
+    const value = cleaned[key];
+    if (value) roots.push(value);
+  }
+
+  for (const key of FOREIGN_PYTHON_ENV_KEYS) {
+    delete cleaned[key];
+  }
+
+  const pathKey = Object.keys(cleaned).find((key) => key.toLowerCase() === 'path');
+  if (!pathKey || cleaned[pathKey] === undefined) {
+    return cleaned;
+  }
+
+  const sep = platform === 'win32' ? ';' : ':';
+  const filtered = cleaned[pathKey]
+    .split(sep)
+    .filter(Boolean)
+    .filter((entry) => !isForeignPythonPathEntry(entry, roots));
+
+  cleaned[pathKey] = filtered.join(sep);
+  return cleaned;
+}

--- a/tests/supervisor/env-sanitizer.test.ts
+++ b/tests/supervisor/env-sanitizer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { sanitizeEnv } from '../../src/supervisor/env-sanitizer.js';
+import { sanitizeEnv, stripForeignPythonEnv } from '../../src/supervisor/env-sanitizer.js';
 
 describe('sanitizeEnv', () => {
   it('strips variables with CLAUDECODE_ prefix', () => {
@@ -207,6 +207,60 @@ describe('sanitizeEnv', () => {
     expect(result.CLAUDE_CODE_RANDOM_OTHER).toBeUndefined();
     expect(result.CLAUDE_CODE_INTERNAL_FLAG).toBeUndefined();
 
+    expect(result.PATH).toBe('/usr/bin');
+  });
+});
+
+describe('stripForeignPythonEnv (#3552)', () => {
+  it('strips VIRTUAL_ENV / PYTHONPATH / PYTHONHOME and keeps UV cache vars', () => {
+    const result = stripForeignPythonEnv({
+      VIRTUAL_ENV: 'C:\\Users\\me\\AppData\\Local\\other-app\\venv',
+      PYTHONPATH: 'C:\\Users\\me\\AppData\\Local\\other-app\\venv\\Lib\\site-packages',
+      PYTHONHOME: 'C:\\Python311',
+      UV_CACHE_DIR: 'C:\\Users\\me\\.cache\\uv',
+      PATH: 'C:\\Windows\\System32',
+      HOME: 'C:\\Users\\me',
+    }, 'win32');
+
+    expect(result.VIRTUAL_ENV).toBeUndefined();
+    expect(result.PYTHONPATH).toBeUndefined();
+    expect(result.PYTHONHOME).toBeUndefined();
+    expect(result.UV_CACHE_DIR).toBe('C:\\Users\\me\\.cache\\uv');
+    expect(result.HOME).toBe('C:\\Users\\me');
+    expect(result.PATH).toBe('C:\\Windows\\System32');
+  });
+
+  it('removes VIRTUAL_ENV Scripts prefix from Windows PATH', () => {
+    const venv = 'C:\\Users\\me\\AppData\\Local\\other-app\\venv';
+    const result = stripForeignPythonEnv({
+      VIRTUAL_ENV: venv,
+      PATH: `${venv}\\Scripts;C:\\Windows\\System32;C:\\Program Files\\nodejs`,
+    }, 'win32');
+
+    expect(result.VIRTUAL_ENV).toBeUndefined();
+    expect(result.PATH).toBe('C:\\Windows\\System32;C:\\Program Files\\nodejs');
+  });
+
+  it('removes heuristic .venv/bin entries on POSIX PATH without VIRTUAL_ENV', () => {
+    const result = stripForeignPythonEnv({
+      PATH: '/home/me/proj/.venv/bin:/usr/bin:/bin',
+    }, 'linux');
+
+    expect(result.PATH).toBe('/usr/bin:/bin');
+  });
+
+  it('strips conda activation vars and CONDA_PREFIX PATH entries', () => {
+    const prefix = '/home/me/miniconda3/envs/ml';
+    const result = stripForeignPythonEnv({
+      CONDA_PREFIX: prefix,
+      CONDA_DEFAULT_ENV: 'ml',
+      CONDA_SHLVL: '1',
+      PATH: `${prefix}/bin:/usr/bin`,
+    }, 'linux');
+
+    expect(result.CONDA_PREFIX).toBeUndefined();
+    expect(result.CONDA_DEFAULT_ENV).toBeUndefined();
+    expect(result.CONDA_SHLVL).toBeUndefined();
     expect(result.PATH).toBe('/usr/bin');
   });
 });


### PR DESCRIPTION
## Summary

Fixes #3552.

`uvx --python 3.13` looked hermetic, but the chroma-mcp child still inherited the worker's activated virtualenv (`VIRTUAL_ENV` / `PYTHONPATH` / `PYTHONHOME` / conda keys, plus matching PATH prefixes). On Windows that pulled a foreign `numpy` ABI into the uv cache interpreter and silently stopped Chroma sync while SQLite stayed healthy.

## Fix

- Add `stripForeignPythonEnv` next to `sanitizeEnv` and run it on the chroma/uvx spawn env.
- Strip foreign Python/conda activation keys and venv `Scripts`/`bin` PATH entries.
- On prewarm failure, log parent contamination booleans (`parentHadVirtualEnv` / `PYTHONPATH` / `PYTHONHOME`) so the next diagnosis does not require reading a mixed traceback.

## Level of fix

Fixed at the chroma spawn env boundary because that is the only place `uvx --python` promised isolation. Broader `sanitizeEnv` stays Claude-Code-leak focused so unrelated subprocesses are unchanged.

## Evidence

```
bun test tests/supervisor/env-sanitizer.test.ts
16 pass
0 fail
```

Also re-ran `chroma-mcp-manager-path` (6 pass). Pre-existing `spawn-contract-windows` cmd.exe path expectations failed on this box (`cmd.exe` vs `C:\WINDOWS\system32\cmd.exe`) and are unrelated to this diff.

## What was not tested

- Live Windows repro with an activated foreign venv + real chroma-mcp prewarm (would need a conflicting numpy install). Unit tests cover the env scrub that removes that contamination vector.

## AI assistance

Implemented with Cursor assistance. Human: Stan Shih (@stantheman0128).

Made with [Cursor](https://cursor.com)