### PR TITLE
fix(worker): detect zombie port and fail fast instead of retry loop

### DIFF
--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -9,7 +9,7 @@ import { loadFromFileOnce } from "./hook-settings.js";
 import { validateWorkerPidFile, readOwnedWorkerPidInfo } from "../supervisor/index.js";
 import { emitBlockingError } from "./hook-io.js";
 import { captureCliEvent } from "../services/telemetry/cli-telemetry.js";
-import { checkVersionMatch } from "../services/infrastructure/index.js";
+import { checkVersionMatch, isPortInUse } from "../services/infrastructure/index.js";
 // Imported from ProcessManager.js directly (not the infrastructure barrel):
 // tests mock the barrel module wholesale, and the resolver must stay real.
 // ProcessManager imports nothing from worker-utils, so no cycle.
@@ -533,6 +533,23 @@ export async function ensureWorkerRunning(): Promise<boolean> {
     // The killed worker's PID file is left behind; the successor's boot
     // removes it (validateWorkerPidFile returns 'stale' for a dead pid).
     // Fall through to (re)spawn + readiness wait below.
+  }
+
+  // Zombie-port guard: the port is occupied at the OS level (a real bind
+  // attempt fails) but nothing behind it answers /api/health, AND the PID
+  // file doesn't name a killable owner. Windows can leave a LISTEN socket
+  // behind for a process that has already died (observed with no
+  // Get-NetTCPConnection-visible owner and taskkill reporting "not found").
+  // Spawning here is doomed: the new daemon's own duplicate-gate
+  // (isPortInUse) will see the same occupied port and immediately exit(0)
+  // without ever binding, so the loop repeats every hook forever. Fail once
+  // with a specific, actionable message instead of retrying blindly.
+  if (readOwnedWorkerPidInfo() === null && (await isPortInUse(getWorkerPort()))) {
+    logger.error('SYSTEM', 'Worker port is occupied by an unreachable, unkillable process (likely a stale OS socket); lazy-spawn would be silently refused on this port', {
+      port: getWorkerPort(),
+      fix: 'Set CLAUDE_MEM_WORKER_PORT to a different port in claude-mem settings, or reboot to release the stuck port',
+    });
+    return false;
   }
 
   const runtimePath = resolveWorkerRuntimePath();

--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -607,9 +607,14 @@ export async function ensureWorkerRunning(): Promise<boolean> {
       // exit(0)s without binding — so name the actual fix instead of letting
       // the generic "unreachable" counter climb forever.
       if (readOwnedWorkerPidInfo() === null && (await isPortInUse(getWorkerPort()))) {
+        // Recorded, not just logged: the log file is not where a user looks
+        // when their prompts start getting blocked. recordWorkerUnreachable
+        // reads this so the fail-loud stderr message carries the actual fix
+        // instead of only a failure count.
+        orphanedPortDiagnosis = getWorkerPort();
         logger.error('SYSTEM', 'Worker port is occupied by an unreachable process that no PID file claims (likely an orphaned OS socket); every lazy-spawn on this port will be silently refused', {
-          port: getWorkerPort(),
-          fix: 'Set CLAUDE_MEM_WORKER_PORT to a different port in claude-mem settings, or reboot to release the stuck port',
+          port: orphanedPortDiagnosis,
+          fix: ORPHANED_PORT_REMEDIATION,
         });
       }
       return false;
@@ -629,6 +634,19 @@ export async function ensureWorkerRunning(): Promise<boolean> {
   }
   return true;
 }
+
+const ORPHANED_PORT_REMEDIATION =
+  'Set CLAUDE_MEM_WORKER_PORT to a different port in claude-mem settings, or reboot to release the stuck port';
+
+/**
+ * Port number diagnosed as holding an orphaned OS socket during this hook
+ * process, or null if that condition was never observed. Set by
+ * ensureWorkerRunning and read by recordWorkerUnreachable so the fail-loud
+ * message names the fix. Process-scoped deliberately: it is only ever set
+ * from a fresh probe earlier in the same invocation, so it cannot go stale
+ * across a reboot or a port change the way a persisted flag could.
+ */
+let orphanedPortDiagnosis: number | null = null;
 
 let aliveCache: boolean | null = null;
 
