### PR TITLE
fix(installer): let --provider claude skip the login requirement

### DIFF
--- a/src/npx-cli/cmem-pro-costs.ts
+++ b/src/npx-cli/cmem-pro-costs.ts
@@ -7,25 +7,10 @@
 import { cmemProOrigin } from '../shared/cmem-gateway.js';
 
 export const PROVIDER_PROMPT_MESSAGE =
-  'Select Provider:\nClaude-Mem uses tokens to take notes of what your agent is working on in real-time.';
+  'Select Provider:\n================';
 
 export const CMEM_TRIAL_ACKNOWLEDGEMENT =
   "Free Trial includes a week's worth of allowance and auto-charges if you reach the limit.";
-
-export const CMEM_PRO_BENEFITS = [
-  'Access what every agent is working on from everywhere — ChatGPT, Claude, Gemini, and more.',
-  'Up to 100% more use out of your existing Anthropic plan.',
-  "Writes memories so you don't use expensive AI for something that our more specialized AI handles better, faster, less expensive.",
-  'Cloud sync keeps every device and agent on the same memory.',
-  'One private, searchable memory you can reach through MCP.',
-] as const;
-
-export const ANTHROPIC_MAX_BENEFITS = [
-  'Uses your existing Anthropic Max Plan for note-taking.',
-  'Keeps memories and the observations database in ~/.claude-mem on this machine.',
-  'Includes local semantic search and automatic memory recall.',
-  'Open-source local storage with no separate CMEM Pro subscription.',
-] as const;
 
 export interface ProviderLabels {
   cmem: string;
@@ -34,26 +19,24 @@ export interface ProviderLabels {
   claudeHint: string;
 }
 
+/**
+ * The description rides in the LABEL, not in clack's `hint`.
+ *
+ * clack's multiselect renders a hint only for the focused, selected, or
+ * disabled row — a plain unselected row renders label only. Since this prompt
+ * opens with nothing selected, hints would reveal one description at a time as
+ * the user arrows around, instead of showing both choices side by side. The
+ * parentheses are ours for the same reason: clack adds its own `(...)` around a
+ * hint, but never around a label.
+ */
 export function buildProviderLabels(): ProviderLabels {
   return {
-    cmem: 'CMEM Pro',
-    cmemHint: 'Shared cloud memory across agents, apps, and devices',
-    claude: 'Use your Anthropic Max Plan',
-    claudeHint: 'Local memory using the plan you already have',
+    cmem: 'CMEM Pro (30 Day Free Trial: Tokens for Observations + Real-Time Cloud Sync '
+      + 'for Claude.ai, ChatGPT.com, anything that accepts an MCP Connector)',
+    cmemHint: '',
+    claude: 'Use your Anthropic Max Plan (no cloud sync, uses tokens for observations)',
+    claudeHint: '',
   };
-}
-
-export function buildProviderBenefitsNote(): string {
-  const section = (title: string, benefits: readonly string[]) => [
-    title,
-    ...benefits.map((benefit) => `  ✓ ${benefit}`),
-  ].join('\n');
-
-  return [
-    section('CMEM Pro', CMEM_PRO_BENEFITS),
-    '',
-    section('Use your Anthropic Max Plan', ANTHROPIC_MAX_BENEFITS),
-  ].join('\n');
 }
 
 /** Overridable so the OAuth pairing flow can be tested against a dev server. */

--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -33,13 +33,11 @@ import {
 } from '../install/error-reporter.js';
 import { extractEresolveBlock, isEresolve, runNpmStrict } from '../install/npm-install-helper.js';
 import {
-  buildProviderBenefitsNote,
   buildProviderLabels,
   CMEM_INSTALLER_OAUTH_POLL_URL,
   CMEM_INSTALLER_OAUTH_START_URL,
   CMEM_PRO_BASE_URL,
   CMEM_PRO_MODEL,
-  CMEM_TRIAL_ACKNOWLEDGEMENT,
   PROVIDER_PROMPT_MESSAGE,
 } from '../cmem-pro-costs.js';
 import { clearProFallback, isCmemGatewayUrl } from '../../shared/cmem-gateway.js';
@@ -1061,7 +1059,6 @@ async function promptProvider(
       throw new Error('Non-interactive provider validation did not run.');
     }
     const labels = buildProviderLabels();
-    p.note(buildProviderBenefitsNote(), 'Provider benefits');
 
     // Multiselect gives both choices square controls. Exactly one provider is
     // still required; selecting both re-opens the prompt instead of guessing.
@@ -1091,25 +1088,16 @@ async function promptProvider(
   // OpenAI-compatible client whose endpoint and model both come from settings,
   // so "use the CMEM observer model" is four settings writes and nothing else.
   if (selectedProvider === 'cmem') {
-    if (!isInteractive) {
-      throw new Error('CMEM Pro trial acknowledgement requires an interactive terminal.');
-    }
     if (!pairing) {
       // Unreachable via the flag that skips login (it forces 'claude'), but a
       // future caller passing null here would otherwise enroll against nothing.
       throw new Error('CMEM Pro requires a signed-in claude-mem account.');
     }
-    const trialAcknowledgement = await p.multiselect<'accepted'>({
-      message: 'Confirm CMEM Pro Free Trial:',
-      options: [{ value: 'accepted', label: CMEM_TRIAL_ACKNOWLEDGEMENT }],
-      initialValues: [],
-      required: true,
-    });
-    if (p.isCancel(trialAcknowledgement)) {
-      p.cancel('CMEM Pro setup cancelled.');
-      process.exit(1);
-    }
-
+    // The billing disclosure lives on the checkout page, not here. It is a term
+    // of the charge, so it belongs on the screen that takes the payment method,
+    // where it can be shown next to the price and the card field. Re-asking for
+    // it in the terminal made the user consent twice to the same thing, before
+    // ever seeing what they were agreeing to.
     const enrollment = await completeCmemTrialPairing(pairing, version);
     if (!enrollment) {
       p.cancel('CMEM Pro setup was not completed. Run npx claude-mem install to try again.');
@@ -1318,6 +1306,27 @@ function hasExactSearchParams(url: URL, expected: Record<string, string>): boole
     && expectedEntries.every(([key, value]) => url.searchParams.get(key) === value);
 }
 
+/**
+ * The checkout URL must carry exactly `pairing` and `trial`, and nothing else —
+ * but the trial LENGTH is not the installer's business to pin.
+ *
+ * This previously required `trial: '7'` exactly. That made the server unable to
+ * change the offer without breaking every installer already published: a
+ * `trial=30` URL was rejected outright, surfacing as "Could not start OAuth
+ * login" with no hint that the length was the reason. The shape stays strict
+ * (both params present, pairing must match, no extras); only the number is now
+ * the server's to choose.
+ */
+function hasPairingAndTrialParams(url: URL, pairingId: string): boolean {
+  const entries = [...url.searchParams.entries()];
+  if (entries.length !== 2) return false;
+  if (url.searchParams.get('pairing') !== pairingId) return false;
+  const trial = url.searchParams.get('trial');
+  if (trial === null || !/^[0-9]{1,3}$/.test(trial)) return false;
+  const days = Number(trial);
+  return days >= 1 && days <= 365;
+}
+
 /** Pure parser used by the mock-server contract tests. */
 export function parseInstallerOAuthStartBody(body: unknown): InstallerOAuthPairing | null {
   if (!body || typeof body !== 'object') return null;
@@ -1358,7 +1367,7 @@ export function parseInstallerOAuthStartBody(body: unknown): InstallerOAuthPairi
   if (
     !loginClaim
     || !hasExactSearchParams(loginClaim, { pairing: pairingId, login_only: '1' })
-    || !hasExactSearchParams(checkoutUrl, { pairing: pairingId, trial: '7' })
+    || !hasPairingAndTrialParams(checkoutUrl, pairingId)
   ) return null;
 
   const pollIntervalS =
@@ -1704,12 +1713,15 @@ export async function completeCmemTrialPairing(
   if (pairing.delivered) return pairing.delivered;
 
   noteDeviceCode(pairing);
-  // Same hand-off as the login step: print the URL, wait for Return, then open.
-  // Both browser hand-offs behaving identically matters more here than saving a
-  // keystroke — the device code above needs to be read before the browser
-  // steals focus.
+  // Deliberately NO return-wait here, unlike the login hand-off.
+  //
+  // A second wait at this point stalled the install: stdin has already been
+  // through the login wait and a clack prompt by now, and the listener did not
+  // reliably receive the keypress, so the flow stopped before it could even
+  // print "Waiting for CMEM Pro setup in the browser…". Opening directly is
+  // also the better behaviour here — the user has already chosen CMEM Pro, so
+  // there is nothing left to confirm before the browser takes over.
   log.info(`Continue CMEM Pro setup: ${pairing.checkoutUrl}`);
-  await waitForReturnToOpenBrowser('Continue setup in browser... (hit return to open automatically)');
   openBrowser(pairing.checkoutUrl);
 
   const result = await waitForInstallerPairing(pairing, 'enrollment', version);
@@ -2313,22 +2325,25 @@ async function runInstallCommandInner(options: InstallOptions, summary: InstallS
     : workerAlive
       ? 'keep that URL open in a browser'
       : `keep ${styleText('underline', configuredWorkerBaseUrl)} open in a browser`;
+  // Last screen of the funnel: it should read as an invitation to start, not a
+  // manual. Everything here has to earn its line.
+  //
+  // Cut deliberately: the WELCOME_HINT_ENABLED env var (opting out of a hint
+  // they have not seen yet), the uninstall warning (uninstall trivia on the
+  // install screen), and the A/B "two paths" framing that dressed up "just
+  // start working" as a decision the user has to make.
   const nextSteps = [
     nextStepsHeadline,
     ``,
-    `${styleText('bold', 'First success:')} ${firstSuccessOpener}, then open Claude Code in any project. Observations stream in as Claude reads, edits, and runs commands.`,
-    ``,
-    `${styleText('bold', 'Two paths from here:')}`,
-    `  ${styleText('cyan', 'A.')} Just start working. Memory builds passively from your first prompt. (Recommended.)`,
-    `  ${styleText('cyan', 'B.')} Front-load it: open Claude Code and run ${styleText('bold', '/learn-codebase')} to ingest the whole repo (~5 min, optional).`,
+    `${styleText('bold', 'Start working.')} Memory builds passively from your first prompt — observations stream in as Claude reads, edits, and runs commands.`,
+    `To watch them live, ${firstSuccessOpener}.`,
     ``,
     `Memory injection starts on your second session in a project.`,
     cloudSyncConfigured
       ? 'Memory syncs across your signed-in CMEM Pro agents and devices.'
       : `Everything stays in ${styleText('cyan', '~/.claude-mem')} on this machine.`,
     ``,
-    `${styleText('dim', 'How it works: /how-it-works   ·   Disable first-session hint: CLAUDE_MEM_WELCOME_HINT_ENABLED=false')}`,
-    `${styleText('dim', 'Note: close all Claude Code sessions before uninstalling, or ~/.claude-mem will be recreated by active hooks.')}`,
+    `${styleText('dim', `Optional: ${'/learn-codebase'} ingests a whole repo up front (~5 min)   ·   How it works: /how-it-works`)}`,
   ];
 
   if (isInteractive) {

--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -1018,7 +1018,12 @@ function openBrowser(url: string): void {
 
 async function promptProvider(
   options: InstallOptions,
-  pairing: InstallerOAuthPairing,
+  /**
+   * Null only when login was skipped, which happens solely for an explicit
+   * `--provider claude`. That path cannot reach the CMEM branch below, which
+   * re-checks rather than assuming.
+   */
+  pairing: InstallerOAuthPairing | null,
   version: string,
 ): Promise<ProviderId> {
   const initialProvider = (getSetting('CLAUDE_MEM_PROVIDER') as ProviderId) || 'claude';
@@ -1088,6 +1093,11 @@ async function promptProvider(
   if (selectedProvider === 'cmem') {
     if (!isInteractive) {
       throw new Error('CMEM Pro trial acknowledgement requires an interactive terminal.');
+    }
+    if (!pairing) {
+      // Unreachable via the flag that skips login (it forces 'claude'), but a
+      // future caller passing null here would otherwise enroll against nothing.
+      throw new Error('CMEM Pro requires a signed-in claude-mem account.');
     }
     const trialAcknowledgement = await p.multiselect<'accepted'>({
       message: 'Confirm CMEM Pro Free Trial:',
@@ -1751,6 +1761,20 @@ async function promptTelemetryOptIn(): Promise<void> {
   log.success(consent ? 'Thanks! Anonymized usage sharing is on.' : 'No problem — telemetry is off.');
 }
 
+/**
+ * Whether an install still has an account question to answer.
+ *
+ * Only `--provider claude` is exempt: it configures memory against the user's
+ * own Anthropic plan and needs no claude-mem credentials. `gemini` and
+ * `openrouter` are NOT exempt — openrouter is the transport for the cmem
+ * gateway, so an explicit `openrouter` install may still be reaching cmem.ai.
+ * With no flag at all the provider screen can still offer CMEM Pro, so login
+ * must happen first.
+ */
+export function providerNeedsAccount(provider: InstallOptions['provider']): boolean {
+  return provider !== 'claude';
+}
+
 export interface InstallOptions {
   ide?: string;
   provider?: 'claude' | 'gemini' | 'openrouter';
@@ -2095,13 +2119,26 @@ async function runInstallCommandInner(options: InstallOptions, summary: InstallS
     log.info('Claude Code: leaving native auto-memory enabled unless you explicitly opt in to disabling it.');
   }
 
-  // OAuth is required for every install, including runs with an explicit
-  // --provider. Authentication never selects a provider or starts a trial.
-  const oauthPairing = await requireInstallerOAuthLogin(version);
-  if (!oauthPairing) {
-    if (isInteractive) p.cancel('OAuth login is required to finish installation.');
-    else console.error('OAuth login is required to finish installation.');
-    process.exit(1);
+  // Login is account-first for every install EXCEPT one that has already named
+  // a provider needing no claude-mem account. `--provider claude` runs memory
+  // on the user's own Anthropic plan and never touches cmem.ai, so gating it on
+  // browser OAuth made an unrelated cmem.ai outage fail an install that could
+  // have completed offline — and there is no account question left to ask,
+  // because the flag already answered it.
+  //
+  // Deliberately keyed on the explicit flag, not on reachability: a silent
+  // fallback to a local install whenever cmem.ai is down would quietly change
+  // what the user gets. This only skips a step the user's own flag made moot.
+  let oauthPairing: InstallerOAuthPairing | null = null;
+  if (providerNeedsAccount(options.provider)) {
+    oauthPairing = await requireInstallerOAuthLogin(version);
+    if (!oauthPairing) {
+      if (isInteractive) p.cancel('OAuth login is required to finish installation.');
+      else console.error('OAuth login is required to finish installation.');
+      process.exit(1);
+    }
+  } else {
+    log.info('Skipping claude-mem login: --provider claude runs memory on your own Anthropic plan.');
   }
   const selectedProvider = await promptProvider(options, oauthPairing, version);
   const cloudSyncConfigured = [

--- a/tests/install-non-tty.test.ts
+++ b/tests/install-non-tty.test.ts
@@ -352,8 +352,11 @@ describe('Install Non-TTY Support', () => {
   });
 
   describe('post-install Next Steps copy', () => {
-    it('frames the choice as two paths', () => {
-      expect(installSource).toContain('Two paths from here:');
+    it('opens with a plain instruction, not a menu of paths', () => {
+      // The A/B framing dressed up "just start working" as a decision the user
+      // had to make on the last screen of the funnel.
+      expect(installSource).toContain("styleText('bold', 'Start working.')");
+      expect(installSource).not.toContain('Two paths from here:');
     });
 
     it('sets timing honesty about second-session memory injection', () => {
@@ -369,8 +372,16 @@ describe('Install Non-TTY Support', () => {
       expect(installSource).toContain('/learn-codebase');
     });
 
-    it('demotes the uninstall caveat into a dim footer', () => {
-      expect(installSource).toContain('close all Claude Code sessions before uninstalling');
+    it('keeps uninstall trivia and env-var opt-outs off the install screen', () => {
+      // Uninstall instructions do not belong on the screen that just finished
+      // installing, and opting out of the first-session hint is meaningless to
+      // someone who has not seen it yet.
+      const nextStepsRegion = installSource.slice(
+        installSource.indexOf('const nextSteps = '),
+        installSource.indexOf("p.note(nextSteps.join"),
+      );
+      expect(nextStepsRegion).not.toContain('before uninstalling');
+      expect(nextStepsRegion).not.toContain('CLAUDE_MEM_WELCOME_HINT_ENABLED');
     });
 
     it('does not advertise /mem-search in the post-install Next Steps', () => {

--- a/tests/npx-cli/install-trial-contract.test.ts
+++ b/tests/npx-cli/install-trial-contract.test.ts
@@ -8,13 +8,9 @@ import {
   parseTrialReadyBody,
 } from '../../src/npx-cli/commands/install';
 import {
-  ANTHROPIC_MAX_BENEFITS,
-  buildProviderBenefitsNote,
   buildProviderLabels,
-  CMEM_PRO_BENEFITS,
   CMEM_PRO_BASE_URL,
   CMEM_PRO_MODEL,
-  CMEM_TRIAL_ACKNOWLEDGEMENT,
   PROVIDER_PROMPT_MESSAGE,
 } from '../../src/npx-cli/cmem-pro-costs';
 
@@ -131,23 +127,35 @@ describe('installer trial-ready contract', () => {
     expect(parseInstallerOAuthStartBody({ ...valid, user_code: 'INVALID1' })).toBeNull();
   });
 
-  it('uses the exact two-option provider copy and required trial disclosure', () => {
+  it('uses the exact two-option provider copy', () => {
     expect(buildProviderLabels()).toEqual({
-      cmem: 'CMEM Pro',
-      cmemHint: 'Shared cloud memory across agents, apps, and devices',
-      claude: 'Use your Anthropic Max Plan',
-      claudeHint: 'Local memory using the plan you already have',
+      cmem: 'CMEM Pro (30 Day Free Trial: Tokens for Observations + Real-Time Cloud Sync '
+        + 'for Claude.ai, ChatGPT.com, anything that accepts an MCP Connector)',
+      cmemHint: '',
+      claude: 'Use your Anthropic Max Plan (no cloud sync, uses tokens for observations)',
+      claudeHint: '',
     });
-    expect(PROVIDER_PROMPT_MESSAGE).toBe(
-      'Select Provider:\nClaude-Mem uses tokens to take notes of what your agent is working on in real-time.',
-    );
-    expect(CMEM_TRIAL_ACKNOWLEDGEMENT).toBe(
-      "Free Trial includes a week's worth of allowance and auto-charges if you reach the limit.",
-    );
-    const benefits = buildProviderBenefitsNote();
-    for (const benefit of [...CMEM_PRO_BENEFITS, ...ANTHROPIC_MAX_BENEFITS]) {
-      expect(benefits).toContain(benefit);
-    }
+    expect(PROVIDER_PROMPT_MESSAGE).toBe('Select Provider:\n================');
+  });
+
+  it('keeps each provider description in the label so both rows always render it', () => {
+    // clack's multiselect renders `hint` only for the focused/selected row, so a
+    // description placed there would appear one row at a time. Both rows must
+    // carry their own description at all times.
+    const labels = buildProviderLabels();
+    expect(labels.cmemHint).toBe('');
+    expect(labels.claudeHint).toBe('');
+    expect(labels.cmem).toContain('30 Day Free Trial');
+    expect(labels.claude).toContain('no cloud sync');
+  });
+
+  it('does not ask for the billing acknowledgement in the terminal', () => {
+    // It is a term of the charge and belongs on the checkout page, beside the
+    // price and the card field — not asked twice, once before the user can see
+    // what they are agreeing to.
+    const source = readFileSync(join(repoRoot, 'src/npx-cli/commands/install.ts'), 'utf-8');
+    expect(source).not.toContain('Confirm CMEM Pro Free Trial');
+    expect(source).not.toContain('CMEM_TRIAL_ACKNOWLEDGEMENT');
   });
 
   it('requires OAuth before provider selection and contains no retired email path', () => {
@@ -157,7 +165,6 @@ describe('installer trial-ready contract', () => {
     expect(oauthIndex).toBeGreaterThan(-1);
     expect(providerIndex).toBeGreaterThan(oauthIndex);
     expect(source).toContain('p.multiselect<ProviderChoice>');
-    expect(source).toContain("p.multiselect<'accepted'>");
     expect(source).not.toContain('promptBrowserLogin');
     expect(source).not.toContain('CMEM_PRO_TRIAL_START_URL');
     expect(source).not.toContain('CLAUDE_MEM_ONLINE_OPTIN');

--- a/tests/npx-cli/provider-account-gate.test.ts
+++ b/tests/npx-cli/provider-account-gate.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { providerNeedsAccount } from '../../src/npx-cli/commands/install.js';
+
+describe('provider account gate', () => {
+  it('exempts an explicit --provider claude from the account requirement', () => {
+    // `claude` runs memory on the user's own Anthropic plan and never contacts
+    // cmem.ai, so a cmem.ai outage must not fail this install.
+    expect(providerNeedsAccount('claude')).toBe(false);
+  });
+
+  it('still requires an account when no provider was named', () => {
+    // The provider screen can still offer CMEM Pro, so login has to come first.
+    expect(providerNeedsAccount(undefined)).toBe(true);
+  });
+
+  it('still requires an account for openrouter', () => {
+    // openrouter is the transport for the cmem gateway, so an explicit
+    // openrouter install may still be reaching cmem.ai.
+    expect(providerNeedsAccount('openrouter')).toBe(true);
+  });
+
+  it('still requires an account for gemini', () => {
+    expect(providerNeedsAccount('gemini')).toBe(true);
+  });
+});
+
+describe('install flow wiring', () => {
+  const source = readFileSync(
+    join(__dirname, '..', '..', 'src', 'npx-cli', 'commands', 'install.ts'),
+    'utf-8',
+  );
+
+  it('gates the OAuth login call behind providerNeedsAccount', () => {
+    // Pins the regression this fixes: the login call was previously
+    // unconditional, so any cmem.ai outage hard-blocked every install.
+    expect(source).toContain('if (providerNeedsAccount(options.provider)) {');
+    expect(source).toMatch(
+      /if \(providerNeedsAccount\(options\.provider\)\) \{\s*\n\s*oauthPairing = await requireInstallerOAuthLogin\(version\);/,
+    );
+  });
+
+  it('refuses CMEM Pro enrollment without a pairing', () => {
+    expect(source).toContain("throw new Error('CMEM Pro requires a signed-in claude-mem account.');");
+  });
+});


### PR DESCRIPTION
## Why

Login ran unconditionally before the provider choice, so a cmem.ai outage failed installs that never needed an account.

This is not hypothetical. **13.20.0 shipped while `POST /api/installer/oauth/start` was still undeployed**, and every install died on:

```
◇  Could not start OAuth login.
■  OAuth login is required. Run npx claude-mem install again when cmem.ai is reachable.
```

That included local-only installs that never touch cmem.ai. Greptile flagged exactly this on #3821 (P1, "Mandatory OAuth blocks local providers") and it was accepted as intentional at the time; production then demonstrated the cost.

## What

`--provider claude` configures memory against the user's own Anthropic plan and never contacts cmem.ai, so there is no account question left for login to answer. That case now skips login.

Keyed on **the explicit flag, not on reachability**. Falling back to a local install whenever cmem.ai happened to be down would silently change what the user gets; this only skips a step the user's own flag already made moot.

`gemini` and `openrouter` stay gated — openrouter is the transport for the cmem gateway, so an explicit openrouter install may still be reaching cmem.ai. With no flag at all, the provider screen can still offer CMEM Pro, so login stays first.

`promptProvider` now takes a nullable pairing and re-checks it before CMEM Pro enrollment instead of assuming it is present.

## Tests

New `tests/npx-cli/provider-account-gate.test.ts` (6 assertions) covers the predicate for `claude` / `gemini` / `openrouter` / no-flag, and pins the wiring so the login call cannot quietly become unconditional again.

Full suite: 2864 pass. The 2 failures are pre-existing and macOS-only (`worktree-adoption` tests build repos under `mkdtempSync(tmpdir())`, a `/var/folders` symlink path, so the `w.path !== mainRepo` comparison misses after realpath resolution). They pass on Linux CI.