### PR TITLE
fix(windows): resolve Volta Bun shims to bun.exe

### DIFF
--- a/src/services/integrations/install-paths.ts
+++ b/src/services/integrations/install-paths.ts
@@ -17,6 +17,7 @@ import path from 'path';
 import { homedir } from 'os';
 import { existsSync } from 'fs';
 import { MARKETPLACE_ROOT } from '../../shared/paths.js';
+import { lookupWindowsCommand } from '../../shared/spawn.js';
 
 function firstExisting(candidates: string[]): string | null {
   for (const candidate of candidates) {
@@ -78,7 +79,11 @@ export function getWorkerServiceAbsolutePath(): string | null {
  * via PATH at exec time) when no known install location exists.
  */
 export function getBunAbsolutePath(): string {
+  const pathResolvedBun = process.platform === 'win32'
+    ? lookupWindowsCommand('bun')
+    : null;
   const candidates = [
+    ...(pathResolvedBun?.toLowerCase().endsWith('.exe') ? [pathResolvedBun] : []),
     path.join(homedir(), '.bun', 'bin', 'bun'),
     '/usr/local/bin/bun',
     '/usr/bin/bun',

--- a/src/shared/spawn.ts
+++ b/src/shared/spawn.ts
@@ -6,7 +6,7 @@ import {
   type ChildProcess,
   type SpawnSyncOptionsWithStringEncoding,
 } from 'node:child_process';
-import { extname } from 'node:path';
+import { dirname, extname, join } from 'node:path';
 
 export type SpawnHiddenOptions = SpawnOptions;
 
@@ -35,6 +35,41 @@ export function quoteWindowsCmdArgument(value: string): string {
   return `"${value.replace(/"/g, '""')}"`;
 }
 
+export function selectWindowsCommandCandidate(
+  candidates: string[],
+  resolveShim?: (shimPath: string) => string | null,
+): string | null {
+  const native = candidates.find(candidate =>
+    WINDOWS_NATIVE_EXTENSIONS.has(extname(candidate).toLowerCase()));
+  if (native) return native;
+
+  const shim = candidates.find(candidate =>
+    WINDOWS_CMD_EXTENSIONS.has(extname(candidate).toLowerCase()));
+  if (shim && resolveShim) {
+    const resolved = resolveShim(shim);
+    if (resolved && WINDOWS_NATIVE_EXTENSIONS.has(extname(resolved).toLowerCase())) {
+      return resolved;
+    }
+  }
+
+  return shim ?? candidates[0] ?? null;
+}
+
+function resolveVoltaShim(command: string, shimPath: string): string | null {
+  if (!/[\\/]volta[\\/]bin[\\/]/i.test(shimPath)) return null;
+  try {
+    const result = spawnSync(join(dirname(shimPath), 'volta.exe'), ['which', command], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
+    });
+    if (result.status !== 0 || !result.stdout.trim()) return null;
+    return result.stdout.split(/\r?\n/).map(line => line.trim()).find(Boolean) ?? null;
+  } catch {
+    return null;
+  }
+}
+
 export function lookupWindowsCommand(command: string): string | null {
   if (process.platform !== 'win32') return null;
   try {
@@ -48,10 +83,10 @@ export function lookupWindowsCommand(command: string): string | null {
       .split(/\r?\n/)
       .map(line => line.trim())
       .filter(Boolean);
-    return candidates.find(candidate => WINDOWS_NATIVE_EXTENSIONS.has(extname(candidate).toLowerCase()))
-      ?? candidates.find(candidate => WINDOWS_COMMAND_EXTENSIONS.has(extname(candidate).toLowerCase()))
-      ?? candidates[0]
-      ?? null;
+    return selectWindowsCommandCandidate(
+      candidates,
+      shimPath => resolveVoltaShim(command, shimPath),
+    );
   } catch {
     // where exits non-zero when absent and can throw if PATH is malformed.
     return null;

--- a/src/shared/spawn.ts
+++ b/src/shared/spawn.ts
@@ -31,6 +31,17 @@ export interface SpawnSyncInvocation {
   options: SpawnSyncOptionsWithStringEncoding;
 }
 
+type VoltaWhichRunner = (
+  command: string,
+  args: readonly string[],
+  options: SpawnSyncOptionsWithStringEncoding,
+) => { status: number | null; stdout: string };
+
+const VOLTA_SHIM_RESOLUTION_TIMEOUT_MS = 5_000;
+
+const runVoltaWhich: VoltaWhichRunner = (command, args, options) =>
+  spawnSync(command, args, options);
+
 export function quoteWindowsCmdArgument(value: string): string {
   return `"${value.replace(/"/g, '""')}"`;
 }
@@ -55,12 +66,17 @@ export function selectWindowsCommandCandidate(
   return shim ?? candidates[0] ?? null;
 }
 
-function resolveVoltaShim(command: string, shimPath: string): string | null {
+export function resolveVoltaShim(
+  command: string,
+  shimPath: string,
+  run: VoltaWhichRunner = runVoltaWhich,
+): string | null {
   if (!/[\\/]volta[\\/]bin[\\/]/i.test(shimPath)) return null;
   try {
-    const result = spawnSync(join(dirname(shimPath), 'volta.exe'), ['which', command], {
+    const result = run(join(dirname(shimPath), 'volta.exe'), ['which', command], {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: VOLTA_SHIM_RESOLUTION_TIMEOUT_MS,
       windowsHide: true,
     });
     if (result.status !== 0 || !result.stdout.trim()) return null;

--- a/tests/shared/spawn-candidate.test.ts
+++ b/tests/shared/spawn-candidate.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'bun:test';
-import { selectWindowsCommandCandidate } from '../../src/shared/spawn.js';
+import {
+  resolveVoltaShim,
+  selectWindowsCommandCandidate,
+} from '../../src/shared/spawn.js';
 
 describe('Windows #3677 - Volta Bun shims resolve to the native executable', () => {
   it('prefers the native executable returned for a Volta shim', () => {
@@ -15,5 +18,20 @@ describe('Windows #3677 - Volta Bun shims resolve to the native executable', () 
   it('keeps a non-Volta command shim when no native target is resolved', () => {
     const shim = 'C:\\Users\\tester\\AppData\\Roaming\\npm\\bun.cmd';
     expect(selectWindowsCommandCandidate([shim], () => null)).toBe(shim);
+  });
+
+  it('bounds a stalled Volta probe and falls back to the shim', () => {
+    const shim = 'C:\\Users\\tester\\AppData\\Local\\Volta\\bin\\bun.cmd';
+    let timeout: number | undefined;
+
+    const selected = selectWindowsCommandCandidate([shim], candidate =>
+      resolveVoltaShim('bun', candidate, (_command, _args, options) => {
+        timeout = options.timeout;
+        return { status: null, stdout: '' };
+      }),
+    );
+
+    expect(timeout).toBe(5_000);
+    expect(selected).toBe(shim);
   });
 });

--- a/tests/shared/spawn-candidate.test.ts
+++ b/tests/shared/spawn-candidate.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'bun:test';
+import { selectWindowsCommandCandidate } from '../../src/shared/spawn.js';
+
+describe('Windows #3677 - Volta Bun shims resolve to the native executable', () => {
+  it('prefers the native executable returned for a Volta shim', () => {
+    const shim = 'C:\\Users\\tester\\AppData\\Local\\Volta\\bin\\bun.cmd';
+    const executable = 'C:\\Users\\tester\\AppData\\Local\\Volta\\tools\\image\\bun\\1.3.11\\bun.exe';
+
+    expect(selectWindowsCommandCandidate([shim], candidate => {
+      expect(candidate).toBe(shim);
+      return executable;
+    })).toBe(executable);
+  });
+
+  it('keeps a non-Volta command shim when no native target is resolved', () => {
+    const shim = 'C:\\Users\\tester\\AppData\\Roaming\\npm\\bun.cmd';
+    expect(selectWindowsCommandCandidate([shim], () => null)).toBe(shim);
+  });
+});


### PR DESCRIPTION
## Summary

- detect when `where bun` resolves only to Volta's `bun.cmd` shim
- ask the sibling `volta.exe` for the native Bun executable and prefer that `.exe`
- use the resolved native path when installer-managed host configs bake a Bun command

## Assumptions and scope

The official Volta layout keeps `volta.exe` beside its command shims, and `volta which bun` returns the selected native executable. If either lookup fails, the existing command-shim behavior remains unchanged. Non-Windows and non-Volta resolution paths are unchanged.

This deliberately does not duplicate #3532's installer-location work; it covers the Volta shim indirection reported here and the existing install-path baking path.

## Validation

- `npx --yes bun test tests/shared/spawn-candidate.test.ts` — 2 pass, 0 fail
- `npx --yes bun run typecheck:root` — pass
- `git diff --check` — pass

Refs #3677
