### PR TITLE
fix(mcp): scope memory reads to the current repository

### DIFF
--- a/src/servers/mcp-server.ts
+++ b/src/servers/mcp-server.ts
@@ -39,6 +39,49 @@ import {
 } from '../services/hooks/runtime-selector.js';
 import { normalizePlatformSource } from '../shared/platform-source.js';
 import { getAdvertisedMcpToolsForRuntime } from './mcp-tool-visibility.js';
+import { getProjectContext } from '../utils/project-name.js';
+
+function scopeMemoryArgs(args: any, toolName: string): any {
+  const projectContext = getProjectContext(process.cwd());
+  const currentProject = projectContext.primary;
+  const requestedProject = typeof args?.project === 'string' ? args.project.trim() : '';
+  const allowCrossProject = process.env.CLAUDE_MEM_ALLOW_CROSS_PROJECT_SEARCH === '1';
+  const serverPath = (process.argv[1] ?? '').replace(/\\/g, '/').toLowerCase();
+  const currentPlatformSource = serverPath.includes('/.codex/plugins/')
+    ? 'codex'
+    : serverPath.includes('/.claude/plugins/') ? 'claude' : '';
+  const requestedPlatformSource = typeof args?.platformSource === 'string'
+    ? args.platformSource.trim().toLowerCase()
+    : '';
+  const allowCrossPlatform = process.env.CLAUDE_MEM_ALLOW_CROSS_PLATFORM_SEARCH === '1';
+  const scopedArgs = { ...args };
+
+  if (requestedProject === '*') {
+    if (!allowCrossProject) {
+      throw new Error(`${toolName}: cross-project memory access is disabled`);
+    }
+    delete scopedArgs.project;
+  } else {
+    if (requestedProject && !projectContext.allProjects.includes(requestedProject) && !allowCrossProject) {
+      throw new Error(
+        `${toolName}: project "${requestedProject}" is outside current repository "${currentProject}"`
+      );
+    }
+    scopedArgs.project = requestedProject || currentProject;
+  }
+
+  if (requestedPlatformSource && currentPlatformSource &&
+      requestedPlatformSource !== currentPlatformSource && !allowCrossPlatform) {
+    throw new Error(
+      `${toolName}: platform "${requestedPlatformSource}" is outside current platform "${currentPlatformSource}"`
+    );
+  }
+  if (currentPlatformSource) {
+    scopedArgs.platformSource = requestedPlatformSource || currentPlatformSource;
+  }
+
+  return scopedArgs;
+}
 
 let mcpServerDirResolutionFailed = false;
 const mcpServerDir = (() => {
@@ -490,6 +533,7 @@ NEVER fetch full details without filtering first. 10x token savings.`,
       additionalProperties: true
     },
     handler: async (args: any) => {
+      args = scopeMemoryArgs(args, 'search');
       // In server-beta runtime the local worker /api/search reads the local SQLite via
       // the Chroma-backed SearchOrchestrator. When the install runs server-beta (where
       // generated observations live in Postgres, not local SQLite) and Chroma is not
@@ -536,6 +580,7 @@ NEVER fetch full details without filtering first. 10x token savings.`,
       additionalProperties: true
     },
     handler: async (args: any) => {
+      args = scopeMemoryArgs(args, 'timeline');
       return await callWorker('/api/timeline', { query: args });
     }
   },
@@ -555,6 +600,7 @@ NEVER fetch full details without filtering first. 10x token savings.`,
       additionalProperties: true
     },
     handler: async (args: any) => {
+      args = scopeMemoryArgs(args, 'get_observations');
       return await callWorker('/api/observations/batch', { body: args });
     }
   },


### PR DESCRIPTION
This closes the default-global behavior on the worker-runtime MCP read path without relying on the model to remember a project filter

The MCP process already has the repository working directory, so this patch uses the existing `getProjectContext()` resolver before forwarding `search`, `timeline`, and `get_observations` requests to the worker

- omitted `project` defaults to the current repository
- the parent/worktree project chain remains allowed
- an explicitly foreign project fails closed by default
- `project: "*"` requires `CLAUDE_MEM_ALLOW_CROSS_PROJECT_SEARCH=1`
- Codex and Claude plugin installs default `platformSource` to their own host
- an explicitly foreign host fails closed unless `CLAUDE_MEM_ALLOW_CROSS_PLATFORM_SEARCH=1`
- hosts that cannot be identified from the installed server path keep their existing platform behavior

This is intentionally at the MCP boundary: direct worker HTTP callers retain their existing API semantics

Validation:

- `bun test tests/servers/mcp-tool-schemas.test.ts tests/servers/mcp-server-name-safety.test.ts` — 15 passed
- production MCP bundle built with esbuild and passed `node --check`
- stdio protocol smoke test confirmed repository defaulting and foreign-project rejection
- mixed-host smoke test confirmed an out-of-platform observation sharing the same project key was excluded from `search`, `timeline`, and `get_observations`

Closes #3764
Related to #1911, #3608, and #3611
