### PR TITLE
fix(worker): make the LLM per-attempt deadline configurable and stop retrying it

### DIFF
--- a/src/services/worker/retry.ts
+++ b/src/services/worker/retry.ts
@@ -45,9 +45,45 @@ export interface RetryOptions {
   abortSignal?: AbortSignal;
 }
 
+/** Bounds shared with the other CLAUDE_MEM_*_TIMEOUT_MS settings. */
+const LLM_TIMEOUT_BOUNDS = { min: 500, max: 300_000 } as const;
+const FALLBACK_PER_ATTEMPT_TIMEOUT_MS = 30_000;
+
+/**
+ * Per-attempt deadline for a provider request.
+ *
+ * 30s suits a hosted provider and is far too short for a local model: a
+ * report on an Ollama backend measured successful requests with a median of
+ * 21s and a p99 of 29.8s, so the deadline was truncating work that had
+ * already been computed. The value was unreachable from configuration, and
+ * the workaround was editing the installed bundle after every update.
+ *
+ * Read here rather than through worker-utils' readTimeoutEnv: this module is
+ * a leaf that imports only the logger and the error classifier, and that one
+ * pulls in the supervisor and telemetry.
+ */
+export function resolveLlmTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.CLAUDE_MEM_LLM_TIMEOUT_MS;
+  if (!raw) return FALLBACK_PER_ATTEMPT_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (
+    Number.isFinite(parsed)
+    && parsed >= LLM_TIMEOUT_BOUNDS.min
+    && parsed <= LLM_TIMEOUT_BOUNDS.max
+  ) {
+    return parsed;
+  }
+  logger.warn('SDK', 'Invalid CLAUDE_MEM_LLM_TIMEOUT_MS, using default', {
+    value: raw,
+    min: LLM_TIMEOUT_BOUNDS.min,
+    max: LLM_TIMEOUT_BOUNDS.max,
+  });
+  return FALLBACK_PER_ATTEMPT_TIMEOUT_MS;
+}
+
 const DEFAULT_OPTIONS: Required<Omit<RetryOptions, 'label' | 'abortSignal'>> = {
   maxRetries: 2,
-  perAttemptTimeoutMs: 30_000,
+  perAttemptTimeoutMs: resolveLlmTimeoutMs(),
   baseDelayMs: 100,
   maxDelayMs: 30_000,
 };
