### PR TITLE
fix(db): guard discovery_tokens column on PRAGMA, not schema_versions (#3738)

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -1323,26 +1323,20 @@ export class SessionStore {
   }
 
   private ensureDiscoveryTokensColumn(): void {
-    const applied = this.db.prepare('SELECT version FROM schema_versions WHERE version = ?').get(11) as SchemaVersion | undefined;
-    if (applied) return;
-
+    // Guard on actual table schema, not schema_versions history (#3738).
+    // An old-version worker can rebuild tables and drop columns while
+    // schema_versions still records the migration as applied.
     const observationsInfo = this.db.query('PRAGMA table_info(observations)').all() as TableColumnInfo[];
-    const obsHasDiscoveryTokens = observationsInfo.some(col => col.name === 'discovery_tokens');
-
-    if (!obsHasDiscoveryTokens) {
+    if (!observationsInfo.some(col => col.name === 'discovery_tokens')) {
       this.db.run('ALTER TABLE observations ADD COLUMN discovery_tokens INTEGER DEFAULT 0');
       logger.debug('DB', 'Added discovery_tokens column to observations table');
     }
 
     const summariesInfo = this.db.query('PRAGMA table_info(session_summaries)').all() as TableColumnInfo[];
-    const sumHasDiscoveryTokens = summariesInfo.some(col => col.name === 'discovery_tokens');
-
-    if (!sumHasDiscoveryTokens) {
+    if (!summariesInfo.some(col => col.name === 'discovery_tokens')) {
       this.db.run('ALTER TABLE session_summaries ADD COLUMN discovery_tokens INTEGER DEFAULT 0');
       logger.debug('DB', 'Added discovery_tokens column to session_summaries table');
     }
-
-    this.db.prepare('INSERT OR IGNORE INTO schema_versions (version, applied_at) VALUES (?, ?)').run(11, new Date().toISOString());
   }
 
   private createPendingMessagesTable(): void {


### PR DESCRIPTION
## What Problem This Solves

`ensureDiscoveryTokensColumn` decides whether `session_summaries.discovery_tokens` exists by checking for `schema_versions` row 11, not by inspecting the table. If an old-version worker rebuilds the table and drops the column, the guard still sees row 11 and skips repair forever. Result: every summary write fails with `table session_summaries has no column named discovery_tokens`.

## Why This Change Was Made

The schema_versions check is a historical proxy that doesn't survive table reconstruction. An old-version worker spawned from a stale plugin cache can rebuild `session_summaries` to its pre-`discovery_tokens` shape while schema_versions still records the migration as applied.

## User Impact

The column-add migration now self-heals regardless of what rewrote the table. One cheap PRAGMA at boot, idempotent, and always checks reality.

## Evidence

- Issue: https://github.com/thedotmack/claude-mem/issues/3738
- Root cause: `ensureDiscoveryTokensColumn` at `SessionStore.ts:1325` guards on schema_versions, not PRAGMA
- Fix: replaced schema_versions check with `PRAGMA table_info` for both tables
- 1 file changed, 5 insertions, 11 deletions
