### PR TITLE
feat: surface the 7-day Pro trial everywhere we show the viewer URL

### DIFF
--- a/cursor-hooks/QUICKSTART.md
+++ b/cursor-hooks/QUICKSTART.md
@@ -83,7 +83,7 @@ Restart Cursor to load the hooks.
 - Browse sessions, observations, and summaries
 - Search your project history
 
-✨ **Get cmem Pro — 7-day free trial: cloud sync + memory model** → https://cmem.ai/pro?from=docs
+✨ **Get 2x more use out of your Max plan for free (7-day trial, $30/mo)** → https://cmem.ai/pro?from=docs
 
 ### Via MCP Tools (if enabled)
 - claude-mem provides search tools via MCP

--- a/cursor-hooks/QUICKSTART.md
+++ b/cursor-hooks/QUICKSTART.md
@@ -83,6 +83,8 @@ Restart Cursor to load the hooks.
 - Browse sessions, observations, and summaries
 - Search your project history
 
+✨ **Get cmem Pro — 7-day free trial: cloud sync + memory model** → https://cmem.ai/pro?from=docs
+
 ### Via MCP Tools (if enabled)
 - claude-mem provides search tools via MCP
 - Use `search`, `timeline`, and `get_observations` tools

--- a/cursor-hooks/README.md
+++ b/cursor-hooks/README.md
@@ -55,6 +55,8 @@ Context is automatically injected via Cursor's **Rules** system:
 - **Web Viewer**: Access context at `http://localhost:37777`
 - **Manual Request**: Ask the agent to search memory
 
+✨ **Get cmem Pro — 7-day free trial: cloud sync + memory model** → https://cmem.ai/pro?from=docs
+
 See [CONTEXT-INJECTION.md](CONTEXT-INJECTION.md) for details.
 
 ## Installation

--- a/cursor-hooks/README.md
+++ b/cursor-hooks/README.md
@@ -55,7 +55,7 @@ Context is automatically injected via Cursor's **Rules** system:
 - **Web Viewer**: Access context at `http://localhost:37777`
 - **Manual Request**: Ask the agent to search memory
 
-✨ **Get cmem Pro — 7-day free trial: cloud sync + memory model** → https://cmem.ai/pro?from=docs
+✨ **Get 2x more use out of your Max plan for free (7-day trial, $30/mo)** → https://cmem.ai/pro?from=docs
 
 See [CONTEXT-INJECTION.md](CONTEXT-INJECTION.md) for details.
 

--- a/cursor-hooks/STANDALONE-SETUP.md
+++ b/cursor-hooks/STANDALONE-SETUP.md
@@ -12,7 +12,7 @@ Use claude-mem's persistent memory in Cursor without a Claude Code subscription.
 - **Context injection** via `.cursor/rules/` - relevant history included in every chat
 - **Web viewer** at http://localhost:37777 - browse and search your project history
 
-✨ **Get cmem Pro — 7-day free trial: cloud sync + memory model** → https://cmem.ai/pro?from=docs
+✨ **Get 2x more use out of your Max plan for free (7-day trial, $30/mo)** → https://cmem.ai/pro?from=docs
 
 **Why This Matters**: Every Cursor session starts fresh. Claude-mem bridges that gap - your AI agent builds cumulative knowledge about your codebase, decisions, and patterns over time.
 
@@ -149,7 +149,7 @@ The worker runs in the background and handles:
 
 4. **Open the web viewer**: http://localhost:37777
 
-✨ **Get cmem Pro — 7-day free trial: cloud sync + memory model** → https://cmem.ai/pro?from=docs
+✨ **Get 2x more use out of your Max plan for free (7-day trial, $30/mo)** → https://cmem.ai/pro?from=docs
 
 ## How It Works
 

--- a/cursor-hooks/STANDALONE-SETUP.md
+++ b/cursor-hooks/STANDALONE-SETUP.md
@@ -12,6 +12,8 @@ Use claude-mem's persistent memory in Cursor without a Claude Code subscription.
 - **Context injection** via `.cursor/rules/` - relevant history included in every chat
 - **Web viewer** at http://localhost:37777 - browse and search your project history
 
