### PR TITLE
fix(oauth): make the Windows CredRead shim compile (#3722)

### DIFF
--- a/src/shared/oauth-token.ts
+++ b/src/shared/oauth-token.ts
@@ -113,18 +113,37 @@ async function readMacOsKeychain(): Promise<OAuthTokenResult> {
  * CredRead API. We use a PowerShell snippet that calls CredRead for the
  * common target name patterns Claude Desktop is known to use.
  */
-async function readWindowsCredentialManager(): Promise<OAuthTokenResult> {
+/**
+ * Printed by the snippet below when the P/Invoke shim itself fails to compile.
+ *
+ * Without it a shim failure is indistinguishable from an empty read — the script exits 0
+ * with no output, and the caller reports "no entry for Claude Code-credentials", sending
+ * anyone debugging it to look for a credential that is in fact present.
+ */
+export const WINDOWS_CRED_SHIM_ERROR_MARKER = '__CLAUDEMEM_CRED_SHIM_ERROR__';
+
+/**
+ * Build the PowerShell snippet that reads the OAuth blob out of Credential Manager.
+ *
+ * Exported so the shim can be checked without a Windows host. `Add-Type -Name <X>`
+ * generates a C# class `<X>`, and C# rejects a class containing a member of its own name
+ * with CS0542, "member names cannot be the same as their enclosing type". The shim was
+ * `-Name CredRead` declaring `CredRead`, so the type never compiled, every call threw,
+ * and the two SilentlyContinue settings swallowed it.
+ */
+export function buildWindowsCredentialScript(username: string): string {
   // PowerShell snippet enumerates likely target names and prints the JSON blob.
   // The exact target name on Windows is "Claude Code-credentials" or
   // "Claude Code:credentials" (Claude Desktop uses `${service}:${account}` or
   // `${service}` depending on version). This script tries both.
   // Username is escaped with PowerShell's single-quote convention (' → '') in
   // case future Windows versions or domain-joined machines permit ' in usernames.
-  const psSafeUsername = userInfo().username.replace(/'/g, "''");
-  const psScript = `
+  const psSafeUsername = username.replace(/'/g, "''");
+  return `
     $ErrorActionPreference = 'SilentlyContinue'
     $candidates = @('Claude Code-credentials', 'Claude Code:credentials', 'Claude Code-credentials:${psSafeUsername}')
-    Add-Type -Namespace ClaudeMem -Name CredRead -MemberDefinition @"
+    try {
+      Add-Type -Namespace ClaudeMem -Name CredApi -MemberDefinition @"
       [DllImport("Advapi32.dll", SetLastError=true, CharSet=CharSet.Unicode)]
       public static extern bool CredRead(string target, uint type, uint reservedFlag, out IntPtr CredentialPtr);
       [DllImport("Advapi32.dll", SetLastError=true)]
@@ -137,21 +156,29 @@ async function readWindowsCredentialManager(): Promise<OAuthTokenResult> {
         public uint Persist; public uint AttributeCount; public IntPtr Attributes;
         public string TargetAlias; public string UserName;
       }
-"@ -ErrorAction SilentlyContinue
+"@ -ErrorAction Stop
+    } catch {
+      Write-Output "${WINDOWS_CRED_SHIM_ERROR_MARKER} $($_.Exception.Message)"
+      exit 0
+    }
     foreach ($t in $candidates) {
       $ptr = [IntPtr]::Zero
-      $ok = [ClaudeMem.CredRead]::CredRead($t, 1, 0, [ref]$ptr)
+      $ok = [ClaudeMem.CredApi]::CredRead($t, 1, 0, [ref]$ptr)
       if ($ok) {
-        $cred = [System.Runtime.InteropServices.Marshal]::PtrToStructure($ptr, [Type][ClaudeMem.CredRead+CREDENTIAL])
+        $cred = [System.Runtime.InteropServices.Marshal]::PtrToStructure($ptr, [Type][ClaudeMem.CredApi+CREDENTIAL])
         $bytes = New-Object byte[] $cred.CredentialBlobSize
         [System.Runtime.InteropServices.Marshal]::Copy($cred.CredentialBlob, $bytes, 0, $cred.CredentialBlobSize)
-        [ClaudeMem.CredRead]::CredFree($ptr) | Out-Null
+        [ClaudeMem.CredApi]::CredFree($ptr) | Out-Null
         [System.Text.Encoding]::Unicode.GetString($bytes)
         exit 0
       }
     }
     exit 0
   `.trim();
+}
+
+async function readWindowsCredentialManager(): Promise<OAuthTokenResult> {
+  const psScript = buildWindowsCredentialScript(userInfo().username);
 
   let stdout: string;
   try {
@@ -169,6 +196,19 @@ async function readWindowsCredentialManager(): Promise<OAuthTokenResult> {
     };
   }
   const raw = stdout.trim();
+  if (raw.startsWith(WINDOWS_CRED_SHIM_ERROR_MARKER)) {
+    // The lookup never ran, so nothing here says anything about whether a credential
+    // exists. Reporting "no entry" would be a wrong answer rather than a missing one.
+    const detail = raw.slice(WINDOWS_CRED_SHIM_ERROR_MARKER.length).trim();
+    logger.warn('OAUTH', 'Windows Credential Manager shim failed to compile', {
+      service: KEYCHAIN_SERVICE_NAME,
+      detail,
+    });
+    return {
+      kind: 'absent',
+      reason: `Windows Credential Manager could not be queried: the CredRead shim failed to compile (${detail})`,
+    };
+  }
   if (!raw) {
     return { kind: 'absent', reason: 'Windows Credential Manager has no entry for "Claude Code-credentials"' };
   }

--- a/tests/shared/windows-credential-shim.test.ts
+++ b/tests/shared/windows-credential-shim.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  buildWindowsCredentialScript,
+  WINDOWS_CRED_SHIM_ERROR_MARKER,
+} from '../../src/shared/oauth-token.js';
+
+/**
+ * `Add-Type -Namespace N -Name X` generates the C# class `N.X`. C# rejects a class that
+ * declares a member of its own name with CS0542, "member names cannot be the same as
+ * their enclosing type". The shim was `-Name CredRead` declaring `public static extern
+ * bool CredRead(...)`, so the type never compiled, `[ClaudeMem.CredRead]::CredRead(...)`
+ * threw on every call, and both `-ErrorAction SilentlyContinue` and the script-level
+ * `$ErrorActionPreference` swallowed it — the Windows keychain path was dead code that
+ * reported itself as "no stored credential".
+ *
+ * These read the generated script rather than running PowerShell, so the rule holds on
+ * the Linux CI runner too.
+ */
+
+const script = buildWindowsCredentialScript('someone');
+
+function declaredTypeName(text: string): string {
+  const match = text.match(/Add-Type\s+-Namespace\s+(\w+)\s+-Name\s+(\w+)/);
+  expect(match, 'the script no longer declares a P/Invoke type').not.toBeNull();
+  return match![2];
+}
+
+function declaredMemberNames(text: string): string[] {
+  return [...text.matchAll(/public\s+(?:static\s+extern\s+)?[\w.<>\[\]]+\s+(\w+)\s*\(/g)].map(
+    (m) => m[1],
+  );
+}
+
+describe('Windows credential shim', () => {
+  it('does not name the generated type after one of its own members (CS0542)', () => {
+    const typeName = declaredTypeName(script);
+    const members = declaredMemberNames(script);
+
+    expect(members.length).toBeGreaterThan(0);
+    expect(members).not.toContain(typeName);
+  });
+
+  it('references the type it actually declares', () => {
+    const typeName = declaredTypeName(script);
+    const references = [...script.matchAll(/\[ClaudeMem\.(\w+)[\]+]/g)].map((m) => m[1]);
+
+    expect(references.length).toBeGreaterThan(0);
+    for (const reference of references) {
+      expect(reference).toBe(typeName);
+    }
+  });
+
+  it('reports a shim failure instead of exiting silently', () => {
+    // Without this the script exits 0 with no output on a compile failure, which the
+    // caller cannot tell apart from a machine that simply has no credential stored.
+    expect(script).toContain(WINDOWS_CRED_SHIM_ERROR_MARKER);
+    expect(script).toMatch(/Add-Type[\s\S]*?-ErrorAction Stop/);
+  });
+
+  it('escapes a single quote in the username', () => {
+    const quoted = buildWindowsCredentialScript("o'brien");
+    expect(quoted).toContain("Claude Code-credentials:o''brien");
+  });
+});


### PR DESCRIPTION
Closes #3722.

`Add-Type -Namespace ClaudeMem -Name CredRead` generates the C# class `ClaudeMem.CredRead`, and that class declares `public static extern bool CredRead(...)`. C# rejects that:

> **CS0542**: 'CredRead': member names cannot be the same as their enclosing type

So the type never compiled, `[ClaudeMem.CredRead]::CredRead($t, 1, 0, [ref]$ptr)` threw on every candidate target, and two separate settings hid it — `-ErrorAction SilentlyContinue` on the `Add-Type` and `$ErrorActionPreference = 'SilentlyContinue'` at the top of the script. The script then reached `exit 0` with empty stdout, which the caller reads as:

```
Windows Credential Manager has no entry for "Claude Code-credentials"
```

That is a **wrong** answer rather than a missing one, and it is the reason this could sit unnoticed: the Windows keychain path reported itself as working correctly on a machine that has the credential.

## Verified on a real Windows host

Windows 11, PowerShell 5.1. The reporter's minimal case:

```
A (type name == member name):  FAILED -> (9,27): error CS0542: 'CredRead': member names
                                        cannot be the same as their enclosing type
B (type renamed):              COMPILED
```

And end to end, feeding the **generated** shim block from `buildWindowsCredentialScript()` into PowerShell after this change:

```
FIXED SHIM: COMPILED -> ClaudeMem.CredApi
```

I ran only the `Add-Type` block, not the credential loop — no secret was read.

## What changed

- The generated type is `CredApi`, distinct from every member it declares. All four references move with it.
- `Add-Type` runs with `-ErrorAction Stop` inside a `try/catch` that prints `__CLAUDEMEM_CRED_SHIM_ERROR__ <message>`. The caller recognises that marker and returns *"Windows Credential Manager could not be queried: the CredRead shim failed to compile (…)"* with a `logger.warn`, instead of claiming there is no entry. The rename fixes today's failure; this is what stops the next one from being invisible.
- The snippet moves into an exported `buildWindowsCredentialScript(username)`. Nothing else about the read path, the candidate target names, or the quoting changes.

## Tests

`tests/shared/windows-credential-shim.test.ts` reads the generated script rather than running PowerShell, so it holds on the Linux CI runner too:

- the declared type name is not among the members the shim declares — the CS0542 condition itself, not the string `CredApi`, so any future rename stays covered
- every `[ClaudeMem.X]` reference names the type actually declared, so a half-done rename fails
- the script carries the failure marker and `-ErrorAction Stop`
- `o'brien` is still escaped to `o''brien`

**Mutation-checked** — restoring `-Name CredRead` and its references fails exactly the CS0542 case:

```
3 pass, 1 fail — "does not name the generated type after one of its own members (CS0542)"
```

```
bun test tests/shared/oauth-token.test.ts tests/shared/windows-credential-shim.test.ts
22 pass / 0 fail
```

`npx tsc --noEmit`: no errors.

Note: `plugin/scripts/worker-service.cjs` is a build artefact of this source, so it picks the fix up on the next bundle; I have not hand-edited it.
