### PR TITLE
fix(observer): recognize monthly spend-limit prose

### DIFF
--- a/src/sdk/output-classifier.ts
+++ b/src/sdk/output-classifier.ts
@@ -60,8 +60,13 @@ export function isQuotaLimitedObserverOutput(raw: unknown): boolean {
   }
 
   const text = raw.toLowerCase().replace(/\s+/g, ' ').trim();
+  const monthlySpendLimit =
+    /\bmonthly\s+(?:spend|usage)\s+limit\b/.test(text) &&
+    /\b(?:hit|reached|exceeded|exhausted|raise|reset|resets)\b/.test(text);
 
   return (
+    /\bcc_cli_limit_message\b/.test(text) ||
+    monthlySpendLimit ||
     /\bclaude\b.*\busage\b.*\blimit\b.*\b(reached|exceeded|exhausted|reset|resets|try again)\b/.test(text) ||
     /\b(reached|exceeded|exhausted)\b.*\bclaude\b.*\busage\b.*\blimit\b/.test(text) ||
     /\bweekly\b.*\b(limit|quota)\b.*\b(reached|exceeded|exhausted|reset|resets|try again)\b/.test(text) ||

--- a/src/sdk/output-classifier.ts
+++ b/src/sdk/output-classifier.ts
@@ -65,7 +65,7 @@ export function isQuotaLimitedObserverOutput(raw: unknown): boolean {
   }
 
   const negatedExhaustion =
-    /\b(?:not|never|didn['’]t|hasn['’]t|haven['’]t|isn['’]t|wasn['’]t)\s+(?:been\s+)?(?:hit|reached|exceeded|exhausted)\b/.test(text);
+    /\b(?:not|never|didn['’]t|hasn['’]t|haven['’]t|isn['’]t|wasn['’]t)\s+(?:yet\s+)?(?:been\s+)?(?:hit|reached|exceeded|exhausted)\b/.test(text);
   if (negatedExhaustion) {
     return false;
   }

--- a/src/sdk/output-classifier.ts
+++ b/src/sdk/output-classifier.ts
@@ -60,12 +60,21 @@ export function isQuotaLimitedObserverOutput(raw: unknown): boolean {
   }
 
   const text = raw.toLowerCase().replace(/\s+/g, ' ').trim();
+  if (/\bcc_cli_limit_message\b/.test(text)) {
+    return true;
+  }
+
+  const negatedExhaustion =
+    /\b(?:not|never|didn['’]t|hasn['’]t|haven['’]t|isn['’]t|wasn['’]t)\s+(?:been\s+)?(?:hit|reached|exceeded|exhausted)\b/.test(text);
+  if (negatedExhaustion) {
+    return false;
+  }
+
   const monthlySpendLimit =
     /\bmonthly\s+(?:spend|usage)\s+limit\b/.test(text) &&
     /\b(?:hit|reached|exceeded|exhausted)\b/.test(text);
 
   return (
-    /\bcc_cli_limit_message\b/.test(text) ||
     monthlySpendLimit ||
     /\bclaude\b.*\busage\b.*\blimit\b.*\b(reached|exceeded|exhausted|reset|resets|try again)\b/.test(text) ||
     /\b(reached|exceeded|exhausted)\b.*\bclaude\b.*\busage\b.*\blimit\b/.test(text) ||

--- a/src/sdk/output-classifier.ts
+++ b/src/sdk/output-classifier.ts
@@ -62,7 +62,7 @@ export function isQuotaLimitedObserverOutput(raw: unknown): boolean {
   const text = raw.toLowerCase().replace(/\s+/g, ' ').trim();
   const monthlySpendLimit =
     /\bmonthly\s+(?:spend|usage)\s+limit\b/.test(text) &&
-    /\b(?:hit|reached|exceeded|exhausted|raise|reset|resets)\b/.test(text);
+    /\b(?:hit|reached|exceeded|exhausted)\b/.test(text);
 
   return (
     /\bcc_cli_limit_message\b/.test(text) ||

--- a/tests/sdk/output-classifier.test.ts
+++ b/tests/sdk/output-classifier.test.ts
@@ -90,6 +90,7 @@ describe('isQuotaLimitedObserverOutput', () => {
   it('does not treat negated monthly spend-limit prose as exhaustion', () => {
     const negatedMessages = [
       'You have not hit your monthly spend limit.',
+      'You have not yet hit your monthly spend limit.',
       'Your monthly spend limit has not been reached.',
     ];
 

--- a/tests/sdk/output-classifier.test.ts
+++ b/tests/sdk/output-classifier.test.ts
@@ -87,6 +87,17 @@ describe('isQuotaLimitedObserverOutput', () => {
     }
   });
 
+  it('does not treat negated monthly spend-limit prose as exhaustion', () => {
+    const negatedMessages = [
+      'You have not hit your monthly spend limit.',
+      'Your monthly spend limit has not been reached.',
+    ];
+
+    for (const message of negatedMessages) {
+      expect(isQuotaLimitedObserverOutput(message)).toBe(false);
+    }
+  });
+
   it('does not treat context-window prose as quota prose', () => {
     expect(
       isQuotaLimitedObserverOutput('I hit the context window and cannot produce valid XML.'),

--- a/tests/sdk/output-classifier.test.ts
+++ b/tests/sdk/output-classifier.test.ts
@@ -63,6 +63,26 @@ describe('isQuotaLimitedObserverOutput', () => {
     ).toBe(true);
   });
 
+  it('detects the monthly spend-limit message from Claude Code', () => {
+    expect(
+      isQuotaLimitedObserverOutput(
+        "You've hit your monthly spend limit · raise it at claude.ai/settings/usage?from=cc_cli_limit_message",
+      ),
+    ).toBe(true);
+  });
+
+  it('detects the Claude Code limit-message marker', () => {
+    expect(isQuotaLimitedObserverOutput('Usage is unavailable (cc_cli_limit_message)')).toBe(true);
+  });
+
+  it('does not treat neutral monthly spend-limit prose as exhaustion', () => {
+    expect(
+      isQuotaLimitedObserverOutput(
+        'The monthly spend limit setting is available in your account settings.',
+      ),
+    ).toBe(false);
+  });
+
   it('does not treat context-window prose as quota prose', () => {
     expect(
       isQuotaLimitedObserverOutput('I hit the context window and cannot produce valid XML.'),

--- a/tests/sdk/output-classifier.test.ts
+++ b/tests/sdk/output-classifier.test.ts
@@ -76,11 +76,15 @@ describe('isQuotaLimitedObserverOutput', () => {
   });
 
   it('does not treat neutral monthly spend-limit prose as exhaustion', () => {
-    expect(
-      isQuotaLimitedObserverOutput(
-        'The monthly spend limit setting is available in your account settings.',
-      ),
-    ).toBe(false);
+    const neutralMessages = [
+      'The monthly spend limit setting is available in your account settings.',
+      'You can raise your monthly spend limit in Settings.',
+      'Your monthly usage limit resets on the first of each month.',
+    ];
+
+    for (const message of neutralMessages) {
+      expect(isQuotaLimitedObserverOutput(message)).toBe(false);
+    }
   });
 
   it('does not treat context-window prose as quota prose', () => {


### PR DESCRIPTION
## Summary

- recognize Claude Code's monthly spend-limit message and its stable cc_cli_limit_message marker as quota output
- preserve the existing guard against neutral settings prose
- add focused regression coverage for the exact reported response

This lets the existing quota-preservation path requeue the claimed batch instead of confirming and dropping it as ordinary prose.

Addresses #3652.

## Validation

- npx --yes bun test tests/sdk/output-classifier.test.ts (19 passed)
- npm run typecheck
- git diff --check