### PR TITLE
fix(chroma): make persistent backfills durable

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "plugin/modes",
     "plugin/scripts/*.js",
     "plugin/scripts/*.cjs",
+    "plugin/scripts/*.py",
     "plugin/sqlite",
     "plugin/skills",
     "plugin/ui",

--- a/plugin/scripts/chroma-mcp-bridge.py
+++ b/plugin/scripts/chroma-mcp-bridge.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""claude-mem's pinned chroma-mcp bridge.
+
+chroma-mcp 0.2.6's ``chroma_add_documents`` fetches every existing ID before
+each add. That makes a rebuild quadratic and pushes ordinary batches past the
+MCP client's 60-second deadline once a collection grows. Chroma's native
+``Collection.add`` already rejects duplicate IDs, so this bridge replaces only
+that tool with a direct, validation-equivalent call and leaves every other
+upstream tool untouched.
+"""
+
+import os
+from threading import Lock
+from typing import Dict, List
+
+
+def _lower_process_priority() -> None:
+    """Keep local embedding/index work from competing with interactive apps."""
+    if not hasattr(os, "setpriority") or not hasattr(os, "PRIO_PROCESS"):
+        return
+
+    try:
+        configured = int(os.environ.get("CLAUDE_MEM_CHROMA_NICE_LEVEL", "15"))
+    except ValueError:
+        configured = 15
+
+    target = min(20, max(0, configured))
+    try:
+        current = os.getpriority(os.PRIO_PROCESS, 0)
+        # Never raise the priority when a caller already launched us with a
+        # lower priority (for example an isolated rebuild under nice -n 20).
+        if target > current:
+            os.setpriority(os.PRIO_PROCESS, 0, target)
+    except OSError:
+        # Priority lowering is a load-safety optimization, not a condition for
+        # serving MCP. Sandboxed platforms may deny setpriority entirely.
+        pass
+
+
+# Apply priority before importing Chroma/ONNX, whose module initialization can
+# perform CPU-heavy native work as well as the later embedding calls.
+_lower_process_priority()
+
+from chromadb.api.types import DefaultEmbeddingFunction
+from chromadb.utils.embedding_functions import ONNXMiniLM_L6_V2
+from chroma_mcp.server import get_chroma_client, main, mcp
+
+
+# Chroma's DefaultEmbeddingFunction constructs ONNXMiniLM_L6_V2 inside every
+# __call__. chroma-mcp resolves a new collection facade for each MCP request,
+# so a rebuild otherwise reloads the same model for every 100-document batch.
+# Patch the class method so even already-created default instances share one
+# lazy model/tokenizer/session. The lock keeps a semantic query from racing a
+# backfill mutation through the same tokenizer/session object.
+_cached_onnx_embedding_function = ONNXMiniLM_L6_V2()
+_embedding_lock = Lock()
+
+
+def _cached_default_embedding_call(self, input):
+    with _embedding_lock:
+        return _cached_onnx_embedding_function(input)
+
+
+DefaultEmbeddingFunction.__call__ = _cached_default_embedding_call
+
+
+async def chroma_add_documents_fast(
+    collection_name: str,
+    documents: List[str],
+    ids: List[str],
+    metadatas: List[Dict] | None = None,
+) -> str:
+    """Add documents without chroma-mcp's full-collection duplicate scan."""
+    if not documents:
+        raise ValueError("The 'documents' list cannot be empty.")
+    if not ids:
+        raise ValueError("The 'ids' list is required and cannot be empty.")
+    if any(not document_id.strip() for document_id in ids):
+        raise ValueError("IDs cannot be empty strings.")
+    if len(ids) != len(documents):
+        raise ValueError(
+            f"Number of ids ({len(ids)}) must match number of documents ({len(documents)})."
+        )
+    if metadatas is not None and len(metadatas) != len(documents):
+        raise ValueError(
+            f"Number of metadatas ({len(metadatas)}) must match number of documents ({len(documents)})."
+        )
+
+    # Defense in depth for callers outside ChromaSync. SQLite's FTS5 trigram
+    # tokenizer persists a malformed inverted index when a document contains
+    # NUL, even though the add itself reports success.
+    documents = [document.replace("\x00", "\ufffd") for document in documents]
+
+    try:
+        collection = get_chroma_client().get_or_create_collection(collection_name)
+        collection.add(documents=documents, metadatas=metadatas, ids=ids)
+        return f"Successfully added {len(documents)} documents to collection {collection_name}"
+    except Exception as error:
+        raise Exception(
+            f"Failed to add documents to collection '{collection_name}': {error}"
+        ) from error
+
+
+tool_manager = getattr(mcp, "_tool_manager", None)
+registered_tools = getattr(tool_manager, "_tools", None)
+if not isinstance(registered_tools, dict) or "chroma_add_documents" not in registered_tools:
+    raise RuntimeError("Unsupported chroma-mcp/FastMCP tool registry; refusing an unverified bridge")
+
+del registered_tools["chroma_add_documents"]
+mcp.add_tool(
+    chroma_add_documents_fast,
+    name="chroma_add_documents",
+    description="Add documents to a Chroma collection.",
+)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -24,6 +24,8 @@ const MCP_CONNECTION_TIMEOUT_MS = 30_000;
 const DEFAULT_CHROMA_PREWARM_TIMEOUT_MS = 120_000;
 const CHROMA_PREWARM_TIMEOUT_SETTING = 'CLAUDE_MEM_CHROMA_PREWARM_TIMEOUT_MS';
 const CHROMA_PREWARM_TIMEOUT_BOUNDS = { min: 1, max: 600_000 } as const;
+const DEFAULT_CHROMA_MUTATION_TIMEOUT_MS = 600_000;
+const CHROMA_MUTATION_TIMEOUT_BOUNDS = { min: 60_000, max: 3_600_000 } as const;
 const CHROMA_PREWARM_REAP_TIMEOUT_MS = 1_000;
 const RECONNECT_BACKOFF_MS = 10_000;
 const CHROMA_WRITER_LOCK_FILENAME = '.claude-mem-chroma-writer.lock';
@@ -50,6 +52,10 @@ const CHROMA_MCP_PINNED_VERSION = '0.2.6';
 // These pins are runtime-only (uvx --with) so we don't have to fork
 // chroma-mcp upstream — they apply only to claude-mem's spawned subprocess.
 const CHROMA_MCP_DEP_OVERRIDES: ReadonlyArray<string> = [
+  // The bridge below patches verified chromadb 1.5.9 internals (default
+  // embedding reuse and the SQLite FTS NUL guard). Do not let uvx silently
+  // resolve a future, incompatible chromadb release underneath it.
+  'chromadb==1.5.9',
   'onnxruntime>=1.20',
   'protobuf<7',
 ];
