### PR TITLE
fix(search): answer CJK and Japanese queries by substring

### DIFF
--- a/src/services/sqlite/SessionSearch.ts
+++ b/src/services/sqlite/SessionSearch.ts
@@ -232,12 +232,25 @@ export class SessionSearch {
   }
 
   /**
-   * Scripts written without word delimiters: Hiragana, Katakana, and the CJK ideograph
-   * blocks. FTS5's unicode61 tokenizer has no delimiter to split them on, so an entire run
-   * folds into a single token and no substring of that run can match it (#3801) — and every
-   * query in these scripts is a substring of some longer run.
+   * Scripts whose runs FTS5's unicode61 tokenizer cannot split: Hiragana, Katakana, the CJK
+   * ideograph blocks, Bopomofo, and Hangul. unicode61 breaks on Unicode whitespace and
+   * punctuation, and these scripts put neither between the characters of a run — so a run
+   * folds into a single token and no substring of it can ever match (#3801), which is every
+   * query a user types in them.
+   *
+   * Korean does space its words, so only the sub-word case is affected there — but that is
+   * still every partial-word query. Measured directly against `tokenize='unicode61'`:
+   *
+   *   설정   inside 설정을            -> 0 rows
+   *   설정을 as a whole token         -> 1 row
+   *   ㄓㄨ   inside ㄓㄨㄛ            -> 0 rows
+   *   项目   inside 修改了项目配置    -> 0 rows
+   *
+   * Bopomofo and Hangul were raised in review on #3810. The blocks are adjacent, so
+   * \u3100-\u318F covers Bopomofo together with the Hangul compatibility jamo beside it.
    */
