### PR TITLE
fix(daemon): stop the worker holding the user's project as its cwd (#3706)

### DIFF
--- a/src/server/runtime/ServerService.ts
+++ b/src/server/runtime/ServerService.ts
@@ -862,6 +862,9 @@ function spawnServerDaemon(port: number): number | undefined {
     detached: true,
     stdio: 'ignore',
     windowsHide: true,
+    // Never the caller's directory: a daemon holds its cwd open for its whole life, and
+    // on Windows that locks the folder against rename or move (#3706).
+    cwd: paths.dataDir(),
     // Strip host CLI bleed-through (CLAUDE_CODE_*, including EFFORT_LEVEL) and
     // Anthropic credentials before handing env to the detached daemon. The
     // daemon re-reads credentials from ~/.claude-mem/.env at SDK spawn time.

--- a/src/server/runtime/ServerService.ts
+++ b/src/server/runtime/ServerService.ts
@@ -858,6 +858,10 @@ function getServerPort(): number {
 
 function spawnServerDaemon(port: number): number | undefined {
   const scriptPath = typeof __filename !== 'undefined' ? __filename : fileURLToPath(import.meta.url);
+  // A cwd that does not exist makes spawn fail with ENOENT, and paths.ts resolves
+  // DATA_DIR without creating it — so create it rather than depend on some earlier
+  // caller having done so. Idempotent.
+  mkdirSync(paths.dataDir(), { recursive: true });
   const child = spawn(process.execPath, [scriptPath, '--daemon'], {
     detached: true,
     stdio: 'ignore',

--- a/src/services/infrastructure/ProcessManager.ts
+++ b/src/services/infrastructure/ProcessManager.ts
@@ -369,7 +369,14 @@ function executeCwdRemap(dbPath: string, effectiveDataDir: string, markerPath: s
  * the time a daemon starts and is never a directory the user is reorganising.
  */
 export function daemonWorkingDirectory(): string {
-  return paths.dataDir();
+  const dir = paths.dataDir();
+  // Created here rather than assumed: a cwd that does not exist makes spawn fail with
+  // ENOENT and Start-Process fail outright, so passing one turns a first run on a fresh
+  // install into a launch failure. paths.ts resolves DATA_DIR but does not create it --
+  // today something else happens to create it first, which is a coupling this must not
+  // depend on. mkdir -p is idempotent, so the usual case costs one stat.
+  mkdirSync(dir, { recursive: true });
+  return dir;
 }
 
 export function buildWindowsDaemonStartCommand(

--- a/src/services/infrastructure/ProcessManager.ts
+++ b/src/services/infrastructure/ProcessManager.ts
@@ -357,7 +357,26 @@ function executeCwdRemap(dbPath: string, effectiveDataDir: string, markerPath: s
   }
 }
 
-export function buildWindowsDaemonStartCommand(runtimePath: string, scriptPath: string): string {
+/**
+ * Where a detached daemon should stand, which is anywhere but the user's project.
+ *
+ * A process holds an open handle on its working directory. On Windows that makes the
+ * directory unrenamable and unmovable for the daemon's whole lifetime, and the daemon
+ * outlives the session that spawned it -- so a project folder became permanently locked
+ * with "The process cannot access the file because it is being used by another process"
+ * until the user found and killed bun.exe (#3706). POSIX allows the rename but still
+ * pins the directory against unmount. claude-mem's own data directory always exists by
+ * the time a daemon starts and is never a directory the user is reorganising.
+ */
+export function daemonWorkingDirectory(): string {
+  return paths.dataDir();
+}
+
+export function buildWindowsDaemonStartCommand(
+  runtimePath: string,
+  scriptPath: string,
+  workingDirectory: string = daemonWorkingDirectory()
+): string {
   const psSingleQuote = (value: string) => value.replace(/'/g, "''");
   // Windows PowerShell 5.1 joins -ArgumentList elements with spaces WITHOUT
   // quoting them when it builds the child's native command line, so a script
@@ -366,7 +385,7 @@ export function buildWindowsDaemonStartCommand(runtimePath: string, scriptPath: 
   // double quotes inside the single-quoted PS string keeps the path a single
   // argument. -FilePath is safe as-is: it is a single-string parameter and
   // never goes through that join.
-  return `Start-Process -FilePath '${psSingleQuote(runtimePath)}' -ArgumentList @('"${psSingleQuote(scriptPath)}"','--daemon') -WindowStyle Hidden`;
+  return `Start-Process -FilePath '${psSingleQuote(runtimePath)}' -ArgumentList @('"${psSingleQuote(scriptPath)}"','--daemon') -WorkingDirectory '${psSingleQuote(workingDirectory)}' -WindowStyle Hidden`;
 }
 
 export const WORKER_BOOT_PROBE_TIMEOUT_MS = 5000;
@@ -520,6 +539,7 @@ export function spawnDaemon(
   const child = spawnHidden(execPath, args, {
     detached: true,
     stdio: 'ignore',
+    cwd: daemonWorkingDirectory(),
     env
   });
 

--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -687,6 +687,9 @@ export async function ensureWorkerRunning(): Promise<boolean> {
       logger.info('SYSTEM', 'Worker not running — lazy-spawning', { runtimePath, scriptPath });
 
       try {
+        // A cwd that does not exist makes spawn fail with ENOENT, and paths.ts resolves
+        // DATA_DIR without creating it. Idempotent, so the usual case costs one stat.
+        mkdirSync(DATA_DIR, { recursive: true });
         const proc = spawnHidden(runtimePath, [scriptPath, '--daemon'], {
           detached: true,
           stdio: ['ignore', 'ignore', 'ignore'],

--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -690,6 +690,10 @@ export async function ensureWorkerRunning(): Promise<boolean> {
         const proc = spawnHidden(runtimePath, [scriptPath, '--daemon'], {
           detached: true,
           stdio: ['ignore', 'ignore', 'ignore'],
+          // This spawn runs from a hook, so the inherited cwd is the user's project. A
+          // daemon holds its cwd open for its whole life, and on Windows that locks the
+          // folder against rename or move long after the session ends (#3706).
+          cwd: DATA_DIR,
         });
         proc.unref();
       } catch (error: unknown) {

--- a/tests/infrastructure/process-manager.test.ts
+++ b/tests/infrastructure/process-manager.test.ts
@@ -833,6 +833,20 @@ describe('ProcessManager', () => {
       expect(daemonWorkingDirectory()).toBe(DATA_DIR);
       expect(daemonWorkingDirectory()).not.toBe(process.cwd());
     });
+
+    // Passing a cwd that does not exist is worse than passing none: spawn fails with
+    // ENOENT and Start-Process refuses outright, so this fix would turn a first run on
+    // a fresh install into a launch failure. paths.ts resolves DATA_DIR but never
+    // creates it — today some earlier caller happens to, which is not a guarantee.
+    it('creates the directory it hands out, so a fresh install can spawn', () => {
+      rmSync(DATA_DIR, { recursive: true, force: true });
+      expect(existsSync(DATA_DIR)).toBe(false);
+
+      const dir = daemonWorkingDirectory();
+
+      expect(existsSync(dir)).toBe(true);
+      expect(statSync(dir).isDirectory()).toBe(true);
+    });
   });
 
   describe('SIGHUP handling', () => {

--- a/tests/infrastructure/process-manager.test.ts
+++ b/tests/infrastructure/process-manager.test.ts
@@ -29,6 +29,7 @@ const {
   probeWorkerBootFailure,
   shouldRetryWorkerBootProbe,
   buildWindowsDaemonStartCommand,
+  daemonWorkingDirectory,
   resolveWorkerRuntimePath,
   captureProcessStartToken,
   verifyPidFileOwnership,
@@ -688,10 +689,10 @@ describe('ProcessManager', () => {
       const runtimePath = String.raw`C:\Users\Test User\.bun\bin\bun.exe`;
       const scriptPath = String.raw`C:\Users\Test User\.claude\plugins\marketplaces\thedotmack\plugin\scripts\worker-service.cjs`;
 
-      const command = buildWindowsDaemonStartCommand(runtimePath, scriptPath);
+      const command = buildWindowsDaemonStartCommand(runtimePath, scriptPath, String.raw`C:\daemon-home`);
 
       expect(command).toBe(
-        `Start-Process -FilePath '${runtimePath}' -ArgumentList @('"${scriptPath}"','--daemon') -WindowStyle Hidden`
+        `Start-Process -FilePath '${runtimePath}' -ArgumentList @('"${scriptPath}"','--daemon') -WorkingDirectory 'C:\\daemon-home' -WindowStyle Hidden`
       );
     });
 
@@ -711,7 +712,7 @@ describe('ProcessManager', () => {
       );
 
       expect(command).toBe(
-        `Start-Process -FilePath 'C:\\Users\\O''Brien\\.bun\\bin\\bun.exe' -ArgumentList @('"C:\\Users\\O''Brien\\plugin\\scripts\\worker-service.cjs"','--daemon') -WindowStyle Hidden`
+        `Start-Process -FilePath 'C:\\Users\\O''Brien\\.bun\\bin\\bun.exe' -ArgumentList @('"C:\\Users\\O''Brien\\plugin\\scripts\\worker-service.cjs"','--daemon') -WorkingDirectory '${DATA_DIR.replace(/'/g, "''")}' -WindowStyle Hidden`
       );
     });
   });
@@ -800,6 +801,37 @@ describe('ProcessManager', () => {
         expect(shouldRetryWorkerBootProbe(enoent, 5, 5000)).toBe(false);
         expect(shouldRetryWorkerBootProbe(undefined, 5, 5000)).toBe(false);
       });
+    });
+  });
+
+  // A process holds an open handle on its working directory. On Windows that locks the
+  // directory against rename and move for as long as the process lives, and a daemon
+  // outlives the session that spawned it -- so a hook-spawned daemon inheriting the
+  // project folder left it permanently locked (#3706).
+  describe('daemon working directory (#3706)', () => {
+    it('pins the daemon to a directory the user is not working in', () => {
+      const command = buildWindowsDaemonStartCommand(
+        String.raw`C:\bun\bun.exe`,
+        String.raw`C:\plugin\worker-service.cjs`
+      );
+
+      expect(command).toContain('-WorkingDirectory');
+      expect(command).toContain(`-WorkingDirectory '${DATA_DIR.replace(/'/g, "''")}'`);
+    });
+
+    it('escapes a single quote in the working directory', () => {
+      const command = buildWindowsDaemonStartCommand(
+        String.raw`C:\bun\bun.exe`,
+        String.raw`C:\plugin\worker-service.cjs`,
+        String.raw`C:\Users\O'Brien\.claude-mem`
+      );
+
+      expect(command).toContain(String.raw`-WorkingDirectory 'C:\Users\O''Brien\.claude-mem'`);
+    });
+
+    it('defaults to the claude-mem data directory, never the caller cwd', () => {
+      expect(daemonWorkingDirectory()).toBe(DATA_DIR);
+      expect(daemonWorkingDirectory()).not.toBe(process.cwd());
     });
   });
 


### PR DESCRIPTION
Closes #3706.

A process holds an open handle on its working directory. The daemon spawns are reached from hooks, which run in the session's project folder, and none of the three spawn sites set a directory — so the daemon inherited the project folder. On Windows that locks it: rename and move fail for as long as the process lives, and a daemon outlives the session that started it.

## Measured on Windows 11

The mechanism, isolated from claude-mem entirely — one process, one directory, nothing else:

```
HELD:   rename FAILED -> The process cannot access the file because it is being used by another process.
EXITED: rename SUCCEEDED
```

A process started with `-WorkingDirectory <dir>` blocks `Rename-Item <dir>` with exactly the message from the report, and the same rename succeeds the moment it exits. That is the whole bug: the daemon simply never exits.

## Three spawn sites, all of them

| site | before |
|---|---|
| `ProcessManager.spawnDaemon` — Windows | `Start-Process … -WindowStyle Hidden`, no `-WorkingDirectory` |
| `ProcessManager.spawnDaemon` — POSIX | `spawnHidden(…, { detached, stdio, env })`, no `cwd` |
| `worker-utils` lazy-spawn | `spawnHidden(…, { detached, stdio })`, no `cwd` |
| `ServerService.spawnServerDaemon` | `spawn(…, { detached, stdio, windowsHide })`, no `cwd` |

The issue names the first and notes the POSIX ones are the same pattern; I fixed all of them rather than the Windows one alone, because the POSIX daemons still pin the directory against unmount — quieter, but the same handle.

All now stand in claude-mem's own data directory, via a small `daemonWorkingDirectory()` that carries the reason. It always exists by the time a daemon starts and is never a directory the user is reorganising.

## Tests

`tests/infrastructure/process-manager.test.ts`, three added under `daemon working directory (#3706)`:

- the built command carries `-WorkingDirectory` and names the data directory
- a `'` in the directory is doubled for PowerShell, like the two paths already are
- `daemonWorkingDirectory()` is the data dir and is **not** `process.cwd()` — the property that actually matters, stated as such

Two existing `#3195` assertions pin the exact command string, so they move with the change; one now passes an explicit directory and the other keeps using the default, which is why the default stays covered.

**Mutation-checked** — dropping `-WorkingDirectory` from the builder fails four cases:

```
51 pass, 5 fail   (4 mine + the pre-existing one below)
```

both new command-shape cases and both `#3195` string assertions, which is the right blast radius for a change to that one string.

```
bun test tests/infrastructure/process-manager.test.ts
55 pass / 1 fail
```

The single failure is `resolveWorkerRuntimePath > should look up Bun on non-Windows when caller is Node`, which fails identically on `main` on this machine — it asserts non-Windows lookup behaviour and I am on Windows. Measured on a clean checkout before this branch, not assumed.

I did not run a typecheck: this checkout has no installed `node_modules`, so `tsc` cannot resolve the `bun` and `node` type libraries. Saying so rather than implying a green check.
