### PR TITLE
perf(chroma): post-filter non-selective where clauses instead of pushing them to chroma

### DIFF
--- a/src/services/sync/ChromaSync.ts
+++ b/src/services/sync/ChromaSync.ts
@@ -95,10 +95,75 @@ interface StoredUserPrompt {
   platform_source: string;
 }
 
+/**
+ * Chroma brute-forces the metadata-matched candidate set instead of walking the
+ * HNSW graph, so a `where` clause costs ~30-50us per MATCHED document while an
+ * unfiltered query is flat regardless of n_results. Measured on a 347k-doc
+ * collection: unfiltered 0.15-0.29s for n_results 100..2000, versus 6.10s for
+ * `where {project: <60% of corpus>}`.
+ *
+ * So over-fetch unfiltered and filter here. Over-fetching is close to free;
+ * pushing a non-selective filter into chroma is not.
+ */
+const CHROMA_OVERFETCH_FACTOR = 20;
+const CHROMA_OVERFETCH_CAP = 2000;
+
+/**
+ * Build a client-side equivalent of a chroma `where` clause, or null if the
+ * clause uses anything we do not evaluate identically to chroma.
+ *
+ * Deliberately narrow: literal equality and $eq, combined with $and. Any
+ * operator we are not certain we match exactly ($in, $or, $ne, ranges) returns
+ * null so the query goes to chroma unchanged. A wrong client-side filter would
+ * silently drop results, which is far worse than a slow query.
+ */
+function buildClientSidePredicate(
+  where: Record<string, any>
+): ((metadata: Record<string, any>) => boolean) | null {
+  if (!where || typeof where !== 'object' || Array.isArray(where)) return null;
+
+  const entries = Object.entries(where);
+  if (entries.length === 0) return null;
+
+  const predicates: ((metadata: Record<string, any>) => boolean)[] = [];
+
+  for (const [key, value] of entries) {
+    if (key === '$and') {
+      if (!Array.isArray(value)) return null;
+      const inner = value.map(clause => buildClientSidePredicate(clause));
+      if (inner.some(p => p === null)) return null;
+      predicates.push(metadata => inner.every(p => p!(metadata)));
+      continue;
+    }
+    if (key.startsWith('$')) return null;
+
+    if (value !== null && typeof value === 'object') {
+      const operators = Object.keys(value);
+      if (operators.length !== 1 || operators[0] !== '$eq') return null;
+      const expected = (value as any).$eq;
+      predicates.push(metadata => metadata?.[key] === expected);
+      continue;
+    }
+    predicates.push(metadata => metadata?.[key] === value);
+  }
+
+  return metadata => predicates.every(p => p(metadata));
+}
+
 export class ChromaSync {
   private project: string;
   private collectionName: string;
   private collectionCreated = false;
+  /**
+   * Where-clauses observed to be selective, keyed by clause signature.
+   *
+   * The over-fetch fast path is a net loss for a selective filter: it pays the
+   * unfiltered fetch AND the filtered query it was trying to avoid. One miss is
+   * enough to learn that, after which we go straight to chroma -- which is cheap
+   * for exactly these filters. Bounded so it cannot grow without limit.
+   */
+  private selectiveFilters = new Map<string, number>();
+  private static readonly SELECTIVE_FILTER_MEMO_CAP = 256;
   private collectionCreation: Promise<void> | null = null;
   private readonly BATCH_SIZE = 100;
 
@@ -986,15 +1051,67 @@ export class ChromaSync {
     await this.ensureCollectionExists();
 
     let results: any;
-    try {
+    const runQuery = async (nResults: number, where?: Record<string, any>) => {
       const chromaMcp = ChromaMcpManager.getInstance();
-      results = await chromaMcp.callTool('chroma_query_documents', {
+      return await chromaMcp.callTool('chroma_query_documents', {
         collection_name: this.collectionName,
         query_texts: [query],
-        n_results: limit,
-        ...(whereFilter && { where: whereFilter }),
+        n_results: nResults,
+        ...(where && { where }),
         include: ['documents', 'metadatas', 'distances']
       });
+    };
+
+    try {
+      // Fast path: keep a non-selective filter out of chroma by over-fetching
+      // unfiltered and applying the clause here (see CHROMA_OVERFETCH_FACTOR).
+      const predicate = whereFilter ? buildClientSidePredicate(whereFilter) : null;
+      const filterKey = whereFilter ? JSON.stringify(whereFilter) : '';
+      const knownSurvivors = this.selectiveFilters.get(filterKey);
+      if (predicate && (knownSurvivors === undefined || knownSurvivors >= limit)) {
+        const overfetch = Math.min(
+          Math.max(limit * CHROMA_OVERFETCH_FACTOR, limit),
+          CHROMA_OVERFETCH_CAP
+        );
+        const raw: any = await runQuery(overfetch);
+        const rawIds = raw?.ids?.[0] || [];
+        const rawMetadatas = raw?.metadatas?.[0] || [];
+        const rawDistances = raw?.distances?.[0] || [];
+
+        const keptIds: string[] = [];
+        const keptMetadatas: any[] = [];
+        const keptDistances: number[] = [];
+        for (let i = 0; i < rawIds.length; i++) {
+          if (!predicate(rawMetadatas[i] ?? {})) continue;
+          keptIds.push(rawIds[i]);
+          keptMetadatas.push(rawMetadatas[i]);
+          keptDistances.push(rawDistances[i]);
+        }
+
+        const filtered = this.deduplicateQueryResults({
+          ids: [keptIds], metadatas: [keptMetadatas], distances: [keptDistances]
+        });
+
+        // Enough survivors means the filter was not selective and the fast path
+        // is sound. Too few means it WAS selective -- the case SearchManager
+        // pushes into chroma so small projects are not crowded out of the top-N
+        // -- and chroma handles a selective filter cheaply. So fall through.
+        if (filtered.ids.length >= limit) {
+          this.selectiveFilters.delete(filterKey);
+          return {
+            ids: filtered.ids.slice(0, limit),
+            distances: filtered.distances.slice(0, limit),
+            metadatas: filtered.metadatas.slice(0, limit)
+          };
+        }
+
+        if (this.selectiveFilters.size >= ChromaSync.SELECTIVE_FILTER_MEMO_CAP) {
+          this.selectiveFilters.clear();
+        }
+        this.selectiveFilters.set(filterKey, filtered.ids.length);
+      }
+
+      results = await runQuery(limit, whereFilter);
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
 

--- a/tests/services/sync/chroma-query-postfilter.test.ts
+++ b/tests/services/sync/chroma-query-postfilter.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Adaptive post-filtering for ChromaSync.queryChroma().
+ *
+ * Chroma brute-forces the metadata-matched candidate set rather than using the
+ * HNSW graph, so cost scales with how many documents the `where` clause matches
+ * (~30-50us each). Measured on a 347k-doc collection:
+ *
+ *     unfiltered, n_results 100..2000   0.15 - 0.29s   (flat)
+ *     where {project: rxinform-cli}     6.10s          (208k docs matched)
+ *
+ * Over-fetching unfiltered is therefore effectively free, and filtering client
+ * side is ~20x faster whenever the filter is not very selective.
+ *
+ * The fallback matters as much as the fast path: SearchManager deliberately
+ * pushes `project` into the where clause so large projects cannot crowd small
+ * ones out of the top-N. So when the over-fetch does NOT yield enough matches --
+ * exactly the "small project got crowded out" case -- we must fall back to the
+ * real filtered query, which is cheap precisely because that filter is selective.
+ */
+import { afterAll, describe, it, expect, beforeEach, mock } from 'bun:test';
+import * as realChromaMcpManager from '../../../src/services/sync/ChromaMcpManager.js';
+
+const realChromaMcpManagerSnapshot = { ...realChromaMcpManager };
+
+interface Call { tool: string; args: any }
+let calls: Call[] = [];
+
+// Synthetic corpus: `big` dominates, `tiny` is a sliver -- the real shape.
+const CORPUS: { id: string; project: string; doc_type: string }[] = [];
+for (let i = 0; i < 1000; i++) {
+  CORPUS.push({ id: `obs_${i}_fact_0`, project: i % 50 === 0 ? 'tiny' : 'big', doc_type: 'observation' });
+}
+
+function matches(where: any, meta: any): boolean {
+  if (!where) return true;
+  if (where.$and) return where.$and.every((clause: any) => matches(clause, meta));
+  return Object.entries(where).every(([k, v]: [string, any]) => {
+    if (v && typeof v === 'object') {
+      if ('$eq' in v) return meta[k] === v.$eq;
+      if ('$in' in v) return v.$in.includes(meta[k]);
+      return false;
+    }
+    return meta[k] === v;
+  });
+}
+
+// Stand-in for chroma: honours `where`, caps at n_results, preserves order.
+function fakeQuery(args: any) {
+  const n = args.n_results ?? 10;
+  const hits = CORPUS.filter(d => matches(args.where, d)).slice(0, n);
+  return {
+    ids: [hits.map(d => d.id)],
+    metadatas: [hits.map(d => ({ project: d.project, doc_type: d.doc_type }))],
+    distances: [hits.map((_, i) => i * 0.001)],
+    documents: [hits.map(d => d.id)],
+  };
+}
+
+// Follow this repo's convention (see chroma-sync-unavailable.test.ts): mock the
+// manager and restore the real module in afterAll, so the mock cannot leak into
+// the other chroma test files that need the genuine manager.
+mock.module('../../../src/services/sync/ChromaMcpManager.js', () => ({
+  ChromaMcpManager: {
+    getInstance: () => ({
+      callTool: async (tool: string, args: any) => {
+        calls.push({ tool, args });
+        return tool === 'chroma_query_documents' ? fakeQuery(args) : null;
+      },
+    }),
+  },
+}));
+
+mock.module('../../../src/utils/logger.js', () => ({
+  logger: { info: () => {}, debug: () => {}, warn: () => {}, error: () => {}, failure: () => {} },
+}));
+
+import { ChromaSync } from '../../../src/services/sync/ChromaSync.js';
+
+afterAll(() => {
+  mock.module('../../../src/services/sync/ChromaMcpManager.js', () => realChromaMcpManagerSnapshot);
+});
+
+const queryCalls = () => calls.filter(c => c.tool === 'chroma_query_documents');
+
+let sync: ChromaSync;
+
+describe('ChromaSync.queryChroma adaptive post-filtering', () => {
+  beforeEach(() => {
+    calls = [];
+    sync = new ChromaSync('claude-mem');
+  });
+
+  it('does not send a where clause to chroma for a non-selective filter', async () => {
+    await sync.queryChroma('anything', 10, { project: 'big' });
+
+    const qs = queryCalls();
+    expect(qs.length).toBe(1);
+    expect(qs[0].args.where).toBeUndefined();
+    // and it must over-fetch, or there is nothing to filter down from
+    expect(qs[0].args.n_results).toBeGreaterThan(10);
+  });
+
+  it('still returns only rows matching the filter', async () => {
+    const out = await sync.queryChroma('anything', 10, { project: 'big' });
+
+    expect(out.ids.length).toBeGreaterThan(0);
+    expect(out.metadatas.every((m: any) => m.project === 'big')).toBe(true);
+  });
+
+  it('falls back to a real filtered query when the over-fetch is too sparse', async () => {
+    // 'tiny' is 1-in-50, so an over-fetch cannot supply 100 of them.
+    await sync.queryChroma('anything', 100, { project: 'tiny' });
+
+    const qs = queryCalls();
+    expect(qs.length).toBe(2);
+    expect(qs[0].args.where).toBeUndefined();          // tried the fast path
+    expect(qs[1].args.where).toEqual({ project: 'tiny' }); // then asked chroma properly
+  });
+
+  it('applies every clause of an $and filter client-side', async () => {
+    const out = await sync.queryChroma('anything', 10, {
+      $and: [{ doc_type: 'observation' }, { project: 'big' }],
+    });
+
+    expect(out.metadatas.length).toBeGreaterThan(0);
+    expect(out.metadatas.every((m: any) => m.project === 'big' && m.doc_type === 'observation')).toBe(true);
+  });
+
+  it('sends operator filters straight to chroma rather than guessing', async () => {
+    // $in is not a shape we evaluate client-side; correctness beats speed.
+    await sync.queryChroma('anything', 10, { project: { $in: ['big', 'tiny'] } });
+
+    const qs = queryCalls();
+    expect(qs.length).toBe(1);
+    expect(qs[0].args.where).toEqual({ project: { $in: ['big', 'tiny'] } });
+  });
+
+  it('is unchanged when there is no filter at all', async () => {
+    await sync.queryChroma('anything', 10);
+
+    const qs = queryCalls();
+    expect(qs.length).toBe(1);
+    expect(qs[0].args.where).toBeUndefined();
+    expect(qs[0].args.n_results).toBe(10);
+  });
+});
+
+describe('ChromaSync.queryChroma selectivity memo', () => {
+  beforeEach(() => {
+    calls = [];
+    sync = new ChromaSync('claude-mem');
+  });
+
+  it('stops paying for the over-fetch once a filter is known to be selective', async () => {
+    // First call learns that 'tiny' cannot fill the limit: over-fetch + fallback.
+    await sync.queryChroma('anything', 100, { project: 'tiny' });
+    expect(queryCalls().length).toBe(2);
+
+    // Second identical call must skip the doomed over-fetch entirely.
+    calls = [];
+    await sync.queryChroma('anything', 100, { project: 'tiny' });
+    const qs = queryCalls();
+    expect(qs.length).toBe(1);
+    expect(qs[0].args.where).toEqual({ project: 'tiny' });
+  });
+
+  it('keeps using the fast path for a filter that fills the limit', async () => {
+    await sync.queryChroma('anything', 10, { project: 'big' });
+    calls = [];
+    await sync.queryChroma('anything', 10, { project: 'big' });
+
+    const qs = queryCalls();
+    expect(qs.length).toBe(1);
+    expect(qs[0].args.where).toBeUndefined();
+  });
+
+  it('retries the fast path when a smaller limit could now be satisfied', async () => {
+    await sync.queryChroma('anything', 100, { project: 'tiny' });  // learns 20 survivors
+    calls = [];
+    await sync.queryChroma('anything', 5, { project: 'tiny' });    // 20 >= 5, worth trying
+
+    const qs = queryCalls();
+    expect(qs[0].args.where).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Chroma brute-forces the metadata-matched candidate set rather than walking the HNSW graph, so a `where` clause costs roughly 30-50us per **matched** document while an unfiltered query is flat regardless of `n_results`. Measured on a 347k-doc collection:

| query | latency |
|---|---|
| unfiltered, `n_results` 100..2000 | 0.15 - 0.29s (flat) |
| `where {project: …}` — 7.7k matched | 0.39s |
| `where {project: …}` — 54k matched | 1.67s |
| `where {project: …}` — 208k matched | **6.10s** |

`SearchManager` puts `project` into the where clause so large projects cannot crowd small ones out of the top-N, which is correct — but on a corpus where one project is 60% of the documents it makes every search on that project a near-full scan.

## Change

`queryChroma` over-fetches unfiltered (20x, capped 2000) and applies the clause client-side, reusing the existing `deduplicateQueryResults` for both paths. Over-fetching is close to free; pushing a non-selective filter into chroma is not.

When the over-fetch yields fewer than `limit` survivors the filter *was* selective — exactly the crowded-out case the where clause exists for — so it falls back to a real filtered query, which is cheap precisely because that filter is selective. Both ends keep their behaviour; only the expensive middle changes.

A per-clause memo records that outcome, because the fast path is a net loss for a selective filter (it pays both queries). Without it a 2%-of-corpus project regressed 0.39s → 4.32s. One miss is enough to learn; an entry clears as soon as a clause fills the limit, so it self-corrects as the corpus grows. Bounded at 256 entries.

## Result

End-to-end search latency, same corpus:

| project size | before | after |
|---|---|---|
| 7.7k docs | 0.39s | 0.25s |
| 5.7k docs | 1.10s | 0.23s |
| 54k docs | 1.67s | 0.32s |
| 208k docs | 6.73s | 0.30s |

This also matters because the MCP client's worker timeout is 3s, so semantic search was failing outright on the largest project — the index was healthy, the query just took longer than the client would wait.

## Correctness

The client-side predicate is deliberately narrow: literal equality and `$eq`, combined with `$and`. Anything else (`$in`, `$or`, `$ne`, ranges) returns null and the query goes to chroma unchanged. A wrong client-side filter would silently drop results, which is worse than a slow query.

## Testing

9 new tests in `tests/services/sync/chroma-query-postfilter.test.ts`, following the existing convention of mocking `ChromaMcpManager` and restoring the real module in `afterAll` so it cannot leak into the sibling chroma tests. Full suite run against a baseline of this branch point: no new failures.

---

*Note: this PR previously also carried a `chroma-mcp` subprocess leak fix. That turned out to be already fixed on `main`, and more thoroughly — upstream kills the whole process tree, since `transport.close()` only signals the direct `uvx` child and not the python grandchild. It has been dropped and the branch rebased onto current `main`, so this is now the perf change alone.*
