### PR TITLE
fix(plugin): treat node_modules without a completion marker as incomplete

### DIFF
--- a/plugin/scripts/version-check.js
+++ b/plugin/scripts/version-check.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from 'child_process';
-import { existsSync, readFileSync, rmSync } from 'fs';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -10,6 +10,7 @@ const VERSION_CHECK_LOG_PREFIX = '[version-check]';
 const BUN_INSTALL_ARGS = Object.freeze(['install', '--production']);
 const BUN_INSTALL_TIMEOUT_MS = 120_000;
 const NODE_MODULES_DIRNAME = 'node_modules';
+const INSTALL_COMPLETE_MARKER = '.claude-mem-install-complete';
 
 function findBun() {
   const pathCheck = IS_WINDOWS
@@ -58,9 +59,30 @@ function findBun() {
 function ensurePluginDependencies(pluginRoot) {
   if (!existsSync(join(pluginRoot, 'package.json'))) return;
 
-  // Guard on node_modules (package-manager marker) rather than a specific
-  // package, so the check stays correct if dependencies are later renamed.
-  if (existsSync(join(pluginRoot, NODE_MODULES_DIRNAME))) return;
+  const nodeModulesPath = join(pluginRoot, NODE_MODULES_DIRNAME);
+  const markerPath = join(nodeModulesPath, INSTALL_COMPLETE_MARKER);
+
+  // Guard on a completion marker written only after `bun install` exits 0,
+  // not on node_modules existing. A worker version-mismatch tree-kill
+  // (worker-utils.ts) SIGKILLs this script's whole process tree, including
+  // this process itself, when this install runs as an observer descendant
+  // (gh #3793). That leaves a partial node_modules with no chance for any
+  // in-process cleanup to run. Trusting mere directory existence then skips
+  // install forever, permanently short-circuiting on a broken plugin.
+  if (existsSync(markerPath)) return;
+
+  if (existsSync(nodeModulesPath)) {
+    // node_modules present without the completion marker means a previous
+    // install was interrupted before finishing. Its mere presence also
+    // disables Bun's own auto-install, so it must be removed before retrying.
+    try {
+      rmSync(nodeModulesPath, { recursive: true, force: true });
+    } catch (rmErr) {
+      const rmReason = rmErr && rmErr.message ? rmErr.message : String(rmErr);
+      console.error(`${VERSION_CHECK_LOG_PREFIX} failed to remove incomplete node_modules (${rmReason}); worker may crash with missing module errors`);
+      return;
+    }
+  }
 
   const bunPath = findBun();
   if (!bunPath) {
@@ -112,7 +134,7 @@ function ensurePluginDependencies(pluginRoot) {
     // partial dir so the next Setup invocation can retry automatically
     // (gh #2650 review).
     try {
-      rmSync(join(pluginRoot, NODE_MODULES_DIRNAME), { recursive: true, force: true });
+      rmSync(nodeModulesPath, { recursive: true, force: true });
     } catch (rmErr) {
       const rmReason = rmErr && rmErr.message ? rmErr.message : String(rmErr);
       console.error(`${VERSION_CHECK_LOG_PREFIX} failed to clean up partial node_modules (${rmReason}); next Setup run may skip retry`);
@@ -122,6 +144,12 @@ function ensurePluginDependencies(pluginRoot) {
     // 120s needs an explicit completion line so users can distinguish a
     // hung install from one that finished silently (gh #2650 review).
     console.error(`${VERSION_CHECK_LOG_PREFIX} plugin dependencies installed successfully`);
+    try {
+      writeFileSync(markerPath, '');
+    } catch (markerErr) {
+      const markerReason = markerErr && markerErr.message ? markerErr.message : String(markerErr);
+      console.error(`${VERSION_CHECK_LOG_PREFIX} failed to write install-complete marker (${markerReason}); next Setup run will reinstall`);
+    }
   }
 }
 

--- a/plugin/scripts/version-check.js
+++ b/plugin/scripts/version-check.js
@@ -93,26 +93,71 @@ function acquireInstallLock(pluginRoot) {
 function releaseInstallLock(lock) {
   if (!lock) return;
   const { lockPath, token } = lock;
+
+  // Claim whatever currently occupies lockPath in one atomic step before
+  // inspecting it. A separate read-then-delete (checking the owner token,
+  // then rmSync-ing the shared path) still leaves a gap: a reclaimer can
+  // replace the lock between the read and the delete, and the delete would
+  // then destroy the replacement (gh #3799 review) — the read only proves
+  // ownership at read time, not at deletion time. renameSync has no such
+  // gap: once it returns, whatever it moved is no longer reachable at
+  // lockPath by anyone else, so it's now safe to inspect at leisure.
+  const claimedPath = `${lockPath}.release-${process.pid}-${Math.random().toString(36).slice(2)}`;
+  try {
+    renameSync(lockPath, claimedPath);
+  } catch {
+    // Nothing at lockPath to claim — already released or fully replaced.
+    return;
+  }
+
   let currentToken;
   try {
-    currentToken = readFileSync(join(lockPath, INSTALL_LOCK_OWNER_FILE), 'utf-8');
+    currentToken = readFileSync(join(claimedPath, INSTALL_LOCK_OWNER_FILE), 'utf-8');
   } catch {
-    // Owner file missing/unreadable: the lock is already gone, or mid-
-    // replacement by a reclaimer. Nothing that's provably ours to remove.
+    currentToken = null;
+  }
+
+  if (currentToken === token) {
+    // Genuinely ours — safe to discard.
+    try {
+      rmSync(claimedPath, { recursive: true, force: true });
+    } catch (err) {
+      const reason = err && err.message ? err.message : String(err);
+      console.error(`${VERSION_CHECK_LOG_PREFIX} failed to release install lock (${reason})`);
+    }
     return;
   }
-  if (currentToken !== token) {
-    // Another process reclaimed this path as stale while we were still
-    // alive. What's there now is its active lock, not ours — removing it
-    // would repeat the exact bug this check exists to prevent.
-    return;
-  }
+
+  // The rename grabbed a reclaimer's fresh lock, not ours — our own lock was
+  // already renamed aside as stale before we got here. Put it back so its
+  // actual owner's release still finds its own token and can clean up
+  // normally, instead of us destroying it.
   try {
-    rmSync(lockPath, { recursive: true, force: true });
+    renameSync(claimedPath, lockPath);
   } catch (err) {
     const reason = err && err.message ? err.message : String(err);
-    console.error(`${VERSION_CHECK_LOG_PREFIX} failed to release install lock (${reason})`);
+    console.error(`${VERSION_CHECK_LOG_PREFIX} could not restore a reclaimer's lock after grabbing it in error (${reason})`);
   }
+}
+
+/**
+ * Cheap, dependency-free check that a node_modules tree actually has what
+ * pluginRoot's package.json declares, so an existing tree without the
+ * completion marker can be told apart from a genuinely interrupted one.
+ * Deliberately shallow (a package.json exists per dependency) rather than
+ * full require.resolve/exports-map resolution: this script cannot import
+ * the richer check used at install time (setup-runtime.ts's
+ * verifyCriticalModules) without depending on the very tree it's verifying.
+ */
+function isNodeModulesValid(pluginRoot, nodeModulesPath) {
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(join(pluginRoot, 'package.json'), 'utf-8'));
+  } catch {
+    return false;
+  }
+  const deps = Object.keys(pkg.dependencies || {});
+  return deps.every((dep) => existsSync(join(nodeModulesPath, ...dep.split('/'), 'package.json')));
 }
 
 function findBun() {
@@ -191,9 +236,27 @@ function ensurePluginDependencies(pluginRoot) {
     if (existsSync(markerPath)) return;
 
     if (existsSync(nodeModulesPath)) {
-      // node_modules present without the completion marker means a previous
-      // install was interrupted before finishing. Its mere presence also
-      // disables Bun's own auto-install, so it must be removed before retrying.
+      // node_modules present without the completion marker is ambiguous: it
+      // could be a previous install interrupted before finishing, OR a
+      // perfectly good tree that predates this marker requirement — e.g. an
+      // installer/repair path that skipped installPluginDependencies (an
+      // already-current install, gh #3799 review), or a marketplace root
+      // this repo's installer never touches at all and that only this
+      // script's own bootstrap has ever populated (gh #2640/#2637 origin).
+      // Validate before condemning it: a tree whose declared dependencies
+      // actually resolve is migrated in place, not discarded and reinstalled
+      // — an unnecessary reinstall that can itself fail and leave the
+      // plugin worse off than before it ever looked "interrupted."
+      if (isNodeModulesValid(pluginRoot, nodeModulesPath)) {
+        try {
+          writeFileSync(markerPath, '');
+        } catch (markerErr) {
+          const markerReason = markerErr && markerErr.message ? markerErr.message : String(markerErr);
+          console.error(`${VERSION_CHECK_LOG_PREFIX} failed to write install-complete marker for a valid legacy install (${markerReason}); next Setup run will re-validate`);
+        }
+        return;
+      }
+
       try {
         rmSync(nodeModulesPath, { recursive: true, force: true });
       } catch (rmErr) {

--- a/plugin/scripts/version-check.js
+++ b/plugin/scripts/version-check.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from 'child_process';
-import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -47,8 +47,28 @@ function acquireInstallLock(pluginRoot) {
     return null;
   }
 
+  // Reclaim atomically: rename the stale lock aside first, THEN mkdir a
+  // fresh one. renameSync is a single winner-take-all filesystem op — if two
+  // processes race to reclaim the same stale lock, only one rename succeeds;
+  // the loser's rename throws ENOENT (source already moved) and backs off.
+  // A naive rmSync-then-mkdirSync here (no shared atomic step between the
+  // two racers) lets both believe they reclaimed it: the second rmSync
+  // deletes the first's freshly-created lock, and both mkdirSync calls then
+  // succeed in sequence (gh #3799 review).
+  const staleAsidePath = `${lockPath}.stale-${process.pid}-${Math.random().toString(36).slice(2)}`;
   try {
-    rmSync(lockPath, { recursive: true, force: true });
+    renameSync(lockPath, staleAsidePath);
+  } catch {
+    return null;
+  }
+  try {
+    rmSync(staleAsidePath, { recursive: true, force: true });
+  } catch {
+    // Non-fatal: orphaned under a unique name, won't be picked up by future
+    // stale-lock checks (different path) — a cosmetic leak, not a hazard.
+  }
+
+  try {
     mkdirSync(lockPath);
     return lockPath;
   } catch {

--- a/plugin/scripts/version-check.js
+++ b/plugin/scripts/version-check.js
@@ -18,20 +18,35 @@ const INSTALL_LOCK_DIRNAME = '.claude-mem-install.lock';
 // hold it.
 const INSTALL_LOCK_STALE_MS = BUN_INSTALL_TIMEOUT_MS + 30_000;
 
+const INSTALL_LOCK_OWNER_FILE = 'owner';
+
 /**
  * Acquire an exclusive, self-cleaning install lock so two Setup hooks racing
  * on the same pluginRoot (e.g. several Claude Code sessions launched at once,
  * gh #3793) cannot interleave: mkdir is atomic, so exactly one process wins.
  * A stale lock (holder was killed mid-install) is reclaimed after
  * INSTALL_LOCK_STALE_MS rather than blocking every future Setup run forever.
- * Returns the lock path on success, or null if another process currently
- * owns it.
+ *
+ * Returns { lockPath, token } on success, or null if another process
+ * currently owns it. `token` is a per-acquisition identity written into the
+ * lock directory; releaseInstallLock only removes the lock if that token is
+ * still the one on disk. Without this, a live-but-slow holder whose lock got
+ * reclaimed as stale would, on reaching its own release, delete whatever
+ * replacement lock now occupies the same path instead of nothing — handing
+ * a third process the same false "it's free" signal (gh #3799 review).
  */
 function acquireInstallLock(pluginRoot) {
   const lockPath = join(pluginRoot, INSTALL_LOCK_DIRNAME);
-  try {
+  const token = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+  const claim = () => {
     mkdirSync(lockPath);
-    return lockPath;
+    writeFileSync(join(lockPath, INSTALL_LOCK_OWNER_FILE), token);
+    return { lockPath, token };
+  };
+
+  try {
+    return claim();
   } catch (err) {
     if (!err || err.code !== 'EEXIST') throw err;
   }
@@ -69,14 +84,29 @@ function acquireInstallLock(pluginRoot) {
   }
 
   try {
-    mkdirSync(lockPath);
-    return lockPath;
+    return claim();
   } catch {
     return null;
   }
 }
 
-function releaseInstallLock(lockPath) {
+function releaseInstallLock(lock) {
+  if (!lock) return;
+  const { lockPath, token } = lock;
+  let currentToken;
+  try {
+    currentToken = readFileSync(join(lockPath, INSTALL_LOCK_OWNER_FILE), 'utf-8');
+  } catch {
+    // Owner file missing/unreadable: the lock is already gone, or mid-
+    // replacement by a reclaimer. Nothing that's provably ours to remove.
+    return;
+  }
+  if (currentToken !== token) {
+    // Another process reclaimed this path as stale while we were still
+    // alive. What's there now is its active lock, not ours — removing it
+    // would repeat the exact bug this check exists to prevent.
+    return;
+  }
   try {
     rmSync(lockPath, { recursive: true, force: true });
   } catch (err) {
@@ -149,8 +179,8 @@ function ensurePluginDependencies(pluginRoot) {
   // a peer is still installing into it (gh #3793 review). A process that
   // loses the race skips this Setup run entirely rather than touching
   // anything; the next Setup run (or the lock holder itself) retries.
-  const lockPath = acquireInstallLock(pluginRoot);
-  if (!lockPath) {
+  const lock = acquireInstallLock(pluginRoot);
+  if (!lock) {
     console.error(`${VERSION_CHECK_LOG_PREFIX} another process is installing plugin dependencies; skipping this Setup run`);
     return;
   }
@@ -241,7 +271,7 @@ function ensurePluginDependencies(pluginRoot) {
       }
     }
   } finally {
-    releaseInstallLock(lockPath);
+    releaseInstallLock(lock);
   }
 }
 

--- a/plugin/scripts/version-check.js
+++ b/plugin/scripts/version-check.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { spawnSync } from 'child_process';
 import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'fs';
+import { createRequire } from 'module';
 import { homedir } from 'os';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -10,6 +11,13 @@ const VERSION_CHECK_LOG_PREFIX = '[version-check]';
 const BUN_INSTALL_ARGS = Object.freeze(['install', '--production']);
 const BUN_INSTALL_TIMEOUT_MS = 120_000;
 const NODE_MODULES_DIRNAME = 'node_modules';
+// zod ships its public API behind subpath exports the worker bundle requires
+// (mirrors setup-runtime.ts's ZOD_REQUIRED_SUBPATHS). The package directory
+// existing does NOT imply these subpaths resolve — a truncated/corrupt copy
+// can have a package.json but be missing the compiled v3/v4 output, which is
+// exactly the `Cannot find module 'zod/v3'` failure this marker exists to
+// prevent (gh #2640, #2637, review on PR #3799).
+const ZOD_REQUIRED_SUBPATHS = Object.freeze(['zod/v3', 'zod/v4', 'zod/v4-mini']);
 const INSTALL_COMPLETE_MARKER = '.claude-mem-install-complete';
 const INSTALL_LOCK_DIRNAME = '.claude-mem-install.lock';
 // A held lock older than this is assumed to belong to a process that was
@@ -157,7 +165,29 @@ function isNodeModulesValid(pluginRoot, nodeModulesPath) {
     return false;
   }
   const deps = Object.keys(pkg.dependencies || {});
-  return deps.every((dep) => existsSync(join(nodeModulesPath, ...dep.split('/'), 'package.json')));
+  const allPackagesPresent = deps.every((dep) => existsSync(join(nodeModulesPath, ...dep.split('/'), 'package.json')));
+  if (!allPackagesPresent) return false;
+
+  // A dependency's own package.json existing does not mean its subpath
+  // exports resolve — a truncated copy can look present but still crash the
+  // worker with `Cannot find module 'zod/v3'` (review on PR #3799).
+  if (deps.includes('zod')) {
+    let requireFromPlugin;
+    try {
+      requireFromPlugin = createRequire(join(pluginRoot, 'package.json'));
+    } catch {
+      return false;
+    }
+    for (const subpath of ZOD_REQUIRED_SUBPATHS) {
+      try {
+        requireFromPlugin.resolve(subpath);
+      } catch {
+        return false;
+      }
+    }
+  }
+
+  return true;
 }
 
 function findBun() {

--- a/plugin/scripts/version-check.js
+++ b/plugin/scripts/version-check.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from 'child_process';
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -11,6 +11,59 @@ const BUN_INSTALL_ARGS = Object.freeze(['install', '--production']);
 const BUN_INSTALL_TIMEOUT_MS = 120_000;
 const NODE_MODULES_DIRNAME = 'node_modules';
 const INSTALL_COMPLETE_MARKER = '.claude-mem-install-complete';
+const INSTALL_LOCK_DIRNAME = '.claude-mem-install.lock';
+// A held lock older than this is assumed to belong to a process that was
+// killed mid-install (e.g. the gh #3793 tree-kill) rather than one still
+// running; BUN_INSTALL_TIMEOUT_MS is the longest a live install should ever
+// hold it.
+const INSTALL_LOCK_STALE_MS = BUN_INSTALL_TIMEOUT_MS + 30_000;
+
+/**
+ * Acquire an exclusive, self-cleaning install lock so two Setup hooks racing
+ * on the same pluginRoot (e.g. several Claude Code sessions launched at once,
+ * gh #3793) cannot interleave: mkdir is atomic, so exactly one process wins.
+ * A stale lock (holder was killed mid-install) is reclaimed after
+ * INSTALL_LOCK_STALE_MS rather than blocking every future Setup run forever.
+ * Returns the lock path on success, or null if another process currently
+ * owns it.
+ */
+function acquireInstallLock(pluginRoot) {
+  const lockPath = join(pluginRoot, INSTALL_LOCK_DIRNAME);
+  try {
+    mkdirSync(lockPath);
+    return lockPath;
+  } catch (err) {
+    if (!err || err.code !== 'EEXIST') throw err;
+  }
+
+  let ageMs = Infinity;
+  try {
+    ageMs = Date.now() - statSync(lockPath).mtimeMs;
+  } catch {
+    // Lock disappeared between the failed mkdir and this stat (the other
+    // process finished) — fall through and retry acquisition below.
+  }
+  if (ageMs <= INSTALL_LOCK_STALE_MS) {
+    return null;
+  }
+
+  try {
+    rmSync(lockPath, { recursive: true, force: true });
+    mkdirSync(lockPath);
+    return lockPath;
+  } catch {
+    return null;
+  }
+}
+
+function releaseInstallLock(lockPath) {
+  try {
+    rmSync(lockPath, { recursive: true, force: true });
+  } catch (err) {
+    const reason = err && err.message ? err.message : String(err);
+    console.error(`${VERSION_CHECK_LOG_PREFIX} failed to release install lock (${reason})`);
+  }
+}
 
 function findBun() {
   const pathCheck = IS_WINDOWS
@@ -71,85 +124,104 @@ function ensurePluginDependencies(pluginRoot) {
   // install forever, permanently short-circuiting on a broken plugin.
   if (existsSync(markerPath)) return;
 
-  if (existsSync(nodeModulesPath)) {
-    // node_modules present without the completion marker means a previous
-    // install was interrupted before finishing. Its mere presence also
-    // disables Bun's own auto-install, so it must be removed before retrying.
-    try {
-      rmSync(nodeModulesPath, { recursive: true, force: true });
-    } catch (rmErr) {
-      const rmReason = rmErr && rmErr.message ? rmErr.message : String(rmErr);
-      console.error(`${VERSION_CHECK_LOG_PREFIX} failed to remove incomplete node_modules (${rmReason}); worker may crash with missing module errors`);
+  // Hold an exclusive lock for the rest of this function: a second Setup
+  // hook racing on the same pluginRoot must never delete node_modules while
+  // a peer is still installing into it (gh #3793 review). A process that
+  // loses the race skips this Setup run entirely rather than touching
+  // anything; the next Setup run (or the lock holder itself) retries.
+  const lockPath = acquireInstallLock(pluginRoot);
+  if (!lockPath) {
+    console.error(`${VERSION_CHECK_LOG_PREFIX} another process is installing plugin dependencies; skipping this Setup run`);
+    return;
+  }
+
+  try {
+    // Re-check after acquiring the lock: the previous holder may have just
+    // finished successfully while we were waiting.
+    if (existsSync(markerPath)) return;
+
+    if (existsSync(nodeModulesPath)) {
+      // node_modules present without the completion marker means a previous
+      // install was interrupted before finishing. Its mere presence also
+      // disables Bun's own auto-install, so it must be removed before retrying.
+      try {
+        rmSync(nodeModulesPath, { recursive: true, force: true });
+      } catch (rmErr) {
+        const rmReason = rmErr && rmErr.message ? rmErr.message : String(rmErr);
+        console.error(`${VERSION_CHECK_LOG_PREFIX} failed to remove incomplete node_modules (${rmReason}); worker may crash with missing module errors`);
+        return;
+      }
+    }
+
+    const bunPath = findBun();
+    if (!bunPath) {
+      console.error(`${VERSION_CHECK_LOG_PREFIX} bun not found on PATH; cannot auto-install plugin dependencies`);
       return;
     }
-  }
 
-  const bunPath = findBun();
-  if (!bunPath) {
-    console.error(`${VERSION_CHECK_LOG_PREFIX} bun not found on PATH; cannot auto-install plugin dependencies`);
-    return;
-  }
+    // Progress diagnostic so users understand the (one-time) Setup hang.
+    console.error(`${VERSION_CHECK_LOG_PREFIX} installing plugin dependencies (first run, one-time)...`);
 
-  // Progress diagnostic so users understand the (one-time) Setup hang.
-  console.error(`${VERSION_CHECK_LOG_PREFIX} installing plugin dependencies (first run, one-time)...`);
+    let result;
+    try {
+      result = spawnSync(bunPath, BUN_INSTALL_ARGS, {
+        cwd: pluginRoot,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: BUN_INSTALL_TIMEOUT_MS,
+        windowsHide: true,
+      });
+    } catch (err) {
+      const reason = err && err.message ? err.message : String(err);
+      console.error(`${VERSION_CHECK_LOG_PREFIX} bun install threw (${reason}); worker may crash with missing module errors`);
+      return;
+    }
 
-  let result;
-  try {
-    result = spawnSync(bunPath, BUN_INSTALL_ARGS, {
-      cwd: pluginRoot,
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: BUN_INSTALL_TIMEOUT_MS,
-      windowsHide: true,
-    });
-  } catch (err) {
-    const reason = err && err.message ? err.message : String(err);
-    console.error(`${VERSION_CHECK_LOG_PREFIX} bun install threw (${reason}); worker may crash with missing module errors`);
-    return;
-  }
-
-  // spawnSync does NOT throw on a failed child. Three distinct failure
-  // modes must be surfaced explicitly:
-  //   1. result.error set (ENOENT / ETIMEDOUT / ...)
-  //   2. non-zero exit code
-  //   3. signal-killed (OOM SIGKILL, SIGTERM, ...) where result.status is
-  //      null AND result.error is undefined — only result.signal is set.
-  const killedBySignal = result.status === null && !!result.signal;
-  const nonZeroExit = result.status !== null && result.status !== 0;
-  if (result.error || nonZeroExit || killedBySignal) {
-    let reason;
-    if (result.error) {
-      reason = result.error.message;
-    } else if (killedBySignal) {
-      reason = `killed by ${result.signal}`;
+    // spawnSync does NOT throw on a failed child. Three distinct failure
+    // modes must be surfaced explicitly:
+    //   1. result.error set (ENOENT / ETIMEDOUT / ...)
+    //   2. non-zero exit code
+    //   3. signal-killed (OOM SIGKILL, SIGTERM, ...) where result.status is
+    //      null AND result.error is undefined — only result.signal is set.
+    const killedBySignal = result.status === null && !!result.signal;
+    const nonZeroExit = result.status !== null && result.status !== 0;
+    if (result.error || nonZeroExit || killedBySignal) {
+      let reason;
+      if (result.error) {
+        reason = result.error.message;
+      } else if (killedBySignal) {
+        reason = `killed by ${result.signal}`;
+      } else {
+        reason = `exit ${result.status}`;
+      }
+      console.error(`${VERSION_CHECK_LOG_PREFIX} bun install failed (${reason}); worker may crash with missing module errors`);
+      // `bun install` often creates `node_modules/` BEFORE the failure point
+      // (network timeout mid-fetch, OOM kill, registry 5xx after partial
+      // resolution). The existence guard above would then permanently skip
+      // retry on every subsequent Setup run, leaving the plugin broken with
+      // no recovery path short of manual `rm -rf node_modules`. Remove the
+      // partial dir so the next Setup invocation can retry automatically
+      // (gh #2650 review).
+      try {
+        rmSync(nodeModulesPath, { recursive: true, force: true });
+      } catch (rmErr) {
+        const rmReason = rmErr && rmErr.message ? rmErr.message : String(rmErr);
+        console.error(`${VERSION_CHECK_LOG_PREFIX} failed to clean up partial node_modules (${rmReason}); next Setup run may skip retry`);
+      }
     } else {
-      reason = `exit ${result.status}`;
+      // Close the diagnostic loop: a Setup hook that can block for up to
+      // 120s needs an explicit completion line so users can distinguish a
+      // hung install from one that finished silently (gh #2650 review).
+      console.error(`${VERSION_CHECK_LOG_PREFIX} plugin dependencies installed successfully`);
+      try {
+        writeFileSync(markerPath, '');
+      } catch (markerErr) {
+        const markerReason = markerErr && markerErr.message ? markerErr.message : String(markerErr);
+        console.error(`${VERSION_CHECK_LOG_PREFIX} failed to write install-complete marker (${markerReason}); next Setup run will reinstall`);
+      }
     }
-    console.error(`${VERSION_CHECK_LOG_PREFIX} bun install failed (${reason}); worker may crash with missing module errors`);
-    // `bun install` often creates `node_modules/` BEFORE the failure point
-    // (network timeout mid-fetch, OOM kill, registry 5xx after partial
-    // resolution). The existence guard above would then permanently skip
-    // retry on every subsequent Setup run, leaving the plugin broken with
-    // no recovery path short of manual `rm -rf node_modules`. Remove the
-    // partial dir so the next Setup invocation can retry automatically
-    // (gh #2650 review).
-    try {
-      rmSync(nodeModulesPath, { recursive: true, force: true });
-    } catch (rmErr) {
-      const rmReason = rmErr && rmErr.message ? rmErr.message : String(rmErr);
-      console.error(`${VERSION_CHECK_LOG_PREFIX} failed to clean up partial node_modules (${rmReason}); next Setup run may skip retry`);
-    }
-  } else {
-    // Close the diagnostic loop: a Setup hook that can block for up to
-    // 120s needs an explicit completion line so users can distinguish a
-    // hung install from one that finished silently (gh #2650 review).
-    console.error(`${VERSION_CHECK_LOG_PREFIX} plugin dependencies installed successfully`);
-    try {
-      writeFileSync(markerPath, '');
-    } catch (markerErr) {
-      const markerReason = markerErr && markerErr.message ? markerErr.message : String(markerErr);
-      console.error(`${VERSION_CHECK_LOG_PREFIX} failed to write install-complete marker (${markerReason}); next Setup run will reinstall`);
-    }
+  } finally {
+    releaseInstallLock(lockPath);
   }
 }
 

--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -20,6 +20,7 @@ import {
   installPluginDependencies,
   writeInstallMarker,
   isInstallCurrent,
+  ensureInstallCompleteMarker,
 } from '../install/setup-runtime.js';
 import { playBanner } from '../banner.js';
 import { normalizeRuntimeFlag } from './server-runtime-setup.js';
@@ -2175,6 +2176,12 @@ async function runInstallCommandInner(options: InstallOptions, summary: InstallS
             }
             writeInstallMarker(cacheDir, version, bunVersion, uvVersion);
           }
+          // isInstallCurrent's fast path above can skip installPluginDependencies
+          // entirely for an already-good install, which would otherwise never get
+          // the completion marker Setup's own auto-install requires (PR #3799
+          // review) — a legacy-valid tree would then look interrupted and get
+          // deleted on the next launch. No-op if the marker is already there.
+          ensureInstallCompleteMarker(cacheDir);
           writeInstallMarker(join(marketplaceDirectory(), 'plugin'), version, bunVersion, uvVersion);
           return `Runtime ready (Bun ${bunVersion}, uv ${uvVersion}) ${styleText('green', 'OK')}`;
         },

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -463,14 +463,26 @@ export async function installPluginDependencies(targetDir: string, bunPath: stri
     throw new Error(`bun install failed in ${targetDir}\n${describeExecError(err)}`);
   }
 
-  verifyCriticalModules(targetDir);
+  ensureInstallCompleteMarker(targetDir);
+}
 
-  // version-check.js's Setup-phase auto-install (gh #3793) treats node_modules
-  // without this marker as an interrupted install and deletes it. Without
-  // writing it here, the very next Setup run after a normal `npx claude-mem
-  // install`/repair would delete the tree it just verified and reinstall from
-  // scratch, breaking the plugin if that reinstall fails.
-  writeFileSync(join(targetDir, 'node_modules', NODE_MODULES_INSTALL_COMPLETE_MARKER), '');
+/**
+ * Write node_modules/.claude-mem-install-complete if it isn't already there,
+ * after confirming targetDir's dependencies actually resolve. version-check.js's
+ * Setup-phase auto-install (gh #3793) treats node_modules without this marker
+ * as an interrupted install and deletes it. A caller that determines an
+ * install is already current (isInstallCurrent) can skip calling
+ * installPluginDependencies entirely and so never reach the write above -
+ * that legacy-valid tree would then look interrupted to Setup and get
+ * deleted, breaking the plugin if the forced reinstall then fails (PR #3799
+ * review). Callers that know an install is current, not just freshly
+ * installed, must still call this to keep the marker's invariant true.
+ */
+export function ensureInstallCompleteMarker(targetDir: string): void {
+  const markerPath = join(targetDir, 'node_modules', NODE_MODULES_INSTALL_COMPLETE_MARKER);
+  if (existsSync(markerPath)) return;
+  verifyCriticalModules(targetDir);
+  writeFileSync(markerPath, '');
 }
 
 export function readInstallMarker(targetDir: string): MarkerSchema | null {

--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -71,6 +71,14 @@ interface MarkerSchema {
 const LEGACY_VERSION_MARKER_RE =
   /^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 
+// Duplicated literal, not shared: this must match plugin/scripts/version-check.js's
+// NODE_MODULES_INSTALL_COMPLETE_MARKER exactly. version-check.js is a dependency-free
+// bootstrap script that cannot import from this compiled module (it runs before/while
+// node_modules is being materialised), so the two files intentionally duplicate this
+// filename rather than share it — matching this file's existing LEGACY_VERSION_MARKER_RE
+// duplication with the same script.
+const NODE_MODULES_INSTALL_COMPLETE_MARKER = '.claude-mem-install-complete';
+
 function markerPath(targetDir: string): string {
   return join(targetDir, '.install-version');
 }
@@ -456,6 +464,13 @@ export async function installPluginDependencies(targetDir: string, bunPath: stri
   }
 
   verifyCriticalModules(targetDir);
+
+  // version-check.js's Setup-phase auto-install (gh #3793) treats node_modules
+  // without this marker as an interrupted install and deletes it. Without
+  // writing it here, the very next Setup run after a normal `npx claude-mem
+  // install`/repair would delete the tree it just verified and reinstall from
+  // scratch, breaking the plugin if that reinstall fails.
+  writeFileSync(join(targetDir, 'node_modules', NODE_MODULES_INSTALL_COMPLETE_MARKER), '');
 }
 
 export function readInstallMarker(targetDir: string): MarkerSchema | null {

--- a/tests/plugin-version-check-ensure-deps.test.ts
+++ b/tests/plugin-version-check-ensure-deps.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { spawn } from 'child_process';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join, resolve } from 'path';
 
@@ -60,7 +60,7 @@ function runVersionCheck(pluginRoot: string, fakeBinDir: string): Promise<{ stde
   });
 }
 
-type BunBehavior = 'success' | 'partial-then-fail';
+type BunBehavior = 'success' | 'partial-then-fail' | 'slow-success';
 
 function makeFreshPlugin(name: string, bunBehavior: BunBehavior = 'success'): { pluginRoot: string; fakeBinDir: string } {
   const pluginRoot = join(tmpRoot, name);
@@ -86,6 +86,17 @@ function makeFreshPlugin(name: string, bunBehavior: BunBehavior = 'success'): { 
   const installBody = bunBehavior === 'success'
     ? [
         `  mkdir -p "${pluginRoot}/node_modules/zod/v3"`,
+        `  : > "${pluginRoot}/node_modules/zod/v3/index.js"`,
+        '  exit 0',
+      ]
+    : bunBehavior === 'slow-success'
+    ? [
+        // Widens the window between "node_modules exists" and "marker
+        // written" so a concurrent second Setup run reliably lands inside
+        // it — reproducing the gh #3793 review race deterministically
+        // instead of relying on timing luck.
+        `  mkdir -p "${pluginRoot}/node_modules/zod/v3"`,
+        '  sleep 1',
         `  : > "${pluginRoot}/node_modules/zod/v3/index.js"`,
         '  exit 0',
       ]
@@ -187,5 +198,58 @@ describe.skipIf(SKIP_NON_UNIX)('version-check Setup-phase ensurePluginDependenci
     expect(stderr).toContain(INSTALL_SUCCESS_DIAGNOSTIC);
     expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(true);
     expect(existsSync(join(pluginRoot, 'node_modules', '.claude-mem-install-complete'))).toBe(true);
+  });
+
+  test('a second Setup run racing the first skips instead of deleting the in-flight install (gh #3793 review)', async () => {
+    // Reproduces the Greptile review finding: two Setup hooks can fire near-
+    // simultaneously (several Claude Code sessions launched at once, the
+    // exact scenario in the original report). Without a lock, the second
+    // process sees node_modules exists without the completion marker yet
+    // (the first is still mid-install) and deletes it out from under the
+    // first, corrupting the install.
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-concurrent-install', 'slow-success');
+
+    const first = runVersionCheck(pluginRoot, fakeBinDir);
+    // Give the first process time to win the lock and start its (1s) bun
+    // install before the second process starts, so the second reliably
+    // lands inside the vulnerable window instead of winning the race itself.
+    await new Promise((r) => setTimeout(r, 200));
+    const second = runVersionCheck(pluginRoot, fakeBinDir);
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    const results = [firstResult, secondResult];
+
+    const installed = results.filter((r) => r.stderr.includes(INSTALL_DIAGNOSTIC));
+    const skipped = results.filter((r) => r.stderr.includes('another process is installing'));
+    expect(installed.length).toBe(1);
+    expect(skipped.length).toBe(1);
+
+    // The install that did run must have completed cleanly — proof the
+    // skipped process never touched the in-flight node_modules.
+    expect(installed[0].stderr).toContain(INSTALL_SUCCESS_DIAGNOSTIC);
+    expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(true);
+    expect(existsSync(join(pluginRoot, 'node_modules', '.claude-mem-install-complete'))).toBe(true);
+  });
+
+  test('reclaims a stale install lock left by a killed process instead of blocking forever (gh #3793 review)', async () => {
+    // A worker version-mismatch tree-kill (the original gh #3793 bug) can
+    // SIGKILL this script mid-install, leaving the lock directory itself
+    // held forever with no process left to release it. Without staleness
+    // recovery, that would trade the old "node_modules exists forever"
+    // deadlock for an equivalent "lock exists forever" deadlock.
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-stale-lock');
+    const lockPath = join(pluginRoot, '.claude-mem-install.lock');
+    mkdirSync(lockPath, { recursive: true });
+    const staleTime = new Date(Date.now() - 10 * 60 * 1000); // 10 minutes old
+    utimesSync(lockPath, staleTime, staleTime);
+
+    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
+    expect(stderr).toContain(INSTALL_DIAGNOSTIC);
+    expect(stderr).toContain(INSTALL_SUCCESS_DIAGNOSTIC);
+    expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(true);
+    // The lock is released after use, not left behind for the next run.
+    expect(existsSync(lockPath)).toBe(false);
   });
 });

--- a/tests/plugin-version-check-ensure-deps.test.ts
+++ b/tests/plugin-version-check-ensure-deps.test.ts
@@ -153,12 +153,13 @@ describe.skipIf(SKIP_NON_UNIX)('version-check Setup-phase ensurePluginDependenci
     expect(existsSync(join(pluginRoot, 'node_modules'))).toBe(false);
   });
 
-  test('skips install when node_modules is already present', async () => {
-    // Setup runs on every Claude Code launch. If node_modules already exists,
+  test('skips install when a completed install marker is already present', async () => {
+    // Setup runs on every Claude Code launch. If a previous install finished,
     // the install MUST be skipped — otherwise we re-run a 100 MB+ install on
     // every cold start and burn the user's bandwidth.
     const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-already-installed');
     mkdirSync(join(pluginRoot, 'node_modules'), { recursive: true });
+    writeFileSync(join(pluginRoot, 'node_modules', '.claude-mem-install-complete'), '');
 
     const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
 
@@ -167,5 +168,24 @@ describe.skipIf(SKIP_NON_UNIX)('version-check Setup-phase ensurePluginDependenci
     // The fake bun would have created zod/v3/index.js if invoked — its
     // absence proves the install path was not taken.
     expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(false);
+  });
+
+  test('removes an interrupted node_modules and reinstalls when the completion marker is missing (gh #3793)', async () => {
+    // Reproduces gh #3793: a worker version-mismatch tree-kill SIGKILLs this
+    // script's own process mid-install, so node_modules exists but is
+    // partial and no cleanup code ever ran. Without a completion marker, the
+    // existsSync(node_modules) guard would skip install forever. A node_modules
+    // present without the marker must be treated as incomplete: removed, then
+    // reinstalled.
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-interrupted-install');
+    mkdirSync(join(pluginRoot, 'node_modules', 'zod'), { recursive: true });
+
+    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
+    expect(stderr).toContain(INSTALL_DIAGNOSTIC);
+    expect(stderr).toContain(INSTALL_SUCCESS_DIAGNOSTIC);
+    expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(true);
+    expect(existsSync(join(pluginRoot, 'node_modules', '.claude-mem-install-complete'))).toBe(true);
   });
 });

--- a/tests/plugin-version-check-ensure-deps.test.ts
+++ b/tests/plugin-version-check-ensure-deps.test.ts
@@ -118,6 +118,34 @@ function makeFreshPlugin(name: string, bunBehavior: BunBehavior = 'success'): { 
   return { pluginRoot, fakeBinDir };
 }
 
+/**
+ * Write a zod package whose './v3', './v4', './v4-mini' subpaths genuinely
+ * resolve, so the validity check's require.resolve calls succeed — a bare
+ * package.json with no exports map is what an actually-broken/truncated
+ * install looks like (review on PR #3799).
+ */
+function writeValidZodPackage(pluginRoot: string): void {
+  const zodDir = join(pluginRoot, 'node_modules', 'zod');
+  const exportsMap = {
+    '.': './index.js',
+    './v3': './v3/index.js',
+    './v4': './v4/index.js',
+    './v4-mini': './v4-mini/index.js',
+  };
+  mkdirSync(zodDir, { recursive: true });
+  writeFileSync(join(zodDir, 'package.json'), JSON.stringify({
+    name: 'zod',
+    version: '3.0.0',
+    type: 'module',
+    exports: exportsMap,
+  }));
+  for (const target of Object.values(exportsMap)) {
+    const relPath = target.replace(/^\.\//, '');
+    mkdirSync(join(zodDir, relPath, '..'), { recursive: true });
+    writeFileSync(join(zodDir, relPath), 'export default {};\n');
+  }
+}
+
 beforeAll(() => {
   tmpRoot = mkdtempSync(join(tmpdir(), 'version-check-deps-'));
 });
@@ -199,6 +227,32 @@ describe.skipIf(SKIP_NON_UNIX)('version-check Setup-phase ensurePluginDependenci
     expect(existsSync(join(pluginRoot, 'node_modules', '.claude-mem-install-complete'))).toBe(true);
   });
 
+  test('does not mark a truncated zod install valid just because its package.json exists (gh #3799 review)', async () => {
+    // A package.json present with the compiled v3/v4 output missing is what
+    // an actually-broken/truncated install looks like — checking only that
+    // node_modules/zod/package.json exists (without resolving its required
+    // subpaths) would mark this "valid" and permanently skip repair, quietly
+    // reproducing the exact `Cannot find module 'zod/v3'` crash this marker
+    // exists to prevent, with no future re-check once marked complete.
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-truncated-zod');
+    mkdirSync(join(pluginRoot, 'node_modules', 'zod'), { recursive: true });
+    writeFileSync(join(pluginRoot, 'node_modules', 'zod', 'package.json'), JSON.stringify({
+      name: 'zod',
+      version: '3.0.0',
+      exports: { '.': './index.js', './v3': './v3/index.js' },
+    }));
+    writeFileSync(join(pluginRoot, 'node_modules', 'zod', 'index.js'), 'export default {};\n');
+    // './v3/index.js' deliberately absent — the truncation.
+
+    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
+    expect(stderr).toContain(INSTALL_DIAGNOSTIC);
+    expect(stderr).toContain(INSTALL_SUCCESS_DIAGNOSTIC);
+    expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(true);
+    expect(existsSync(join(pluginRoot, 'node_modules', '.claude-mem-install-complete'))).toBe(true);
+  });
+
   test('migrates a valid legacy install in place instead of deleting and reinstalling it (gh #3799 review)', async () => {
     // A node_modules that predates this marker requirement (e.g. an
     // installer/repair path that skipped installPluginDependencies because
@@ -210,17 +264,15 @@ describe.skipIf(SKIP_NON_UNIX)('version-check Setup-phase ensurePluginDependenci
     // whose declared dependency actually resolves must be marked complete
     // in place, not discarded.
     const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-legacy-valid-install');
-    mkdirSync(join(pluginRoot, 'node_modules', 'zod'), { recursive: true });
-    writeFileSync(join(pluginRoot, 'node_modules', 'zod', 'package.json'), JSON.stringify({ name: 'zod', version: '3.0.0' }));
+    writeValidZodPackage(pluginRoot);
 
     const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
 
     expect(code).toBe(0);
+    // Proves no reinstall was attempted — only a marker write for the tree
+    // that was already there.
     expect(stderr).not.toContain(INSTALL_DIAGNOSTIC);
     expect(existsSync(join(pluginRoot, 'node_modules', '.claude-mem-install-complete'))).toBe(true);
-    // The fake bun would have created zod/v3/index.js if invoked — its
-    // absence proves no reinstall happened, only a marker write.
-    expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(false);
   });
 
   test('a second Setup run racing the first skips instead of deleting the in-flight install (gh #3793 review)', async () => {

--- a/tests/plugin-version-check-ensure-deps.test.ts
+++ b/tests/plugin-version-check-ensure-deps.test.ts
@@ -181,13 +181,12 @@ describe.skipIf(SKIP_NON_UNIX)('version-check Setup-phase ensurePluginDependenci
     expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(false);
   });
 
-  test('removes an interrupted node_modules and reinstalls when the completion marker is missing (gh #3793)', async () => {
+  test('removes an interrupted node_modules and reinstalls when it fails validation (gh #3793)', async () => {
     // Reproduces gh #3793: a worker version-mismatch tree-kill SIGKILLs this
     // script's own process mid-install, so node_modules exists but is
-    // partial and no cleanup code ever ran. Without a completion marker, the
-    // existsSync(node_modules) guard would skip install forever. A node_modules
-    // present without the marker must be treated as incomplete: removed, then
-    // reinstalled.
+    // partial (the declared zod dependency has no package.json) and no
+    // cleanup code ever ran. A node_modules that fails validation and lacks
+    // the marker must be treated as incomplete: removed, then reinstalled.
     const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-interrupted-install');
     mkdirSync(join(pluginRoot, 'node_modules', 'zod'), { recursive: true });
 
@@ -198,6 +197,30 @@ describe.skipIf(SKIP_NON_UNIX)('version-check Setup-phase ensurePluginDependenci
     expect(stderr).toContain(INSTALL_SUCCESS_DIAGNOSTIC);
     expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(true);
     expect(existsSync(join(pluginRoot, 'node_modules', '.claude-mem-install-complete'))).toBe(true);
+  });
+
+  test('migrates a valid legacy install in place instead of deleting and reinstalling it (gh #3799 review)', async () => {
+    // A node_modules that predates this marker requirement (e.g. an
+    // installer/repair path that skipped installPluginDependencies because
+    // the install was already current, or a marketplace root this repo's
+    // installer never touches at all — this script's own bootstrap is the
+    // only thing that has ever populated it) is otherwise perfectly good.
+    // Deleting and forcing a reinstall is an unnecessary risk: if that
+    // reinstall then fails, the plugin goes from working to broken. A tree
+    // whose declared dependency actually resolves must be marked complete
+    // in place, not discarded.
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-legacy-valid-install');
+    mkdirSync(join(pluginRoot, 'node_modules', 'zod'), { recursive: true });
+    writeFileSync(join(pluginRoot, 'node_modules', 'zod', 'package.json'), JSON.stringify({ name: 'zod', version: '3.0.0' }));
+
+    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
+    expect(stderr).not.toContain(INSTALL_DIAGNOSTIC);
+    expect(existsSync(join(pluginRoot, 'node_modules', '.claude-mem-install-complete'))).toBe(true);
+    // The fake bun would have created zod/v3/index.js if invoked — its
+    // absence proves no reinstall happened, only a marker write.
+    expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(false);
   });
 
   test('a second Setup run racing the first skips instead of deleting the in-flight install (gh #3793 review)', async () => {

--- a/tests/plugin-version-check.test.ts
+++ b/tests/plugin-version-check.test.ts
@@ -27,10 +27,12 @@ describe('plugin/scripts/version-check.js install marker compatibility', () => {
     );
     mkdirSync(tempDir, { recursive: true });
     writeFileSync(join(tempDir, 'package.json'), JSON.stringify({ version: '12.4.4' }));
-    // Pre-create node_modules so version-check's Setup-phase dependency
-    // auto-install (gh #2649) short-circuits — these tests are about
-    // .install-version marker compatibility, not dependency materialisation.
+    // Pre-create a completed node_modules (with the completion marker) so
+    // version-check's Setup-phase dependency auto-install (gh #2649, #3793)
+    // short-circuits — these tests are about .install-version marker
+    // compatibility, not dependency materialisation.
     mkdirSync(join(tempDir, 'node_modules'), { recursive: true });
+    writeFileSync(join(tempDir, 'node_modules', '.claude-mem-install-complete'), '');
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Symptom

After a plugin auto-update gets tree-killed mid-install (see #3793), `node_modules/` is left partially populated. Every subsequent Setup hook sees `node_modules` exists, skips install, and the worker keeps crashing with `Cannot find module 'zod/v3'` (or similar) until someone manually deletes the directory.

## Root cause

`ensurePluginDependencies()` in `plugin/scripts/version-check.js` gates the install entirely on `existsSync(node_modules)`. That guard cannot distinguish a completed install from one interrupted before it finished. A worker version-mismatch tree-kill (`src/shared/worker-utils.ts`) SIGKILLs the whole process tree, including this script's own process, whenever the install runs as an observer descendant — so the existing in-process cleanup (which only runs when `spawnSync` itself observes a failure) never gets a chance to execute. The directory is left behind looking "installed."

## Fix

Gate the skip on a completion marker (`node_modules/.claude-mem-install-complete`) written only after `bun install` exits 0. `node_modules` present without the marker is treated as an interrupted install: removed (its mere presence also disables Bun's own auto-install per the linked issue) and reinstalled.

## Verification

- `bun test tests/plugin-version-check-ensure-deps.test.ts` — 4 pass, 0 fail (existing 3 tests updated/passing + 1 new regression test for the interrupted-install case)
- Diff is limited to the one function that owns the incorrect guard, plus its test file.

## Not included

Does not touch the worker's version-mismatch tree-kill logic (`worker-utils.ts`) — that SIGKILL-only teardown is deliberate, documented history (#3378, #3482) to avoid restart storms, and out of scope for this fix. No new environment variable, no retry/fallback/circuit-breaker, no background process or lifecycle manager.

Closes #3793 (partially — addresses the "nothing cleans it up" half of the report; the tree-kill-vs-installer interaction itself is a separate, larger architectural question the issue also raises).
