### PR TITLE
fix(worker): reuse OpenAI-compatible synthetic session IDs

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -1883,6 +1883,14 @@ export class SessionStore {
   }
 
   updateMemorySessionId(sessionDbId: number, memorySessionId: string | null): void {
+    const current = this.db.prepare(`
+      SELECT memory_session_id
+      FROM sdk_sessions
+      WHERE id = ?
+    `).get(sessionDbId) as { memory_session_id: string | null } | undefined;
+
+    if (!current || current.memory_session_id === memorySessionId) return;
+
     this.db.prepare(`
       UPDATE sdk_sessions
       SET memory_session_id = ?

--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -90,10 +90,18 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     }
 
     if (!session.memorySessionId) {
-      const syntheticMemorySessionId = `${this.syntheticIdPrefix}-${session.contentSessionId}-${Date.now()}`;
-      session.memorySessionId = syntheticMemorySessionId;
-      this.dbManager.getSessionStore().updateMemorySessionId(session.sessionDbId, syntheticMemorySessionId);
-      logger.info('SESSION', `MEMORY_ID_GENERATED | sessionDbId=${session.sessionDbId} | provider=${this.providerName}`);
+      const persistedMemorySessionId = this.dbManager.getSessionById(session.sessionDbId).memory_session_id;
+      const syntheticIdPrefix = `${this.syntheticIdPrefix}-${session.contentSessionId}-`;
+
+      if (persistedMemorySessionId?.startsWith(syntheticIdPrefix)) {
+        session.memorySessionId = persistedMemorySessionId;
+        logger.info('SESSION', `MEMORY_ID_REUSED | sessionDbId=${session.sessionDbId} | provider=${this.providerName}`);
+      } else {
+        const syntheticMemorySessionId = `${syntheticIdPrefix}${Date.now()}`;
+        session.memorySessionId = syntheticMemorySessionId;
+        this.dbManager.getSessionStore().updateMemorySessionId(session.sessionDbId, syntheticMemorySessionId);
+        logger.info('SESSION', `MEMORY_ID_GENERATED | sessionDbId=${session.sessionDbId} | provider=${this.providerName}`);
+      }
     }
 
     const mode = ModeManager.getInstance().getActiveMode();

--- a/tests/worker/openai-compatible-summary-tier.test.ts
+++ b/tests/worker/openai-compatible-summary-tier.test.ts
@@ -121,4 +121,37 @@ describe('OpenAICompatibleProvider summary tier routing', () => {
 
     expect(provider.queriedModels).toEqual(['session-model', 'session-model']);
   });
+
+  it('reuses the persisted synthetic id when an in-memory session restarts', async () => {
+    const updateMemorySessionId = mock(() => {});
+    const provider = new TestProvider({
+      getSessionById: () => ({ memory_session_id: 'test-test-session-1234' }),
+      getSessionStore: () => ({ updateMemorySessionId }),
+    } as any, {
+      getMessageIterator: async function* () {},
+    } as any);
+    const session = makeSession({ memorySessionId: null });
+
+    await provider.startSession(session);
+
+    expect(session.memorySessionId).toBe('test-test-session-1234');
+    expect(updateMemorySessionId).not.toHaveBeenCalled();
+  });
+
+  it('replaces a persisted synthetic id from a different provider', async () => {
+    const updateMemorySessionId = mock(() => {});
+    const provider = new TestProvider({
+      getSessionById: () => ({ memory_session_id: 'other-test-session-1234' }),
+      getSessionStore: () => ({ updateMemorySessionId }),
+    } as any, {
+      getMessageIterator: async function* () {},
+    } as any);
+    const session = makeSession({ memorySessionId: null });
+
+    await provider.startSession(session);
+
+    expect(session.memorySessionId).toStartWith('test-test-session-');
+    expect(updateMemorySessionId).toHaveBeenCalledTimes(1);
+    expect(updateMemorySessionId).toHaveBeenCalledWith(1, session.memorySessionId);
+  });
 });

--- a/tests/worker/sync/mutation-sites.test.ts
+++ b/tests/worker/sync/mutation-sites.test.ts
@@ -168,6 +168,16 @@ describe('mutation sites', () => {
       }
     });
 
+    it('updateMemorySessionId emits nothing when the id is unchanged', () => {
+      store.updateMemorySessionId(1, 'mem-late');
+      expect(outboxRows(db).length).toBe(2);
+
+      store.updateMemorySessionId(1, 'mem-late');
+
+      expect(outboxRows(db).length).toBe(2);
+      for (const row of promptRows()) expect(row.sync_rev).toBe('2');
+    });
+
     it('ensureMemorySessionIdRegistered goes through the same repair (only when the id actually changes)', () => {
       store.ensureMemorySessionIdRegistered(1, 'mem-late');
       expect(outboxRows(db).length).toBe(2);


### PR DESCRIPTION
## Summary

- reuse a persisted synthetic memory-session ID when an OpenRouter or Gemini generator restarts for the same content session
- mint and persist a new synthetic ID only when the stored ID belongs to a different provider/session
- make `updateMemorySessionId` a no-op when the value is unchanged, preventing redundant prompt repair operations from any caller

## Root cause

`SessionManager` intentionally initializes reloaded in-memory sessions without a memory-session ID so Claude SDK sessions are not resumed with stale remote IDs. OpenAI-compatible providers use local synthetic IDs instead, but they treated every reload as a new identity. Each new timestamped ID called `updateMemorySessionId`, which requeued every native prompt in the conversation as a `set_prompt_session` mutation.

That makes the sync outbox grow with `generator restarts × prompts`, so large, active, multi-agent conversations amplify the database and worker overhead.

The provider now reuses a persisted synthetic ID only when its provider/content prefix matches. Provider changes still create a fresh ID once. The store-level equality guard provides a second idempotency boundary.

## Verification

- `bun run typecheck`
- `bun test tests` — 2,560 passed, 18 skipped, 0 failed
- reproduced against an active multi-agent workload: before the patch, the outbox added 163 rows between consecutive reads and reached 3.9 million `set_prompt_session` rows; after the patch, repeated generator restarts logged `MEMORY_ID_REUSED` and the cleaned outbox remained at zero

Related to #2793. Complements #3537 by preventing the redundant requeue work at its source.
