### PR TITLE
OpenRouter attribution: rename to Claude-Mem, centralize the app identity

### DIFF
--- a/src/server/generation/providers/OpenRouterObservationProvider.ts
+++ b/src/server/generation/providers/OpenRouterObservationProvider.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { resolveOpenRouterChatCompletionsUrl } from '../../../shared/openrouter-base-url.js';
+import { openRouterAttributionHeaders, OPENROUTER_APP_URL, OPENROUTER_APP_TITLE } from '../../../shared/openrouter-attribution.js';
 import { logger } from '../../../utils/logger.js';
 import {
   ServerClassifiedProviderError,
@@ -60,8 +61,8 @@ export class OpenRouterObservationProvider implements ServerGenerationProvider {
     this.model = options.model ?? DEFAULT_MODEL;
     this.apiUrl = resolveOpenRouterChatCompletionsUrl(options.baseUrl);
     this.maxOutputTokens = options.maxOutputTokens ?? 4096;
-    this.siteUrl = options.siteUrl ?? 'https://github.com/thedotmack/claude-mem';
-    this.appName = options.appName ?? 'claude-mem';
+    this.siteUrl = options.siteUrl ?? OPENROUTER_APP_URL;
+    this.appName = options.appName ?? OPENROUTER_APP_TITLE;
     this.fetchImpl = options.fetchImpl ?? fetch;
   }
 
@@ -144,8 +145,7 @@ export class OpenRouterObservationProvider implements ServerGenerationProvider {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${this.apiKey}`,
-        'HTTP-Referer': this.siteUrl,
-        'X-Title': this.appName,
+        ...openRouterAttributionHeaders(this.siteUrl, this.appName),
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({

--- a/src/services/worker/OpenRouterProvider.ts
+++ b/src/services/worker/OpenRouterProvider.ts
@@ -1,6 +1,7 @@
 
 import { getCredential } from '../../shared/EnvManager.js';
 import { resolveOpenRouterChatCompletionsUrl } from '../../shared/openrouter-base-url.js';
+import { openRouterAttributionHeaders, OPENROUTER_APP_TITLE } from '../../shared/openrouter-attribution.js';
 import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js';
 import { USER_SETTINGS_PATH } from '../../shared/paths.js';
 import { logger } from '../../utils/logger.js';
@@ -283,8 +284,7 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${apiKey}`,
-        'HTTP-Referer': siteUrl || 'https://github.com/thedotmack/claude-mem',
-        'X-Title': appName || 'claude-mem',
+        ...openRouterAttributionHeaders(siteUrl, appName),
         'Content-Type': 'application/json',
         ...(priorRequestId ? { 'x-claude-mem-prior-request-id': priorRequestId } : {}),
       },
@@ -431,7 +431,7 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
     const apiUrl = resolveOpenRouterChatCompletionsUrl(baseUrl);
 
     const siteUrl = settings.CLAUDE_MEM_OPENROUTER_SITE_URL || '';
-    const appName = settings.CLAUDE_MEM_OPENROUTER_APP_NAME || 'claude-mem';
+    const appName = settings.CLAUDE_MEM_OPENROUTER_APP_NAME || OPENROUTER_APP_TITLE;
 
     return { apiKey, model, apiUrl, siteUrl, appName };
   }

