### PR TITLE
fix(worker): preserve the queued batch when the observer returns empty

### DIFF
--- a/src/services/worker-types.ts
+++ b/src/services/worker-types.ts
@@ -25,9 +25,11 @@ export interface ActiveSession {
   currentProvider: 'claude' | 'gemini' | 'openrouter' | null;
   consecutiveRestarts: number;
   /**
-   * Legacy invalid-output counter. Ordinary non-XML observer output is now
-   * confirmed as a no-op and resets this to 0 so skip acknowledgements never
-   * accumulate respawn debt.
+   * Consecutive empty observer responses. Each one preserves the queued batch
+   * and retries; past EMPTY_RESPONSE_RETRY_LIMIT the batch is dropped so a
+   * provider stuck on empty cannot loop. Any parseable output — and any prose
+   * skip acknowledgement, which is a deliberate no-op rather than a miss —
+   * resets this to 0.
    */
   consecutiveInvalidOutputs: number;
   forceInit?: boolean;

--- a/src/services/worker/GeminiProvider.ts
+++ b/src/services/worker/GeminiProvider.ts
@@ -220,7 +220,6 @@ interface GeminiConfig {
 export class GeminiProvider extends OpenAICompatibleProvider<GeminiConfig> {
   protected readonly providerName = 'Gemini';
   protected readonly syntheticIdPrefix = 'gemini';
-  protected readonly forwardEmptyMessageResponse = false;
 
   constructor(dbManager: DatabaseManager, sessionManager: SessionManager) {
     super(dbManager, sessionManager);

--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -44,13 +44,6 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
   protected abstract readonly providerName: string;
   /** Prefix for the synthetic memorySessionId (e.g. 'gemini', 'openrouter'). */
   protected abstract readonly syntheticIdPrefix: string;
-  /**
-   * When a query returns empty content for an observation/summary message:
-   * OpenRouter still calls processAgentResponse('') (forwards the empty batch
-   * to the parser/recovery path); Gemini skips it and logs a warning. This flag
-   * preserves that per-provider divergence.
-   */
-  protected abstract readonly forwardEmptyMessageResponse: boolean;
 
   constructor(dbManager: DatabaseManager, sessionManager: SessionManager) {
     this.dbManager = dbManager;
@@ -221,16 +214,14 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
       session.lastUsage = this.buildLastUsage(obsResponse);
     }
 
-    if (obsResponse.content || this.forwardEmptyMessageResponse) {
-      await processAgentResponse(
-        obsResponse.content || '', session, this.dbManager, this.sessionManager,
-        worker, tokensUsed, originalTimestamp, this.providerName, lastCwd, obsResponse.servedModel ?? config.model
-      );
-    } else {
-      logger.warn('SDK', `Empty ${this.providerName} observation response, leaving queue intact`, {
-        sessionId: session.sessionDbId
-      });
-    }
+    // Empty content is forwarded, not swallowed: the old skip-and-warn branch
+    // claimed to leave the queue intact but never un-claimed the batch, so the
+    // next successful turn's confirmClaimedMessages swept it away unobserved.
+    // processAgentResponse now owns that decision for every provider.
+    await processAgentResponse(
+      obsResponse.content || '', session, this.dbManager, this.sessionManager,
+      worker, tokensUsed, originalTimestamp, this.providerName, lastCwd, obsResponse.servedModel ?? config.model
+    );
   }
 
   private async processSummaryMessage(
@@ -268,16 +259,12 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
       session.lastUsage = this.buildLastUsage(summaryResponse);
     }
 
-    if (summaryResponse.content || this.forwardEmptyMessageResponse) {
-      await processAgentResponse(
-        summaryResponse.content || '', session, this.dbManager, this.sessionManager,
-        worker, tokensUsed, originalTimestamp, this.providerName, lastCwd, summaryResponse.servedModel ?? config.model
-      );
-    } else {
-      logger.warn('SDK', `Empty ${this.providerName} summary response, leaving queue intact`, {
-        sessionId: session.sessionDbId
-      });
-    }
+    // See processObservationMessage: empty content goes through the same
+    // preserve-and-retry path instead of a per-provider skip branch.
+    await processAgentResponse(
+      summaryResponse.content || '', session, this.dbManager, this.sessionManager,
+      worker, tokensUsed, originalTimestamp, this.providerName, lastCwd, summaryResponse.servedModel ?? config.model
+    );
   }
 
   protected handleSessionError(error: unknown, session: ActiveSession, _worker?: WorkerRef): never {

--- a/src/services/worker/OpenRouterProvider.ts
+++ b/src/services/worker/OpenRouterProvider.ts
@@ -139,7 +139,6 @@ interface OpenRouterConfig {
 export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfig> {
   protected readonly providerName = 'OpenRouter';
   protected readonly syntheticIdPrefix = 'openrouter';
-  protected readonly forwardEmptyMessageResponse = true;
 
   constructor(dbManager: DatabaseManager, sessionManager: SessionManager) {
     super(dbManager, sessionManager);

--- a/src/services/worker/agents/ResponseProcessor.ts
+++ b/src/services/worker/agents/ResponseProcessor.ts
@@ -19,6 +19,15 @@ import type { WorkerRef, StorageResult } from './types.js';
 import { broadcastObservation, broadcastSummary } from './ObservationBroadcaster.js';
 import { telemetryBuffer } from '../../telemetry/buffer.js';
 
+/**
+ * How many consecutive empty responses a session may retry before the batch is
+ * dropped. resetProcessingToPending un-claims immediately and
+ * SessionMessageBuffer.drain re-yields on its very next loop turn, so this
+ * ceiling — not the reset itself — is what stops a provider stuck on empty from
+ * spinning against the API.
+ */
+const EMPTY_RESPONSE_RETRY_LIMIT = 3;
+
 export async function processAgentResponse(
   text: string,
   session: ActiveSession,
@@ -69,10 +78,49 @@ export async function processAgentResponse(
     }
 
     // Classify the non-XML output so a dropped batch is visible, not silent.
-    // Ordinary idle/prose is a claimed no-op batch: confirm it and do not build
-    // any respawn debt from repeated skip acknowledgements.
     const outputClass = classifyObserverOutput(text);
     const preview = previewOutput(text);
+
+    // An empty response is not a skip acknowledgement. The provider returned no
+    // content at all, so the batch was never observed and dropping it loses work
+    // the model never looked at. Preserve it and let the next pass re-ask,
+    // bounded by EMPTY_RESPONSE_RETRY_LIMIT so a provider stuck on empty cannot
+    // spin. Prose skips are handled below and still dropped.
+    if (outputClass === 'idle') {
+      session.consecutiveInvalidOutputs++;
+
+      if (session.consecutiveInvalidOutputs <= EMPTY_RESPONSE_RETRY_LIMIT) {
+        logger.warn('PARSER', `${agentName} returned an empty response — preserving queued batch for retry`, {
+          sessionId: session.sessionDbId,
+          outputClass,
+          preview,
+          consecutiveInvalidOutputs: session.consecutiveInvalidOutputs,
+          retryLimit: EMPTY_RESPONSE_RETRY_LIMIT,
+        });
+
+        await sessionManager.resetProcessingToPending(session.sessionDbId);
+        worker?.broadcastProcessingStatus?.();
+        return;
+      }
+
+      logger.warn('PARSER', `${agentName} returned ${session.consecutiveInvalidOutputs} consecutive empty responses — dropping queued batch to break the retry loop`, {
+        sessionId: session.sessionDbId,
+        outputClass,
+        preview,
+        consecutiveInvalidOutputs: session.consecutiveInvalidOutputs,
+        retryLimit: EMPTY_RESPONSE_RETRY_LIMIT,
+      });
+
+      session.consecutiveInvalidOutputs = 0;
+      await sessionManager.confirmClaimedMessages(session.sessionDbId);
+      session.earliestPendingTimestamp = null;
+      return;
+    }
+
+    // Plain-text skip responses are intentionally ignored. Re-queueing them
+    // creates an observer loop where the same low-signal batch is retried, and
+    // unlike an empty response the model did look at the batch and chose to say
+    // nothing. Confirm it and build no respawn debt from repeated skips.
     session.consecutiveInvalidOutputs = 0;
 
     logger.warn('PARSER', `${agentName} returned non-XML ${outputClass} response — ignoring queued batch`, {
@@ -82,8 +130,6 @@ export async function processAgentResponse(
       consecutiveInvalidOutputs: session.consecutiveInvalidOutputs,
     });
 
-    // Plain-text skip responses are intentionally ignored. Re-queueing them
-    // creates an observer loop where the same low-signal batch is retried.
     await sessionManager.confirmClaimedMessages(session.sessionDbId);
     session.earliestPendingTimestamp = null;
     return;

--- a/tests/worker/agents/response-processor.test.ts
+++ b/tests/worker/agents/response-processor.test.ts
@@ -122,6 +122,7 @@ describe('ResponseProcessor', () => {
       claimedMessageIds: [],
       conversationHistory: [],
       currentProvider: 'claude',
+      consecutiveInvalidOutputs: 0,
       ...overrides,
     } as ActiveSession;
   }
@@ -456,25 +457,102 @@ describe('ResponseProcessor', () => {
   });
 
   describe('handling empty / non-XML response', () => {
-    it('clears pending work and does NOT call storeObservations on empty response', async () => {
+    function emptyResponseSessionManager() {
       const confirmClaimedMessages = mock(() => Promise.resolve(0));
-      mockSessionManager = {
+      const resetProcessingToPending = mock(() => Promise.resolve(1));
+      const sessionManager = {
         getMessageIterator: async function* () { yield* []; },
         getPendingMessageStore: () => ({ confirmProcessed: mock(() => {}) }),
         confirmClaimedMessages,
+        resetProcessingToPending,
       } as unknown as SessionManager;
+      return { sessionManager, confirmClaimedMessages, resetProcessingToPending };
+    }
 
+    it('preserves the queued batch and does NOT call storeObservations on empty response', async () => {
+      const { sessionManager, confirmClaimedMessages, resetProcessingToPending } = emptyResponseSessionManager();
       const session = createMockSession();
-      const responseText = '';
+      const earliest = session.earliestPendingTimestamp;
 
       await processAgentResponse(
-        responseText, session, mockDbManager, mockSessionManager, mockWorker,
+        '', session, mockDbManager, sessionManager, mockWorker,
         100, null, 'TestAgent'
       );
 
       expect(mockStoreObservations).not.toHaveBeenCalled();
+      expect(resetProcessingToPending).toHaveBeenCalledWith(1);
+      expect(confirmClaimedMessages).not.toHaveBeenCalled();
+      // The batch is still queued, so its age must not be forgotten.
+      expect(session.earliestPendingTimestamp).toBe(earliest);
+      expect(session.consecutiveInvalidOutputs).toBe(1);
+    });
+
+    it('treats whitespace-only output as empty and preserves the batch', async () => {
+      const { sessionManager, confirmClaimedMessages, resetProcessingToPending } = emptyResponseSessionManager();
+      const session = createMockSession();
+
+      await processAgentResponse(
+        '   \n\t  ', session, mockDbManager, sessionManager, mockWorker,
+        100, null, 'TestAgent'
+      );
+
+      expect(resetProcessingToPending).toHaveBeenCalledWith(1);
+      expect(confirmClaimedMessages).not.toHaveBeenCalled();
+      expect(session.consecutiveInvalidOutputs).toBe(1);
+    });
+
+    it('drops the batch once consecutive empty responses exceed the retry limit', async () => {
+      const { sessionManager, confirmClaimedMessages, resetProcessingToPending } = emptyResponseSessionManager();
+      const session = createMockSession();
+
+      // Three retries are allowed; the fourth consecutive empty breaks the loop.
+      for (let attempt = 0; attempt < 4; attempt++) {
+        await processAgentResponse(
+          '', session, mockDbManager, sessionManager, mockWorker,
+          100, null, 'TestAgent'
+        );
+      }
+
+      expect(resetProcessingToPending).toHaveBeenCalledTimes(3);
       expect(confirmClaimedMessages).toHaveBeenCalledWith(1);
+      expect(confirmClaimedMessages).toHaveBeenCalledTimes(1);
       expect(session.earliestPendingTimestamp).toBeNull();
+      // Counter clears so the next batch gets a full retry budget.
+      expect(session.consecutiveInvalidOutputs).toBe(0);
+      expect(mockStoreObservations).not.toHaveBeenCalled();
+    });
+
+    it('resets the empty-response counter once a valid XML response arrives', async () => {
+      const { sessionManager, resetProcessingToPending } = emptyResponseSessionManager();
+      const session = createMockSession();
+
+      await processAgentResponse('', session, mockDbManager, sessionManager, mockWorker, 100, null, 'TestAgent');
+      await processAgentResponse('', session, mockDbManager, sessionManager, mockWorker, 100, null, 'TestAgent');
+      expect(session.consecutiveInvalidOutputs).toBe(2);
+
+      await processAgentResponse(
+        `<observation><type>discovery</type><title>Back on track</title><narrative>Recovered.</narrative></observation>`,
+        session, mockDbManager, sessionManager, mockWorker, 100, null, 'TestAgent'
+      );
+
+      expect(session.consecutiveInvalidOutputs).toBe(0);
+      expect(resetProcessingToPending).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not let a prose skip build toward the empty-response limit', async () => {
+      const { sessionManager, confirmClaimedMessages, resetProcessingToPending } = emptyResponseSessionManager();
+      const session = createMockSession();
+
+      await processAgentResponse('', session, mockDbManager, sessionManager, mockWorker, 100, null, 'TestAgent');
+      await processAgentResponse(
+        'Skipping — repeated log scan with no new findings.',
+        session, mockDbManager, sessionManager, mockWorker, 100, null, 'TestAgent'
+      );
+
+      // The prose skip is still dropped, and it clears the empty-response streak.
+      expect(confirmClaimedMessages).toHaveBeenCalledWith(1);
+      expect(session.consecutiveInvalidOutputs).toBe(0);
+      expect(resetProcessingToPending).toHaveBeenCalledTimes(1);
     });
 
     it('clears pending work and does NOT call storeObservations on plain-text response', async () => {


### PR DESCRIPTION
## The problem

`processAgentResponse` treats an empty observer response the same as a plain-text skip: it calls `confirmClaimedMessages` and the batch is gone. But those two things are not the same event.

A prose skip means the model read the batch and decided there was nothing worth recording. An empty response means the provider returned no content at all — `data.choices[0].message.content` was missing, `OpenRouterProvider` logged `Empty response from OpenRouter` and returned `{ content: '' }`. The batch was never looked at, and confirming the claim deletes work that was never observed.

The classifier's own doc comment carries the assumption this PR is challenging: `idle` is described as *"empty / whitespace-only. Benign: the SDK had nothing to say."* For a provider HTTP response, empty is not benign — it's a miss.

## What I measured

Running 13.10.2 against OpenRouter, 25–30 Aug:

| | empty responses | batches lost |
|---|---|---|
| Gemini era (17–24 Aug) | 62 | 0 *(see below)* |
| OpenRouter era (25–30 Aug) | 57 | 34 |

That's ~2.1% of calls, and 42 of 73 drops happened while the queue was non-empty. The rate of empty responses is roughly the same in both eras (0.2%–1% per call) — what changed at the provider switch was the **handling**, not the failure.

The Gemini zero is not a real zero. `forwardEmptyMessageResponse = false` meant the empty response never reached `processAgentResponse` at all; `OpenAICompatibleProvider` logged `Empty ... response, leaving queue intact` and returned. But that branch never calls `resetProcessingToPending`, so the message stayed `claimed`. Following all 297 `leaving queue intact` events forward through the logs: in 282 the hanging message was swept by the next successful turn's `confirmClaimedMessages`, and in 15 it went away with the session. Zero were actually recovered. So the Gemini branch lost the same batches — just with no log line, no counter, and no way to measure it.

## Why not just re-queue

Because `resetProcessingToPending` un-claims immediately and `SessionMessageBuffer.drain` re-yields on its very next loop turn. An unconditional reset on empty is a hot loop against the provider API. The comment in the non-XML branch is right about that risk:

> Plain-text skip responses are intentionally ignored. Re-queueing them creates an observer loop where the same low-signal batch is retried.

So this PR keeps that decision where it applies and bounds the case where it doesn't.

## The change

**`ResponseProcessor.ts`** — split `idle` out of the non-XML branch:

- `idle` → increment `consecutiveInvalidOutputs`, `resetProcessingToPending`, retry. Past `EMPTY_RESPONSE_RETRY_LIMIT` (3) the batch is dropped and the counter clears, so a provider stuck on empty can't spin.
- `prose` → unchanged. Still confirmed and dropped, still resets the counter.

This also wires up `consecutiveInvalidOutputs`, which was reset in three places and incremented in none — the breaker was written but never connected.

**`OpenAICompatibleProvider.ts` / `GeminiProvider.ts` / `OpenRouterProvider.ts`** — removed `forwardEmptyMessageResponse`. Its own doc comment said it exists only to "preserve that per-provider divergence", and the divergence was strictly worse on the Gemini side (silent hanging claim). Both providers now go through the one path that owns this decision.

**Claude/SDK path** is unaffected in practice. `buildHardenedSdkOptions` runs the Observer with `tools: []`, so an assistant message with only `tool_use` blocks can't occur; an empty `textContent` there means the same failure and gets the same treatment.

## Tests

`tests/worker/agents/response-processor.test.ts`: the existing empty-response test asserted the old drop behaviour and is updated. Added coverage for whitespace-only input, the retry ceiling and its counter reset, recovery on a valid XML response, and that a prose skip does not accumulate toward the empty limit.

```
bun test        2249 pass, 15 skip, 0 fail
tsc --noEmit    clean
```
