### PR TITLE
fix(sqlite): repair discovery_tokens by inspecting the table, not the history (#3738)

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -1322,10 +1322,21 @@ export class SessionStore {
     logger.debug('DB', 'Successfully created user_prompts table');
   }
 
+  /**
+   * Guarded on the columns themselves, not on `schema_versions` row 11.
+   *
+   * The row records that the migration once ran; it says nothing about whether the
+   * columns are there NOW. When something rebuilds `session_summaries` to its
+   * pre-`discovery_tokens` shape -- an old-version worker spawned from a stale plugin
+   * cache does exactly that -- the row survives, so an early return here skipped the
+   * repair forever and every summary write failed with `table session_summaries has no
+   * column named discovery_tokens` until someone ran the ALTER by hand (#3738).
+   *
+   * The body below was already introspecting and already idempotent; only the
+   * short-circuit above it stopped it running. The cost of dropping it is two PRAGMA
+   * queries per boot.
+   */
   private ensureDiscoveryTokensColumn(): void {
-    const applied = this.db.prepare('SELECT version FROM schema_versions WHERE version = ?').get(11) as SchemaVersion | undefined;
-    if (applied) return;
-
     const observationsInfo = this.db.query('PRAGMA table_info(observations)').all() as TableColumnInfo[];
     const obsHasDiscoveryTokens = observationsInfo.some(col => col.name === 'discovery_tokens');
 

--- a/tests/sqlite/session-store-discovery-tokens-repair.test.ts
+++ b/tests/sqlite/session-store-discovery-tokens-repair.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SessionStore } from '../../src/services/sqlite/SessionStore.js';
+
+/**
+ * `schema_versions` row 11 records that the discovery_tokens migration once ran. It says
+ * nothing about whether the columns are there now — and something rebuilding
+ * `session_summaries` to its pre-discovery_tokens shape (an old-version worker spawned
+ * from a stale plugin cache) leaves the row behind. The guard used to return early on
+ * that row, so the repair never ran again and every summary write failed with
+ * `table session_summaries has no column named discovery_tokens` (#3738).
+ */
+
+function hasColumn(db: Database, table: string, column: string): boolean {
+  const info = db.query(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  return info.some(col => col.name === column);
+}
+
+/**
+ * A database whose migration history says "applied" while the column is absent.
+ *
+ * Only row 11 is seeded. The canonical `session_summaries` CREATE does not declare
+ * `discovery_tokens` — migration 11 is what adds it — so letting the store build the
+ * table while the row already exists reproduces the reported state exactly: the shape an
+ * old-version worker leaves behind, with the history claiming the migration is done.
+ */
+function seedHistoryWithoutTheColumn(db: Database): void {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS schema_versions (
+      id INTEGER PRIMARY KEY,
+      version INTEGER UNIQUE NOT NULL,
+      applied_at TEXT NOT NULL
+    )
+  `);
+  db.prepare('INSERT OR IGNORE INTO schema_versions (version, applied_at) VALUES (?, ?)').run(
+    11,
+    new Date().toISOString(),
+  );
+}
+
+describe('discovery_tokens column repair (#3738)', () => {
+  let store: SessionStore | undefined;
+
+  afterEach(() => {
+    store?.close();
+    store = undefined;
+  });
+
+  it('re-adds the column when history says applied but the table lacks it', () => {
+    const db = new Database(':memory:');
+    seedHistoryWithoutTheColumn(db);
+
+    const applied = db
+      .prepare('SELECT version FROM schema_versions WHERE version = ?')
+      .get(11) as { version: number } | undefined;
+    expect(applied?.version).toBe(11);
+
+    store = new SessionStore(db);
+
+    expect(hasColumn(db, 'session_summaries', 'discovery_tokens')).toBe(true);
+    expect(hasColumn(db, 'observations', 'discovery_tokens')).toBe(true);
+  });
+
+  it('lets a summary row carry discovery_tokens afterwards', () => {
+    const db = new Database(':memory:');
+    seedHistoryWithoutTheColumn(db);
+    store = new SessionStore(db);
+
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO sdk_sessions (content_session_id, memory_session_id, project, started_at, started_at_epoch, status)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run('content-1', 'mem-1', 'proj', now, Date.now(), 'completed');
+
+    // The failure users reported was on the write, not at boot, so drive a write.
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO session_summaries (memory_session_id, project, created_at, created_at_epoch, discovery_tokens)
+           VALUES (?, ?, ?, ?, ?)`,
+        )
+        .run('mem-1', 'proj', now, Date.now(), 7),
+    ).not.toThrow();
+
+    const row = db
+      .prepare('SELECT discovery_tokens FROM session_summaries WHERE memory_session_id = ?')
+      .get('mem-1') as { discovery_tokens: number } | undefined;
+    expect(row?.discovery_tokens).toBe(7);
+  });
+
+  it('adds the column once, not once per boot', () => {
+    const db = new Database(':memory:');
+    seedHistoryWithoutTheColumn(db);
+
+    // Not closed between the two: `close()` closes the shared handle, and what is
+    // under test is the second boot seeing the repaired table, not connection reuse.
+    new SessionStore(db);
+    // A second boot must not try to ALTER an already-present column.
+    store = new SessionStore(db);
+
+    const info = db.query('PRAGMA table_info(session_summaries)').all() as Array<{ name: string }>;
+    expect(info.filter(col => col.name === 'discovery_tokens').length).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #3738.

```js
private ensureDiscoveryTokensColumn(): void {
  const applied = this.db.prepare('SELECT version FROM schema_versions WHERE version = ?').get(11);
  if (applied) return;                 // ← the whole bug
  …PRAGMA table_info(observations)…    // already introspecting
  …PRAGMA table_info(session_summaries)…
}
```

Row 11 records that the migration *once ran*. It says nothing about whether the columns are there **now**. So when something rebuilds `session_summaries` to its pre-`discovery_tokens` shape, the row survives the rebuild, the guard returns early, and the repair never runs again — every summary write then fails with `table session_summaries has no column named discovery_tokens` until a human runs the `ALTER` by hand.

The part worth noting: **the body below that line was already doing the right thing.** It reads `PRAGMA table_info` for both tables and adds each column only if absent — introspective and idempotent already. Only the short-circuit above it stopped it running. So the fix is to delete the short-circuit rather than to write new migration logic, and the cost is two PRAGMA queries per boot.

The trailing `INSERT OR IGNORE INTO schema_versions … (11)` stays, so the history stays truthful for anything else reading it.

## Tests

`tests/sqlite/session-store-discovery-tokens-repair.test.ts`, three cases on an in-memory DB.

The seed is the part I want to point at: **it only inserts row 11.** The canonical `session_summaries` CREATE does not declare `discovery_tokens` — migration 11 is what adds it — so letting the store build the table while that row already exists reproduces the reported state exactly, without hand-crafting a table shape that might drift from the real one.

- the column comes back on both `session_summaries` and `observations`
- a summary row then carries `discovery_tokens` through an insert — the failure users actually saw was on the write, not at boot, so one test drives a write
- two boots add it once, not once per boot

**Mutation-checked** — restoring `if (applied) return;` fails all three.

```
bun test tests/sqlite/session-store-discovery-tokens-repair.test.ts
3 pass / 0 fail
```

```
bun test tests/sqlite/
87 pass / 4 fail   (91 tests)
```

The 4 failures are pre-existing: `bun test tests/sqlite/` on a clean `main` gives **84 pass / 4 fail** across 88 tests — same four, all in `SessionStore migration chain over a legacy DB with orphaned FK children (#3378)`:

```
v9 observations rebuild completes over an orphaned observation and repairs its parent
v7 session_summaries rebuild completes over an orphaned summary and repairs its parent
boot sequence over a DB with both orphan kinds: migrations then v12.4.3 cleanup, nothing lost
repair is idempotent: reconstructing over the repaired DB is a no-op
```

84 → 87 is exactly the three tests this PR adds. Measured on a clean checkout before this branch, not assumed.

The issue notes this is an instance of the class #3609 proposes to fix. I have kept to the one column that caused the outage rather than converting every `schema_versions`-keyed migration — same reasoning as the issue's own "two-line standalone remedy". The pattern generalises whenever you want it applied.
