### PR TITLE
fix(promo): advertise the 30-day trial everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Install with a single command:
 npx claude-mem install
 ```
 
-The installer sets everything up first, then asks you to sign in to claude-mem in your browser (email magic link — no card required). Signing in provisions a memory key for your account and unlocks the **claude-mem observer**: memory that runs off-plan, free for your first 7 days, so you get up to 100% more usage from your plan. When the free week ends, memory automatically falls back to your Anthropic plan unless you subscribe. After sign-in you pick your memory provider — the claude-mem observer, your own OpenRouter or Gemini key, or your Anthropic plan.
+The installer sets everything up first, then asks you to sign in to claude-mem in your browser (email magic link — no card required). Signing in provisions a memory key for your account and unlocks the **claude-mem observer**: memory that runs off-plan, free for your first 30 days, so you get up to 100% more usage from your plan. When the free trial ends, memory automatically falls back to your Anthropic plan unless you subscribe. After sign-in you pick your memory provider — the claude-mem observer, your own OpenRouter or Gemini key, or your Anthropic plan.
 
 Prefer to skip the sign-in? Pass an explicit `--provider` flag, set `CLAUDE_MEM_ONLINE_OPTIN=false`, or run in CI/non-interactive shells — the installer completes without any account interaction.
 

--- a/docs/public/installation.mdx
+++ b/docs/public/installation.mdx
@@ -23,7 +23,7 @@ The interactive installer runs in three stages — install first, sign in second
 
 ### Memory Provider Options
 
-- **claude-mem observer (recommended)** — memory runs off-plan: get up to 100% more usage from your plan. Free for 7 days; when the free week ends, memory automatically falls back to your Anthropic plan unless you subscribe.
+- **claude-mem observer (recommended)** — memory runs off-plan: get up to 100% more usage from your plan. Free for 30 days; when the free trial ends, memory automatically falls back to your Anthropic plan unless you subscribe.
 - **Your OpenRouter key** — memory runs off-plan on your OpenRouter credit.
 - **Gemini API key** — memory runs off-plan on your Gemini key.
 - **Anthropic plan** — memory shares your Claude plan usage. Prompts for the Claude model used to compress observations (Haiku / Sonnet / Opus).

--- a/src/cli/handlers/context.ts
+++ b/src/cli/handlers/context.ts
@@ -106,7 +106,7 @@ export const contextHandler: EventHandler = {
       && settings.CLAUDE_MEM_PROVIDER === 'openrouter'
       && isCmemGatewayUrl(settings.CLAUDE_MEM_OPENROUTER_BASE_URL);
     if (fallbackActive && !hasShownProFallbackNotice()) {
-      const fallbackNotice = 'Your claude-mem free week ended — memory now runs on your Anthropic plan.\n'
+      const fallbackNotice = 'Your claude-mem free trial ended — memory now runs on your Anthropic plan.\n'
         + `Keep it off-plan (up to ${PLAN_USAGE_GAIN_PERCENT}% more usage): ${proTrialUrl('fallback')}`;
       additionalContext = additionalContext
         ? `${fallbackNotice}\n\n${additionalContext}`
@@ -130,14 +130,14 @@ export const contextHandler: EventHandler = {
     // back to the plain additionalContext for terminal display.
     const displayContent = coloredTimeline || (platform === 'antigravity-cli' ? additionalContext : '');
 
-    // Days-remaining nicety: while the free week is active (plan 'trial', an
+    // Days-remaining nicety: while the free trial is active (plan 'trial', an
     // end date stored, no fallback), append the countdown. Computed locally —
     // no network — and display-only: nothing is enabled or disabled by it.
     const daysLeft = !fallbackActive && settings.CLAUDE_MEM_PRO_PLAN === 'trial'
       ? trialDaysRemaining(settings.CLAUDE_MEM_PRO_TRIAL_ENDS_AT)
       : null;
     const trialDaysLine = daysLeft !== null && daysLeft >= 0
-      ? `claude-mem free week: ${daysLeft} day${daysLeft === 1 ? '' : 's'} left`
+      ? `claude-mem free trial: ${daysLeft} day${daysLeft === 1 ? '' : 's'} left`
       : null;
 
     const systemMessage = showTerminalOutput && displayContent

--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -41,6 +41,7 @@ import {
   PROVIDER_PROMPT_MESSAGE,
 } from '../cmem-pro-costs.js';
 import { clearProFallback, isCmemGatewayUrl } from '../../shared/cmem-gateway.js';
+import { PRO_TRIAL_PITCH, proTrialUrl } from '../../shared/pro-promo.js';
 import {
   buildAnthropicMaxLocalSettings,
   buildCmemActivationSettings,
@@ -2342,6 +2343,7 @@ async function runInstallCommandInner(options: InstallOptions, summary: InstallS
     cloudSyncConfigured
       ? 'Memory syncs across your signed-in CMEM Pro agents and devices.'
       : `Everything stays in ${styleText('cyan', '~/.claude-mem')} on this machine.`,
+    ...(cloudSyncConfigured ? [] : [`${PRO_TRIAL_PITCH}: ${styleText('underline', proTrialUrl('installer'))}`]),
     ``,
     `${styleText('dim', `Optional: ${'/learn-codebase'} ingests a whole repo up front (~5 min)   ·   How it works: /how-it-works`)}`,
   ];

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -208,7 +208,7 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_PRO_TRIAL_EMAIL: '',     // Email the sign-in link was sent to (don't-re-nag marker)
     CLAUDE_MEM_PRO_TRIAL_AT: '',        // ISO timestamp of the last sign-in link send
     CLAUDE_MEM_PRO_TRIAL_STATE: '',     // 'link_sent' (started, credentials never picked up) | 'active' (done)
-    CLAUDE_MEM_PRO_TRIAL_ENDS_AT: '',   // ISO date the free week ends (from poll trial.ends_at); '' when absent
+    CLAUDE_MEM_PRO_TRIAL_ENDS_AT: '',   // ISO date the free trial ends (from poll trial.ends_at); '' when absent
     CLAUDE_MEM_PRO_PLAN: '',            // 'trial' | 'pro' | 'none' — plan reported by the poll on ready
     CLAUDE_MEM_PRO_FALLBACK_AT: '',     // ISO timestamp when the cmem gateway terminally rejected the delivered key and memory fell back to the Anthropic plan; '' = no fallback. Event-driven only (never set from trial dates); cleared by a successful gateway response or fresh installer key material.
     CLAUDE_MEM_PRO_MEMORY_KEY: '',       // One-shot browser-pairing memory key, staged until provider selection (settings.json is chmod 0600 by the installer)

--- a/src/shared/cmem-gateway.ts
+++ b/src/shared/cmem-gateway.ts
@@ -6,7 +6,7 @@
  * When the installer's browser login delivers a memory key, the worker talks
  * to the cmem.ai gateway through the generic OpenRouter provider
  * (CLAUDE_MEM_OPENROUTER_BASE_URL points at `${CMEM_PRO_ORIGIN}/api/inference/v1`).
- * Once the free week ends without a subscription, the gateway answers with a
+ * Once the free trial ends without a subscription, the gateway answers with a
  * terminal quota/key error — and instead of surfacing an outage, memory falls
  * back to the user's Anthropic plan. The fallback state lives in settings.json
  * as CLAUDE_MEM_PRO_FALLBACK_AT (ISO timestamp; '' = no fallback) and is

--- a/src/shared/pro-promo.ts
+++ b/src/shared/pro-promo.ts
@@ -1,5 +1,5 @@
 /**
- * cmem Pro 7-day-trial promo copy — the single source of truth for every place
+ * cmem Pro trial promo copy — the single source of truth for every place
  * claude-mem tells an existing user the trial exists.
  *
  * Almost nobody running the free plugin knows the trial is there, so the pitch
@@ -27,14 +27,21 @@ export type ProPromoSource =
   | 'context-banner'
   | 'welcome-hint'
   | 'viewer'
-  /** One-time session-start notice after the free week ends and memory falls back on-plan. */
+  /** One-time session-start notice after the free trial ends and memory falls back on-plan. */
   | 'fallback'
   /** Hand-written links in the cursor-hooks setup docs — no TS caller. */
   | 'docs';
 
+/**
+ * Trial length advertised by every client-side promo link, in days. The landing
+ * page reads `?trial=` to render the offer, so this has to match the copy in
+ * PRO_TRIAL_PITCH and the length the server actually grants at checkout.
+ */
+export const PRO_TRIAL_DAYS = 30;
+
 /** Trial landing URL tagged with the surface the user clicked from. */
 export function proTrialUrl(source: ProPromoSource): string {
-  return `${PRO_TRIAL_URL}?from=${source}`;
+  return `${PRO_TRIAL_URL}?from=${source}&trial=${PRO_TRIAL_DAYS}`;
 }
 
 /**
@@ -44,7 +51,7 @@ export function proTrialUrl(source: ProPromoSource): string {
 export const PLAN_USAGE_GAIN_PERCENT = 100;
 
 /** The offer itself, without a URL — for surfaces that link separately. */
-export const PRO_TRIAL_PITCH = `Get up to ${PLAN_USAGE_GAIN_PERCENT}% more usage from your plan — memory runs off-plan, free for 7 days`;
+export const PRO_TRIAL_PITCH = `Get up to ${PLAN_USAGE_GAIN_PERCENT}% more usage from your plan — memory runs off-plan, free for ${PRO_TRIAL_DAYS} days`;
 
 /**
  * One-line pitch + link, for plain-text surfaces (hook banners, welcome hint).

--- a/src/ui/viewer/constants/promo.ts
+++ b/src/ui/viewer/constants/promo.ts
@@ -7,7 +7,9 @@
  */
 
 /** Trial landing URL, tagged so cmem.ai can attribute viewer-sourced signups. */
-export const PRO_TRIAL_URL = 'https://cmem.ai/pro?from=viewer';
+export const PRO_TRIAL_DAYS = 30;
+
+export const PRO_TRIAL_URL = `https://cmem.ai/pro?from=viewer&trial=${PRO_TRIAL_DAYS}`;
 
 /**
  * How much more plan usage running memory off-plan buys, as a "% more" figure.
@@ -15,7 +17,7 @@ export const PRO_TRIAL_URL = 'https://cmem.ai/pro?from=viewer';
  */
 export const PLAN_USAGE_GAIN_PERCENT = 100;
 
