### PR TITLE
fix(server-beta): stop discarding session-summary responses (recurrence of #1345)

### DIFF
--- a/src/server/generation/processGeneratedResponse.ts
+++ b/src/server/generation/processGeneratedResponse.ts
@@ -477,6 +477,15 @@ function renderObservationContent(observation: ParsedObservation): string {
   if (observation.facts && observation.facts.length > 0) {
     parts.push(observation.facts.map(f => `- ${f}`).join('\n'));
   }
+  // The parser treats concepts as content: an observation whose only populated
+  // field is <concepts> survives its empty-observation guard. This renderer did
+  // not, so that observation rendered to '' and was dropped by the empty-content
+  // skip in persistGeneratedObservations - accepted, discarded, job completed.
+  // Rendered last-resort only, so responses that carry prose keep the body they
+  // already have and no existing content changes shape.
+  if (parts.length === 0 && observation.concepts && observation.concepts.length > 0) {
+    parts.push(`Concepts: ${observation.concepts.join(', ')}`);
+  }
   return parts.join('\n\n').trim();
 }
 

--- a/src/server/generation/processGeneratedResponse.ts
+++ b/src/server/generation/processGeneratedResponse.ts
@@ -196,7 +196,17 @@ export async function processSessionSummaryResponse(
 
   const summary = parsed.summary ?? null;
   const skipped = summary?.skipped === true;
-  const summaryContent = summary ? renderSummaryContent(summary) : '';
+
+  // Defence in depth: a provider that answers with <observation> blocks instead of
+  // a <summary> block used to be dropped here silently — parsed.summary was null,
+  // the content was judged empty, the job completed and parsed.observations was
+  // never looked at. Fold those blocks into the summary body rather than
+  // discarding a response the model was billed for.
+  const fallbackObservations = !summary && !skipped ? parsed.observations : [];
+  const summaryContent = summary
+    ? renderSummaryContent(summary)
+    : fallbackObservations.map(o => renderObservationContent(o)).join('\n\n');
+
   const privateContentDetected = skipped || summaryContent.trim().length === 0;
 
   const rendered: RenderedObservation[] = privateContentDetected

--- a/src/server/generation/providers/shared/prompt-builder.ts
+++ b/src/server/generation/providers/shared/prompt-builder.ts
@@ -72,6 +72,42 @@ export function buildServerGenerationPrompt(
 
   const observationOutputSchema = buildObservationOutputSchema(mode);
 
+  // Summary jobs are a different task from event jobs, and the persistence path
+  // for them (processGeneratedResponse -> parsed.summary) only understands a
+  // <summary> block. Asking for <observation> here yields a response the summary
+  // path silently discards, so branch the instruction on the job's source type.
+  const isSessionSummary = context.job.sourceType === 'session_summary';
+
+  const summaryInstruction = [
+    'You are reviewing a complete agent session. Return a single',
+    '<summary>...</summary> XML block describing the arc of the session. If the',
+    'session contains nothing worth recording (e.g., everything was scrubbed by',
+    'privacy filters or the activity was trivial), return a single self-closing',
+    '<skip_summary /> tag and nothing else. Do not include any prose outside the XML.',
+    '',
+    'Schema for the <summary> block (at least one of the first five is required):',
+    '<summary>',
+    '  <request>what the user asked for</request>',
+    '  <investigated>what was explored, and how</investigated>',
+    '  <learned>durable findings worth remembering later</learned>',
+    '  <completed>what was actually done</completed>',
+    '  <next_steps>what is left open</next_steps>',
+    '  <notes>anything else worth keeping</notes>',
+    '</summary>',
+  ];
+
+  const observationInstruction = [
+    'You are observing an agent at work. Return one or more',
+    '<observation>...</observation> XML blocks summarizing durable, useful',
+    'discoveries from the events above. If the events contain nothing worth',
+    'recording (e.g., everything was scrubbed by privacy filters or the',
+    'activity was trivial), return a single self-closing <skip_summary />',
+    'tag and nothing else. Do not include any prose outside the XML.',
+    '',
+    'Schema for each <observation> block:',
+    observationOutputSchema,
+  ];
+
   const prompt = [
     '<server_beta_observation_request>',
     `  <project_id>${escapeXml(context.project.projectId)}</project_id>`,
@@ -82,15 +118,7 @@ export function buildServerGenerationPrompt(
     '  </agent_events>',
     '</server_beta_observation_request>',
     '',
-    'You are observing an agent at work. Return one or more',
-    '<observation>...</observation> XML blocks summarizing durable, useful',
-    'discoveries from the events above. If the events contain nothing worth',
-    'recording (e.g., everything was scrubbed by privacy filters or the',
-    'activity was trivial), return a single self-closing <skip_summary />',
-    'tag and nothing else. Do not include any prose outside the XML.',
-    '',
-    'Schema for each <observation> block:',
-    observationOutputSchema,
+    ...(isSessionSummary ? summaryInstruction : observationInstruction),
   ].join('\n');
 
   return { prompt, hadPrivateContent, skippedAll };

--- a/tests/server/generation/process-generated-response.test.ts
+++ b/tests/server/generation/process-generated-response.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../src/storage/postgres/index.js';
 import {
   processGeneratedResponse,
+  processSessionSummaryResponse,
   markGenerationFailed,
 } from '../../../src/server/generation/processGeneratedResponse.js';
 import { ModeManager } from '../../../src/services/domain/ModeManager.js';
@@ -96,6 +97,73 @@ describe('processGeneratedResponse + markGenerationFailed', () => {
       teamId,
     });
   }
+
+
+  // Regression: the summary path used to read only parsed.summary. A provider that
+  // answered with <observation> blocks (which is what the shared prompt asked for)
+  // produced summary=null, was judged empty, and the job completed having discarded
+  // a paid-for response. Measured on a production deployment: 4,898 summary jobs,
+  // zero observations persisted.
+  it('persists a summary job answered with <observation> blocks instead of dropping it', async () => {
+    const session = await storage.sessions.create({
+      projectId,
+      teamId,
+      contentSessionId: `content-${crypto.randomUUID()}`,
+      agentId: 'agent-1',
+      platformSource: 'claude-code',
+      metadata: {},
+    });
+
+    const summaryJob = await storage.observationGenerationJobs.create({
+      projectId,
+      teamId,
+      sourceType: 'session_summary',
+      sourceId: session.id,
+      serverSessionId: session.id,
+      jobType: 'observation_generate_session_summary',
+    });
+
+    await storage.observationGenerationJobs.transitionStatus({
+      id: summaryJob.id,
+      projectId,
+      teamId,
+      status: 'processing',
+    });
+
+    const fresh = (await storage.observationGenerationJobs.getByIdForScope({
+      id: summaryJob.id,
+      projectId,
+      teamId,
+    }))!;
+
+    const outcome = await processSessionSummaryResponse({
+      pool: pool as unknown as Parameters<typeof processSessionSummaryResponse>[0]['pool'],
+      job: fresh,
+      rawText: `
+        <observation>
+          <type>discovery</type>
+          <title>Session arc</title>
+          <facts><fact>the run ended with the queue drained</fact></facts>
+        </observation>
+      `,
+      providerLabel: 'fake',
+      modelId: 'fake-1',
+    });
+
+    expect(outcome.kind).toBe('completed');
+    if (outcome.kind === 'completed') {
+      // the point of the fix: the response is kept, not silently discarded
+      expect(outcome.observations.length).toBeGreaterThan(0);
+      expect(outcome.observations[0]!.content).toContain('queue drained');
+    }
+
+    const reloaded = await storage.observationGenerationJobs.getByIdForScope({
+      id: summaryJob.id,
+      projectId,
+      teamId,
+    });
+    expect(reloaded?.status).toBe('completed');
+  });
 
   it('persists observation, links source, and marks job completed for valid XML', async () => {
     const xml = `

--- a/tests/server/generation/process-generated-response.test.ts
+++ b/tests/server/generation/process-generated-response.test.ts
@@ -165,6 +165,95 @@ describe('processGeneratedResponse + markGenerationFailed', () => {
     expect(reloaded?.status).toBe('completed');
   });
 
+  // The parser's empty-observation guard accepts a block whose only populated
+  // field is <concepts>, but renderObservationContent ignored concepts, so the
+  // block rendered to '' and was skipped as empty content - the same
+  // accepted-then-discarded shape this PR is about, one layer down.
+  it('persists a concepts-only response instead of completing the job empty', async () => {
+    const session = await storage.sessions.create({
+      projectId,
+      teamId,
+      contentSessionId: `content-${crypto.randomUUID()}`,
+      agentId: 'agent-1',
+      platformSource: 'claude-code',
+      metadata: {},
+    });
+
+    const summaryJob = await storage.observationGenerationJobs.create({
+      projectId,
+      teamId,
+      sourceType: 'session_summary',
+      sourceId: session.id,
+      serverSessionId: session.id,
+      jobType: 'observation_generate_session_summary',
+    });
+
+    await storage.observationGenerationJobs.transitionStatus({
+      id: summaryJob.id,
+      projectId,
+      teamId,
+      status: 'processing',
+    });
+
+    const fresh = (await storage.observationGenerationJobs.getByIdForScope({
+      id: summaryJob.id,
+      projectId,
+      teamId,
+    }))!;
+
+    const outcome = await processSessionSummaryResponse({
+      pool: pool as unknown as Parameters<typeof processSessionSummaryResponse>[0]['pool'],
+      job: fresh,
+      rawText: `
+        <observation>
+          <type>discovery</type>
+          <concepts><concept>outbox drain</concept><concept>valkey backpressure</concept></concepts>
+        </observation>
+      `,
+      providerLabel: 'fake',
+      modelId: 'fake-1',
+    });
+
+    expect(outcome.kind).toBe('completed');
+    if (outcome.kind === 'completed') {
+      expect(outcome.observations).toHaveLength(1);
+      expect(outcome.observations[0]!.content).toContain('outbox drain');
+      expect(outcome.observations[0]!.content).toContain('valkey backpressure');
+      expect(outcome.privateContentDetected).toBe(false);
+    }
+  });
+
+  // Same defect on the per-event path: concepts-only blocks were skipped by the
+  // empty-content guard and the job still completed.
+  it('persists a concepts-only observation on the per-event path', async () => {
+    await storage.observationGenerationJobs.transitionStatus({
+      id: jobId,
+      projectId,
+      teamId,
+      status: 'processing',
+    });
+    const fresh = (await reloadJob())!;
+
+    const outcome = await processGeneratedResponse({
+      pool: pool as unknown as Parameters<typeof processGeneratedResponse>[0]['pool'],
+      job: fresh,
+      rawText: `
+        <observation>
+          <type>discovery</type>
+          <concepts><concept>lease renewal</concept></concepts>
+        </observation>
+      `,
+      providerLabel: 'fake',
+      modelId: 'fake-1',
+    });
+
+    expect(outcome.kind).toBe('completed');
+    if (outcome.kind === 'completed') {
+      expect(outcome.observations).toHaveLength(1);
+      expect(outcome.observations[0]!.content).toContain('lease renewal');
+    }
+  });
+
   it('persists observation, links source, and marks job completed for valid XML', async () => {
     const xml = `
       <observation>

--- a/tests/server/generation/providers.test.ts
+++ b/tests/server/generation/providers.test.ts
@@ -20,14 +20,14 @@ import { OpenRouterObservationProvider } from '../../../src/server/generation/pr
 import { buildServerGenerationPrompt } from '../../../src/server/generation/providers/shared/prompt-builder.js';
 import type { ServerGenerationContext } from '../../../src/server/generation/providers/shared/types.js';
 
-function makeContext(overrides: Partial<{ payload: unknown; serverSessionId: string | null }> = {}): ServerGenerationContext {
+function makeContext(overrides: Partial<{ payload: unknown; serverSessionId: string | null; sourceType: 'agent_event' | 'session_summary' }> = {}): ServerGenerationContext {
   return {
     job: {
       id: 'job-1',
       projectId: 'proj-1',
       teamId: 'team-1',
       agentEventId: 'evt-1',
-      sourceType: 'agent_event',
+      sourceType: overrides.sourceType ?? 'agent_event',
       sourceId: 'evt-1',
       serverSessionId: overrides.serverSessionId ?? null,
       jobType: 'observation_generate_for_event',
@@ -159,6 +159,35 @@ describe('shared error classification', () => {
 });
 
 describe('buildServerGenerationPrompt', () => {
+  // A session_summary job is a different task, and its persistence path only
+  // understands a <summary> block. Asking it for <observation> produced responses
+  // that the summary path discarded without a trace.
+  it('asks for a <summary> block on session_summary jobs', () => {
+    const result = buildServerGenerationPrompt(makeContext({ sourceType: 'session_summary' }));
+    expect(result.prompt).toContain('<summary>...</summary>');
+    expect(result.prompt).toContain('<request>');
+    expect(result.prompt).toContain('<learned>');
+    expect(result.prompt).toContain('<next_steps>');
+  });
+
+  it('does not ask a session_summary job for <observation> blocks', () => {
+    const result = buildServerGenerationPrompt(makeContext({ sourceType: 'session_summary' }));
+    expect(result.prompt).not.toContain('<observation>...</observation>');
+  });
+
+  it('still asks for <observation> blocks on agent_event jobs', () => {
+    const result = buildServerGenerationPrompt(makeContext());
+    expect(result.prompt).toContain('<observation>...</observation>');
+    expect(result.prompt).not.toContain('<summary>...</summary>');
+  });
+
+  it('keeps offering the skip escape hatch on both job types', () => {
+    for (const sourceType of ['agent_event', 'session_summary'] as const) {
+      expect(buildServerGenerationPrompt(makeContext({ sourceType })).prompt)
+        .toContain('<skip_summary />');
+    }
+  });
+
   it('strips <private> tags from event payload before sending', () => {
     const context = makeContext({
       payload: '<private>secret</private>visible',


### PR DESCRIPTION
## This is #1345 reappearing in server-beta

#1345 (merged 13 Mar) described exactly this:

> the LLM responds with `<observation>` XML tags instead of the expected `<summary>` tags. `parseSummary()` finds no `<summary>` block, returns null, and the summary is silently lost. The stop hook reports "Summary completed" (false positive) because the pending queue is empty.

That fix landed in the SDK path (`src/sdk/prompts.ts`, `src/sdk/parser.ts`). server-beta arrived on 8 May with its own prompt builder and its own summary persistence path, and neither inherited the lesson:

- `buildServerGenerationPrompt` is shared by both job types and asks for `<observation>` blocks — including for summary jobs
- `parseAgentXml` sees an `<observation>` root and returns `{ observations: [...], summary: null }`
- `processSessionSummaryResponse` reads only `parsed.summary`, computes an empty body, and completes the job without looking at `parsed.observations`

Same cause, same silent loss, new runtime. The earlier reports of the legacy symptom are #1649, #1823 and #1546; the `WARN [PARSER]` that made it noticeable there was later removed by #2074, so the server-beta recurrence arrived without any signal at all.

## Measured impact

On a deployment running server-beta since May:

| | |
|---|---:|
| `session_summary` jobs | **4,898** |
| completed | 4,836 |
| observations written by any of them | **0** |

No observation in the database has `created_by_job_id` pointing at a summary job, in three months. I confirmed the mechanism by replaying a real call with the current prompt: the model returned a well-formed `<observation>` block with useful content, and it was discarded.

## Changes

**1. Ask summary jobs for what the summary path stores.** The prompt now branches on `job.sourceType` and requests a `<summary>` block with the sub-tags `parseSummaryBlock` already understands. This is the same shape of fix as #1345 — condition the prompt for the task — applied to the runtime that was written after it.

All the summary machinery already exists (`parseSummaryBlock`, `renderSummaryContent`, the `ParsedSummary` fields); it simply was never reachable, because the prompt asked for something else.

**2. Keep `<observation>` answers instead of dropping them.** Defensive: if a provider answers with observation blocks anyway, fold them into the summary body rather than discarding a response that was already billed.

Note that #1604 and #2058 proposed salvage-only fixes for the legacy path and were not merged, while the prompt-conditioning fix (#1345) was. If you'd rather keep this PR to the prompt change alone, say so and I'll drop the second commit — the fallback is there to protect existing deployments during the window before a prompt change reaches them, not to replace the conditioning fix.

## Known limitation, not addressed here

This does **not** make summaries complete. `loadEvents` feeds summary jobs from `listUnprocessedEvents`, which excludes every event that already has a completed per-event generation job. On the same deployment, counting what a summary prompt would actually receive:

| events visible to the summary prompt | sessions |
|---|---:|
| **zero** | **3,399** |
| 1–5 | 1,203 |
| 6–50 | 102 |
| 50+ | 194 |

So for ~69% of sessions the prompt arrives with an empty `<agent_events>` block. With this PR those sessions will emit `<skip_summary />` and correctly persist nothing — which is the right outcome, but it means the fix only recovers sessions that still carry unprocessed events.

Making summaries actually describe a session needs a different input (the session's full event set, or the observations already generated from it). That's a design change and I'd rather not smuggle it in here; happy to open it separately if useful.

## Tests

- 4 cases pinning the prompt per source type (summary asks for `<summary>`, event still asks for `<observation>`, both keep the `<skip_summary />` escape hatch)
- 1 integration test: a summary job answered with `<observation>` now persists — verified failing before the change (0 observations) and passing after

**On the suite:** `tests/server/generation/process-generated-response.test.ts` is flaky when the whole file runs against one Postgres — on a clean `upstream/main` checkout it already reports 5 failures out of 7 in my environment, and every case passes in isolation. Looks related to the shared pool + per-test schema `search_path` workaround noted in the setup comment; untouched here.
