### PR TITLE
fix(oauth): scope the keychain lookup to CLAUDE_CONFIG_DIR (#3718)

### DIFF
--- a/src/shared/oauth-token.ts
+++ b/src/shared/oauth-token.ts
@@ -143,6 +143,22 @@ async function readMacOsKeychain(): Promise<OAuthTokenResult> {
 }
 
 /**
+ * Windows Credential Manager target names to try, most specific first.
+ *
+ * Returned RAW — the caller applies the single PowerShell escaping pass. Escaping a
+ * component here instead would double it: for username `O'Brien` the literal became
+ * `'Claude Code-credentials:O''''Brien'`, which PowerShell parses as
+ * `Claude Code-credentials:O''Brien` — a different target than the stored credential,
+ * so CredRead missed it and the account fell through to the re-login warning.
+ */
+export function windowsCredentialTargets(
+  username: string = userInfo().username,
+  services: string[] = keychainServiceNames(),
+): string[] {
+  return [...services, 'Claude Code:credentials', `Claude Code-credentials:${username}`];
+}
+
+/**
  * Windows: Credential Manager (DPAPI). Claude Desktop on Windows stores
  * OAuth credentials under a target like "Claude Code:credentials" via the
  * Wincred API. We read it via PowerShell's CredentialManager wrapper.
@@ -157,16 +173,9 @@ async function readWindowsCredentialManager(): Promise<OAuthTokenResult> {
   // The exact target name on Windows is "Claude Code-credentials" or
   // "Claude Code:credentials" (Claude Desktop uses `${service}:${account}` or
   // `${service}` depending on version). This script tries both.
-  // Username is escaped with PowerShell's single-quote convention (' → '') in
-  // case future Windows versions or domain-joined machines permit ' in usernames.
-  const psSafeUsername = userInfo().username.replace(/'/g, "''");
-  // Config-scoped names first, then the plain ones. Each is single-quoted with the
-  // PowerShell doubling convention, same as the username above.
-  const psCandidates = [
-    ...keychainServiceNames(),
-    'Claude Code:credentials',
-    `Claude Code-credentials:${psSafeUsername}`,
-  ]
+  const psCandidates = windowsCredentialTargets()
+    // Sole PowerShell escaping pass: ' → '' inside a single-quoted literal. Targets must
+    // reach here raw — pre-escaping any part of one would double it (see the helper).
     .map(name => `'${name.replace(/'/g, "''")}'`)
     .join(', ');
   const psScript = `

--- a/src/shared/oauth-token.ts
+++ b/src/shared/oauth-token.ts
@@ -11,9 +11,10 @@
 
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import { createHash } from 'crypto';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
-import { userInfo } from 'os';
-import { join } from 'path';
+import { userInfo, homedir } from 'os';
+import { join, resolve } from 'path';
 import { paths } from './paths.js';
 import { logger } from '../utils/logger.js';
 
@@ -21,6 +22,35 @@ const execFileAsync = promisify(execFile);
 
 const KEYCHAIN_SERVICE_NAME = 'Claude Code-credentials';
 const READ_TIMEOUT_MS = 5000;
+
+/**
+ * Keychain service names to try, most specific first.
+ *
+ * Claude Code scopes its credential entry by config directory: with a non-default
+ * `CLAUDE_CONFIG_DIR` the token lives under `Claude Code-credentials-<sha256(dir)[:8]>`,
+ * not the plain name. Reading only the plain name finds whatever stale token happens to
+ * sit there, decides it is expired, and writes the stale marker — so every session start
+ * warns "re-login via Claude Desktop" about a token that is not the one in use, and
+ * re-logging in changes nothing (#3718).
+ *
+ * The plain name always stays in the list, so a default install reads exactly what it
+ * read before and an unscoped entry is still found when the scoped one is absent.
+ */
+export function keychainServiceNames(
+  env: NodeJS.ProcessEnv = process.env,
+  home: string = homedir(),
+): string[] {
+  const configDir = env.CLAUDE_CONFIG_DIR?.trim();
+  if (!configDir) return [KEYCHAIN_SERVICE_NAME];
+
+  // The default directory is the unscoped case: Claude Code does not hash it.
+  if (resolve(configDir) === resolve(join(home, '.claude'))) {
+    return [KEYCHAIN_SERVICE_NAME];
+  }
+
+  const digest = createHash('sha256').update(configDir).digest('hex').slice(0, 8);
+  return [`${KEYCHAIN_SERVICE_NAME}-${digest}`, KEYCHAIN_SERVICE_NAME];
+}
 
 // Grace window: even if expiresAt is in the past by less than this, allow the
 // token through. Claude Desktop typically refreshes shortly before expiry, so
@@ -80,27 +110,36 @@ function isExpired(expiresAtMs: number | undefined): boolean {
  */
 async function readMacOsKeychain(): Promise<OAuthTokenResult> {
   const account = userInfo().username;
-  let stdout: string;
-  try {
-    ({ stdout } = await execFileAsync(
-      'security',
-      ['find-generic-password', '-s', KEYCHAIN_SERVICE_NAME, '-a', account, '-w'],
-      { timeout: READ_TIMEOUT_MS, windowsHide: true },
-    ));
-  } catch (error) {
-    const err = error instanceof Error ? error : new Error(String(error));
-    // `security` exits non-zero when the entry doesn't exist — fail-fast as absent.
-    logger.warn('OAUTH', 'macOS keychain lookup failed', { service: KEYCHAIN_SERVICE_NAME, account }, err);
+  const services = keychainServiceNames();
+  let lastError: Error | undefined;
+
+  for (const service of services) {
+    let stdout: string;
+    try {
+      ({ stdout } = await execFileAsync(
+        'security',
+        ['find-generic-password', '-s', service, '-a', account, '-w'],
+        { timeout: READ_TIMEOUT_MS, windowsHide: true },
+      ));
+    } catch (error) {
+      // `security` exits non-zero when the entry doesn't exist, so a miss here is
+      // ordinary when a more specific name is being tried first.
+      lastError = error instanceof Error ? error : new Error(String(error));
+      continue;
+    }
+    const raw = stdout.trim();
+    if (raw) return parseKeychainPayload(raw);
+  }
+
+  const tried = services.join('", "');
+  if (lastError) {
+    logger.warn('OAUTH', 'macOS keychain lookup failed', { services, account }, lastError);
     return {
       kind: 'absent',
-      reason: `macOS keychain lookup failed for service "${KEYCHAIN_SERVICE_NAME}" (account=${account}): ${err.message}`,
+      reason: `macOS keychain lookup failed for service "${tried}" (account=${account}): ${lastError.message}`,
     };
   }
-  const raw = stdout.trim();
-  if (!raw) {
-    return { kind: 'absent', reason: 'macOS keychain returned empty value for "Claude Code-credentials"' };
-  }
-  return parseKeychainPayload(raw);
+  return { kind: 'absent', reason: `macOS keychain returned empty value for "${tried}"` };
 }
 
 /**
@@ -121,9 +160,18 @@ async function readWindowsCredentialManager(): Promise<OAuthTokenResult> {
   // Username is escaped with PowerShell's single-quote convention (' → '') in
   // case future Windows versions or domain-joined machines permit ' in usernames.
   const psSafeUsername = userInfo().username.replace(/'/g, "''");
+  // Config-scoped names first, then the plain ones. Each is single-quoted with the
+  // PowerShell doubling convention, same as the username above.
+  const psCandidates = [
+    ...keychainServiceNames(),
+    'Claude Code:credentials',
+    `Claude Code-credentials:${psSafeUsername}`,
+  ]
+    .map(name => `'${name.replace(/'/g, "''")}'`)
+    .join(', ');
   const psScript = `
     $ErrorActionPreference = 'SilentlyContinue'
-    $candidates = @('Claude Code-credentials', 'Claude Code:credentials', 'Claude Code-credentials:${psSafeUsername}')
+    $candidates = @(${psCandidates})
     Add-Type -Namespace ClaudeMem -Name CredRead -MemberDefinition @"
       [DllImport("Advapi32.dll", SetLastError=true, CharSet=CharSet.Unicode)]
       public static extern bool CredRead(string target, uint type, uint reservedFlag, out IntPtr CredentialPtr);
@@ -182,26 +230,34 @@ async function readWindowsCredentialManager(): Promise<OAuthTokenResult> {
  */
 async function readLinuxLibsecret(): Promise<OAuthTokenResult> {
   const account = userInfo().username;
-  let stdout: string;
-  try {
-    ({ stdout } = await execFileAsync(
-      'secret-tool',
-      ['lookup', 'service', KEYCHAIN_SERVICE_NAME, 'account', account],
-      { timeout: READ_TIMEOUT_MS, windowsHide: true },
-    ));
-  } catch (error) {
-    const err = error instanceof Error ? error : new Error(String(error));
-    logger.warn('OAUTH', 'Linux libsecret lookup failed', { service: KEYCHAIN_SERVICE_NAME, account }, err);
+  const services = keychainServiceNames();
+  let lastError: Error | undefined;
+
+  for (const service of services) {
+    let stdout: string;
+    try {
+      ({ stdout } = await execFileAsync(
+        'secret-tool',
+        ['lookup', 'service', service, 'account', account],
+        { timeout: READ_TIMEOUT_MS, windowsHide: true },
+      ));
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      continue;
+    }
+    const raw = stdout.trim();
+    if (raw) return parseKeychainPayload(raw);
+  }
+
+  const tried = services.join('", "');
+  if (lastError) {
+    logger.warn('OAUTH', 'Linux libsecret lookup failed', { services, account }, lastError);
     return {
       kind: 'absent',
-      reason: `Linux libsecret lookup failed (is secret-tool installed?): ${err.message}`,
+      reason: `Linux libsecret lookup failed (is secret-tool installed?): ${lastError.message}`,
     };
   }
-  const raw = stdout.trim();
-  if (!raw) {
-    return { kind: 'absent', reason: 'Linux libsecret returned empty value for "Claude Code-credentials"' };
-  }
-  return parseKeychainPayload(raw);
+  return { kind: 'absent', reason: `Linux libsecret returned empty value for "${tried}"` };
 }
 
 /**

--- a/tests/shared/keychain-service-names.test.ts
+++ b/tests/shared/keychain-service-names.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'bun:test';
+import { createHash } from 'crypto';
+import { join } from 'path';
+import { keychainServiceNames } from '../../src/shared/oauth-token.js';
+
+/**
+ * Claude Code scopes its credential entry by config directory, so with a non-default
+ * `CLAUDE_CONFIG_DIR` the live token is not under the plain service name. Reading only the
+ * plain name found whatever stale entry sat there, called it expired, and warned
+ * "re-login via Claude Desktop" on every session start about a token that is not the one
+ * in use — re-logging in could not fix it (#3718).
+ */
+
+const PLAIN = 'Claude Code-credentials';
+const HOME = '/home/tester';
+
+function scopedFor(dir: string): string {
+  return `${PLAIN}-${createHash('sha256').update(dir).digest('hex').slice(0, 8)}`;
+}
+
+describe('keychainServiceNames (#3718)', () => {
+  it('reads only the plain name when CLAUDE_CONFIG_DIR is unset', () => {
+    expect(keychainServiceNames({}, HOME)).toEqual([PLAIN]);
+  });
+
+  it('treats the default config dir as unscoped', () => {
+    // Claude Code does not hash the default directory, so scoping it would send the
+    // reader looking for an entry that never exists.
+    expect(keychainServiceNames({ CLAUDE_CONFIG_DIR: join(HOME, '.claude') }, HOME)).toEqual([
+      PLAIN,
+    ]);
+  });
+
+  it('tries the config-scoped name first, then the plain one', () => {
+    const dir = '/home/tester/.claude_b';
+    expect(keychainServiceNames({ CLAUDE_CONFIG_DIR: dir }, HOME)).toEqual([
+      scopedFor(dir),
+      PLAIN,
+    ]);
+  });
+
+  it('keeps the plain name as a fallback, so an unscoped entry is still found', () => {
+    const names = keychainServiceNames({ CLAUDE_CONFIG_DIR: '/tmp/elsewhere' }, HOME);
+    expect(names).toHaveLength(2);
+    expect(names[names.length - 1]).toBe(PLAIN);
+  });
+
+  it('derives the suffix from the configured string, not from the resolved path', () => {
+    // Two directories that differ only by trailing content must not collide.
+    const a = keychainServiceNames({ CLAUDE_CONFIG_DIR: '/tmp/a' }, HOME)[0];
+    const b = keychainServiceNames({ CLAUDE_CONFIG_DIR: '/tmp/b' }, HOME)[0];
+    expect(a).not.toBe(b);
+    expect(a).toBe(scopedFor('/tmp/a'));
+  });
+
+  it('ignores whitespace-only values', () => {
+    expect(keychainServiceNames({ CLAUDE_CONFIG_DIR: '   ' }, HOME)).toEqual([PLAIN]);
+  });
+});

--- a/tests/shared/windows-credential-targets.test.ts
+++ b/tests/shared/windows-credential-targets.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'bun:test';
+import { windowsCredentialTargets } from '../../src/shared/oauth-token.js';
+
+/**
+ * The Windows reader interpolates each target into a PowerShell single-quoted literal,
+ * where `'` is escaped by doubling. Escaping the username a second time before that
+ * turned `O'Brien` into the literal `'Claude Code-credentials:O''''Brien'`, which
+ * PowerShell parses back as `Claude Code-credentials:O''Brien` — CredRead then queried a
+ * target that does not exist and the account fell through to the re-login warning.
+ *
+ * These tests pin the contract at the seam: the helper returns RAW targets, and exactly
+ * one escaping pass survives a literal round-trip.
+ */
+
+const PLAIN = 'Claude Code-credentials';
+const Q = "'";
+
+/** What PowerShell yields for a single-quoted literal: strip the quotes, undouble `''`. */
+function parsePowerShellLiteral(literal: string): string {
+  return literal.slice(1, -1).split(Q + Q).join(Q);
+}
+
+/** The single escaping pass the reader applies, mirrored here. */
+function toPowerShellLiteral(raw: string): string {
+  return `${Q}${raw.replace(/'/g, "''")}${Q}`;
+}
+
+describe('windowsCredentialTargets', () => {
+  it('returns targets raw, so the caller owns the only escaping pass', () => {
+    expect(windowsCredentialTargets("O'Brien", [PLAIN])).toEqual([
+      PLAIN,
+      'Claude Code:credentials',
+      `Claude Code-credentials:O'Brien`,
+    ]);
+  });
+
+  it('survives the PowerShell literal round-trip unchanged (apostrophe username)', () => {
+    for (const raw of windowsCredentialTargets("O'Brien", [PLAIN])) {
+      expect(parsePowerShellLiteral(toPowerShellLiteral(raw))).toBe(raw);
+    }
+  });
+
+  it('puts the config-scoped service names first', () => {
+    const scoped = `${PLAIN}-deadbeef`;
+    expect(windowsCredentialTargets('tester', [scoped, PLAIN]).slice(0, 2)).toEqual([
+      scoped,
+      PLAIN,
+    ]);
+  });
+
+  it('still ends with the username-suffixed target, the pre-#3718 last resort', () => {
+    const targets = windowsCredentialTargets('tester', [PLAIN]);
+    expect(targets[targets.length - 1]).toBe(`${PLAIN}:tester`);
+  });
+});


### PR DESCRIPTION
Closes #3718.

`KEYCHAIN_SERVICE_NAME` was a single constant used by all three platform readers, so the preflight always looked under the plain `Claude Code-credentials`. With a non-default `CLAUDE_CONFIG_DIR` that is not where the live token is, so the read found whatever older entry happened to sit there, judged it expired, wrote `oauth-stale.marker`, and every session start warned *"re-login via Claude Desktop"* — about a token that is not the one in use. Re-logging in cannot fix that, which is the part that sends people down the wrong path.

All three readers now take a candidate list, most specific first:

```ts
export function keychainServiceNames(env = process.env, home = homedir()): string[]
```

- no `CLAUDE_CONFIG_DIR`, or it points at `~/.claude` → `["Claude Code-credentials"]`, byte-identical to today
- otherwise → `["Claude Code-credentials-<sha256(dir)[:8]>", "Claude Code-credentials"]`

macOS and Linux loop the list and take the first entry that yields a value; a miss on the scoped name is ordinary rather than an error, so only an all-candidates failure reports `absent`. Windows already enumerated candidates in its PowerShell snippet, so the scoped names go on the front of that array, quoted with the same `''` doubling the username already uses.

**The plain name is never dropped.** A default install reads exactly what it read before, and a machine whose entry is unscoped is still found. That is deliberate: it makes this change unable to regress anyone even if the scoping rule is wrong.

## What I verified, and what I did not

Verified here: the name derivation and ordering (the tests below), that a default or absent `CLAUDE_CONFIG_DIR` produces the unchanged single-name behaviour, and that the existing `oauth-token` suite still passes.

**Not verified here:** that Claude Code's actual suffix is `sha256(configDir)[:8]`. That formula comes from the issue, where it is given with a runnable derivation (`printf "%s" "$CLAUDE_CONFIG_DIR" | shasum -a 256 | cut -c1-8`) and a `security find-generic-password` on both names showing fresh-vs-stale. I have no machine here with a non-default `CLAUDE_CONFIG_DIR` and a Claude Code credential to confirm it against — `cmdkey /list` on this box shows no Claude entries at all — so I am taking the reporter's measurement rather than repeating it. If the formula is wrong the scoped lookup simply misses and the fallback restores today's behaviour; if you have a machine in that state, one `security`/`secret-tool` call against the derived name settles it.

## Tests

`tests/shared/keychain-service-names.test.ts`, six cases against the pure resolver, with `env` and `home` injected so nothing depends on the machine running them:

- unset → plain name only
- the default `~/.claude` is treated as unscoped, so the reader is not sent hunting for an entry that never exists
- a non-default dir → scoped first, then plain
- the plain name is always last, so the fallback cannot be dropped by accident
- two different dirs give different suffixes, and the suffix is derived from the configured string
- whitespace-only values are ignored

**Mutation-checked** — returning only the plain name from the scoped branch fails three of the six, and leaves the three that pin the unchanged default-install behaviour green.

```
bun test tests/shared/keychain-service-names.test.ts tests/shared/oauth-token.test.ts
24 pass / 0 fail
```

```
bun test tests/shared/
153 pass / 4 fail   (157 tests)
```

The 4 failures are pre-existing — `bun test tests/shared/` on clean `main` gives 4 fail across 151 tests, the same ones (`findClaudeExecutable` ×2, `extractFirstFile` ×2), none of them touching OAuth. 151 → 157 is exactly the six added here.

Note: `plugin/scripts/*.cjs` is a build artefact and I have not rebuilt it here, for the reason set out on #3726 — a rebuild today carries ~834 lines of unrelated drift and a +418 KB jump that trips the build's own size guard. Happy to include it if you would rather have it in this PR.
