### PR TITLE
fix(openrouter): accept empty reasoning responses

### DIFF
--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -45,7 +45,7 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
   /** Prefix for the synthetic memorySessionId (e.g. 'gemini', 'openrouter'). */
   protected abstract readonly syntheticIdPrefix: string;
   /**
-   * When a query returns empty content for an observation/summary message:
+   * When a query returns empty content:
    * OpenRouter still calls processAgentResponse('') (forwards the empty batch
    * to the parser/recovery path); Gemini skips it and logs a warning. This flag
    * preserves that per-provider divergence.
@@ -163,14 +163,15 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     worker: WorkerRef | undefined,
     model: string
   ): Promise<void> {
-    if (initResponse.content) {
-      session.conversationHistory.push({ role: 'assistant', content: initResponse.content });
+    if (initResponse.content || this.forwardEmptyMessageResponse) {
+      const content = initResponse.content || '';
+      session.conversationHistory.push({ role: 'assistant', content });
       const tokensUsed = initResponse.tokensUsed || 0;
       session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
       session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
       session.lastUsage = this.buildLastUsage(initResponse);
       await processAgentResponse(
-        initResponse.content, session, this.dbManager, this.sessionManager,
+        content, session, this.dbManager, this.sessionManager,
         worker, tokensUsed, null, this.providerName, undefined, initResponse.servedModel ?? model
       );
     } else {

--- a/src/services/worker/OpenRouterProvider.ts
+++ b/src/services/worker/OpenRouterProvider.ts
@@ -108,6 +108,7 @@ interface OpenRouterResponse {
     message?: {
       role?: string;
       content?: string;
+      reasoning_content?: string;
     };
     finish_reason?: string;
   }>;
@@ -286,12 +287,20 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
       return responseData;
     }, { label: `OpenRouter ${model}` });
 
-    if (!data.choices?.[0]?.message?.content) {
+    const choice = data.choices?.[0];
+    const message = choice?.message;
+    if (!message || typeof message.content !== 'string') {
       logger.error('SDK', 'Empty response from OpenRouter');
       return { content: '' };
     }
 
-    const content = data.choices[0].message.content;
+    const content = message.content;
+    if (content.length === 0) {
+      logger.debug('SDK', 'OpenRouter returned an empty message', {
+        finishReason: choice.finish_reason,
+        hasReasoningContent: Boolean(message.reasoning_content),
+      });
+    }
     const tokensUsed = data.usage?.total_tokens;
     const realInputTokens = data.usage?.prompt_tokens;
     const realOutputTokens = data.usage?.completion_tokens;

--- a/tests/worker/openrouter-empty-content.test.ts
+++ b/tests/worker/openrouter-empty-content.test.ts
@@ -53,6 +53,56 @@ describe('OpenRouterProvider empty content', () => {
     }
   });
 
+  it('preserves bookkeeping for an empty initialization response', async () => {
+    const confirmClaimedMessages = mock(() => Promise.resolve());
+    const provider = new OpenRouterProvider(
+      {} as any,
+      { confirmClaimedMessages } as any,
+    );
+    const session = {
+      sessionDbId: 42,
+      contentSessionId: 'content-session',
+      project: 'test-project',
+      conversationHistory: [],
+      cumulativeInputTokens: 0,
+      cumulativeOutputTokens: 0,
+      lastUsage: null,
+      currentProvider: 'openrouter',
+      platformSource: 'claude',
+      lastGeneratorSource: 'init',
+      lastPromptSentAt: Date.now(),
+      lastPromptNumber: 1,
+      consecutiveInvalidOutputs: 0,
+      earliestPendingTimestamp: null,
+      abortController: new AbortController(),
+    } as any;
+    const errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
+
+    try {
+      await (provider as any).handleInitResponse(
+        {
+          content: '',
+          tokensUsed: 20,
+          inputTokens: 12,
+          outputTokens: 8,
+          servedModel: 'reasoning-model',
+        },
+        session,
+        undefined,
+        'configured-model',
+      );
+
+      expect(session.conversationHistory).toEqual([{ role: 'assistant', content: '' }]);
+      expect(session.cumulativeInputTokens).toBe(14);
+      expect(session.cumulativeOutputTokens).toBe(6);
+      expect(session.lastUsage).toEqual({ input: 12, output: 8 });
+      expect(confirmClaimedMessages).toHaveBeenCalledWith(42);
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it('still rejects a response without a message object', async () => {
     global.fetch = mock(() => Promise.resolve(new Response(JSON.stringify({
       choices: [{ finish_reason: 'stop' }],

--- a/tests/worker/openrouter-empty-content.test.ts
+++ b/tests/worker/openrouter-empty-content.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import { OpenRouterProvider } from '../../src/services/worker/OpenRouterProvider.js';
+import { logger } from '../../src/utils/logger.js';
+
+describe('OpenRouterProvider empty content', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('accepts an empty message from a reasoning model and preserves usage', async () => {
+    global.fetch = mock(() => Promise.resolve(new Response(JSON.stringify({
+      model: 'reasoning-model',
+      choices: [{
+        message: {
+          role: 'assistant',
+          content: '',
+          reasoning_content: 'internal reasoning',
+        },
+        finish_reason: 'stop',
+      }],
+      usage: {
+        prompt_tokens: 12,
+        completion_tokens: 8,
+        total_tokens: 20,
+      },
+    }), { status: 200 })));
+    const errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
+
+    try {
+      const provider = new OpenRouterProvider({} as any, {} as any);
+      const result = await (provider as any).query(
+        [{ role: 'user', content: 'remember this' }],
+        {
+          apiKey: 'test-key',
+          model: 'reasoning-model',
+          apiUrl: 'https://openrouter.ai/api/v1/chat/completions',
+        },
+      );
+
+      expect(result).toEqual({
+        content: '',
+        tokensUsed: 20,
+        inputTokens: 12,
+        outputTokens: 8,
+        costUsd: undefined,
+        servedModel: 'reasoning-model',
+      });
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('still rejects a response without a message object', async () => {
+    global.fetch = mock(() => Promise.resolve(new Response(JSON.stringify({
+      choices: [{ finish_reason: 'stop' }],
+    }), { status: 200 })));
+    const errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
+
+    try {
+      const provider = new OpenRouterProvider({} as any, {} as any);
+      const result = await (provider as any).query(
+        [{ role: 'user', content: 'remember this' }],
+        {
+          apiKey: 'test-key',
+          model: 'reasoning-model',
+          apiUrl: 'https://openrouter.ai/api/v1/chat/completions',
+        },
+      );
+
+      expect(result).toEqual({ content: '' });
+      expect(errorSpy).toHaveBeenCalledWith('SDK', 'Empty response from OpenRouter');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- distinguish a structurally missing OpenRouter message from a present empty string response
- accept empty messages produced by reasoning models without logging an SDK error
- preserve usage, served-model metadata, assistant history, and initialization bookkeeping
- retain the malformed-response guard when the message or content field is absent

Closes #3569

## Test plan
- OpenRouter empty-content and initialization tests: 3 passed
- npm run typecheck: passed
- npm run build: passed