### PR TITLE
fix(context): skip empty CLAUDE.md creation

### DIFF
--- a/src/utils/claude-md-utils.ts
+++ b/src/utils/claude-md-utils.ts
@@ -360,7 +360,7 @@ export async function updateFolderClaudeMdFiles(
       continue;
     }
 
-    if (hasNoActivity && !fileExists) {
+    if (isEmptyOrSkeleton && !fileExists) {
       logger.debug('FOLDER_INDEX', 'Skipping empty context file creation', { folderPath, targetFilename });
       continue;
     }

--- a/tests/utils/claude-md-utils.test.ts
+++ b/tests/utils/claude-md-utils.test.ts
@@ -1110,6 +1110,23 @@ describe('skeleton CLAUDE.md deny-list (#2400)', () => {
     content: [{ text: 'no observation rows here' }],
   };
 
+  it('does not create a new CLAUDE.md when the formatted timeline is empty', async () => {
+    delete process.env[ENV_KEY];
+
+    const folderPath = join(tempDir, 'empty-timeline');
+    mkdirSync(folderPath, { recursive: true });
+    const filePath = join(folderPath, 'file.ts');
+
+    global.fetch = mock(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(emptySkeletonResponse),
+    } as Response));
+
+    await updateFolderClaudeMdFiles([filePath], 'test-project', 37777, tempDir);
+
+    expect(existsSync(join(folderPath, 'CLAUDE.md'))).toBe(false);
+  });
+
   it('does NOT overwrite an existing CLAUDE.md with a skeleton when the folder matches the deny-list', async () => {
     process.env[ENV_KEY] = JSON.stringify(['**/transient']);
 


### PR DESCRIPTION
## Summary
- use the existing empty-or-skeleton classification when deciding whether to create a context file
- keep existing-file cleanup behavior unchanged
- add a regression test for an empty formatted timeline with no deny-list

Closes #3544

## Test plan
- focused empty-file regression test: passed
- npm run typecheck: passed
- full test file: 62 passed; 7 unrelated Windows path-separator assertions fail on the current base