-export const PRO_TRIAL_PITCH = `Get up to ${PLAN_USAGE_GAIN_PERCENT}% more usage from your plan — memory runs off-plan, free for 7 days`;
+export const PRO_TRIAL_PITCH = `Get up to ${PLAN_USAGE_GAIN_PERCENT}% more usage from your plan — memory runs off-plan, free for ${PRO_TRIAL_DAYS} days`;
 
 /** Header CTA label. The full pitch rides in the title/aria attributes. */
 export const PRO_TRIAL_SHORT = 'Get up to 100% more usage from your plan';


### PR DESCRIPTION
Every client-side promo link now carries `?trial=30` and every surface says "30 days" instead of "7".

## Why

The installer's provider screen advertises a **30 Day Free Trial** and the server now issues 30-day checkout URLs (claude-mem-pro `3af9a5a`), but every other client surface still said 7. The landing page link also carried no trial length at all.

That last part is not cosmetic. `ProOffer` reads `?trial=` through `parseTrialDays()` and is deliberately **length-neutral without it** — so today a click from the session-start banner, the viewer, or the context banner lands on a page that never names a trial length, and Stripe Checkout gets no `trialDays`. With `&trial=30` the page renders "Start your 30-day free trial." and carries 30 into Checkout. `30` is in `SELECTABLE_TRIAL_DAYS` and maps to the `test_30` experiment arm.

