### PR TITLE
fix(transcripts): scan configured dot-directories

### DIFF
--- a/src/services/transcripts/watcher.ts
+++ b/src/services/transcripts/watcher.ts
@@ -223,7 +223,7 @@ export class TranscriptWatcher {
   }
 
   private scanGlob(pattern: string): string[] {
-    return Array.from(new Bun.Glob(pattern).scanSync({ absolute: true, onlyFiles: true }));
+    return Array.from(new Bun.Glob(pattern).scanSync({ absolute: true, onlyFiles: true, dot: true }));
   }
 
   private normalizeGlobPattern(inputPath: string): string {

--- a/tests/transcripts/watcher-start-at-end.test.ts
+++ b/tests/transcripts/watcher-start-at-end.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import { appendFileSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import type { NormalizedHookInput } from '../../src/cli/types.js';
 import type { TranscriptSchema, WatchTarget } from '../../src/services/transcripts/types.js';
 
@@ -40,6 +40,29 @@ describe('TranscriptWatcher startAtEnd', () => {
   afterEach(() => {
     loggerSpies.forEach(spy => spy.mockRestore());
     rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('discovers transcripts inside dot-directories', () => {
+    const transcriptPath = join(
+      tmpRoot,
+      'brain',
+      'conversation-id',
+      '.system_generated',
+      'logs',
+      'transcript_full.jsonl',
+    );
+    mkdirSync(join(transcriptPath, '..'), { recursive: true });
+    writeFileSync(transcriptPath, '', 'utf8');
+
+    const watcher = new TranscriptWatcher(
+      { version: 1, watches: [] },
+      join(tmpRoot, 'state.json'),
+    );
+    const pattern = join(tmpRoot, 'brain', '**', '.system_generated', 'logs', 'transcript_full.jsonl');
+
+    const matches = (watcher as any).resolveWatchFiles(pattern) as string[];
+
+    expect(matches.map(match => resolve(match))).toEqual([resolve(transcriptPath)]);
   });
 
   it('does not replay history from transcript files discovered after startup', async () => {


### PR DESCRIPTION
## Summary
- enable Bun glob matching through dot-directories for transcript watches
- keep matching constrained to the configured watch pattern
- add a behavioral regression test using a real `.system_generated/logs` path

Closes #3512

## Test plan
- focused dot-directory transcript watcher test: passed
- npm run typecheck: passed
