### PR TITLE
feat(cli): track installer trial offer exposure

### DIFF
--- a/docs/public/telemetry.mdx
+++ b/docs/public/telemetry.mdx
@@ -70,6 +70,10 @@ Every event property passes through a strict whitelist scrubber — any key not 
 | `install_method` | `npm` | Which package manager launched the CLI: npm / bun / pnpm / yarn |
 | `bun_version` / `uv_version` | `1.3.9` / `0.7.2` | Toolchain versions detected during install |
 | `claude_code_version` | `2.0.14` | Claude Code CLI version, if detectable |
+| `trial_days` | `14` | Assigned CMEM Pro installer offer length: 7, 14, or 30 days |
+| `trial_variant` | `test_14` | Canonical trial experiment arm: control_7 / test_14 / test_30 |
+| `offer_surface` / `funnel_source` | `installer` / `installer` | Closed source labels on the installer offer exposure event |
+| `stage` | `awaiting_checkout` | Installer trial polling stage: awaiting_login / awaiting_checkout / awaiting_approval |
 | `mode` | `code` | Active claude-mem mode id (our mode list) |
 | `model` | `claude-haiku-4-5` | Model id used for compression |
 | `hook` | `ingest` | What triggered a compression: init / ingest / summarize |
@@ -118,6 +122,11 @@ One value is derived server-side rather than sent by the client: PostHog resolve
 |---|---|---|
 | `install_completed` | `npx claude-mem install` finishes | `ide`, `provider`, `runtime_mode`, `is_update`, `outcome`, `duration_ms`, `interactive`, `install_method`, `bun_version`, `uv_version`, `claude_code_version` |
 | `install_failed` | The installer aborts | `error_category` (our error-taxonomy id), `interactive`, `install_method`, `claude_code_version` |
+| `pro_offer_viewed` | A CMEM Pro offer is displayed in the installer | `trial_days`, `trial_variant`, `offer_surface` (`installer`), `funnel_source` (`installer`) |
+| `trial_email_submitted` | The user submits an email to start the installer trial flow | `version` only — never the email |
+| `trial_link_sent` | The trial start API accepts the request and sends a sign-in link | `version`, `duration_ms` — never the email, link, pairing secret, or device code |
+| `trial_activated` | Trial credentials are received and saved after browser approval | `version`, `duration_ms` |
+| `trial_poll_timeout` | Browser completion polling is cancelled, expires, times out, or becomes unreachable | `version`, `stage`, `outcome`, `duration_ms` |
 | `uninstall_completed` | `npx claude-mem uninstall` finishes | — |
 | `worker_started` | The background worker starts, plus one heartbeat per 24h of uptime | `trigger` (start / heartbeat), `duration_ms`, `ide`, `provider`, `mode`, `runtime_mode`, process memory (`process_rss_mb`, `heap_used_mb`), the install snapshot: `db_observation_count`, `db_session_count`, `db_summary_count`, `db_project_count`, `db_size_mb`, `install_age_days`, `obs_count_7d`, `obs_count_30d`, `days_since_last_obs`; on a real start also crash detection: `previous_shutdown` (crash / clean / unknown) and, after a clean shutdown, `previous_uptime_seconds` |
 | `observer_turn_rollup` | Emitted **once per session, at session end** — a per-session rollup that aggregates every compression in that session (stored observations, invalid-output drops, failures, aborts) instead of one event per turn | `rollup_reason` (session_end / worker_shutdown / safety_flush), `window_seq`, aggregated `outcomes_*` counts, `total_tokens_input`, `total_tokens_output`, `total_cost_usd`, `avg_duration_ms`, `avg_compression_ms`, `top_model`, `observations_created` (sum of observations generated in the session — pairs with `total_cost_usd` to derive cost per observation), summed `obs_type_*` buckets, `window_start_ts`, plus the per-turn fields it summarizes (`provider`, `ide`, `hook`) |

--- a/src/npx-cli/cmem-pro-costs.ts
+++ b/src/npx-cli/cmem-pro-costs.ts
@@ -46,6 +46,17 @@ export const CMEM_PRO_MONTHLY_USD = 30;
 /** The three trial lengths accepted by cmem.ai's installer funnel. */
 export const CMEM_PRO_TRIAL_LENGTHS = [7, 14, 30] as const;
 export type CmemProTrialDays = (typeof CMEM_PRO_TRIAL_LENGTHS)[number];
