### PR TITLE
fix(transcripts): serialize tail reads and reset partial data on truncation

### DIFF
--- a/src/services/transcripts/watcher.ts
+++ b/src/services/transcripts/watcher.ts
@@ -14,6 +14,8 @@ interface TailState {
 class FileTailer {
   private watcher: ReturnType<typeof fsWatch> | null = null;
   private tailState: TailState;
+  private readTask: Promise<void> | null = null;
+  private readPending = false;
 
   constructor(
     private filePath: string,
@@ -25,9 +27,9 @@ class FileTailer {
   }
 
   start(): void {
-    this.readNewData().catch(() => undefined);
+    this.requestRead();
     this.watcher = fsWatch(this.filePath, { persistent: true }, () => {
-      this.readNewData().catch(() => undefined);
+      this.requestRead();
     });
   }
 
@@ -37,7 +39,25 @@ class FileTailer {
   }
 
   poke(): void {
-    this.readNewData().catch(() => undefined);
+    this.requestRead();
+  }
+
+  private requestRead(): void {
+    if (this.readTask) {
+      this.readPending = true;
+      return;
+    }
+
+    this.readTask = this.drainReads().finally(() => {
+      this.readTask = null;
+    });
+  }
+
+  private async drainReads(): Promise<void> {
+    do {
+      this.readPending = false;
+      await this.readNewData().catch(() => undefined);
+    } while (this.readPending);
   }
 
   private async readNewData(): Promise<void> {
@@ -53,6 +73,7 @@ class FileTailer {
 
     if (size < this.tailState.offset) {
       this.tailState.offset = 0;
+      this.tailState.partial = '';
     }
 
     if (size === this.tailState.offset) return;

--- a/tests/transcripts/watcher-start-at-end.test.ts
+++ b/tests/transcripts/watcher-start-at-end.test.ts
@@ -32,6 +32,30 @@ import { TranscriptWatcher } from '../../src/services/transcripts/watcher.js';
 
 const waitForAsyncTail = () => new Promise(resolve => setTimeout(resolve, 50));
 
+const createUserMessage = (sessionId: string, prompt: string) => JSON.stringify({
+  type: 'event',
+  payload: {
+    type: 'user_message',
+    session_id: sessionId,
+    message: prompt,
+  },
+});
+
+const createSchema = (): TranscriptSchema => ({
+  name: 'codex-test',
+  events: [
+    {
+      name: 'user-message',
+      match: { path: 'payload.type', equals: 'user_message' },
+      action: 'session_init',
+      fields: {
+        sessionId: 'payload.session_id',
+        prompt: 'payload.message',
+      },
+    },
+  ],
+});
+
 describe('TranscriptWatcher startAtEnd', () => {
   let tmpRoot: string;
   let loggerSpies: ReturnType<typeof spyOn>[] = [];
@@ -60,31 +84,11 @@ describe('TranscriptWatcher startAtEnd', () => {
 
     writeFileSync(
       filePath,
-      `${JSON.stringify({
-        type: 'event',
-        payload: {
-          type: 'user_message',
-          session_id: sessionId,
-          message: 'historical prompt that must not be replayed',
-        },
-      })}\n`,
+      `${createUserMessage(sessionId, 'historical prompt that must not be replayed')}\n`,
       'utf8',
     );
 
-    const schema: TranscriptSchema = {
-      name: 'codex-test',
-      events: [
-        {
-          name: 'user-message',
-          match: { path: 'payload.type', equals: 'user_message' },
-          action: 'session_init',
-          fields: {
-            sessionId: 'payload.session_id',
-            prompt: 'payload.message',
-          },
-        },
-      ],
-    };
+    const schema = createSchema();
     const watch: WatchTarget = {
       name: 'codex',
       path: join(tmpRoot, '*.jsonl'),
@@ -100,14 +104,7 @@ describe('TranscriptWatcher startAtEnd', () => {
 
     appendFileSync(
       filePath,
-      `${JSON.stringify({
-        type: 'event',
-        payload: {
-          type: 'user_message',
-          session_id: sessionId,
-          message: 'live prompt',
-        },
-      })}\n`,
+      `${createUserMessage(sessionId, 'live prompt')}\n`,
       'utf8',
     );
 
@@ -118,5 +115,64 @@ describe('TranscriptWatcher startAtEnd', () => {
     const prompts = sessionInitCalls.map(call => call.prompt);
     expect(prompts).toContain('live prompt');
     expect(prompts).not.toContain('historical prompt that must not be replayed');
+  });
+
+  it('serializes overlapping poke calls for the same appended data', async () => {
+    const sessionId = '019e050e-7ae0-71b2-b19f-6cc428e5763b';
+    const filePath = join(tmpRoot, `${sessionId}.jsonl`);
+    const statePath = join(tmpRoot, 'state.json');
+    const schema = createSchema();
+    const watch: WatchTarget = {
+      name: 'codex',
+      path: filePath,
+      schema,
+      startAtEnd: true,
+    };
+
+    writeFileSync(filePath, `${createUserMessage(sessionId, 'historical prompt')}\n`, 'utf8');
+
+    const watcher = new TranscriptWatcher({ version: 1, watches: [watch] }, statePath);
+    await (watcher as any).addTailer(filePath, watch, schema);
+    await waitForAsyncTail();
+
+    const tailer = (watcher as any).tailers.get(filePath);
+    tailer.close();
+    appendFileSync(filePath, `${createUserMessage(sessionId, 'live prompt')}\n`, 'utf8');
+
+    tailer.poke();
+    tailer.poke();
+    await waitForAsyncTail();
+    watcher.stop();
+
+    const livePrompts = sessionInitCalls.filter(call => call.prompt === 'live prompt');
+    expect(livePrompts).toHaveLength(1);
+  });
+
+  it('discards a buffered partial line when the file is truncated', async () => {
+    const sessionId = '019e050e-7ae0-71b2-b19f-6cc428e5763c';
+    const filePath = join(tmpRoot, `${sessionId}.jsonl`);
+    const statePath = join(tmpRoot, 'state.json');
+    const schema = createSchema();
+    const watch: WatchTarget = {
+      name: 'codex',
+      path: filePath,
+      schema,
+    };
+
+    writeFileSync(filePath, `{"incomplete":"${'x'.repeat(1024)}`, 'utf8');
+
+    const watcher = new TranscriptWatcher({ version: 1, watches: [watch] }, statePath);
+    await (watcher as any).addTailer(filePath, watch, schema);
+    await waitForAsyncTail();
+
+    const tailer = (watcher as any).tailers.get(filePath);
+    tailer.close();
+    writeFileSync(filePath, `${createUserMessage(sessionId, 'after truncation')}\n`, 'utf8');
+
+    tailer.poke();
+    await waitForAsyncTail();
+    watcher.stop();
+
+    expect(sessionInitCalls.map(call => call.prompt)).toEqual(['after truncation']);
   });
 });


### PR DESCRIPTION

## Summary

- Route all `FileTailer` read triggers through a single coalescing scheduler.
- Prevent overlapping reads from consuming the same transcript range.
- Clear buffered partial-line data when a file shrink is detected.
- Add regression tests for concurrent `poke()` calls and truncation.

## Problem

`FileTailer.start()`, the per-file `fs.watch` callback, and `poke()` can all invoke `readNewData()` without any serialization.

Because `readNewData()` awaits stream I/O, two calls can observe the same shared state before either updates it:

1. Both calls observe `offset = 100` and `size = 200`.
2. Both create a stream for bytes `100..199`.
3. Both update the shared offset and process the same lines.

This can deliver the same transcript entry more than once. When calls observe different file sizes, an older read can also finish last and move the shared offset backwards. If the input does not end with a newline, concurrent calls can additionally duplicate or corrupt `tailState.partial`.

Duplicate transcript processing is particularly risky here because downstream processing can create persistent sessions, observations, or memory state.

There is a separate truncation edge case. The existing shrink handling resets
`offset` but retains `partial`:

```ts
if (size < this.tailState.offset) {
  this.tailState.offset = 0;
}
```

A fragment buffered from the old file can therefore be prepended to the first line of the truncated file, producing invalid JSON.

## Changes

- Add a single-flight, coalescing read scheduler used by `start()`, `fs.watch`,
  and `poke()`.
- Keep at most one `readNewData()` call in flight for each `FileTailer`.
- If another notification arrives while reading, perform one follow-up read
  after the current read completes.
- Reset both `offset` and `partial` when `size < offset`.

## Tests

- Trigger two `poke()` calls before the first read completes and verify that
  the appended transcript entry is processed once.
- Buffer an incomplete line, truncate the file, write a valid JSONL entry,
  and verify that the stale fragment is not prepended.

## Scope

This fixes concurrency within one `FileTailer` and the existing detected-shrink path. It does not add inode-based rotation detection or claim end-to-end exactly-once delivery across process crashes.

Related: #2192, #2209, #2219, #1661
