### PR TITLE
fix(server-beta): bound session-summary input by payload size, not event count

### DIFF
--- a/src/server/generation/ProviderObservationGenerator.ts
+++ b/src/server/generation/ProviderObservationGenerator.ts
@@ -58,6 +58,57 @@ export interface ProviderObservationGeneratorOptions {
   workerId?: string;
 }
 
+
+// The `limit` on listUnprocessedEvents caps the event COUNT, not the payload
+// volume, and event size varies by orders of magnitude. Long sessions therefore
+// still blow the provider context window: measured on a production deployment,
+// sessions that failed with "context overflow" carried up to 34 MB of event
+// payload (~9M tokens), and even truncated to the 500-event default they still
+// averaged ~634k tokens with a 1.55M worst case — against a ~200k window. No
+// model currently on offer absorbs that, so the input has to be bounded by size.
+//
+// Keep the head and the tail of the session: the opening carries the goal, the
+// close carries the outcome and what was left pending. Dropping the middle
+// yields a partial summary, which is strictly better than the current outcome
+// for these sessions — an unrecoverable failure and no summary at all.
+const SUMMARY_INPUT_BUDGET_BYTES = Number.parseInt(
+  process.env.CLAUDE_MEM_SUMMARY_INPUT_BUDGET_BYTES ?? '',
+  10,
+) || 600_000;
+
+export function capSummaryInput<T>(events: T[]): T[] {
+  const size = (e: T): number => {
+    try {
+      return JSON.stringify(e)?.length ?? 0;
+    } catch {
+      return 0;
+    }
+  };
+  let total = 0;
+  for (const e of events) total += size(e);
+  if (total <= SUMMARY_INPUT_BUDGET_BYTES) return events;
+
+  const half = SUMMARY_INPUT_BUDGET_BYTES / 2;
+  const head: T[] = [];
+  let headBytes = 0;
+  for (const e of events) {
+    const s = size(e);
+    if (headBytes + s > half) break;
+    head.push(e);
+    headBytes += s;
+  }
+  const tail: T[] = [];
+  let tailBytes = 0;
+  for (let i = events.length - 1; i >= head.length; i -= 1) {
+    const e = events[i] as T;
+    const s = size(e);
+    if (tailBytes + s > SUMMARY_INPUT_BUDGET_BYTES - headBytes) break;
+    tail.unshift(e);
+    tailBytes += s;
+  }
+  return [...head, ...tail];
+}
+
 export class ProviderObservationGenerator {
   constructor(private readonly options: ProviderObservationGeneratorOptions) {}
 
@@ -518,7 +569,7 @@ export class ProviderObservationGenerator {
         projectId: job.projectId,
         teamId: job.teamId,
       });