--- a/src/shared/openrouter-attribution.ts
+++ b/src/shared/openrouter-attribution.ts
@@ -29,41 +29,28 @@ export const OPENROUTER_APP_URL = 'https://github.com/thedotmack/claude-mem';
 export const OPENROUTER_APP_TITLE = 'Claude-Mem';
 
 /**
- * Marketplace categories. OpenRouter accepts at most 2 per request but stores
- * up to 10 per app, so a request sends one PAIR and the app accumulates the
- * union over time. That is the only way to hold more than two.
+ * Marketplace categories. Max 2 per request, 10 per app, merged server-side.
  *
- * Why these four:
- *   cli-agent          — what claude-mem is; the crowded headline category.
- *   ide-extension      — it ships as a plugin to agent harnesses.
- *   writing-assistant  — the observation/digest workload is prose generation.
- *   creative-writing   — the narrative reports (timeline, weekly digests).
+ * Only two are claimed, because only two do anything:
+ *   cli-agent        — what claude-mem is. Shown on the app's own page.
+ *   creative-writing — the one category that buys visible placement. The
+ *                      /apps marketplace renders a top-5 box per GROUP, and
+ *                      Creative is the only group claude-mem can enter at its
+ *                      current volume; the Coding box's 5th slot is ~16x our
+ *                      daily tokens. Justified by the narrative reports
+ *                      (timeline, weekly digests), not a fiction claim.
  *
- * Deliberately NOT claimed: video-gen / image-gen / audio-gen (claude-mem
- * generates no media) and roleplay / game. Those would rank well precisely
- * because they are uncontested, which is the tell that they would be false.
+ * Not claimed: ide-extension and writing-assistant rank well (#4 and #1) in
+ * categories with no visible surface, so they bought nothing and cost a
+ * rotation mechanism to hold. video-gen / image-gen / audio-gen and
+ * roleplay / game would be false — claude-mem generates no media and runs no
+ * roleplay — and image-gen/audio-gen are uncontested, which is the tell.
  *
  * OpenRouter drops unrecognized values silently — a typo costs the category
  * with no error — so these are checked against its published list in
  * tests/shared/openrouter-attribution.test.ts.
  */
-export const OPENROUTER_APP_CATEGORY_PAIRS = [
-  'cli-agent,ide-extension',
-  'writing-assistant,creative-writing',
-] as const;
-
-/**
- * Pick the pair for one request.
- *
- * Random, not a rotating counter: the cmem.ai gateway runs serverless, where a
- * per-process counter restarts at 0 on every cold start and would send the
- * first pair almost exclusively — the later categories would never register.
- */
-export function pickOpenRouterCategories(): string {
-  return OPENROUTER_APP_CATEGORY_PAIRS[
-    Math.floor(Math.random() * OPENROUTER_APP_CATEGORY_PAIRS.length)
-  ];
-}
+export const OPENROUTER_APP_CATEGORIES = 'cli-agent,creative-writing';
 
 /**
  * Attribution headers for an OpenRouter chat-completions request.
@@ -82,6 +69,6 @@ export function openRouterAttributionHeaders(
   return {
     'HTTP-Referer': siteUrl || OPENROUTER_APP_URL,
     'X-OpenRouter-Title': appName || OPENROUTER_APP_TITLE,
-    'X-OpenRouter-Categories': pickOpenRouterCategories(),
+    'X-OpenRouter-Categories': OPENROUTER_APP_CATEGORIES,
   };
 }

--- a/src/shared/openrouter-attribution.ts
+++ b/src/shared/openrouter-attribution.ts
@@ -29,10 +29,41 @@ export const OPENROUTER_APP_URL = 'https://github.com/thedotmack/claude-mem';
 export const OPENROUTER_APP_TITLE = 'Claude-Mem';
 
 /**
- * Marketplace categories. Max 2 per request, 10 per app. OpenRouter drops
- * unrecognized values silently, so these must come from its published list.
+ * Marketplace categories. OpenRouter accepts at most 2 per request but stores
+ * up to 10 per app, so a request sends one PAIR and the app accumulates the
+ * union over time. That is the only way to hold more than two.
+ *
+ * Why these four:
+ *   cli-agent          — what claude-mem is; the crowded headline category.
+ *   ide-extension      — it ships as a plugin to agent harnesses.
+ *   writing-assistant  — the observation/digest workload is prose generation.
+ *   creative-writing   — the narrative reports (timeline, weekly digests).
+ *
+ * Deliberately NOT claimed: video-gen / image-gen / audio-gen (claude-mem
+ * generates no media) and roleplay / game. Those would rank well precisely
+ * because they are uncontested, which is the tell that they would be false.
+ *
+ * OpenRouter drops unrecognized values silently — a typo costs the category
+ * with no error — so these are checked against its published list in
+ * tests/shared/openrouter-attribution.test.ts.
  */
