### PR TITLE
test: restore the real modules after mock.module, not the stubs

### DIFF
--- a/tests/cli/handlers/context-session-start.test.ts
+++ b/tests/cli/handlers/context-session-start.test.ts
@@ -5,6 +5,20 @@ import * as realOauthToken from '../../../src/shared/oauth-token.js';
 import * as realProjectName from '../../../src/utils/project-name.js';
 import * as realWorkerUtils from '../../../src/shared/worker-utils.js';
 
+// Snapshot the real modules BEFORE mock.module mutates the live namespaces.
+// bun's mock.module rewrites the existing namespace object in place, so
+// spreading `realProjectName` from inside afterAll re-registers the STUB, not
+// the real module — the restore silently becomes a no-op. That left
+// getProjectContext pinned to 'repo-project' for every later file in the run,
+// which is what made adoptMergedWorktrees adopt nothing in
+// tests/worker/sync/mutation-sites.test.ts and
+// tests/services/infrastructure/worktree-adoption-chroma.test.ts. Same idiom
+// and same reason as tests/transcripts/processor-codex-context.test.ts.
+const realHookSettingsSnapshot = { ...realHookSettings };
+const realOauthTokenSnapshot = { ...realOauthToken };
+const realProjectNameSnapshot = { ...realProjectName };
+const realWorkerUtilsSnapshot = { ...realWorkerUtils };
+
 const calls: unknown[][] = [];
 
 mock.module('../../../src/shared/hook-settings.js', () => ({
@@ -32,10 +46,10 @@ mock.module('../../../src/shared/worker-utils.js', () => ({
 }));
 
 afterAll(() => {
-  mock.module('../../../src/shared/hook-settings.js', () => ({ ...realHookSettings }));
-  mock.module('../../../src/shared/oauth-token.js', () => ({ ...realOauthToken }));
-  mock.module('../../../src/utils/project-name.js', () => ({ ...realProjectName }));
-  mock.module('../../../src/shared/worker-utils.js', () => ({ ...realWorkerUtils }));
+  mock.module('../../../src/shared/hook-settings.js', () => realHookSettingsSnapshot);
+  mock.module('../../../src/shared/oauth-token.js', () => realOauthTokenSnapshot);
+  mock.module('../../../src/utils/project-name.js', () => realProjectNameSnapshot);
+  mock.module('../../../src/shared/worker-utils.js', () => realWorkerUtilsSnapshot);
 });
 
 describe('contextHandler SessionStart path', () => {

--- a/tests/worker/session-manager-project.test.ts
+++ b/tests/worker/session-manager-project.test.ts
@@ -6,6 +6,22 @@ import type { ActiveSession } from '../../src/services/worker-types.js';
 import type { DatabaseManager } from '../../src/services/worker/DatabaseManager.js';
 import type { StorageResult, WorkerRef } from '../../src/services/worker/agents/types.js';
 
+// Same snapshot-and-restore dance as the ModeManager stub below, for the same
+// reason: both stubs replace the whole module namespace with a single export.
+// Without this, getWorkerPort stays pinned at 37777 for every file that runs
+// after this one, so any later test that boots a real server on a real port
+// and expects a client to reach it fails with a connection error instead.
+import * as realWorkerServiceModule from '../../src/services/worker-service.js';
+import * as realWorkerUtilsModule from '../../src/shared/worker-utils.js';
+
+const realWorkerServiceSnapshot = { ...realWorkerServiceModule };
+const realWorkerUtilsSnapshot = { ...realWorkerUtilsModule };
+
+afterAll(() => {
+  mock.module('../../src/services/worker-service.js', () => realWorkerServiceSnapshot);
+  mock.module('../../src/shared/worker-utils.js', () => realWorkerUtilsSnapshot);
+});
+
 mock.module('../../src/services/worker-service.js', () => ({
   updateCursorContextForProject: () => Promise.resolve(),
 }));


### PR DESCRIPTION
Two tests on `main` fail or pass depending on the order bun happens to walk the test files:

```
(fail) mutation sites > adoptMergedWorktrees emits remap_project through its own connection
(fail) worktree adoption Chroma hydration > patches a session-summary document when the adopted worktree has no observations
```

Both pass when their files run alone, and both report `adoptedSummaries` of 0 where 1 is expected — which reads like a bug in the worktree adoption path. It isn't.

## Cause

`tests/cli/handlers/context-session-start.test.ts` restores four stubbed modules in `afterAll` by spreading the imported namespace at that moment:

```js
mock.module('.../project-name.js', () => ({ ...realProjectName }));
```

`mock.module` rewrites the live namespace object in place, so by the time `afterAll` runs, `realProjectName` **is** the stub. The restore re-registers the stub and is a silent no-op.

`getProjectContext` then answers `'repo-project'` for every path for the rest of the run. `WorktreeAdoption` computes a worktree project name that matches no seeded row, and the `UPDATE` reports 0 changes.

Found by instrumenting `WorktreeAdoption` to print the project name it computed; it printed `repo-project`, which appears in exactly one stub.

## Fix

The idiom the rest of the suite already uses — capture `{ ...module }` at load time, above the `mock.module` calls, and re-register that object. `tests/transcripts/processor-codex-context.test.ts` spells out the same reasoning in a comment.

`tests/worker/session-manager-project.test.ts` has the other half of the same problem: its `worker-service` and `worker-utils` stubs each replace a whole module namespace with a single export and are never restored at all, so `getWorkerPort` stays pinned at `37777` for every file after it. Nothing on `main` currently trips over that one — it's a trap for the next test that boots a server on a real port and expects a client to reach it. Given the same guard.

Swept `tests/` for both shapes; no other occurrence.

## Result

```
bun test tests
before  2714 pass / 27 skip / 2 fail
after   2716 pass / 27 skip / 0 fail   (three consecutive runs)
```

## One thing I did not fix

`mutation sites > adoptMergedWorktrees` timed out at exactly 5s on the *first* suite run in a freshly created worktree — once out of four such runs, across two separate checkouts — and passed on every run after. It looks like a cold page cache meeting a tight 5s budget for real `git init` / `git worktree add` work, not a logic bug, so I left it alone. Flagging it because a 5s timeout on a test that shells out to git that many times may deserve a longer budget or a warm-up.