### PR TITLE
fix(windsurf): read hooks.json with the BOM-tolerant parser

### DIFF
--- a/src/services/integrations/WindsurfHooksInstaller.ts
+++ b/src/services/integrations/WindsurfHooksInstaller.ts
@@ -4,6 +4,7 @@ import { homedir } from 'os';
 import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync, renameSync } from 'fs';
 import { logger } from '../../utils/logger.js';
 import { getWorkerHost, getWorkerPort } from '../../shared/worker-utils.js';
+import { parseJsonWithBom } from '../../shared/atomic-json.js';
 import { DATA_DIR } from '../../shared/paths.js';
 import { getBunAbsolutePath as findBunPath, getWorkerServiceAbsolutePath as findWorkerServicePath } from './install-paths.js';
 
@@ -129,7 +130,7 @@ function mergeAndWriteHooksJson(
   let existingConfig: WindsurfHooksJson = { hooks: {} };
   if (existsSync(WINDSURF_HOOKS_JSON_PATH)) {
     try {
-      existingConfig = JSON.parse(readFileSync(WINDSURF_HOOKS_JSON_PATH, 'utf-8'));
+      existingConfig = parseJsonWithBom<WindsurfHooksJson>(readFileSync(WINDSURF_HOOKS_JSON_PATH, 'utf-8'));
       if (!existingConfig.hooks) {
         existingConfig.hooks = {};
       }
@@ -316,7 +317,7 @@ export function uninstallWindsurfHooks(): number {
 }
 
 function removeClaudeMemHookEntries(): void {
-  const parsed = JSON.parse(readFileSync(WINDSURF_HOOKS_JSON_PATH, 'utf-8')) as Partial<WindsurfHooksJson>;
+  const parsed = parseJsonWithBom<Partial<WindsurfHooksJson>>(readFileSync(WINDSURF_HOOKS_JSON_PATH, 'utf-8'));
   const config: WindsurfHooksJson = { hooks: parsed.hooks ?? {} };
 
   for (const eventName of WINDSURF_HOOK_EVENTS) {
@@ -363,7 +364,7 @@ export function checkWindsurfHooksStatus(): number {
 
     let parsedConfig: Partial<WindsurfHooksJson> | null = null;
     try {
-      parsedConfig = JSON.parse(readFileSync(WINDSURF_HOOKS_JSON_PATH, 'utf-8'));
+      parsedConfig = parseJsonWithBom(readFileSync(WINDSURF_HOOKS_JSON_PATH, 'utf-8'));
     } catch (error) {
       const normalizedError = error instanceof Error ? error : new Error(String(error));
       logger.error('WORKER', 'Unable to parse hooks.json', { path: WINDSURF_HOOKS_JSON_PATH }, normalizedError);

--- a/tests/windsurf-hooks-bom.test.ts
+++ b/tests/windsurf-hooks-bom.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { parseJsonWithBom } from '../src/shared/atomic-json.js';
+
+// The installer writes to a fixed path under the real home directory, so a filesystem test would
+// touch the developer's own Windsurf config. This asserts against the source instead, the same way
+// npm-install-windows-hide.test.ts does for its spawn options.
+const SOURCE = readFileSync(
+  join(import.meta.dir, '../src/services/integrations/WindsurfHooksInstaller.ts'),
+  'utf8',
+);
+
+describe("WindsurfHooksInstaller reads Windsurf's hooks.json", () => {
+  it('never parses that file with a BOM-blind JSON.parse', () => {
+    // A hooks.json rewritten by PowerShell 5.1 or a Windows editor carries a UTF-8 BOM. Parsing it
+    // with JSON.parse throws, and the catch turns a perfectly valid file into "Corrupt hooks.json,
+    // refusing to overwrite" — so install and uninstall both stop on a file that is not corrupt.
+    expect(SOURCE).not.toMatch(/JSON\.parse\(\s*readFileSync\(\s*WINDSURF_HOOKS_JSON_PATH/);
+  });
+
+  it('uses the shared BOM-tolerant reader for each of the three reads', () => {
+    // `[^(]*` rather than `<[^>]*>` so a nested type argument such as
+    // `<Partial<WindsurfHooksJson>>` still counts.
+    const uses = SOURCE.match(
+      /parseJsonWithBom[^(]*\(\s*readFileSync\(\s*WINDSURF_HOOKS_JSON_PATH/g,
+    );
+    expect(uses?.length).toBe(3);
+  });
+
+  it('that reader accepts what JSON.parse rejects', () => {
+    const bommed = '﻿' + JSON.stringify({ hooks: { afterFileEdit: [] } });
+    expect(() => JSON.parse(bommed)).toThrow();
+    expect(parseJsonWithBom<{ hooks: Record<string, unknown> }>(bommed).hooks).toBeDefined();
+  });
+});


### PR DESCRIPTION
### Symptom

On Windows, a valid `~/.codeium/windsurf/hooks.json` is reported as corrupt and both install and uninstall stop:

```
Corrupt hooks.json at <path>, refusing to overwrite
```

The file is not corrupt. It carries a UTF-8 BOM, which PowerShell 5.1 and several Windows editors add when they rewrite JSON. Windsurf itself reads it fine.

### Root cause

`src/services/integrations/WindsurfHooksInstaller.ts` read that file with a raw `JSON.parse`, in three places — the install merge, `removeClaudeMemHookEntries`, and the verify pass. Node decodes a BOM to `U+FEFF` at offset 0, `JSON.parse` rejects it, and the surrounding `catch` converts the throw into the "corrupt" message above.

This is exactly the failure described in #3013 and fixed for `readJsonSafe` in #3307. `parseJsonWithBom` already backs twenty-odd call sites across the tree; these three were still going around it.

### Scope

Only the three reads of **Windsurf's own** `hooks.json` are changed. `WINDSURF_REGISTRY_FILE` on line 47 is deliberately left as-is — claude-mem writes that file itself, so it can never carry a BOM, and changing it would be hardening rather than a fix.

### Verified

`parseJsonWithBom` loaded from the real source under Node, given the exact input the installer would see:

```
JSON.parse on a BOM'd hooks.json  -> THROWS: Unexpected token '﻿', "﻿{"hooks":"... is not valid JSON
parseJsonWithBom on the same input -> {"hooks":{"afterFileEdit":[]}}
2/2 checks passed
```

`tests/windsurf-hooks-bom.test.ts` asserts three things: the file no longer calls `JSON.parse` on that path, all three reads go through the shared reader, and the shared reader accepts what `JSON.parse` rejects. The first two are source assertions rather than filesystem ones, because the installer writes to a fixed path under the real home directory — `npm-install-windows-hide.test.ts` takes the same approach for the same reason.

### Against the rubric

Correct reader replacing an incorrect one, at three call sites in one file. No guard, no retry, no fallback, no new state, no env-var gate, and nothing added to the catch block — the catch stays exactly as it was, and now only fires on files that really are corrupt.

I could not run `bun test` locally (no bun on this machine), so CI is the first full-suite run.
