### PR TITLE
fix(codex): stop an unparseable Bash command from blocking the tool call

### DIFF
--- a/src/cli/adapters/codex-file-context.ts
+++ b/src/cli/adapters/codex-file-context.ts
@@ -88,7 +88,19 @@ function extractFromBash(toolInput: unknown, cwd: string): string[] {
   const command = normalizeCommand((toolInput as { command?: unknown } | undefined)?.command);
   if (!command) return [];
 
-  const tokens = parse(command);
+  // `parse` throws on substitutions it cannot resolve — `${}` raises
+  // "Bad substitution" on every shell-quote 1.x, including 1.10.x. This is a
+  // best-effort enrichment that only adds `filePaths` for read commands, so an
+  // unparseable command must yield no paths rather than propagate: the throw
+  // escaped to the generic hook handler, which answers BLOCKING_ERROR and
+  // discards the tool call entirely (#3688). Failing to enrich is invisible;
+  // blocking the user's command is not.
+  let tokens: ParsedToken[];
+  try {
+    tokens = parse(command);
+  } catch {
+    return [];
+  }
   const paths: string[] = [];
 
   for (const segment of splitSegments(tokens)) {

--- a/tests/cli/adapters/codex-file-context.test.ts
+++ b/tests/cli/adapters/codex-file-context.test.ts
@@ -60,4 +60,26 @@ describe('extractFilePaths', () => {
     expect(extractFilePaths('mcp__fs__read_write', { path: 'README.md' }, tmpDir)).toEqual([]);
     expect(extractFilePaths('mcp__server__readonly', { path: 'README.md' }, tmpDir)).toEqual([]);
   });
+
+  // #3688: `parse` throws "Bad substitution" on `${}`. The throw escaped this
+  // best-effort enrichment and reached the generic hook handler, which answers
+  // BLOCKING_ERROR — so an ordinary shell command was blocked and the tool call
+  // discarded, to add a convenience field.
+  it('yields no paths instead of throwing on an unparseable substitution', () => {
+    expect(() => extractFilePaths('Bash', { command: 'cat ${}' }, tmpDir)).not.toThrow();
+    expect(extractFilePaths('Bash', { command: 'cat ${}' }, tmpDir)).toEqual([]);
+  });
+
+  it('yields no paths when the unparseable part rides alongside a real read', () => {
+    // The readable file is genuinely there, so this fails only because the
+    // command as a whole cannot be tokenised — not because the path is bad.
+    expect(
+      extractFilePaths('Bash', { command: 'cat README.md && cat ${}' }, tmpDir)
+    ).toEqual([]);
+  });
+
+  it('still extracts paths from a command that parses', () => {
+    // The guard must not swallow the feature it protects.
+    expect(extractFilePaths('Bash', { command: 'cat README.md' }, tmpDir)).toEqual(['README.md']);
+  });
 });


### PR DESCRIPTION
Closes #3688.

`extractFromBash` calls shell-quote's `parse()` on every Bash PreToolUse command to enrich the payload with `filePaths` for read commands. `parse()` throws on substitutions it cannot resolve, nothing caught it here, and the throw reached the generic hook handler — which logs `Hook error:` and returns `BLOCKING_ERROR`.

**A best-effort convenience field was turning an ordinary shell command into a blocked, discarded tool call.**

## Reproduced on the version installed today, not just the 1.8.4 in the report

```
shell-quote 1.10.0
parse("cat ${}")            -> throws  Bad substitution: ${}
parse("echo hi && cat ${}") -> throws  Bad substitution: ${}
parse('grep -r "${}" .')    -> throws  Bad substitution: ${}
```

The trigger is an **empty** substitution. That detail is worth stating, because my first attempt to reproduce failed: `${FOO}`, `${#FOO}`, `${!FOO}`, `${FOO/a/b}`, `${FOO:?err}` and `${arr[@]}` **all parse fine** on 1.10.0. Had I stopped there I would have closed this as fixed-by-upgrade. The bundled throw is:

```js
if ($ === "{") { y += 1; if (u.charAt(y) === "}") throw new Error("Bad substitution: " + …) }
```

It also does not depend on what a fresh `npm install` resolves: `plugin/scripts/worker-service.cjs` — the file that actually ships — carries a bundled copy containing that same `Bad substitution` throw.

## The fix

The parse is guarded and yields no paths on failure. Failing to enrich is invisible to the user; blocking their command is not.

## Tests

Three, **two of which fail without the guard** (`7 pass / 2 fail`):

| test | why it is there |
|---|---|
| an unparseable substitution yields `[]` instead of throwing | the reported failure |
| …and the same when it rides alongside a genuinely readable file | makes the failure attributable to *tokenisation*, not to a bad path |
| a command that parses still extracts its paths | the guard must not swallow the feature it protects |

`bun test tests/cli tests/hooks` — **116 passed**.

## The bundle

Left untouched deliberately. Rebuilding `plugin/scripts/worker-service.cjs` here diverges from the committed artifact for reasons unrelated to this change, so it should be regenerated by the normal release build rather than carried in this PR. Say the word if you would rather I include a rebuild.