## Changes

- **`src/shared/pro-promo.ts`** — new `PRO_TRIAL_DAYS = 30`, the single knob. `proTrialUrl()` now emits `?from=<source>&trial=30`; `PRO_TRIAL_PITCH` interpolates the constant instead of hardcoding "7 days".
- **`src/ui/viewer/constants/promo.ts`** — mirrored. The viewer's tsconfig pins `rootDir` to its own directory so it cannot import the shared module; the two files carry reciprocal "change both together" comments.
- **`src/npx-cli/commands/install.ts`** — restores the trial link in the Next Steps block. `'installer'` was declared in `ProPromoSource` but had **no caller** after the Next Steps trim in 7ac207ebe, so the last screen of the funnel never mentioned the offer. Shows for non-Pro installs only (gated on `cloudSyncConfigured`).
- **`src/cli/handlers/context.ts`** — "free week ended" → "free trial ended"; countdown reads "claude-mem free trial: N days left".
- **`README.md`, `docs/public/installation.mdx`** — "free for your first 30 days"; "when the free trial ends".
- Comment wording in `cmem-gateway.ts` and `SettingsDefaultsManager.ts`.

Zero remaining "7 day" / "seven day" / "free week" references in `src/`, `docs/`, `tests/`, or `README.md`.

## Verification

`tsc --noEmit` clean. `tests/install-non-tty.test.ts` 45 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DD5YMaAiXXeY3zaitbGC6n