+export type CmemProTrialVariant = 'control_7' | 'test_14' | 'test_30';
+
+/** Canonical experiment arm shared with cmem.ai's Stripe metadata. */
+export function cmemProTrialVariant(trialDays: CmemProTrialDays): CmemProTrialVariant {
+  switch (trialDays) {
+    case 7: return 'control_7';
+    case 14: return 'test_14';
+    case 30: return 'test_30';
+    default: throw new Error('trial days must be 7, 14, or 30');
+  }
+}
 
 /** Validate a persisted/API-shaped trial length without coercing other values. */
 export function parseCmemProTrialDays(value: unknown): CmemProTrialDays | null {

--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -36,6 +36,7 @@ import {
   buildProviderLabels,
   cmemProSignupUrl,
   cmemProTrialPitch,
+  cmemProTrialVariant,
   CMEM_PRO_BASE_URL,
   CMEM_PRO_KEY_PATTERN,
   CMEM_PRO_MODEL,
@@ -66,6 +67,18 @@ function detectInstallMethod(): string {
   if (name === 'npm' || name === 'bun' || name === 'pnpm' || name === 'yarn') return name;
   if (process.versions.bun) return 'bun';
   return 'unknown';
+}
+
+/** Record one exposure after an installer CMEM Pro offer is actually shown. */
+export async function captureInstallerProOfferViewed(
+  trialDays: CmemProTrialDays,
+): Promise<void> {
+  await captureCliEvent('pro_offer_viewed', {
+    trial_days: trialDays,
+    trial_variant: cmemProTrialVariant(trialDays),
+    offer_surface: 'installer',
+    funnel_source: 'installer',
+  });
 }
 
 /**
@@ -1190,7 +1203,7 @@ async function promptProvider(
     // still gets a working prompt — just with last-known figures.
     const labels = await buildProviderLabels(trialDays);
 
-    const providerResult = await p.select<ProviderChoice>({
+    const providerResultPromise = p.select<ProviderChoice>({
       message: 'Which memory provider do you want to use?',
       options: [
         { value: 'cmem', label: labels.cmem, hint: labels.cmemHint },
@@ -1200,6 +1213,8 @@ async function promptProvider(
       ],
       initialValue: 'cmem',
     });
+    void captureInstallerProOfferViewed(trialDays);
+    const providerResult = await providerResultPromise;
     if (p.isCancel(providerResult)) {
       p.cancel('Installation cancelled.');
       process.exit(0);
@@ -1218,6 +1233,7 @@ async function promptProvider(
         + `Sign in, start your ${trialDays}-day trial, and copy the key you're shown.`,
       `cmem Pro — ${trialDays} days free`,
     );
+    void captureInstallerProOfferViewed(trialDays);
     openBrowser(signupUrl);
 
     const keyResult = await p.text({
@@ -1678,6 +1694,7 @@ async function promptProTrialOptIn(
     ].join('\n'),
     `cmem Pro — ${trialDays} days free`,
   );
+  void captureInstallerProOfferViewed(trialDays);
 
   const emailResult = await p.text({
     message: 'Your email (press Enter to skip):',
@@ -2391,6 +2408,7 @@ async function runInstallCommandInner(options: InstallOptions, summary: InstallS
     : workerAlive
       ? 'keep that URL open in a browser'
       : `keep ${styleText('underline', configuredWorkerBaseUrl)} open in a browser`;
+  const proOfferDisplayed = !trialActivated;
   const nextSteps = [
     nextStepsHeadline,
     ``,
@@ -2405,13 +2423,13 @@ async function runInstallCommandInner(options: InstallOptions, summary: InstallS
     ``,
     // Suppressed when the trial was just activated in this same run — pitching
     // an offer the user already accepted 30 seconds ago reads as broken.
-    ...(trialActivated
-      ? []
-      : [
+    ...(proOfferDisplayed
+      ? [
           `${styleText(['bold', 'cyan'], cmemProTrialPitch(trialDays))}`,
           `  ${styleText('underline', cmemProSignupUrl(trialDays))}`,
           ``,
-        ]),
+        ]
+      : []),
     `${styleText('dim', 'How it works: /how-it-works   ·   Disable first-session hint: CLAUDE_MEM_WELCOME_HINT_ENABLED=false')}`,
     `${styleText('dim', 'Note: close all Claude Code sessions before uninstalling, or ~/.claude-mem will be recreated by active hooks.')}`,
   ];
@@ -2435,6 +2453,10 @@ async function runInstallCommandInner(options: InstallOptions, summary: InstallS
     } else {
       console.log('\nclaude-mem installed successfully!');
     }
+  }
+
+  if (proOfferDisplayed) {
+    await captureInstallerProOfferViewed(trialDays);
   }
 
   // After promptTelemetryOptIn so a just-made consent choice is honored.

--- a/src/services/telemetry/scrub.ts
+++ b/src/services/telemetry/scrub.ts
@@ -44,6 +44,12 @@ export const ALLOWED_PROPERTY_KEYS: Set<string> = new Set([
   'bun_version',
   'uv_version',
   'claude_code_version',
+  // Installer CMEM Pro offer exposure — a fixed trial-length integer plus
+  // closed experiment/surface/source enums. Never user or account data.
+  'trial_days',
+  'trial_variant',
+  'offer_surface',
+  'funnel_source',
   // context_injected depth/economics — integers, booleans, and our own enums.
   'observation_count',
   'session_count',

--- a/tests/npx-cli/install-trial-length.test.ts
+++ b/tests/npx-cli/install-trial-length.test.ts
@@ -1,23 +1,35 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { afterEach, describe, expect, it } from 'bun:test';
-import { readFileSync } from 'fs';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
 import { join } from 'path';
 import {
   CMEM_PRO_TRIAL_LENGTHS,
   CMEM_PRO_TRIAL_START_URL,
   cmemProSignupUrl,
   cmemProTrialPitch,
+  cmemProTrialVariant,
   parseCmemProTrialDays,
   pickCmemProTrialDays,
 } from '../../src/npx-cli/cmem-pro-costs.js';
 import {
+  captureInstallerProOfferViewed,
   parseStoredTrialState,
   resolveInstallerTrialDays,
   startTrialPairing,
 } from '../../src/npx-cli/commands/install.js';
 
 const originalFetch = globalThis.fetch;
+const originalTelemetryEnv = {
+  CLAUDE_MEM_TELEMETRY: process.env.CLAUDE_MEM_TELEMETRY,
+  CLAUDE_MEM_TELEMETRY_DEBUG: process.env.CLAUDE_MEM_TELEMETRY_DEBUG,
+  CLAUDE_MEM_TELEMETRY_HOST: process.env.CLAUDE_MEM_TELEMETRY_HOST,
+  CLAUDE_MEM_TELEMETRY_KEY: process.env.CLAUDE_MEM_TELEMETRY_KEY,
+  CLAUDE_MEM_DATA_DIR: process.env.CLAUDE_MEM_DATA_DIR,
+  DO_NOT_TRACK: process.env.DO_NOT_TRACK,
+};
+let telemetryDataDir: string | null = null;
 const installSource = readFileSync(
   join(__dirname, '..', '..', 'src', 'npx-cli', 'commands', 'install.ts'),
   'utf-8',
@@ -25,6 +37,14 @@ const installSource = readFileSync(
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+  if (telemetryDataDir) {
+    rmSync(telemetryDataDir, { recursive: true, force: true });
+    telemetryDataDir = null;
+  }
+  for (const [key, value] of Object.entries(originalTelemetryEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
 });
 
 describe('installer trial length', () => {
@@ -50,6 +70,55 @@ describe('installer trial length', () => {
     expect(cmemProSignupUrl(trialDays)).toBe(
       `https://cmem.ai/pro?from=installer&trial=${trialDays}`,
     );
+  });
+
+  it('maps every trial length to the canonical cmem.ai experiment arm', () => {
+    expect(CMEM_PRO_TRIAL_LENGTHS.map(cmemProTrialVariant)).toEqual([
+      'control_7',
+      'test_14',
+      'test_30',
+    ]);
+  });
+
+  it('captures one installer offer exposure per call for all arms on the stable install id', async () => {
+    telemetryDataDir = mkdtempSync(join(tmpdir(), 'claude-mem-offer-telemetry-'));
+    process.env.CLAUDE_MEM_DATA_DIR = telemetryDataDir;
+    process.env.CLAUDE_MEM_TELEMETRY = '1';
+    process.env.DO_NOT_TRACK = '0';
+    delete process.env.CLAUDE_MEM_TELEMETRY_DEBUG;
+    process.env.CLAUDE_MEM_TELEMETRY_HOST = 'https://telemetry.example';
+    process.env.CLAUDE_MEM_TELEMETRY_KEY = 'test-key';
+
+    const requests: Array<{ url: string; body: Record<string, unknown> }> = [];
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      requests.push({
+        url: String(url),
+        body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+      });
+      return new Response(null, { status: 200 });
+    }) as typeof fetch;
+
+    for (const trialDays of CMEM_PRO_TRIAL_LENGTHS) {
+      await captureInstallerProOfferViewed(trialDays);
+    }
+
+    expect(requests).toHaveLength(3);
+    expect(requests.every(({ url }) => url === 'https://telemetry.example/capture/')).toBe(true);
+    expect(new Set(requests.map(({ body }) => body.distinct_id)).size).toBe(1);
+    for (const [index, trialDays] of CMEM_PRO_TRIAL_LENGTHS.entries()) {
+      expect(requests[index]?.body).toMatchObject({
+        api_key: 'test-key',
+        event: 'pro_offer_viewed',
+        distinct_id: expect.any(String),
+        properties: {
+          trial_days: trialDays,
+          trial_variant: cmemProTrialVariant(trialDays),
+          offer_surface: 'installer',
+          funnel_source: 'installer',
+          $process_person_profile: false,
+        },
+      });
+    }
   });
 
   it.each(CMEM_PRO_TRIAL_LENGTHS)('sends %d days to trial start and retains it for later copy', async (trialDays) => {
@@ -128,5 +197,42 @@ describe('installer trial length', () => {
     expect(installSource).toContain('cmemProTrialPitch(trialDays)');
     expect(installSource.match(/CLAUDE_MEM_PRO_TRIAL_DAYS: String\(trialDays\)/g)).toHaveLength(2);
     expect(installSource).not.toMatch(/free week|7 days free|7-day trial/i);
+  });
+
+  it('records all four real offer surfaces once without counting resend/activation copy', () => {
+    const resendFlow = installSource.slice(
+      installSource.indexOf('if (prior) {'),
+      installSource.indexOf('// The alt-path figure is live-fetched'),
+    );
+    expect(resendFlow).not.toContain('captureInstallerProOfferViewed');
+
+    const optInOffer = installSource.slice(
+      installSource.indexOf('// The alt-path figure is live-fetched'),
+      installSource.indexOf("const emailResult = await p.text({"),
+    );
+    expect(optInOffer).toContain("p.note(");
+    expect(optInOffer.match(/void captureInstallerProOfferViewed\(trialDays\);/g)).toHaveLength(1);
+
+    const providerChoiceOffer = installSource.slice(
+      installSource.indexOf('const labels = await buildProviderLabels(trialDays);'),
+      installSource.indexOf('if (p.isCancel(providerResult))'),
+    );
+    expect(providerChoiceOffer).toContain('const providerResultPromise = p.select<ProviderChoice>({');
+    expect(providerChoiceOffer).toContain('const providerResult = await providerResultPromise;');
+    expect(providerChoiceOffer.match(/void captureInstallerProOfferViewed\(trialDays\);/g)).toHaveLength(1);
+
+    const selectedCmemOffer = installSource.slice(
+      installSource.indexOf("if (selectedProvider === 'cmem') {"),
+      installSource.indexOf("const keyResult = await p.text({"),
+    );
+    expect(selectedCmemOffer).toContain('Opening ${signupUrl}');
+    expect(selectedCmemOffer.match(/void captureInstallerProOfferViewed\(trialDays\);/g)).toHaveLength(1);
+
+    const finalOffer = installSource.slice(
+      installSource.indexOf('const proOfferDisplayed = !trialActivated;'),
+      installSource.indexOf('// After promptTelemetryOptIn so a just-made consent choice is honored.'),
+    );
+    expect(finalOffer).toContain('cmemProTrialPitch(trialDays)');
+    expect(finalOffer.match(/await captureInstallerProOfferViewed\(trialDays\);/g)).toHaveLength(1);
   });
 });

--- a/tests/telemetry/scrub.test.ts
+++ b/tests/telemetry/scrub.test.ts
@@ -78,6 +78,22 @@ describe('scrubProperties', () => {
     });
   });
 
+  it('keeps bounded installer offer experiment properties', () => {
+    const result = scrubProperties({
+      trial_days: 14,
+      trial_variant: 'test_14',
+      offer_surface: 'installer',
+      funnel_source: 'installer',
+    });
+
+    expect(result).toEqual({
+      trial_days: 14,
+      trial_variant: 'test_14',
+      offer_surface: 'installer',
+      funnel_source: 'installer',
+    });
+  });
+
   it('keeps the depth/economics keys with primitive values', () => {
     const result = scrubProperties({
       observation_count: 50,


### PR DESCRIPTION
## Summary

- emit one `pro_offer_viewed` event for each CMEM Pro offer actually rendered by the installer
- attach `trial_days`, the canonical `trial_variant`, and installer surface/source labels through the existing anonymous CLI telemetry identity
- whitelist and document the bounded fields plus the existing installer trial funnel events

## Tests

- `bun test tests/npx-cli/install-trial-length.test.ts tests/telemetry/scrub.test.ts` (37 pass)
- `bun test tests/install-non-tty.test.ts` (43 pass)
- `bun run typecheck:root`
- `git diff --check`