@@ -87,7 +123,11 @@ export async function withRetry<T>(
 
     // Per-attempt timeout via AbortController. Forward external aborts too.
     const attemptController = new AbortController();
-    const timeoutHandle = setTimeout(() => attemptController.abort(), opts.perAttemptTimeoutMs);
+    let deadlineExpired = false;
+    const timeoutHandle = setTimeout(() => {
+      deadlineExpired = true;
+      attemptController.abort();
+    }, opts.perAttemptTimeoutMs);
     const onExternalAbort = () => attemptController.abort();
     options.abortSignal?.addEventListener('abort', onExternalAbort, { once: true });
 
@@ -96,9 +136,21 @@ export async function withRetry<T>(
     } catch (err: unknown) {
       lastError = err;
 
+      // Our own deadline, not a network blip. The abort surfaces with no HTTP  // status, so it classifies as transient and was retried twice — against a
+      // backend that is already saturated, those attempts are what turn a
+      // latency problem into a congestion collapse. Raise the deadline instead.
+      if (deadlineExpired) {
+        throw new Error(
+          `${opts.label ?? 'Request'} exceeded the ${opts.perAttemptTimeoutMs}ms per-attempt deadline. `
+          + 'Raise CLAUDE_MEM_LLM_TIMEOUT_MS if the backend is simply slow.',
+          { cause: err },
+        );
+      }
+
       if (!isRetryableKind(err)) {
         throw err;
       }
+    
 
       if (attempt === opts.maxRetries) {
         throw err;

--- a/tests/worker/llm-timeout.test.ts
+++ b/tests/worker/llm-timeout.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'bun:test';
+import { resolveLlmTimeoutMs, withRetry } from '../../src/services/worker/retry.js';
+
+// #3794: the per-attempt deadline was hardcoded at 30s and unreachable from
+// configuration. On a local model that truncates work already computed — a
+// reported Ollama backend had a p99 of 29.8s against a 30s deadline — and the
+// only workaround was editing the installed bundle after every update.
+describe('resolveLlmTimeoutMs', () => {
+  it('defaults to 30s when nothing is configured', () => {
+    expect(resolveLlmTimeoutMs({})).toBe(30_000);
+  });
+
+  it('takes a value inside the shared 500..300000 bounds', () => {
+    expect(resolveLlmTimeoutMs({ CLAUDE_MEM_LLM_TIMEOUT_MS: '90000' })).toBe(90_000);
+    expect(resolveLlmTimeoutMs({ CLAUDE_MEM_LLM_TIMEOUT_MS: '500' })).toBe(500);
+    expect(resolveLlmTimeoutMs({ CLAUDE_MEM_LLM_TIMEOUT_MS: '300000' })).toBe(300_000);
+  });
+
+  it('falls back to the default rather than trusting a value out of range', () => {
+    // A zero or a negative would disable the deadline; a huge one would park a
+    // worker for hours. Both keep the default, matching the other
+    // CLAUDE_MEM_*_TIMEOUT_MS settings.
+    for (const value of ['0', '-1', '499', '300001', 'abc', '']) {
+      expect(resolveLlmTimeoutMs({ CLAUDE_MEM_LLM_TIMEOUT_MS: value })).toBe(30_000);
+    }
+  });
+});
+
+describe('per-attempt deadline', () => {
+  it('does not retry a request that blew the deadline', async () => {
+    // The abort surfaces with no HTTP status, so it classified as transient and
+    // was retried twice against a backend that is already saturated.
+    let attempts = 0;
+    const started = Date.now();
+    await expect(
+      withRetry(
+        async signal => {
+          attempts += 1;
+          await new Promise((_resolve, reject) => {
+            signal.addEventListener('abort', () => reject(new Error('The operation was aborted.')), { once: true });
+          });
+          return 'unreachable';
+        },
+        { label: 'probe', perAttemptTimeoutMs: 20, maxRetries: 2 },
+      ),
+    ).rejects.toThrow(/per-attempt deadline/);
+    expect(attempts).toBe(1);
+    // Three attempts plus backoff would take far longer than one deadline.
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+
+  it('still retries a genuine transient failure', async () => {
+    let attempts = 0;
+    const out = await withRetry(
+      async () => {
+        attempts += 1;
+        if (attempts < 2) throw new Error('socket hang up');
+        return 'ok';
+      },
+      { label: 'probe', perAttemptTimeoutMs: 5_000, maxRetries: 2, baseDelayMs: 1 },
+    );
+    expect(out).toBe('ok');
+    expect(attempts).toBe(2);
+  });
+});


### PR DESCRIPTION
Fixes #3794.

## The deadline was unreachable

`perAttemptTimeoutMs` defaulted to 30s in `DEFAULT_OPTIONS`, and neither of the two `withRetry` call sites passes an override, so no configuration could reach it. That is fine against a hosted provider and wrong against a local model — the report's Ollama backend measured, over 2111 requests:

- successful: median 20.99s, p90 28.07s, **p99 29.77s**, max 29.99s
- failed: **all at exactly 30.000s**

A distribution truncated by the deadline, not a slow one — the fastest success was 1.69s. Everything past 30s was work already computed and then discarded. The reporter's stopgap was rewriting `perAttemptTimeoutMs:3e4` in the installed bundle after every plugin update.

`CLAUDE_MEM_LLM_TIMEOUT_MS` now sets it, validated against the same `500..300000` bounds the other `CLAUDE_MEM_*_TIMEOUT_MS` settings use, with the same warn-and-fall-back behaviour on a bad value. Hosted users keep 30s and see no change.

## The deadline was also retried

An abort from our own deadline reaches the classifier with no HTTP status, so it landed in the `transient` branch and ran two more attempts. Against a backend that is already saturated, those attempts are what turn a latency problem into a congestion collapse — and a request that missed the deadline once will very likely miss it again.

It now fails immediately with a message naming the deadline and the setting that raises it, rather than a bare `The operation was aborted.` The original error is preserved as `cause`. Genuine transient failures still retry exactly as before.

## One thing to check

`resolveLlmTimeoutMs` duplicates the shape of `readTimeoutEnv` in `src/shared/worker-utils.ts` rather than importing it. `retry.ts` is a leaf that imports only the logger and the error classifier, while `worker-utils` pulls in the supervisor, telemetry and settings manager — importing it from here would drag all of that into the retry path. Happy to export `readTimeoutEnv` and use it instead if you would rather have the single copy.

## Tests

```
bun test tests/worker/llm-timeout.test.ts tests/worker/retry-policy.test.ts
12 pass, 0 fail
```

`tests/worker/llm-timeout.test.ts`:

- default is 30s with nothing configured
- accepts values at and inside the bounds (500, 90000, 300000)
- rejects `0`, `-1`, `499`, `300001`, `abc` and empty — a zero would disable the deadline, a huge one would park a worker for hours
- a request that blows the deadline runs **once**, not three times, and fails fast
- a genuine transient failure still retries

**Mutation-checked.** Letting the deadline abort fall through to the retry branch:

```
4 pass, 1 fail — does not retry a request that blew the deadline
```

The existing `tests/worker/retry-policy.test.ts` is untouched and still passes.
