### PR TITLE
chore(installer): delete the stale trial acknowledgement constant

### DIFF
--- a/src/npx-cli/cmem-pro-costs.ts
+++ b/src/npx-cli/cmem-pro-costs.ts
@@ -9,9 +9,6 @@ import { cmemProOrigin } from '../shared/cmem-gateway.js';
 export const PROVIDER_PROMPT_MESSAGE =
   'Select Provider:\n================';
 
-export const CMEM_TRIAL_ACKNOWLEDGEMENT =
-  "Free Trial includes a week's worth of allowance and auto-charges if you reach the limit.";
-
 export interface ProviderLabels {
   cmem: string;
   cmemHint: string;


### PR DESCRIPTION
## Summary

Deletes `CMEM_TRIAL_ACKNOWLEDGEMENT` from `src/npx-cli/cmem-pro-costs.ts` — a dead exported constant carrying stale copy from the original 7-day / $2.33 trial ("a week's worth of allowance").

The trial is now 30 days, so the copy was wrong. It was never rendered anywhere: the billing disclosure deliberately moved to the Stripe checkout page (to avoid making users consent twice before seeing what they agreed to). Dead code carrying wrong user-facing copy is a landmine for whoever re-renders it later, so it's deleted rather than fixed.

## Verification

Before deleting, confirmed the only two references in the repo were the definition and the guard test:

```
$ grep -rn "CMEM_TRIAL_ACKNOWLEDGEMENT" src/ tests/
src/npx-cli/cmem-pro-costs.ts:12:export const CMEM_TRIAL_ACKNOWLEDGEMENT =
tests/npx-cli/install-trial-contract.test.ts:158:    expect(source).not.toContain('CMEM_TRIAL_ACKNOWLEDGEMENT');
```

`install.ts`'s import block from `cmem-pro-costs.js` was checked directly and does not include it. The test at `install-trial-contract.test.ts:158` only checks that `install.ts`'s source text does not contain the string `'CMEM_TRIAL_ACKNOWLEDGEMENT'` — it does not import the constant itself, so removing the export does not affect it. That test assertion is left in place, per the task.

`buildProviderLabels()` (already correctly says "30 Day Free Trial") and `PROVIDER_PROMPT_MESSAGE` are untouched — diff is a 3-line removal only.

- `npm run typecheck` — clean, no errors
- `bun test tests/npx-cli/install-trial-contract.test.ts` — 17 pass, 0 fail
- `bun test tests/npx-cli/` (full directory, sanity check) — 55 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtsatUzhRK8FMMqCCxUEXR