### PR TITLE
fix(openrouter): name the max_tokens cap when it cuts a reply off

### DIFF
--- a/src/services/worker/OpenRouterProvider.ts
+++ b/src/services/worker/OpenRouterProvider.ts
@@ -174,6 +174,12 @@ export function classifyOpenRouterError(input: {
 
 const CHARS_PER_TOKEN_ESTIMATE = 4;
 
+/**
+ * Output cap sent on every chat-completions request. Named so the truncation
+ * warning can point at the number that cut the reply off.
+ */
+const OPENROUTER_MAX_OUTPUT_TOKENS = 4096;
+
 interface OpenAIMessage {
   role: 'user' | 'assistant' | 'system';
   content: string;
@@ -292,7 +298,7 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
         model,
         messages,
         temperature: 0.3,  // Lower temperature for structured extraction
-        max_tokens: 4096,
+        max_tokens: OPENROUTER_MAX_OUTPUT_TOKENS,
         // Ask openrouter.ai for usage accounting (token counts + cost).
         // Only sent to openrouter.ai — strict custom gateways may reject
         // unknown body fields.
@@ -365,8 +371,19 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
       return responseData;
     }, { label: `OpenRouter ${model}` });
 
+    // `length` means the model was cut off at max_tokens rather than finishing.
+    // The reply is then a partial observation block, the parser rejects it as
+    // prose, and the batch is confirmed and dropped — so without this the only
+    // trace is a "non-XML response" warning that blames the model instead of
+    // the cap that truncated it.
+    const finishReason = data.choices?.[0]?.finish_reason;
+    const truncatedByCap = finishReason === 'length';
+
     if (!data.choices?.[0]?.message?.content) {
-      logger.error('SDK', 'Empty response from OpenRouter');
+      logger.error('SDK', 'Empty response from OpenRouter', {
+        ...(finishReason ? { finishReason } : {}),
+        ...(truncatedByCap ? { maxTokens: OPENROUTER_MAX_OUTPUT_TOKENS } : {}),
+      });
       return { content: '' };
     }
 
@@ -385,6 +402,16 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
       ? (orCost ?? 0) + (upstreamCost ?? 0)
       : undefined;
     const servedModel = typeof data.model === 'string' && data.model ? data.model : undefined;
+
+    if (truncatedByCap) {
+      logger.warn('SDK', 'OpenRouter reply hit the max_tokens cap — the observation block is cut off and will not parse', {
+        model: servedModel ?? model,
+        maxTokens: OPENROUTER_MAX_OUTPUT_TOKENS,
+        outputTokens: realOutputTokens ?? 0,
+        contentChars: content.length,
+        messagesInContext: history.length,
+      });
+    }
 
     if (tokensUsed) {
       logger.info('SDK', 'OpenRouter API usage', {

--- a/src/services/worker/OpenRouterProvider.ts
+++ b/src/services/worker/OpenRouterProvider.ts
@@ -404,10 +404,10 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
     const servedModel = typeof data.model === 'string' && data.model ? data.model : undefined;
 
     if (truncatedByCap) {
-      logger.warn('SDK', 'OpenRouter reply hit the max_tokens cap — the observation block is cut off and will not parse', {
+      logger.warn('SDK', 'OpenRouter reply hit the max_tokens cap — the structured response is cut off and may not parse', {
         model: servedModel ?? model,
         maxTokens: OPENROUTER_MAX_OUTPUT_TOKENS,
-        outputTokens: realOutputTokens ?? 0,
+        outputTokens: realOutputTokens,
         contentChars: content.length,
         messagesInContext: history.length,
       });

--- a/tests/worker/openrouter-truncation-warning.test.ts
+++ b/tests/worker/openrouter-truncation-warning.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import { OpenRouterProvider } from '../../src/services/worker/OpenRouterProvider.js';
+import { logger } from '../../src/utils/logger.js';
+import type { ConversationMessage } from '../../src/services/worker-types.js';
+
+const CONFIG = {
+  apiKey: 'test-key',
+  model: 'test/model',
+  apiUrl: 'https://openrouter.ai/api/v1/chat/completions',
+};
+
+/** Exposes the protected query() so the response-parsing path can be driven directly. */
+class TestOpenRouterProvider extends OpenRouterProvider {
+  runQuery(history: ConversationMessage[]) {
+    return this.query(history, CONFIG as never);
+  }
+}
+
+function respondWith(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function makeProvider() {
+  return new TestOpenRouterProvider({} as never, {} as never);
+}
+
+const HISTORY: ConversationMessage[] = [{ role: 'user', content: 'observe this' }];
+
+describe('OpenRouter max_tokens truncation', () => {
+  let fetchSpy: ReturnType<typeof spyOn>;
+  let warnSpy: ReturnType<typeof spyOn>;
+  let errorSpy: ReturnType<typeof spyOn>;
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+    warnSpy?.mockRestore();
+    errorSpy?.mockRestore();
+    mock.restore();
+  });
+
+  it('warns and names the cap when the reply is cut off at max_tokens', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(async () => respondWith({
+      model: 'test/model',
+      choices: [{ message: { content: '<observation><type>bugfix</type><title>half a ti' }, finish_reason: 'length' }],
+      usage: { prompt_tokens: 900, completion_tokens: 4096, total_tokens: 4996 },
+    }));
+    warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
+
+    const result = await makeProvider().runQuery(HISTORY);
+
+    expect(result.content).toContain('<observation>');
+
+    const truncationWarning = warnSpy.mock.calls.find(
+      call => typeof call[1] === 'string' && call[1].includes('max_tokens')
+    );
+    expect(truncationWarning).toBeDefined();
+    expect(truncationWarning?.[2]).toMatchObject({ maxTokens: 4096, outputTokens: 4096 });
+  });
+
+  it('stays quiet when the model stopped on its own', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(async () => respondWith({
+      model: 'test/model',
+      choices: [{ message: { content: '<observation></observation>' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 900, completion_tokens: 120, total_tokens: 1020 },
+    }));
+    warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await makeProvider().runQuery(HISTORY);
+
+    const truncationWarning = warnSpy.mock.calls.find(
+      call => typeof call[1] === 'string' && call[1].includes('max_tokens')
+    );
+    expect(truncationWarning).toBeUndefined();
+  });
+
+  it('names the cap on an empty reply that was also cut off', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(async () => respondWith({
+      model: 'test/model',
+      choices: [{ message: { content: '' }, finish_reason: 'length' }],
+      usage: { prompt_tokens: 900, completion_tokens: 4096, total_tokens: 4996 },
+    }));
+    errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
+
+    const result = await makeProvider().runQuery(HISTORY);
+
+    expect(result.content).toBe('');
+    expect(errorSpy.mock.calls[0]?.[2]).toMatchObject({ finishReason: 'length', maxTokens: 4096 });
+  });
+});

--- a/tests/worker/openrouter-truncation-warning.test.ts
+++ b/tests/worker/openrouter-truncation-warning.test.ts
@@ -89,4 +89,40 @@ describe('OpenRouter max_tokens truncation', () => {
     expect(result.content).toBe('');
     expect(errorSpy.mock.calls[0]?.[2]).toMatchObject({ finishReason: 'length', maxTokens: 4096 });
   });
+
+  it('does not call a capped summary reply an observation block', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(async () => respondWith({
+      model: 'test/model',
+      choices: [{ message: { content: '<summary><request>partial summ' }, finish_reason: 'length' }],
+      usage: { prompt_tokens: 900, completion_tokens: 4096, total_tokens: 4996 },
+    }));
+    warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await makeProvider().runQuery(HISTORY);
+
+    // query() is shared by the observation and summary turns, so the wording
+    // must not claim a response type the caller never told it about.
+    const truncationWarning = warnSpy.mock.calls.find(
+      call => typeof call[1] === 'string' && call[1].includes('max_tokens')
+    );
+    expect(truncationWarning?.[1]).not.toContain('observation');
+  });
+
+  it('leaves output tokens undefined when the gateway reports no completion usage', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(async () => respondWith({
+      model: 'test/model',
+      choices: [{ message: { content: '<observation><type>bugfix</type><title>cut' }, finish_reason: 'length' }],
+      usage: { prompt_tokens: 900 },
+    }));
+    warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
+
+    await makeProvider().runQuery(HISTORY);
+
+    const truncationWarning = warnSpy.mock.calls.find(
+      call => typeof call[1] === 'string' && call[1].includes('max_tokens')
+    );
+    // Unknown usage stays unknown: reporting 0 output tokens next to non-empty
+    // content reads as a provider bug that isn't there.
+    expect((truncationWarning?.[2] as Record<string, unknown>).outputTokens).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Defect

`OpenRouterResponse` declares `finish_reason`. The provider reads it in only two places: the empty-message debug line and the Telegram wrap-up error. Every request carries a 4096-token output cap (as `max_tokens`, or as `max_completion_tokens` on the compatibility retry). When a reply stops at a limit (`finish_reason: "length"`), nothing at WARN level says so:

- **A structured block cut off mid-tag never closes.** `parseObservationBlocks` only matches closed `<observation>…</observation>` blocks. If earlier blocks in the reply are complete, they are stored and the cut one disappears without a log line. If none is complete, the reply is classified `xml`, logged as `returned non-XML xml response — ignoring queued batch`, and the batch is confirmed away.
- **A reasoning model that spends the whole cap before answering** comes back as an empty reply, again with nothing naming the limit.

This is the first of the revised suggestions in #3490's correction: *"Log `finish_reason` … `length` should at minimum produce a WARN."* The same correction found that the original 76% figure came from the model repeating itself, not from observations running out of room. So this PR does not raise the cap or retry. It only makes `length` visible.

## Fix

A single `logger.warn` fires when `finish_reason === 'length'`:

```
OpenRouter reply was cut off at the output-token limit
  { model, requestId, maxTokens: 4096, outputTokens, contentChars, messagesInContext }
```

- **Placement.** The warning comes right after the reply text is read, **before** the plain-text (Telegram wrap-up) and empty-reply exits, so every reply shape is covered.
- **Wording.** The message names no response type, because `query()` serves the init, observation, summary and Telegram wrap-up turns. It says "output-token limit" rather than "cap" because `length` can also come from a model limit below the cap; `outputTokens` next to `maxTokens` shows which one it was.
- **Missing usage.** `outputTokens` stays `undefined` when the gateway reports no completion usage.
- **`requestId`.** It lets a user find the generation in the OpenRouter dashboard, as the Telegram error line already does.
- **Named cap.** `4096` becomes `OPENROUTER_MAX_OUTPUT_TOKENS`, used by `buildOpenRouterRequestBody` and by the fallback in `fetchChatCompletion`, so the warning reports the number the request sent.

Returned content, retries and the existing `Empty response from OpenRouter` error are unchanged. `openrouter-empty-content.test.ts` asserts that error's exact two-argument call.

**Overlap with #3868.** #3868 (CONFLICTING, waiting on its rebase) makes the cap configurable through `CLAUDE_MEM_OPENROUTER_MAX_TOKENS` and threads `finish_reason` into the response pipeline. If it lands first, I'll rebase this so the warning reports the configured value instead of the constant.

## Rebased onto current `main`

`main` has restructured this file since the PR was opened:

- the request body is built by `buildOpenRouterRequestBody`
- empty replies are accepted since #4017
- a plain-text path serves the Telegram wrap-up

So the change is reapplied on current code instead of rebased line by line. The earlier version extended the `logger.error` line for empty replies. On current `main` an empty string is no longer an error, so the warning covers that case instead.

## Tests

The new `tests/worker/openrouter-truncation-warning.test.ts` drives the real `query()` path with a mocked `fetch` and asserts the exact warning call. It has 6 tests:

- a cut-off reply warns with `maxTokens: 4096` and the output-token count
- `finish_reason: "stop"` does not warn (negative control)
- an empty reply from a reasoning model that used the whole cap still warns
- a `null` reply warns, and the existing error line is still logged unchanged
- the Telegram wrap-up path warns before it throws on an empty reply
- missing completion usage is reported as `undefined`, not `0`

Each mutation below is caught:

| Mutation | Caught by |
|---|---|
| Remove the warning | 5 of the 6 tests |
| Warn on every `finish_reason` | `stays quiet when the model stopped on its own` |
| Move the warning below the plain-text exit | `names the cap before the Telegram wrap-up gives up on an empty reply` |
| Move the warning below the empty-reply exit | the `null` reply test and the Telegram test |
| Name a response type in the message | 5 of the 6 tests (exact-message assertion) |
| Report missing usage as `0` | `leaves output tokens undefined when the gateway reports no completion usage` |

```
bun test tests/worker/openrouter-*.test.ts tests/worker/telegram-wrapup-provider.test.ts \
  tests/worker/provider-classifiers.test.ts tests/worker/provider-dispatch.test.ts \
  tests/shared/openrouter-attribution.test.ts

143 pass, 0 fail
```

`tsc --noEmit` is clean for the root and viewer configs. The new test file also type-checks clean against the root `tsconfig.json` (strict) when included explicitly; `tests/` is excluded from the regular `typecheck` script.

Refs #3490. Tracked under #3606 (plan-18), step 3.
