### PR TITLE
fix(worker): preserve buffered work after reactive provider quota errors (closes #3700)

### DIFF
--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -310,6 +310,14 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     }
 
     if (isClassified(error)) {
+      if (error.kind === 'quota_exhausted' || error.kind === 'rate_limit') {
+        session.abortReason = `quota:${error.kind}`;
+        try {
+          session.abortController.abort();
+        } catch {
+          // Abort is best-effort; preserve the provider error as the cause.
+        }
+      }
       // Logged once at SessionRoutes' `Observer failed` line.
       logger.debug('SDK', `${this.providerName} agent error`, { sessionDbId: session.sessionDbId, kind: error.kind }, error);
     } else {

--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -303,22 +303,20 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     }
   }
 
-  protected handleSessionError(error: unknown, session: ActiveSession, _worker?: WorkerRef): never {
+  protected async handleSessionError(error: unknown, session: ActiveSession, _worker?: WorkerRef): Promise<never> {
     if (isAbortError(error)) {
       logger.warn('SDK', `${this.providerName} agent aborted`, { sessionId: session.sessionDbId });
       throw error;
     }
 
     if (isClassified(error)) {
-      if (error.kind === 'quota_exhausted' || error.kind === 'rate_limit') {
-        session.abortReason = `quota:${error.kind}`;
-        try {
-          session.abortController.abort();
-        } catch {
-          // Abort is best-effort; preserve the provider error as the cause.
-        }
+      if (error.kind === 'quota_exhausted' || error.kind === 'rate_limit' || error.kind === 'auth_invalid') {
+        await this.sessionManager.resetProcessingToPending(session.sessionDbId);
+        session.abortReason = error.kind === 'auth_invalid'
+          ? `auth:${error.kind}`
+          : `quota:${error.kind}`;
       }
-      // Logged once at SessionRoutes' `Observer failed` line.
+      // Leave the controller active so SessionRoutes records observer health before exit.
       logger.debug('SDK', `${this.providerName} agent error`, { sessionDbId: session.sessionDbId, kind: error.kind }, error);
     } else {
       logger.failure('SDK', `${this.providerName} agent error`, { sessionDbId: session.sessionDbId }, error instanceof Error ? error : new Error(String(error)));

--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -16,6 +16,13 @@ import {
   type WorkerRef
 } from './agents/index.js';
 
+function rollbackPrompt(session: ActiveSession, prompt: string): void {
+  const lastMessage = session.conversationHistory.at(-1);
+  if (lastMessage?.role === 'user' && lastMessage.content === prompt) {
+    session.conversationHistory.pop();
+  }
+}
+
 /**
  * Normalized result returned by a concrete provider's `query()`.
  * Optional fields (costUsd, servedModel) are populated only by providers that
@@ -111,6 +118,7 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
       const initResponse = await this.query(session.conversationHistory, config);
       await this.handleInitResponse(initResponse, session, worker, model, initContext);
     } catch (error: unknown) {
+      rollbackPrompt(session, initPrompt);
       // Classified errors are logged once, at SessionRoutes' `Observer failed`
       // line; here they're debug-level so one failure isn't five error lines.
       if (isClassified(error)) {
@@ -222,7 +230,13 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     session.conversationHistory.push({ role: 'user', content: obsPrompt });
     session.lastPromptSentAt = Date.now();
     session.lastGeneratorSource = 'ingest';
-    const obsResponse = await this.query(session.conversationHistory, config);
+    let obsResponse: ProviderQueryResult;
+    try {
+      obsResponse = await this.query(session.conversationHistory, config);
+    } catch (error: unknown) {
+      rollbackPrompt(session, obsPrompt);
+      throw error;
+    }
 
     let tokensUsed = 0;
     if (obsResponse.content) {
@@ -280,7 +294,13 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
         sessionId: session.sessionDbId, model: summaryModel
       });
     }
-    const summaryResponse = await this.query(session.conversationHistory, summaryConfig);
+    let summaryResponse: ProviderQueryResult;
+    try {
+      summaryResponse = await this.query(session.conversationHistory, summaryConfig);
+    } catch (error: unknown) {
+      rollbackPrompt(session, summaryPrompt);
+      throw error;
+    }
 
     let tokensUsed = 0;
     if (summaryResponse.content) {

--- a/src/services/worker/http/routes/SessionRoutes.ts
+++ b/src/services/worker/http/routes/SessionRoutes.ts
@@ -42,13 +42,14 @@ const MAX_USER_PROMPT_BYTES = 256 * 1024;
  */
 function normalizeAbortReason(
   reason: string | null | undefined
-): 'idle' | 'shutdown' | 'overflow' | 'restart_guard' | 'quota' | 'none' {
+): 'idle' | 'shutdown' | 'overflow' | 'restart_guard' | 'quota' | 'auth' | 'none' {
   switch ((reason ?? '').split(':')[0]) {
     case 'idle': return 'idle';
     case 'shutdown': return 'shutdown';
     case 'overflow': return 'overflow';
     case 'restart-guard': return 'restart_guard';
     case 'quota': return 'quota';
+    case 'auth': return 'auth';
     default: return 'none';
   }
 }
@@ -235,16 +236,20 @@ export class SessionRoutes extends BaseRouteHandler {
         recordObserverFailure(provider, isClassified(error)
           ? { message: error.message, code: error.code, action: error.action, url: error.url, requestId: error.requestId }
           : errorMsg);
-        telemetryBuffer.record('session_compressed', session.sessionDbId, {
-          outcome: 'error',
-          provider,
-          // Providers seed lastModelId when they start; 'unknown' covers a
-          // generator that died before resolving its model.
-          model: session.lastModelId ?? 'unknown',
-          error_category: 'provider_error',
-          hook: session.lastGeneratorSource,
-          ide: session.platformSource,
-        });
+        // The pause reason gets the single session_compressed record in
+        // finally; fatal errors keep the existing error record here.
+        if (session.abortReason === null) {
+          telemetryBuffer.record('session_compressed', session.sessionDbId, {
+            outcome: 'error',
+            provider,
+            // Providers seed lastModelId when they start; 'unknown' covers a
+            // generator that died before resolving its model.
+            model: session.lastModelId ?? 'unknown',
+            error_category: 'provider_error',
+            hook: session.lastGeneratorSource,
+            ide: session.platformSource,
+          });
+        }
       })
       .finally(async () => {
         if (skipGeneratorExitFinalization) {
@@ -260,10 +265,8 @@ export class SessionRoutes extends BaseRouteHandler {
         const reason = session.abortReason ?? null;
         session.abortReason = null;  // consume the reason
         if (reason !== null) {
-          // Abort accounting lives HERE, where the reason is consumed — the
-          // ONLY point every abort flow (idle / shutdown / overflow / quota)
-          // passes through. Emit the closed enum, never the raw
-          // string ('quota:…' carries a window suffix).
+          // Pause accounting lives here, where the reason is consumed. Emit
+          // the closed enum, never the raw string ('quota:…' carries a suffix).
           telemetryBuffer.record('session_compressed', session.sessionDbId, {
             outcome: 'aborted',
             provider,

--- a/src/services/worker/http/routes/SessionRoutes.ts
+++ b/src/services/worker/http/routes/SessionRoutes.ts
@@ -205,10 +205,9 @@ export class SessionRoutes extends BaseRouteHandler {
         //
         // The local error line (full fidelity) and the scrubbed
         // session_compressed rollup are one logical event.
-        // No abort_reason here: every site that sets abortReason aborts the
-        // controller on its next line, so aborted generators either resolve
-        // normally (quota/overflow break) or hit the signal-aborted early
-        // return above — this catch only ever sees non-abort rejections.
+        // Reactive provider pause errors deliberately keep this controller
+        // active long enough for this catch to record observer health; the
+        // finally block consumes their abortReason and preserves the buffer.
         if (isClassified(error)) {
           // The single error-level line for a classified provider failure:
           // code, message, action, link, and request id — same words the

--- a/tests/worker/poison-respawn.test.ts
+++ b/tests/worker/poison-respawn.test.ts
@@ -480,6 +480,13 @@ describe('observer invalid-output handling (Phase 3 recovery)', () => {
     },
   );
 
+  it('rolls back the failed observation prompt before a paused session restarts', async () => {
+    const result = await runReactiveProviderExit('quota_exhausted', 18);
+
+    expect(result.session.conversationHistory).toHaveLength(1);
+    expect(result.session.conversationHistory[0]?.role).toBe('user');
+  });
+
   it('preserves a worktree-adopted session without changing its parent project', async () => {
     const result = await runReactiveProviderExit('rate_limit', 14, 'parent-project');
 

--- a/tests/worker/poison-respawn.test.ts
+++ b/tests/worker/poison-respawn.test.ts
@@ -62,7 +62,7 @@ async function runReactiveProviderExit(
   kind: 'quota_exhausted' | 'rate_limit' | 'auth_invalid' | 'unrecoverable' | 'transient',
   sessionDbId: number,
   project = 'origin-project',
-): Promise<{ session: ActiveSession; sessionManager: SessionManager; finalizeSession: ReturnType<typeof mock>; removeSession: ReturnType<typeof spyOn>; error: unknown }> {
+): Promise<{ session: ActiveSession; sessionManager: SessionManager; finalizeSession: ReturnType<typeof mock>; removeSession: ReturnType<typeof spyOn>; error: unknown; expectedError: unknown }> {
   const sessionManager = new SessionManager(makeDbManager());
   const session = sessionManager.initializeSession(sessionDbId, 'do the thing', 1);
   session.memorySessionId = `mem-${sessionDbId}`;
@@ -89,7 +89,7 @@ async function runReactiveProviderExit(
     sessionManager,
     completionHandler: { finalizeSession } as any,
   });
-  return { session, sessionManager, finalizeSession, removeSession, error: thrown };
+  return { session, sessionManager, finalizeSession, removeSession, error: thrown, expectedError: error };
 }
 
 async function queueAndClaimOne(sm: SessionManager, sessionDbId: number): Promise<void> {
@@ -468,6 +468,7 @@ describe('observer invalid-output handling (Phase 3 recovery)', () => {
       const result = await runReactiveProviderExit(kind, kind === 'quota_exhausted' ? 12 : 13);
 
       expect(result.error).toBeInstanceOf(ClassifiedProviderError);
+      expect(result.error).toBe(result.expectedError);
       expect(result.session.abortReason).toBe(kind === 'auth_invalid' ? `auth:${kind}` : `quota:${kind}`);
       expect(result.session.abortController.signal.aborted).toBe(false);
       expect(result.finalizeSession).not.toHaveBeenCalled();
@@ -494,6 +495,7 @@ describe('observer invalid-output handling (Phase 3 recovery)', () => {
       const result = await runReactiveProviderExit(kind, kind === 'unrecoverable' ? 15 : 16);
 
       expect(result.error).toBeInstanceOf(ClassifiedProviderError);
+      expect(result.error).toBe(result.expectedError);
       expect(result.session.abortReason ?? null).toBeNull();
       expect(result.finalizeSession).toHaveBeenCalledWith(result.session.sessionDbId);
       expect(result.removeSession).toHaveBeenCalledWith(result.session.sessionDbId);

--- a/tests/worker/poison-respawn.test.ts
+++ b/tests/worker/poison-respawn.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from 'bun:test';
+import { describe, it, expect, mock, beforeAll, beforeEach, afterAll, afterEach, spyOn } from 'bun:test';
 import { logger } from '../../src/utils/logger.js';
 import { SessionManager } from '../../src/services/worker/SessionManager.js';
 import { processAgentResponse } from '../../src/services/worker/agents/ResponseProcessor.js';
@@ -9,6 +9,7 @@ import { OpenAICompatibleProvider, type ProviderQueryResult } from '../../src/se
 import { ClassifiedProviderError } from '../../src/services/worker/provider-errors.js';
 import type { ActiveSession, ConversationMessage } from '../../src/services/worker-types.js';
 import { ModeManager } from '../../src/services/domain/ModeManager.js';
+import type { ModeConfig } from '../../src/services/domain/types.js';
 
 function makeDbManager(storeObservations = mock(() => ({ observationIds: [], summaryId: null, createdAtEpoch: 0 }))): DatabaseManager {
   return {
@@ -108,11 +109,29 @@ async function queueAndClaimOne(sm: SessionManager, sessionDbId: number): Promis
 }
 
 let spies: ReturnType<typeof spyOn>[] = [];
+let testMode: ModeConfig;
+let previousModeId: string | null = null;
+
+beforeAll(() => {
+  const manager = ModeManager.getInstance();
+  try {
+    previousModeId = manager.getActiveModeId();
+  } catch {
+    previousModeId = null;
+  }
+  testMode = manager.loadMode('code');
+});
+
+afterAll(() => {
+  if (previousModeId && previousModeId !== 'code') {
+    ModeManager.getInstance().loadMode(previousModeId);
+  }
+});
 
 describe('observer invalid-output handling (Phase 3 recovery)', () => {
   beforeEach(() => {
-    ModeManager.getInstance().loadMode('code');
     spies = [
+      spyOn(ModeManager.getInstance(), 'getActiveMode').mockReturnValue(testMode),
       spyOn(logger, 'info').mockImplementation(() => {}),
       spyOn(logger, 'debug').mockImplementation(() => {}),
       spyOn(logger, 'warn').mockImplementation(() => {}),
@@ -498,6 +517,7 @@ describe('observer invalid-output handling (Phase 3 recovery)', () => {
     }
     const finalizeSession = mock(() => Promise.resolve());
     const removeSession = spyOn(sessionManager, 'removeSessionImmediate');
+    spies.push(removeSession);
     await handleGeneratorExit(session, session.abortReason, {
       sessionManager,
       completionHandler: { finalizeSession } as any,

--- a/tests/worker/poison-respawn.test.ts
+++ b/tests/worker/poison-respawn.test.ts
@@ -5,6 +5,10 @@ import { processAgentResponse } from '../../src/services/worker/agents/ResponseP
 import { handleGeneratorExit } from '../../src/services/worker/session/GeneratorExitHandler.js';
 import type { DatabaseManager } from '../../src/services/worker/DatabaseManager.js';
 import type { WorkerRef } from '../../src/services/worker/agents/types.js';
+import { OpenAICompatibleProvider, type ProviderQueryResult } from '../../src/services/worker/OpenAICompatibleProvider.js';
+import { ClassifiedProviderError } from '../../src/services/worker/provider-errors.js';
+import type { ActiveSession, ConversationMessage } from '../../src/services/worker-types.js';
+import { ModeManager } from '../../src/services/domain/ModeManager.js';
 
 function makeDbManager(storeObservations = mock(() => ({ observationIds: [], summaryId: null, createdAtEpoch: 0 }))): DatabaseManager {
   return {
@@ -28,6 +32,52 @@ const makeWorker = (): WorkerRef => ({
   broadcastProcessingStatus: mock(() => {}),
 }) as unknown as WorkerRef;
 
+class ReactiveQuotaTestProvider extends OpenAICompatibleProvider<{ apiKey: string; model: string }> {
+  protected readonly providerName = 'Gemini';
+  protected readonly syntheticIdPrefix = 'gemini';
+  protected readonly forwardEmptyMessageResponse = false;
+  constructor(dbManager: DatabaseManager, sessionManager: SessionManager, private readonly failure: unknown) {
+    super(dbManager, sessionManager);
+  }
+  protected getConfig() { return { apiKey: 'test-key', model: 'gemini-test' }; }
+  protected missingApiKeyError(): Error { return new Error('missing key'); }
+  protected async query(_history: ConversationMessage[], _config: { apiKey: string; model: string }): Promise<ProviderQueryResult> {
+    throw this.failure;
+  }
+  protected estimateTokens(): number { return 0; }
+  protected buildLastUsage(): ActiveSession['lastUsage'] { return null; }
+}
+
+async function runReactiveProviderExit(
+  kind: 'quota_exhausted' | 'rate_limit' | 'unrecoverable' | 'transient',
+  sessionDbId: number,
+  project = 'origin-project',
+): Promise<{ session: ActiveSession; sessionManager: SessionManager; finalizeSession: ReturnType<typeof mock>; removeSession: ReturnType<typeof spyOn>; error: unknown }> {
+  const sessionManager = new SessionManager(makeDbManager());
+  const session = sessionManager.initializeSession(sessionDbId, 'do the thing', 1);
+  session.memorySessionId = `mem-${sessionDbId}`;
+  session.project = project;
+  session.generatorPromise = Promise.resolve();
+  await queueAndClaimOne(sessionManager, sessionDbId);
+  const error = kind === 'unrecoverable' || kind === 'transient'
+    ? new ClassifiedProviderError(`${kind} failure`, { kind, cause: new Error('provider') })
+    : new ClassifiedProviderError('Gemini quota exhausted (status 429)', { kind, cause: new Error('provider') });
+  const provider = new ReactiveQuotaTestProvider(makeDbManager(), sessionManager, error);
+  let thrown: unknown;
+  try {
+    await provider.startSession(session, makeWorker());
+  } catch (caught) {
+    thrown = caught;
+  }
+  const finalizeSession = mock(() => Promise.resolve());
+  const removeSession = spyOn(sessionManager, 'removeSessionImmediate');
+  await handleGeneratorExit(session, session.abortReason, {
+    sessionManager,
+    completionHandler: { finalizeSession } as any,
+  });
+  return { session, sessionManager, finalizeSession, removeSession, error: thrown };
+}
+
 async function queueAndClaimOne(sm: SessionManager, sessionDbId: number): Promise<void> {
   await sm.queueObservation(sessionDbId, {
     tool_name: 'Read',
@@ -48,6 +98,7 @@ let spies: ReturnType<typeof spyOn>[] = [];
 
 describe('observer invalid-output handling (Phase 3 recovery)', () => {
   beforeEach(() => {
+    ModeManager.getInstance().loadMode('code');
     spies = [
       spyOn(logger, 'info').mockImplementation(() => {}),
       spyOn(logger, 'debug').mockImplementation(() => {}),
@@ -377,5 +428,69 @@ describe('observer invalid-output handling (Phase 3 recovery)', () => {
 
     expect(skipSm.getMessageBuffer().getPendingCount(4)).toBe(0);
     expect(quotaSm.getMessageBuffer().getPendingCount(5)).toBe(1);
+  });
+
+  it.each(['quota_exhausted', 'rate_limit'] as const)(
+    'reactive %s errors preserve claimed work through provider exit',
+    async (kind) => {
+      const result = await runReactiveProviderExit(kind, kind === 'quota_exhausted' ? 12 : 13);
+
+      expect(result.error).toBeInstanceOf(ClassifiedProviderError);
+      expect(result.session.abortReason).toBe(`quota:${kind}`);
+      expect(result.session.abortController.signal.aborted).toBe(true);
+      expect(result.finalizeSession).not.toHaveBeenCalled();
+      expect(result.removeSession).not.toHaveBeenCalled();
+      expect(result.sessionManager.getSession(result.session.sessionDbId)).toBe(result.session);
+      expect(result.sessionManager.getMessageBuffer().getPendingCount(result.session.sessionDbId)).toBe(1);
+    },
+  );
+
+  it('preserves a worktree-adopted session without changing its parent project', async () => {
+    const result = await runReactiveProviderExit('rate_limit', 14, 'parent-project');
+
+    expect(result.session.project).toBe('parent-project');
+    expect(result.session.abortReason).toBe('quota:rate_limit');
+    expect(result.sessionManager.getMessageBuffer().getPendingCount(14)).toBe(1);
+    expect(result.finalizeSession).not.toHaveBeenCalled();
+  });
+
+  it.each(['unrecoverable', 'transient'] as const)(
+    'reactive %s errors retain fatal cleanup',
+    async (kind) => {
+      const result = await runReactiveProviderExit(kind, kind === 'unrecoverable' ? 15 : 16);
+
+      expect(result.error).toBeInstanceOf(ClassifiedProviderError);
+      expect(result.session.abortReason ?? null).toBeNull();
+      expect(result.finalizeSession).toHaveBeenCalledWith(result.session.sessionDbId);
+      expect(result.removeSession).toHaveBeenCalledWith(result.session.sessionDbId);
+      expect(result.sessionManager.getSession(result.session.sessionDbId)).toBeUndefined();
+      expect(result.sessionManager.getMessageBuffer().getPendingCount(result.session.sessionDbId)).toBe(0);
+    },
+  );
+
+  it('keeps an unclassified reactive error on the existing fatal path', async () => {
+    const sessionManager = new SessionManager(makeDbManager());
+    const session = sessionManager.initializeSession(17, 'do the thing', 1);
+    session.memorySessionId = 'mem-17';
+    await queueAndClaimOne(sessionManager, 17);
+    const error = new TypeError('provider transport failed');
+    const provider = new ReactiveQuotaTestProvider(makeDbManager(), sessionManager, error);
+    let thrown: unknown;
+    try {
+      await provider.startSession(session, makeWorker());
+    } catch (caught) {
+      thrown = caught;
+    }
+    const finalizeSession = mock(() => Promise.resolve());
+    const removeSession = spyOn(sessionManager, 'removeSessionImmediate');
+    await handleGeneratorExit(session, session.abortReason, {
+      sessionManager,
+      completionHandler: { finalizeSession } as any,
+    });
+
+    expect(thrown).toBe(error);
+    expect(session.abortReason ?? null).toBeNull();
+    expect(finalizeSession).toHaveBeenCalledWith(17);
+    expect(removeSession).toHaveBeenCalledWith(17);
   });
 });

--- a/tests/worker/poison-respawn.test.ts
+++ b/tests/worker/poison-respawn.test.ts
@@ -36,12 +36,21 @@ class ReactiveQuotaTestProvider extends OpenAICompatibleProvider<{ apiKey: strin
   protected readonly providerName = 'Gemini';
   protected readonly syntheticIdPrefix = 'gemini';
   protected readonly forwardEmptyMessageResponse = false;
-  constructor(dbManager: DatabaseManager, sessionManager: SessionManager, private readonly failure: unknown) {
+  private queryCount = 0;
+  constructor(
+    dbManager: DatabaseManager,
+    sessionManager: SessionManager,
+    private readonly failure: unknown,
+    private readonly failOnMessageLoop = false,
+  ) {
     super(dbManager, sessionManager);
   }
   protected getConfig() { return { apiKey: 'test-key', model: 'gemini-test' }; }
   protected missingApiKeyError(): Error { return new Error('missing key'); }
   protected async query(_history: ConversationMessage[], _config: { apiKey: string; model: string }): Promise<ProviderQueryResult> {
+    if (this.failOnMessageLoop && this.queryCount++ === 0) {
+      return { content: '' };
+    }
     throw this.failure;
   }
   protected estimateTokens(): number { return 0; }
@@ -49,7 +58,7 @@ class ReactiveQuotaTestProvider extends OpenAICompatibleProvider<{ apiKey: strin
 }
 
 async function runReactiveProviderExit(
-  kind: 'quota_exhausted' | 'rate_limit' | 'unrecoverable' | 'transient',
+  kind: 'quota_exhausted' | 'rate_limit' | 'auth_invalid' | 'unrecoverable' | 'transient',
   sessionDbId: number,
   project = 'origin-project',
 ): Promise<{ session: ActiveSession; sessionManager: SessionManager; finalizeSession: ReturnType<typeof mock>; removeSession: ReturnType<typeof spyOn>; error: unknown }> {
@@ -61,8 +70,11 @@ async function runReactiveProviderExit(
   await queueAndClaimOne(sessionManager, sessionDbId);
   const error = kind === 'unrecoverable' || kind === 'transient'
     ? new ClassifiedProviderError(`${kind} failure`, { kind, cause: new Error('provider') })
-    : new ClassifiedProviderError('Gemini quota exhausted (status 429)', { kind, cause: new Error('provider') });
-  const provider = new ReactiveQuotaTestProvider(makeDbManager(), sessionManager, error);
+    : new ClassifiedProviderError(
+      kind === 'auth_invalid' ? 'Gemini auth invalid (status 401)' : 'Gemini quota exhausted (status 429)',
+      { kind, cause: new Error('provider') },
+    );
+  const provider = new ReactiveQuotaTestProvider(makeDbManager(), sessionManager, error, true);
   let thrown: unknown;
   try {
     await provider.startSession(session, makeWorker());
@@ -71,6 +83,7 @@ async function runReactiveProviderExit(
   }
   const finalizeSession = mock(() => Promise.resolve());
   const removeSession = spyOn(sessionManager, 'removeSessionImmediate');
+  spies.push(removeSession);
   await handleGeneratorExit(session, session.abortReason, {
     sessionManager,
     completionHandler: { finalizeSession } as any,
@@ -430,17 +443,19 @@ describe('observer invalid-output handling (Phase 3 recovery)', () => {
     expect(quotaSm.getMessageBuffer().getPendingCount(5)).toBe(1);
   });
 
-  it.each(['quota_exhausted', 'rate_limit'] as const)(
+  it.each(['quota_exhausted', 'rate_limit', 'auth_invalid'] as const)(
     'reactive %s errors preserve claimed work through provider exit',
     async (kind) => {
       const result = await runReactiveProviderExit(kind, kind === 'quota_exhausted' ? 12 : 13);
 
       expect(result.error).toBeInstanceOf(ClassifiedProviderError);
-      expect(result.session.abortReason).toBe(`quota:${kind}`);
-      expect(result.session.abortController.signal.aborted).toBe(true);
+      expect(result.session.abortReason).toBe(kind === 'auth_invalid' ? `auth:${kind}` : `quota:${kind}`);
+      expect(result.session.abortController.signal.aborted).toBe(false);
       expect(result.finalizeSession).not.toHaveBeenCalled();
       expect(result.removeSession).not.toHaveBeenCalled();
       expect(result.sessionManager.getSession(result.session.sessionDbId)).toBe(result.session);
+      expect(result.session.claimedMessageIds).toEqual([]);
+      expect(result.sessionManager.getClaimedMessages(result.session.sessionDbId)).toEqual([]);
       expect(result.sessionManager.getMessageBuffer().getPendingCount(result.session.sessionDbId)).toBe(1);
     },
   );


### PR DESCRIPTION
## Summary

Reactive quota_exhausted, rate_limit, and auth_invalid errors from the OpenAI-compatible worker path currently rethrow without marking the session as paused. Generator cleanup therefore finalizes the session and drops buffered observations.

The shared error handler now resets claimed work, records the existing quota or auth reason, and rethrows without aborting the controller, so SessionRoutes can record observer health before the existing pause path preserves the session and buffer. Failed provider prompts are rolled back before restart, and pause telemetry remains one record with a closed quota or auth reason. Non-pausing failures and existing proactive or observer-text paths remain unchanged.

Closes #3700

## Why

Gemini and OpenRouter classify provider failures before they reach OpenAICompatibleProvider.handleSessionError. That method currently logs and rethrows, leaving abortReason unset. GeneratorExitHandler then takes its ordinary finalization path. The fix completes the existing reason-plus-reset contract at the shared provider boundary, leaves the controller active long enough for SessionRoutes to record observer health, and prevents a failed prompt from being appended again on restart.

## Scope

This PR covers reactive classified quota, rate-limit, and auth errors. It does not change provider classifiers, retry behavior, proactive allowance handling, observer-text classification, or the server generation provider stack.

## Risk

Three classified kinds enter the pause path. Other errors keep the existing fatal behavior, and the existing GeneratorExitHandler remains the owner of session retention.

## Verification

- [x] bun test tests/worker/poison-respawn.test.ts tests/worker/provider-classifiers.test.ts tests/server/generation/providers.test.ts, 105 pass
- [x] npx tsc --noEmit
- [x] npm run lint:hook-io && npm run lint:spawn-env
- [x] npm run build, generated minified outputs restored per repository policy