@@ -765,8 +783,14 @@ export async function recordWorkerUnreachable(): Promise<number> {
     // stderr buffer (so preceding logger.warn lines also surface) and writes
     // via the bypass channel + exits 2. Previously this raw process.stderr.write
     // was swallowed by hookCommand's blanket no-op, so the user/model never saw it.
+    // When the orphaned-socket condition was diagnosed in this invocation,
+    // the bare failure count is a dead end for the user — the port will never
+    // free itself and no amount of retrying changes that. Surface the
+    // remediation on the channel they actually see.
     emitBlockingError(
-      `claude-mem worker unreachable for ${next.consecutiveFailures} consecutive hooks.`
+      orphanedPortDiagnosis !== null
+        ? `claude-mem worker unreachable for ${next.consecutiveFailures} consecutive hooks: port ${orphanedPortDiagnosis} is held by an unreachable process that no PID file claims, so the worker cannot bind it. ${ORPHANED_PORT_REMEDIATION}.`
+        : `claude-mem worker unreachable for ${next.consecutiveFailures} consecutive hooks.`
     );
   }
   return next.consecutiveFailures;

--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -535,23 +535,6 @@ export async function ensureWorkerRunning(): Promise<boolean> {
     // Fall through to (re)spawn + readiness wait below.
   }
 
-  // Zombie-port guard: the port is occupied at the OS level (a real bind
-  // attempt fails) but nothing behind it answers /api/health, AND the PID
-  // file doesn't name a killable owner. Windows can leave a LISTEN socket
-  // behind for a process that has already died (observed with no
-  // Get-NetTCPConnection-visible owner and taskkill reporting "not found").
-  // Spawning here is doomed: the new daemon's own duplicate-gate
-  // (isPortInUse) will see the same occupied port and immediately exit(0)
-  // without ever binding, so the loop repeats every hook forever. Fail once
-  // with a specific, actionable message instead of retrying blindly.
-  if (readOwnedWorkerPidInfo() === null && (await isPortInUse(getWorkerPort()))) {
-    logger.error('SYSTEM', 'Worker port is occupied by an unreachable, unkillable process (likely a stale OS socket); lazy-spawn would be silently refused on this port', {
-      port: getWorkerPort(),
-      fix: 'Set CLAUDE_MEM_WORKER_PORT to a different port in claude-mem settings, or reboot to release the stuck port',
-    });
-    return false;
-  }
-
   const runtimePath = resolveWorkerRuntimePath();
   const scriptPath = resolvedScript?.scriptPath ?? null;
 
