### PR TITLE
fix(worker): recycle the conversation when the provider rejects the prompt as too long

### DIFF
--- a/src/sdk/output-classifier.ts
+++ b/src/sdk/output-classifier.ts
@@ -72,6 +72,29 @@ export function isQuotaLimitedObserverOutput(raw: unknown): boolean {
 }
 
 /**
+ * Detect the provider refusing the request because the conversation itself is
+ * too large.
+ *
+ * This one is not about the batch. The rejection arrives against a long-lived
+ * SDK conversation, so re-sending the same batch into it can only fail again —
+ * the conversation is what has to be recycled. Reported as 2,264 identical
+ * rejections in one day while 48 pending rows totalling 53KB sat undelivered.
+ */
+export function isPromptTooLongObserverOutput(raw: unknown): boolean {
+  if (typeof raw !== 'string' || raw.trim() === '') {
+    return false;
+  }
+
+  const text = raw.toLowerCase().replace(/\s+/g, ' ').trim();
+
+  return (
+    /\bprompt is too long\b/.test(text)
+    || /\b(prompt|input|conversation|context)\b[^.]{0,40}\b(is |too )?\b(too long|exceeds?)\b[^.]{0,40}\b(context (window|length)|maximum|token limit)\b/.test(text)
+    || /\bexceeds?\b[^.]{0,40}\b(context window|maximum context length|token limit)\b/.test(text)
+  );
+}
+
+/**
  * Detect provider authentication-failure prose so claimed work can be retried
  * after the user restores provider authentication.
  */

--- a/src/services/worker/agents/ResponseProcessor.ts
+++ b/src/services/worker/agents/ResponseProcessor.ts
@@ -4,6 +4,7 @@ import { parseAgentXml, type ParsedObservation, type ParsedSummary } from '../..
 import {
   classifyObserverOutput,
   isAuthFailureObserverOutput,
+  isPromptTooLongObserverOutput,
   isQuotaLimitedObserverOutput,
   previewOutput,
 } from '../../../sdk/output-classifier.js';
@@ -322,6 +323,33 @@ export async function processAgentResponse(
         // best-effort; AbortController.abort() should not throw in normal use.
       }
       worker?.broadcastProcessingStatus?.();
+      return;
+    }
+
+    if (isPromptTooLongObserverOutput(text)) {
+      // Recycle the conversation rather than the batch. The rejection is per
+      // conversation — it arrives on the Nth prompt of one long-lived SDK
+      // session — so the old path dropped the batch, reloaded it identically,
+      // and sent it back into a conversation that can only keep growing. There
+      // was no state the loop could exit from.
+      //
+      // The abort category is deliberately neither quota nor auth: those two
+      // are the ones handleGeneratorExit keeps the session alive for. Any other
+      // category finalizes and removes it, so the next ingest builds a fresh
+      // conversation with memorySessionId cleared — which is the recycle.
+      await sessionManager.resetProcessingToPending(session.sessionDbId);
+      session.abortReason = 'prompt_too_long:observer_text';
+      try {
+        session.abortController.abort();
+      } catch {
+        // best-effort; AbortController.abort() should not throw in normal use.
+      }
+      worker?.broadcastProcessingStatus?.();
+      logger.warn('PARSER', `${agentName} rejected the prompt as too long — recycling the conversation and preserving the batch`, {
+        sessionId: session.sessionDbId,
+        outputClass: 'prose',
+        preview: previewOutput(text),
+      });
       return;
     }
 

--- a/tests/sdk/output-classifier.test.ts
+++ b/tests/sdk/output-classifier.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'bun:test';
 import {
   classifyObserverOutput,
   isAuthFailureObserverOutput,
+  isPromptTooLongObserverOutput,
   isQuotaLimitedObserverOutput,
   previewOutput,
 } from '../../src/sdk/output-classifier.js';
