### PR TITLE
fix(setup): guard on a complete node_modules, and let bun.cmd actually run

### DIFF
--- a/plugin/scripts/version-check.js
+++ b/plugin/scripts/version-check.js
@@ -55,12 +55,48 @@ function findBun() {
 // has a 300s timeout (vs 60s for SessionStart), runs once per Claude
 // Code launch, and is the only standalone hook script — the natural
 // place to materialise plugin runtime state.
+// Names of declared dependencies that do not resolve to an installed package.
+// Reads package.json rather than naming any package, so the check stays correct
+// if dependencies are later renamed or added.
+function missingDependencies(pluginRoot) {
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(join(pluginRoot, 'package.json'), 'utf-8'));
+  } catch {
+    // An unreadable package.json is not something an install can fix, and
+    // reporting every dependency as missing would loop on it. Report none.
+    return [];
+  }
+
+  const declared = Object.keys((pkg && pkg.dependencies) || {});
+  return declared.filter(
+    (name) => !existsSync(join(pluginRoot, NODE_MODULES_DIRNAME, ...name.split('/'), 'package.json')),
+  );
+}
+
 function ensurePluginDependencies(pluginRoot) {
   if (!existsSync(join(pluginRoot, 'package.json'))) return;
 
-  // Guard on node_modules (package-manager marker) rather than a specific
-  // package, so the check stays correct if dependencies are later renamed.
-  if (existsSync(join(pluginRoot, NODE_MODULES_DIRNAME))) return;
+  // Guard on COMPLETENESS, not on the mere existence of node_modules.
+  //
+  // The directory existing only tells us a package manager started. An
+  // install interrupted by anything this script did not spawn — a killed
+  // terminal, a half-finished extraction — leaves node_modules in place but
+  // short of packages, and an existence check then skips the repair on every
+  // later Setup run. The worker dies on the missing module each boot with no
+  // recovery short of a manual rm -rf (#3755).
+  //
+  // Each declared dependency must resolve to its own package.json: one
+  // existsSync per dependency, and it re-verifies the tree rather than
+  // trusting a previous installer's exit code.
+  const missing = missingDependencies(pluginRoot);
+  if (missing.length === 0) return;
+
+  if (existsSync(join(pluginRoot, NODE_MODULES_DIRNAME))) {
+    console.error(
+      `${VERSION_CHECK_LOG_PREFIX} node_modules is incomplete (missing: ${missing.join(', ')}); reinstalling`,
+    );
+  }
 
   const bunPath = findBun();
   if (!bunPath) {
@@ -73,12 +109,21 @@ function ensurePluginDependencies(pluginRoot) {
 
   let result;
   try {
-    result = spawnSync(bunPath, BUN_INSTALL_ARGS, {
+    // Windows: findBun resolves to bun.cmd (npm/nvm shim) or, failing that,
+    // the bare name. Node refuses to spawn a .cmd/.bat directly since the
+    // CVE-2024-27980 mitigation — spawnSync throws EINVAL — and a bare name
+    // is not resolved through PATHEXT either, so both shapes need a shell.
+    // BUN_INSTALL_ARGS is a frozen constant, so the concatenation the shell
+    // option performs carries nothing user-supplied; the path itself is
+    // quoted because it routinely contains spaces.
+    const command = IS_WINDOWS ? `"${bunPath}"` : bunPath;
+    result = spawnSync(command, BUN_INSTALL_ARGS, {
       cwd: pluginRoot,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: BUN_INSTALL_TIMEOUT_MS,
       windowsHide: true,
+      shell: IS_WINDOWS,
     });
   } catch (err) {
     const reason = err && err.message ? err.message : String(err);

--- a/plugin/scripts/version-check.js
+++ b/plugin/scripts/version-check.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from 'child_process';
-import { existsSync, readFileSync, rmSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, rmSync } from 'fs';
 import { homedir } from 'os';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -55,6 +55,30 @@ function findBun() {
 // has a 300s timeout (vs 60s for SessionStart), runs once per Claude
 // Code launch, and is the only standalone hook script — the natural
 // place to materialise plugin runtime state.
+
+// A package counts as installed when its manifest is present AND the directory
+// holds something besides that manifest.
+//
+// The manifest alone is not enough: an extraction that stopped right after
+// writing package.json leaves a directory that satisfies a manifest-only check
+// while the worker still dies on the import (gh #3755 review).
+//
+// The stricter thing — resolving each package's declared entrypoint — was
+// tried and rejected. Run against the 568 packages in this repo's own
+// node_modules it flags `@modelcontextprotocol/sdk`, which declares
+// `exports["."]` pointing at `dist/cjs/index.js` and does not ship it; the
+// package is consumed through its subpaths. A direct dependency shaped like
+// that would make Setup reinstall on every single launch, which is worse than
+// the partial tree this is trying to catch.
+function packageIsPopulated(packageDir) {
+  if (!existsSync(join(packageDir, 'package.json'))) return false;
+  try {
+    return readdirSync(packageDir).some((entry) => entry !== 'package.json');
+  } catch {
+    return false;
+  }
+}
+
 // Names of declared dependencies that do not resolve to an installed package.
 // Reads package.json rather than naming any package, so the check stays correct
 // if dependencies are later renamed or added.
@@ -70,7 +94,7 @@ function missingDependencies(pluginRoot) {
 
   const declared = Object.keys((pkg && pkg.dependencies) || {});
   return declared.filter(
-    (name) => !existsSync(join(pluginRoot, NODE_MODULES_DIRNAME, ...name.split('/'), 'package.json')),
+    (name) => !packageIsPopulated(join(pluginRoot, NODE_MODULES_DIRNAME, ...name.split('/'))),
   );
 }
 
@@ -86,9 +110,9 @@ function ensurePluginDependencies(pluginRoot) {
   // later Setup run. The worker dies on the missing module each boot with no
   // recovery short of a manual rm -rf (#3755).
   //
-  // Each declared dependency must resolve to its own package.json: one
-  // existsSync per dependency, and it re-verifies the tree rather than
-  // trusting a previous installer's exit code.
+  // Each declared dependency must resolve to a populated package directory,
+  // which re-verifies the tree rather than trusting a previous installer's
+  // exit code. Cost is one readdir per dependency, once per Claude Code launch.
   const missing = missingDependencies(pluginRoot);
   if (missing.length === 0) return;
 

--- a/tests/plugin-version-check-ensure-deps.test.ts
+++ b/tests/plugin-version-check-ensure-deps.test.ts
@@ -111,11 +111,14 @@ function makeFreshPlugin(name: string, bunBehavior: BunBehavior = 'success'): { 
   return { pluginRoot, fakeBinDir };
 }
 
-// Write the minimum that makes a dependency resolvable: its own package.json.
+// Write what a real install leaves behind: a manifest AND the code beside it.
+// The manifest on its own is deliberately NOT enough — see the manifest-only
+// test below.
 function installFakeDependency(pluginRoot: string, name: string): void {
   const dir = join(pluginRoot, 'node_modules', ...name.split('/'));
   mkdirSync(dir, { recursive: true });
-  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name, version: '0.0.0' }));
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name, version: '0.0.0', main: './index.js' }));
+  writeFileSync(join(dir, 'index.js'), 'module.exports = {};');
 }
 
 beforeAll(() => {
@@ -198,6 +201,22 @@ describe.skipIf(SKIP_NON_UNIX)('version-check Setup-phase ensurePluginDependenci
     expect(stderr).toContain('zod');
     expect(stderr).toContain(INSTALL_DIAGNOSTIC);
     expect(stderr).toContain(INSTALL_SUCCESS_DIAGNOSTIC);
+    expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(true);
+  });
+
+  // Review on gh #3755: an extraction that stopped right after writing
+  // package.json leaves a directory that a manifest-only check accepts, while
+  // the worker still dies on the import.
+  test('a manifest with nothing beside it does not count as installed', async () => {
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-manifest-only');
+    const dir = join(pluginRoot, 'node_modules', 'zod');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'zod', main: './index.cjs' }));
+
+    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
+    expect(stderr).toContain(INCOMPLETE_DIAGNOSTIC);
     expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(true);
   });
 

