### PR TITLE
fix(cleanup): tolerate negative statfs availability

### DIFF
--- a/src/services/infrastructure/CleanupV12_4_3.ts
+++ b/src/services/infrastructure/CleanupV12_4_3.ts
@@ -142,10 +142,10 @@ function executeCleanup(dbPath: string, effectiveDataDir: string, markerPath: st
     // and will ship in the next Bun release after 1.3.14. Until then, any
     // `bavail * bsize` math returns 0 and this gate would permanently skip
     // the cleanup with a misleading `free=0` error. Treat non-credible
-    // readings (bsize <= 0, NaN, or non-finite) as "skip the gate" rather
+    // readings (bsize <= 0, bavail < 0, NaN, or non-finite) as "skip the gate" rather
     // than "disk is full" -- a real out-of-space condition will still
     // surface from the subsequent VACUUM INTO / copyFileSync.
-    if (!Number.isFinite(bsize) || !Number.isFinite(bavail) || bsize <= 0) {
+    if (!Number.isFinite(bsize) || !Number.isFinite(bavail) || bsize <= 0 || bavail < 0) {
       logger.warn(
         'SYSTEM',
         'statfsSync returned non-credible values; proceeding without disk-space pre-flight',

--- a/tests/infrastructure/cleanup-v12_4_3.test.ts
+++ b/tests/infrastructure/cleanup-v12_4_3.test.ts
@@ -211,6 +211,41 @@ describe('runOneTimeV12_4_3Cleanup', () => {
     );
   });
 
+  it('proceeds with cleanup when statfsSync returns a negative available block count', () => {
+    const dbPath = path.join(tmpDataDir, 'claude-mem.db');
+    seedDatabase(dbPath, { observerSessions: 2, stuckCount: 10 });
+
+    const statfsSpy = spyOn(fs, 'statfsSync').mockImplementation(() => ({
+      type: 0,
+      bsize: 4096,
+      blocks: 4096,
+      bfree: 1048576,
+      bavail: -1,
+      files: 0,
+      ffree: 0,
+    }) as unknown as ReturnType<typeof fs.statfsSync>);
+
+    try {
+      runOneTimeV12_4_3Cleanup(tmpDataDir);
+    } finally {
+      statfsSpy.mockRestore();
+    }
+
+    const markerPath = path.join(tmpDataDir, '.cleanup-v12.4.3-applied');
+    expect(existsSync(markerPath)).toBe(true);
+    const payload = JSON.parse(readFileSync(markerPath, 'utf8'));
+    expect(payload.counts.observerSessions).toBe(2);
+    expect(payload.counts.stuckPendingMessages).toBe(10);
+    expect(payload.backupPath).toBeTruthy();
+    expect(existsSync(payload.backupPath)).toBe(true);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'SYSTEM',
+      expect.stringContaining('non-credible'),
+      expect.objectContaining({ bsize: 4096, bavail: -1 }),
+    );
+  });
+
   it('honors CLAUDE_MEM_SKIP_CLEANUP_V12_4_3=1 by exiting without writing the marker', () => {
     const dbPath = path.join(tmpDataDir, 'claude-mem.db');
     seedDatabase(dbPath, { observerSessions: 1, stuckCount: 10 });


### PR DESCRIPTION
## Summary
- treat negative `statfsSync().bavail` values as non-credible disk telemetry
- bypass only the pre-flight disk-space gate for that case
- add a regression test that verifies cleanup and backup still complete

Closes #3551

## Test plan
- `npm run typecheck` — passed
- `npm run build` — passed
- `npx -y bun@1.3.14 test tests/infrastructure/cleanup-v12_4_3.test.ts` — assertions complete, but Windows cleanup hits the file's existing SQLite `EBUSY` in `afterEach` (also affects the existing cases); Linux CI should provide the authoritative result