### PR TITLE
fix(server-beta): accept contentSessionId on /v1/memories, mirroring /v1/events

### DIFF
--- a/src/server/routes/v1/ServerV1PostgresRoutes.ts
+++ b/src/server/routes/v1/ServerV1PostgresRoutes.ts
@@ -874,6 +874,12 @@ export class ServerV1PostgresRoutes implements RouteHandler {
       z.object({
         projectId: z.string().min(1),
         serverSessionId: z.string().min(1).nullable().optional(),
+        // Callers that write memories from inside a session know the agent's own
+        // session id, not the server_sessions row UUID. /v1/events already accepts
+        // contentSessionId and resolves it (#2634); without the same affordance here
+        // every such memory lands with server_session_id NULL and can never be
+        // grouped, scoped or compared by session.
+        contentSessionId: z.string().min(1).nullable().optional(),
         kind: z.string().min(1).optional(),
         content: z.string().min(1),
         metadata: z.record(z.string(), z.unknown()).optional(),
@@ -882,10 +888,16 @@ export class ServerV1PostgresRoutes implements RouteHandler {
         const teamId = this.requireTeamId(req, res);
         if (!teamId) return;
         if (!this.ensureProjectAllowed(req, res, body.projectId)) return;
+        const linkedSessionId = await this.resolveMemorySessionLink({
+          serverSessionId: body.serverSessionId ?? null,
+          contentSessionId: body.contentSessionId ?? null,
+          projectId: body.projectId,
+          teamId,
+        });
         const createInput = {
           projectId: body.projectId,
           teamId,
-          serverSessionId: body.serverSessionId ?? null,
+          serverSessionId: linkedSessionId,
           kind: body.kind ?? 'manual',
           content: body.content,
           metadata: body.metadata ?? {},
@@ -1183,6 +1195,44 @@ export class ServerV1PostgresRoutes implements RouteHandler {
       return null;
     }
     return teamId;
+  }
+
+
+  /**
+   * Resolve the server_sessions row for a memory write.
+   *
+   * Callers writing from inside a session know the agent's own session id, not the
+   * server_sessions row UUID. /v1/events already accepts contentSessionId and resolves
+   * it (#2634); without the same affordance on the memory path every such write lands
+   * with server_session_id NULL and can never be grouped or scoped by session.
+   *
+   * Explicit serverSessionId always wins. The lookup is best-effort, mirroring the
+   * ingest path: a failure must not fail the write — store unlinked, as before.
+   * Unlike /v1/events there is no idempotency concern: observations key off `id`, and
+   * server_session_id is a plain FK (ON DELETE SET NULL), so linking later cannot
+   * drift a key.
+   */
+  private async resolveMemorySessionLink(input: {
+    serverSessionId: string | null;
+    contentSessionId: string | null;
+    projectId: string;
+    teamId: string;
+  }): Promise<string | null> {
+    if (input.serverSessionId) return input.serverSessionId;
+    if (!input.contentSessionId) return null;
+    try {
+      return await new PostgresServerSessionsRepository(this.options.pool)
+        .findIdByContentSessionId({
+          contentSessionId: input.contentSessionId,
+          projectId: input.projectId,
+          teamId: input.teamId,
+        });
+    } catch (err) {
+      logger.warn('HTTP', 'session linkage lookup failed; storing memory unlinked', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
   }
 
   private async applyContentSessionLinks(

--- a/src/server/routes/v1/ServerV1PostgresRoutes.ts
+++ b/src/server/routes/v1/ServerV1PostgresRoutes.ts
@@ -880,6 +880,10 @@ export class ServerV1PostgresRoutes implements RouteHandler {
         // every such memory lands with server_session_id NULL and can never be
         // grouped, scoped or compared by session.
         contentSessionId: z.string().min(1).nullable().optional(),
+        // Two sessions in the same team/project can share a contentSessionId across
+        // platforms; without the scope the lookup picks whichever started last, so a
+        // Cursor memory can land on a Codex session. /v1/events already scopes this.
+        platformSource: z.string().min(1).nullable().optional(),
         kind: z.string().min(1).optional(),
         content: z.string().min(1),
         metadata: z.record(z.string(), z.unknown()).optional(),
@@ -893,6 +897,9 @@ export class ServerV1PostgresRoutes implements RouteHandler {
           contentSessionId: body.contentSessionId ?? null,
           projectId: body.projectId,
           teamId,
+          // same normalization the ingest path applies, so an omitted field and an
+          // explicit null keep meaning different things
+          ...this.sessionLookupPlatformScope(req.body),
         });
         const createInput = {
           projectId: body.projectId,
@@ -1217,15 +1224,20 @@ export class ServerV1PostgresRoutes implements RouteHandler {
     contentSessionId: string | null;
     projectId: string;
     teamId: string;
+    platformSource?: string | null;
   }): Promise<string | null> {
     if (input.serverSessionId) return input.serverSessionId;
     if (!input.contentSessionId) return null;
+    const platformScope = Object.prototype.hasOwnProperty.call(input, 'platformSource')
+      ? { platformSource: input.platformSource ?? null }
+      : {};
     try {
       return await new PostgresServerSessionsRepository(this.options.pool)
         .findIdByContentSessionId({
           contentSessionId: input.contentSessionId,
           projectId: input.projectId,
           teamId: input.teamId,
+          ...platformScope,
         });
     } catch (err) {
       logger.warn('HTTP', 'session linkage lookup failed; storing memory unlinked', {

--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -232,6 +232,8 @@ function wrapHandler<Args>(
 interface ObservationAddArgs {
   projectId?: string;
   serverSessionId?: string | null;
+  contentSessionId?: string | null;
+  platformSource?: string | null;
   kind?: string;
   content: string;
   metadata?: Record<string, unknown>;
@@ -247,6 +249,8 @@ const handleObservationAdd = wrapHandler('observation_add', async (args: Observa
     projectId,
     content: args.content,
     ...(args.serverSessionId !== undefined ? { serverSessionId: args.serverSessionId } : {}),
+    ...(args.contentSessionId !== undefined ? { contentSessionId: args.contentSessionId } : {}),
+    ...(args.platformSource !== undefined ? { platformSource: args.platformSource } : {}),
     ...(args.kind !== undefined ? { kind: args.kind } : {}),
     ...(args.metadata !== undefined ? { metadata: args.metadata } : {}),
   };

--- a/src/services/hooks/server-client.ts
+++ b/src/services/hooks/server-client.ts
@@ -132,6 +132,10 @@ export interface ServerEndSessionResponse {
 export interface ServerAddObservationRequest {
   projectId: string;
   serverSessionId?: string | null;
+  // Callers inside a session know the agent's own session id, not the
+  // server_sessions row UUID; the server resolves it (mirrors /v1/events).
+  contentSessionId?: string | null;
+  platformSource?: string | null;
   kind?: string;
   content: string;
   metadata?: Record<string, unknown>;
@@ -299,6 +303,10 @@ export class ServerClient {
       narrative: content,
       ...(metadataTitle ? { title: metadataTitle } : {}),
       ...(input.serverSessionId !== undefined ? { serverSessionId: input.serverSessionId } : {}),
+      // Forward the in-session identifiers so the server can resolve the
+      // server_sessions row itself; without these the memory lands unlinked.
+      ...(input.contentSessionId !== undefined ? { contentSessionId: input.contentSessionId } : {}),
+      ...(input.platformSource !== undefined ? { platformSource: input.platformSource } : {}),
       ...(input.metadata !== undefined ? { metadata: input.metadata } : {}),
     };
   }

--- a/tests/server/runtime/server-session-linkage.test.ts
+++ b/tests/server/runtime/server-session-linkage.test.ts
@@ -134,6 +134,7 @@ describe('ServerV1PostgresRoutes content session linkage', () => {
           contentSessionId: string | null;
           projectId: string;
           teamId: string;
+          platformSource?: string | null;
         }): Promise<string | null>;
       };
 
@@ -183,6 +184,47 @@ describe('ServerV1PostgresRoutes content session linkage', () => {
       });
       expect(linked).toBeNull();
       expect(calls).toHaveLength(0);
+    });
+
+
+    it('carries the platform scope into the lookup', async () => {
+      const calls: unknown[][] = [];
+      const pool = {
+        async query(_text: string, values?: unknown[]) {
+          calls.push(values ?? []);
+          return { command: 'SELECT', rowCount: 1, oid: 0, fields: [], rows: [{ id: 'scoped-session' }] };
+        },
+      };
+      const linked = await routesWith(pool).resolveMemorySessionLink({
+        serverSessionId: null,
+        contentSessionId: 'shared-content',
+        projectId: 'project-1',
+        teamId: 'team-1',
+        platformSource: 'cursor',
+      });
+      expect(linked).toBe('scoped-session');
+      // without the scope the lookup returns whichever session started last, so a
+      // memory from one platform can be attached to another platform's session
+      expect(calls[0]).toContain('cursor');
+    });
+
+    it('distinguishes an omitted platformSource from an explicit null', async () => {
+      const seen: unknown[][] = [];
+      const pool = {
+        async query(_text: string, values?: unknown[]) {
+          seen.push(values ?? []);
+          return { command: 'SELECT', rowCount: 0, oid: 0, fields: [], rows: [] };
+        },
+      };
+      const routes = routesWith(pool);
+      await routes.resolveMemorySessionLink({
+        serverSessionId: null, contentSessionId: 'c', projectId: 'p', teamId: 't',
+      });
+      await routes.resolveMemorySessionLink({
+        serverSessionId: null, contentSessionId: 'c', projectId: 'p', teamId: 't', platformSource: null,
+      });
+      expect(seen).toHaveLength(2);
+      expect(JSON.stringify(seen[0])).not.toBe(JSON.stringify(seen[1]));
     });
 
     it('never fails the write when the lookup throws', async () => {

--- a/tests/server/runtime/server-session-linkage.test.ts
+++ b/tests/server/runtime/server-session-linkage.test.ts
@@ -120,6 +120,86 @@ describe('ServerV1PostgresRoutes content session linkage', () => {
       ['shared-content', 'project-1', 'team-1', false, null],
     ]);
   });
+
+  // /v1/memories path (#2634 gave /v1/events this affordance; memories lacked it,
+  // so every in-session memory write landed with server_session_id NULL).
+  describe('resolveMemorySessionLink', () => {
+    const routesWith = (pool: unknown) =>
+      new ServerV1PostgresRoutes({
+        pool: pool as PostgresPool,
+        queueManager: new DisabledServerQueueManager('unit test'),
+      }) as unknown as {
+        resolveMemorySessionLink(input: {
+          serverSessionId: string | null;
+          contentSessionId: string | null;
+          projectId: string;
+          teamId: string;
+        }): Promise<string | null>;
+      };
+
+    const okPool = (rows: Array<{ id: string }>) => {
+      const calls: unknown[][] = [];
+      return {
+        pool: {
+          async query(_text: string, values?: unknown[]) {
+            calls.push(values ?? []);
+            return { command: 'SELECT', rowCount: rows.length, oid: 0, fields: [], rows };
+          },
+        },
+        calls,
+      };
+    };
+
+    it('prefers an explicit serverSessionId and does not query', async () => {
+      const { pool, calls } = okPool([{ id: 'should-not-be-used' }]);
+      const linked = await routesWith(pool).resolveMemorySessionLink({
+        serverSessionId: 'explicit-session',
+        contentSessionId: 'content-1',
+        projectId: 'project-1',
+        teamId: 'team-1',
+      });
+      expect(linked).toBe('explicit-session');
+      expect(calls).toHaveLength(0);
+    });
+
+    it('resolves contentSessionId when serverSessionId is absent', async () => {
+      const { pool } = okPool([{ id: 'resolved-session' }]);
+      const linked = await routesWith(pool).resolveMemorySessionLink({
+        serverSessionId: null,
+        contentSessionId: 'content-1',
+        projectId: 'project-1',
+        teamId: 'team-1',
+      });
+      expect(linked).toBe('resolved-session');
+    });
+
+    it('stores unlinked when neither id is supplied', async () => {
+      const { pool, calls } = okPool([]);
+      const linked = await routesWith(pool).resolveMemorySessionLink({
+        serverSessionId: null,
+        contentSessionId: null,
+        projectId: 'project-1',
+        teamId: 'team-1',
+      });
+      expect(linked).toBeNull();
+      expect(calls).toHaveLength(0);
+    });
+
+    it('never fails the write when the lookup throws', async () => {
+      const pool = {
+        async query() {
+          throw new Error('connection reset');
+        },
+      };
+      const linked = await routesWith(pool).resolveMemorySessionLink({
+        serverSessionId: null,
+        contentSessionId: 'content-1',
+        projectId: 'project-1',
+        teamId: 'team-1',
+      });
+      expect(linked).toBeNull();
+    });
+  });
 });
 
 function createInput(overrides: Partial<CreatePostgresAgentEventInput> = {}): CreatePostgresAgentEventInput {


### PR DESCRIPTION
## Problem

#2634 taught the ingest path to resolve `contentSessionId` into a `server_sessions` row, because callers writing from inside a session know the agent's own session id, not the `server_sessions` row UUID.

The memory write path never got the same affordance. `/v1/memories` accepts only `serverSessionId`:

```ts
z.object({
  projectId: z.string().min(1),
  serverSessionId: z.string().min(1).nullable().optional(),   // ← no contentSessionId
  ...
})
```

So any client writing a memory from inside a session lands with `server_session_id NULL`, and those rows can never be grouped, scoped or compared by session afterwards.

## Measurement

On a production deployment running server-beta since May:

| write path | rows | linked to a session |
|---|---:|---:|
| generation path (`/v1/events` → generator) | 187,970 | **85.7%** |
| direct memory writes (`/v1/memories`) | 2,948 | **0.0%** |

Not a sampling artifact — it is 2,948 out of 2,948. The information exists on the caller side (we carry it in `metadata` as a workaround), it simply has nowhere to go in the request.

## Fix

Accept `contentSessionId` and resolve it through the same `findIdByContentSessionId` used by the ingest path.

- an explicit `serverSessionId` still wins, and short-circuits without querying
- the lookup is best-effort: a failure logs and stores the memory unlinked, exactly as today, so no write can begin failing because of this change
- behaviour for callers that do not send `contentSessionId` is unchanged

## Why the #2634 idempotency concern does not apply here

Review of #2634 flagged idempotency-key drift, since the ingest path derives its key partly from session linkage. That does not carry over: `observations` keys off `id`, and `server_session_id` is a plain FK with `ON DELETE SET NULL`. Resolving the link later cannot drift a key.

## Tests

Four cases added to the #2634 linkage suite (`tests/server/runtime/server-session-linkage.test.ts`), same mocked-pool style:

- explicit `serverSessionId` wins **and issues no query**
- `contentSessionId` resolves when `serverSessionId` is absent
- neither id supplied → stores unlinked, no query
- lookup throws → returns null, write proceeds

```
6 pass, 0 fail   (2 pre-existing + 4 new)
```

`tsc --noEmit -p tsconfig.json` clean for the touched file.