+✨ **Get cmem Pro — 7-day free trial: cloud sync + memory model** → https://cmem.ai/pro?from=docs
+
 **Why This Matters**: Every Cursor session starts fresh. Claude-mem bridges that gap - your AI agent builds cumulative knowledge about your codebase, decisions, and patterns over time.
 
 ## Prerequisites
@@ -146,6 +148,8 @@ The worker runs in the background and handles:
    Should return: `{"status":"ready"}`
 
 4. **Open the web viewer**: http://localhost:37777
+
+✨ **Get cmem Pro — 7-day free trial: cloud sync + memory model** → https://cmem.ai/pro?from=docs
 
 ## How It Works
 

--- a/src/cli/handlers/context.ts
+++ b/src/cli/handlers/context.ts
@@ -18,6 +18,7 @@ import { shouldTrackProject } from '../../shared/should-track-project.js';
 import { readStaleMarker } from '../../shared/oauth-token.js';
 import { normalizePlatformSource } from '../../shared/platform-source.js';
 import { callMcpToolOnce } from '../../shared/mcp-client.js';
+import { proTrialLine } from '../../shared/pro-promo.js';
 
 async function requestSessionStartContext(args: {
   projects: string[];
@@ -159,7 +160,7 @@ export const contextHandler: EventHandler = {
     const displayContent = coloredTimeline || (platform === 'antigravity-cli' ? additionalContext : '');
 
     const systemMessage = showTerminalOutput && displayContent
-      ? `${displayContent}\n\nView Observations Live @ http://localhost:${port}`
+      ? `${displayContent}\n\nView Observations Live @ http://localhost:${port}\n${proTrialLine('session-start')}`
       : undefined;
 
     return {

--- a/src/cli/handlers/user-message.ts
+++ b/src/cli/handlers/user-message.ts
@@ -8,6 +8,7 @@ import {
 } from '../../shared/worker-utils.js';
 import { HOOK_EXIT_CODES } from '../../shared/hook-constants.js';
 import { normalizePlatformSource } from '../../shared/platform-source.js';
+import { proTrialLine } from '../../shared/pro-promo.js';
 
 export const userMessageHandler: EventHandler = {
   async execute(input: NormalizedHookInput): Promise<HookResult> {
@@ -37,7 +38,8 @@ export const userMessageHandler: EventHandler = {
       output +
       "\n\n" + String.fromCodePoint(0x1F4A1) + " Wrap any message with <private> ... </private> to prevent storing sensitive information.\n" +
       "\n" + String.fromCodePoint(0x1F4AC) + " Community https://discord.gg/J4wttp9vDu" +
-      `\n` + String.fromCodePoint(0x1F4FA) + ` Watch live in browser http://localhost:${port}/\n`;
+      `\n` + String.fromCodePoint(0x1F4FA) + ` Watch live in browser http://localhost:${port}/\n` +
+      proTrialLine('context-banner') + `\n`;
 
     return { exitCode: HOOK_EXIT_CODES.SUCCESS, systemMessage: bannerText };
   },

--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -45,6 +45,7 @@ import {
   costPer1kObservations,
   fetchBlendedRates,
 } from '../cmem-pro-costs.js';
+import { PRO_TRIAL_PITCH, proTrialUrl } from '../../shared/pro-promo.js';
 
 function getSetting<K extends keyof SettingsDefaults>(key: K): SettingsDefaults[K] {
   return SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH)[key];
@@ -2341,6 +2342,15 @@ async function runInstallCommandInner(options: InstallOptions, summary: InstallS
     `Memory injection starts on your second session in a project.`,
     `Everything stays in ${styleText('cyan', '~/.claude-mem')} on this machine.`,
     ``,
+    // Suppressed when the trial was just activated in this same run — pitching
+    // an offer the user already accepted 30 seconds ago reads as broken.
+    ...(trialActivated
+      ? []
+      : [
+          `${styleText(['bold', 'cyan'], PRO_TRIAL_PITCH)}`,
+          `  ${styleText('underline', proTrialUrl('installer'))}`,
+          ``,
+        ]),
     `${styleText('dim', 'How it works: /how-it-works   ·   Disable first-session hint: CLAUDE_MEM_WELCOME_HINT_ENABLED=false')}`,
     `${styleText('dim', 'Note: close all Claude Code sessions before uninstalling, or ~/.claude-mem will be recreated by active hooks.')}`,
   ];

--- a/src/services/worker/http/routes/SearchRoutes.ts
+++ b/src/services/worker/http/routes/SearchRoutes.ts
@@ -15,6 +15,7 @@ import { USER_SETTINGS_PATH } from '../../../../shared/paths.js';
 import type { ObservationSearchResult, SessionSummarySearchResult } from '../../../sqlite/types.js';
 import { captureEvent } from '../../../telemetry/telemetry.js';
 import { telemetryBuffer } from '../../../telemetry/buffer.js';
+import { proTrialLine } from '../../../../shared/pro-promo.js';
 
 const ONBOARDING_EXPLAINER_PATH: string = path.resolve(__dirname, '../skills/how-it-works/onboarding-explainer.md');
 
@@ -51,6 +52,7 @@ Memory injection starts on your second session in a project.
 \`/learn-codebase\` is available if the user wants to front-load the entire repo into memory in a single pass (~5 minutes on a typical repo, optional). Otherwise memory builds passively as work happens.
 
 Live activity: {viewer_url}
+{pro_trial_line}
 How it works: \`/how-it-works\`
 
 This message disappears once the first observation lands.
@@ -311,7 +313,9 @@ export class SearchRoutes extends BaseRouteHandler {
       if (!this.projectsHaveObservations(sessionStore, projects, platformSource)) {
         const port = process.env.CLAUDE_MEM_WORKER_PORT ?? settings.CLAUDE_MEM_WORKER_PORT;
         const viewerUrl = `http://localhost:${port}`;
-        const hintBody = WELCOME_HINT_TEMPLATE.replace('{viewer_url}', viewerUrl);
+        const hintBody = WELCOME_HINT_TEMPLATE
+          .replace('{viewer_url}', viewerUrl)
+          .replace('{pro_trial_line}', proTrialLine('welcome-hint'));
         res.setHeader('Content-Type', 'text/plain; charset=utf-8');
         res.send(hintBody);
         return;

--- a/src/shared/pro-promo.ts
+++ b/src/shared/pro-promo.ts
@@ -1,0 +1,48 @@
+/**
+ * cmem Pro 7-day-trial promo copy — the single source of truth for every place
+ * claude-mem tells an existing user the trial exists.
+ *
+ * Almost nobody running the free plugin knows the trial is there, so the pitch
+ * rides along with the messages they already read: the session-start banner,
+ * the per-message context banner, the first-session welcome hint, the installer
+ * "Next Steps" block, and the viewer header. Keeping the wording and the URL
+ * here means the funnel copy changes in one edit instead of five.
+ *
+ * The viewer keeps its own copy in `src/ui/viewer/constants/promo.ts` — its
+ * tsconfig pins rootDir to the viewer directory, so it cannot import this file.
+ * Change both together.
+ */
+
+/** Landing page for the trial (cmem-pro `src/app/(landing)/pro/page.tsx`). */
+export const PRO_TRIAL_URL = 'https://cmem.ai/pro';
+
+/**
+ * Where a click came from. Passed through as `?from=` so cmem.ai can attribute
+ * signups per surface — the landing page only special-cases `installer`, every
+ * other value is attribution-only and renders the standard offer.
+ */
+export type ProPromoSource =
+  | 'installer'
+  | 'session-start'
+  | 'context-banner'
+  | 'welcome-hint'
+  | 'viewer'
+  /** Hand-written links in the cursor-hooks setup docs — no TS caller. */
+  | 'docs';
+
+/** Trial landing URL tagged with the surface the user clicked from. */
+export function proTrialUrl(source: ProPromoSource): string {
+  return `${PRO_TRIAL_URL}?from=${source}`;
+}
+
+/** The offer itself, without a URL — for surfaces that link separately. */
+export const PRO_TRIAL_PITCH = 'Get cmem Pro — 7-day free trial: cloud sync + memory model';
+
+/**
+ * One-line pitch + link, for plain-text surfaces (hook banners, welcome hint).
+ * Callers that want ANSI styling should compose from PRO_TRIAL_PITCH and
+ * proTrialUrl() instead so the escape codes stay at the presentation layer.
+ */
+export function proTrialLine(source: ProPromoSource): string {
+  return `${String.fromCodePoint(0x2728)} ${PRO_TRIAL_PITCH} ${proTrialUrl(source)}`;
+}

--- a/src/shared/pro-promo.ts
+++ b/src/shared/pro-promo.ts
@@ -36,7 +36,7 @@ export function proTrialUrl(source: ProPromoSource): string {
 }
 
 /** The offer itself, without a URL — for surfaces that link separately. */
-export const PRO_TRIAL_PITCH = 'Get cmem Pro — 7-day free trial: cloud sync + memory model';
+export const PRO_TRIAL_PITCH = 'Get 2x more use out of your Max plan for free (7-day trial, $30/mo)';
 
 /**
  * One-line pitch + link, for plain-text surfaces (hook banners, welcome hint).

--- a/src/ui/viewer-template.html
+++ b/src/ui/viewer-template.html
@@ -483,6 +483,42 @@
       }
     }
 
+    /* cmem Pro trial CTA — lives in .header-main so the responsive rules that
+       hide .icon-link on tablet/mobile leave it alone. */
+    .pro-trial-cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      height: 30px;
+      padding: 0 12px;
+      border: 1px solid var(--color-accent-primary);
+      border-radius: 999px;
+      color: var(--color-accent-primary);
+      background: var(--color-bg-card);
+      font-size: 12px;
+      font-weight: 500;
+      letter-spacing: -0.01em;
+      white-space: nowrap;
+      text-decoration: none;
+      transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    .pro-trial-cta:hover {
+      background: var(--color-bg-card-hover);
+      border-color: var(--color-accent-focus);
+      transform: translateY(-1px);
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+    }
+
+    .pro-trial-cta svg {
+      flex-shrink: 0;
+    }
+
+    /* Full pitch by default; the shortened label takes over on narrow screens. */
+    .pro-trial-cta-short {
+      display: none;
+    }
+
     .icon-link {
       display: flex;
       align-items: center;
@@ -1378,6 +1414,15 @@
         display: none;
       }
 
+      /* Keep the trial CTA, but drop to the shorter label */
+      .pro-trial-cta-full {
+        display: none;
+      }
+
+      .pro-trial-cta-short {
+        display: inline;
+      }
+
       /* Feed adjustments */
       .feed {
         padding: 20px 16px;
@@ -1455,6 +1500,23 @@
       /* Hide icon links on mobile */
       .icon-link {
         display: none;
+      }
+
+      /* The CTA stays — it is the whole point of the bar for free users.
+         Shortest label, sized to match the other mobile controls. */
+      .pro-trial-cta {
+        height: 28px;
+        padding: 0 10px;
+        font-size: 11px;
+        flex-shrink: 0;
+      }
+
+      .pro-trial-cta-full {
+        display: none;
+      }
+
+      .pro-trial-cta-short {
+        display: inline;
       }
 
       .settings-btn,

--- a/src/ui/viewer/components/Header.tsx
+++ b/src/ui/viewer/components/Header.tsx
@@ -3,6 +3,7 @@ import { ThemeToggle } from './ThemeToggle';
 import { ThemePreference } from '../hooks/useTheme';
 import { GitHubStarsButton } from './GitHubStarsButton';
 import { useSpinningFavicon } from '../hooks/useSpinningFavicon';
+import { PRO_TRIAL_PITCH, PRO_TRIAL_SHORT, PRO_TRIAL_URL } from '../constants/promo';
 
 interface HeaderProps {
   projects: string[];
@@ -43,6 +44,23 @@ export function Header({
           </div>
           <span className="logo-text">claude-mem</span>
         </h1>
+        {/* Most people running the free plugin never learn the trial exists.
+            It sits beside the logo (not in .status) so it survives the
+            responsive rules that hide the icon links on tablet and mobile. */}
+        <a
+          className="pro-trial-cta"
+          href={PRO_TRIAL_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={PRO_TRIAL_PITCH}
+          aria-label={PRO_TRIAL_PITCH}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="m12 3-1.9 5.8a2 2 0 0 1-1.3 1.3L3 12l5.8 1.9a2 2 0 0 1 1.3 1.3L12 21l1.9-5.8a2 2 0 0 1 1.3-1.3L21 12l-5.8-1.9a2 2 0 0 1-1.3-1.3Z" />
+          </svg>
+          <span className="pro-trial-cta-full">{PRO_TRIAL_PITCH}</span>
+          <span className="pro-trial-cta-short">{PRO_TRIAL_SHORT}</span>
+        </a>
       </div>
       <div className="status">
         <a

--- a/src/ui/viewer/constants/promo.ts
+++ b/src/ui/viewer/constants/promo.ts
@@ -9,7 +9,7 @@
 /** Trial landing URL, tagged so cmem.ai can attribute viewer-sourced signups. */
 export const PRO_TRIAL_URL = 'https://cmem.ai/pro?from=viewer';
 
-export const PRO_TRIAL_PITCH = 'Get cmem Pro — 7-day free trial: cloud sync + memory model';
+export const PRO_TRIAL_PITCH = 'Get 2x more use out of your Max plan for free (7-day trial, $30/mo)';
 
 /** Header CTA label. The full pitch rides in the title/aria attributes. */
-export const PRO_TRIAL_SHORT = 'Get cmem Pro — 7-day free trial';
+export const PRO_TRIAL_SHORT = 'Get 2x more from your Max plan';

--- a/src/ui/viewer/constants/promo.ts
+++ b/src/ui/viewer/constants/promo.ts
@@ -1,0 +1,15 @@
+/**
+ * cmem Pro trial promo for the viewer header.
+ *
+ * Mirrors `src/shared/pro-promo.ts` — the viewer's tsconfig pins rootDir to
+ * this directory, so it cannot import the Node-side module. Change both
+ * together when the offer or the URL moves.
+ */
+
+/** Trial landing URL, tagged so cmem.ai can attribute viewer-sourced signups. */
+export const PRO_TRIAL_URL = 'https://cmem.ai/pro?from=viewer';
+
+export const PRO_TRIAL_PITCH = 'Get cmem Pro — 7-day free trial: cloud sync + memory model';
+
+/** Header CTA label. The full pitch rides in the title/aria attributes. */
+export const PRO_TRIAL_SHORT = 'Get cmem Pro — 7-day free trial';


### PR DESCRIPTION
Branch `claude/free-trial-promotion-links-ypgmjp` (2 commits, 2026-08-13) — opening so it lands in v13.15.1.

- New `src/shared/pro-promo.ts`: single source of truth for the trial pitch + `https://cmem.ai/pro?from=<surface>` attribution links.
- Surfaces: session-start banner, per-message context banner, first-session welcome hint, installer "Next Steps" (suppressed when the trial was just activated), viewer header, cursor-hooks docs.
- Pitch reframed around Max-plan savings.

Merges cleanly onto main after #3612 (welcome-hint health warning); bundles are regenerated at release.

Companion (cmem.ai side, separate deploy): thedotmack/claude-mem-pro#101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BPptieMC1vzUNGtUErU3UM