### PR TITLE
fix(hooks): fail open when stdin cannot be read, instead of exit 2

### DIFF
--- a/src/cli/hook-command.ts
+++ b/src/cli/hook-command.ts
@@ -1,4 +1,4 @@
-import { readJsonFromStdin } from './stdin-reader.js';
+import { readJsonFromStdin, HookInputUnreadable } from './stdin-reader.js';
 import { getPlatformAdapter } from './adapters/index.js';
 import { AdapterRejectedInput } from './adapters/errors.js';
 import { getEventHandler } from './handlers/index.js';
@@ -74,7 +74,20 @@ export function isWorkerUnavailableError(error: unknown): boolean {
   return false;
 }
 
+/**
+ * True when the hook could not obtain its own input — stdin never arrived as
+ * parseable JSON, or the transcript it was pointed at is gone.
+ *
+ * These must never exit non-zero. `UserPromptSubmit` and `SessionStart` are
+ * the two hooks in hooks.json registered WITHOUT `"async": true`, so Claude
+ * Code reads their real exit status instead of synthesising 0. On
+ * UserPromptSubmit an exit of 2 blocks the submission and discards the typed
+ * prompt, which is a far worse outcome than the missed observation that
+ * failing open costs us (#3699).
+ */
 export function isNonBlockingHookInputError(error: unknown): boolean {
+  if (error instanceof HookInputUnreadable) return true;
+
   const message = error instanceof Error ? error.message : String(error);
   const lower = message.toLowerCase();
 
@@ -132,6 +145,20 @@ export async function hookCommand(platform: string, event: string, options: Hook
     }
     if (isNonBlockingHookInputError(error)) {
       logger.warn('HOOK', `Hook input unavailable, skipping hook: ${error instanceof Error ? error.message : error}`);
+      // Failing open here used to be failing SILENT: before #3699 an
+      // unreadable stdin fell through to the catch-all, which emitted
+      // hook_failed. Keep that signal so the maintainers still see these —
+      // the exit code changes, the reporting does not. Awaited for the same
+      // reason as the catch-all below: exitGraceful calls process.exit(0),
+      // which would kill a fire-and-forget POST mid-flight.
+      {
+        const hookType = getActiveHookType();
+        await captureCliEvent('hook_failed', {
+          ...(hookType !== null ? { hook_type: hookType } : {}),
+          error_mode: 'input_unavailable',
+          threshold_tripped: false,
+        });
+      }
       emitModelContext(adapter, buildNoOpResult(event));
       exitGraceful(options);
       return HOOK_EXIT_CODES.SUCCESS;

--- a/src/cli/hook-command.ts
+++ b/src/cli/hook-command.ts
@@ -24,6 +24,39 @@ export interface HookCommandOptions {
 }
 
 /**
+ * How long the fail-open path will wait for its telemetry POST.
+ *
+ * Short on purpose. `UserPromptSubmit` and `SessionStart` are synchronous, so
+ * every millisecond here is a millisecond the user waits — and this branch
+ * exists precisely to stop a hook that cannot read its stdin from costing them
+ * anything.
+ */
+export const NON_BLOCKING_TELEMETRY_DEADLINE_MS = 250;
+
+/**
+ * Resolve when `work` settles or when `ms` elapses, whichever is first.
+ *
+ * The abandoned promise is not cancelled — `captureCliEvent` never throws and
+ * never has a caller waiting on its result, so leaving it in flight until
+ * `process.exit` is exactly as harmless as the fire-and-forget it replaces.
+ */
+export async function raceDeadline(work: Promise<unknown>, ms: number): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      work,
+      new Promise<void>(resolve => {
+        timer = setTimeout(resolve, ms);
+        // Do not hold the event loop open for a deadline nobody is waiting on.
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
  * No-op result for hooks that must exit before their handler ran (adapter
  * rejected input, transcript path missing). `context` is the sole handler
  * key that produces SessionStart output on every platform; a bare
@@ -145,21 +178,28 @@ export async function hookCommand(platform: string, event: string, options: Hook
     }
     if (isNonBlockingHookInputError(error)) {
       logger.warn('HOOK', `Hook input unavailable, skipping hook: ${error instanceof Error ? error.message : error}`);
+      // Answer FIRST, report second. This branch exists so a hook that cannot
+      // read its own stdin never costs the user their prompt, and holding the
+      // response for a telemetry POST would reintroduce that cost in seconds
+      // instead of in a blocked submission.
+      emitModelContext(adapter, buildNoOpResult(event));
       // Failing open here used to be failing SILENT: before #3699 an
       // unreadable stdin fell through to the catch-all, which emitted
-      // hook_failed. Keep that signal so the maintainers still see these —
-      // the exit code changes, the reporting does not. Awaited for the same
-      // reason as the catch-all below: exitGraceful calls process.exit(0),
-      // which would kill a fire-and-forget POST mid-flight.
+      // hook_failed. The signal is kept, but on a leash — captureCliEvent is
+      // capped at 2s internally, which is 2s this particular hook does not
+      // have. Past the deadline the event is abandoned: one lost data point,
+      // against a UserPromptSubmit that stalls on every malformed stdin.
       {
         const hookType = getActiveHookType();
-        await captureCliEvent('hook_failed', {
-          ...(hookType !== null ? { hook_type: hookType } : {}),
-          error_mode: 'input_unavailable',
-          threshold_tripped: false,
-        });
+        await raceDeadline(
+          captureCliEvent('hook_failed', {
+            ...(hookType !== null ? { hook_type: hookType } : {}),
+            error_mode: 'input_unavailable',
+            threshold_tripped: false,
+          }),
+          NON_BLOCKING_TELEMETRY_DEADLINE_MS,
+        );
       }
-      emitModelContext(adapter, buildNoOpResult(event));
       exitGraceful(options);
       return HOOK_EXIT_CODES.SUCCESS;
     }

--- a/src/cli/stdin-reader.ts
+++ b/src/cli/stdin-reader.ts
@@ -1,6 +1,22 @@
 
 import { logger } from '../utils/logger.js';
 
+/**
+ * stdin could not be read as JSON — the bytes were truncated or malformed.
+ *
+ * Typed rather than message-sniffed because the classifier that decides
+ * whether a hook may exit non-zero has to be exact: on UserPromptSubmit and
+ * SessionStart (the two hooks registered without `async`) a blocking exit
+ * costs the user their prompt, so "is this an unreadable-input failure" must
+ * not hinge on wording that a later edit could drift away from. See #3699.
+ */
+export class HookInputUnreadable extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'HookInputUnreadable';
+  }
+}
+
 function isStdinAvailable(): boolean {
   try {
     const stdin = process.stdin;
@@ -83,7 +99,7 @@ export async function readJsonFromStdin(): Promise<unknown> {
       if (!resolved) {
         if (!tryResolveWithJson()) {
           if (input.trim()) {
-            rejectWith(new Error(`Incomplete JSON after ${SAFETY_TIMEOUT_MS}ms: ${input.slice(0, 100)}...`));
+            rejectWith(new HookInputUnreadable(`Incomplete JSON after ${SAFETY_TIMEOUT_MS}ms: ${input.slice(0, 100)}...`));
           } else {
             resolveWith(undefined);
           }
@@ -103,7 +119,7 @@ export async function readJsonFromStdin(): Promise<unknown> {
       if (!resolved) {
         if (!tryResolveWithJson()) {
           if (input.trim()) {
-            rejectWith(new Error(`Malformed JSON at stdin EOF: ${input.slice(0, 100)}...`));
+            rejectWith(new HookInputUnreadable(`Malformed JSON at stdin EOF: ${input.slice(0, 100)}...`));
           } else {
             resolveWith(undefined);
           }

--- a/src/npx-cli/commands/telemetry.ts
+++ b/src/npx-cli/commands/telemetry.ts
@@ -76,7 +76,7 @@ const COLLECTED_FIELDS = [
   'shutdown_reason  stop / restart / signal',
   'process_rss_mb / heap_used_mb   worker memory, integer megabytes',
   'hook_type        context / session-init / observation / summarize / file-context',
-  'error_mode       worker_unavailable / blocking_error (never a message)',
+  'error_mode       worker_unavailable / blocking_error / input_unavailable (never a message)',
   'consecutive_failures   hook failures in a row (the fail-loud counter)',
   'threshold_tripped      whether the fail-loud threshold was reached',
 ];

--- a/src/services/telemetry/scrub.ts
+++ b/src/services/telemetry/scrub.ts
@@ -111,8 +111,9 @@ export const ALLOWED_PROPERTY_KEYS: Set<string> = new Set([
   'heap_used_mb',
   // hook_failed distress signal — hook_type is one of OUR hook names
   // (context | session-init | observation | summarize | file-context),
-  // error_mode (worker_unavailable | blocking_error), plus a consecutive
-  // failure counter and threshold flag. Never an error message.
+  // error_mode (worker_unavailable | blocking_error | input_unavailable),
+  // plus a consecutive failure counter and threshold flag. Never an error
+  // message.
   'hook_type',
   'error_mode',
   'consecutive_failures',

--- a/tests/cli/stdin-reader.test.ts
+++ b/tests/cli/stdin-reader.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, afterEach } from 'bun:test';
 import { Readable } from 'stream';
 
-import { readJsonFromStdin } from '../../src/cli/stdin-reader.js';
+import { readJsonFromStdin, HookInputUnreadable } from '../../src/cli/stdin-reader.js';
 
 const realStdin = process.stdin;
 const realStdinDescriptor = Object.getOwnPropertyDescriptor(process, 'stdin');
@@ -47,5 +47,13 @@ describe('readJsonFromStdin — onEnd contract (#2089)', () => {
   it('rejects when stdin closes with junk that is clearly not JSON', async () => {
     installFakeStdin('not json at all');
     await expect(readJsonFromStdin()).rejects.toThrow(/Malformed JSON at stdin EOF/);
+  });
+
+  // The class, not the wording, is what hook-command keys off to decide the
+  // hook may not exit 2 (#3699). Asserting the message alone would let a
+  // reworded throw silently go back to eating the user's prompt.
+  it('rejects with a typed HookInputUnreadable so the classifier cannot drift', async () => {
+    installFakeStdin('{"truncated":');
+    await expect(readJsonFromStdin()).rejects.toBeInstanceOf(HookInputUnreadable);
   });
 });

--- a/tests/hook-command.test.ts
+++ b/tests/hook-command.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from 'bun:test';
-import { buildNoOpResult, isNonBlockingHookInputError, isWorkerUnavailableError } from '../src/cli/hook-command.js';
+import { describe, it, expect, afterEach } from 'bun:test';
+import { Readable } from 'stream';
+import { buildNoOpResult, hookCommand, isNonBlockingHookInputError, isWorkerUnavailableError } from '../src/cli/hook-command.js';
+import { HookInputUnreadable } from '../src/cli/stdin-reader.js';
+import { HOOK_EXIT_CODES } from '../src/shared/hook-constants.js';
 
 describe('buildNoOpResult', () => {
   it('attaches a valid SessionStart hookSpecificOutput for the context event (#2972)', () => {
@@ -43,6 +46,18 @@ describe('isNonBlockingHookInputError', () => {
   it('does not classify unrelated hook errors as non-blocking input errors', () => {
     expect(isNonBlockingHookInputError(new Error('Cannot read properties of undefined'))).toBe(false);
     expect(isNonBlockingHookInputError(new Error('Request failed: 400'))).toBe(false);
+  });
+
+  // #3699: stdin that never arrives as parseable JSON is an input failure,
+  // not a handler bug — the hook has nothing to work with and must fail open.
+  it('classifies unreadable stdin as a non-blocking hook input error', () => {
+    expect(isNonBlockingHookInputError(new HookInputUnreadable('Malformed JSON at stdin EOF: {...'))).toBe(true);
+    expect(isNonBlockingHookInputError(new HookInputUnreadable('Incomplete JSON after 30000ms: {...'))).toBe(true);
+  });
+
+  // A plain Error carrying the same text is NOT the signal — only the type is.
+  it('does not classify a look-alike message from an untyped throw', () => {
+    expect(isNonBlockingHookInputError(new Error('Malformed JSON at stdin EOF: {...'))).toBe(false);
   });
 });
 
@@ -195,4 +210,49 @@ describe('isWorkerUnavailableError', () => {
       expect(isWorkerUnavailableError(undefined)).toBe(false);
     });
   });
+});
+
+/**
+ * #3699 — the hook must not exit 2 when it cannot read its own stdin.
+ *
+ * In plugin/hooks/hooks.json, PostToolUse / PreToolUse / Stop all carry
+ * `"async": true`, so Claude Code backgrounds them and synthesises status 0.
+ * UserPromptSubmit (session-init) and SessionStart (context) do NOT, so their
+ * real exit code is read — and on UserPromptSubmit an exit of 2 blocks the
+ * submission and discards what the user typed.
+ *
+ * Driving hookCommand end to end (rather than the predicate alone) is what
+ * makes these regression tests: stdin is rejected before any handler runs, so
+ * no worker is contacted and the assertion is purely about the exit contract.
+ */
+describe('hookCommand exit contract on unreadable stdin (#3699)', () => {
+  const realStdinDescriptor = Object.getOwnPropertyDescriptor(process, 'stdin');
+
+  function installFakeStdin(payload: string): void {
+    const fake = Readable.from([payload], { objectMode: false }) as unknown as NodeJS.ReadStream;
+    Object.defineProperty(fake, 'isTTY', { value: false, configurable: true });
+    Object.defineProperty(process, 'stdin', { configurable: true, writable: true, value: fake });
+  }
+
+  afterEach(() => {
+    if (realStdinDescriptor) {
+      Object.defineProperty(process, 'stdin', realStdinDescriptor);
+    }
+  });
+
+  // The synchronously-registered hooks — the ones where exit 2 reaches the
+  // harness and costs the user something.
+  for (const event of ['session-init', 'context']) {
+    it(`exits 0 on truncated stdin for the ${event} hook`, async () => {
+      installFakeStdin('{"session_id":"s","cwd":"/tmp"');
+      const code = await hookCommand('claude-code', event, { skipExit: true });
+      expect(code).toBe(HOOK_EXIT_CODES.SUCCESS);
+    });
+
+    it(`exits 0 on stdin that is not JSON at all for the ${event} hook`, async () => {
+      installFakeStdin('not json at all');
+      const code = await hookCommand('claude-code', event, { skipExit: true });
+      expect(code).toBe(HOOK_EXIT_CODES.SUCCESS);
+    });
+  }
 });

--- a/tests/hook-command.test.ts
+++ b/tests/hook-command.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'bun:test';
 import { Readable } from 'stream';
-import { buildNoOpResult, hookCommand, isNonBlockingHookInputError, isWorkerUnavailableError } from '../src/cli/hook-command.js';
+import { buildNoOpResult, hookCommand, isNonBlockingHookInputError, isWorkerUnavailableError, NON_BLOCKING_TELEMETRY_DEADLINE_MS, raceDeadline } from '../src/cli/hook-command.js';
 import { HookInputUnreadable } from '../src/cli/stdin-reader.js';
 import { HOOK_EXIT_CODES } from '../src/shared/hook-constants.js';
 
@@ -255,4 +255,63 @@ describe('hookCommand exit contract on unreadable stdin (#3699)', () => {
       expect(code).toBe(HOOK_EXIT_CODES.SUCCESS);
     });
   }
+});
+
+/**
+ * Review on #3699 — the fail-open path must not be held by its own telemetry.
+ *
+ * The branch exists so a hook that cannot read stdin costs the user nothing.
+ * Awaiting an optional POST reintroduced that cost: with telemetry enabled and
+ * an endpoint that accepts but never answers, the no-op response was delayed by
+ * seconds on a synchronously-registered hook.
+ */
+describe('fail-open telemetry is on a deadline (#3699 review)', () => {
+  const realStdinDescriptor = Object.getOwnPropertyDescriptor(process, 'stdin');
+
+  function installFakeStdin(payload: string): void {
+    const fake = Readable.from([payload], { objectMode: false }) as unknown as NodeJS.ReadStream;
+    Object.defineProperty(fake, 'isTTY', { value: false, configurable: true });
+    Object.defineProperty(process, 'stdin', { configurable: true, writable: true, value: fake });
+  }
+
+  afterEach(() => {
+    if (realStdinDescriptor) {
+      Object.defineProperty(process, 'stdin', realStdinDescriptor);
+    }
+  });
+
+  it('keeps the deadline short enough to be invisible on a synchronous hook', () => {
+    // UserPromptSubmit and SessionStart are read for their real exit status,
+    // so this budget is time the user spends waiting.
+    expect(NON_BLOCKING_TELEMETRY_DEADLINE_MS).toBeLessThanOrEqual(500);
+  });
+
+  // Driving hookCommand would NOT prove this: telemetry consent is off under
+  // test, so captureCliEvent returns immediately and the branch is fast either
+  // way. The mechanism is what has to be pinned.
+  it('gives up on a POST that never answers', async () => {
+    const neverSettles = new Promise<void>(() => {});
+
+    const startedAt = Date.now();
+    await raceDeadline(neverSettles, 50);
+    const elapsed = Date.now() - startedAt;
+
+    expect(elapsed).toBeLessThan(1_000);
+  });
+
+  it('does not delay a POST that answers before the deadline', async () => {
+    const startedAt = Date.now();
+    await raceDeadline(Promise.resolve('sent'), 5_000);
+    const elapsed = Date.now() - startedAt;
+
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  it('still exits 0 on truncated stdin with the deadline in place', async () => {
+    installFakeStdin('{"session_id":"s","cwd":"/tmp"');
+
+    const code = await hookCommand('claude-code', 'session-init', { skipExit: true });
+
+    expect(code).toBe(HOOK_EXIT_CODES.SUCCESS);
+  });
 });


### PR DESCRIPTION
Fixes #3699.

## What happens today

`readJsonFromStdin` rejects when stdin closes on bytes that never parse as JSON. Nothing in `hookCommand` classified that rejection, so it fell through to the catch-all and exited **2**.

`plugin/hooks/hooks.json` is what makes that matter unevenly:

| hook | command | `async` |
|---|---|---|
| PostToolUse | `hook claude-code observation` | ✅ |
| PreToolUse | `hook claude-code file-context` | ✅ |
| Stop | `hook claude-code summarize` | ✅ |
| **UserPromptSubmit** | `hook claude-code session-init` | ❌ |
| **SessionStart** | `hook claude-code context` | ❌ |

Claude Code backgrounds config-async hooks and synthesises status 0, so the three at the top are contained. The bottom two are read for real — and on `UserPromptSubmit`, exit 2 blocks the submission and discards what the user typed.

I reproduced it in-process against `main` before changing anything, so this isn't inferred from the shipped bundle:

```
Hook error: Malformed JSON at stdin EOF: {"session_id":"abc","cwd":"/tmp"...
OBSERVED EXIT CODE = 2
```

## The change

`readJsonFromStdin` now throws a typed `HookInputUnreadable`, and `isNonBlockingHookInputError` recognises it alongside the existing missing-transcript case — routing it into the branch that already warns and exits 0.

The issue suggested matching on the message text. I went with a class instead, for one reason: the wording is a diagnostic string that a future edit may reasonably reword, and if it drifts the hook quietly goes back to eating prompts. There's a test asserting a plain `Error` carrying the identical text is *not* treated as non-blocking, so the type is doing the work, not the prose.

## One judgement call worth your eye

Because these rejections used to reach the catch-all, they used to emit `hook_failed` telemetry. Routing them to the non-blocking branch would have deleted that signal — my fix would have made a real bug **less** visible than it is today.

So the non-blocking branch now emits `hook_failed` too, under a new `error_mode: 'input_unavailable'` (documented in `scrub.ts` and the `telemetry` help text; the allowlist is keyed by property name, so no value validator needed changing). It's `await`ed for the same reason the catch-all is — `exitGraceful` calls `process.exit(0)` and would kill a fire-and-forget POST mid-flight.

Side effect to be aware of: this also starts emitting telemetry for the pre-existing missing-transcript case, which was silent before. That's the shared branch. **If you'd rather keep this to a pure exit-code fix, say so and I'll drop the telemetry hunk** — it's self-contained and the rest stands without it.

## Verification

Reverting **only** `hook-command.ts` (keeping the typed error, so it compiles) turns the new tests red with the exact signature:

```
Expected: true / Received: false
(fail) classifies unreadable stdin as a non-blocking hook input error

Expected: 0 / Received: 2
(fail) exits 0 on truncated stdin for the session-init hook
(fail) exits 0 on stdin that is not JSON at all for the session-init hook
(fail) exits 0 on truncated stdin for the context hook
(fail) exits 0 on stdin that is not JSON at all for the context hook

34 pass / 5 fail
```

With the fix applied: `bun test tests/hook-command.test.ts tests/cli tests/hooks tests/telemetry` → **320 pass / 0 fail**, and `tsc --noEmit` is clean.

The exit-contract tests drive `hookCommand` end to end rather than the predicate alone. That's deliberate and safe: stdin is rejected *before* any handler runs, so no worker is contacted and the assertion is purely about the exit code.

## Not included

- **No bundle rebuild.** `plugin/scripts/worker-service.cjs` is committed but built; I left it to your release step rather than committing a generated artifact — same as #3756. Happy to add it if you'd prefer the PR to be self-contained.
- **The `stop_hook_active` half of the issue.** The reporter is right that the `claude-code` adapter's `normalizeInput` drops the field while the codex one keeps it, so the summarize re-entry guard never fires. That's a separate defect with a separate blast radius, and I didn't want to bundle it into a prompt-loss fix. I can open it as its own PR if useful.