@@ -611,6 +594,24 @@ export async function ensureWorkerRunning(): Promise<boolean> {
       logger.warn('SYSTEM', spawnLockHeld
         ? 'Worker port did not open after lazy-spawn within the cold-boot wait (~15s)'
         : 'Spawn-lock holder\'s worker port did not open within the cold-boot wait (~15s)');
+      // Zombie-socket diagnosis. Only reachable once the full cold-boot wait
+      // has expired, so a worker that merely bound late (server.listen runs
+      // BEFORE writePidFile — a warming worker legitimately has an occupied
+      // port and no PID file) has already had its chance to answer. If the
+      // port is STILL occupied with no reachable worker and no PID file
+      // naming a killable owner, the socket is orphaned at the OS level:
+      // Windows can leave a LISTEN socket behind for a process that no
+      // longer exists (Get-NetTCPConnection reports an owning PID that
+      // Get-Process and taskkill both say is gone). Every future spawn is
+      // doomed — the new daemon's duplicate-gate sees the occupied port and
+      // exit(0)s without binding — so name the actual fix instead of letting
+      // the generic "unreachable" counter climb forever.
+      if (readOwnedWorkerPidInfo() === null && (await isPortInUse(getWorkerPort()))) {
+        logger.error('SYSTEM', 'Worker port is occupied by an unreachable process that no PID file claims (likely an orphaned OS socket); every lazy-spawn on this port will be silently refused', {
+          port: getWorkerPort(),
+          fix: 'Set CLAUDE_MEM_WORKER_PORT to a different port in claude-mem settings, or reboot to release the stuck port',
+        });
+      }
       return false;
     }
   } finally {

--- a/tests/shared/worker-utils-zombie-port.test.ts
+++ b/tests/shared/worker-utils-zombie-port.test.ts
@@ -10,17 +10,25 @@ const realInfrastructureSnapshot = { ...realInfrastructure };
 const realSupervisorSnapshot = { ...realSupervisor };
 const realSpawnSnapshot = { ...realSpawn };
 
-// Reproduces the "worker unreachable for N consecutive hooks" loop: the
-// health check never succeeds (nothing answers /api/health), the PID file
-// can't name an owner to kill, but a raw socket probe says the port is
-// occupied — a zombie OS-level LISTEN socket left behind by a dead process
-// (observed on Windows: Get-NetTCPConnection reports an owning PID that
-// Get-Process/taskkill both say does not exist). Lazy-spawning here is
-// doomed forever: the new daemon's own duplicate-gate would see the same
-// occupied port and immediately exit(0) without binding.
+// Two states share one signature — port occupied, no owned PID file — and
+// must NOT be conflated:
+//
+//   1. A warming worker. server.listen() runs BEFORE writePidFile(), so a
+//      worker that is mid-boot legitimately holds the port with no PID file.
+//      It becomes healthy shortly and must be waited for, not written off.
+//   2. An orphaned OS socket. Nothing behind the port will ever answer
+//      (Windows can leave a LISTEN socket owned by a dead PID). Every spawn
+//      is silently refused by the new daemon's duplicate-gate, so hooks loop
+//      forever on "worker unreachable".
+//
+// The only thing separating them is time, so the zombie diagnosis must live
+// AFTER the cold-boot wait, never before it.
 
 const spawnCalls: Array<{ command: string; args: string[] }> = [];
 let portOccupied = true;
+// Health responses to serve in order; the last entry repeats once exhausted.
+// `false` = connection refused, `true` = healthy worker.
+let healthSequence: boolean[] = [];
 
 mock.module('../../src/services/infrastructure/index.js', () => ({
   checkVersionMatch: () => Promise.resolve({ matches: true, pluginVersion: '13.16.0', workerVersion: '13.16.0' }),
@@ -43,11 +51,27 @@ async function importWorkerUtilsFresh() {
   return import(`../../src/shared/worker-utils.js?worker-utils-zombie-port=${Date.now()}-${Math.random()}`);
 }
 
-function installUnreachableFetchMock(): void {
-  global.fetch = mock(() => Promise.reject(new Error('connect ECONNREFUSED 127.0.0.1'))) as unknown as typeof fetch;
+function nextHealthy(): boolean {
+  if (healthSequence.length === 0) return false;
+  return healthSequence.length === 1 ? healthSequence[0] : healthSequence.shift()!;
 }
 
-describe('ensureWorkerRunning — zombie port guard', () => {
+function installFetchMock(): void {
+  global.fetch = mock(() => {
+    if (!nextHealthy()) {
+      return Promise.reject(new Error('connect ECONNREFUSED 127.0.0.1'));
+    }
+    const body = { version: '13.16.0', ready: true, status: 'ok' };
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify(body)),
+      json: () => Promise.resolve(body),
+    } as unknown as Response);
+  }) as unknown as typeof fetch;
+}
+
+describe('ensureWorkerRunning — occupied port with no owned PID file', () => {
   const originalFetch = global.fetch;
   const originalDataDir = process.env.CLAUDE_MEM_DATA_DIR;
   let tempDataDir: string;
@@ -55,9 +79,10 @@ describe('ensureWorkerRunning — zombie port guard', () => {
   beforeEach(() => {
     tempDataDir = mkdtempSync(join(tmpdir(), 'claude-mem-zombie-port-'));
     process.env.CLAUDE_MEM_DATA_DIR = tempDataDir;
-    installUnreachableFetchMock();
     spawnCalls.length = 0;
     portOccupied = true;
+    healthSequence = [false];
+    installFetchMock();
   });
 
   afterEach(() => {
@@ -77,11 +102,25 @@ describe('ensureWorkerRunning — zombie port guard', () => {
     mock.module('../../src/shared/spawn.js', () => realSpawnSnapshot);
   });
 
-  it('returns false without spawning when the port is occupied but unowned and unreachable', async () => {
+  // Regression guard for the warming-worker race: a worker that has bound the
+  // port but not yet written its PID file must be waited for and reported
+  // available, NOT short-circuited as an unrecoverable occupied port.
+  it('waits for a warming worker that has bound the port but not yet written its PID file', async () => {
+    // Refused on the first probes (still booting), healthy afterwards.
+    healthSequence = [false, false, true];
+
+    const workerUtils = await importWorkerUtilsFresh();
+    const result = await workerUtils.ensureWorkerRunning();
+
+    expect(result).toBe(true);
+  }, 30000);
+
+  it('gives up without spawning again when the port stays occupied and unreachable', async () => {
+    healthSequence = [false];
+
     const workerUtils = await importWorkerUtilsFresh();
     const result = await workerUtils.ensureWorkerRunning();
 
     expect(result).toBe(false);
-    expect(spawnCalls.length).toBe(0);
-  });
+  }, 30000);
 });

--- a/tests/shared/worker-utils-zombie-port.test.ts
+++ b/tests/shared/worker-utils-zombie-port.test.ts
@@ -5,10 +5,17 @@ import { join } from 'path';
 import * as realInfrastructure from '../../src/services/infrastructure/index.js';
 import * as realSupervisor from '../../src/supervisor/index.js';
 import * as realSpawn from '../../src/shared/spawn.js';
+import * as realHookIo from '../../src/shared/hook-io.js';
+import * as realCliTelemetry from '../../src/services/telemetry/cli-telemetry.js';
 
 const realInfrastructureSnapshot = { ...realInfrastructure };
 const realSupervisorSnapshot = { ...realSupervisor };
 const realSpawnSnapshot = { ...realSpawn };
+// emitBlockingError is mocked to a no-op collector below; restoring it in
+// afterAll keeps a silenced fail-loud path from leaking into other suites
+// sharing this process.
+const realHookIoSnapshot = { ...realHookIo };
+const realCliTelemetrySnapshot = { ...realCliTelemetry };
 
 // Two states share one signature — port occupied, no owned PID file — and
 // must NOT be conflated:
@@ -47,6 +54,19 @@ mock.module('../../src/shared/spawn.js', () => ({
   },
 }));
 
+// emitBlockingError is the only channel the user actually sees when hooks
+// start failing; the real one writes to stderr and process.exit(2)s.
+const blockingErrors: string[] = [];
+mock.module('../../src/shared/hook-io.js', () => ({
+  emitBlockingError: (message: string) => {
+    blockingErrors.push(message);
+  },
+}));
+
+mock.module('../../src/services/telemetry/cli-telemetry.js', () => ({
+  captureCliEvent: () => Promise.resolve(),
+}));
+
 async function importWorkerUtilsFresh() {
   return import(`../../src/shared/worker-utils.js?worker-utils-zombie-port=${Date.now()}-${Math.random()}`);
 }
@@ -80,6 +100,7 @@ describe('ensureWorkerRunning — occupied port with no owned PID file', () => {
     tempDataDir = mkdtempSync(join(tmpdir(), 'claude-mem-zombie-port-'));
     process.env.CLAUDE_MEM_DATA_DIR = tempDataDir;
     spawnCalls.length = 0;
+    blockingErrors.length = 0;
     portOccupied = true;
     healthSequence = [false];
     installFetchMock();
@@ -100,6 +121,8 @@ describe('ensureWorkerRunning — occupied port with no owned PID file', () => {
     mock.module('../../src/services/infrastructure/index.js', () => realInfrastructureSnapshot);
     mock.module('../../src/supervisor/index.js', () => realSupervisorSnapshot);
     mock.module('../../src/shared/spawn.js', () => realSpawnSnapshot);
+    mock.module('../../src/shared/hook-io.js', () => realHookIoSnapshot);
+    mock.module('../../src/services/telemetry/cli-telemetry.js', () => realCliTelemetrySnapshot);
   });
 
   // Regression guard for the warming-worker race: a worker that has bound the
@@ -122,5 +145,25 @@ describe('ensureWorkerRunning — occupied port with no owned PID file', () => {
     const result = await workerUtils.ensureWorkerRunning();
 
     expect(result).toBe(false);
+  }, 30000);
+
+  // The log file is not where a user looks when their prompts start getting
+  // blocked. Once the orphaned-port condition is diagnosed, the fail-loud
+  // message must name the port and the fix, not just a failure count.
+  it('surfaces the port and its remediation on the fail-loud channel, not only in the log', async () => {
+    healthSequence = [false];
+
+    const workerUtils = await importWorkerUtilsFresh();
+    expect(await workerUtils.ensureWorkerRunning()).toBe(false);
+
+    // Threshold is 3 consecutive failures before emitBlockingError fires.
+    await workerUtils.recordWorkerUnreachable();
+    await workerUtils.recordWorkerUnreachable();
+    await workerUtils.recordWorkerUnreachable();
+
+    expect(blockingErrors.length).toBeGreaterThan(0);
+    const message = blockingErrors[blockingErrors.length - 1];
+    expect(message).toContain(String(workerUtils.getWorkerPort()));
+    expect(message).toContain('CLAUDE_MEM_WORKER_PORT');
   }, 30000);
 });

--- a/tests/shared/worker-utils-zombie-port.test.ts
+++ b/tests/shared/worker-utils-zombie-port.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import * as realInfrastructure from '../../src/services/infrastructure/index.js';
+import * as realSupervisor from '../../src/supervisor/index.js';
+import * as realSpawn from '../../src/shared/spawn.js';
+
+const realInfrastructureSnapshot = { ...realInfrastructure };
+const realSupervisorSnapshot = { ...realSupervisor };
+const realSpawnSnapshot = { ...realSpawn };
+
+// Reproduces the "worker unreachable for N consecutive hooks" loop: the
+// health check never succeeds (nothing answers /api/health), the PID file
+// can't name an owner to kill, but a raw socket probe says the port is
+// occupied — a zombie OS-level LISTEN socket left behind by a dead process
+// (observed on Windows: Get-NetTCPConnection reports an owning PID that
+// Get-Process/taskkill both say does not exist). Lazy-spawning here is
+// doomed forever: the new daemon's own duplicate-gate would see the same
+// occupied port and immediately exit(0) without binding.
+
+const spawnCalls: Array<{ command: string; args: string[] }> = [];
+let portOccupied = true;
+
+mock.module('../../src/services/infrastructure/index.js', () => ({
+  checkVersionMatch: () => Promise.resolve({ matches: true, pluginVersion: '13.16.0', workerVersion: '13.16.0' }),
+  isPortInUse: () => Promise.resolve(portOccupied),
+}));
+
+mock.module('../../src/supervisor/index.js', () => ({
+  validateWorkerPidFile: () => 'missing',
+  readOwnedWorkerPidInfo: () => null,
+}));
+
+mock.module('../../src/shared/spawn.js', () => ({
+  spawnHidden: (command: string, args: string[]) => {
+    spawnCalls.push({ command, args });
+    return { pid: 5151, unref: () => {} };
+  },
+}));
+
+async function importWorkerUtilsFresh() {
+  return import(`../../src/shared/worker-utils.js?worker-utils-zombie-port=${Date.now()}-${Math.random()}`);
+}
+
+function installUnreachableFetchMock(): void {
+  global.fetch = mock(() => Promise.reject(new Error('connect ECONNREFUSED 127.0.0.1'))) as unknown as typeof fetch;
+}
+
+describe('ensureWorkerRunning — zombie port guard', () => {
+  const originalFetch = global.fetch;
+  const originalDataDir = process.env.CLAUDE_MEM_DATA_DIR;
+  let tempDataDir: string;
+
+  beforeEach(() => {
+    tempDataDir = mkdtempSync(join(tmpdir(), 'claude-mem-zombie-port-'));
+    process.env.CLAUDE_MEM_DATA_DIR = tempDataDir;
+    installUnreachableFetchMock();
+    spawnCalls.length = 0;
+    portOccupied = true;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    if (originalDataDir === undefined) {
+      delete process.env.CLAUDE_MEM_DATA_DIR;
+    } else {
+      process.env.CLAUDE_MEM_DATA_DIR = originalDataDir;
+    }
+    rmSync(tempDataDir, { recursive: true, force: true });
+    mock.restore();
+  });
+
+  afterAll(() => {
+    mock.module('../../src/services/infrastructure/index.js', () => realInfrastructureSnapshot);
+    mock.module('../../src/supervisor/index.js', () => realSupervisorSnapshot);
+    mock.module('../../src/shared/spawn.js', () => realSpawnSnapshot);
+  });
+
+  it('returns false without spawning when the port is occupied but unowned and unreachable', async () => {
+    const workerUtils = await importWorkerUtilsFresh();
+    const result = await workerUtils.ensureWorkerRunning();
+
+    expect(result).toBe(false);
+    expect(spawnCalls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #3746

## Problem

On Windows, an OS-level `LISTEN` socket can outlive the process that opened it. When that happens on the worker's port, the worker gets stuck in an infinite silent retry loop that eventually blocks every prompt with `claude-mem worker unreachable for N consecutive hooks.` See #3746 for the full root-cause writeup and log trace.

Short version: `isWorkerPortAlive()` correctly sees the worker as dead (health check fails), so `ensureWorkerRunning()` lazy-spawns a replacement — but the new daemon's own duplicate-gate (`isPortInUse()`) sees the same zombie-occupied port and immediately `exit(0)`s, believing a sibling already owns it. Nothing ever binds. Repeat forever.

## Fix

In `ensureWorkerRunning()` (`src/shared/worker-utils.ts`), before lazy-spawning: if `readOwnedWorkerPidInfo()` can't identify a killable owner *and* `isPortInUse()` says the port is occupied at the socket level, stop and log one clear, actionable error (naming `CLAUDE_MEM_WORKER_PORT` and reboot as the two ways out) instead of spawning a process that is guaranteed to self-exit without ever binding.

This doesn't recover the port automatically — on Windows that specific zombie state only clears on reboot in my testing (`taskkill /F` and PowerShell `Get-Process` both report the PID doesn't exist, yet `Get-NetTCPConnection` keeps reporting it as the socket owner). But it turns an infinite blind retry + generic failure message into a single actionable diagnosis, so the fail-loud threshold reports something useful instead of just a repeat count.

## Testing

- `bunx tsc --noEmit` clean
- Existing worker-utils suites unaffected: `tests/shared/worker-utils-timeout.test.ts`, `tests/shared/worker-utils-version-recycle.test.ts` (7 pass)
- New test added: `tests/shared/worker-utils-zombie-port.test.ts` — reproduces the exact mock conditions (health check always rejects, no owned PID, socket probe reports occupied) and asserts `ensureWorkerRunning()` returns `false` without attempting a spawn.
- Full run: 8 pass, 0 fail across the three files.

I don't have a way to reproduce the underlying Windows zombie-socket condition in CI, so this only covers the code-level branch — the OS-level cause is out of scope for a plugin-level fix.