-export const OPENROUTER_APP_CATEGORIES = 'cli-agent,programming-app';
+export const OPENROUTER_APP_CATEGORY_PAIRS = [
+  'cli-agent,ide-extension',
+  'writing-assistant,creative-writing',
+] as const;
+
+/**
+ * Pick the pair for one request.
+ *
+ * Random, not a rotating counter: the cmem.ai gateway runs serverless, where a
+ * per-process counter restarts at 0 on every cold start and would send the
+ * first pair almost exclusively — the later categories would never register.
+ */
+export function pickOpenRouterCategories(): string {
+  return OPENROUTER_APP_CATEGORY_PAIRS[
+    Math.floor(Math.random() * OPENROUTER_APP_CATEGORY_PAIRS.length)
+  ];
+}
 
 /**
  * Attribution headers for an OpenRouter chat-completions request.
@@ -51,6 +82,6 @@ export function openRouterAttributionHeaders(
   return {
     'HTTP-Referer': siteUrl || OPENROUTER_APP_URL,
     'X-OpenRouter-Title': appName || OPENROUTER_APP_TITLE,
-    'X-OpenRouter-Categories': OPENROUTER_APP_CATEGORIES,
+    'X-OpenRouter-Categories': pickOpenRouterCategories(),
   };
 }

--- a/src/shared/openrouter-attribution.ts
+++ b/src/shared/openrouter-attribution.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared OpenRouter app-attribution headers.
+ *
+ * OpenRouter builds its public app leaderboard from these headers. claude-mem
+ * has one entry there (app id 2605040) and both providers — the worker-runtime
+ * one (src/services/worker/OpenRouterProvider.ts) and the server-runtime one
+ * (src/server/generation/providers/OpenRouterObservationProvider.ts) — must
+ * send identical values, or the same product splits into two apps and the
+ * ranking splits with it.
+ *
+ * THE APP'S IDENTITY IS THE REFERER URL, NOT THE TITLE. OpenRouter's docs:
+ * "Your app's URL becomes its unique identifier in the system." Changing the
+ * title keeps the accumulated ranking; changing the URL mints a brand-new app
+ * and strands every token the old one earned. So APP_TITLE is safe to edit and
+ * APP_URL is not — do not "tidy" it to the marketing domain.
+ *
+ * The cmem.ai Pro gateway sends these same values on the user's behalf when a
+ * subscriber's traffic is proxied, so gateway and bring-your-own-key traffic
+ * land under one entry (claude-mem-pro
+ * src/app/api/inference/v1/chat/completions/route.ts).
+ */
+
+/** The app's unique identifier on OpenRouter. Changing this resets the ranking. */
+export const OPENROUTER_APP_URL = 'https://github.com/thedotmack/claude-mem';
+
+/** Display name only — safe to change, does not affect ranking. */
+export const OPENROUTER_APP_TITLE = 'Claude-Mem';
+
+/**
+ * Marketplace categories. Max 2 per request, 10 per app. OpenRouter drops
+ * unrecognized values silently, so these must come from its published list.
+ */
+export const OPENROUTER_APP_CATEGORIES = 'cli-agent,programming-app';
+
+/**
+ * Attribution headers for an OpenRouter chat-completions request.
+ *
+ * `siteUrl` and `appName` come from CLAUDE_MEM_OPENROUTER_SITE_URL /
+ * CLAUDE_MEM_OPENROUTER_APP_NAME. A user who sets them is deliberately
+ * attributing their own traffic elsewhere; blank/unset falls back to ours.
+ *
+ * X-OpenRouter-Title is the canonical header name. X-Title is still accepted
+ * as a back-compat alias, but new code should send the canonical one.
+ */
+export function openRouterAttributionHeaders(
+  siteUrl?: string,
+  appName?: string
+): Record<string, string> {
+  return {
+    'HTTP-Referer': siteUrl || OPENROUTER_APP_URL,
+    'X-OpenRouter-Title': appName || OPENROUTER_APP_TITLE,
+    'X-OpenRouter-Categories': OPENROUTER_APP_CATEGORIES,
+  };
+}

--- a/tests/shared/openrouter-attribution.test.ts
+++ b/tests/shared/openrouter-attribution.test.ts
@@ -2,10 +2,11 @@
 
 import { describe, expect, it } from 'bun:test';
 import {
-  OPENROUTER_APP_CATEGORIES,
+  OPENROUTER_APP_CATEGORY_PAIRS,
   OPENROUTER_APP_TITLE,
   OPENROUTER_APP_URL,
   openRouterAttributionHeaders,
+  pickOpenRouterCategories,
 } from '../../src/shared/openrouter-attribution.js';
 
 // OpenRouter's recognized category slugs. Unrecognized values are dropped
