### PR TITLE
fix(server-beta): re-pin payload.generation_job_id on idempotent re-create

### DIFF
--- a/src/storage/postgres/generation-jobs.ts
+++ b/src/storage/postgres/generation-jobs.ts
@@ -125,7 +125,16 @@ export class PostgresObservationGenerationJobRepository {
         )
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb)
         ON CONFLICT (idempotency_key) DO UPDATE SET
-          payload = observation_generation_jobs.payload || excluded.payload,
+          -- The conflicting INSERT carries a freshly generated job id in both $1
+          -- and payload.generation_job_id. ON CONFLICT keeps the existing row, so
+          -- $1 is discarded -- but the merge below would otherwise let the new
+          -- payload overwrite generation_job_id with that discarded id, leaving
+          -- the row pointing at a job that never existed. The worker resolves the
+          -- job via payload.generation_job_id, so such a row can never be locked
+          -- and is silently dropped. Re-pin the pointer to the surviving row.
+          payload = observation_generation_jobs.payload
+                    || excluded.payload
+                    || jsonb_build_object('generation_job_id', observation_generation_jobs.id),
           updated_at = now()
         RETURNING *
       `,

--- a/tests/storage/postgres/postgres-storage.test.ts
+++ b/tests/storage/postgres/postgres-storage.test.ts
@@ -504,6 +504,39 @@ describe('server beta postgres observation storage', () => {
     })).resolves.toBeNull();
   });
 
+  it('re-pins payload.generation_job_id to the surviving row on idempotent re-create', async () => {
+    const { project, event } = await createFixtureScopeWithEventJob(storage);
+
+    const first = await storage.observationGenerationJobs.create({
+      projectId: project.id,
+      teamId: project.teamId,
+      sourceType: 'agent_event',
+      sourceId: event.id,
+      agentEventId: event.id,
+      jobType: 'payload_id_drift',
+      payload: { generation_job_id: 'id-minted-for-the-first-insert' }
+    });
+
+    // The second create collides on idempotency_key. ON CONFLICT keeps the
+    // existing row, so the id minted for this attempt is discarded -- but the
+    // caller still put it in the payload it is handing over.
+    const second = await storage.observationGenerationJobs.create({
+      projectId: project.id,
+      teamId: project.teamId,
+      sourceType: 'agent_event',
+      sourceId: event.id,
+      agentEventId: event.id,
+      jobType: 'payload_id_drift',
+      payload: { generation_job_id: 'id-discarded-by-on-conflict' }
+    });
+
+    expect(second.id).toBe(first.id);
+    // The worker resolves the job through payload.generation_job_id. If the
+    // discarded id survived here, the row could never be locked and the job
+    // would be dropped silently while reporting success to the queue.
+    expect((second.payload as { generation_job_id?: string }).generation_job_id).toBe(first.id);
+  });
+
   it('rejects illegal generation job lifecycle transitions and max-attempt retries', async () => {
     const { project, event } = await createFixtureScopeWithEventJob(storage);
     const job = await storage.observationGenerationJobs.create({


### PR DESCRIPTION
## Problem

A generation job whose `payload.generation_job_id` points at a row that does not exist is dropped **silently**.

`ProviderObservationGenerator` resolves the canonical row through the payload:

```ts
const fresh = await this.lockOutbox(payload.generation_job_id, payload.team_id, payload.project_id);
if (!fresh) {
  logger.info('SYSTEM', 'job no longer exists or is in terminal status; nothing to do', ...);
  return { jobId: payload.generation_job_id, status: 'completed', observationCount: 0 };
}
```

When the id is stale, `lockOutbox` returns `null` and the worker reports **`completed` to BullMQ without touching Postgres**. The queue drains clean, the row stays `queued` forever, and nothing is ever recorded as `failed`. The only trace is a `logger.info` line, which is below the default log level.

## Why the pointer goes stale

Every re-create mints a fresh id for `$1` and carries that same id in the payload it hands over. On `ON CONFLICT (idempotency_key)` the existing row wins, so the minted id is discarded for the `id` column — but the payload merge still lets it overwrite `generation_job_id`:

```sql
ON CONFLICT (idempotency_key) DO UPDATE SET
  payload = observation_generation_jobs.payload || excluded.payload,
```

The row now points at an id that was never inserted.

## Why only `session_summary` is affected

`buildObservationGenerationJobIdempotencyKey` derives the key from `sourceId`:

| source type | `sourceId` is | collides? |
|---|---|---|
| `agent_event` | the individual event id | never |
| `session_summary` | the **session** id | on every re-run of that session's summary |

Summaries are re-enqueued for the same session, so they hit `ON CONFLICT` routinely. Event jobs mint a new key each time and never conflict.

## Fix

Re-pin `generation_job_id` to the surviving row inside the same merge, so the payload can never outlive the id it names.

## Evidence from a production deployment

Running server-beta since May:

- **190** summary jobs stranded in `queued` across four months
- **190/190** had `payload->>'generation_job_id'` absent from the table
- event jobs on the same instance: **0** divergences in ~221k rows
- after re-pointing the payload of those rows, they started draining immediately — the same jobs that had been inert for months

## Test

Added a regression test to `tests/storage/postgres/postgres-storage.test.ts`. Verified it fails without the fix and passes with it:

```
# without the patch
Expected: "9f2e1624-5970-4b83-b82f-14aa5c88afba"
Received: "id-discarded-by-on-conflict"
(fail) re-pins payload.generation_job_id to the surviving row on idempotent re-create

# with the patch
23 pass, 0 fail   (full file)
```

## Relation to #2459 / discussion #2460

#2459 asked for an operator re-queue command for stranded summary jobs, with the guidance to *"reuse the persisted payload and deterministic BullMQ job ID"*.

Worth flagging: replaying the persisted payload replays the stale pointer, so those rows are dropped again, just as silently. I re-enqueued the 190 rows that way first and they evaporated exactly as before. An operator tool built on that guidance would appear not to work. This patch fixes the data going forward; existing stranded rows also need their payload pointer repaired once.