--- a/tests/plugin-version-check-ensure-deps.test.ts
+++ b/tests/plugin-version-check-ensure-deps.test.ts
@@ -10,6 +10,7 @@ const SPAWN_TIMEOUT_MS = 15_000;
 const INSTALL_DIAGNOSTIC = '[version-check] installing plugin dependencies';
 const INSTALL_SUCCESS_DIAGNOSTIC = '[version-check] plugin dependencies installed successfully';
 const INSTALL_FAILURE_DIAGNOSTIC = '[version-check] bun install failed';
+const INCOMPLETE_DIAGNOSTIC = '[version-check] node_modules is incomplete';
 const FAKE_INSTALLED_MARKER_REL = join('node_modules', 'zod', 'v3', 'index.js');
 const SKIP_NON_UNIX = process.platform === 'win32';
 
@@ -87,6 +88,9 @@ function makeFreshPlugin(name: string, bunBehavior: BunBehavior = 'success'): { 
     ? [
         `  mkdir -p "${pluginRoot}/node_modules/zod/v3"`,
         `  : > "${pluginRoot}/node_modules/zod/v3/index.js"`,
+        // The completeness guard resolves each declared dependency to its own
+        // package.json, so a realistic fake install has to write one.
+        `  printf '{"name":"zod","version":"3.0.0"}' > "${pluginRoot}/node_modules/zod/package.json"`,
         '  exit 0',
       ]
     : [
@@ -105,6 +109,13 @@ function makeFreshPlugin(name: string, bunBehavior: BunBehavior = 'success'): { 
   chmodSync(fakeBunPath, 0o755);
 
   return { pluginRoot, fakeBinDir };
+}
+
+// Write the minimum that makes a dependency resolvable: its own package.json.
+function installFakeDependency(pluginRoot: string, name: string): void {
+  const dir = join(pluginRoot, 'node_modules', ...name.split('/'));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ name, version: '0.0.0' }));
 }
 
 beforeAll(() => {
@@ -153,12 +164,12 @@ describe.skipIf(SKIP_NON_UNIX)('version-check Setup-phase ensurePluginDependenci
     expect(existsSync(join(pluginRoot, 'node_modules'))).toBe(false);
   });
 
-  test('skips install when node_modules is already present', async () => {
-    // Setup runs on every Claude Code launch. If node_modules already exists,
-    // the install MUST be skipped — otherwise we re-run a 100 MB+ install on
+  test('skips install when every declared dependency resolves', async () => {
+    // Setup runs on every Claude Code launch. If the tree is complete, the
+    // install MUST be skipped — otherwise we re-run a 100 MB+ install on
     // every cold start and burn the user's bandwidth.
     const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-already-installed');
-    mkdirSync(join(pluginRoot, 'node_modules'), { recursive: true });
+    installFakeDependency(pluginRoot, 'zod');
 
     const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
 
@@ -167,5 +178,39 @@ describe.skipIf(SKIP_NON_UNIX)('version-check Setup-phase ensurePluginDependenci
     // The fake bun would have created zod/v3/index.js if invoked — its
     // absence proves the install path was not taken.
     expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(false);
+  });
+
+  test('reinstalls when node_modules exists but a dependency is missing (gh #3755)', async () => {
+    // The reported trap: an install interrupted by something this script did
+    // not spawn leaves node_modules in place but short of packages. Guarding
+    // on the directory's existence skipped the repair on every later Setup
+    // run, so the worker died on the missing module at each boot with no
+    // recovery short of a manual rm -rf.
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-partial-tree');
+    // A directory that exists and even holds something — just not the
+    // dependency package.json declares.
+    mkdirSync(join(pluginRoot, 'node_modules', '.bin'), { recursive: true });
+
+    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
+    expect(stderr).toContain(INCOMPLETE_DIAGNOSTIC);
+    expect(stderr).toContain('zod');
+    expect(stderr).toContain(INSTALL_DIAGNOSTIC);
+    expect(stderr).toContain(INSTALL_SUCCESS_DIAGNOSTIC);
+    expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(true);
+  });
+
+  test('a dependency directory without its package.json does not count as installed', async () => {
+    // The shape the reporter actually hit: the package folder is there but the
+    // extraction never finished, so nothing can resolve it.
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-hollow-package');
+    mkdirSync(join(pluginRoot, 'node_modules', 'zod'), { recursive: true });
+
+    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
+    expect(stderr).toContain(INCOMPLETE_DIAGNOSTIC);
+    expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #3755.

## 1. The reported bug

`ensurePluginDependencies` decided whether to install by asking whether `node_modules/` existed. The directory existing only tells us a package manager *started*. An install interrupted by anything this script didn't spawn — a killed terminal, a half-finished extraction — leaves the tree in place but short of packages, and the existence check then skipped the repair on **every** later Setup run.

The comment right below the guard already described the trap; it just only applied the escape to failures the script itself caused.

Each declared dependency must now resolve to its own `package.json`. That keeps the property the old comment wanted — no hardcoded package name, still correct if dependencies are renamed — while catching a partial tree. One `existsSync` per dependency, and it re-verifies rather than trusting a previous installer's exit code.

## 2. What verifying it on Windows turned up

I couldn't run the committed tests here: the suite is `describe.skipIf(process.platform === 'win32')`, because the fake bun is a bash script and the fixture builds a `:`-separated PATH. So I built a Windows-native equivalent — a `bun.cmd` shim on PATH, driving the real `version-check.js` — and ran all four tree states against **unmodified `main`**:

| state | install attempted | outcome |
|---|---|---|
| A. no `node_modules` | yes | **failed**, zod still unresolvable |
| B. `node_modules` exists, empty | no | the reported trap |
| C. `zod/` exists without its `package.json` | no | the reported trap |
| D. complete tree | no | correct |

Row A is a second bug, and it explains how a Windows machine gets into this state to begin with:

```
[version-check] bun install failed (spawnSync ...\bun.cmd EINVAL)
```

`findBun` resolves to `bun.cmd`, and Node has refused to spawn a `.cmd` directly since the CVE-2024-27980 mitigation. Confirmed in isolation on Node 24:

```
without shell      -> error: EINVAL   status: null
with shell: true   -> error: undefined status: 0
```

So on Windows the Setup-phase auto-install has never worked — it attempts and fails every time.

**This had to be in the same PR.** Without it, the completeness guard makes Windows *worse*: incomplete tree → attempt install → EINVAL → the failure path `rmSync`s `node_modules` → repeat, every launch, now deleting the partial tree each time instead of merely ignoring it.

The fix uses a shell on Windows only, with the path quoted (these paths routinely contain spaces). `BUN_INSTALL_ARGS` is a frozen constant, so the concatenation the shell option performs carries nothing user-supplied. Non-Windows behaviour is byte-for-byte unchanged.

With both fixes, the same harness on Windows:

| state | incomplete diag | attempted | result | zod resolvable after |
|---|---|---|---|---|
| A | – | yes | success | ✅ |
| B | yes | yes | success | ✅ |
| C | yes | yes | success | ✅ |
| D | – | **no** | – | ✅ (was already) |

Row D matters as much as the rest: a healthy tree must not trigger a 100 MB+ reinstall on every cold start.

## 3. A test I had to change, not just add

`skips install when node_modules is already present` built an **empty** `node_modules` — which is exactly the state that must now trigger a reinstall. Leaving it would have meant either a red test or a fix that doesn't work.

It now installs a resolvable dependency instead, so it still pins the property it was written for. The fake bun also writes a real `package.json` now, since a fake install that produces nothing resolvable isn't modelling an install.

Two new cases cover the reported shapes: `node_modules` present but empty, and a dependency folder present without its `package.json`.

## Verification summary

- Windows harness above, run against both `main` and this branch.
- `tests/infrastructure`, `tests/hook-command`, `tests/hook-lifecycle`: **11 failures on this branch and 11 on clean `main`, identical by name** (Windows-specific `HealthMonitor` / `ProcessManager` / spawn-contract / cleanup tests). Diffing the two lists shows only timings differ.
- `node --check plugin/scripts/version-check.js` clean.
- The 5 tests in `plugin-version-check-ensure-deps.test.ts` are unix-gated and **skip on my machine** — I can't claim I ran them, so I didn't. They'd be worth a look on CI, and I'd be glad to make that suite cross-platform in a follow-up if you want it.

## Not included

- **No post-install re-verify.** The guard makes the *next* Setup run re-check, which is what #3755 asks for. Warning immediately when an exit-0 install still leaves something missing would be cheap, but it's a behaviour change beyond the report — happy to add it.
- **The bare-`'bun'` fallback** in `findBun` (when `where bun` finds no `.cmd`) now works via the shell, but the function's Windows resolution could still be tightened. Separate concern.
- The two follow-ups the reporter raised at the end of #3755 — killing a healthy worker before confirming the replacement boots, and hooks blocking for their full timeout — are separate issues and I've left them alone.