-      return events;
+      return capSummaryInput(events);
     }
 
     if (job.sourceType !== 'agent_event') {

--- a/src/server/generation/ProviderObservationGenerator.ts
+++ b/src/server/generation/ProviderObservationGenerator.ts
@@ -73,6 +73,13 @@ export interface ProviderObservationGeneratorOptions {
 // close carries the outcome and what was left pending. Dropping the middle
 // yields a partial summary, which is strictly better than the current outcome
 // for these sessions — an unrecoverable failure and no summary at all.
+// Bounds the SESSION INPUT, not the finished prompt: buildServerGenerationPrompt
+// wraps the selected event blocks in request/project/job tags, the instructions and
+// the observation schema. That envelope is a fixed cost — 1,244 bytes with the mode
+// active here, independent of event count and payload size — so it is left out of
+// the budget rather than reserved from it. At the default that is 0.2%; only a
+// budget small enough to be unusable anyway (~1 KB buys one truncated tool call)
+// would be decided by it.
 const SUMMARY_INPUT_BUDGET_BYTES = Number.parseInt(
   process.env.CLAUDE_MEM_SUMMARY_INPUT_BUDGET_BYTES ?? '',
   10,

--- a/src/server/generation/ProviderObservationGenerator.ts
+++ b/src/server/generation/ProviderObservationGenerator.ts
@@ -76,14 +76,35 @@ const SUMMARY_INPUT_BUDGET_BYTES = Number.parseInt(
   10,
 ) || 600_000;
 
+// Mirrors MAX_PAYLOAD_CHARS in providers/shared/prompt-builder.ts: each event's
+// payload is truncated there before it reaches the model.
+const PROMPT_PAYLOAD_CAP_CHARS = 16 * 1024;
+
+/**
+ * Bytes this event will actually contribute to the prompt.
+ *
+ * Measuring the raw row instead would be wrong twice over: the payload is
+ * truncated to 16 KiB during prompt construction, so a single oversized event
+ * would consume the whole budget and could be dropped entirely — leaving the
+ * request with no session content at all, even though its truncated form fits.
+ * And `String.length` counts UTF-16 units, so non-ASCII content under-reports
+ * against a byte budget.
+ */
+function promptFootprint(event: unknown): number {
+  try {
+    const payload = (event as { payload?: unknown })?.payload;
+    const raw = typeof payload === 'string' ? payload : JSON.stringify(payload ?? {});
+    const truncated = raw.length > PROMPT_PAYLOAD_CAP_CHARS
+      ? raw.slice(0, PROMPT_PAYLOAD_CAP_CHARS)
+      : raw;
+    return Buffer.byteLength(truncated, 'utf8');
+  } catch {
+    return 0;
+  }
+}
+
 export function capSummaryInput<T>(events: T[]): T[] {
-  const size = (e: T): number => {
-    try {
-      return JSON.stringify(e)?.length ?? 0;
-    } catch {
-      return 0;
-    }
-  };
+  const size = (e: T): number => promptFootprint(e);
   let total = 0;
   for (const e of events) total += size(e);
   if (total <= SUMMARY_INPUT_BUDGET_BYTES) return events;

--- a/src/server/generation/ProviderObservationGenerator.ts
+++ b/src/server/generation/ProviderObservationGenerator.ts
@@ -3,6 +3,8 @@
 import type { Job } from 'bullmq';
 import { logger } from '../../utils/logger.js';
 import { PostgresAgentEventsRepository } from '../../storage/postgres/agent-events.js';
+import type { PostgresAgentEvent } from '../../storage/postgres/agent-events.js';
+import { eventBlockBytes } from './providers/shared/prompt-builder.js';
 import { PostgresObservationGenerationJobRepository } from '../../storage/postgres/generation-jobs.js';
 import { PostgresProjectsRepository } from '../../storage/postgres/projects.js';
 import { PostgresAuthRepository } from '../../storage/postgres/auth.js';
@@ -76,31 +78,22 @@ const SUMMARY_INPUT_BUDGET_BYTES = Number.parseInt(
   10,
 ) || 600_000;
 
-// Mirrors MAX_PAYLOAD_CHARS in providers/shared/prompt-builder.ts: each event's
-// payload is truncated there before it reaches the model.
-const PROMPT_PAYLOAD_CAP_CHARS = 16 * 1024;
-
 /**
  * Bytes this event will actually contribute to the prompt.
  *
- * Measuring the raw row instead would be wrong twice over: the payload is
- * truncated to 16 KiB during prompt construction, so a single oversized event
- * would consume the whole budget and could be dropped entirely — leaving the
- * request with no session content at all, even though its truncated form fits.
- * And `String.length` counts UTF-16 units, so non-ASCII content under-reports
- * against a byte budget.
+ * Delegates to the prompt builder instead of estimating: the builder
+ * pretty-prints, privacy-strips, truncates, XML-escapes and wraps every payload,
+ * and an estimate that skips any of those steps under-counts the request it is
+ * supposed to bound. Measuring the raw row would also count UTF-16 units rather
+ * than bytes, and would charge full price for a payload the builder truncates.
+ *
+ * Not defensive on purpose: an event that cannot be turned into a block here
+ * cannot be turned into one during prompt construction either, so swallowing the
+ * error would only trade a loud failure for the context overflow this budget
+ * exists to prevent.
  */
 function promptFootprint(event: unknown): number {
-  try {
-    const payload = (event as { payload?: unknown })?.payload;
-    const raw = typeof payload === 'string' ? payload : JSON.stringify(payload ?? {});
-    const truncated = raw.length > PROMPT_PAYLOAD_CAP_CHARS
-      ? raw.slice(0, PROMPT_PAYLOAD_CAP_CHARS)
-      : raw;
-    return Buffer.byteLength(truncated, 'utf8');
-  } catch {
-    return 0;
-  }
+  return eventBlockBytes(event as PostgresAgentEvent);
 }
 
 export function capSummaryInput<T>(events: T[]): T[] {

--- a/src/server/generation/providers/shared/prompt-builder.ts
+++ b/src/server/generation/providers/shared/prompt-builder.ts
@@ -131,6 +131,24 @@ function buildEventBlock(event: PostgresAgentEvent): EventBlockResult {
   };
 }
 
+/**
+ * Bytes this event contributes to the prompt.
+ *
+ * Measured on the block the prompt actually carries, not estimated from the raw
+ * row: the payload is pretty-printed, privacy-stripped, truncated, XML-escaped
+ * and wrapped in metadata tags above, and a caller that budgets the input has to
+ * agree with all of it. Deriving the number a second time is what let the two
+ * drift apart in the first place.
+ *
+ * Returns 0 for an event whose block is dropped, so it costs no budget either.
+ */
+export function eventBlockBytes(event: PostgresAgentEvent): number {
+  const { body } = buildEventBlock(event);
+  if (body.length === 0) return 0;
+  // + 1 for the '\n' that joins this block to the next one
+  return Buffer.byteLength(body, 'utf8') + 1;
+}
+
 function loadActiveModeOrFallback(): ModeConfig | { observation_types: ReadonlyArray<Pick<ObservationType, 'id'>> } {
   try {
     return ModeManager.getInstance().getActiveMode();

--- a/tests/server/generation/summary-input-budget.test.ts
+++ b/tests/server/generation/summary-input-budget.test.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'bun:test';
+import { capSummaryInput } from '../../../src/server/generation/ProviderObservationGenerator.js';
+
+// listUnprocessedEvents caps the event COUNT, not the payload volume. Sessions
+// whose events are large still overflow the provider window, which surfaces as
+// an `unrecoverable` job and no summary at all. capSummaryInput bounds the
+// input by size, keeping the head (goal) and the tail (outcome).
+
+const budget = () =>
+  Number.parseInt(process.env.CLAUDE_MEM_SUMMARY_INPUT_BUDGET_BYTES ?? '', 10) || 600_000;
+
+const eventOf = (id: number, bytes: number) => ({ id, blob: 'x'.repeat(bytes) });
+const sizeOf = (list: unknown[]) =>
+  list.reduce<number>((acc, e) => acc + JSON.stringify(e).length, 0);
+
+describe('capSummaryInput', () => {
+  it('returns every event when the batch fits the budget', () => {
+    const events = [eventOf(1, 10), eventOf(2, 10), eventOf(3, 10)];
+    expect(capSummaryInput(events)).toEqual(events);
+  });
+
+  it('bounds an oversized batch to the byte budget', () => {
+    const events = Array.from({ length: 400 }, (_, i) => eventOf(i, 5_000));
+    expect(sizeOf(events)).toBeGreaterThan(budget());
+
+    const capped = capSummaryInput(events);
+
+    expect(capped.length).toBeLessThan(events.length);
+    expect(sizeOf(capped)).toBeLessThanOrEqual(budget());
+  });
+
+  it('keeps both ends of the session, not just one', () => {
+    const events = Array.from({ length: 400 }, (_, i) => eventOf(i, 5_000));
+    const capped = capSummaryInput(events);
+
+    // the opening carries the goal, the close carries the outcome
+    expect(capped[0]?.id).toBe(0);
+    expect(capped[capped.length - 1]?.id).toBe(399);
+  });
+
+  it('preserves chronological order', () => {
+    const events = Array.from({ length: 400 }, (_, i) => eventOf(i, 5_000));
+    const ids = capSummaryInput(events).map((e) => e.id);
+    expect(ids).toEqual([...ids].sort((a, b) => a - b));
+  });
+});

--- a/tests/server/generation/summary-input-budget.test.ts
+++ b/tests/server/generation/summary-input-budget.test.ts
@@ -11,9 +11,13 @@ import { capSummaryInput } from '../../../src/server/generation/ProviderObservat
 const budget = () =>
   Number.parseInt(process.env.CLAUDE_MEM_SUMMARY_INPUT_BUDGET_BYTES ?? '', 10) || 600_000;
 
-const eventOf = (id: number, bytes: number) => ({ id, blob: 'x'.repeat(bytes) });
-const sizeOf = (list: unknown[]) =>
-  list.reduce<number>((acc, e) => acc + JSON.stringify(e).length, 0);
+const eventOf = (id: number, bytes: number) => ({ id, payload: 'x'.repeat(bytes) });
+// same footprint the prompt builder produces: payload truncated to 16 KiB, UTF-8
+const PROMPT_PAYLOAD_CAP = 16 * 1024;
+const footprint = (e: { payload: string }) =>
+  Buffer.byteLength(e.payload.slice(0, PROMPT_PAYLOAD_CAP), 'utf8');
+const sizeOf = (list: { payload: string }[]) =>
+  list.reduce<number>((acc, e) => acc + footprint(e), 0);
 
 describe('capSummaryInput', () => {
   it('returns every event when the batch fits the budget', () => {
@@ -38,6 +42,24 @@ describe('capSummaryInput', () => {
     // the opening carries the goal, the close carries the outcome
     expect(capped[0]?.id).toBe(0);
     expect(capped[capped.length - 1]?.id).toBe(399);
+  });
+
+
+  it('keeps an oversized single event instead of returning nothing', () => {
+    // A 700 KB event exceeds both the head and the tail allowance. Measuring the
+    // raw row would drop it and hand the provider an empty session, even though
+    // the prompt truncates the payload to 16 KiB and it fits comfortably.
+    const capped = capSummaryInput([eventOf(1, 700_000)]);
+    expect(capped.length).toBe(1);
+    expect(sizeOf(capped)).toBeLessThanOrEqual(budget());
+  });
+
+  it('measures UTF-8 bytes, not UTF-16 code units', () => {
+    // 'é' is 1 UTF-16 unit but 2 UTF-8 bytes; a budget checked in .length would
+    // let the real request exceed the limit and fail as context overflow.
+    const wide = { id: 1, payload: 'é'.repeat(400_000) };
+    const capped = capSummaryInput([wide]);
+    expect(sizeOf(capped as { payload: string }[])).toBeLessThanOrEqual(budget());
   });
 
   it('preserves chronological order', () => {

--- a/tests/server/generation/summary-input-budget.test.ts
+++ b/tests/server/generation/summary-input-budget.test.ts
@@ -2,31 +2,49 @@
 
 import { describe, expect, it } from 'bun:test';
 import { capSummaryInput } from '../../../src/server/generation/ProviderObservationGenerator.js';
+import { eventBlockBytes } from '../../../src/server/generation/providers/shared/prompt-builder.js';
+import type { PostgresAgentEvent } from '../../../src/storage/postgres/agent-events.js';
 
 // listUnprocessedEvents caps the event COUNT, not the payload volume. Sessions
 // whose events are large still overflow the provider window, which surfaces as
 // an `unrecoverable` job and no summary at all. capSummaryInput bounds the
 // input by size, keeping the head (goal) and the tail (outcome).
+//
+// The budget is measured with eventBlockBytes — the same function the prompt
+// builder feeds — so these tests fail if the two ever disagree again.
 
 const budget = () =>
   Number.parseInt(process.env.CLAUDE_MEM_SUMMARY_INPUT_BUDGET_BYTES ?? '', 10) || 600_000;
 
-const eventOf = (id: number, bytes: number) => ({ id, payload: 'x'.repeat(bytes) });
-// same footprint the prompt builder produces: payload truncated to 16 KiB, UTF-8
-const PROMPT_PAYLOAD_CAP = 16 * 1024;
-const footprint = (e: { payload: string }) =>
-  Buffer.byteLength(e.payload.slice(0, PROMPT_PAYLOAD_CAP), 'utf8');
-const sizeOf = (list: { payload: string }[]) =>
-  list.reduce<number>((acc, e) => acc + footprint(e), 0);
+const eventOf = (id: number, payload: string): PostgresAgentEvent => ({
+  id: `evt-${id}`,
+  projectId: 'p',
+  teamId: 't',
+  serverSessionId: 's',
+  sourceAdapter: 'hook',
+  sourceEventId: null,
+  idempotencyKey: `k-${id}`,
+  eventType: 'tool_use',
+  platformSource: 'claude',
+  payload,
+  metadata: {},
+  occurredAtEpoch: 1_700_000_000_000 + id,
+  receivedAtEpoch: 1_700_000_000_000 + id,
+  createdAtEpoch: 1_700_000_000_000 + id,
+});
+
+const filler = (id: number, bytes: number) => eventOf(id, 'x'.repeat(bytes));
+const sizeOf = (list: PostgresAgentEvent[]) =>
+  list.reduce<number>((acc, e) => acc + eventBlockBytes(e), 0);
 
 describe('capSummaryInput', () => {
   it('returns every event when the batch fits the budget', () => {
-    const events = [eventOf(1, 10), eventOf(2, 10), eventOf(3, 10)];
+    const events = [filler(1, 10), filler(2, 10), filler(3, 10)];
     expect(capSummaryInput(events)).toEqual(events);
   });
 
   it('bounds an oversized batch to the byte budget', () => {
-    const events = Array.from({ length: 400 }, (_, i) => eventOf(i, 5_000));
+    const events = Array.from({ length: 400 }, (_, i) => filler(i, 5_000));
     expect(sizeOf(events)).toBeGreaterThan(budget());
 
     const capped = capSummaryInput(events);
@@ -36,20 +54,19 @@ describe('capSummaryInput', () => {
   });
 
   it('keeps both ends of the session, not just one', () => {
-    const events = Array.from({ length: 400 }, (_, i) => eventOf(i, 5_000));
+    const events = Array.from({ length: 400 }, (_, i) => filler(i, 5_000));
     const capped = capSummaryInput(events);
 
     // the opening carries the goal, the close carries the outcome
-    expect(capped[0]?.id).toBe(0);
-    expect(capped[capped.length - 1]?.id).toBe(399);
+    expect(capped[0]?.id).toBe('evt-0');
+    expect(capped[capped.length - 1]?.id).toBe('evt-399');
   });
-
 
   it('keeps an oversized single event instead of returning nothing', () => {
     // A 700 KB event exceeds both the head and the tail allowance. Measuring the
     // raw row would drop it and hand the provider an empty session, even though
     // the prompt truncates the payload to 16 KiB and it fits comfortably.
-    const capped = capSummaryInput([eventOf(1, 700_000)]);
+    const capped = capSummaryInput([filler(1, 700_000)]);
     expect(capped.length).toBe(1);
     expect(sizeOf(capped)).toBeLessThanOrEqual(budget());
   });
@@ -57,14 +74,33 @@ describe('capSummaryInput', () => {
   it('measures UTF-8 bytes, not UTF-16 code units', () => {
     // 'é' is 1 UTF-16 unit but 2 UTF-8 bytes; a budget checked in .length would
     // let the real request exceed the limit and fail as context overflow.
-    const wide = { id: 1, payload: 'é'.repeat(400_000) };
-    const capped = capSummaryInput([wide]);
-    expect(sizeOf(capped as { payload: string }[])).toBeLessThanOrEqual(budget());
+    const capped = capSummaryInput([eventOf(1, 'é'.repeat(400_000))]);
+    expect(sizeOf(capped)).toBeLessThanOrEqual(budget());
+  });
+
+  it('counts XML escaping and block overhead, not just the raw payload', () => {
+    // Regression for the estimate this replaced: it measured the compact raw
+    // payload, while the builder pretty-prints, escapes and wraps it. 100 events
+    // of 3 KB of '<' weigh ~300 KB raw (under budget, so nothing was dropped)
+    // and render past 1 MB once every '<' becomes '&lt;'.
+    const events = Array.from({ length: 100 }, (_, i) => eventOf(i, '<'.repeat(3_000)));
+    const rawBytes = events.reduce((acc, e) => acc + Buffer.byteLength(e.payload as string), 0);
+
+    expect(rawBytes).toBeLessThan(budget());
+    expect(sizeOf(events)).toBeGreaterThan(budget());
+
+    expect(sizeOf(capSummaryInput(events))).toBeLessThanOrEqual(budget());
+  });
+
+  it('charges nothing for an event the builder drops', () => {
+    // A payload that strips to blank produces no block at all, so it must not
+    // consume budget the way the raw-row estimate made it.
+    expect(eventBlockBytes(eventOf(1, '   '))).toBe(0);
   });
 
   it('preserves chronological order', () => {
-    const events = Array.from({ length: 400 }, (_, i) => eventOf(i, 5_000));
-    const ids = capSummaryInput(events).map((e) => e.id);
-    expect(ids).toEqual([...ids].sort((a, b) => a - b));
+    const events = Array.from({ length: 400 }, (_, i) => filler(i, 5_000));
+    const stamps = capSummaryInput(events).map((e) => e.occurredAtEpoch);
+    expect(stamps).toEqual([...stamps].sort((a, b) => a - b));
   });
 });


### PR DESCRIPTION
## Problem

`listUnprocessedEvents` caps the event **count** (default 500), not the payload **volume**. Event payloads vary by orders of magnitude, so that cap does not bound what actually reaches the provider. Long sessions overflow the context window, the job is classified `unrecoverable`, and the session ends up with **no summary at all**.

## Measurements

From a production deployment running server-beta since May, over the sessions that failed with `Anthropic context overflow`:

| session | unprocessed events | payload | ≈ tokens |
|---|---:|---:|---:|
| A | 3,099 | **34 MB** | ~9,000k |
| B | 2,412 | 19 MB | ~5,011k |
| C | 2,411 | 15 MB | ~4,060k |

And the part that matters: **even truncated to the existing 500-event default**, those sessions still averaged **~634k tokens**, worst case **~1.55M** — against a ~200k window.

So the existing limit is not merely too generous; it is the wrong dimension. No context window currently on offer absorbs 9M tokens, which means raising the model tier does not fix this either.

## Fix

Bound the summary input by size:

- `CLAUDE_MEM_SUMMARY_INPUT_BUDGET_BYTES`, default `600_000` (≈150k tokens, leaving room for prompt + output)
- Keep the **head and the tail** of the session rather than an arbitrary prefix: the opening carries the goal, the close carries the outcome and what was left pending
- Sessions that already fit are untouched — same objects, same order

## Trade-off, stated plainly

For very long sessions this produces a **partial** summary: the middle of the session is dropped. That is a real loss of fidelity.

It is still strictly better than the current behaviour *for those same sessions*, which is an unrecoverable failure and no summary whatsoever. Sessions within budget see no change at all.

A fuller answer would be hierarchical summarisation (chunk → summarise → summarise the summaries). That is a much larger change and a different PR; this one stops the data loss.

## Tests

`tests/server/generation/summary-input-budget.test.ts` — 4 cases: passthrough under budget, bounding over budget, both ends preserved, chronological order preserved.

```
4 pass, 0 fail
```

`tsc --noEmit -p tsconfig.json` clean for the touched files.
