### PR TITLE
fix(health): bound worker fetch duration

### DIFF
--- a/src/services/infrastructure/HealthMonitor.ts
+++ b/src/services/infrastructure/HealthMonitor.ts
@@ -58,6 +58,10 @@ export async function isPortInUse(port: number, timeoutMs: number = REQUEST_TIME
       });
       return response.ok;
     } catch (error) {
+      if (controller.signal.aborted) {
+        logger.debug('SYSTEM', 'Windows health check timed out (treating port as occupied)', {});
+        return true;
+      }
       if (error instanceof Error) {
         logger.debug('SYSTEM', 'Windows health check failed (port not in use)', {}, error);
       } else {

--- a/src/services/infrastructure/HealthMonitor.ts
+++ b/src/services/infrastructure/HealthMonitor.ts
@@ -6,6 +6,14 @@ import { logger } from '../../utils/logger.js';
 import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js';
 import { MARKETPLACE_ROOT, USER_SETTINGS_PATH } from '../../shared/paths.js';
 
+const REQUEST_TIMEOUT_MS = 5000;
+
+function createRequestTimeout(timeoutMs: number): { controller: AbortController; timer: ReturnType<typeof setTimeout> } {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), Math.max(1, timeoutMs));
+  return { controller, timer };
+}
+
 function getWorkerHost(): string {
   return SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH).CLAUDE_MEM_WORKER_HOST;
 }
@@ -20,22 +28,34 @@ function formatHostForUrl(host: string): string {
 async function httpRequestToWorker(
   port: number,
   endpointPath: string,
-  method: string = 'GET'
+  method: string = 'GET',
+  timeoutMs: number = REQUEST_TIMEOUT_MS,
 ): Promise<{ ok: boolean; statusCode: number; body: string }> {
-  const response = await fetch(`http://${formatHostForUrl(getWorkerHost())}:${port}${endpointPath}`, { method });
-  let body = '';
+  const { controller, timer } = createRequestTimeout(timeoutMs);
   try {
-    body = await response.text();
-  } catch {
-    // Body unavailable — health/readiness checks only need .ok
+    const response = await fetch(`http://${formatHostForUrl(getWorkerHost())}:${port}${endpointPath}`, {
+      method,
+      signal: controller.signal,
+    });
+    let body = '';
+    try {
+      body = await response.text();
+    } catch {
+      // Body unavailable — health/readiness checks only need .ok
+    }
+    return { ok: response.ok, statusCode: response.status, body };
+  } finally {
+    clearTimeout(timer);
   }
-  return { ok: response.ok, statusCode: response.status, body };
 }
 
-export async function isPortInUse(port: number): Promise<boolean> {
+export async function isPortInUse(port: number, timeoutMs: number = REQUEST_TIMEOUT_MS): Promise<boolean> {
   if (process.platform === 'win32') {
+    const { controller, timer } = createRequestTimeout(timeoutMs);
     try {
-      const response = await fetch(`http://${formatHostForUrl(getWorkerHost())}:${port}/api/health`);
+      const response = await fetch(`http://${formatHostForUrl(getWorkerHost())}:${port}/api/health`, {
+        signal: controller.signal,
+      });
       return response.ok;
     } catch (error) {
       if (error instanceof Error) {
@@ -44,6 +64,8 @@ export async function isPortInUse(port: number): Promise<boolean> {
         logger.debug('SYSTEM', 'Windows health check failed (port not in use)', { error: String(error) });
       }
       return false;
+    } finally {
+      clearTimeout(timer);
     }
   }
 
@@ -70,10 +92,11 @@ async function pollEndpointUntilOk(
   timeoutMs: number,
   retryLogMessage: string
 ): Promise<boolean> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
     try {
-      const result = await httpRequestToWorker(port, endpointPath);
+      const remainingMs = deadline - Date.now();
+      const result = await httpRequestToWorker(port, endpointPath, 'GET', Math.min(REQUEST_TIMEOUT_MS, remainingMs));
       if (result.ok) return true;
     } catch (error) {
       if (error instanceof Error) {
@@ -82,7 +105,10 @@ async function pollEndpointUntilOk(
         logger.debug('SYSTEM', retryLogMessage, { error: String(error) });
       }
     }
-    await new Promise(r => setTimeout(r, 500));
+    const retryDelayMs = Math.min(500, deadline - Date.now());
+    if (retryDelayMs > 0) {
+      await new Promise(r => setTimeout(r, retryDelayMs));
+    }
   }
   return false;
 }
@@ -96,10 +122,14 @@ export function waitForReadiness(port: number, timeoutMs: number = 30000): Promi
 }
 
 export async function waitForPortFree(port: number, timeoutMs: number = 10000): Promise<boolean> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    if (!(await isPortInUse(port))) return true;
-    await new Promise(r => setTimeout(r, 500));
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const remainingMs = deadline - Date.now();
+    if (!(await isPortInUse(port, Math.min(REQUEST_TIMEOUT_MS, remainingMs)))) return true;
+    const retryDelayMs = Math.min(500, deadline - Date.now());
+    if (retryDelayMs > 0) {
+      await new Promise(r => setTimeout(r, retryDelayMs));
+    }
   }
   return false;
 }

--- a/tests/infrastructure/health-monitor.test.ts
+++ b/tests/infrastructure/health-monitor.test.ts
@@ -24,6 +24,22 @@ describe('HealthMonitor', () => {
 
   describe('isPortInUse', () => {
 
+    it('should not report a timed-out Windows health probe as a free port', async () => {
+      if (process.platform !== 'win32') return;
+
+      global.fetch = mock((_input: RequestInfo | URL, init?: RequestInit) => new Promise((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) {
+          reject(new Error('expected an abort signal'));
+          return;
+        }
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+      }));
+
+      expect(await isPortInUse(37777, 50)).toBe(true);
+      expect(await waitForPortFree(37777, 100)).toBe(false);
+    });
+
     it('should return true for occupied port (EADDRINUSE)', async () => {
       const createServerMock = mock(() => ({
         once: mock((event: string, cb: Function) => {

--- a/tests/infrastructure/health-monitor.test.ts
+++ b/tests/infrastructure/health-monitor.test.ts
@@ -139,6 +139,25 @@ describe('HealthMonitor', () => {
       expect(elapsed).toBeLessThan(2500);
     });
 
+    it('should abort a fetch that never responds within the overall timeout', async () => {
+      global.fetch = mock((_input: RequestInfo | URL, init?: RequestInit) => new Promise((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) {
+          reject(new Error('expected an abort signal'));
+          return;
+        }
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+      }));
+
+      const start = Date.now();
+      const result = await waitForHealth(39999, 100);
+      const elapsed = Date.now() - start;
+
+      expect(result).toBe(false);
+      expect(elapsed).toBeGreaterThanOrEqual(90);
+      expect(elapsed).toBeLessThan(500);
+    });
+
     it('should succeed after server becomes available', async () => {
       let callCount = 0;
       global.fetch = mock(() => {


### PR DESCRIPTION
## Summary
- abort worker HTTP requests after a bounded timeout
- cap each polling attempt to the remaining overall deadline
- apply the same bound to the Windows health probe used by port checks
- treat a timed-out Windows port probe as occupied/indeterminate, preventing false `EADDRINUSE` restart attempts
- avoid sleeping past the caller's polling deadline

Closes #3553

## Test plan
- focused never-resolving fetch and Windows occupied-port regressions: 2 passed
- npm run typecheck: passed
- npm run build: passed
- full health-monitor file on local Windows: unrelated base tests assume the non-Windows socket branch