### PR TITLE
fix(install): register claude-mem MCP server in opencode.json

### DIFF
--- a/src/services/integrations/OpenCodeInstaller.ts
+++ b/src/services/integrations/OpenCodeInstaller.ts
@@ -6,8 +6,10 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, copyFileSync, unlin
 import { logger } from '../../utils/logger.js';
 import { CONTEXT_TAG_OPEN, CONTEXT_TAG_CLOSE, injectContextIntoMarkdownFile } from '../../utils/context-injection.js';
 import { getWorkerHost, getWorkerPort } from '../../shared/worker-utils.js';
+import { getMcpServerAbsolutePath, getNodeAbsolutePath } from './install-paths.js';
 
 const OPENCODE_PLUGIN_CONFIG_PATH = './plugins/claude-mem.js';
+const OPENCODE_MCP_SERVER_KEY = 'claude-mem';
 
 type OpenCodeConfig = {
   $schema?: string;
@@ -66,6 +68,64 @@ export function removeOpenCodePluginReference(config: OpenCodeConfig): OpenCodeC
   };
 }
 
+function getOpenCodeMcpEntry(config: OpenCodeConfig): Record<string, unknown> {
+  return (config.mcp && typeof config.mcp === 'object')
+    ? config.mcp as Record<string, unknown>
+    : {};
+}
+
+/**
+ * Register claude-mem's MCP server in opencode.json as a local MCP server that
+ * launches `node <absolute-path-to-mcp-server.cjs>` — OpenCode does NOT do
+ * `${CLAUDE_PLUGIN_ROOT}` substitution, so the path must be baked absolute
+ * (Rule B in install-paths.ts). Other MCP servers are preserved untouched.
+ * Returns the config unchanged (no mcp entry) when the server script cannot be
+ * resolved, so a broken build never corrupts the user's opencode.json.
+ */
+export function addOpenCodeMcpReference(config: OpenCodeConfig): OpenCodeConfig {
+  const mcpServerPath = getMcpServerAbsolutePath();
+  if (!mcpServerPath) return config;
+
+  const command = [getNodeAbsolutePath(), mcpServerPath];
+  const existingMcp = getOpenCodeMcpEntry(config);
+  const current = existingMcp[OPENCODE_MCP_SERVER_KEY];
+  if (
+    current
+    && typeof current === 'object'
+    && (current as { type?: unknown }).type === 'local'
+    && Array.isArray((current as { command?: unknown }).command)
+    && JSON.stringify((current as { command: unknown[] }).command) === JSON.stringify(command)
+  ) {
+    return config;
+  }
+
+  return {
+    ...config,
+    mcp: {
+      ...existingMcp,
+      [OPENCODE_MCP_SERVER_KEY]: { type: 'local', command },
+    },
+  };
+}
+
+/**
+ * Remove only claude-mem's MCP entry from opencode.json, preserving every other
+ * MCP server. The `mcp` block itself is dropped when it becomes empty.
+ */
+export function removeOpenCodeMcpReference(config: OpenCodeConfig): OpenCodeConfig {
+  const existingMcp = getOpenCodeMcpEntry(config);
+  if (!(OPENCODE_MCP_SERVER_KEY in existingMcp)) {
+    return config;
+  }
+
+  const { [OPENCODE_MCP_SERVER_KEY]: _removed, ...remainingMcp } = existingMcp;
+  const next: OpenCodeConfig = { ...config, mcp: remainingMcp };
+  if (Object.keys(remainingMcp).length === 0) {
+    delete next.mcp;
+  }
+  return next;
+}
+
 export function registerOpenCodePluginInConfig(): number {
   const configPath = getOpenCodeConfigPath();
   const defaultConfig: OpenCodeConfig = {
@@ -76,7 +136,12 @@ export function registerOpenCodePluginInConfig(): number {
     const config = existsSync(configPath)
       ? JSON.parse(readFileSync(configPath, 'utf-8')) as OpenCodeConfig
       : defaultConfig;
-    const updatedConfig = addOpenCodePluginReference(config);
+    const withPlugin = addOpenCodePluginReference(config);
+    const updatedConfig = addOpenCodeMcpReference(withPlugin);
+
+    if (withPlugin.mcp === updatedConfig.mcp && updatedConfig.mcp === undefined) {
+      logger.warn('OPENCODE', 'MCP server script not found — registered plugin without MCP entry', { path: configPath });
+    }
 
     writeFileSync(configPath, `${JSON.stringify(updatedConfig, null, 2)}\n`, 'utf-8');
     console.log(`  Plugin registered in: ${configPath}`);
@@ -98,7 +163,7 @@ export function deregisterOpenCodePluginFromConfig(): number {
 
   try {
     const config = JSON.parse(readFileSync(configPath, 'utf-8')) as OpenCodeConfig;
-    const updatedConfig = removeOpenCodePluginReference(config);
+    const updatedConfig = removeOpenCodeMcpReference(removeOpenCodePluginReference(config));
 
     writeFileSync(configPath, `${JSON.stringify(updatedConfig, null, 2)}\n`, 'utf-8');
     console.log(`  Plugin deregistered from: ${configPath}`);
@@ -284,6 +349,27 @@ export function checkOpenCodeStatus(): number {
     console.log(`  Has claude-mem context: ${hasContextTags ? 'yes' : 'no'}`);
   } else {
     console.log(`  Exists: no`);
+  }
+  console.log('');
+
+  console.log(`MCP server (opencode.json):`);
+  try {
+    if (existsSync(getOpenCodeConfigPath())) {
+      const config = JSON.parse(readFileSync(getOpenCodeConfigPath(), 'utf-8')) as OpenCodeConfig;
+      const mcpEntry = getOpenCodeMcpEntry(config)[OPENCODE_MCP_SERVER_KEY];
+      if (mcpEntry && typeof mcpEntry === 'object') {
+        const command = (mcpEntry as { command?: unknown }).command;
+        console.log(`  Registered: yes`);
+        console.log(`  Command: ${Array.isArray(command) ? command.join(' ') : 'unknown'}`);
+      } else {
+        console.log(`  Registered: no`);
+      }
+    } else {
+      console.log(`  Registered: no (${getOpenCodeConfigPath()} does not exist)`);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(`  Registered: unknown (could not read config: ${message})`);
   }
 
   console.log('');

--- a/tests/integration/opencode-installer.test.ts
+++ b/tests/integration/opencode-installer.test.ts
@@ -3,12 +3,15 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
+  addOpenCodeMcpReference,
   addOpenCodePluginReference,
   deregisterOpenCodePluginFromConfig,
   getOpenCodeConfigPath,
-  removeOpenCodePluginReference,
   registerOpenCodePluginInConfig,
+  removeOpenCodeMcpReference,
+  removeOpenCodePluginReference,
 } from '../../src/services/integrations/OpenCodeInstaller.js';
+import { getMcpServerAbsolutePath } from '../../src/services/integrations/install-paths.js';
 
 describe('OpenCode installer config registration', () => {
   let tempDir: string;
@@ -75,6 +78,10 @@ describe('OpenCode installer config registration', () => {
     const config = JSON.parse(readFileSync(getOpenCodeConfigPath(), 'utf-8'));
     expect(config.$schema).toBe('https://opencode.ai/config.json');
     expect(config.plugin).toEqual(['./plugins/claude-mem.js']);
+    expect(config.mcp?.['claude-mem']).toMatchObject({ type: 'local' });
+    const mcpCommand = config.mcp['claude-mem'].command as string[];
+    expect(mcpCommand[0]).toBe(process.execPath);
+    expect(mcpCommand[1]).toBe(getMcpServerAbsolutePath());
   });
 
   it('preserves existing config fields when registering the plugin', () => {
@@ -90,12 +97,14 @@ describe('OpenCode installer config registration', () => {
     const config = JSON.parse(readFileSync(getOpenCodeConfigPath(), 'utf-8'));
     expect(config.plugin).toEqual(['context-mode', './plugins/claude-mem.js']);
     expect(config.provider).toEqual({ openai: { models: {} } });
+    expect(config.mcp?.['claude-mem']).toMatchObject({ type: 'local' });
   });
 
   it('removes the plugin reference from opencode.json during deregistration', () => {
     writeFileSync(getOpenCodeConfigPath(), JSON.stringify({
       $schema: 'https://opencode.ai/config.json',
       plugin: ['context-mode', './plugins/claude-mem.js'],
+      mcp: { 'claude-mem': { type: 'local', command: ['node', '/x/mcp-server.cjs'] } },
     }), 'utf-8');
 
     const result = deregisterOpenCodePluginFromConfig();
@@ -103,5 +112,54 @@ describe('OpenCode installer config registration', () => {
     expect(result).toBe(0);
     const config = JSON.parse(readFileSync(getOpenCodeConfigPath(), 'utf-8'));
     expect(config.plugin).toEqual(['context-mode']);
+    expect('mcp' in config).toBe(false);
+  });
+
+  it('adds the claude-mem MCP entry while preserving other MCP servers', () => {
+    const config = addOpenCodeMcpReference({
+      $schema: 'https://opencode.ai/config.json',
+      plugin: ['./plugins/claude-mem.js'],
+      mcp: { context7: { enabled: true } },
+    });
+
+    expect(config.mcp).toMatchObject({ context7: { enabled: true } });
+    expect(config.mcp?.['claude-mem']).toMatchObject({ type: 'local' });
+    const mcpCommand = (config.mcp?.['claude-mem'] as { command: string[] }).command;
+    expect(mcpCommand[0]).toBe(process.execPath);
+    expect(mcpCommand[1]).toBe(getMcpServerAbsolutePath());
+  });
+
+  it('is idempotent for an already-registered claude-mem MCP entry', () => {
+    const config: { $schema: string; plugin: string[]; mcp: Record<string, unknown> } = {
+      $schema: 'https://opencode.ai/config.json',
+      plugin: ['./plugins/claude-mem.js'],
+      mcp: {
+        'claude-mem': { type: 'local', command: [process.execPath, getMcpServerAbsolutePath()!] },
+        context7: { enabled: true },
+      },
+    };
+
+    expect(addOpenCodeMcpReference(config)).toBe(config);
+  });
+
+  it('removes only the claude-mem MCP entry, preserving other servers', () => {
+    const config = removeOpenCodeMcpReference({
+      plugin: ['./plugins/claude-mem.js'],
+      mcp: {
+        'claude-mem': { type: 'local', command: ['node', '/x/mcp-server.cjs'] },
+        context7: { enabled: true },
+      },
+    });
+
+    expect(config.mcp).toEqual({ context7: { enabled: true } });
+  });
+
+  it('drops the mcp block when it becomes empty', () => {
+    const config = removeOpenCodeMcpReference({
+      plugin: ['./plugins/claude-mem.js'],
+      mcp: { 'claude-mem': { type: 'local', command: ['node', '/x/mcp-server.cjs'] } },
+    });
+
+    expect('mcp' in config).toBe(false);
   });
 });


### PR DESCRIPTION
## Why

The OpenCode installer only wrote the plugin reference (`plugin: ["./plugins/claude-mem.js"]`), so the `claude-mem` MCP server never appeared in OpenCode. Users had to hand-edit `opencode.json` to add an `mcp.claude-mem` block before the MCP was discoverable.

## Changes

`src/services/integrations/OpenCodeInstaller.ts`:

- `addOpenCodeMcpReference` / `removeOpenCodeMcpReference` write/remove only `mcp["claude-mem"] = { "type": "local", "command": [node, "<absolute mcp-server.cjs>"] }`, preserving all other MCP servers. OpenCode does no `${CLAUDE_PLUGIN_ROOT}` substitution, so the path is baked absolute via the shared resolvers in `install-paths.ts` (Rule B).
- Registration writes plugin + MCP in one pass; deregistration removes both; `checkOpenCodeStatus` now reports MCP registration state.
- Fails safe: if the MCP script cannot be resolved, the plugin is still registered but no `mcp` block is written (with a logged warning), so a broken build never corrupts the user's `opencode.json`.

## Tests

`tests/integration/opencode-installer.test.ts`: MCP add/remove/idempotency, merge with existing MCP servers (e.g. `context7`), removal on deregistration, and the empty-`mcp`-block cleanup. The entry shape is asserted against OpenCode's local-server schema (`type: "local"`, `command: string[]`).

## Verification

- `npx tsc --noEmit` — clean
- `npm run build` — clean
- `tests/integration/` + `tests/integrations/`: 73/73 pass (incl. opencode-plugin-contract)