### PR TITLE
fix(observer): recognise the CLI's signed-out wording as an auth failure

### DIFF
--- a/src/sdk/output-classifier.ts
+++ b/src/sdk/output-classifier.ts
@@ -88,11 +88,16 @@ export function isAuthFailureObserverOutput(raw: unknown): boolean {
 
   return (
     // The CLI's own signed-out wording, which says nothing about
-    // "authentication" and so matched none of the patterns below. Anchored,
-    // because the same words appear in an observer narrating a past outage
-    // ("the session was not logged in during the reboot") and that is a
-    // completed batch, not a dead login.
-    /^not logged in\b/.test(text) ||
+    // "authentication" and so matched none of the patterns below.
+    //
+    // Anchoring alone is NOT enough here: a completed observation can open with
+    // the same words ("Not logged in during the reboot window; the observer
+    // recorded no new findings"), and treating that as an auth failure resets a
+    // batch that already succeeded and pauses the generator. So the state has
+    // to BE the response — it ends there, or it introduces the rest with a
+    // separator, which is what the CLI's own "· Please run /login" does. Prose
+    // runs straight on into a sentence and is left alone.
+    /^not logged in\b\s*(?:[·|:\-–—]|[.!]?\s*$)/.test(text) ||
     // The remediation half of the same line: "<state> · Please run /login".
     // Required to END the response, so it is the CLI telling the user what to
     // do rather than an observation quoting the instruction — the existing

--- a/src/sdk/output-classifier.ts
+++ b/src/sdk/output-classifier.ts
@@ -87,6 +87,18 @@ export function isAuthFailureObserverOutput(raw: unknown): boolean {
   const text = raw.toLowerCase().replace(/\s+/g, ' ').trim();
 
   return (
+    // The CLI's own signed-out wording, which says nothing about
+    // "authentication" and so matched none of the patterns below. Anchored,
+    // because the same words appear in an observer narrating a past outage
+    // ("the session was not logged in during the reboot") and that is a
+    // completed batch, not a dead login.
+    /^not logged in\b/.test(text) ||
+    // The remediation half of the same line: "<state> · Please run /login".
+    // Required to END the response, so it is the CLI telling the user what to
+    // do rather than an observation quoting the instruction — the existing
+    // false cases ("Please run /login in the observed project instructions")
+    // run on into a sentence and stay unmatched.
+    /(?:^|[·|]\s*)please run \/login\b\s*[.!]?\s*$/.test(text) ||
     /\bfailed to authenticate\b/.test(text) ||
     /\bauthentication (?:failed|failure|error)\b/.test(text) ||
     /\b(?:authentication|auth)\b.{0,20}\b(?:required|expired|invalid|again)\b.{0,20}\/login\b/.test(text) ||

--- a/src/sdk/output-classifier.ts
+++ b/src/sdk/output-classifier.ts
@@ -90,14 +90,19 @@ export function isAuthFailureObserverOutput(raw: unknown): boolean {
     // The CLI's own signed-out wording, which says nothing about
     // "authentication" and so matched none of the patterns below.
     //
-    // Anchoring alone is NOT enough here: a completed observation can open with
-    // the same words ("Not logged in during the reboot window; the observer
-    // recorded no new findings"), and treating that as an auth failure resets a
-    // batch that already succeeded and pauses the generator. So the state has
-    // to BE the response — it ends there, or it introduces the rest with a
-    // separator, which is what the CLI's own "· Please run /login" does. Prose
-    // runs straight on into a sentence and is left alone.
-    /^not logged in\b\s*(?:[·|:\-–—]|[.!]?\s*$)/.test(text) ||
+    // Anchored at BOTH ends, because every looser shape I tried let prose
+    // through: a completed observation can open with the same words ("Not
+    // logged in during the reboot window; …"), and it can follow them with a
+    // separator too ("Not logged in — the observer recorded nothing new"). A
+    // leading anchor answers the first and not the second; only requiring the
+    // status to be the WHOLE response answers both. Misclassifying prose here
+    // resets a batch that already succeeded and pauses the generator, so the
+    // rule has to close, not narrow.
+    //
+    // Two shapes, and the CLI emits no third: the status alone, or the status
+    // plus its own /login remediation.
+    /^not logged in\b\s*[.!]?\s*$/.test(text) ||
+    /^not logged in\b\s*[·|:\-–—]\s*(?:please\s+)?run\s+\/login\b\s*[.!]?\s*$/.test(text) ||
     // The remediation half of the same line: "<state> · Please run /login".
     // Required to END the response, so it is the CLI telling the user what to
     // do rather than an observation quoting the instruction — the existing

--- a/tests/sdk/output-classifier.test.ts
+++ b/tests/sdk/output-classifier.test.ts
@@ -113,3 +113,44 @@ describe('previewOutput', () => {
     expect(previewOutput(42)).toContain('non-string');
   });
 });
+
+describe('isAuthFailureObserverOutput recognises the CLI signed-out wording (#3606)', () => {
+  // Reported from a 25-session fleet: after a reboot logged the default
+  // ~/.claude profile out, every batch came back as this prose. None of the
+  // existing patterns mention it — they all key on the word "authentication" —
+  // so the response fell through to the prose branch, which calls
+  // confirmClaimedMessages. 857 batches were confirmed and dropped over three
+  // hours, and no observation was written.
+  const SIGNED_OUT = [
+    'Not logged in · Please run /login',
+    'Not logged in',
+    'Invalid API key · Please run /login',
+    'Please run /login',
+  ];
+
+  for (const output of SIGNED_OUT) {
+    it(`preserves the batch for: ${output}`, () => {
+      expect(isAuthFailureObserverOutput(output)).toBe(true);
+    });
+  }
+
+  // The same words in a completed observation must stay prose. Preserving a
+  // batch that already succeeded pauses the generator and retries it, so a
+  // false positive here is the mirror of the bug being fixed.
+  const NARRATIVE = [
+    'The observer noted the session was not logged in during the reboot window.',
+    'Please run /login in the observed project instructions.',
+    'The project authentication guide says to run /login before testing.',
+    'Documented that "Not logged in" is the wording the CLI uses when signed out.',
+  ];
+
+  for (const prose of NARRATIVE) {
+    it(`leaves prose alone: ${prose.slice(0, 45)}…`, () => {
+      expect(isAuthFailureObserverOutput(prose)).toBe(false);
+    });
+  }
+
+  it('still leaves XML alone', () => {
+    expect(isAuthFailureObserverOutput('<observation><title>Not logged in</title></observation>')).toBe(false);
+  });
+});

--- a/tests/sdk/output-classifier.test.ts
+++ b/tests/sdk/output-classifier.test.ts
@@ -129,6 +129,7 @@ describe('isAuthFailureObserverOutput recognises the CLI signed-out wording (#36
     // The status line may stand alone, or introduce its remediation.
     'Not logged in.',
     'Not logged in: run /login',
+    'Not logged in — Please run /login',
   ];
 
   for (const output of SIGNED_OUT) {
@@ -151,6 +152,11 @@ describe('isAuthFailureObserverOutput recognises the CLI signed-out wording (#36
     'Not logged in during the reboot window; the observer recorded no new findings.',
     'Not logged in. The observer recorded no new findings for this batch.',
     'Not logged in sessions were reviewed and the retry path documented.',
+    // Reported on the second review round: a separator after the status is
+    // not enough either, so the status must be the WHOLE response.
+    'Not logged in — the observer recorded nothing new.',
+    'Not logged in: sessions were reviewed and the retry path documented.',
+    'Not logged in · the reboot window is documented in the runbook.',
   ];
 
   for (const prose of NARRATIVE) {

--- a/tests/sdk/output-classifier.test.ts
+++ b/tests/sdk/output-classifier.test.ts
@@ -126,6 +126,9 @@ describe('isAuthFailureObserverOutput recognises the CLI signed-out wording (#36
     'Not logged in',
     'Invalid API key · Please run /login',
     'Please run /login',
+    // The status line may stand alone, or introduce its remediation.
+    'Not logged in.',
+    'Not logged in: run /login',
   ];
 
   for (const output of SIGNED_OUT) {
@@ -142,6 +145,12 @@ describe('isAuthFailureObserverOutput recognises the CLI signed-out wording (#36
     'Please run /login in the observed project instructions.',
     'The project authentication guide says to run /login before testing.',
     'Documented that "Not logged in" is the wording the CLI uses when signed out.',
+    // Reported on review: anchoring alone does not separate the CLI's status
+    // line from an observation that OPENS with the same words. Preserving one
+    // of these resets a batch that already succeeded and pauses the generator.
+    'Not logged in during the reboot window; the observer recorded no new findings.',
+    'Not logged in. The observer recorded no new findings for this batch.',
+    'Not logged in sessions were reviewed and the retry path documented.',
   ];
 
   for (const prose of NARRATIVE) {

--- a/tests/worker/agents/response-processor.test.ts
+++ b/tests/worker/agents/response-processor.test.ts
@@ -983,6 +983,36 @@ describe('ResponseProcessor', () => {
     });
   });
 
+  describe('signed-out CLI prose preserves the batch (#3606)', () => {
+    // End to end over the branch the matcher gates: the CLI's signed-out
+    // wording must reach the auth branch (reset to pending + abort) instead of
+    // the prose fallback, which confirms the claim and loses the work.
+    it('resets the batch to pending instead of confirming it', async () => {
+      const confirmClaimedMessages = mock(() => Promise.resolve(0));
+      const resetProcessingToPending = mock(() => Promise.resolve(1));
+      mockSessionManager = {
+        getMessageIterator: async function* () { yield* []; },
+        confirmClaimedMessages,
+        resetProcessingToPending,
+      } as unknown as SessionManager;
+      const session = createMockSession();
+
+      await processAgentResponse(
+        'Not logged in · Please run /login',
+        session,
+        mockDbManager,
+        mockSessionManager,
+        mockWorker,
+        100,
+        null,
+        'TestAgent'
+      );
+
+      expect(resetProcessingToPending).toHaveBeenCalledWith(1);
+      expect(confirmClaimedMessages).not.toHaveBeenCalled();
+      expect(session.abortReason).toBe('auth:observer_text');
+    });
+  });
   describe('lastSummaryStored tracking (#1633)', () => {
     it('should set lastSummaryStored=true when storage returns a summaryId', async () => {
       mockStoreObservations.mockImplementation(() => ({


### PR DESCRIPTION
Refs #3606, from @Priscu's fleet report there: a reboot signed the default `~/.claude` profile out, and over ~3 hours 857 batches were logged as `returned non-XML prose response — ignoring queued batch`, confirmed, and lost. Zero observations written.

## The matcher looks for a word the CLI does not use

Every pattern in `isAuthFailureObserverOutput` keys on *authentication*:

```ts
/\bfailed to authenticate\b/
/\bauthentication (?:failed|failure|error)\b/
/\b(?:authentication|auth)\b.{0,20}\b(?:required|expired|invalid|again)\b.{0,20}\/login\b/
…401/403 shapes…
/\/login\b.{0,40}\b(?:to\s+authenticate|again|to\s+continue|…)\b/
```

The CLI, when the profile is signed out, says `Not logged in · Please run /login`. That phrase contains none of those. The last pattern nearly catches it, but it requires a qualifier **after** `/login` and the CLI's line ends there.

Measured against `main` before touching anything:

```
false  "Not logged in · Please run /login"
false  "Not logged in"
false  "Invalid API key · Please run /login"
false  "Please run /login"
true   "Authentication failed. Please run /login to authenticate."
```

## Why a miss here loses data rather than degrading

`ResponseProcessor` handles the auth case by preserving the work:

```ts
if (isAuthFailureObserverOutput(text)) {
  await sessionManager.resetProcessingToPending(session.sessionDbId);
  session.abortReason = 'auth:observer_text';
  …
```

Fall past it and the prose fallback runs `confirmClaimedMessages(session.sessionDbId)` — the claim is acknowledged, the batch is gone, and there is nothing left to retry once the user logs back in. Which is exactly the reported outcome, and it matches the log line in the report verbatim.

## The fix

Two anchored patterns:

```ts
/^not logged in\b/
/(?:^|[·|]\s*)please run \/login\b\s*[.!]?\s*$/
```

The anchoring is the load-bearing part, and it is aimed at two existing must-**not**-match cases in the suite:

- `Please run /login in the observed project instructions.` — an observation quoting the instruction. The remediation pattern requires the phrase to **end** the response, so this runs on into its sentence and stays prose.
- The bare state pattern requires `not logged in` to **open** the response, because an observer narrating a past outage ("the session was not logged in during the reboot window") uses the same words, and preserving a batch that already succeeded pauses the generator and retries completed work — the mirror of the bug being fixed.

`Invalid API key · Please run /login` is caught as a side effect of the separator form rather than by enumerating prefixes, which is why I wrote it that way instead of listing every signed-out state the CLI might print.

## Verification

Five cases red against `main` — matcher cases with the source file stashed:

```
(fail) preserves the batch for: Not logged in · Please run /login
(fail) preserves the batch for: Not logged in
(fail) preserves the batch for: Invalid API key · Please run /login
(fail) preserves the batch for: Please run /login
 23 pass, 4 fail
```

and one end-to-end case over `processAgentResponse`, which is the assertion that actually describes the harm:

```
(fail) ResponseProcessor > signed-out CLI prose preserves the batch (#3606)
       > resets the batch to pending instead of confirming it
       expect(resetProcessingToPending).toHaveBeenCalledWith(1)
 23 pass, 1 fail
```

It asserts `confirmClaimedMessages` was **not** called and `abortReason === 'auth:observer_text'`, so a future change that classifies the prose correctly but still confirms the claim would not pass.

After: `output-classifier` **27 pass, 0 fail**; `response-processor` **24 pass, 0 fail**. Four narrative cases guard the other direction.

## Scope

Only the matcher. #3606's broader proposal — never confirm a batch on any unparsed prose — is the right end state and this does not pre-empt it; it closes the specific wording that is losing data today, in a form that is easy to verify against a real fleet. @Priscu offered to test a build, and this branch is the smallest thing worth testing.

I did not touch the existing patterns. They are unanchored, which is loose in the same way, but widening or tightening them is a separate change with its own blast radius.