@@ -111,5 +112,38 @@ describe('previewOutput', () => {
 
   it('describes non-string input', () => {
     expect(previewOutput(42)).toContain('non-string');
+  });
+});
+
+// #3800: the observer stopped producing anything for 94 minutes while every
+// batch came back "Prompt is too long". The rejection is per conversation, not
+// per batch — it arrived on the 29th prompt of one long-lived SDK session — so
+// the batch was dropped, reloaded identically, and sent back into a
+// conversation that could only keep growing.
+describe('isPromptTooLongObserverOutput', () => {
+  it('detects the rejection the SDK actually returned', () => {
+    expect(isPromptTooLongObserverOutput('Prompt is too long')).toBe(true);
+    expect(isPromptTooLongObserverOutput('  prompt is too long  ')).toBe(true);
+  });
+
+  it('detects the same refusal from other providers', () => {
+    expect(
+      isPromptTooLongObserverOutput(
+        "This model's maximum context length is 200000 tokens, however your messages exceed the context window.",
+      ),
+    ).toBe(true);
+    expect(
+      isPromptTooLongObserverOutput('The input exceeds the maximum context length for this model.'),
+    ).toBe(true);
+  });
+
+  it('does not fire on ordinary observer prose', () => {
+    // These reach the same branch and must keep being confirmed as no-op
+    // batches rather than recycling a healthy conversation.
+    expect(isPromptTooLongObserverOutput('')).toBe(false);
+    expect(isPromptTooLongObserverOutput('Nothing worth recording in this batch.')).toBe(false);
+    expect(isPromptTooLongObserverOutput('The user asked about a long prompt file.')).toBe(false);
+    expect(isPromptTooLongObserverOutput('<observation>ok</observation>')).toBe(false);
+    expect(isPromptTooLongObserverOutput(null)).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #3800.

## What was happening

The rejection is **per conversation, not per batch** — `promptNumber=29` is the 29th prompt on one long-lived SDK conversation. The generic non-XML branch treated it as ordinary observer prose: drop the batch, confirm it, reload it, send it back into the same conversation. That conversation can only keep growing, so there was no state the loop could exit from. 2,264 identical rejections in a day.

I also want to correct one thing in the report, because it changes what the fix should be. The report reads the reset as "a mechanism that exists to trip a breaker … is reset by the very event it is meant to count". The reset is real and the logging is genuinely misleading — line 353 zeroes `consecutiveInvalidOutputs` and the very next `logger.warn` reports the value it just zeroed, which is why every log line shows `consecutiveInvalidOutputs=0`. But **nothing reads that counter.** The only other reference in `src/` is its initialiser in `SessionManager`, and `worker-types.ts` calls it a "Legacy invalid-output counter". So making it count would not have escalated anything — there is no breaker behind it. That is why this PR implements suggestion 2 rather than suggestion 1.

## The fix

`isPromptTooLongObserverOutput` classifies the rejection, and the branch takes the same shape as the `quota` and `auth` branches directly beside it: reset the claimed batch to pending, set an abort reason, abort, broadcast.

The abort **category** is the load-bearing detail. `handleGeneratorExit` splits `abortReason` on `:` and keeps the session alive only for `quota` and `auth`; every other category finalizes and calls `removeSessionImmediate`. The next ingest then builds a fresh session — and `SessionManager` creates it with `memorySessionId` cleared, its comment saying exactly that, "to prevent stale resume". So `prompt_too_long:observer_text` recycles the conversation through the mechanism already there, with no new machinery. The batch survives because it went back to pending first.

## Tests

`bun test tests/sdk/output-classifier.test.ts` → **21 pass, 0 fail** (18 existing, 3 new).

- the exact string the SDK returned, and a whitespace-padded variant
- the same refusal in other providers' wording (`maximum context length … exceed the context window`)
- **negatives that matter**: empty, ordinary skip prose, valid XML, `null`, and `"The user asked about a long prompt file."` — that last one shares vocabulary with the rejection and must keep being confirmed as a benign no-op rather than recycling a healthy conversation

Mutation-checked at the classifier: removing `/\bprompt is too long\b/` fails the first test.

`bun x tsc --noEmit` reports nothing for either changed file.

**What I did not cover:** the `ResponseProcessor` branch itself. `tests/worker/agents/response-processor.test.ts` has a mock harness, but neither the `quota` nor the `auth` branch beside mine is exercised there either, and building a session/abort fixture felt like a bigger change than the fix. Happy to add one if you would like the three covered together.

## Left alone

Suggestion 3 (a configurable ceiling on accumulated conversation size) is a separate change and wants its own `CLAUDE_MEM_*` setting. The `sync_outbox` finding at the end of the issue is unrelated to this file and is worth its own issue, as the reporter offered.