@@ -21,6 +22,7 @@ describe('OpenRouter app identity', () => {
   // This is the one value that must never drift. OpenRouter keys the public
   // leaderboard on the referer URL, so changing it mints a brand-new app and
   // strands every token the existing entry (app id 2605040) has earned.
+  // Deliberately no rank here — the daily rank moves and would rot.
   it('pins the app URL that owns the ranking', () => {
     expect(OPENROUTER_APP_URL).toBe('https://github.com/thedotmack/claude-mem');
   });
@@ -55,24 +57,49 @@ describe('openRouterAttributionHeaders', () => {
     expect(h).not.toHaveProperty('X-Title');
   });
 
-  it('always sends categories, even for a custom site URL', () => {
-    expect(openRouterAttributionHeaders('https://example.com')['X-OpenRouter-Categories'])
-      .toBe(OPENROUTER_APP_CATEGORIES);
+  it('always sends a valid category pair, even for a custom site URL', () => {
+    expect(OPENROUTER_APP_CATEGORY_PAIRS).toContain(
+      openRouterAttributionHeaders('https://example.com')['X-OpenRouter-Categories'],
+    );
   });
 });
 
-describe('OPENROUTER_APP_CATEGORIES', () => {
-  const parsed = OPENROUTER_APP_CATEGORIES.split(',');
+describe('OPENROUTER_APP_CATEGORY_PAIRS', () => {
+  const all = OPENROUTER_APP_CATEGORY_PAIRS.flatMap((p) => p.split(','));
 
   it('sends at most 2 categories per request', () => {
-    expect(parsed.length).toBeLessThanOrEqual(2);
+    for (const pair of OPENROUTER_APP_CATEGORY_PAIRS) {
+      expect(pair.split(',').length).toBeLessThanOrEqual(2);
+    }
+  });
+
+  it('stays under the 10-category-per-app ceiling', () => {
+    expect(all.length).toBeLessThanOrEqual(10);
   });
 
   it('uses only categories OpenRouter recognizes', () => {
-    for (const c of parsed) expect(RECOGNIZED_CATEGORIES).toContain(c);
+    for (const c of all) expect(RECOGNIZED_CATEGORIES).toContain(c);
+  });
+
+  it('claims no media-generation or roleplay category', () => {
+    for (const c of ['video-gen', 'image-gen', 'audio-gen', 'roleplay', 'game']) {
+      expect(all).not.toContain(c);
+    }
+  });
+
+  it('claims no category twice', () => {
+    expect(new Set(all).size).toBe(all.length);
   });
 
   it('has no stray whitespace', () => {
-    expect(OPENROUTER_APP_CATEGORIES).toBe(parsed.map((c) => c.trim()).join(','));
+    for (const pair of OPENROUTER_APP_CATEGORY_PAIRS) {
+      expect(pair).toBe(pair.split(',').map((c) => c.trim()).join(','));
+    }
+  });
+
+  it('only ever picks a defined pair', () => {
+    for (let i = 0; i < 200; i++) {
+      expect(OPENROUTER_APP_CATEGORY_PAIRS).toContain(pickOpenRouterCategories());
+    }
   });
 });

--- a/tests/shared/openrouter-attribution.test.ts
+++ b/tests/shared/openrouter-attribution.test.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'bun:test';
+import {
+  OPENROUTER_APP_CATEGORIES,
+  OPENROUTER_APP_TITLE,
+  OPENROUTER_APP_URL,
+  openRouterAttributionHeaders,
+} from '../../src/shared/openrouter-attribution.js';
+
+// OpenRouter's recognized category slugs. Unrecognized values are dropped
+// silently, so a typo here would cost the app its categories with no error.
+const RECOGNIZED_CATEGORIES = new Set([
+  'cli-agent', 'ide-extension', 'cloud-agent', 'programming-app', 'native-app-builder',
+  'creative-writing', 'video-gen', 'image-gen', 'audio-gen',
+  'writing-assistant', 'general-chat', 'personal-agent', 'legal',
+  'roleplay', 'game',
+]);
+
+describe('OpenRouter app identity', () => {
+  // This is the one value that must never drift. OpenRouter keys the public
+  // leaderboard on the referer URL, so changing it mints a brand-new app and
+  // strands every token the existing entry (app id 2605040) has earned.
+  it('pins the app URL that owns the ranking', () => {
+    expect(OPENROUTER_APP_URL).toBe('https://github.com/thedotmack/claude-mem');
+  });
+
+  it('sends the title as the display name', () => {
+    expect(OPENROUTER_APP_TITLE).toBe('Claude-Mem');
+  });
+});
+
+describe('openRouterAttributionHeaders', () => {
+  it('falls back to the claude-mem app identity when unconfigured', () => {
+    const h = openRouterAttributionHeaders(undefined, undefined);
+    expect(h['HTTP-Referer']).toBe(OPENROUTER_APP_URL);
+    expect(h['X-OpenRouter-Title']).toBe(OPENROUTER_APP_TITLE);
+  });
+
+  it('treats empty strings as unset', () => {
+    const h = openRouterAttributionHeaders('', '');
+    expect(h['HTTP-Referer']).toBe(OPENROUTER_APP_URL);
+    expect(h['X-OpenRouter-Title']).toBe(OPENROUTER_APP_TITLE);
+  });
+
+  it('lets a user attribute their own traffic elsewhere', () => {
+    const h = openRouterAttributionHeaders('https://example.com', 'My Fork');
+    expect(h['HTTP-Referer']).toBe('https://example.com');
+    expect(h['X-OpenRouter-Title']).toBe('My Fork');
+  });
+
+  it('uses the canonical header name, not the X-Title alias', () => {
+    const h = openRouterAttributionHeaders();
+    expect(h).toHaveProperty('X-OpenRouter-Title');
+    expect(h).not.toHaveProperty('X-Title');
+  });
+
+  it('always sends categories, even for a custom site URL', () => {
+    expect(openRouterAttributionHeaders('https://example.com')['X-OpenRouter-Categories'])
+      .toBe(OPENROUTER_APP_CATEGORIES);
+  });
+});
+
+describe('OPENROUTER_APP_CATEGORIES', () => {
+  const parsed = OPENROUTER_APP_CATEGORIES.split(',');
+
+  it('sends at most 2 categories per request', () => {
+    expect(parsed.length).toBeLessThanOrEqual(2);
+  });
+
+  it('uses only categories OpenRouter recognizes', () => {
+    for (const c of parsed) expect(RECOGNIZED_CATEGORIES).toContain(c);
+  });
+
+  it('has no stray whitespace', () => {
+    expect(OPENROUTER_APP_CATEGORIES).toBe(parsed.map((c) => c.trim()).join(','));
+  });
+});

--- a/tests/shared/openrouter-attribution.test.ts
+++ b/tests/shared/openrouter-attribution.test.ts
@@ -2,11 +2,10 @@
 
 import { describe, expect, it } from 'bun:test';
 import {
-  OPENROUTER_APP_CATEGORY_PAIRS,
+  OPENROUTER_APP_CATEGORIES,
   OPENROUTER_APP_TITLE,
   OPENROUTER_APP_URL,
   openRouterAttributionHeaders,
-  pickOpenRouterCategories,
 } from '../../src/shared/openrouter-attribution.js';
 
 // OpenRouter's recognized category slugs. Unrecognized values are dropped
@@ -57,24 +56,17 @@ describe('openRouterAttributionHeaders', () => {
     expect(h).not.toHaveProperty('X-Title');
   });
 
-  it('always sends a valid category pair, even for a custom site URL', () => {
-    expect(OPENROUTER_APP_CATEGORY_PAIRS).toContain(
-      openRouterAttributionHeaders('https://example.com')['X-OpenRouter-Categories'],
-    );
+  it('always sends categories, even for a custom site URL', () => {
+    expect(openRouterAttributionHeaders('https://example.com')['X-OpenRouter-Categories'])
+      .toBe(OPENROUTER_APP_CATEGORIES);
   });
 });
 
-describe('OPENROUTER_APP_CATEGORY_PAIRS', () => {
-  const all = OPENROUTER_APP_CATEGORY_PAIRS.flatMap((p) => p.split(','));
+describe('OPENROUTER_APP_CATEGORIES', () => {
+  const all = OPENROUTER_APP_CATEGORIES.split(',');
 
   it('sends at most 2 categories per request', () => {
-    for (const pair of OPENROUTER_APP_CATEGORY_PAIRS) {
-      expect(pair.split(',').length).toBeLessThanOrEqual(2);
-    }
-  });
-
-  it('stays under the 10-category-per-app ceiling', () => {
-    expect(all.length).toBeLessThanOrEqual(10);
+    expect(all.length).toBeLessThanOrEqual(2);
   });
 
   it('uses only categories OpenRouter recognizes', () => {
@@ -92,14 +84,6 @@ describe('OPENROUTER_APP_CATEGORY_PAIRS', () => {
   });
 
   it('has no stray whitespace', () => {
-    for (const pair of OPENROUTER_APP_CATEGORY_PAIRS) {
-      expect(pair).toBe(pair.split(',').map((c) => c.trim()).join(','));
-    }
-  });
-
-  it('only ever picks a defined pair', () => {
-    for (let i = 0; i < 200; i++) {
-      expect(OPENROUTER_APP_CATEGORY_PAIRS).toContain(pickOpenRouterCategories());
-    }
+    expect(OPENROUTER_APP_CATEGORIES).toBe(all.map((c) => c.trim()).join(','));
   });
 });


### PR DESCRIPTION
## What

Renames the OpenRouter app to **Claude-Mem**, moves the attribution values into one shared module, adopts the canonical header name, and claims two marketplace categories.

## Why this is safe for the ranking

OpenRouter keys app identity on **`HTTP-Referer`, not on the title**. From their docs: *"Your app's URL becomes its unique identifier in the system"* — changing the title *"maintains the app's accumulated ranking."*

**The referer is unchanged**, and `tests/shared/openrouter-attribution.test.ts` pins it so a future "tidy-up" to the marketing domain fails CI instead of silently resetting the leaderboard to zero.

## Where the app actually stands

App id `2605040`, from the live top-200:

| Window | Tokens | Global rank |
|---|---|---|
| Day | 12.2B | #39 |
| Week | 67.1B | #45 |
| Month | 210.8B | #49 |

Ranks move daily, so none are hardcoded in comments.

## Why a shared module

`OpenRouterProvider.ts` (worker runtime) and `OpenRouterObservationProvider.ts` (server runtime) each carried their own hardcoded copy of the headers. They are **one app** on the leaderboard, so drift between the copies splits the ranking. `src/shared/openrouter-attribution.ts` now holds the identity, beside the existing `openrouter-base-url.ts`.

## Categories: `cli-agent,creative-writing`

Only categories with a visible surface buy anything. `/apps` renders a **top-5 box per group**, and at 12.2B/day the Coding box is unreachable — its 5th slot is OpenClaw at 195.8B/day, ~16x our volume. Productivity is the same. **Creative is the only group claude-mem can enter, at #4.**

`cli-agent` rides along because the app's own page displays its categories, and a lone `creative-writing` tag would make a memory tool for coding agents read as a fiction app. The creative-writing claim rests on the narrative reports (timeline, weekly digests), not on any fiction claim.

Not claimed: `ide-extension` (#4) and `writing-assistant` (#1) rank well in categories with no visible surface. `video-gen` / `image-gen` / `audio-gen` and `roleplay` / `game` would be false; a test asserts none of them can ever appear.

`CLAUDE_MEM_OPENROUTER_SITE_URL` / `_APP_NAME` still override, so forks and self-hosted gateways keep attributing their own traffic.

## Pairs with

`thedotmack/claude-mem-pro#112`, which sends identical values when a Pro subscriber's traffic is proxied through cmem.ai. **Both should land before the next release** so one version bump carries the rename.

Rollout is gradual by nature: installed versions keep sending `claude-mem` until users upgrade. Cosmetic, since the ranking follows the referer.

## Not fixable in code: the logo

`favicon_url` is `null`, so the rankings page falls back to Google's favicon service for the referer URL, resolving **github.com's octocat**. That field, plus `main_url`, `slug`, and `source_code_url`, are real fields on OpenRouter's record and all null — **OpenRouter-side**, not header-settable.

## Verification

- `npm run typecheck` — clean
- `bun test tests/shared/ tests/worker/ tests/server/` — **746 pass, 13 skip, 0 fail**
- 12 tests covering the identity pin, fallbacks, overrides, canonical header, category validity, and the excluded-category guard