### PR TITLE
refactor: simplify subprocess tool lockdown to tools:[] + canUseTool, add systemPrompt

### DIFF
--- a/src/sdk/hardened-options.ts
+++ b/src/sdk/hardened-options.ts
@@ -9,58 +9,47 @@
  * guarantee was enforced ONLY by `disallowedTools`. If a future SDK release
  * shipped a new built-in tool that was not in our deny-list, the Observer could
  * autonomously call Edit/Write/Bash on the user's source tree. This helper
- * makes the prompt's guarantee true at the SDK-config layer with
- * defense-in-depth — no single option is load-bearing:
+ * makes the prompt's guarantee true at the SDK-config layer with a simplified
+ * two-layer model:
  *
- *   - belt:        `tools: []`           — the SDK's TRUE restrictive allowlist.
+ *   - restriction: `tools: []`           — the SDK's TRUE restrictive allowlist.
  *                                          Per the SDK type docs, `tools: []`
  *                                          disables ALL built-in tools. (Note:
  *                                          `allowedTools` is an AUTO-APPROVE
- *                                          list, NOT a restriction — see below.)
- *   - empty allow: `allowedTools: []`    — nothing is auto-approved.
- *   - suspenders:  `disallowedTools`     — explicit per-tool deny list.
- *   - braces:      `permissionMode`      — 'dontAsk' = deny unless pre-approved
- *                                          (nothing is pre-approved here).
+ *                                          list, NOT a restriction, so it is
+ *                                          not part of this model.)
  *   - backstop:    `canUseTool`          — denies EVERY invocation and writes an
  *                                          append-only audit entry.
+ *
+ * Three formerly redundant layers — `allowedTools: []`, `disallowedTools`
+ * (the explicit per-tool deny list), and `permissionMode: 'dontAsk'` — were
+ * removed. All three operate on a tool surface that `tools: []` has already
+ * emptied: once the SDK's built-in tool list is `[]`, there is nothing left
+ * for an auto-approve list, a deny list, or a permission-prompt mode to act
+ * on. Keeping them added no independent security property, only maintenance
+ * surface (e.g. a deny-list that could silently drift out of sync with a new
+ * SDK-added tool while still being masked by `tools: []`).
+ *
+ * `systemPrompt` (below) adds a defense-in-depth layer of its own, separate
+ * from tool lockdown: it re-asserts the "no tool access" identity text
+ * directly in the subprocess's system prompt, complementing
+ * `settingSources: []` which already suppresses CLAUDE.md inheritance.
+ *
  *   - isolation:   `cwd` jail + `mcpServers:{}` + `settingSources:[]` +
  *                  `strictMcpConfig` + `additionalDirectories:[]` — even with
  *                  tools disabled, these prevent settings/MCP inheritance and
  *                  filesystem escape hatches.
  *
- * The redundancy IS the security property: removing any one layer must not
- * re-open the gap. Verified against @anthropic-ai/claude-agent-sdk v0.2.141
- * (sdk.d.ts): `tools`, `allowedTools`, `disallowedTools`, `permissionMode`
- * ('dontAsk' = "Don't prompt for permissions, deny if not pre-approved"),
- * `canUseTool` (returns PermissionResult { behavior: 'deny', message }),
- * `additionalDirectories`, `mcpServers`, `settingSources`, `strictMcpConfig`
- * all exist on the `Options` type.
+ * Verified against @anthropic-ai/claude-agent-sdk v0.2.141 (sdk.d.ts):
+ * `tools`, `canUseTool` (returns PermissionResult { behavior: 'deny', message }),
+ * `additionalDirectories`, `mcpServers`, `settingSources`, `strictMcpConfig`,
+ * `systemPrompt` all exist on the `Options` type.
  */
 
 import type { Options } from '@anthropic-ai/claude-agent-sdk';
 import { OBSERVER_SESSIONS_DIR } from '../shared/paths.js';
 import { recordObserverToolAttempt } from '../utils/observer-audit.js';
 import { logger } from '../utils/logger.js';