-  private static readonly UNSEGMENTED_SCRIPT = /[\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]/;
+  private static readonly UNSEGMENTED_SCRIPT =
+    /[\u3040-\u30FF\u3100-\u318F\u3400-\u4DBF\u4E00-\u9FFF\uAC00-\uD7AF\uF900-\uFAFF]/;
 
   /**
    * Build the substring predicate used when the index cannot represent the query. The

--- a/src/services/sqlite/SessionSearch.ts
+++ b/src/services/sqlite/SessionSearch.ts
@@ -231,6 +231,26 @@ export class SessionSearch {
     return conditions.length > 0 ? conditions.join(' AND ') : '';
   }
 
+  /**
+   * Scripts written without word delimiters: Hiragana, Katakana, and the CJK ideograph
+   * blocks. FTS5's unicode61 tokenizer has no delimiter to split them on, so an entire run
+   * folds into a single token and no substring of that run can match it (#3801) — and every
+   * query in these scripts is a substring of some longer run.
+   */
+  private static readonly UNSEGMENTED_SCRIPT = /[\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]/;
+
+  /**
+   * Build the substring predicate used when the index cannot represent the query. The
+   * escaping matches {@link searchUserPrompts}, which has always searched by substring.
+   */
+  private static buildSubstringClause(query: string, columns: string[]): { clause: string; params: string[] } {
+    const pattern = `%${query.replace(/[\\%_]/g, '\\$&')}%`;
+    return {
+      clause: `(${columns.map(column => `${column} LIKE ? ESCAPE '\\'`).join(' OR ')})`,
+      params: columns.map(() => pattern),
+    };
+  }
+
   private buildOrderClause(orderBy: SearchOptions['orderBy'] = 'relevance', hasFTS: boolean = true, ftsTable: string = 'observations_fts'): string {
     switch (orderBy) {
       case 'relevance':
@@ -264,6 +284,27 @@ export class SessionSearch {
         LIMIT ? OFFSET ?
       `;
 
+      params.push(limit, offset);
+      return this.db.prepare(sql).all(...params) as ObservationSearchResult[];
+    }
+
+    if (SessionSearch.UNSEGMENTED_SCRIPT.test(query)) {
+      const filterClause = this.buildFilterClause(filters, params, 'o');
+      const orderClause = this.buildOrderClause(orderBy, false);
+      const match = SessionSearch.buildSubstringClause(query, [
+        'o.title', 'o.subtitle', 'o.narrative', 'o.text', 'o.facts', 'o.concepts',
+      ]);
+
+      const sql = `
+        SELECT o.*, o.discovery_tokens
+        FROM observations o
+        WHERE ${match.clause}
+        ${filterClause ? 'AND ' + filterClause : ''}
+        ${orderClause}
+        LIMIT ? OFFSET ?
+      `;
+
+      params.unshift(...match.params);
       params.push(limit, offset);
       return this.db.prepare(sql).all(...params) as ObservationSearchResult[];
     }
@@ -322,6 +363,31 @@ export class SessionSearch {
         LIMIT ? OFFSET ?
       `;
 
+      params.push(limit, offset);
+      return this.db.prepare(sql).all(...params) as SessionSummarySearchResult[];
+    }
+
+    if (SessionSearch.UNSEGMENTED_SCRIPT.test(query)) {
+      const filterOptions = { ...filters };
+      delete filterOptions.type;
+      const filterClause = this.buildFilterClause(filterOptions, params, 's');
+      const orderClause = orderBy === 'date_asc'
+        ? 'ORDER BY s.created_at_epoch ASC'
+        : 'ORDER BY s.created_at_epoch DESC';
+      const match = SessionSearch.buildSubstringClause(query, [
+        's.request', 's.investigated', 's.learned', 's.completed', 's.next_steps', 's.notes',
+      ]);
+
+      const sql = `
+        SELECT s.*, s.discovery_tokens
+        FROM session_summaries s
+        WHERE ${match.clause}
+        ${filterClause ? 'AND ' + filterClause : ''}
+        ${orderClause}
+        LIMIT ? OFFSET ?
+      `;
+
+      params.unshift(...match.params);
       params.push(limit, offset);
       return this.db.prepare(sql).all(...params) as SessionSummarySearchResult[];
     }

--- a/tests/services/sqlite/search-cjk-fallback.test.ts
+++ b/tests/services/sqlite/search-cjk-fallback.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { SessionStore } from '../../../src/services/sqlite/SessionStore.js';
+import { SessionSearch } from '../../../src/services/sqlite/SessionSearch.js';
+
+// FTS5's unicode61 tokenizer has no delimiter to split CJK on, so an entire run of
+// ideographs folds into ONE token and no substring of it can ever match (#3801).
+// Queries in those scripts are answered by substring, the way searchUserPrompts
+// has always answered every query.
+describe('search in scripts FTS5 cannot segment', () => {
+  let store: SessionStore;
+  let search: SessionSearch;
+
+  function seedObservation(sessionId: string, project: string, title: string, narrative: string): void {
+    const sdkId = store.createSDKSession(sessionId, project, 'prompt');
+    store.ensureMemorySessionIdRegistered(sdkId, `${sessionId}-mem`);
+    store.storeObservation(`${sessionId}-mem`, project, {
+      type: 'discovery',
+      title,
+      subtitle: null,
+      facts: [],
+      narrative,
+      concepts: [],
+      files_read: [],
+      files_modified: [],
+    }, 1);
+  }
+
+  function seedSummary(memorySessionId: string, project: string, request: string): void {
+    const sdkId = store.createSDKSession(`${memorySessionId}-raw`, project, 'prompt');
+    store.ensureMemorySessionIdRegistered(sdkId, memorySessionId);
+    store.importSessionSummary({
+      memory_session_id: memorySessionId,
+      project,
+      request,
+      investigated: null,
+      learned: null,
+      completed: null,
+      next_steps: null,
+      files_read: null,
+      files_edited: null,
+      notes: null,
+      prompt_number: 1,
+      discovery_tokens: 0,
+      created_at: new Date(1_700_000_000_000).toISOString(),
+      created_at_epoch: 1_700_000_000_000,
+    });
+  }
+
+  beforeEach(() => {
+    store = new SessionStore(':memory:');
+    search = new SessionSearch(store.db);
+    seedObservation('cjk-1', 'cjk-project', '用户身份验证流程', '这是关于用户身份的观察记录');
+    seedObservation('cjk-2', 'cjk-project', '数据库连接池配置', '调整数据库连接池的大小');
+    seedObservation('jp-1', 'cjk-project', 'ユーザー認証の設計', 'ユーザー認証をやり直した');
+    seedObservation('en-1', 'cjk-project', 'Database Path resolution', 'the database path is resolved at startup');
+    seedObservation('other-1', 'other-project', '用户身份验证流程', '另一个项目里的同名观察');
+    seedSummary('sum-cjk', 'cjk-project', '重构用户身份验证的会话');
+    seedSummary('sum-en', 'cjk-project', 'refactor the database path');
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  it('finds a Chinese keyword that appears inside a longer run', () => {
+    const results = search.searchObservations('用户身份', { project: 'cjk-project' });
+    expect(results.map(r => r.title)).toEqual(['用户身份验证流程']);
+  });
+
+  it('finds a two-character Chinese keyword, which a trigram index could not', () => {
+    const results = search.searchObservations('数据', { project: 'cjk-project' });
+    expect(results.map(r => r.title)).toEqual(['数据库连接池配置']);
+  });
+
+  it('finds Japanese, which has no word delimiter either', () => {
+    const results = search.searchObservations('ユーザー認証', { project: 'cjk-project' });
+    expect(results.map(r => r.title)).toEqual(['ユーザー認証の設計']);
+  });
+
+  it('searches session summaries the same way', () => {
+    const results = search.searchSessions('用户身份', { project: 'cjk-project' });
+    expect(results.map(r => r.request)).toEqual(['重构用户身份验证的会话']);
+  });
+
+  it('still applies the project filter on this path', () => {
+    expect(search.searchObservations('用户身份', { project: 'other-project' }).map(r => r.memory_session_id))
+      .toEqual(['other-1-mem']);
+    expect(search.searchObservations('用户身份', {}).length).toBe(2);
+  });
+
+  it('still applies the type filter on this path', () => {
+    expect(search.searchObservations('用户身份', { project: 'cjk-project', type: 'discovery' }).length).toBe(1);
+    expect(search.searchObservations('用户身份', { project: 'cjk-project', type: 'decision' }).length).toBe(0);
+  });
+
+  it('treats LIKE wildcards in the query as literal characters', () => {
+    expect(search.searchObservations('用户%验证', { project: 'cjk-project' })).toEqual([]);
+    expect(search.searchObservations('用户_验证', { project: 'cjk-project' })).toEqual([]);
+  });
+
+  it('does not widen an English query that FTS5 already answers', () => {
+    const results = search.searchObservations('Database Path', { project: 'cjk-project' });
+    expect(results.map(r => r.title)).toEqual(['Database Path resolution']);
+    expect(search.searchSessions('database path', { project: 'cjk-project' }).map(r => r.request))
+      .toEqual(['refactor the database path']);
+  });
+});

--- a/tests/services/sqlite/search-cjk-fallback.test.ts
+++ b/tests/services/sqlite/search-cjk-fallback.test.ts
@@ -52,6 +52,8 @@ describe('search in scripts FTS5 cannot segment', () => {
     seedObservation('cjk-1', 'cjk-project', '用户身份验证流程', '这是关于用户身份的观察记录');
     seedObservation('cjk-2', 'cjk-project', '数据库连接池配置', '调整数据库连接池的大小');
     seedObservation('jp-1', 'cjk-project', 'ユーザー認証の設計', 'ユーザー認証をやり直した');
+    seedObservation('ko-1', 'cjk-project', '프로젝트 설정을 변경했습니다', '설정을 바꾼 기록');
+    seedObservation('bpmf-1', 'cjk-project', 'ㄓㄨㄛ ㄖㄣ ㄊㄢ', 'ㄓㄨㄛ 的紀錄');
     seedObservation('en-1', 'cjk-project', 'Database Path resolution', 'the database path is resolved at startup');
     seedObservation('other-1', 'other-project', '用户身份验证流程', '另一个项目里的同名观察');
     seedSummary('sum-cjk', 'cjk-project', '重构用户身份验证的会话');
@@ -75,6 +77,20 @@ describe('search in scripts FTS5 cannot segment', () => {
   it('finds Japanese, which has no word delimiter either', () => {
     const results = search.searchObservations('ユーザー認証', { project: 'cjk-project' });
     expect(results.map(r => r.title)).toEqual(['ユーザー認証の設計']);
+  });
+
+  // Korean spaces its words, so only the sub-word case breaks — but that case is every
+  // partial-word query. Against tokenize='unicode61', 설정 inside 설정을 returns 0 rows
+  // while the whole token 설정을 returns 1, which is the tokenizer folding the run.
+  it('finds a Korean keyword inside a word, which the tokenizer folds', () => {
+    const results = search.searchObservations('설정', { project: 'cjk-project' });
+    expect(results.map(r => r.title)).toEqual(['프로젝트 설정을 변경했습니다']);
+  });
+
+  // Bopomofo has no delimiters at all, the same as the ideographs.
+  it('finds a Bopomofo keyword inside a longer run', () => {
+    const results = search.searchObservations('ㄓㄨ', { project: 'cjk-project' });
+    expect(results.map(r => r.title)).toEqual(['ㄓㄨㄛ ㄖㄣ ㄊㄢ']);
   });
 
   it('searches session summaries the same way', () => {


### PR DESCRIPTION
Fixes #3801.

## ⚠️ The suggested trigram fix does not fix the reported case

Before writing anything I built the trigram index the issue proposes and queried it:

```
trigram  "用户身份"  -> 1
trigram  "用户"      -> 0     <- the issue's own primary example (826 rows contain it)
trigram  "数据"      -> 0
trigram  "db"        -> 0     <- regression: unicode61 answers this today
trigram  "database"  -> 1
```

Trigram indexes 3-character substrings, so it cannot answer a 2-character query **at all**. `用户` is exactly the query the issue opens with, and `db` is an English query that works today. Trigram would also require detecting and rebuilding the FTS tables on every existing install, since they are created with `CREATE VIRTUAL TABLE IF NOT EXISTS` and would otherwise silently keep the old tokenizer.

So I took suggestion 3 instead, which is accurate for every query length and needs no migration.

## The fix

`unicode61` has no delimiter to split Chinese or Japanese on, so a whole run of ideographs folds into one token — and every query in those scripts is a *substring* of some longer run, which can never match a token. Route those queries to a substring predicate over the same columns the FTS table indexes.

This is not a new mechanism in this class. `searchUserPrompts` has always answered every query this way, escaping included:

```ts
const escapedQuery = query.replace(/[\%_]/g, '\$&');
baseConditions.push("up.prompt_text LIKE ? ESCAPE '\'");
```

The new helper is that line, generalised over a column list. Queries FTS5 *can* tokenize keep the FTS path untouched — same SQL, same `rank` ordering.

One correction to the issue: `user_prompts_fts` needs nothing, because prompt search never used it. The affected paths are `searchObservations` and `searchSessions`.

## Scope and cost

The predicate scans `observations` / `session_summaries` rather than an index. That is the price of a correct answer here — there is no index in the schema that can represent these queries. It runs only when the query contains Hiragana, Katakana, or a CJK ideograph, so no English query changes plan. If you would rather bound it further, the natural next step is a generated bigram column, and I am happy to send that instead.

## Tests

`tests/services/sqlite/search-cjk-fallback.test.ts`, 8 tests: Chinese inside a longer run, a 2-character Chinese query, Japanese, session summaries, `project` and `type` filters still applied on the new path (the parameter order is easy to get wrong), `%`/`_` in a query treated literally, and English unchanged for both observations and summaries.

Reverting the change proves they hold it:

| mutation | result |
|---|---|
| dispatch never fires | 6 fail |
| drop the wildcard escaping | 1 fail |

```
bun test tests/services/sqlite/search-cjk-fallback.test.ts     8 pass, 0 fail
bun test tests/services/sqlite/ tests/worker/search/ \
         tests/sqlite/ tests/storage/sqlite/                   204 pass, 4 fail
tsc --noEmit                                                   clean
```

The 4 failures are the pre-existing Windows `EBUSY: resource busy or locked` teardown failures in `session-store-orphan-fk-repair.test.ts`. I confirmed they are identical on a clean tree — same four names, before and after.
