### PR TITLE
fix(worktree): use remote ancestry to adopt merged worktrees, including detached heads (refs #3698)

### DIFF
--- a/src/services/infrastructure/WorktreeAdoption.ts
+++ b/src/services/infrastructure/WorktreeAdoption.ts
@@ -37,6 +37,13 @@ export function formatAdoptionErrors(errors: AdoptionResult['errors']): string {
 interface WorktreeEntry {
   path: string;
   branch: string | null;
+  head: string | null;
+}
+
+interface GitCommandResult {
+  status: number | null;
+  stdout: string;
+  error: Error | undefined;
 }
 
 const GIT_TIMEOUT_MS = 15000;
@@ -48,7 +55,7 @@ class DryRunRollback extends Error {
   }
 }
 
-function gitCapture(cwd: string, args: string[]): string | null {
+function gitRun(cwd: string, args: string[]): GitCommandResult {
   const startTime = Date.now();
   const r = spawnSync('git', ['-C', cwd, ...args], {
     encoding: 'utf8',
@@ -66,16 +73,21 @@ function gitCapture(cwd: string, args: string[]): string | null {
       error: r.error.message,
       timedOut: r.error.name === 'ETIMEDOUT' || (r.status === null && r.signal === 'SIGTERM')
     });
-    return null;
+    return { status: r.status, stdout: '', error: r.error };
   }
 
   if (r.status !== 0) {
     logger.debug('GIT', `Git returned non-zero exit code ${r.status}: git -C ${cwd} ${args.join(' ')}`, {
       stderr: r.stderr?.toString().trim()
     });
-    return null;
+    return { status: r.status, stdout: '', error: undefined };
   }
-  return (r.stdout ?? '').trim();
+  return { status: r.status, stdout: (r.stdout ?? '').trim(), error: undefined };
+}
+
+function gitCapture(cwd: string, args: string[]): string | null {
+  const result = gitRun(cwd, args);
+  return result.status === 0 ? result.stdout : null;
 }
 
 function resolveMainRepoPath(cwd: string): string | null {
@@ -100,33 +112,41 @@ function listWorktrees(mainRepo: string): WorktreeEntry[] {
   let current: Partial<WorktreeEntry> = {};
   for (const line of raw.split('\n')) {
     if (line.startsWith('worktree ')) {
-      if (current.path) entries.push({ path: current.path, branch: current.branch ?? null });
-      current = { path: line.slice('worktree '.length).trim(), branch: null };
+      if (current.path) entries.push({ path: current.path, branch: current.branch ?? null, head: current.head ?? null });
+      current = { path: line.slice('worktree '.length).trim(), branch: null, head: null };
+    } else if (line.startsWith('HEAD ')) {
+      current.head = line.slice('HEAD '.length).trim() || null;
     } else if (line.startsWith('branch ')) {
       const refName = line.slice('branch '.length).trim();
       current.branch = refName.startsWith('refs/heads/')
         ? refName.slice('refs/heads/'.length)
         : refName;
     } else if (line === '' && current.path) {
-      entries.push({ path: current.path, branch: current.branch ?? null });
+      entries.push({ path: current.path, branch: current.branch ?? null, head: current.head ?? null });
       current = {};
     }
   }
-  if (current.path) entries.push({ path: current.path, branch: current.branch ?? null });
+  if (current.path) entries.push({ path: current.path, branch: current.branch ?? null, head: current.head ?? null });
   return entries;
 }
 
-function listMergedBranches(mainRepo: string): Set<string> {
-  const raw = gitCapture(mainRepo, [
-    'branch',
-    '--merged',
-    'HEAD',
-    '--format=%(refname:short)'
-  ]);
-  if (!raw) return new Set();
-  return new Set(
-    raw.split('\n').map(b => b.trim()).filter(b => b.length > 0)
-  );
+function resolveCandidateOids(mainRepo: string): Set<string> {
+  const oids = new Set<string>();
+  for (const ref of ['HEAD', 'origin/HEAD', 'origin/main', 'origin/master']) {
+    const result = gitRun(mainRepo, ['rev-parse', '--verify', `${ref}^{commit}`]);
+    if (result.status === 0 && result.stdout) oids.add(result.stdout);
+  }
+  return oids;
+}
+
+function hasProvenAncestry(mainRepo: string, worktreeHead: string, candidateOids: Set<string>): boolean {
+  for (const candidateOid of candidateOids) {
+    const result = gitRun(mainRepo, ['merge-base', '--is-ancestor', worktreeHead, candidateOid]);
+    if (result.status === 0) return true;
+    // Status 1 is a known negative. Spawn failures and other statuses remain
+    // conservative by simply leaving this worktree unselected.
+  }
+  return false;
 }
 
 export async function adoptMergedWorktrees(opts: {
@@ -178,8 +198,10 @@ export async function adoptMergedWorktrees(opts: {
   if (opts.onlyBranch) {
     targets = childWorktrees.filter(w => w.branch === opts.onlyBranch);
   } else {
-    const merged = listMergedBranches(mainRepo);
-    targets = childWorktrees.filter(w => w.branch !== null && merged.has(w.branch));
+    const candidateOids = resolveCandidateOids(mainRepo);
+    targets = childWorktrees.filter(w =>
+      w.head !== null && hasProvenAncestry(mainRepo, w.head, candidateOids)
+    );
   }
 
   result.mergedBranches = targets

--- a/src/services/infrastructure/WorktreeAdoption.ts
+++ b/src/services/infrastructure/WorktreeAdoption.ts
@@ -140,9 +140,13 @@ function resolveCandidateOids(mainRepo: string): Set<string> {
 }
 
 export function hasProvenAncestry(mainRepo: string, worktreeHead: string, candidateOids: Set<string>): boolean {
+  // A detached worktree at an exact candidate tip is a fresh checkout of the
+  // parent or remote integration tip, not evidence of a merged child branch.
+  if ([...candidateOids].some(candidateOid => candidateOid === worktreeHead)) return false;
+
   for (const candidateOid of candidateOids) {
     const result = gitRun(mainRepo, ['merge-base', '--is-ancestor', worktreeHead, candidateOid]);
-    if (result.status === 0) return true;
+    if (result.status === 0 && !result.error) return true;
     // Status 1 is a known negative. Spawn failures and other statuses remain
     // conservative by simply leaving this worktree unselected.
   }

--- a/src/services/infrastructure/WorktreeAdoption.ts
+++ b/src/services/infrastructure/WorktreeAdoption.ts
@@ -140,10 +140,6 @@ function resolveCandidateOids(mainRepo: string): Set<string> {
 }
 
 export function hasProvenAncestry(mainRepo: string, worktreeHead: string, candidateOids: Set<string>): boolean {
-  // A detached worktree at an exact candidate tip is a fresh checkout of the
-  // parent or remote integration tip, not evidence of a merged child branch.
-  if ([...candidateOids].some(candidateOid => candidateOid === worktreeHead)) return false;
-
   for (const candidateOid of candidateOids) {
     const result = gitRun(mainRepo, ['merge-base', '--is-ancestor', worktreeHead, candidateOid]);
     if (result.status === 0 && !result.error) return true;
@@ -204,7 +200,11 @@ export async function adoptMergedWorktrees(opts: {
   } else {
     const candidateOids = resolveCandidateOids(mainRepo);
     targets = childWorktrees.filter(w =>
-      w.head !== null && hasProvenAncestry(mainRepo, w.head, candidateOids)
+      w.head !== null &&
+      // A branch at the current parent tip is a valid existing worktree;
+      // detached exact-tip checkouts are fresh inspection worktrees.
+      (w.branch !== null || !candidateOids.has(w.head)) &&
+      hasProvenAncestry(mainRepo, w.head, candidateOids)
     );
   }
 

--- a/src/services/infrastructure/WorktreeAdoption.ts
+++ b/src/services/infrastructure/WorktreeAdoption.ts
@@ -139,7 +139,7 @@ function resolveCandidateOids(mainRepo: string): Set<string> {
   return oids;
 }
 
-function hasProvenAncestry(mainRepo: string, worktreeHead: string, candidateOids: Set<string>): boolean {
+export function hasProvenAncestry(mainRepo: string, worktreeHead: string, candidateOids: Set<string>): boolean {
   for (const candidateOid of candidateOids) {
     const result = gitRun(mainRepo, ['merge-base', '--is-ancestor', worktreeHead, candidateOid]);
     if (result.status === 0) return true;

--- a/tests/worker/sync/mutation-sites.test.ts
+++ b/tests/worker/sync/mutation-sites.test.ts
@@ -20,7 +20,7 @@ import { spawnSync } from 'child_process';
 import { SessionStore } from '../../../src/services/sqlite/SessionStore.js';
 import { openConfiguredSqliteDatabase } from '../../../src/services/sqlite/connection.js';
 import { emitRemapProject, hasSyncLane } from '../../../src/services/sync/remap-outbox.js';
-import { adoptMergedWorktrees } from '../../../src/services/infrastructure/WorktreeAdoption.js';
+import { adoptMergedWorktrees, hasProvenAncestry } from '../../../src/services/infrastructure/WorktreeAdoption.js';
 import { runOneTimeCwdRemap } from '../../../src/services/infrastructure/ProcessManager.js';
 
 const ISO = '2026-07-09T00:00:00.000Z';
@@ -33,6 +33,15 @@ function git(cwd: string, ...args: string[]): void {
   if (r.status !== 0) {
     throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
   }
+}
+
+function gitOutput(cwd: string, ...args: string[]): string {
+  const r = spawnSync('git', ['-C', cwd, '-c', 'user.email=test@test', '-c', 'user.name=test', ...args], {
+    encoding: 'utf8',
+    timeout: 15000,
+  });
+  if (r.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
+  return r.stdout.trim();
 }
 
 interface OutboxRow {
@@ -368,12 +377,13 @@ describe('mutation sites', () => {
     }
   });
 
-  it('adopts branched and detached worktrees proven by a remote commit while preserving negative space', async () => {
+    it('adopts branched and detached worktrees proven by a remote commit while preserving negative space', async () => {
     const bareOrigin = join(tempDir, 'origin.git');
     const repo = join(tempDir, 'parent-repo');
     const integration = join(tempDir, 'integration-repo');
     const featureWorktree = join(tempDir, 'feature-wt');
     const detachedWorktree = join(tempDir, 'detached-wt');
+    const historicalWorktree = join(tempDir, 'historical-wt');
     const unmergedWorktree = join(tempDir, 'unmerged-wt');
     mkdirSync(bareOrigin);
     mkdirSync(repo);
@@ -392,14 +402,13 @@ describe('mutation sites', () => {
     git(featureWorktree, 'commit', '-m', 'feature');
     git(repo, 'push', '-u', 'origin', 'feature');
     git(repo, 'worktree', 'add', '--detach', detachedWorktree, 'feature');
+    git(repo, 'worktree', 'add', '--detach', historicalWorktree, 'HEAD');
 
     git(repo, 'worktree', 'add', '-b', 'unmerged', unmergedWorktree);
     writeFileSync(join(unmergedWorktree, 'unmerged.txt'), 'unmerged\n');
     git(unmergedWorktree, 'add', '.');
     git(unmergedWorktree, 'commit', '-m', 'unmerged');
 
-    git(integration, 'config', 'user.email', 'test@test');
-    git(integration, 'config', 'user.name', 'test');
     git(integration, 'fetch', 'origin');
     git(integration, 'merge', '--no-ff', 'origin/feature', '-m', 'merge feature');
     git(integration, 'push', 'origin', 'main');
@@ -414,6 +423,7 @@ describe('mutation sites', () => {
         ['native', 'parent-repo'],
         ['feature', 'parent-repo/feature-wt'],
         ['detached', 'parent-repo/detached-wt'],
+        ['historical', 'parent-repo/historical-wt'],
         ['unmerged', 'parent-repo/unmerged-wt'],
       ]) {
         store.db.prepare(`
@@ -428,9 +438,9 @@ describe('mutation sites', () => {
       store.close();
 
       const result = await adoptMergedWorktrees({ repoPath: repo, dataDirectory: dataDir });
-      expect(result.scannedWorktrees).toBe(3);
+      expect(result.scannedWorktrees).toBe(4);
       expect(result.mergedBranches).toEqual(['feature']);
-      expect(result.adoptedSummaries).toBe(2);
+      expect(result.adoptedSummaries).toBe(3);
 
       const verify = openConfiguredSqliteDatabase(dbPath);
       try {
@@ -440,6 +450,7 @@ describe('mutation sites', () => {
         expect(rows).toEqual([
           { memory_session_id: 'detached', project: 'parent-repo/detached-wt', merged_into_project: 'parent-repo' },
           { memory_session_id: 'feature', project: 'parent-repo/feature-wt', merged_into_project: 'parent-repo' },
+          { memory_session_id: 'historical', project: 'parent-repo/historical-wt', merged_into_project: 'parent-repo' },
           { memory_session_id: 'native', project: 'parent-repo', merged_into_project: null },
           { memory_session_id: 'unmerged', project: 'parent-repo/unmerged-wt', merged_into_project: null },
         ]);
@@ -455,10 +466,30 @@ describe('mutation sites', () => {
       expect(override.mergedBranches).toEqual(['unmerged']);
       expect(override.adoptedSummaries).toBe(1);
     } finally {
-      for (const worktree of [featureWorktree, detachedWorktree, unmergedWorktree]) {
+      for (const worktree of [featureWorktree, detachedWorktree, historicalWorktree, unmergedWorktree]) {
         if (existsSync(worktree)) git(repo, 'worktree', 'remove', '--force', worktree);
       }
     }
+  }, 30000);
+
+  it('keeps failed merge-base probes unproven', () => {
+    const repo = join(tempDir, 'provenance-repo');
+    const unrelated = join(tempDir, 'unrelated-repo');
+    mkdirSync(repo);
+    mkdirSync(unrelated);
+    git(repo, 'init', '-b', 'main');
+    writeFileSync(join(repo, 'base.txt'), 'base\n');
+    git(repo, 'add', '.');
+    git(repo, 'commit', '-m', 'base');
+    git(unrelated, 'init', '-b', 'main');
+    writeFileSync(join(unrelated, 'other.txt'), 'other\n');
+    git(unrelated, 'add', '.');
+    git(unrelated, 'commit', '-m', 'unrelated');
+
+    const head = gitOutput(repo, 'rev-parse', 'HEAD');
+    const unrelatedHead = gitOutput(unrelated, 'rev-parse', 'HEAD');
+    expect(hasProvenAncestry(repo, head, new Set([unrelatedHead]))).toBe(false);
+    expect(hasProvenAncestry(repo, 'not-a-commit', new Set([head]))).toBe(false);
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/worker/sync/mutation-sites.test.ts
+++ b/tests/worker/sync/mutation-sites.test.ts
@@ -440,7 +440,7 @@ describe('mutation sites', () => {
       const result = await adoptMergedWorktrees({ repoPath: repo, dataDirectory: dataDir });
       expect(result.scannedWorktrees).toBe(4);
       expect(result.mergedBranches).toEqual(['feature']);
-      expect(result.adoptedSummaries).toBe(3);
+      expect(result.adoptedSummaries).toBe(2);
 
       const verify = openConfiguredSqliteDatabase(dbPath);
       try {
@@ -450,7 +450,7 @@ describe('mutation sites', () => {
         expect(rows).toEqual([
           { memory_session_id: 'detached', project: 'parent-repo/detached-wt', merged_into_project: 'parent-repo' },
           { memory_session_id: 'feature', project: 'parent-repo/feature-wt', merged_into_project: 'parent-repo' },
-          { memory_session_id: 'historical', project: 'parent-repo/historical-wt', merged_into_project: 'parent-repo' },
+          { memory_session_id: 'historical', project: 'parent-repo/historical-wt', merged_into_project: null },
           { memory_session_id: 'native', project: 'parent-repo', merged_into_project: null },
           { memory_session_id: 'unmerged', project: 'parent-repo/unmerged-wt', merged_into_project: null },
         ]);

--- a/tests/worker/sync/mutation-sites.test.ts
+++ b/tests/worker/sync/mutation-sites.test.ts
@@ -368,6 +368,99 @@ describe('mutation sites', () => {
     }
   });
 
+  it('adopts branched and detached worktrees proven by a remote commit while preserving negative space', async () => {
+    const bareOrigin = join(tempDir, 'origin.git');
+    const repo = join(tempDir, 'parent-repo');
+    const integration = join(tempDir, 'integration-repo');
+    const featureWorktree = join(tempDir, 'feature-wt');
+    const detachedWorktree = join(tempDir, 'detached-wt');
+    const unmergedWorktree = join(tempDir, 'unmerged-wt');
+    mkdirSync(bareOrigin);
+    mkdirSync(repo);
+    git(bareOrigin, 'init', '--bare');
+    git(repo, 'init', '-b', 'main');
+    writeFileSync(join(repo, 'base.txt'), 'base\n');
+    git(repo, 'add', '.');
+    git(repo, 'commit', '-m', 'base');
+    git(repo, 'remote', 'add', 'origin', bareOrigin);
+    git(repo, 'push', '-u', 'origin', 'main');
+    git(tempDir, 'clone', bareOrigin, integration);
+
+    git(repo, 'worktree', 'add', '-b', 'feature', featureWorktree);
+    writeFileSync(join(featureWorktree, 'feature.txt'), 'feature\n');
+    git(featureWorktree, 'add', '.');
+    git(featureWorktree, 'commit', '-m', 'feature');
+    git(repo, 'push', '-u', 'origin', 'feature');
+    git(repo, 'worktree', 'add', '--detach', detachedWorktree, 'feature');
+
+    git(repo, 'worktree', 'add', '-b', 'unmerged', unmergedWorktree);
+    writeFileSync(join(unmergedWorktree, 'unmerged.txt'), 'unmerged\n');
+    git(unmergedWorktree, 'add', '.');
+    git(unmergedWorktree, 'commit', '-m', 'unmerged');
+
+    git(integration, 'config', 'user.email', 'test@test');
+    git(integration, 'config', 'user.name', 'test');
+    git(integration, 'fetch', 'origin');
+    git(integration, 'merge', '--no-ff', 'origin/feature', '-m', 'merge feature');
+    git(integration, 'push', 'origin', 'main');
+    git(repo, 'fetch', 'origin');
+
+    try {
+      const dataDir = join(tempDir, 'data');
+      mkdirSync(dataDir);
+      const dbPath = join(dataDir, 'claude-mem.db');
+      const store = new SessionStore(dbPath);
+      for (const [memorySessionId, project] of [
+        ['native', 'parent-repo'],
+        ['feature', 'parent-repo/feature-wt'],
+        ['detached', 'parent-repo/detached-wt'],
+        ['unmerged', 'parent-repo/unmerged-wt'],
+      ]) {
+        store.db.prepare(`
+          INSERT INTO sdk_sessions (content_session_id, memory_session_id, project, started_at, started_at_epoch, status)
+          VALUES (?, ?, ?, ?, 1751234567000, 'active')
+        `).run(`sess-${memorySessionId}`, memorySessionId, project, ISO);
+        store.db.prepare(`
+          INSERT INTO session_summaries (memory_session_id, project, request, created_at, created_at_epoch, sync_rev, synced_at)
+          VALUES (?, ?, 'req', ?, 1751234567891, 1, 123)
+        `).run(memorySessionId, project, ISO);
+      }
+      store.close();
+
+      const result = await adoptMergedWorktrees({ repoPath: repo, dataDirectory: dataDir });
+      expect(result.scannedWorktrees).toBe(3);
+      expect(result.mergedBranches).toEqual(['feature']);
+      expect(result.adoptedSummaries).toBe(2);
+
+      const verify = openConfiguredSqliteDatabase(dbPath);
+      try {
+        const rows = verify.prepare(
+          'SELECT memory_session_id, project, merged_into_project FROM session_summaries ORDER BY memory_session_id'
+        ).all() as Array<{ memory_session_id: string; project: string; merged_into_project: string | null }>;
+        expect(rows).toEqual([
+          { memory_session_id: 'detached', project: 'parent-repo/detached-wt', merged_into_project: 'parent-repo' },
+          { memory_session_id: 'feature', project: 'parent-repo/feature-wt', merged_into_project: 'parent-repo' },
+          { memory_session_id: 'native', project: 'parent-repo', merged_into_project: null },
+          { memory_session_id: 'unmerged', project: 'parent-repo/unmerged-wt', merged_into_project: null },
+        ]);
+      } finally {
+        verify.close();
+      }
+
+      const override = await adoptMergedWorktrees({
+        repoPath: repo,
+        dataDirectory: dataDir,
+        onlyBranch: 'unmerged',
+      });
+      expect(override.mergedBranches).toEqual(['unmerged']);
+      expect(override.adoptedSummaries).toBe(1);
+    } finally {
+      for (const worktree of [featureWorktree, detachedWorktree, unmergedWorktree]) {
+        if (existsSync(worktree)) git(repo, 'worktree', 'remove', '--force', worktree);
+      }
+    }
+  });
+
   // ---------------------------------------------------------------------------
   // (d) one-time cwd remap — the REAL site, own connection, real git repo
   // classified from pending_messages.cwd.

--- a/tests/worker/sync/mutation-sites.test.ts
+++ b/tests/worker/sync/mutation-sites.test.ts
@@ -394,7 +394,7 @@ describe('mutation sites', () => {
     git(repo, 'commit', '-m', 'base');
     git(repo, 'remote', 'add', 'origin', bareOrigin);
     git(repo, 'push', '-u', 'origin', 'main');
-    git(tempDir, 'clone', bareOrigin, integration);
+    git(tempDir, 'clone', '--branch', 'main', bareOrigin, integration);
 
     git(repo, 'worktree', 'add', '-b', 'feature', featureWorktree);
     writeFileSync(join(featureWorktree, 'feature.txt'), 'feature\n');


### PR DESCRIPTION
## Summary

Worktree adoption currently checks branch names merged into the parent checkout's local HEAD. A remote merge can be complete while that checkout is stale, and detached worktrees have no branch name to match.

The selection now checks each worktree HEAD against locally available HEAD and remote-tracking integration refs without fetching. Adoption remains conservative when Git cannot prove ancestry, and the existing SQLite and Chroma update paths remain unchanged.

Refs #3698

## Why

listWorktrees already discovers detached worktrees, but the automatic filter discards them and listMergedBranches only knows what local git branch --merged HEAD reports. The change uses the worktree's porcelain HEAD and Git's merge-base ancestry result, so selection reflects the commit graph rather than branch-name inference.

## Scope

This PR covers the remote-ancestry worktree-selection slice. The live-worker Chroma patch described in the issue is separate work.

## Risk

The change adds bounded local Git probes and does not fetch or prompt for credentials. A missing ref or failed probe remains a skip, so adoption cannot occur without positive ancestry evidence. A detached worktree at an exact parent or remote candidate tip is treated as a fresh checkout and remains unadopted; a detached feature tip with proven ancestry is adoptable. Detached-only adoption can report `Merged branches: (none)` while adopted counts are positive because detached worktrees have no branch name; the counts and remap remain authoritative.

## Verification

- [x] bun test tests/worker/sync/mutation-sites.test.ts -t "adopts branched and detached worktrees proven by a remote commit"
- [!] bun test tests/worker/sync/mutation-sites.test.ts tests/services/infrastructure/worktree-adoption-chroma.test.ts, 9 pass and 6 pre-existing Windows EBUSY cleanup failures
- [x] npm run build
- [x] npm run lint:hook-io && npm run lint:spawn-env
- [x] npm run strip-comments:check
