### PR TITLE
fix(sqlite): guard discovery_tokens on the column, not on schema_versions

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -1322,10 +1322,23 @@ export class SessionStore {
     logger.debug('DB', 'Successfully created user_prompts table');
   }
 
+  /**
+   * Add `discovery_tokens` to `observations` / `session_summaries` when it is
+   * missing.
+   *
+   * Deliberately NOT short-circuited on `schema_versions` row 11. The row
+   * records that the migration once ran, which is not the same as the column
+   * being there now: an old-version worker spawned from a stale plugin cache
+   * rebuilds `session_summaries` in its pre-`discovery_tokens` shape, and the
+   * version row survives that. Guarding on history meant the repair was
+   * skipped forever and every summary write failed with
+   * "table session_summaries has no column named discovery_tokens" until
+   * someone ran the ALTER by hand (#3738).
+   *
+   * The two PRAGMAs below are the actual guard, they are already idempotent,
+   * and they cost one table_info each at boot.
+   */
   private ensureDiscoveryTokensColumn(): void {
-    const applied = this.db.prepare('SELECT version FROM schema_versions WHERE version = ?').get(11) as SchemaVersion | undefined;
-    if (applied) return;
-
     const observationsInfo = this.db.query('PRAGMA table_info(observations)').all() as TableColumnInfo[];
     const obsHasDiscoveryTokens = observationsInfo.some(col => col.name === 'discovery_tokens');
 

--- a/tests/sqlite/session-store-migrations.test.ts
+++ b/tests/sqlite/session-store-migrations.test.ts
@@ -127,6 +127,11 @@ function revisionColumnInfo(
   }>).find(info => info.name === column)!;
 }
 
+function hasColumn(db: Database, table: string, column: string): boolean {
+  const info = db.query(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  return info.some(col => col.name === column);
+}
+
 function insertSchemaVersions(db: Database, throughVersion: number): void {
   const now = new Date().toISOString();
   for (let version = 4; version <= throughVersion; version++) {
@@ -1036,6 +1041,73 @@ describe('SessionStore migrations', () => {
       expect(invalid.synced_at).toBe(555);
       expect(invalid.sync_rev).toBe('4');
     } finally {
+      db.close();
+    }
+  });
+
+  // #3738 — the version row records that the migration once ran, which is not
+  // the same as the column being there now. A stale-cache worker can rebuild
+  // session_summaries in its pre-discovery_tokens shape while row 11 survives.
+  it('re-adds a dropped discovery_tokens column even though schema_versions row 11 survives', () => {
+    const db = new Database(':memory:');
+    try {
+      store = new SessionStore(db);
+      expect(hasColumn(db, 'session_summaries', 'discovery_tokens')).toBe(true);
+
+      // What the old worker leaves behind: the column gone, the history intact.
+      db.run('ALTER TABLE session_summaries DROP COLUMN discovery_tokens');
+      expect(hasColumn(db, 'session_summaries', 'discovery_tokens')).toBe(false);
+      const row = db.prepare('SELECT version FROM schema_versions WHERE version = 11').get();
+      expect(row).toBeTruthy();
+
+      // A second boot on the SAME connection: closing the store would close
+      // the in-memory database with it.
+      new SessionStore(db);
+
+      expect(hasColumn(db, 'session_summaries', 'discovery_tokens')).toBe(true);
+    } finally {
+      store?.close();
+      store = undefined;
+      db.close();
+    }
+  });
+
+  it('re-adds a dropped discovery_tokens column on observations too', () => {
+    const db = new Database(':memory:');
+    try {
+      store = new SessionStore(db);
+      db.run('ALTER TABLE observations DROP COLUMN discovery_tokens');
+      expect(hasColumn(db, 'observations', 'discovery_tokens')).toBe(false);
+
+      // A second boot on the SAME connection: closing the store would close
+      // the in-memory database with it.
+      new SessionStore(db);
+
+      expect(hasColumn(db, 'observations', 'discovery_tokens')).toBe(true);
+    } finally {
+      store?.close();
+      store = undefined;
+      db.close();
+    }
+  });
+
+  it('leaves an intact schema alone across repeated opens', () => {
+    // The guard now runs on every boot, so it has to be a no-op when there is
+    // nothing to repair.
+    const db = new Database(':memory:');
+    try {
+      store = new SessionStore(db);
+      // A second boot on the SAME connection: closing the store would close
+      // the in-memory database with it.
+      new SessionStore(db);
+
+      expect(hasColumn(db, 'session_summaries', 'discovery_tokens')).toBe(true);
+      expect(hasColumn(db, 'observations', 'discovery_tokens')).toBe(true);
+      const rows = db.prepare('SELECT COUNT(*) as count FROM schema_versions WHERE version = 11').get() as { count: number };
+      expect(rows.count).toBe(1);
+    } finally {
+      store?.close();
+      store = undefined;
       db.close();
     }
   });


### PR DESCRIPTION
Closes #3738.

`ensureDiscoveryTokensColumn` **already introspects** with `PRAGMA table_info` — the checks are right there. They just sit behind an early return:

```ts
const applied = this.db.prepare('SELECT version FROM schema_versions WHERE version = ?').get(11);
if (applied) return;          // <- the PRAGMAs below can never run again
```

The row records that the migration *once ran*, which is not the same as the column being there *now*. An old-version worker spawned from a stale plugin cache rebuilds `session_summaries` in its pre-`discovery_tokens` shape, and the version row survives that rebuild. The repair is then skipped forever and every summary write fails with `table session_summaries has no column named discovery_tokens`.

**Dropping the early return is the whole fix.** The two PRAGMA checks are already the correct guard and already idempotent; they were simply unreachable on a second boot. Cost is one `table_info` per table at boot.

## Tests

Three, **two of which fail against the early-return version** (`20 pass / 2 fail`):

| test | why it is shaped that way |
|---|---|
| a dropped column on `session_summaries` is re-added **even though row 11 is still present** | the test asserts the row survives, so it reproduces the reported scenario rather than a plain missing migration |
| the same for `observations` | the function repairs both tables; only testing one would leave half unpinned |
| an intact schema is untouched across repeated opens, and row 11 is inserted exactly once | the guard now runs on **every** boot, so it must be a no-op when there is nothing to repair — this is the cost of removing the early return, and it deserves a test rather than a claim |

One thing worth flagging for anyone extending these tests: `store.close()` closes the underlying `Database`, so a second boot has to be `new SessionStore(db)` on the same connection. My first draft closed between opens and got `error: Database has closed` on all three.

## Suite result

`bun test tests/sqlite` — **87 passed, 4 failed**.

Those 4 are **pre-existing**. A clean `main` on this machine gives the same 4 by name — all in the `#3378` orphaned-FK migration file — with 84 passing:

```
(fail) … (#3378) > v9 observations rebuild completes over an orphaned observation and repairs its parent
(fail) … (#3378) > v7 session_summaries rebuild completes over an orphaned summary and repairs its parent
(fail) … (#3378) > boot sequence over a DB with both orphan kinds: migrations then v12.4.3 cleanup, nothing lost
(fail) … (#3378) > repair is idempotent: reconstructing over the repaired DB is a no-op
```

I checked that one specifically rather than waving at the count, because "repair is idempotent" is exactly the kind of test this change could have broken.

## Scope

The issue notes the same pattern applies to any column-add migration keyed off `schema_versions`. This PR fixes only the one that caused the outage; converting the others is a larger sweep and should be its own change (and is what #3609 proposes).