### PR TITLE
fix(sqlite): repair a session_summaries FK left without ON UPDATE CASCADE

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -4,6 +4,7 @@ import { DATA_DIR, DB_PATH, ensureDir, OBSERVER_SESSIONS_PROJECT } from '../../s
 import { logger } from '../../utils/logger.js';
 import {
   TableColumnInfo,
+  ForeignKeyInfo,
   IndexInfo,
   TableNameRow,
   SchemaVersion,
@@ -118,6 +119,7 @@ export class SessionStore {
     this.ensureSyncOutbox();
     this.ensureSyncEntityLedger();
     this.ensureSyncRevisionTextAffinity();
+    this.ensureOnUpdateCascadeToSessions();
     this.initializeSyncHubLaunchBaseline();
     this.normalizeConceptTags();
   }
@@ -1621,6 +1623,122 @@ export class SessionStore {
     const hasSummariesFTS = (this.db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='session_summaries_fts'").all() as { name: string }[]).length > 0;
     if (hasSummariesFTS) {
       this.db.run(ftsTriggersSQL);
+    }
+  }
+
+  /**
+   * v21 (addOnUpdateCascadeToForeignKeys) stamps a single schema_versions row
+   * for the two tables it rebuilds, so a database that recorded 21 under a
+   * build where the session_summaries half of that migration did not yet run
+   * keeps a session_summaries FK with no ON UPDATE CASCADE for good: the
+   * version gate reports the work as done and the rebuild never runs again.
+   * Databases in exactly that state exist in the wild - observations carrying
+   * the cascade and its sibling not, both under one "applied" row. The stamp
+   * suppresses the re-check for both tables, so either one or both can be
+   * left behind; the sibling is never safe to assume from the one that was
+   * reported.
+   *
+   * The asymmetry is not cosmetic. ensureMemorySessionIdRegistered re-points
+   * sdk_sessions.memory_session_id whenever the worker captures a fresh SDK
+   * id, which is every worker restart since #817 began discarding the stale
+   * one. observations follow the parent key; session_summaries rows do not,
+   * so SQLite aborts that UPDATE with 'FOREIGN KEY constraint failed'. Every
+   * session that already owns a summary row then fails before it can store
+   * anything, is torn down, is re-initialised by the next observation and
+   * fails again - an observer crash loop no retry can clear, because what is
+   * wrong is the schema.
+   *
+   * So gate on the constraint itself rather than on the ledger, and check
+   * both halves of the pair rather than the half that got reported.
+   */
+  private ensureOnUpdateCascadeToSessions(): void {
+    for (const table of ['observations', 'session_summaries'] as const) {
+      if (this.hasOnUpdateCascadeToSessions(table)) continue;
+      this.rebuildWithOnUpdateCascadeToSessions(table);
+    }
+  }
+
+  private hasOnUpdateCascadeToSessions(table: string): boolean {
+    const parent = this.sessionParentForeignKey(table);
+    // A table with no FK to sdk_sessions(memory_session_id) has nothing to
+    // repair. Never invent a constraint that was not declared.
+    return !parent || parent.on_update.toUpperCase() === 'CASCADE';
+  }
+
+  private sessionParentForeignKey(table: string): ForeignKeyInfo | undefined {
+    return (this.db.query(`PRAGMA foreign_key_list(${table})`).all() as ForeignKeyInfo[])
+      .find(fk => fk.table === 'sdk_sessions' && fk.to === 'memory_session_id');
+  }
+
+  private rebuildWithOnUpdateCascadeToSessions(table: string): void {
+    const createSQL = (this.db.prepare(
+      `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?`
+    ).get(table) as { sql: string | null } | undefined)?.sql;
+    const parent = this.sessionParentForeignKey(table);
+    if (!createSQL || !parent) return;
+
+    // Rewrite the one clause and keep every column exactly as declared. The
+    // column list of these two tables has grown a dozen times across
+    // migrations, and a repair that runs on constraint state rather than on a
+    // version number can run at any point in that sequence, so a column list
+    // written out here would silently drop whatever a later migration adds.
+    const fkClause = /FOREIGN\s+KEY\s*\(\s*memory_session_id\s*\)\s*REFERENCES\s+sdk_sessions\s*\(\s*memory_session_id\s*\)(?:\s+ON\s+(?:DELETE|UPDATE)\s+(?:CASCADE|RESTRICT|SET\s+NULL|SET\s+DEFAULT|NO\s+ACTION))*/gi;
+    const declarations = createSQL.match(fkClause);
+    if (declarations?.length !== 1) {
+      // An unrecognised declaration is not something to guess at, and #3378 is
+      // the standing reminder that a constructor migration which throws takes
+      // the whole worker down with it. Leaving the table exactly as it was
+      // costs the repair, not the process.
+      logger.error('DB', 'Skipping ON UPDATE CASCADE repair: unrecognised FK declaration', {
+        table,
+        declarations: declarations?.length ?? 0
+      });
+      return;
+    }
+
+    const body = createSQL.slice(createSQL.indexOf('(') + 1, createSQL.lastIndexOf(')'));
+    const repairedBody = body.replace(
+      fkClause,
+      `FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) `
+        + `ON DELETE ${parent.on_delete} ON UPDATE CASCADE`
+    );
+
+    // Indexes and triggers go down with the table, so carry their own DDL
+    // across rather than a copy of it that has to be kept in step.
+    const attached = this.db.prepare(`
+      SELECT sql FROM sqlite_master
+      WHERE tbl_name = ? AND sql IS NOT NULL AND type IN ('index', 'trigger')
+    `).all(table) as Array<{ sql: string }>;
+
+    const temporary = `${table}_on_update_cascade`;
+
+    logger.debug('DB', 'Repairing FK missing ON UPDATE CASCADE', { table, onDelete: parent.on_delete });
+
+    // PRAGMA foreign_keys is a no-op inside a transaction, so it is set before
+    // BEGIN and restored once the outcome is decided.
+    this.db.run('PRAGMA foreign_keys = OFF');
+    this.db.run('BEGIN TRANSACTION');
+    try {
+      this.db.run(`DROP TABLE IF EXISTS ${temporary}`);
+      this.db.run(`CREATE TABLE ${temporary} (${repairedBody})`);
+      this.db.run(`INSERT INTO ${temporary} SELECT * FROM ${table}`);
+      this.db.run(`DROP TABLE ${table}`);
+      this.db.run(`ALTER TABLE ${temporary} RENAME TO ${table}`);
+      for (const object of attached) {
+        this.db.run(object.sql);
+      }
+      this.db.run('COMMIT');
+      logger.debug('DB', 'Repaired FK missing ON UPDATE CASCADE', { table });
+    } catch (error) {
+      this.db.run('ROLLBACK');
+      logger.error(
+        'DB',
+        'ON UPDATE CASCADE repair failed; leaving table as it was',
+        { table },
+        error instanceof Error ? error : new Error(String(error))
+      );
+    } finally {
+      this.db.run('PRAGMA foreign_keys = ON');
     }
   }
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -14,6 +14,17 @@ export interface IndexInfo {
   partial: number;
 }
 
+export interface ForeignKeyInfo {
+  id: number;
+  seq: number;
+  table: string;
+  from: string;
+  to: string | null;
+  on_update: string;
+  on_delete: string;
+  match: string;
+}
+
 export interface TableNameRow {
   name: string;
 }

--- a/tests/sqlite/session-store-summaries-on-update-cascade.test.ts
+++ b/tests/sqlite/session-store-summaries-on-update-cascade.test.ts
@@ -245,12 +245,21 @@ describe('session_summaries FK left without ON UPDATE CASCADE by a half-reported
         AND name = 'idx_session_summaries_sdk_session'
     `)).toBe(1);
 
-    // AUTOINCREMENT keeps counting from where the copied rows left off.
+    // AUTOINCREMENT survived the rebuild, so ids keep counting from where the
+    // copied rows left off instead of being reused. The copied row is deleted
+    // first because that is the only state the two declarations disagree on:
+    // with it still present both AUTOINCREMENT and a plain INTEGER PRIMARY KEY
+    // hand out 2, and the assertion would pass on a rebuild that dropped the
+    // keyword. On an empty table a plain rowid restarts at 1.
+    store.db.run(`DELETE FROM session_summaries WHERE id = 1`);
     store.db.prepare(`
       INSERT INTO session_summaries (memory_session_id, project, request, created_at, created_at_epoch)
       VALUES ('mem-stale', 'proj-a', 'second summary', ?, ?)
     `).run(ISO, EPOCH + 1);
-    expect(count(store.db, `SELECT COUNT(*) AS n FROM session_summaries WHERE id = 1`)).toBe(1);
+    expect(count(
+      store.db,
+      `SELECT id AS n FROM session_summaries WHERE request = 'second summary'`
+    )).toBe(2);
 
     store.db.close();
   });

--- a/tests/sqlite/session-store-summaries-on-update-cascade.test.ts
+++ b/tests/sqlite/session-store-summaries-on-update-cascade.test.ts
@@ -1,0 +1,290 @@
+// Pin-down + regression tests for a session_summaries FK left without
+// ON UPDATE CASCADE while its sibling observations FK has it.
+//
+// How a database reaches that state: v21 (addOnUpdateCascadeToForeignKeys)
+// rebuilds observations and session_summaries and stamps ONE schema_versions
+// row for both. A database that recorded 21 under a build whose v21 did not
+// yet rebuild session_summaries keeps the old declaration for good - the
+// version gate reports the work as done, so the rebuild never runs again.
+// The seed below reproduces it through the project's own migration chain: v7
+// (removeSessionSummariesUniqueConstraint) recreates session_summaries and v9
+// (makeObservationsTextNullable) recreates observations, both with ON DELETE
+// CASCADE only, and a pre-stamped 21 means nothing ever adds the update half
+// back to either. So the stamped ledger can leave one table or both without
+// it - which is why the repair checks both halves of the pair rather than the
+// one the field report named.
+//
+// Faulting mechanism these tests pin: ensureMemorySessionIdRegistered
+// re-points sdk_sessions.memory_session_id every time the worker captures a
+// fresh SDK id (#817 discards the stale one on each worker restart).
+// observations follow the parent key, session_summaries rows do not, and
+// SQLite aborts the UPDATE with 'FOREIGN KEY constraint failed'. Every
+// session that already owns a summary row then fails before storing
+// anything, is torn down, is re-initialised by the next observation and
+// fails again - an observer crash loop that only ends when the schema is
+// repaired.
+//
+// The fix gates on the constraint itself (PRAGMA foreign_key_list) instead of
+// on the schema_versions ledger, and checks both halves of the pair.
+import { describe, it, expect, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { mkdtempSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { SessionStore } from '../../src/services/sqlite/SessionStore.js';
+
+const ISO = '2025-07-01T00:00:00.000Z';
+const EPOCH = 1751328000000;
+
+interface ForeignKeyRow {
+  table: string;
+  from: string;
+  to: string | null;
+  on_update: string;
+  on_delete: string;
+}
+
+function sessionParentFk(db: Database, table: string): ForeignKeyRow | undefined {
+  return (db.query(`PRAGMA foreign_key_list(${table})`).all() as ForeignKeyRow[])
+    .find(fk => fk.table === 'sdk_sessions' && fk.to === 'memory_session_id');
+}
+
+function count(db: Database, sql: string, ...params: Array<string | number>): number {
+  return (db.prepare(sql).get(...params) as { n: number }).n;
+}
+
+/**
+ * A v4-era database - the shape initializeSchema() creates, stamped at 4 -
+ * carrying one session with a summary and an observation, and additionally
+ * stamped at 21 so the migration chain replays v7's session_summaries rebuild
+ * (ON DELETE CASCADE only) and then skips the v21 repair.
+ */
+function seedDbWithV21Stamped(dbPath: string): void {
+  const db = new Database(dbPath);
+  db.run('PRAGMA foreign_keys = OFF');
+
+  db.run(`
+    CREATE TABLE schema_versions (
+      id INTEGER PRIMARY KEY,
+      version INTEGER UNIQUE NOT NULL,
+      applied_at TEXT NOT NULL
+    )
+  `);
+  db.run(`
+    CREATE TABLE sdk_sessions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      content_session_id TEXT NOT NULL,
+      memory_session_id TEXT UNIQUE,
+      project TEXT NOT NULL,
+      platform_source TEXT NOT NULL DEFAULT 'claude',
+      user_prompt TEXT,
+      started_at TEXT NOT NULL,
+      started_at_epoch INTEGER NOT NULL,
+      completed_at TEXT,
+      completed_at_epoch INTEGER,
+      status TEXT CHECK(status IN ('active', 'completed', 'failed')) NOT NULL DEFAULT 'active'
+    )
+  `);
+  db.run(`
+    CREATE TABLE observations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      memory_session_id TEXT NOT NULL,
+      project TEXT NOT NULL,
+      text TEXT NOT NULL,
+      type TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      created_at_epoch INTEGER NOT NULL,
+      FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE CASCADE
+    )
+  `);
+  db.run(`
+    CREATE TABLE session_summaries (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      memory_session_id TEXT UNIQUE NOT NULL,
+      project TEXT NOT NULL,
+      request TEXT,
+      investigated TEXT,
+      learned TEXT,
+      completed TEXT,
+      next_steps TEXT,
+      files_read TEXT,
+      files_edited TEXT,
+      notes TEXT,
+      created_at TEXT NOT NULL,
+      created_at_epoch INTEGER NOT NULL,
+      FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE CASCADE
+    )
+  `);
+
+  const stamp = db.prepare('INSERT INTO schema_versions (version, applied_at) VALUES (?, ?)');
+  stamp.run(4, ISO);
+  // The half-reported repair: 21 on the ledger, only observations rebuilt.
+  stamp.run(21, ISO);
+
+  db.prepare(`
+    INSERT INTO sdk_sessions (content_session_id, memory_session_id, project, started_at, started_at_epoch, status)
+    VALUES ('content-a', 'mem-stale', 'proj-a', ?, ?, 'completed')
+  `).run(ISO, EPOCH);
+  db.prepare(`
+    INSERT INTO observations (memory_session_id, project, text, type, created_at, created_at_epoch)
+    VALUES ('mem-stale', 'proj-a', 'observation text', 'discovery', ?, ?)
+  `).run(ISO, EPOCH);
+  db.prepare(`
+    INSERT INTO session_summaries (memory_session_id, project, request, created_at, created_at_epoch)
+    VALUES ('mem-stale', 'proj-a', 'summary request', ?, ?)
+  `).run(ISO, EPOCH);
+
+  db.run('PRAGMA foreign_keys = ON');
+  db.close();
+}
+
+describe('session_summaries FK left without ON UPDATE CASCADE by a half-reported v21', () => {
+  let tempDir: string;
+
+  afterEach(() => {
+    if (tempDir && existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  function makeTempDbPath(): string {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'claude-mem-summaries-cascade-'));
+    return path.join(tempDir, 'claude-mem.db');
+  }
+
+  it('pins the faulting mechanism: without the update half, re-pointing the parent key aborts', () => {
+    const db = new Database(':memory:');
+    db.run('PRAGMA foreign_keys = ON');
+    db.run(`
+      CREATE TABLE sdk_sessions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        memory_session_id TEXT UNIQUE
+      )
+    `);
+    db.run(`
+      CREATE TABLE session_summaries (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        memory_session_id TEXT NOT NULL,
+        FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE
+      )
+    `);
+    db.run(`
+      CREATE TABLE observations (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        memory_session_id TEXT NOT NULL,
+        FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE CASCADE
+      )
+    `);
+    db.run(`INSERT INTO sdk_sessions (memory_session_id) VALUES ('mem-stale')`);
+    db.run(`INSERT INTO observations (memory_session_id) VALUES ('mem-stale')`);
+
+    // The cascading sibling alone survives a re-point.
+    db.run(`UPDATE sdk_sessions SET memory_session_id = 'mem-fresh' WHERE id = 1`);
+    expect(
+      (db.prepare('SELECT memory_session_id AS m FROM observations WHERE id = 1').get() as { m: string }).m
+    ).toBe('mem-fresh');
+
+    // Add a summary row and the same re-point now aborts: this is the error
+    // the observer reports as 'Generator failed {error=FOREIGN KEY constraint failed}'.
+    db.run(`INSERT INTO session_summaries (memory_session_id) VALUES ('mem-fresh')`);
+    expect(() => {
+      db.run(`UPDATE sdk_sessions SET memory_session_id = 'mem-fresher' WHERE id = 1`);
+    }).toThrow(/FOREIGN KEY constraint failed/);
+
+    db.close();
+  });
+
+  it('repairs a database that recorded v21 with only the observations half applied', () => {
+    const dbPath = makeTempDbPath();
+    seedDbWithV21Stamped(dbPath);
+
+    // Unfixed code: the chain leaves session_summaries on ON DELETE CASCADE
+    // only, because 21 is already on the ledger.
+    const store = new SessionStore(dbPath);
+
+    expect(sessionParentFk(store.db, 'session_summaries')?.on_update).toBe('CASCADE');
+    expect(sessionParentFk(store.db, 'session_summaries')?.on_delete).toBe('CASCADE');
+
+    // The production call that used to abort, through the real code path.
+    const sessionDbId = (store.db.prepare(
+      `SELECT id FROM sdk_sessions WHERE content_session_id = 'content-a'`
+    ).get() as { id: number }).id;
+
+    expect(() => store.ensureMemorySessionIdRegistered(sessionDbId, 'mem-fresh')).not.toThrow();
+
+    // Both children followed the parent key.
+    expect(count(store.db, `SELECT COUNT(*) AS n FROM session_summaries WHERE memory_session_id = 'mem-fresh'`)).toBe(1);
+    expect(count(store.db, `SELECT COUNT(*) AS n FROM observations WHERE memory_session_id = 'mem-fresh'`)).toBe(1);
+
+    store.db.close();
+  });
+
+  it('carries rows, indexes and triggers across the rebuild', () => {
+    const dbPath = makeTempDbPath();
+    seedDbWithV21Stamped(dbPath);
+
+    const store = new SessionStore(dbPath);
+
+    expect(count(store.db, 'SELECT COUNT(*) AS n FROM session_summaries')).toBe(1);
+    const summary = store.db.prepare(
+      'SELECT project, request, created_at_epoch FROM session_summaries WHERE id = 1'
+    ).get() as { project: string; request: string; created_at_epoch: number };
+    expect(summary.project).toBe('proj-a');
+    expect(summary.request).toBe('summary request');
+    expect(summary.created_at_epoch).toBe(EPOCH);
+
+    // Every index and trigger the chain put on the table is still attached.
+    const attached = store.db.prepare(`
+      SELECT COUNT(*) AS n FROM sqlite_master
+      WHERE tbl_name = 'session_summaries' AND sql IS NOT NULL AND type IN ('index', 'trigger')
+    `).get() as { n: number };
+    expect(attached.n).toBeGreaterThan(0);
+    expect(count(store.db, `
+      SELECT COUNT(*) AS n FROM sqlite_master
+      WHERE type = 'index' AND tbl_name = 'session_summaries'
+        AND name = 'idx_session_summaries_sdk_session'
+    `)).toBe(1);
+
+    // AUTOINCREMENT keeps counting from where the copied rows left off.
+    store.db.prepare(`
+      INSERT INTO session_summaries (memory_session_id, project, request, created_at, created_at_epoch)
+      VALUES ('mem-stale', 'proj-a', 'second summary', ?, ?)
+    `).run(ISO, EPOCH + 1);
+    expect(count(store.db, `SELECT COUNT(*) AS n FROM session_summaries WHERE id = 1`)).toBe(1);
+
+    store.db.close();
+  });
+
+  it('is idempotent, and leaves an already-cascading observations table untouched', () => {
+    const dbPath = makeTempDbPath();
+    seedDbWithV21Stamped(dbPath);
+
+    const first = new SessionStore(dbPath);
+    const observationsDDL = (first.db.prepare(
+      `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'observations'`
+    ).get() as { sql: string }).sql;
+    const summariesDDL = (first.db.prepare(
+      `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'session_summaries'`
+    ).get() as { sql: string }).sql;
+    first.db.close();
+
+    const second = new SessionStore(dbPath);
+    // A second boot rewrites nothing: the constraint gate is already satisfied.
+    expect((second.db.prepare(
+      `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'observations'`
+    ).get() as { sql: string }).sql).toBe(observationsDDL);
+    expect((second.db.prepare(
+      `SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'session_summaries'`
+    ).get() as { sql: string }).sql).toBe(summariesDDL);
+    expect(count(second.db, 'SELECT COUNT(*) AS n FROM session_summaries')).toBe(1);
+    expect(count(second.db, 'SELECT COUNT(*) AS n FROM observations')).toBe(1);
+    expect(sessionParentFk(second.db, 'observations')?.on_update).toBe('CASCADE');
+
+    // No temporary table was left behind by either boot.
+    expect(count(second.db, `
+      SELECT COUNT(*) AS n FROM sqlite_master WHERE name LIKE '%_on_update_cascade'
+    `)).toBe(0);
+
+    second.db.close();
+  });
+});


### PR DESCRIPTION
## Symptom

The observer crash-loops for any session that already has a `session_summaries`
row, logging the same line until the schema is repaired:

```
[ERROR] [SESSION] [session-266] Generator failed {provider=claude, error=FOREIGN KEY constraint failed} FOREIGN KEY constraint failed
```

On the database this was found on, that ran 4,064 times over two days. Every
affected session was torn down before it could store anything, re-initialised by
the next observation, and failed again. The observer-health banner reports it as
"failed N times in a row", which reads like a provider outage; the provider is
fine.

## Root cause

`v21 addOnUpdateCascadeToForeignKeys` rebuilds `observations` and
`session_summaries` and stamps **one** `schema_versions` row for both. A database
that recorded 21 under a build whose v21 had not yet rebuilt both tables keeps
the old declaration permanently, because the gate is

```ts
const applied = this.db.prepare('SELECT version FROM schema_versions WHERE version = ?').get(21);
if (applied) return;
```

so the rebuild never gets another look. The result is a `session_summaries` FK
with `ON DELETE CASCADE` and no update half, next to an `observations` FK that
has both.

That asymmetry is what breaks. `ensureMemorySessionIdRegistered` re-points
`sdk_sessions.memory_session_id` whenever the worker captures a fresh SDK id,
which since #817 (discard the stale id on worker restart) is every restart:

```ts
this.db.prepare('UPDATE sdk_sessions SET memory_session_id = ? WHERE id = ?').run(memorySessionId, sessionDbId);
```

`observations` rows follow the parent key. `session_summaries` rows do not, so
SQLite aborts the UPDATE. The throw happens before `MEMORY_ID_CAPTURED`, so the
session never registers, never stores, and the next queued observation starts the
cycle again. Sessions with zero summary rows are unaffected, which is why this
looks intermittent: on the database in question, every failing session had at
least one summary row and the one healthy session had none.

Worth noting for anyone diagnosing it: `PRAGMA foreign_key_check` passes
throughout. The constraint is only violated at the moment of the parent-key
update, so integrity checks report a clean database.

## Fix

Gate the repair on the constraint itself rather than on the ledger, and check
both tables rather than the one a report happens to name:

```ts
private hasOnUpdateCascadeToSessions(table: string): boolean {
  const parent = this.sessionParentForeignKey(table);
  return !parent || parent.on_update.toUpperCase() === 'CASCADE';
}
```

The rebuild rewrites only the FK clause of the stored `CREATE TABLE` and carries
indexes and triggers across by their own DDL, rather than restating a column list.
Both tables have gained columns a dozen times across migrations, and a repair
keyed on constraint state can land anywhere in that sequence, so a column list
written into this method would silently drop whatever a later migration adds.
`ON DELETE` is preserved from `PRAGMA foreign_key_list` rather than assumed.

Two judgement calls, both easy to reverse if you would rather they went the other
way:

- **A declaration the regex does not recognise is logged and skipped, not thrown.**
  Neighbouring rebuilds rethrow after rollback. Here the rollback already
  guarantees the database is untouched, and this repair is opportunistic rather
  than a required schema step, so throwing would turn "could not repair one table"
  into "worker never boots" - which is the #3378 failure mode. Happy to switch it
  to a throw if you prefer consistency with its neighbours.
- **No new `schema_versions` row.** Adding one would recreate the exact gate that
  caused this. The PRAGMA check is naturally idempotent: once the cascade is
  present the method returns immediately, which the idempotence test covers.

Placed after `ensureSyncRevisionTextAffinity()` so every column-adding migration
has already run.

## Verification

- **Against a real affected database** (38,125 observations, 3,369 summaries, 224
  sessions). Before: `session_summaries on_update=NO ACTION`, and the parent-key
  update fails. After running the migration chain with this fix: `on_update=CASCADE`,
  all rows intact, FTS index intact (same match count), and
  `ensureMemorySessionIdRegistered` on the session that had failed 2,828 times
  succeeds, with 12 summaries and 44 observations following the key.
- **4 new tests** in `tests/sqlite/session-store-summaries-on-update-cascade.test.ts`,
  seeded through the project's own migration chain: a v4-era database stamped at
  21 replays v7 and v9, which recreate both tables with `ON DELETE CASCADE` only,
  and the stamp suppresses the repair. One test pins the faulting mechanism
  directly, one drives the real `ensureMemorySessionIdRegistered` path, one covers
  rows/indexes/triggers/AUTOINCREMENT across the rebuild, one covers idempotence
  and leaves an already-cascading table byte-identical.
- **Mutation-tested**, since a passing test is not necessarily a discriminating
  one. Disabling the migration fails 2, narrowing it to `session_summaries` only
  fails 2, and dropping the index/trigger re-attach fails 1.
- `bun test tests` - 2,627 pass, 0 fail. `tsc --noEmit` - clean.

## Not included

`plugin/` is not rebuilt in this PR, so the bundled `plugin/sqlite/SessionStore.js`
still carries the old code. Happy to run `npm run build` and push the artifact if
that is what you would like from an outside contributor, otherwise it comes along
with the next version bump.