-
-/**
- * Tools explicitly named in the deny-list. `tools: []` already disables all
- * built-ins; this list is the redundant "suspenders" layer and documents
- * intent for human reviewers.
- */
-export const OBSERVER_DISALLOWED_TOOLS = [
-  'Bash',           // Prevent infinite loops
-  'Read',           // No file reading
-  'Write',          // No file writing
-  'Edit',           // No file editing
-  'Grep',           // No code searching
-  'Glob',           // No file pattern matching
-  'WebFetch',       // No web fetching
-  'WebSearch',      // No web searching
-  'Task',           // No spawning sub-agents
-  'NotebookEdit',   // No notebook editing
-  'AskUserQuestion',// No asking questions
-  'TodoWrite',
-] as const;
 
 export interface HardenedSdkOptionsInput {
   /** Which call site is constructing options — flows into audit entries. */
@@ -69,6 +58,9 @@ export interface HardenedSdkOptionsInput {
   sessionDbId?: number;
   contentSessionId?: string;
   project?: string;
+
+  /** System identity text for the subprocess (defense-in-depth). */
+  systemPrompt: string;
 
   // Pass-through fields the caller still owns:
   model: string;
@@ -117,6 +109,7 @@ export function buildHardenedSdkOptions(input: HardenedSdkOptionsInput): Options
     cwd: input.cwd ?? OBSERVER_SESSIONS_DIR,
     env: input.env,
     pathToClaudeCodeExecutable: input.pathToClaudeCodeExecutable,
+    systemPrompt: input.systemPrompt,
     ...(input.abortController ? { abortController: input.abortController } : {}),
     ...(input.resume ? { resume: input.resume } : {}),
     ...(input.spawnClaudeCodeProcess ? { spawnClaudeCodeProcess: input.spawnClaudeCodeProcess } : {}),
@@ -124,10 +117,7 @@ export function buildHardenedSdkOptions(input: HardenedSdkOptionsInput): Options
     ...(input.source === 'Observer' ? { thinkingConfig: { type: 'disabled' as const } } : {}),
 
     // === Tool lockdown (defense-in-depth) ===
-    tools: [],                                        // belt: disable ALL built-in tools
-    allowedTools: [],                                 // nothing auto-approved
-    disallowedTools: [...OBSERVER_DISALLOWED_TOOLS],  // suspenders: explicit deny
-    permissionMode: 'dontAsk',                        // braces: deny unless pre-approved (nothing is)
+    tools: [],                                        // restriction: disable ALL built-in tools
     canUseTool,                                       // backstop: deny + audit every attempt
 
     // === Filesystem / settings / MCP isolation ===

--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -253,6 +253,7 @@ export class ClaudeProvider {
       }
 
       ensureDir(OBSERVER_SESSIONS_DIR);
+      const mode = ModeManager.getInstance().getActiveMode();
       const queryResult = query({
         prompt: messageGenerator,
         options: buildHardenedSdkOptions({
@@ -260,6 +261,7 @@ export class ClaudeProvider {
           sessionDbId: session.sessionDbId,
           contentSessionId: session.contentSessionId,
           project: session.project,
+          systemPrompt: mode.prompts.system_identity,
           model: modelId,
           env: isolatedEnv,  // Use isolated credentials from ~/.claude-mem/.env, not process.env
           pathToClaudeCodeExecutable: claudePath,

--- a/src/services/worker/knowledge/KnowledgeAgent.ts
+++ b/src/services/worker/knowledge/KnowledgeAgent.ts
@@ -45,6 +45,7 @@ export class KnowledgeAgent {
       options: buildHardenedSdkOptions({
         source: 'KnowledgeAgent',
         project: corpus.name,
+        systemPrompt: corpus.system_prompt,
         model: this.getModelId(),
         env: isolatedEnv,
         pathToClaudeCodeExecutable: claudePath,
@@ -137,6 +138,7 @@ export class KnowledgeAgent {
       options: buildHardenedSdkOptions({
         source: 'KnowledgeAgent',
         project: corpus.name,
+        systemPrompt: corpus.system_prompt,
         model: this.getModelId(),
         env: isolatedEnv,
         pathToClaudeCodeExecutable: claudePath,

--- a/tests/security/observer-tool-enforcement.test.ts
+++ b/tests/security/observer-tool-enforcement.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { readFileSync, existsSync, rmSync } from 'fs';
-import {
-  buildHardenedSdkOptions,
-  OBSERVER_DISALLOWED_TOOLS,
-} from '../../src/sdk/hardened-options.js';
+import { buildHardenedSdkOptions } from '../../src/sdk/hardened-options.js';
 import {
   recordObserverToolAttempt,
   getObserverAuditLogPath,
@@ -15,6 +12,7 @@ const BASE_INPUT = {
   model: 'claude-sonnet-4-6',
   env: {} as NodeJS.ProcessEnv,
   pathToClaudeCodeExecutable: '/usr/bin/claude',
+  systemPrompt: 'You are a test observer.',
 };
 
 const AUDIT_PATH = getObserverAuditLogPath();
@@ -28,37 +26,23 @@ function readAuditLines(): Array<Record<string, unknown>> {
 }
 
 describe('Observer/KnowledgeAgent SDK tool enforcement (hardened-options)', () => {
-  describe('belt + suspenders + braces: option surface', () => {
+  describe('tool lockdown: tools:[] + canUseTool audit backstop', () => {
     it('sets tools to an empty array (disables ALL built-in tools)', () => {
       const opts = buildHardenedSdkOptions({ ...BASE_INPUT });
       expect(Array.isArray(opts.tools)).toBe(true);
       expect(opts.tools).toHaveLength(0);
     });
 
-    it('sets allowedTools to an empty array (nothing auto-approved)', () => {
+    it('does not set allowedTools, disallowedTools, or permissionMode', () => {
       const opts = buildHardenedSdkOptions({ ...BASE_INPUT });
-      expect(Array.isArray(opts.allowedTools)).toBe(true);
-      expect(opts.allowedTools).toHaveLength(0);
+      expect(opts.allowedTools).toBeUndefined();
+      expect(opts.disallowedTools).toBeUndefined();
+      expect(opts.permissionMode).toBeUndefined();
     });
 
-    it('keeps the full disallowedTools deny-list (12 tools)', () => {
+    it('passes systemPrompt through unchanged', () => {
       const opts = buildHardenedSdkOptions({ ...BASE_INPUT });
-      const denied = opts.disallowedTools ?? [];
-      for (const tool of OBSERVER_DISALLOWED_TOOLS) {
-        expect(denied).toContain(tool);
-      }
-      expect(denied).toHaveLength(OBSERVER_DISALLOWED_TOOLS.length);
-      expect(OBSERVER_DISALLOWED_TOOLS).toHaveLength(12);
-    });
-
-    it("uses the most restrictive non-interactive permissionMode ('dontAsk')", () => {
-      const opts = buildHardenedSdkOptions({ ...BASE_INPUT });
-      expect(opts.permissionMode).toBe('dontAsk');
-    });
-
-    it('never uses bypassPermissions', () => {
-      const opts = buildHardenedSdkOptions({ ...BASE_INPUT });
-      expect(opts.permissionMode).not.toBe('bypassPermissions');
+      expect(opts.systemPrompt).toBe('You are a test observer.');
     });
 
     it('isolates settings, MCP, and extra directories', () => {
@@ -166,9 +150,7 @@ describe('Observer/KnowledgeAgent SDK tool enforcement (hardened-options)', () =
       const o = buildHardenedSdkOptions(input);
       return {
         tools: o.tools,
-        allowedTools: o.allowedTools,
-        disallowedTools: o.disallowedTools,
-        permissionMode: o.permissionMode,
+        systemPrompt: o.systemPrompt,
         mcpServers: o.mcpServers,
         settingSources: o.settingSources,
         strictMcpConfig: o.strictMcpConfig,
@@ -187,6 +169,7 @@ describe('Observer/KnowledgeAgent SDK tool enforcement (hardened-options)', () =
         model: 'm',
         env: {},
         pathToClaudeCodeExecutable: '/c',
+        systemPrompt: 'You are a test observer.',
         abortController: new AbortController(),
         spawnClaudeCodeProcess: () => ({}) as never,
       });
@@ -196,9 +179,17 @@ describe('Observer/KnowledgeAgent SDK tool enforcement (hardened-options)', () =
         model: 'm',
         env: {},
         pathToClaudeCodeExecutable: '/c',
+        systemPrompt: 'You are a test observer.',
         resume: 'session-xyz',
       });
       expect(observer).toEqual(knowledge);
+    });
+  });
+
+  describe('OBSERVER_DISALLOWED_TOOLS is no longer exported', () => {
+    it('is not present on the hardened-options module', async () => {
+      const mod = await import('../../src/sdk/hardened-options.js');
+      expect('OBSERVER_DISALLOWED_TOOLS' in mod).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Remove three redundant SDK lockdown layers (`allowedTools: []`, `disallowedTools: [list]`, `permissionMode: 'dontAsk'`) that operated on a tool surface already emptied by `tools: []`
- Delete the `OBSERVER_DISALLOWED_TOOLS` constant (no longer needed)
- Add `systemPrompt` pass-through on `buildHardenedSdkOptions()` — defense-in-depth for the system identity text, complementing `settingSources: []`
- Thread `mode.prompts.system_identity` (Observer) and `corpus.system_prompt` (KnowledgeAgent) through all three call sites

## Rationale

Verified against `@anthropic-ai/claude-agent-sdk` v0.3.x:
- `tools: []` is the SDK's TRUE restrictive allowlist — disables ALL built-in tools
- `allowedTools` is an auto-approve list, NOT a restriction — `allowedTools: []` means "nothing auto-approved" but all tools remain callable
- `disallowedTools` and `permissionMode` operate on a surface that `tools: []` has already emptied
- `canUseTool` remains the deny + audit backstop

The `systemPrompt` option (SDK v0.1.0+) sets the system prompt slot directly. `settingSources: []` already suppresses CLAUDE.md in the SDK, but explicit `systemPrompt` documents intent and guards against regressions.

## Test plan

- [x] RED phase: tests rewritten to assert target state (3 expected failures)
- [x] GREEN phase: implementation simplified, all 12 security tests pass
- [x] TypeScript compilation clean (`npx tsc --noEmit` — 0 errors)
- [x] Full test suite: 2283 pass, 0 fail across 198 files
- [x] Verified `process-registry.ts` pair-aware arg filter untouched
- [x] Verified `EnvManager.ts` / `env-sanitizer.ts` untouched
- [x] No dangling references to deleted symbols