### PR TITLE
fix(observer): strip image payloads out of the observation prompt

### DIFF
--- a/src/sdk/prompts.ts
+++ b/src/sdk/prompts.ts
@@ -137,9 +137,16 @@ function stripImagePayloads(value: unknown, depth = 0): unknown {
   const record = value as Record<string, unknown>;
 
   // Anthropic content block: { type: 'image', source: { data: '<base64>' } }.
+  // A url-backed source is the same case as OpenAI's plain http URL — short,
+  // and it carries signal — so only an inlined payload is removed.
   const source = record.source;
   if (record.type === 'image' && source !== null && typeof source === 'object') {
-    return { type: 'image', source: elideImageSource(source as Record<string, unknown>) };
+    const record_source = source as Record<string, unknown>;
+    const url = record_source.url;
+    if (typeof url === 'string' && !url.startsWith('data:')) {
+      return value;
+    }
+    return { type: 'image', source: elideImageSource(record_source) };
   }
 
   // OpenAI content block: { type: 'image_url', image_url: { url: 'data:...' } }.

--- a/src/sdk/prompts.ts
+++ b/src/sdk/prompts.ts
@@ -104,6 +104,66 @@ const OBS_PROMPT_FIELD_MAX_CHARS = 16_000;
 const OBS_PROMPT_FIELD_HEAD_RATIO = 0.6;
 const OBS_PROMPT_FIELD_TAIL_RATIO = 0.3;
 
+// Image content blocks carry base64 payloads that are worthless to a text
+// observer and ruinously expensive to carry. Two things compound (#3730):
+// truncateObservationField keeps the head and tail of an oversized field, so
+// what survives a screenshot is thousands of characters of base64 rather than
+// the caption beside it; and the prompt is appended to
+// session.conversationHistory, which every later observation in the session
+// re-sends in full. A browser-automation session taking a few hundred
+// screenshots replays all of it, every time.
+//
+// Stripping generically, on the shape of the content block, rather than by
+// tool name: CLAUDE_MEM_SKIP_TOOLS needs every screenshot-producing tool
+// enumerated ahead of time, and it drops the observation entirely instead of
+// keeping the part that has signal.
+const MAX_SANITIZE_DEPTH = 12;
+
+function elideImageSource(source: Record<string, unknown>): Record<string, unknown> {
+  const data = source.data;
+  const elided: Record<string, unknown> = { elided: 'image data withheld from the observer' };
+  if (typeof source.media_type === 'string') elided.media_type = source.media_type;
+  if (typeof data === 'string') elided.bytes = data.length;
+  return elided;
+}
+
+function stripImagePayloads(value: unknown, depth = 0): unknown {
+  if (depth > MAX_SANITIZE_DEPTH || value === null || typeof value !== 'object') return value;
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => stripImagePayloads(entry, depth + 1));
+  }
+
+  const record = value as Record<string, unknown>;
+
+  // Anthropic content block: { type: 'image', source: { data: '<base64>' } }.
+  const source = record.source;
+  if (record.type === 'image' && source !== null && typeof source === 'object') {
+    return { type: 'image', source: elideImageSource(source as Record<string, unknown>) };
+  }
+
+  // OpenAI content block: { type: 'image_url', image_url: { url: 'data:...' } }.
+  const imageUrl = record.image_url;
+  if (record.type === 'image_url' && imageUrl !== null && typeof imageUrl === 'object') {
+    const url = (imageUrl as Record<string, unknown>).url;
+    // A plain http(s) URL is short and can carry signal; only a data: URL is
+    // the inlined payload this exists to remove.
+    if (typeof url === 'string' && url.startsWith('data:')) {
+      return {
+        type: 'image_url',
+        image_url: { elided: 'image data withheld from the observer', bytes: url.length },
+      };
+    }
+    return value;
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(record)) {
+    out[key] = stripImagePayloads(entry, depth + 1);
+  }
+  return out;
+}
+
 function truncateObservationField(value: unknown, maxChars: number = OBS_PROMPT_FIELD_MAX_CHARS): string {
   // JSON.stringify returns undefined for undefined / functions / symbols;
   // fall back to empty string so the call sites (template literal output)
@@ -143,8 +203,8 @@ export function buildObservationPrompt(obs: Observation): string {
   return `<observed_from_primary_session>
   <what_happened>${obs.tool_name}</what_happened>
   <occurred_at>${new Date(obs.created_at_epoch).toISOString()}</occurred_at>${obs.cwd ? `\n  <working_directory>${obs.cwd}</working_directory>` : ''}
-  <parameters>${truncateObservationField(toolInput)}</parameters>
-  <outcome>${truncateObservationField(toolOutput)}</outcome>
+  <parameters>${truncateObservationField(stripImagePayloads(toolInput))}</parameters>
+  <outcome>${truncateObservationField(stripImagePayloads(toolOutput))}</outcome>
 </observed_from_primary_session>
 
 If a <parameters> or <outcome> block above contains an "<elided chars=... />" marker, that field was truncated to fit the observer's context window. Describe only what you can see in the kept portion and do not infer details about the elided range.

--- a/tests/sdk/prompts.test.ts
+++ b/tests/sdk/prompts.test.ts
@@ -55,3 +55,138 @@ describe('buildObservationPrompt oversized field truncation (#2468)', () => {
     expect(prompt).not.toContain('reason="oversize"');
   });
 });
+
+describe('buildObservationPrompt image-payload stripping (#3730)', () => {
+  const BASE64 = 'iVBORw0KGgoAAAANSUhEUg' + 'A'.repeat(200_000);
+
+  function screenshotOutcome() {
+    return JSON.stringify({
+      content: [
+        { type: 'text', text: 'Took a screenshot of the viewport at 1280x720.' },
+        { type: 'image', source: { type: 'base64', media_type: 'image/png', data: BASE64 } },
+      ],
+    });
+  }
+
+  it('keeps no base64 run from an Anthropic image content block', () => {
+    const prompt = buildObservationPrompt({
+      id: 1,
+      tool_name: 'mcp__claude-in-chrome__computer',
+      tool_input: JSON.stringify({ action: 'screenshot' }),
+      tool_output: screenshotOutcome(),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    // Truncation alone did NOT solve this: it keeps the head and tail of an
+    // oversized field, so a screenshot used to survive as thousands of
+    // characters of base64 rather than as the caption beside it.
+    expect(/A{200,}/.test(prompt)).toBe(false);
+    expect(prompt).not.toContain('iVBORw0KGgo');
+  });
+
+  it('keeps the text that sits beside the image', () => {
+    const prompt = buildObservationPrompt({
+      id: 2,
+      tool_name: 'mcp__claude-in-chrome__computer',
+      tool_input: JSON.stringify({ action: 'screenshot' }),
+      tool_output: screenshotOutcome(),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    // Stripping must not degrade into skipping: the caption is the part the
+    // observer can actually narrate.
+    expect(prompt).toContain('Took a screenshot of the viewport');
+  });
+
+  it('says what was removed instead of removing it silently', () => {
+    const prompt = buildObservationPrompt({
+      id: 3,
+      tool_name: 'mcp__claude-in-chrome__computer',
+      tool_input: JSON.stringify({ action: 'screenshot' }),
+      tool_output: screenshotOutcome(),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(prompt).toContain('image data withheld from the observer');
+    expect(prompt).toContain('image/png');
+  });
+
+  it('collapses the prompt far below the per-field truncation cap', () => {
+    const prompt = buildObservationPrompt({
+      id: 4,
+      tool_name: 'mcp__claude-in-chrome__browser_batch',
+      tool_input: JSON.stringify({ action: 'screenshot' }),
+      tool_output: screenshotOutcome(),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    // The prompt is appended to session.conversationHistory and re-sent by
+    // every later observation in the session, so this saving compounds.
+    expect(prompt.length).toBeLessThan(2_000);
+  });
+
+  it('strips images nested inside arrays and objects', () => {
+    const prompt = buildObservationPrompt({
+      id: 5,
+      tool_name: 'mcp__browser__batch',
+      tool_input: JSON.stringify({ steps: [{ shot: { type: 'image', source: { data: BASE64 } } }] }),
+      tool_output: JSON.stringify({
+        results: { pages: [{ blocks: [{ type: 'image', source: { data: BASE64 } }] }] },
+      }),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(/A{200,}/.test(prompt)).toBe(false);
+  });
+
+  it('strips an OpenAI-style inlined data: URL', () => {
+    const prompt = buildObservationPrompt({
+      id: 6,
+      tool_name: 'some_openai_tool',
+      tool_input: JSON.stringify({}),
+      tool_output: JSON.stringify({
+        content: [{ type: 'image_url', image_url: { url: 'data:image/png;base64,' + BASE64 } }],
+      }),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(/A{200,}/.test(prompt)).toBe(false);
+    expect(prompt).toContain('image data withheld from the observer');
+  });
+
+  it('leaves a plain http image URL alone — it is short and it carries signal', () => {
+    const prompt = buildObservationPrompt({
+      id: 7,
+      tool_name: 'some_openai_tool',
+      tool_input: JSON.stringify({}),
+      tool_output: JSON.stringify({
+        content: [{ type: 'image_url', image_url: { url: 'https://example.com/shot.png' } }],
+      }),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(prompt).toContain('https://example.com/shot.png');
+  });
+
+  it('does not touch ordinary tool output', () => {
+    const prompt = buildObservationPrompt({
+      id: 8,
+      tool_name: 'exec_command',
+      tool_input: JSON.stringify({ cmd: 'pwd' }),
+      tool_output: JSON.stringify({ output: '/repo', type: 'image_of_the_day' }),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(prompt).toContain('/repo');
+    expect(prompt).toContain('image_of_the_day');
+    expect(prompt).not.toContain('withheld');
+  });
+});

--- a/tests/sdk/prompts.test.ts
+++ b/tests/sdk/prompts.test.ts
@@ -190,3 +190,41 @@ describe('buildObservationPrompt image-payload stripping (#3730)', () => {
     expect(prompt).not.toContain('withheld');
   });
 });
+
+describe('buildObservationPrompt keeps url-backed image sources (#3730 review)', () => {
+  it('leaves an Anthropic url source alone, the same as the OpenAI branch does', () => {
+    const prompt = buildObservationPrompt({
+      id: 9,
+      tool_name: 'mcp__browser__shot',
+      tool_input: JSON.stringify({}),
+      tool_output: JSON.stringify({
+        content: [
+          { type: 'image', source: { type: 'url', url: 'https://example.com/shot.png' } },
+        ],
+      }),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(prompt).toContain('https://example.com/shot.png');
+    expect(prompt).not.toContain('withheld');
+  });
+
+  it('still elides an Anthropic source whose url is an inlined data: URL', () => {
+    const prompt = buildObservationPrompt({
+      id: 10,
+      tool_name: 'mcp__browser__shot',
+      tool_input: JSON.stringify({}),
+      tool_output: JSON.stringify({
+        content: [
+          { type: 'image', source: { type: 'url', url: 'data:image/png;base64,' + 'A'.repeat(100_000) } },
+        ],
+      }),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(/A{200,}/.test(prompt)).toBe(false);
+    expect(prompt).toContain('image data withheld from the observer');
+  });
+});


### PR DESCRIPTION
Fixes #3730.

## Measured, before anything was changed

One screenshot-shaped `tool_result` through `buildObservationPrompt` on `main`:

```
prompt chars:              15,460
longest base64 run kept:    9,338
```

The per-field truncation at 16,000 chars doesn't save you here — it keeps the **head and tail** of the oversized field, so what survives a screenshot is thousands of characters of base64, while the caption next to it is a few dozen.

After:

```
prompt chars:               1,277
longest base64 run kept:        0
kept the text block:         true
```

## Why the reported cost is 10-20x rather than 1.2x

The issue attributes the blowup to base64 being dense, which is true but not the whole mechanism. The prompt is pushed onto `session.conversationHistory`, and `query(session.conversationHistory, config)` sends the **whole history** on every later observation in the session.

So a screenshot isn't billed once. It's billed again on every subsequent observation in that session. At the reporter's 210 + 52 image results and ~9.3K of surviving base64 each, the tail of the session is re-sending millions of characters of noise per call — which is what puts a single observation at 400K-1M `discovery_tokens` against a 30K-50K baseline, and it's why the effect scales with how screenshot-heavy the session was rather than with any one tool call.

## The fix

`stripImagePayloads` walks the parsed tool input/output and elides image payloads before truncation:

- **Anthropic** `{ type: 'image', source: { data: '<base64>' } }` → `{ type: 'image', source: { elided: …, media_type, bytes } }`
- **OpenAI** `{ type: 'image_url', image_url: { url: 'data:…' } }` → same treatment
- **A plain `https://…` image URL is left alone** — it's short and it carries signal. Only an inlined `data:` URL is the payload this exists to remove.

Three deliberate choices:

1. **Generic on the block shape, not on tool name.** `CLAUDE_MEM_SKIP_TOOLS` needs every screenshot-producing tool enumerated ahead of time — the reporter's workaround covers the one browser MCP they happen to use — and it drops the whole observation instead of keeping the part with signal.
2. **Strip, don't skip.** The caption beside the image ("Took a screenshot of the viewport at 1280x720") is exactly what a text observer can narrate. There's a test pinning that it survives.
3. **Say what was removed.** The placeholder reports `media_type` and byte count, so a silently-thinner context doesn't become its own mystery.

It's in `buildObservationPrompt`, so all three providers (Claude, Gemini, OpenRouter) get it from one place.

## Verification

`tests/sdk/prompts.test.ts`, 8 new tests. Reverting only `src/sdk/prompts.ts` turns **5 of them red**:

```
(fail) keeps no base64 run from an Anthropic image content block
(fail) says what was removed instead of removing it silently
(fail) collapses the prompt far below the per-field truncation cap
(fail) strips images nested inside arrays and objects
(fail) strips an OpenAI-style inlined data: URL

6 pass / 5 fail
```

The other three pass both ways on purpose — they're the guards against over-stripping: the sibling text survives, a plain http URL survives, and ordinary tool output (including a field that merely *starts with* `image_`) is untouched.

`bun test tests/sdk tests/worker/agents tests/hook-command.test.ts` → **125 pass / 0 fail**. `tsc --noEmit` clean.

## Notes

- **Nothing is stripped from what's stored** — only from the prompt handed to the observer. Storage and the transcript are untouched.
- The reporter offered to test against the session that reproduces it. That'd be worth taking up: my measurement is a synthetic tool_result shaped like Claude Code's, so it pins the mechanism but not their exact payload shapes.
- A depth cap of 12 bounds the walk. Parsed JSON can't be cyclic, but the field can also arrive as an object that was never serialised.
- If you'd ever want vision context deliberately, this is the right seam for it — the block is identified here rather than being lost in a byte stream.
