### PR TITLE
fix(installer): pre-select CMEM Pro and Claude Code

### DIFF
--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -645,10 +645,17 @@ async function promptForIDESelection(): Promise<string[]> {
     };
   });
 
+  // Pre-check Claude Code (plus anything else detected). It is the IDE almost
+  // everyone installing claude-mem is running, and an empty multiselect makes
+  // the common case a required chore before the install can continue.
+  const preselected = detectedIDEs
+    .filter((ide) => ide.detected || ide.id === 'claude-code')
+    .map((ide) => ide.id);
+
   const result = await p.multiselect({
     message: 'Which IDEs do you use?',
     options,
-    initialValues: [],
+    initialValues: preselected,
     required: true,
   });
 
@@ -1070,7 +1077,10 @@ async function promptProvider(
           { value: 'cmem', label: labels.cmem, hint: labels.cmemHint },
           { value: 'claude', label: labels.claude, hint: labels.claudeHint },
         ],
-        initialValues: [],
+        // CMEM Pro pre-selected: it is the recommended path and the one the
+        // funnel is built around. Selecting it no longer means "pay now" —
+        // it opens the offer page to read first.
+        initialValues: ['cmem'],
         required: true,
       });
       if (p.isCancel(providerResult)) {


### PR DESCRIPTION
Both installer prompts opened with nothing checked, making the recommended path a required chore before the install could continue.

- **Provider prompt** — `initialValues: ['cmem']`. CMEM Pro is the path the funnel is built around, and selecting it no longer means "pay now": it opens the offer page to read first (claude-mem-pro `ea8a4d2`).
- **IDE prompt** — pre-checks everything detected, plus Claude Code, which is what essentially everyone installing claude-mem is running.

Both stay multiselects with `required: true`, so anyone who wants something else unchecks and picks.

## Context

This pairs with the server-side funnel fix in claude-mem-pro `ea8a4d2`. `/api/pro/trial/claim` used to 302 a non-entitled user straight into Stripe Checkout, so picking CMEM Pro opened a browser on a bare card form and `/pro` was only ever reached on an error or cancellation. Payment is meant to be deferred until after login — it was, and then demanded immediately. The claim route now routes through `/pro?from=installer&pairing=…&trial=…` and only starts Checkout when that page's CTA returns with `checkout=1`.

That fix is already live and needs no client release: it changes where the route sends people, not the URL the installer opens (published installers pin that path).

## Verification

`tsc --noEmit` clean. `tests/install-non-tty.test.ts` 45 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DD5YMaAiXXeY3zaitbGC6n