### PR TITLE
fix: guard on dependency completeness, not node_modules existence (fixes #3755)

### DIFF
--- a/plugin/scripts/version-check.js
+++ b/plugin/scripts/version-check.js
@@ -55,12 +55,22 @@ function findBun() {
 // has a 300s timeout (vs 60s for SessionStart), runs once per Claude
 // Code launch, and is the only standalone hook script — the natural
 // place to materialise plugin runtime state.
+function missingDeps(pluginRoot) {
+  const pkg = JSON.parse(readFileSync(join(pluginRoot, 'package.json'), 'utf-8'));
+  return Object.keys(pkg.dependencies || {}).filter(
+    (d) => !existsSync(join(pluginRoot, NODE_MODULES_DIRNAME, ...d.split('/'), 'package.json'))
+  );
+}
+
 function ensurePluginDependencies(pluginRoot) {
   if (!existsSync(join(pluginRoot, 'package.json'))) return;
 
-  // Guard on node_modules (package-manager marker) rather than a specific
-  // package, so the check stays correct if dependencies are later renamed.
-  if (existsSync(join(pluginRoot, NODE_MODULES_DIRNAME))) return;
+  // Guard on completeness rather than existence: verify every declared
+  // dependency has its own package.json inside node_modules, so a
+  // partially-populated directory (interrupted install, killed process,
+  // partial extraction) is caught and retried instead of being
+  // permanently skipped (gh #3755).
+  if (missingDeps(pluginRoot).length === 0) return;
 
   const bunPath = findBun();
   if (!bunPath) {

--- a/tests/plugin-version-check-ensure-deps.test.ts
+++ b/tests/plugin-version-check-ensure-deps.test.ts
@@ -153,12 +153,16 @@ describe.skipIf(SKIP_NON_UNIX)('version-check Setup-phase ensurePluginDependenci
     expect(existsSync(join(pluginRoot, 'node_modules'))).toBe(false);
   });
 
-  test('skips install when node_modules is already present', async () => {
-    // Setup runs on every Claude Code launch. If node_modules already exists,
-    // the install MUST be skipped — otherwise we re-run a 100 MB+ install on
-    // every cold start and burn the user's bandwidth.
+  test('skips install when all dependencies are present', async () => {
+    // Setup runs on every Claude Code launch. If all declared dependencies
+    // already have their package.json inside node_modules, the install MUST
+    // be skipped, otherwise we re-run a 100 MB+ install on every cold start
+    // and burn the user's bandwidth. The completeness guard (gh #3755) checks
+    // each dependency individually rather than trusting the node_modules
+    // directory marker.
     const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-already-installed');
-    mkdirSync(join(pluginRoot, 'node_modules'), { recursive: true });
+    mkdirSync(join(pluginRoot, 'node_modules', 'zod'), { recursive: true });
+    writeFileSync(join(pluginRoot, 'node_modules', 'zod', 'package.json'), JSON.stringify({ name: 'zod' }));
 
     const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
 
@@ -167,5 +171,20 @@ describe.skipIf(SKIP_NON_UNIX)('version-check Setup-phase ensurePluginDependenci
     // The fake bun would have created zod/v3/index.js if invoked — its
     // absence proves the install path was not taken.
     expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(false);
+  });
+
+  test('triggers install when node_modules exists but is incomplete (gh #3755)', async () => {
+    // When a prior install was interrupted, killed, or partially extracted,
+    // node_modules/ exists but is missing some dependencies. The completeness
+    // guard must detect this and retry the install.
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-partial-deps');
+    mkdirSync(join(pluginRoot, 'node_modules'), { recursive: true });
+
+    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
+    expect(stderr).toContain(INSTALL_DIAGNOSTIC);
+    expect(stderr).toContain(INSTALL_SUCCESS_DIAGNOSTIC);
+    expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #3755: the Setup dependency guard now checks whether each declared dependency has its own `package.json` inside `node_modules`, instead of only checking if the `node_modules/` directory exists. A partially-populated `node_modules/` from an interrupted install, killed process, or partial extraction is now caught and retried instead of being permanently skipped.

## Background

`ensurePluginDependencies()` in `plugin/scripts/version-check.js` guarded on `existsSync(node_modules)`. If `node_modules/` existed but was incomplete, the guard returned early on every subsequent Setup run, and the worker died on `Cannot find module` at boot forever. The only recovery path was manual `rm -rf node_modules`.

## Changes

- `plugin/scripts/version-check.js`: added `missingDeps()` helper that reads `package.json` dependencies and verifies each one has its own `package.json` inside `node_modules`. The guard now calls `missingDeps(pluginRoot).length === 0` instead of `existsSync(node_modules)`.
- `tests/plugin-version-check-ensure-deps.test.ts`: updated the "skips install" test to create complete dependency files so the completeness guard passes. Added a new test for the partial install scenario where `node_modules/` exists but is incomplete.

## Verification

- Existing tests updated to match the new guard semantics
- New test added for the partial install scenario
- The cleanup-after-failed-install path still works correctly