### PR TITLE
test(worker): pin one assistant turn per observer reply, summary included

### DIFF
--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -40,6 +40,12 @@ export interface ProviderQueryResult {
  * truncation — is identical between them. Per-provider differences (config
  * resolution, request shape, token estimation, usage/cost reporting) are
  * supplied by abstract members.
+ *
+ * History ownership: this class pushes the *user* half of every turn;
+ * `processAgentResponse` is the single writer of the *assistant* half, for all
+ * providers including Claude. Appending the reply here too left two identical
+ * assistant messages in front of each user turn and doubled the assistant side
+ * of every later request.
  */
 export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string; model: string }> {
   protected dbManager: DatabaseManager;
@@ -177,7 +183,6 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     responseContext: ReturnType<typeof snapshotResponseContext>
   ): Promise<void> {
     if (initResponse.content) {
-      session.conversationHistory.push({ role: 'assistant', content: initResponse.content });
       const tokensUsed = initResponse.tokensUsed || 0;
       session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
       session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
@@ -226,7 +231,6 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
 
     let tokensUsed = 0;
     if (obsResponse.content) {
-      session.conversationHistory.push({ role: 'assistant', content: obsResponse.content });
       tokensUsed = obsResponse.tokensUsed || 0;
       session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
       session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
@@ -284,7 +288,6 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
 
     let tokensUsed = 0;
     if (summaryResponse.content) {
-      session.conversationHistory.push({ role: 'assistant', content: summaryResponse.content });
       tokensUsed = summaryResponse.tokensUsed || 0;
       session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
       session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);

--- a/tests/worker/openai-compatible-history-append.test.ts
+++ b/tests/worker/openai-compatible-history-append.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import { ModeManager } from '../../src/services/domain/ModeManager.js';
+import { OpenAICompatibleProvider, type ProviderQueryResult } from '../../src/services/worker/OpenAICompatibleProvider.js';
+import { SettingsDefaultsManager } from '../../src/shared/SettingsDefaultsManager.js';
+import type { ActiveSession, ConversationMessage } from '../../src/services/worker-types.js';
+
+const mockMode = {
+  name: 'code',
+  prompts: {
+    init: 'init prompt',
+    observation: 'obs prompt',
+    summary: 'summary prompt',
+  },
+  observation_types: [{ id: 'discovery' }],
+  observation_concepts: [],
+};
+
+function makeSession(overrides: Partial<ActiveSession> = {}): ActiveSession {
+  return {
+    sessionDbId: 1,
+    contentSessionId: 'test-session',
+    memorySessionId: 'mem-session-123',
+    project: 'test-project',
+    platformSource: 'claude',
+    userPrompt: 'test prompt',
+    abortController: new AbortController(),
+    generatorPromise: null,
+    lastPromptNumber: 1,
+    startTime: Date.now(),
+    cumulativeInputTokens: 0,
+    cumulativeOutputTokens: 0,
+    earliestPendingTimestamp: null,
+    claimedMessageIds: [],
+    conversationHistory: [],
+    currentProvider: null,
+    consecutiveRestarts: 0,
+    consecutiveInvalidOutputs: 0,
+    lastGeneratorActivity: Date.now(),
+    ...overrides,
+  } as ActiveSession;
+}
+
+/**
+ * Replies are deliberately non-XML: the parser rejects them, which routes
+ * processAgentResponse down its confirm-and-return path. That keeps the test on
+ * the history bookkeeping under test instead of the storage path.
+ */
+class TestProvider extends OpenAICompatibleProvider<{ apiKey: string; model: string }> {
+  protected readonly providerName = 'TestProvider';
+  protected readonly syntheticIdPrefix = 'test';
+  protected readonly forwardEmptyMessageResponse = false;
+
+  constructor(replies: string[], sessionManager: unknown) {
+    super({} as never, sessionManager as never);
+    this.replies = [...replies];
+  }
+
+  private replies: string[];
+
+  protected getConfig() {
+    return { apiKey: 'test-api-key', model: 'session-model' };
+  }
+
+  protected missingApiKeyError(): Error {
+    return new Error('missing key');
+  }
+
+  protected async query(_history: ConversationMessage[]): Promise<ProviderQueryResult> {
+    return { content: this.replies.shift() ?? '' };
+  }
+
+  protected estimateTokens(): number {
+    return 0;
+  }
+
+  protected buildLastUsage(): ActiveSession['lastUsage'] {
+    return null;
+  }
+}
+
+function makeSessionManager(messages: unknown[]) {
+  return {
+    getMessageIterator: async function* () {
+      for (const message of messages) {
+        yield message;
+      }
+    },
+    confirmClaimedMessages: async () => {},
+    resetProcessingToPending: async () => {},
+    getClaimedMessages: () => [],
+  };
+}
+
+describe('OpenAICompatibleProvider conversation history', () => {
+  let modeManagerSpy: ReturnType<typeof spyOn>;
+  let loadFromFileSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    modeManagerSpy = spyOn(ModeManager, 'getInstance').mockImplementation(() => ({
+      getActiveMode: () => mockMode,
+      loadMode: () => {},
+    } as any));
+    loadFromFileSpy = spyOn(SettingsDefaultsManager, 'loadFromFile').mockImplementation(() => ({
+      ...SettingsDefaultsManager.getAllDefaults(),
+      CLAUDE_MEM_TIER_ROUTING_ENABLED: 'false',
+    }));
+  });
+
+  afterEach(() => {
+    modeManagerSpy.mockRestore();
+    loadFromFileSpy?.mockRestore();
+    mock.restore();
+  });
+
+  it('records each assistant reply exactly once across init, observation, and summary turns', async () => {
+    const session = makeSession();
+    const provider = new TestProvider(
+      ['INIT_REPLY', 'OBSERVATION_REPLY', 'SUMMARY_REPLY'],
+      makeSessionManager([
+        { type: 'observation', tool_name: 'Read', tool_input: {}, tool_response: {}, prompt_number: 2 },
+        { type: 'summarize', last_assistant_message: 'done' },
+      ])
+    );
+
+    await provider.startSession(session);
+
+    const assistantContents = session.conversationHistory
+      .filter(message => message.role === 'assistant')
+      .map(message => message.content);
+
+    expect(assistantContents).toEqual(['INIT_REPLY', 'OBSERVATION_REPLY', 'SUMMARY_REPLY']);
+  });
+
+  it('never leaves two consecutive assistant turns in the history it sends back', async () => {
+    const session = makeSession();
+    const provider = new TestProvider(
+      ['INIT_REPLY', 'OBSERVATION_REPLY'],
+      makeSessionManager([
+        { type: 'observation', tool_name: 'Read', tool_input: {}, tool_response: {}, prompt_number: 2 },
+      ])
+    );
+
+    await provider.startSession(session);
+
+    const roles = session.conversationHistory.map(message => message.role);
+    expect(roles).toEqual(['user', 'assistant', 'user', 'assistant']);
+  });
+
+  it('leaves history untouched for an empty reply so an errored turn adds no phantom assistant message', async () => {
+    const session = makeSession();
+    const provider = new TestProvider(
+      ['INIT_REPLY', ''],
+      makeSessionManager([
+        { type: 'observation', tool_name: 'Read', tool_input: {}, tool_response: {}, prompt_number: 2 },
+      ])
+    );
+
+    await provider.startSession(session);
+
+    expect(session.conversationHistory.filter(message => message.role === 'assistant')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Status

The source fix from this PR is on `main`. 7a7ada5f ("bound observer conversation growth…", on `main` since 2026-08-31) removed the provider-side `conversationHistory.push` calls, and its message cites this PR. This branch is now rebased onto current `main` and cut down to the test file. It no longer touches `src/`.

The one assistant push left in `OpenAICompatibleProvider` is in `handleInitResponse`, and it is not a double append. Since a00ce61e the init reply no longer goes through `processAgentResponse`, so the provider records it itself, once. `processAgentResponse` records the observation and summary replies.

## Why the test is still worth having

`main` pins the observation path: `tests/worker/openai-compatible-init-response.test.ts` asserts that roles alternate after init plus one observation.

Two paths have no test:

- **Summary.** Putting the push back in `processSummaryMessage` changes no result in any of the 21 test files that drive the OpenAI-compatible providers or `processAgentResponse`.
- **Empty observation reply, not forwarded.** When a provider does not forward empty replies (`forwardEmptyMessageResponse = false`), an empty observation reply must add no assistant turn. Pushing one there also changes no result in those 21 files.

This file pins both:

- `records each reply exactly once across the init, observation and summary turns`: three queries, roles alternate `user, assistant` three times, and the assistant turns are the three replies in order.
- `adds no assistant turn for an empty observation reply when empty replies are not forwarded`: roles are `user, assistant, user`.

## Verification

Each mutation below was applied to `main`'s `OpenAICompatibleProvider.ts`. The 21 upstream files were compared with an unmutated run by test name, because this Windows machine has pre-existing failures in that set.

| Mutation | 21 upstream files | This file |
|---|---|---|
| Put the push back in `processObservationMessage` | `init-response` fails | test 1 fails |
| Put the push back in `processSummaryMessage` | no change | test 1 fails |
| Push an empty turn for an unforwarded empty observation reply | no change | test 2 fails |

The new file passes (2 pass, 0 fail). It also type-checks clean against the root `tsconfig.json` (strict) when included explicitly; `tests/` is excluded from the regular `typecheck` script.

Refs #3499, #3497. Tracked under #3606 (plan-18).