@@ -93,6 +99,7 @@ export class ChromaMcpManager {
   private mutationTail: Promise<void> = Promise.resolve();
   private pendingMutationCalls = 0;
   private readonly maxPendingMutationCalls: number;
+  private readonly mutationTimeoutMs: number;
   private readonly serializeMutations: boolean;
   private acceptingLocalMutations = true;
   private static uvxAvailabilityProbe: ((command: string, env: Record<string, string>, platform: NodeJS.Platform) => boolean) | null = null;
@@ -103,6 +110,13 @@ export class ChromaMcpManager {
     this.maxPendingMutationCalls = Number.isInteger(configuredLimit) && configuredLimit > 0
       ? configuredLimit
       : DEFAULT_MAX_PENDING_MUTATIONS;
+    const configuredMutationTimeout = Number.parseInt(settings.CLAUDE_MEM_CHROMA_MUTATION_TIMEOUT_MS, 10);
+    this.mutationTimeoutMs = Number.isInteger(configuredMutationTimeout)
+      ? Math.min(
+          CHROMA_MUTATION_TIMEOUT_BOUNDS.max,
+          Math.max(CHROMA_MUTATION_TIMEOUT_BOUNDS.min, configuredMutationTimeout)
+        )
+      : DEFAULT_CHROMA_MUTATION_TIMEOUT_MS;
     this.serializeMutations = (settings.CLAUDE_MEM_CHROMA_MODE || 'local') !== 'remote';
   }
 
@@ -528,20 +542,29 @@ export class ChromaMcpManager {
 
   private static buildLauncherPrefix(pythonVersion: string): string[] {
     const depOverrideFlags = CHROMA_MCP_DEP_OVERRIDES.flatMap(spec => ['--with', spec]);
+    const bridgeScript = ChromaMcpManager.resolveBridgeScript();
     return [
       '--python', pythonVersion,
       ...depOverrideFlags,
       '--from', `chroma-mcp==${CHROMA_MCP_PINNED_VERSION}`,
-      'chroma-mcp',
+      ...(bridgeScript ? ['python', bridgeScript] : ['chroma-mcp']),
     ];
   }
 
   private static buildPrewarmCommandArgs(commandArgs: string[]): string[] {
-    const executableIndex = commandArgs.indexOf('chroma-mcp');
-    const launcherPrefix = executableIndex >= 0
-      ? commandArgs.slice(0, executableIndex + 1)
-      : commandArgs;
+    const pythonIndex = commandArgs.indexOf('python');
+    const executableIndex = pythonIndex >= 0 ? pythonIndex + 1 : commandArgs.indexOf('chroma-mcp');
+    const launcherPrefix = executableIndex >= 0 ? commandArgs.slice(0, executableIndex + 1) : commandArgs;
     return [...launcherPrefix, '--help'];
+  }
+
+  private static resolveBridgeScript(): string | null {
+    const entryDir = process.argv[1] ? path.dirname(path.resolve(process.argv[1])) : '';
+    const candidates = [
+      entryDir ? path.join(entryDir, 'chroma-mcp-bridge.py') : '',
+      path.join(process.cwd(), 'plugin', 'scripts', 'chroma-mcp-bridge.py'),
+    ].filter(Boolean);
+    return candidates.find(candidate => fs.existsSync(candidate)) ?? null;
   }
 
   private static parseBoundedTimeoutMs(rawValue: string | undefined): number | null {
@@ -716,8 +739,19 @@ export class ChromaMcpManager {
     const callGeneration = this.connectionGeneration;
     await this.ensureConnected();
 
+    // Chroma embedding/index mutations routinely exceed the MCP SDK's
+    // 60-second default once a persistent collection grows. The SDK treats
+    // that deadline as a request failure; our reconnect path then tears down
+    // chroma-mcp while SQLite/FTS5 may still be committing, which can leave the
+    // persistent index malformed. Give mutations a bounded, configurable
+    // deadline while keeping read/query latency at the SDK default.
+    const requestOptions = ChromaMcpManager.isMutationTool(toolName)
+      ? { timeout: this.mutationTimeoutMs }
+      : undefined;
+
     logger.debug('CHROMA_MCP', `Calling tool: ${toolName}`, {
-      arguments: JSON.stringify(toolArguments).slice(0, 200)
+      arguments: JSON.stringify(toolArguments).slice(0, 200),
+      ...(requestOptions ? { timeoutMs: requestOptions.timeout } : {})
     });
 
     let result;
@@ -725,7 +759,7 @@ export class ChromaMcpManager {
       result = await this.client!.callTool({
         name: toolName,
         arguments: toolArguments
-      });
+      }, undefined, requestOptions);
     } catch (transportError) {
       logger.warn('CHROMA_MCP', `Transport error during "${toolName}", reconnecting and retrying once`, {
         error: transportError instanceof Error ? transportError.message : String(transportError)
@@ -748,7 +782,7 @@ export class ChromaMcpManager {
         result = await this.client!.callTool({
           name: toolName,
           arguments: toolArguments
-        });
+        }, undefined, requestOptions);
       } catch (retryError) {
         this.connected = false;
         throw new Error(`chroma-mcp transport error during "${toolName}" (retry failed): ${retryError instanceof Error ? retryError.message : String(retryError)}`);

--- a/src/services/sync/ChromaSync.ts
+++ b/src/services/sync/ChromaSync.ts
@@ -151,8 +151,6 @@ export class ChromaSync {
   }
 
   private formatObservationDocs(obs: StoredObservation): ChromaDocument[] {
-    const documents: ChromaDocument[] = [];
-
     const facts = obs.facts ? JSON.parse(obs.facts) : [];
     const concepts = obs.concepts ? JSON.parse(obs.concepts) : [];
     // parseFileList is SQLite-shaped (`bun:sqlite` in the import chain) —
@@ -189,36 +187,33 @@ export class ChromaSync {
       baseMetadata.files_modified = files_modified.join(',');
     }
 
-    if (obs.narrative) {
-      documents.push({
-        id: `obs_${obs.id}_narrative`,
-        document: obs.narrative,
-        metadata: { ...baseMetadata, field_type: 'narrative' }
-      });
+    // Search hydrates the complete SQLite row after Chroma returns its id, so
+    // emitting one vector per field only multiplies embeddings and crowds the
+    // top-k with duplicate hits for the same observation. Keep a single,
+    // prioritized semantic projection per source row. Retain the historical
+    // `_narrative` id shape so typed-id hydration and in-place upgrades remain
+    // compatible.
+    const semanticProjection = [
+      obs.title ? `Title: ${obs.title}` : '',
+      obs.subtitle ? `Subtitle: ${obs.subtitle}` : '',
+      obs.narrative ? `Narrative: ${obs.narrative}` : '',
+      facts.length > 0 ? `Facts: ${facts.join(' | ')}` : '',
+      obs.text ? `Text: ${obs.text}` : '',
+      concepts.length > 0 ? `Concepts: ${concepts.join(', ')}` : '',
+    ].filter(Boolean).join('\n');
+
+    if (!semanticProjection) {
+      return [];
     }
 
-    if (obs.text) {
-      documents.push({
-        id: `obs_${obs.id}_text`,
-        document: obs.text,
-        metadata: { ...baseMetadata, field_type: 'text' }
-      });
-    }
-
-    facts.forEach((fact: string, index: number) => {
-      documents.push({
-        id: `obs_${obs.id}_fact_${index}`,
-        document: fact,
-        metadata: { ...baseMetadata, field_type: 'fact', fact_index: index }
-      });
-    });
-
-    return documents;
+    return [{
+      id: `obs_${obs.id}_narrative`,
+      document: semanticProjection,
+      metadata: { ...baseMetadata, field_type: 'narrative' }
+    }];
   }
 
   private formatSummaryDocs(summary: StoredSummary): ChromaDocument[] {
-    const documents: ChromaDocument[] = [];
-
     const baseMetadata: Record<string, string | number | null> = {
       sqlite_id: summary.id,
       doc_type: 'session_summary',
@@ -232,55 +227,24 @@ export class ChromaSync {
       prompt_number: summary.prompt_number || 0
     };
 
-    if (summary.request) {
-      documents.push({
-        id: `summary_${summary.id}_request`,
-        document: summary.request,
-        metadata: { ...baseMetadata, field_type: 'request' }
-      });
+    const semanticProjection = [
+      summary.request ? `Request: ${summary.request}` : '',
+      summary.completed ? `Completed: ${summary.completed}` : '',
+      summary.learned ? `Learned: ${summary.learned}` : '',
+      summary.investigated ? `Investigated: ${summary.investigated}` : '',
+      summary.next_steps ? `Next steps: ${summary.next_steps}` : '',
+      summary.notes ? `Notes: ${summary.notes}` : '',
+    ].filter(Boolean).join('\n');
+
+    if (!semanticProjection) {
+      return [];
     }
 
-    if (summary.investigated) {
-      documents.push({
-        id: `summary_${summary.id}_investigated`,
-        document: summary.investigated,
-        metadata: { ...baseMetadata, field_type: 'investigated' }
-      });
-    }
-
-    if (summary.learned) {
-      documents.push({
-        id: `summary_${summary.id}_learned`,
-        document: summary.learned,
-        metadata: { ...baseMetadata, field_type: 'learned' }
-      });
-    }
-
-    if (summary.completed) {
-      documents.push({
-        id: `summary_${summary.id}_completed`,
-        document: summary.completed,
-        metadata: { ...baseMetadata, field_type: 'completed' }
-      });
-    }
-
-    if (summary.next_steps) {
-      documents.push({
-        id: `summary_${summary.id}_next_steps`,
-        document: summary.next_steps,
-        metadata: { ...baseMetadata, field_type: 'next_steps' }
-      });
-    }
-
-    if (summary.notes) {
-      documents.push({
-        id: `summary_${summary.id}_notes`,
-        document: summary.notes,
-        metadata: { ...baseMetadata, field_type: 'notes' }
-      });
-    }
-
-    return documents;
+    return [{
+      id: `summary_${summary.id}_request`,
+      document: semanticProjection,
+      metadata: { ...baseMetadata, field_type: 'request' }
+    }];
   }
 
   /**
@@ -301,6 +265,28 @@ export class ChromaSync {
   public async addDocuments(documents: ChromaDocument[]): Promise<number> {
     if (documents.length === 0) {
       return 0;
+    }
+
+    // SQLite FTS5's trigram tokenizer accepts NUL-containing TEXT but builds
+    // an index that subsequently fails PRAGMA quick_check / integrity_check as
+    // "malformed inverted index". Codex transcripts can legitimately contain
+    // NUL bytes copied from terminal or binary output, so sanitize at the last
+    // common boundary before every Chroma add/update path. U+FFFD preserves a
+    // visible boundary without making unrelated text run together.
+    let nulSanitizedDocuments = 0;
+    const safeDocuments = documents.map(document => {
+      if (!document.document.includes('\0')) return document;
+      nulSanitizedDocuments += 1;
+      return {
+        ...document,
+        document: document.document.replaceAll('\0', '\uFFFD'),
+      };
+    });
+    if (nulSanitizedDocuments > 0) {
+      logger.warn('CHROMA_SYNC', 'Sanitized NUL bytes before Chroma FTS indexing', {
+        collection: this.collectionName,
+        documents: nulSanitizedDocuments,
+      });
     }
 
     try {
@@ -325,8 +311,8 @@ export class ChromaSync {
     const chromaMcp = ChromaMcpManager.getInstance();
 
     let written = 0;
-    for (let i = 0; i < documents.length; i += this.BATCH_SIZE) {
-      const batch = documents.slice(i, i + this.BATCH_SIZE);
+    for (let i = 0; i < safeDocuments.length; i += this.BATCH_SIZE) {
+      const batch = safeDocuments.slice(i, i + this.BATCH_SIZE);
 
       const cleanMetadatas = batch.map(d =>
         Object.fromEntries(
@@ -687,12 +673,17 @@ export class ChromaSync {
       WHERE project = ?
       ORDER BY id ASC
     `).all(project) as Array<{ id: number }>;
+    // Codex transcript/hook imports can contain replay bursts of the same
+    // prompt text hundreds of times inside one session. Chroma only needs the
+    // latest occurrence for semantic retrieval; indexing every replay both
+    // crowds the top-k results and turns recovery into a multi-hour rebuild.
     const promptIds = store.db.prepare(`
-      SELECT up.id
+      SELECT MAX(up.id) AS id
       FROM user_prompts up
       JOIN sdk_sessions s ON up.session_db_id = s.id
       WHERE s.project = ?
-      ORDER BY up.id ASC
+      GROUP BY up.session_db_id, up.prompt_text
+      ORDER BY id ASC
     `).all(project) as Array<{ id: number }>;
     const observationBootstrap = this.summarizeBootstrapPending(observationIds.map(row => row.id), existing.observations);
     const summaryBootstrap = this.summarizeBootstrapPending(summaryIds.map(row => row.id), existing.summaries);
@@ -749,11 +740,11 @@ export class ChromaSync {
    * Shared batch/watermark loop for all three backfill kinds. Returns the
    * number of documents produced from `rows`.
    *
-   * Watermark durability is row-atomic, not batch-atomic: one observation or
-   * summary can expand into several Chroma documents and span multiple
-   * BATCH_SIZE writes. We only clear pending state and bump the row watermark
-   * after every document for that row lands, otherwise a later batch failure or
-   * restart can strand the tail of a split row forever.
+   * Watermark correctness is row-atomic, but transport writes are document-
+   * batched. Packing complete source rows into BATCH_SIZE calls avoids one MCP
+   * embedding request per observation while still recording every source row
+   * in an under-written batch as pending. A single source row larger than one
+   * batch remains pending until all of its chunks land.
    */
   private async backfillKind<T extends { id: number }>(
     rows: T[],
@@ -764,47 +755,92 @@ export class ChromaSync {
     const rowsWithDocs = rows.map(row => ({ row, docs: formatDocs(row) }));
     const totalDocs = rowsWithDocs.reduce((sum, { docs }) => sum + docs.length, 0);
     let processedDocs = 0;
+    let pendingBatch: Array<{ row: T; docs: ChromaDocument[] }> = [];
+    let pendingDocCount = 0;
 
-    for (const { row, docs } of rowsWithDocs) {
-      if (docs.length === 0) {
-        continue;
-      }
+    const logProgress = (): void => {
+      logger.debug('CHROMA_SYNC', 'Backfill progress', {
+        project: backfillProject,
+        progress: `${Math.min(processedDocs, totalDocs)}/${totalDocs}`
+      });
+    };
 
-      let rowComplete = true;
-      for (let i = 0; i < docs.length; i += this.BATCH_SIZE) {
-        const batch = docs.slice(i, i + this.BATCH_SIZE);
-        const writtenInBatch = await this.addDocuments(batch);
-        processedDocs += batch.length;
-        // Only advance the watermark for documents that actually landed in
-        // Chroma. addDocuments() logs and continues on per-batch failures, so a
-        // partial write must not mark unwritten docs as synced.
-        if (writtenInBatch < batch.length) {
-          ChromaSyncState.markPending(backfillProject, kind, [row.id]);
-          logger.debug('CHROMA_SYNC', 'Recorded pending watermark gap for failed/partial row batch', {
-            project: backfillProject,
-            kind,
-            rowId: row.id,
-            batchStart: i,
-            requested: batch.length,
-            written: writtenInBatch
-          });
-          rowComplete = false;
-          break;
-        }
+    const flushPackedRows = async (): Promise<void> => {
+      if (pendingBatch.length === 0) return;
 
-        logger.debug('CHROMA_SYNC', 'Backfill progress', {
+      const batchRows = pendingBatch;
+      const batch = batchRows.flatMap(({ docs }) => docs);
+      const rowIds = batchRows.map(({ row }) => row.id);
+      pendingBatch = [];
+      pendingDocCount = 0;
+
+      const writtenInBatch = await this.addDocuments(batch);
+      processedDocs += batch.length;
+      if (writtenInBatch === batch.length) {
+        ChromaSyncState.completeBatch(backfillProject, kind, rowIds);
+      } else {
+        // addDocuments reports a count, not the identities that landed. Keep
+        // every source row in the partial batch pending rather than advancing
+        // a watermark across an uncertain gap.
+        ChromaSyncState.markPending(backfillProject, kind, rowIds);
+        logger.debug('CHROMA_SYNC', 'Recorded pending watermark gaps for failed/partial packed batch', {
           project: backfillProject,
-          progress: `${Math.min(processedDocs, totalDocs)}/${totalDocs}`
+          kind,
+          rowIds,
+          requested: batch.length,
+          written: writtenInBatch
         });
       }
+      logProgress();
+    };
 
-      if (!rowComplete) {
+    for (const entry of rowsWithDocs) {
+      const { row, docs } = entry;
+      if (docs.length === 0) {
+        await flushPackedRows();
+        ChromaSyncState.completeBatch(backfillProject, kind, [row.id]);
         continue;
       }
 
-      ChromaSyncState.clearPending(backfillProject, kind, [row.id]);
-      ChromaSyncState.bump(backfillProject, kind, row.id);
+      if (docs.length > this.BATCH_SIZE) {
+        await flushPackedRows();
+        let rowComplete = true;
+        for (let i = 0; i < docs.length; i += this.BATCH_SIZE) {
+          const batch = docs.slice(i, i + this.BATCH_SIZE);
+          const writtenInBatch = await this.addDocuments(batch);
+          processedDocs += batch.length;
+          if (writtenInBatch < batch.length) {
+            ChromaSyncState.markPending(backfillProject, kind, [row.id]);
+            logger.debug('CHROMA_SYNC', 'Recorded pending watermark gap for failed/partial oversized row', {
+              project: backfillProject,
+              kind,
+              rowId: row.id,
+              batchStart: i,
+              requested: batch.length,
+              written: writtenInBatch
+            });
+            rowComplete = false;
+            break;
+          }
+          logProgress();
+        }
+        if (rowComplete) {
+          ChromaSyncState.completeBatch(backfillProject, kind, [row.id]);
+        }
+        continue;
+      }
+
+      if (pendingDocCount + docs.length > this.BATCH_SIZE) {
+        await flushPackedRows();
+      }
+      pendingBatch.push(entry);
+      pendingDocCount += docs.length;
+      if (pendingDocCount === this.BATCH_SIZE) {
+        await flushPackedRows();
+      }
     }
+
+    await flushPackedRows();
 
     return totalDocs;
   }
@@ -924,15 +960,24 @@ export class ChromaSync {
   ): Promise<number> {
     const pendingIds = ChromaSyncState.getPending(backfillProject, 'prompts');
     const prompts = db.db.prepare(`
-      SELECT
-        up.*,
-        s.project,
-        s.memory_session_id,
-        COALESCE(NULLIF(s.platform_source, ''), 'claude') as platform_source
-      FROM user_prompts up
-      JOIN sdk_sessions s ON up.session_db_id = s.id
-      WHERE s.project = ? AND up.id > ?
-      ORDER BY up.id ASC
+      WITH deduped_prompts AS (
+        SELECT
+          up.*,
+          s.project,
+          s.memory_session_id,
+          COALESCE(NULLIF(s.platform_source, ''), 'claude') as platform_source,
+          ROW_NUMBER() OVER (
+            PARTITION BY up.session_db_id, up.prompt_text
+            ORDER BY up.id DESC
+          ) as dedupe_rank
+        FROM user_prompts up
+        JOIN sdk_sessions s ON up.session_db_id = s.id
+        WHERE s.project = ?
+      )
+      SELECT *
+      FROM deduped_prompts
+      WHERE dedupe_rank = 1 AND id > ?
+      ORDER BY id ASC
     `).all(backfillProject, watermark) as StoredUserPrompt[];
     let pendingRows: StoredUserPrompt[] = [];
     if (pendingIds.length > 0) {
@@ -946,6 +991,13 @@ export class ChromaSync {
         FROM user_prompts up
         JOIN sdk_sessions s ON up.session_db_id = s.id
         WHERE s.project = ? AND up.id IN (${placeholders})
+          AND NOT EXISTS (
+            SELECT 1
+            FROM user_prompts newer
+            WHERE newer.session_db_id = up.session_db_id
+              AND newer.prompt_text = up.prompt_text
+              AND newer.id > up.id
+          )
         ORDER BY up.id ASC
       `).all(backfillProject, ...pendingIds) as StoredUserPrompt[];
       const foundPendingIds = new Set(pendingRows.map(row => row.id));
@@ -962,9 +1014,13 @@ export class ChromaSync {
 
     const totalPromptCount = db.db.prepare(`
       SELECT COUNT(*) as count
-      FROM user_prompts up
-      JOIN sdk_sessions s ON up.session_db_id = s.id
-      WHERE s.project = ?
+      FROM (
+        SELECT 1
+        FROM user_prompts up
+        JOIN sdk_sessions s ON up.session_db_id = s.id
+        WHERE s.project = ?
+        GROUP BY up.session_db_id, up.prompt_text
+      )
     `).get(backfillProject) as { count: number };
 
     logger.info('CHROMA_SYNC', 'Backfilling user prompts', {
@@ -1068,7 +1124,9 @@ export class ChromaSync {
   private static backfillInProgress = false;
 
   /**
-   * Backfill all projects that have observations in SQLite but may be missing from Chroma.
+   * Backfill all projects that have any searchable SQLite entity but may be
+   * missing from Chroma. Some Codex/worktree projects contain prompts only;
+   * enumerating observations alone silently omitted those projects forever.
    * Uses a single shared ChromaSync('claude-mem') instance and Chroma connection.
    * Per-project scoping is passed as a parameter to ensureBackfilled(), avoiding
    * instance state mutation. All documents land in the cm__claude-mem collection
@@ -1089,9 +1147,21 @@ export class ChromaSync {
 
     ChromaSync.backfillInProgress = true;
     try {
-      const projects = store.db.prepare(
-        'SELECT DISTINCT project FROM observations WHERE project IS NOT NULL AND project != ?'
-      ).all('') as { project: string }[];
+      const projects = store.db.prepare(`
+        SELECT project
+        FROM observations
+        WHERE project IS NOT NULL AND project != ''
+        UNION
+        SELECT project
+        FROM session_summaries
+        WHERE project IS NOT NULL AND project != ''
+        UNION
+        SELECT s.project
+        FROM user_prompts up
+        JOIN sdk_sessions s ON s.id = up.session_db_id
+        WHERE s.project IS NOT NULL AND s.project != ''
+        ORDER BY project
+      `).all() as { project: string }[];
 
       logger.info('CHROMA_SYNC', `Backfill check for ${projects.length} projects`);
 
@@ -1114,6 +1184,7 @@ export class ChromaSync {
       // before starting the next one. Simple and predictable — no semaphore
       // overhead, no unbounded fan-out.
       const concurrency = ChromaSync.BACKFILL_CONCURRENCY_LIMIT;
+      const failedProjects = new Set<string>();
       for (let i = 0; i < projects.length; i += concurrency) {
         const chunk = projects.slice(i, i + concurrency);
         const chunkResults = await Promise.allSettled(
@@ -1124,6 +1195,7 @@ export class ChromaSync {
           const result = chunkResults[j];
           if (result.status === 'rejected') {
             const project = chunk[j].project;
+            failedProjects.add(project);
             const error = result.reason;
             if (error instanceof Error) {
               logger.error('CHROMA_SYNC', `Backfill failed for project: ${project}`, {}, error);
@@ -1133,6 +1205,54 @@ export class ChromaSync {
             // Continue to next chunk — don't let one failure stop others
           }
         }
+      }
+
+      // addDocuments deliberately records uncertain rows as pending instead
+      // of aborting the whole rebuild. Give transient failures one bounded
+      // repair pass, then reject the overall backfill if any gap remains so
+      // worker-service never logs a false "complete for all projects" result.
+      const kinds: Array<'observations' | 'summaries' | 'prompts'> = [
+        'observations',
+        'summaries',
+        'prompts',
+      ];
+      const projectsWithPending = projects
+        .map(({ project }) => project)
+        .filter(project => kinds.some(kind => ChromaSyncState.getPending(project, kind).length > 0));
+      const repairProjects = [...new Set([...failedProjects, ...projectsWithPending])];
+
+      if (repairProjects.length > 0) {
+        logger.warn('CHROMA_SYNC', 'Retrying incomplete projects once', {
+          projects: repairProjects,
+        });
+        for (const project of repairProjects) {
+          try {
+            await sync.ensureBackfilled(project, store);
+            failedProjects.delete(project);
+          } catch (error) {
+            failedProjects.add(project);
+            logger.error('CHROMA_SYNC', `Backfill repair failed for project: ${project}`,
+              {}, error instanceof Error ? error : new Error(String(error)));
+          }
+        }
+      }
+
+      const unresolvedPending = projects
+        .map(({ project }) => ({
+          project,
+          pending: Object.fromEntries(
+            kinds
+              .map(kind => [kind, ChromaSyncState.getPending(project, kind)] as const)
+              .filter(([, ids]) => ids.length > 0),
+          ),
+        }))
+        .filter(({ pending }) => Object.keys(pending).length > 0);
+
+      if (failedProjects.size > 0 || unresolvedPending.length > 0) {
+        throw new Error(
+          `Chroma backfill incomplete: failedProjects=${JSON.stringify([...failedProjects])} ` +
+          `pending=${JSON.stringify(unresolvedPending)}`
+        );
       }
     } finally {
       ChromaSync.backfillInProgress = false;

--- a/src/services/sync/ChromaSyncState.ts
+++ b/src/services/sync/ChromaSyncState.ts
@@ -127,6 +127,51 @@ export const ChromaSyncState = {
     persist();
   },
 
+  /**
+   * Mark a group of source rows durable with one state-file write.
+   *
+   * Backfill writes Chroma documents in batches. Persisting the watermark once
+   * per source row turns a large rebuild into thousands of tiny fsync/rename
+   * cycles, so successful batches advance to their highest row id and clear
+   * any repaired gaps atomically.
+   */
+  completeBatch(project: string, kind: DocKind, ids: number[]): void {
+    const normalizedIds = normalizePendingIds(ids);
+    if (normalizedIds.length === 0) return;
+
+    const all = load();
+    const current = normalizeProjectWatermarks(all[project] ?? ZERO);
+    let changed = false;
+    const highestId = normalizedIds[normalizedIds.length - 1];
+
+    if (highestId > current[kind]) {
+      current[kind] = highestId;
+      changed = true;
+    }
+
+    const pending = current.pending?.[kind] ?? [];
+    if (pending.length > 0) {
+      const completed = new Set(normalizedIds);
+      const filtered = pending.filter(id => !completed.has(id));
+      if (filtered.length !== pending.length) {
+        current.pending = current.pending ?? {};
+        if (filtered.length === 0) {
+          delete current.pending[kind];
+        } else {
+          current.pending[kind] = filtered;
+        }
+        if (current.pending && Object.keys(current.pending).length === 0) {
+          delete current.pending;
+        }
+        changed = true;
+      }
+    }
+
+    if (!changed) return;
+    all[project] = current;
+    persist();
+  },
+
   replace(project: string, marks: ProjectWatermarks): void {
     const all = load();
     all[project] = normalizeProjectWatermarks(marks);

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -78,6 +78,7 @@ export interface SettingsDefaults {
   CLAUDE_MEM_CHROMA_TENANT: string;
   CLAUDE_MEM_CHROMA_DATABASE: string;
   CLAUDE_MEM_CHROMA_PREWARM_TIMEOUT_MS: string;
+  CLAUDE_MEM_CHROMA_MUTATION_TIMEOUT_MS: string;
   CLAUDE_MEM_CHROMA_MAX_PENDING_MUTATIONS: string;
   // Worker-native cloud sync. Active ⇔ TOKEN, USER_ID, and HUB_URL are all
   // non-empty — there is no separate enabled flag. HUB_URL points at the
@@ -173,6 +174,7 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_CHROMA_TENANT: 'default_tenant',
     CLAUDE_MEM_CHROMA_DATABASE: 'default_database',
     CLAUDE_MEM_CHROMA_PREWARM_TIMEOUT_MS: '120000',
+    CLAUDE_MEM_CHROMA_MUTATION_TIMEOUT_MS: '600000', // Chroma embedding/index writes can exceed the MCP SDK's 60s default
     CLAUDE_MEM_CHROMA_MAX_PENDING_MUTATIONS: '5000', // Bound burst imports without changing normal live indexing
     // Worker-native cloud sync: credentials come from cmem.ai → Connect.
     CLAUDE_MEM_CLOUD_SYNC_TOKEN: '',

--- a/tests/services/sync/chroma-mcp-manager-singleton.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-singleton.test.ts
@@ -124,7 +124,10 @@ mock.module('@modelcontextprotocol/sdk/client/stdio.js', () => ({
 }));
 
 let connectImpl: (transport: FakeTransport) => Promise<void> = async () => {};
-let callToolImpl: (request?: { name: string; arguments?: Record<string, unknown> }) => Promise<unknown> = async () => ({
+let callToolImpl: (
+  request?: { name: string; arguments?: Record<string, unknown> },
+  options?: { timeout?: number }
+) => Promise<unknown> = async () => ({
   content: [{ type: 'text', text: '{}' }],
 });
 
@@ -133,8 +136,12 @@ class FakeClient {
   async connect(transport: FakeTransport): Promise<void> {
     await connectImpl(transport);
   }
-  async callTool(request?: { name: string; arguments?: Record<string, unknown> }): Promise<unknown> {
-    return await callToolImpl(request);
+  async callTool(
+    request?: { name: string; arguments?: Record<string, unknown> },
+    _resultSchema?: unknown,
+    options?: { timeout?: number }
+  ): Promise<unknown> {
+    return await callToolImpl(request, options);
   }
   async close(): Promise<void> {
     this.closed = true;
@@ -151,6 +158,7 @@ mock.module('../../../src/shared/SettingsDefaultsManager.js', () => ({
     getInt: () => 0,
     loadFromFile: () => ({
       CLAUDE_MEM_CHROMA_MAX_PENDING_MUTATIONS: '5000',
+      CLAUDE_MEM_CHROMA_MUTATION_TIMEOUT_MS: '600000',
       ...mockedSettings,
     }),
   },
@@ -420,6 +428,26 @@ describe('ChromaMcpManager singleton enforcement (#2313)', () => {
     await Promise.all([firstMutation, secondMutation]);
 
     expect(maxActiveMutations).toBe(1);
+  });
+
+  it('extends only mutation request timeouts and honors the configured bound', async () => {
+    mockedSettings = {
+      CLAUDE_MEM_CHROMA_MUTATION_TIMEOUT_MS: '900000',
+    };
+    const mgr = ChromaMcpManager.getInstance();
+    const calls: Array<{ name?: string; timeout?: number }> = [];
+    callToolImpl = async (request, options) => {
+      calls.push({ name: request?.name, timeout: options?.timeout });
+      return { content: [{ type: 'text', text: '{}' }] };
+    };
+
+    await mgr.callTool('chroma_add_documents', { ids: ['one'] });
+    await mgr.callTool('chroma_query_documents', { query_texts: ['fast read'] });
+
+    expect(calls).toEqual([
+      { name: 'chroma_add_documents', timeout: 900000 },
+      { name: 'chroma_query_documents', timeout: undefined },
+    ]);
   });
 
   it('bounds the pending mutation queue and leaves rejected writes for backfill', async () => {

--- a/tests/services/sync/chroma-mcp-manager-ssl.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-ssl.test.ts
@@ -120,11 +120,13 @@ function expectLauncherPrefixBeforeMode(args: string[], mode: 'http' | 'persiste
   const fromIdx = args.indexOf('--from');
   expect(fromIdx).toBeGreaterThan(-1);
   expect(args[fromIdx + 1]).toBe('chroma-mcp==0.2.6');
-  expect(args[fromIdx + 2]).toBe('chroma-mcp');
-  expect(args[fromIdx + 3]).toBe('--client-type');
-  expect(args[fromIdx + 4]).toBe(mode);
+  expect(args[fromIdx + 2]).toBe('python');
+  expect(args[fromIdx + 3]).toEndWith('plugin/scripts/chroma-mcp-bridge.py');
+  expect(args[fromIdx + 4]).toBe('--client-type');
+  expect(args[fromIdx + 5]).toBe(mode);
   expect(args.slice(0, fromIdx)).toEqual([
     '--python', '3.13',
+    '--with', 'chromadb==1.5.9',
     '--with', 'onnxruntime>=1.20',
     '--with', 'protobuf<7',
   ]);

--- a/tests/services/sync/chroma-sync-reconcile.test.ts
+++ b/tests/services/sync/chroma-sync-reconcile.test.ts
@@ -61,6 +61,19 @@ function newSync(): ChromaSync {
 }
 
 describe('ChromaSync duplicate-ID reconcile', () => {
+  it('sanitizes NUL bytes before Chroma add to prevent trigram FTS corruption', async () => {
+    const sync = newSync();
+
+    const written = await sync.addDocuments([
+      { id: 'prompt_1', document: 'before\0after', metadata: { sqlite_id: 1 } },
+    ]);
+
+    expect(written).toBe(1);
+    const add = calls.find(call => call.tool === 'chroma_add_documents');
+    expect(add?.args.documents).toEqual(['before\uFFFDafter']);
+    expect(add?.args.documents[0]).not.toContain('\0');
+  });
+
   it('coalesces concurrent collection creation into one Chroma mutation', async () => {
     const sync = new ChromaSync('project');
     let releaseCreation: (() => void) | null = null;

--- a/tests/services/sync/chroma-sync-watermarks.test.ts
+++ b/tests/services/sync/chroma-sync-watermarks.test.ts
@@ -8,6 +8,7 @@ const realChromaMcpManagerSnapshot = { ...realChromaMcpManager };
 
 let existingObservationIds = new Set<number>();
 const addDocumentCalls: string[][] = [];
+let addFailuresRemaining = 0;
 
 mock.module('../../../src/services/sync/ChromaMcpManager.js', () => ({
   ChromaMcpManager: {
@@ -33,6 +34,10 @@ mock.module('../../../src/services/sync/ChromaMcpManager.js', () => ({
 
         if (toolName === 'chroma_add_documents') {
           addDocumentCalls.push((args.ids as string[]) ?? []);
+          if (addFailuresRemaining > 0) {
+            addFailuresRemaining -= 1;
+            throw new Error('simulated transient Chroma add failure');
+          }
           return {};
         }
 
@@ -44,6 +49,7 @@ mock.module('../../../src/services/sync/ChromaMcpManager.js', () => ({
 
 import { ChromaSync } from '../../../src/services/sync/ChromaSync.js';
 import { ChromaSyncState } from '../../../src/services/sync/ChromaSyncState.js';
+import { SessionStore } from '../../../src/services/sqlite/SessionStore.js';
 
 afterAll(() => {
   mock.module('../../../src/services/sync/ChromaMcpManager.js', () => realChromaMcpManagerSnapshot);
@@ -138,6 +144,7 @@ describe('ChromaSync watermark gap persistence', () => {
     process.env.CLAUDE_MEM_DATA_DIR = mkdtempSync(join(tmpdir(), 'claude-mem-watermarks-'));
     existingObservationIds = new Set<number>();
     addDocumentCalls.length = 0;
+    addFailuresRemaining = 0;
     ChromaSyncState.replace(project, { observations: 0, summaries: 0, prompts: 0, pending: {} });
   });
 
@@ -213,6 +220,14 @@ describe('ChromaSync watermark gap persistence', () => {
     const sync = new ChromaSync(project) as ChromaSync & {
       addDocuments: (documents: Array<{ id: string }>) => Promise<number>;
     };
+    (sync as any).formatObservationDocs = () => Array.from(
+      { length: 102 },
+      (_, index) => ({
+        id: index === 0 ? 'obs_1_narrative' : `obs_1_fact_${index - 1}`,
+        document: `Document ${index}`,
+        metadata: { sqlite_id: 1 },
+      }),
+    );
     let callCount = 0;
     sync.addDocuments = async (documents) => {
       addDocumentCalls.push(documents.map(document => document.id));
@@ -235,5 +250,134 @@ describe('ChromaSync watermark gap persistence', () => {
     expect(ChromaSyncState.get(project).observations).toBe(1);
     expect(ChromaSyncState.getPending(project, 'observations')).toEqual([]);
     expect(addDocumentCalls.some(batch => batch.includes('obs_1_fact_100'))).toBe(true);
+  });
+
+  it('packs complete source rows into document batches instead of one MCP call per row', async () => {
+    const rows = Array.from({ length: 120 }, (_, index) => makeObservationRow(index + 1, project));
+    const sync = new ChromaSync(project) as ChromaSync & {
+      addDocuments: (documents: Array<{ id: string }>) => Promise<number>;
+    };
+    sync.addDocuments = async (documents) => {
+      addDocumentCalls.push(documents.map(document => document.id));
+      return documents.length;
+    };
+
+    await sync.ensureBackfilled(project, makeStoreFromRows(project, rows));
+
+    expect(addDocumentCalls.map(batch => batch.length)).toEqual([100, 20]);
+    expect(ChromaSyncState.get(project).observations).toBe(120);
+    expect(ChromaSyncState.getPending(project, 'observations')).toEqual([]);
+  });
+
+  it('persists every uncertain row in a partial packed batch and repairs it on retry', async () => {
+    const rows = Array.from({ length: 120 }, (_, index) => makeObservationRow(index + 1, project));
+    const sync = new ChromaSync(project) as ChromaSync & {
+      addDocuments: (documents: Array<{ id: string }>) => Promise<number>;
+    };
+    let callCount = 0;
+    sync.addDocuments = async (documents) => {
+      addDocumentCalls.push(documents.map(document => document.id));
+      callCount += 1;
+      return callCount === 1 ? 0 : documents.length;
+    };
+
+    await sync.ensureBackfilled(project, makeStoreFromRows(project, rows));
+
+    expect(ChromaSyncState.get(project).observations).toBe(120);
+    expect(ChromaSyncState.getPending(project, 'observations')).toEqual(
+      Array.from({ length: 100 }, (_, index) => index + 1),
+    );
+
+    addDocumentCalls.length = 0;
+    sync.addDocuments = async (documents) => {
+      addDocumentCalls.push(documents.map(document => document.id));
+      return documents.length;
+    };
+    await sync.ensureBackfilled(project, makeStoreFromRows(project, rows));
+
+    expect(addDocumentCalls.map(batch => batch.length)).toEqual([100]);
+    expect(ChromaSyncState.get(project).observations).toBe(120);
+    expect(ChromaSyncState.getPending(project, 'observations')).toEqual([]);
+  });
+
+  it('indexes only the latest exact prompt replay within each session', async () => {
+    const store = new SessionStore(':memory:');
+    const contentSessionId = 'codex-replay-session';
+    const sessionDbId = store.createSDKSession(contentSessionId, project, 'initial', undefined, 'codex');
+    const olderReplayId = store.saveUserPrompt(contentSessionId, 1, 'Repeated prompt', sessionDbId);
+    const uniquePromptId = store.saveUserPrompt(contentSessionId, 2, 'Unique prompt', sessionDbId);
+    const latestReplayId = store.saveUserPrompt(contentSessionId, 3, 'Repeated prompt', sessionDbId);
+    const sync = new ChromaSync(project);
+
+    try {
+      await sync.ensureBackfilled(project, store);
+    } finally {
+      store.close();
+    }
+
+    const writtenIds = addDocumentCalls.flat();
+    expect(writtenIds).not.toContain(`prompt_${olderReplayId}`);
+    expect(writtenIds).toContain(`prompt_${uniquePromptId}`);
+    expect(writtenIds).toContain(`prompt_${latestReplayId}`);
+    expect(ChromaSyncState.get(project).prompts).toBe(latestReplayId);
+  });
+
+  it('includes prompt-only projects in the all-project backfill', async () => {
+    const store = new SessionStore(':memory:');
+    const promptOnlyProject = `${project}-prompt-only`;
+    const contentSessionId = 'prompt-only-session';
+    const sessionDbId = store.createSDKSession(
+      contentSessionId,
+      promptOnlyProject,
+      'initial',
+      undefined,
+      'codex',
+    );
+    const promptId = store.saveUserPrompt(contentSessionId, 1, 'Prompt without observations', sessionDbId);
+
+    try {
+      await ChromaSync.backfillAllProjects(store);
+    } finally {
+      store.close();
+    }
+
+    expect(addDocumentCalls.flat()).toContain(`prompt_${promptId}`);
+    expect(ChromaSyncState.get(promptOnlyProject).prompts).toBe(promptId);
+  });
+
+  it('repairs a transient pending batch before reporting all-project completion', async () => {
+    const store = new SessionStore(':memory:');
+    const repairProject = `${project}-repair`;
+    const contentSessionId = 'repair-session';
+    const sessionDbId = store.createSDKSession(contentSessionId, repairProject, 'initial', undefined, 'codex');
+    const promptId = store.saveUserPrompt(contentSessionId, 1, 'Repair this prompt', sessionDbId);
+    addFailuresRemaining = 1;
+
+    try {
+      await ChromaSync.backfillAllProjects(store);
+    } finally {
+      store.close();
+    }
+
+    expect(addDocumentCalls.flat().filter(id => id === `prompt_${promptId}`)).toHaveLength(2);
+    expect(ChromaSyncState.getPending(repairProject, 'prompts')).toEqual([]);
+    expect(ChromaSyncState.get(repairProject).prompts).toBe(promptId);
+  });
+
+  it('rejects all-project completion while a pending batch remains unresolved', async () => {
+    const store = new SessionStore(':memory:');
+    const brokenProject = `${project}-broken`;
+    const contentSessionId = 'broken-session';
+    const sessionDbId = store.createSDKSession(contentSessionId, brokenProject, 'initial', undefined, 'codex');
+    store.saveUserPrompt(contentSessionId, 1, 'Still broken', sessionDbId);
+    addFailuresRemaining = 2;
+
+    try {
+      await expect(ChromaSync.backfillAllProjects(store)).rejects.toThrow('Chroma backfill incomplete');
+    } finally {
+      store.close();
+    }
+
+    expect(ChromaSyncState.getPending(brokenProject, 'prompts')).not.toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Make local persistent Chroma rebuilds durable, bounded, and source-complete without leaving a sustained foreground load.

## Root cause

Several independent costs compounded during a large rebuild:

- MCP mutations inherited the SDK's 60-second request deadline. A timeout triggered reconnect teardown while Chroma could still be committing.
- `chroma-mcp` 0.2.6 scans all existing IDs before every add, making repeated backfill calls quadratic.
- Chroma's default ONNX embedding function was reconstructed for each collection facade/request.
- Observations and summaries emitted one vector per field, and exact prompt replays were indexed repeatedly.
- NUL-containing documents can make Chroma 1.5.9's trigram FTS index fail `PRAGMA quick_check` with a malformed inverted index.
- Project discovery omitted prompt-only namespaces, and pending write failures could still end with an all-project completion message.

## Changes

- Add a bounded, configurable 10-minute timeout for mutation tools only; queries retain the normal SDK deadline.
- Ship a pinned `chroma-mcp` bridge that:
  - bypasses the full-collection duplicate scan for adds,
  - reuses one locked ONNX embedding runtime,
  - sanitizes NUL text defensively,
  - lowers local Chroma priority to nice 15.
- Pack source rows into 100-document mutations while preserving pending-gap/watermark correctness.
- Emit one prioritized semantic projection per observation or summary.
- Deduplicate exact prompt replays within each session, keeping the latest row.
- Discover projects from observations, summaries, and prompts.
- Retry incomplete projects once, then fail the rebuild if any failed or pending rows remain.
- Package the Python bridge and add regression coverage for timeout scoping, batching, repair, prompt deduplication, prompt-only projects, and NUL sanitization.

## Validation

- `bun test tests/services/sync`: 53 passed, 0 failed.
- `npm run typecheck`: root and viewer typechecks passed.
- Package dry-run: 116 files; Python bridge and worker bundle both included.
- Full persistent rebuild validation:
  - 57 project namespaces,
  - 31,888 Chroma documents exactly matching 10,781 observations + 3,358 summaries + 17,749 deduplicated prompts,
  - zero pending rows and zero watermark mismatches,
  - stopped-state `PRAGMA quick_check` and `integrity_check` both returned `ok`,
  - semantic API search returned results for a query with zero SQLite FTS matches,
  - one worker and one persistent Chroma Python process; both measured 0% CPU while idle after rebuild.
