### PR TITLE
fix: mention Codex hook trust after install

### DIFF
--- a/src/services/integrations/CodexCliInstaller.ts
+++ b/src/services/integrations/CodexCliInstaller.ts
@@ -472,7 +472,8 @@ Plugin source:     ${marketplaceRoot}
 
 Next steps:
   1. Open Codex CLI in your project
-  2. Restart any running Codex sessions so native hooks are loaded
+  2. Review and trust the five claude-mem hooks when Codex prompts you
+  3. Restart sessions opened before trusting the hooks
 
 For a fresh setup, the supported entry point is:
   npx claude-mem@latest install

--- a/tests/install-non-tty.test.ts
+++ b/tests/install-non-tty.test.ts
@@ -187,6 +187,11 @@ describe('Install Non-TTY Support', () => {
       expect(installRegion).not.toContain('plugin_hooks');
     });
 
+    it('tells Codex users to trust the native hooks before restarting sessions', () => {
+      expect(codexInstallerSource).toContain('Review and trust the five claude-mem hooks when Codex prompts you');
+      expect(codexInstallerSource).toContain('Restart sessions opened before trusting the hooks');
+    });
+
     it('captures Codex CLI output for install failure reporting', () => {
       // codex is spawned through the centralized codexSpawn() helper (#2695:
       // shell-resolved on Windows so codex.cmd is found). The helper region


### PR DESCRIPTION
Codex keeps newly installed plugin hooks disabled until the user reviews them. The existing completion message only said to open Codex and restart sessions, which made a healthy install look like a broken observation pipeline.

This adds the missing trust step to the Codex installer output and clarifies that only sessions opened before approval need restarting. The source-copy test keeps that guidance from disappearing.

Tested with:

```
bun test tests/integration/codex-cli-installer.test.ts tests/install-non-tty.test.ts
```

Closes #3771