### PR TITLE
fix(hooks): fail open when Bash path enrichment cannot parse

### DIFF
--- a/src/cli/adapters/codex-file-context.ts
+++ b/src/cli/adapters/codex-file-context.ts
@@ -88,7 +88,15 @@ function extractFromBash(toolInput: unknown, cwd: string): string[] {
   const command = normalizeCommand((toolInput as { command?: unknown } | undefined)?.command);
   if (!command) return [];
 
-  const tokens = parse(command);
+  let tokens: ParsedToken[];
+  try {
+    tokens = parse(command);
+  } catch {
+    // File-path enrichment is best-effort metadata. shell-quote rejects some
+    // valid shell expansions (for example ${VAR:-$(...)}); that must not turn
+    // a capture hook into a blocking error for the underlying command.
+    return [];
+  }
   const paths: string[] = [];
 
   for (const segment of splitSegments(tokens)) {

--- a/tests/cli/adapters/codex-file-context.test.ts
+++ b/tests/cli/adapters/codex-file-context.test.ts
@@ -43,6 +43,16 @@ describe('extractFilePaths', () => {
     expect(paths).toEqual([]);
   });
 
+  it('fails open when shell-quote cannot parse a Bash expansion', () => {
+    expect(() => extractFilePaths('Bash', {
+      command: 'PORT="${CLAUDE_MEM_WORKER_PORT:-$(node -e "const x=1")}"; cat README.md',
+    }, tmpDir)).not.toThrow();
+
+    expect(extractFilePaths('Bash', {
+      command: 'echo "${}"',
+    }, tmpDir)).toEqual([]);
+  });
+
   it('extracts MCP read tool path arrays', () => {
     const paths = extractFilePaths('mcp__local_filesystem__read_file', {
       paths: ['README.md', 'notes.txt', 'missing.txt'],


### PR DESCRIPTION
## Summary

- contain `shell-quote` parse failures inside Codex Bash file-path enrichment
- return no enriched paths for unsupported shell syntax while preserving the original tool input
- add regressions for `${}` and nested default/command-substitution forms

## Assumptions and scope

File-path extraction is best-effort capture metadata; failure to derive it must not block the user's command. The catch is intentionally limited to the parser call, so filesystem and hook behavior outside enrichment are unchanged.

This is independent of the open shell-quote version update in #3646: a dependency update does not establish a fail-open boundary for future unsupported shell syntax.

## Validation

- `npx --yes bun test tests/cli/adapters/codex-file-context.test.ts` — 7 pass, 0 fail
- `npx --yes bun run typecheck:root` — pass
- `git diff --check` — pass

Refs #3688
