### PR TITLE
fix(installer): put the provider choice first and collapse the browser trip

### DIFF
--- a/plans/2026-08-31-funnel-immediacy-restore.md
+++ b/plans/2026-08-31-funnel-immediacy-restore.md
@@ -1,0 +1,216 @@
+# Restore Funnel Immediacy: Provider Choice First, Lazy Login, One Browser Trip
+
+**Date:** 2026-08-31
+**Repos:** `claude-mem` CLI (this worktree, branch `fix/installer-preselect-defaults`) + `claude-mem-pro` server (`~/Scripts/claude-mem-pro`, main @ `ea8a4d2`)
+
+---
+
+## Problem
+
+The Aug 31 OAuth rewrite inverted the funnel. Mandatory browser login was placed **before** the value proposition, so:
+
+- A free, open-source plugin demands GitHub/Google OAuth before it will finish installing.
+- The pitch had to move *after* the login wall, splitting one offer across three surfaces.
+- Users take **5 terminal↔browser context switches**; the old email funnel took 3.
+
+The audit that triggered the rewrite was misread: the terminal email step converted 2,222 installers (96.6% delivery), while the **browser callback** failed 1,907 times (`auth_callback_failed`). The converting step was deleted; the failing step was promoted to mandatory.
+
+**Root cause of the inversion** — from `claim/route.ts`'s own comment: they wanted a `pro_users` row for every install ("registered-but-not-paid is a real state"). Mandatory login was a *measurement* decision wearing an *auth* decision's clothes.
+
+## Goal
+
+Restore the old funnel's shape — **cheap, early, terminal-native commitment** — while keeping every security fix from the rewrite.
+
+Picking "CMEM Pro" in the terminal becomes the new "type your email": instant, free, zero context switch, and it *is* the conversion event.
+
+**Target: 5 context switches → 4. Forced switches for a user who never pays: 1 → 0.**
+
+> **Corrected after verification.** An earlier draft of this plan claimed 5 → 2. That was wrong.
+> The device-approval step still sends the user back to the terminal to read the code and then
+> returns them to the browser, which costs two switches that Phases 1–3 do not remove. The
+> **delta is real** — one entire browser round trip is deleted, −2 switches — but the absolute
+> figure is 4. Reaching 2 requires Phase 4 (device-code narrowing), which is deferred.
+
+---
+
+## Phase 0: Discovery Findings (COMPLETE — do not re-investigate)
+
+### Allowed APIs / verified facts
+
+**CLI (`src/npx-cli/commands/install.ts`)**
+- `promptProvider(options, pairing, version)` at `:1025`. `pairing` is used in exactly **3** places: the signature (`:1032`), a null-check (`:1102`), and `completeCmemTrialPairing(pairing, version)` (`:1112`). The code is already shaped for lazy login.
+- Main flow call sites: `providerNeedsAccount` gate at `:2156`, `requireInstallerOAuthLogin(version)` at `:2157`, `promptProvider(options, oauthPairing, version)` at `:2166`.
+- `providerNeedsAccount(provider)` at `:1797` returns `provider !== 'claude'`.
+- `validateNonInteractiveProvider(options, summary)` is at `:1925`.
+- `hasPairingAndTrialParams` at `:1331`: requires **exactly** `{pairing, trial}`, trial 1–365. FROZEN — back-compat with published installers.
+- `parseInstallerOAuthStartBody` at `:1342`: validates origins and that the login `next` is exactly `{pairing, login_only:1}`. FROZEN.
+- `CMEM_TRIAL_ACKNOWLEDGEMENT` (`cmem-pro-costs.ts:12`) is **dead code** — no consumer in `src/`.
+
+**Server (`~/Scripts/claude-mem-pro`)**
+- `POST /api/installer/oauth/start` returns exactly 7 keys (`start/route.ts:105-116`): `pairing_id`, `secret`, `user_code`, `authorization_url`, `checkout_url`, `expires_in`, `poll_interval`. There is **no `login_next` key** — the login-only claim is embedded in `authorization_url`'s `next=` param (`:56`).
+  - `authorization_url` = `/login?next=<urlencoded /api/pro/trial/claim?pairing=X&login_only=1>`
+  - `checkout_url` = `/api/pro/trial/claim?pairing=X&trial=30` (`:50-53`, `INSTALLER_TRIAL_DAYS=30` at `:29`)
+- **KEY FACT** — `claim/route.ts` already handles sessionless visitors: when `getUser()` returns null it redirects to `/login?next=<the same claim URL>` and returns after auth. **Opening `checkout_url` with no session already performs login-then-claim in one trip.**
+- **BLOCKER** — `claim/route.ts:115-123` two-visit state machine: `login_only` advances `pending → authenticated`; the checkout visit advances **only** `authenticated → claimed`. A `pending` row visiting without `login_only` stays `pending`. This must allow `pending → claimed`.
+- `poll/route.ts` stages: `awaiting_login` when `!pairing.userId` (`:161`); `awaiting_checkout` when not entitled (`:184`) or entitled-but-no-setupToken (`:198`); `awaiting_approval` when entitled but `!pairing.approvedAt` (`:194`). Returns `authenticated` only when `status === 'authenticated'` (`:169-176`), `ready` after the atomic `deliverPairing` flip (`:228`).
+- Poll auth: `secretMatches` — SHA-256 + `timingSafeEqual` against `secret_hash` (`:47-51`, `:149`). No cookie.
+- `approve/route.ts` requires **session + user_code + Origin header** (`:124-127`, `:130`, `:174-176`, `:184-186`). It does **NOT** take the pairing secret. The user_code is the real browser↔terminal binding.
+- `cliPairings` schema (`src/db/schema.ts:195-212`): `pairingId, secretHash, email, status, userId, source, createdAt, claimedAt, deliveredAt, expiresAt, userCode, deviceName, approvedAt`. **No `authenticatedAt` and no session column.** `status` is overwritten in place, so it cannot distinguish which claim happened.
+- `/installer/authorized` page renders only: "Login complete. Close this window and go back to your terminal." — the mid-flow bounce we are deleting from the Pro path.
+
+### Anti-pattern guards
+- Do NOT change `checkout_url` / `authorization_url` **URL shapes**. Published installers (≤13.21.2) reject anything else. Redirect *destinations* are free to change; URL *shapes* are frozen.
+- Do NOT switch the provider prompt away from `p.multiselect<ProviderChoice>` — pinned at `install-trial-contract.test.ts:167`.
+- Do NOT reintroduce `promptBrowserLogin`, `CMEM_PRO_TRIAL_START_URL`, `CLAUDE_MEM_ONLINE_OPTIN`, or `Your email:` — forbidden at `install-trial-contract.test.ts:168-171`. **We are NOT restoring email capture.**
+- Do NOT move the `requireInstallerOAuthLogin(version)` call site textually **above** line 1925 — `install-non-tty.test.ts:97-103` asserts `validateNonInteractiveProvider` appears earlier in the file by byte position.
+
+### Commands
+- Installer tests: `bun test tests/npx-cli/install-trial-contract.test.ts tests/npx-cli/provider-account-gate.test.ts tests/install-non-tty.test.ts`
+- All tests: `npm test` · Typecheck: `npm run typecheck`
+- **Verified baseline: 68 pass, 0 fail.**
+
+---
+
+## Phase 1 — Lazy login (CLI only, self-contained)
+
+**Goal:** provider choice happens first and costs nothing; OAuth runs only on the CMEM Pro branch.
+
+### What to implement
+
+Split `promptProvider` into a **choice** step and an **apply** step, so the login call stays in the main flow textually below line 1925 (respects the byte-position trap).
+
+1. In `src/npx-cli/commands/install.ts`, extract the multiselect block (currently `:1066-1092`) into `promptProviderChoice(options): Promise<ProviderChoice>`. It takes **no pairing** and performs **no network calls**. Copy the existing multiselect verbatim — same `p.multiselect<ProviderChoice>`, same `initialValues: ['cmem']`, same `required: true`, same both-selected re-prompt loop.
+2. Change `promptProvider` to accept the already-made `selectedProvider` plus `pairing`, keeping its existing CMEM/claude/BYO branches unchanged (`:1101-1140+`).
+3. Rewrite the main flow at `:2145-2166` to:
+   - call `promptProviderChoice` first when no `options.provider` was given;
+   - call `requireInstallerOAuthLogin(version)` **only** when the resolved choice is `'cmem'` (or when `options.provider` is set and `providerNeedsAccount()` is true, preserving the non-interactive path);
+   - then call `promptProvider` with the resolved choice and the pairing.
+4. Update `providerNeedsAccount`'s doc comment at `:1791-1797`: it no longer means "login first for everyone", it means "this flag still needs an account". Keep the function's return values identical — `provider-account-gate.test.ts:10-25` asserts them and those assertions remain correct.
+5. Delete the now-stale comment at `:1694-1696` ("logging in is required of every user and runs BEFORE the provider choice") and replace it with one describing lazy login.
+6. **Re-check the stdin sequencing dependency at `:1726-1734`.** That comment says `completeCmemTrialPairing` deliberately skips the return-wait because "stdin has already been through the login wait and a clack prompt by now". Reordering changes that history — the provider prompt now runs *before* login. Verify by hand (Phase 5 manual run) whether the wait behaves; adjust only if it actually stalls. No test covers this.
+
+### Tests to update (deliberate contract flips, not incidental breaks)
+- `tests/npx-cli/install-trial-contract.test.ts:161-172` — the test named **"requires OAuth before provider selection"**. This assertion *is* the inversion. Rewrite it to assert the opposite: provider choice appears before the login call, and login is reached only on the CMEM branch. Keep the `not.toContain` forbid-list at `:168-171` exactly as is.
+- `tests/npx-cli/provider-account-gate.test.ts:35-42` — the verbatim-adjacency regex on `if (providerNeedsAccount(options.provider)) {`. Rewrite to match the new gate.
+- `tests/npx-cli/provider-account-gate.test.ts:13-16` — the comment "The provider screen can still offer CMEM Pro, so login has to come first" is now false. Keep `providerNeedsAccount(undefined) === true` (still correct) but rewrite the comment.
+- `tests/install-non-tty.test.ts:97-103` — must still pass. If the login call site moved above line 1925, that is a mistake; move it back rather than weakening the test.
+
+### Verification checklist
+- [ ] `npm run typecheck` clean
+- [ ] `bun test tests/npx-cli/ tests/install-non-tty.test.ts` — all pass
+- [ ] `npm test` — no regressions vs the 68-pass baseline
+- [ ] `grep -n "requireInstallerOAuthLogin(version)" src/npx-cli/commands/install.ts` returns a line number **> 1925**
+- [ ] Manual: `--provider claude` completes with **cmem.ai unreachable** (block it in `/etc/hosts`) and never opens a browser
+- [ ] Manual: choosing "Use your Anthropic Max Plan" at the prompt never opens a browser
+
+---
+
+## Phase 2 — One uninterrupted browser trip
+
+**Goal:** OAuth → offer → Stripe → done, with no bounce back to the terminal in the middle.
+
+### Server (`~/Scripts/claude-mem-pro`) — do this FIRST and deploy before shipping the CLI
+
+1. In `src/app/api/pro/trial/claim/route.ts:115-123`, relax the non-`login_only` status transition to also accept `pending`:
+   ```
+   WHEN status IN ('pending', 'authenticated') THEN 'claimed'
+   ```
+   Keep the `login_only` branch exactly as is. Preserve every existing guard in the `.where(...)` clause at `:130-137` (`ne(status,'delivered')`, `gt(expiresAt, now)`, the userId ownership check) — those are load-bearing for exactly-once delivery.
+2. Do **not** change `authorization_url` or `checkout_url` construction in `start/route.ts:44-57`. Shapes are frozen.
+3. Leave `/installer/authorized` in place — installers ≤13.21.2 still land there.
+
+### CLI
+
+4. In the CMEM Pro branch, open `pairing.checkoutUrl` **instead of** `pairing.authorizationUrl`, and drop the separate login round trip. The claim route's sessionless bounce (`claim/route.ts`, the `if (!user)` block) performs login inline and returns to the claim.
+5. The poll loop needs no change — with a direct `pending → claimed`, `poll` moves `awaiting_login` → `awaiting_checkout` → `awaiting_approval` on its own.
+6. Update `waitForInstallerPairing`'s `stageMessages` (`:1555-1560`) — the `phase: 'login'` vs `'enrollment'` split may collapse to a single phase. Only simplify if Phase 1 actually made one branch unreachable; do not delete a still-used branch.
+
+### Phase 2b — Close the stranding hole (real defect found in discovery)
+
+`ProOffer.tsx:91-92` derives `installerPairing` from a 32-hex `pairing` param, but `funnelSource === 'installer'` is driven by `from=installer` **alone** (`:83-84`). So an installer-tagged visit with a missing or malformed `pairing` skips the resume branch at `:166`, falls through to `startCheckout` (`:172`), and lands on `/pro/key` — a manual paste-back screen the installer has **no paste path for**. The Stripe session is tagged `funnel_source: installer` but carries **no `pairing_id` metadata**, so the webhook can never match delivery back to the waiting terminal. It polls `awaiting_approval` until timeout.
+
+This is the `/pro/key` dead-end observed in production on 2026-08-31.
+
+Fix: when `fromInstaller` is true but `installerPairing` is null, do **not** silently start a bare checkout. Show a recoverable error telling the user to re-run `npx claude-mem install` for a fresh link (the same message `/pro?trial_error=expired` already renders). Add a `posthog.capture` for this branch so the rate is visible.
+
+Verification:
+- [ ] Visiting `/pro?from=installer` with no `pairing` param shows the recover-and-rerun message, not a checkout button that strands the terminal
+- [ ] Visiting `/pro?from=installer&pairing=notvalidhex` does the same
+- [ ] A valid pairing still routes through `/api/pro/trial/claim?...&checkout=1` unchanged
+
+### Verification checklist
+- [ ] Server: existing pro tests pass; typecheck/build clean
+- [ ] A **published** installer (13.21.2 from npm, not the local build) still completes end-to-end against the updated server — this is the back-compat gate, and it must be run
+- [ ] New CLI: exactly one browser window opens on the CMEM Pro path
+- [ ] Confirm `pro_users` still gets a row for a user who reaches checkout
+- [ ] Confirm an expired/delivered pairing still fails closed (guards intact)
+
+---
+
+## Phase 3 — Copy trim
+
+**Goal:** one offer, one line. (The cost overwording is already ~80% resolved — the live pricing engine was deleted in `2ed78c58d`, and the billing acknowledgement was moved to the checkout page. Do **not** re-litigate that.)
+
+1. In `src/npx-cli/cmem-pro-costs.ts:33-38`, trim the CMEM Pro label from its current two-line run-on to a single line. Constraints from `install-trial-contract.test.ts:146-149`: hints must stay `''`, the cmem label must still contain `30 Day Free Trial`, the claude label must still contain `no cloud sync`. Keep the rationale comment at `:22-31` (clack renders hints only on the focused row).
+2. Delete the dead `CMEM_TRIAL_ACKNOWLEDGEMENT` export at `:12-13`. Confirm with `grep -rn CMEM_TRIAL_ACKNOWLEDGEMENT src/` returning nothing. Leave the guard at `install-trial-contract.test.ts:158` in place — it should keep passing.
+3. Update the exact-copy assertion at `install-trial-contract.test.ts:132-138` to the new label.
+
+### Verification checklist
+- [ ] `bun test tests/npx-cli/install-trial-contract.test.ts` passes
+- [ ] Label renders on one line at 80 columns
+- [ ] `grep -rn "CMEM_TRIAL_ACKNOWLEDGEMENT" src/` is empty
+
+---
+
+## Phase 4 — Device-code narrowing (OPTIONAL, LAST, SECURITY-REVIEWED)
+
+**Do not start this until Phases 1–3 are shipped and verified.** Phases 1–3 already deliver 5 switches → 2. This phase is a bonus and must not risk them.
+
+**Discovery confirmed this is genuinely expensive:**
+- There is **no** `authenticatedAt` or browser-session column on `cliPairings`; `status` is overwritten in place. Same-session continuity requires a **migration**.
+- `approve/route.ts` does **not** take the pairing secret — it authenticates with session + user_code + Origin. The user_code is the actual browser↔terminal binding.
+- The pairing id **does** travel in URLs (checkout_url, offer link, success URL), so it is a bearer value. The code defends against someone holding a leaked pairing id completing checkout against your terminal, and against your terminal receiving credentials provisioned under an attacker-chosen account.
+
+**Therefore: narrowing, never deletion.** Only skip the code re-entry when the *same browser session* both (a) completed the claim for this pairing and (b) returned from Stripe with matching `pairing_id` metadata.
+
+Requires: a new nullable column (e.g. `authenticated_session_id`), a migration, and an explicit security review. Write the migration additively; never drop `userCode`.
+
+**If review rejects this, close it out. Phases 1–3 stand alone.**
+
+---
+
+## Phase 5 — Final verification
+
+1. `npm run typecheck` and `npm test` both clean.
+2. Anti-pattern grep:
+   - `grep -rn "promptBrowserLogin\|CMEM_PRO_TRIAL_START_URL\|CLAUDE_MEM_ONLINE_OPTIN\|Your email:" src/` → **empty** (we did not restore email capture)
+   - `grep -n "p.multiselect<ProviderChoice>" src/npx-cli/commands/install.ts` → present
+   - login call site line number > 1925
+3. **Full manual walkthrough**, counting context switches out loud:
+   - CMEM Pro path: expect **4** (terminal → browser → terminal for the code → browser → terminal). Was 5; Phase 4 would take it to 2.
+   - Anthropic Max path: expect **0** browser opens
+   - `--provider claude` with cmem.ai unreachable: completes offline
+4. **Back-compat gate:** published 13.21.2 from npm still completes against the updated server.
+5. Count switches before/after and record them in the PR body.
+
+---
+
+## Sequencing & release notes
+
+- **Server Phase 2 deploys before the CLI ships.** claude-mem-pro auto-deploys from main on push to Vercel. A new CLI opening `checkout_url` first would break against the old state machine.
+- Phase 1 is CLI-only and self-contained — it can land and be tested independently.
+- CLI release needs a version bump + npm publish, which is human-gated (see the `version-bump` skill). Do not publish autonomously.
+- Two repos, two PRs. Branch `fix/installer-preselect-defaults` already has PR #3825 open; consider a fresh branch for this work rather than growing that PR.
+
+## Verified risks (from the Phase 5 adversarial trace)
+
+1. **Poll budget — FIXED during Phase 5.** `OAUTH_POLL_BUDGET_MS` was a single 240s window. Under the old two-trip flow it was spent twice (240s for login, a fresh 240s for checkout); the one-trip design silently collapsed that into one 240s window covering OAuth + reading the offer + Stripe card entry + device-code entry, exiting the installer non-zero on overrun. Split into `OAUTH_POLL_BUDGET_LOGIN_MS` (240s) and `OAUTH_POLL_BUDGET_ENROLLMENT_MS` (25 min, bounded by the server's 30-min `PAIRING_TTL_SECONDS`).
+2. **Misleading failure message — FIXED during Phase 5.** A CMEM Pro path that failed at checkout or approval printed "OAuth login is required to finish installation." It now names the step that actually failed.
+3. **Stripe cancel stranded the user — FIXED during Phase 5.** `cancelUrl` carried `from=installer` but no `pairing`, so cancelling tripped the new Phase 2b guard and told the user their authorization had expired while their pairing was still live and still being polled. `cancelUrl` now carries the pairing, so cancel offers a retry rather than a restart.
+4. **UNVERIFIED — stdin sequencing.** `waitForReturnToOpenBrowser` runs after a clack multiselect on the CMEM path. A pty repro passed, but the same harness also passed the ordering the code comment says previously stalled, so it has no demonstrated sensitivity. Structural argument says low risk (the "clack prompt precedes this wait" configuration already ships today, and the *second* raw-mode wait that was blamed no longer exists on this path). Only a live interactive run settles it.
+5. **UNVERIFIED — the back-compat gate was not run.** A published 13.21.2 installer from npm has not been exercised against the updated server. Static evidence is strong: `hasPairingAndTrialParams` and `parseInstallerOAuthStartBody` are byte-identical to HEAD, `start/route.ts` is not in the diff at all, and the state-machine walk shows `'authenticated'` still matches the widened CASE. But the gate is formally open.
+6. **UNTESTED — the Phase 2b guard** has no automated coverage in any server `test:*` script.
+
+## Open risk
+
+Making login lazy costs `pro_users` its `registered` rows — and this is **broader than first stated**. New installers never send `login_only=1`, and that branch is the only place the `registered` row is inserted. So a user who signs in via the checkout URL and then abandons at the offer page or at Stripe now leaves **no `pro_users` row at all**, not merely the Anthropic-Max users. The server-side `installer_oauth_completed` capture lives on the same branch and likewise stops firing for new installers (the CLI still emits its own client-side event). **That is a deliberate, stated trade** — top-of-funnel visibility moves to anonymous installer telemetry (`captureCliEvent`, `installId`), which already exists and does not require an account. Measurement should ride on telemetry, not on a login wall.

--- a/src/npx-cli/cmem-pro-costs.ts
+++ b/src/npx-cli/cmem-pro-costs.ts
@@ -9,9 +9,6 @@ import { cmemProOrigin } from '../shared/cmem-gateway.js';
 export const PROVIDER_PROMPT_MESSAGE =
   'Select Provider:\n================';
 
-export const CMEM_TRIAL_ACKNOWLEDGEMENT =
-  "Free Trial includes a week's worth of allowance and auto-charges if you reach the limit.";
-
 export interface ProviderLabels {
   cmem: string;
   cmemHint: string;
@@ -28,11 +25,14 @@ export interface ProviderLabels {
  * the user arrows around, instead of showing both choices side by side. The
  * parentheses are ours for the same reason: clack adds its own `(...)` around a
  * hint, but never around a label.
+ *
+ * Each label stays on one line inside 80 columns. The terminal only has to be
+ * enough to choose by — the full offer is on the /pro page the user lands on
+ * next, and repeating it here is the third time we pitch the same thing.
  */
 export function buildProviderLabels(): ProviderLabels {
   return {
-    cmem: 'CMEM Pro (30 Day Free Trial: Tokens for Observations + Real-Time Cloud Sync '
-      + 'for Claude.ai, ChatGPT.com, anything that accepts an MCP Connector)',
+    cmem: 'CMEM Pro (30 Day Free Trial: cloud sync, tokens included)',
     cmemHint: '',
     claude: 'Use your Anthropic Max Plan (no cloud sync, uses tokens for observations)',
     claudeHint: '',

--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -1830,11 +1830,19 @@ async function requireCmemProTrialPairing(version: string): Promise<InstallerOAu
   if (!pairing) return null;
 
   noteDeviceCode(pairing);
-  // The URL is printed before the browser is opened, so a headless or SSH user
-  // who has no opener is never blocked — they can open it by hand and the wait
-  // still clears on Return.
+  // No "press Return to continue" gate here, deliberately.
+  //
+  // The user picked CMEM Pro one prompt ago, so there is nothing left to
+  // confirm — a keypress gate would be a step that only adds ways to get
+  // stuck. waitForReturnToOpenBrowser has no timeout, so a keypress that the
+  // raw-mode listener misses hangs the install forever; that is the worst
+  // outcome available here and it buys nothing. (completeCmemTrialPairing
+  // reached this same conclusion for the same reason.)
+  //
+  // The URL is still printed before the browser opens, so a headless or SSH
+  // user with no opener is never blocked — they open it by hand and the poll
+  // below is already running.
   log.info(`Open this URL: ${pairing.checkoutUrl}`);
-  await waitForReturnToOpenBrowser('Continue setup in browser... (hit return to open automatically)');
   openBrowser(pairing.checkoutUrl);
   await captureCliEvent('installer_oauth_started', { version });
 

--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -1022,12 +1022,59 @@ function openBrowser(url: string): void {
   }
 }
 
+/**
+ * The provider CHOICE, split out from applying it.
+ *
+ * This step is deliberately free: no network call, no pairing, no login. It is
+ * what the user sees first, so the offer is read before anything is spent on
+ * it, and a user who picks the local path never pays for a browser round trip
+ * they did not need. Applying the choice is `promptProvider`, below.
+ */
+async function promptProviderChoice(options: InstallOptions): Promise<ProviderChoice> {
+  if (options.provider) return options.provider;
+
+  if (!isInteractive) {
+    throw new Error('Non-interactive provider validation did not run.');
+  }
+  const labels = buildProviderLabels();
+
+  // Multiselect gives both choices square controls. Exactly one provider is
+  // still required; selecting both re-opens the prompt instead of guessing.
+  while (true) {
+    const providerResult = await p.multiselect<ProviderChoice>({
+      message: PROVIDER_PROMPT_MESSAGE,
+      options: [
+        { value: 'cmem', label: labels.cmem, hint: labels.cmemHint },
+        { value: 'claude', label: labels.claude, hint: labels.claudeHint },
+      ],
+      // CMEM Pro pre-selected: it is the recommended path and the one the
+      // funnel is built around. Selecting it no longer means "pay now" —
+      // it opens the offer page to read first.
+      initialValues: ['cmem'],
+      required: true,
+    });
+    if (p.isCancel(providerResult)) {
+      p.cancel('Installation cancelled.');
+      process.exit(1);
+    }
+    if (providerResult.length === 1) {
+      return providerResult[0];
+    }
+    log.warn('Select exactly one provider.');
+  }
+}
+
 async function promptProvider(
-  options: InstallOptions,
   /**
-   * Null only when login was skipped, which happens solely for an explicit
-   * `--provider claude`. That path cannot reach the CMEM branch below, which
-   * re-checks rather than assuming.
+   * Already resolved by `promptProviderChoice` — and, for the CMEM branch,
+   * resolved BEFORE `pairing` was obtained. Choosing is what triggers login,
+   * not the other way round.
+   */
+  selectedProvider: ProviderChoice,
+  /**
+   * Null whenever login was skipped, which happens for any resolved choice that
+   * needs no claude-mem account. That path cannot reach the CMEM branch below,
+   * which re-checks rather than assuming.
    */
   pairing: InstallerOAuthPairing | null,
   version: string,
@@ -1058,42 +1105,6 @@ async function promptProvider(
     log.info('Disabled cloud sync and saved local Anthropic Max configuration.');
     log.info('Configured claude-mem to use your logged-in Claude SDK account.');
   };
-
-  let selectedProvider: ProviderChoice;
-  if (options.provider) {
-    selectedProvider = options.provider;
-  } else {
-    if (!isInteractive) {
-      throw new Error('Non-interactive provider validation did not run.');
-    }
-    const labels = buildProviderLabels();
-
-    // Multiselect gives both choices square controls. Exactly one provider is
-    // still required; selecting both re-opens the prompt instead of guessing.
-    while (true) {
-      const providerResult = await p.multiselect<ProviderChoice>({
-        message: PROVIDER_PROMPT_MESSAGE,
-        options: [
-          { value: 'cmem', label: labels.cmem, hint: labels.cmemHint },
-          { value: 'claude', label: labels.claude, hint: labels.claudeHint },
-        ],
-        // CMEM Pro pre-selected: it is the recommended path and the one the
-        // funnel is built around. Selecting it no longer means "pay now" —
-        // it opens the offer page to read first.
-        initialValues: ['cmem'],
-        required: true,
-      });
-      if (p.isCancel(providerResult)) {
-        p.cancel('Installation cancelled.');
-        process.exit(1);
-      }
-      if (providerResult.length === 1) {
-        selectedProvider = providerResult[0];
-        break;
-      }
-      log.warn('Select exactly one provider.');
-    }
-  }
 
   // CMEM Pro: no new provider code. The worker's OpenRouter client is a generic
   // OpenAI-compatible client whose endpoint and model both come from settings,
@@ -1274,7 +1285,23 @@ function nonEmptyTrimmedString(value: unknown): string | null {
 
 const OAUTH_START_TIMEOUT_MS = 10_000;
 const OAUTH_POLL_TIMEOUT_MS = 10_000;
-const OAUTH_POLL_BUDGET_MS = 240_000;
+/**
+ * How long the terminal waits on the browser, per phase.
+ *
+ * The 'login' phase is one hop: sign in, come back. Four minutes is plenty.
+ *
+ * The 'enrollment' phase is the whole funnel in a single browser visit — OAuth,
+ * read the offer, enter a card at Stripe, then fetch the device code and type
+ * it. This used to be two separate 240s budgets (one per browser trip); folding
+ * it into one trip must not also fold it into one 240s window, or a user doing
+ * an unhurried card entry gets the installer exited out from under them.
+ *
+ * Bounded by the server's own pairing TTL (PAIRING_TTL_SECONDS = 30 min in
+ * /api/installer/oauth/start): waiting past that only reports an expiry the
+ * server has already decided, so stop just short of it.
+ */
+const OAUTH_POLL_BUDGET_LOGIN_MS = 240_000;
+const OAUTH_POLL_BUDGET_ENROLLMENT_MS = 25 * 60_000;
 const OAUTH_DEFAULT_POLL_INTERVAL_S = 3;
 
 type InstallerPollStage = 'awaiting_login' | 'awaiting_checkout' | 'awaiting_approval';
@@ -1542,23 +1569,35 @@ function sleepUnlessCancelled(ms: number, isCancelled: () => boolean): Promise<v
 
 async function waitForInstallerPairing(
   pairing: InstallerOAuthPairing,
+  /**
+   * `'login'` stops as soon as the account exists — it is the account-only
+   * flow behind an explicit `--provider openrouter|gemini`, which never
+   * enrolls in CMEM Pro. `'enrollment'` runs the whole CMEM Pro trip through
+   * to delivered credentials.
+   */
   phase: 'login' | 'enrollment',
   version: string,
 ): Promise<InstallerPollOutcome | null> {
   const startedAt = Date.now();
-  // The login phase must never name CMEM Pro. Logging in is required of every
-  // user and happens BEFORE the provider choice, so naming a paid plan here
-  // reads as an upsell attached to a mandatory step and muddies the funnel.
-  // The poll loop prints whatever stage the server reports, so a server-side
-  // 'awaiting_checkout' during login would otherwise leak the Pro wording.
+  // The login phase must never name CMEM Pro: it is reached only by a flag
+  // that already picked a different provider, so a Pro line there is an upsell
+  // bolted onto someone else's install. The poll loop prints whatever stage the
+  // server reports, so a server-side 'awaiting_checkout' during a login-only
+  // wait would otherwise leak the Pro wording.
+  //
+  // Both phases now open on a signed-out browser — the enrollment trip starts
+  // at the claim URL and lets the claim route bounce through login inline — so
+  // both start at 'awaiting_login' and follow the server from there.
   const stageMessages: Record<InstallerPollStage, string> = {
-    awaiting_login: 'Waiting for OAuth login in the browser…',
+    awaiting_login: phase === 'login'
+      ? 'Waiting for OAuth login in the browser…'
+      : 'Waiting for sign-in in the browser…',
     awaiting_checkout: phase === 'login'
       ? 'Waiting for the browser to finish signing you in…'
       : 'Waiting for CMEM Pro setup in the browser…',
     awaiting_approval: `Enter code ${pairing.userCode} in the browser to approve this device…`,
   };
-  let stage: InstallerPollStage = phase === 'login' ? 'awaiting_login' : 'awaiting_checkout';
+  let stage: InstallerPollStage = 'awaiting_login';
   log.info(stageMessages[stage]);
 
   let cancelled = false;
@@ -1583,7 +1622,10 @@ async function waitForInstallerPairing(
 
   try {
     let consecutiveFailures = 0;
-    while (Date.now() - startedAt < OAUTH_POLL_BUDGET_MS) {
+    const budgetMs = phase === 'login'
+      ? OAUTH_POLL_BUDGET_LOGIN_MS
+      : OAUTH_POLL_BUDGET_ENROLLMENT_MS;
+    while (Date.now() - startedAt < budgetMs) {
       if (cancelled) return null;
       const result = await pollInstallerPairingOnce(pairing);
       if (cancelled) return null;
@@ -1628,8 +1670,10 @@ async function waitForInstallerPairing(
 }
 
 /**
- * Required account step. OAuth completes before provider choice and never
- * chooses or enrolls a paid provider on its own.
+ * Account-only login. Reached from `requireInstallerOAuthLogin`, i.e. from an
+ * explicit `--provider openrouter|gemini` that still needs a claude-mem
+ * account. It never chooses or enrolls a paid provider on its own — the CMEM
+ * Pro path does not come through here.
  */
 export async function completeInstallerOAuthLogin(
   pairing: InstallerOAuthPairing,
@@ -1680,20 +1724,52 @@ async function waitForReturnToOpenBrowser(message: string): Promise<void> {
   });
 }
 
-async function requireInstallerOAuthLogin(version: string): Promise<InstallerOAuthPairing | null> {
+/**
+ * Opens a pairing, or explains why it could not. Shared by both browser paths
+ * so the "cmem.ai is unreachable" failure reads the same either way.
+ */
+async function startPairingOrExplain(
+  startMessage: string,
+  readyMessage: string,
+  failMessage: string,
+): Promise<InstallerOAuthPairing | null> {
   const spinner = isInteractive ? p.spinner() : null;
-  spinner?.start('Starting secure OAuth login…');
+  spinner?.start(startMessage);
   const pairing = await startInstallerOAuthPairing();
   if (!pairing) {
-    spinner?.stop(styleText('red', 'Could not start OAuth login.'));
+    spinner?.stop(styleText('red', failMessage));
     log.error('OAuth login is required. Run npx claude-mem install again when cmem.ai is reachable.');
     return null;
   }
-  spinner?.stop('OAuth login ready.');
+  spinner?.stop(readyMessage);
+  return pairing;
+}
 
-  // No provider, plan, or pricing language on this step: logging in is required
-  // of every user and runs BEFORE the provider choice, so anything about a paid
-  // plan here is an upsell bolted onto a mandatory step.
+/**
+ * Account-only login: ONE browser trip that ends the moment the account
+ * exists.
+ *
+ * This is the `login_only=1` claim embedded in `authorizationUrl`, and it is
+ * now reached only from an explicit `--provider openrouter|gemini` — flags that
+ * need a claude-mem account but do NOT enroll in CMEM Pro. The CMEM Pro path
+ * deliberately does not come through here: it opens `checkoutUrl` instead (see
+ * `requireCmemProTrialPairing`) so login, offer, checkout and device approval
+ * happen in a single uninterrupted visit rather than bouncing the user back to
+ * the terminal in between.
+ */
+async function requireInstallerOAuthLogin(version: string): Promise<InstallerOAuthPairing | null> {
+  const pairing = await startPairingOrExplain(
+    'Starting secure OAuth login…',
+    'OAuth login ready.',
+    'Could not start OAuth login.',
+  );
+  if (!pairing) return null;
+
+  // Login is lazy: this only runs once the resolved provider choice actually
+  // needs a claude-mem account, so the user has already opted into it and there
+  // is nothing left to pitch. No provider, plan, or pricing language here — the
+  // offer was made and accepted on the provider screen, and repeating it would
+  // sell the same thing twice.
   log.info(`Open this URL: ${pairing.authorizationUrl}`);
   await waitForReturnToOpenBrowser('Continue setup in browser... (hit return to open automatically)');
   openBrowser(pairing.authorizationUrl);
@@ -1714,8 +1790,73 @@ function noteDeviceCode(pairing: InstallerOAuthPairing): void {
 }
 
 /**
- * Continues the already-authenticated pairing only after the CMEM Pro choice
- * and required trial acknowledgement.
+ * Stages the one-shot credentials a ready poll delivered. Marks the pairing
+ * delivered so nothing can spend the same one-time delivery twice.
+ */
+function persistTrialDelivery(
+  pairing: InstallerOAuthPairing,
+  result: TrialReadyResult,
+): boolean {
+  if (!mergeSettings(buildTrialReadySettings(result))) {
+    log.error('Could not save the one-time CMEM Pro credentials.');
+    return false;
+  }
+  pairing.delivered = result;
+  clearProFallback();
+  log.success('CMEM Pro Free Trial active.');
+  return true;
+}
+
+/**
+ * The CMEM Pro path: ONE browser trip, start to finish.
+ *
+ * Opens `checkoutUrl` (the plain claim URL) rather than `authorizationUrl`
+ * (the `login_only=1` claim). The claim route bounces a sessionless visitor
+ * through `/login?next=<the same claim URL>` and resumes there afterwards, so
+ * sign-in, the offer, Stripe and device approval all happen in one unbroken
+ * visit. The old shape made two trips and parked the user on a "close this
+ * window and go back to your terminal" page in the middle of the funnel.
+ *
+ * The device code is printed BEFORE the browser opens: the approval screen is
+ * inside this same trip now, so the user needs the code in hand before they
+ * leave the terminal, not after they come back.
+ */
+async function requireCmemProTrialPairing(version: string): Promise<InstallerOAuthPairing | null> {
+  const pairing = await startPairingOrExplain(
+    'Starting secure CMEM Pro setup…',
+    'CMEM Pro setup ready.',
+    'Could not start CMEM Pro setup.',
+  );
+  if (!pairing) return null;
+
+  noteDeviceCode(pairing);
+  // The URL is printed before the browser is opened, so a headless or SSH user
+  // who has no opener is never blocked — they can open it by hand and the wait
+  // still clears on Return.
+  log.info(`Open this URL: ${pairing.checkoutUrl}`);
+  await waitForReturnToOpenBrowser('Continue setup in browser... (hit return to open automatically)');
+  openBrowser(pairing.checkoutUrl);
+  await captureCliEvent('installer_oauth_started', { version });
+
+  // Straight through to 'ready': login, checkout and approval are all stages of
+  // this single wait now, so there is no intermediate 'authenticated' stop.
+  const result = await waitForInstallerPairing(pairing, 'enrollment', version);
+  if (!result || result.kind !== 'ready') return null;
+  await captureCliEvent('installer_oauth_completed', { version });
+
+  if (!persistTrialDelivery(pairing, result)) return null;
+  await captureCliEvent('trial_activated', { version });
+  return pairing;
+}
+
+/**
+ * Applies an already-delivered CMEM Pro enrollment.
+ *
+ * On the current flow the pairing always arrives delivered — the single trip in
+ * `requireCmemProTrialPairing` polled it to 'ready' before the provider was
+ * applied — so this short-circuits on `pairing.delivered` and opens no second
+ * browser window. The fallback below is the legacy two-trip continuation, kept
+ * for a caller that hands over a merely-authenticated pairing.
  */
 export async function completeCmemTrialPairing(
   pairing: InstallerOAuthPairing,
@@ -1724,10 +1865,10 @@ export async function completeCmemTrialPairing(
   if (pairing.delivered) return pairing.delivered;
 
   noteDeviceCode(pairing);
-  // Deliberately NO return-wait here, unlike the login hand-off.
+  // Deliberately NO return-wait here, unlike the browser hand-off.
   //
   // A second wait at this point stalled the install: stdin has already been
-  // through the login wait and a clack prompt by now, and the listener did not
+  // through a browser wait and a clack prompt by now, and the listener did not
   // reliably receive the keypress, so the flow stopped before it could even
   // print "Waiting for CMEM Pro setup in the browser…". Opening directly is
   // also the better behaviour here — the user has already chosen CMEM Pro, so
@@ -1738,14 +1879,7 @@ export async function completeCmemTrialPairing(
   const result = await waitForInstallerPairing(pairing, 'enrollment', version);
   if (!result || result.kind !== 'ready') return null;
 
-  const wrote = mergeSettings(buildTrialReadySettings(result));
-  if (!wrote) {
-    log.error('Could not save the one-time CMEM Pro credentials.');
-    return null;
-  }
-  pairing.delivered = result;
-  clearProFallback();
-  log.success('CMEM Pro Free Trial active.');
+  if (!persistTrialDelivery(pairing, result)) return null;
   await captureCliEvent('trial_activated', { version });
   return result;
 }
@@ -1785,14 +1919,21 @@ async function promptTelemetryOptIn(): Promise<void> {
 }
 
 /**
- * Whether an install still has an account question to answer.
+ * Whether an explicit `--provider` flag still leaves a claude-mem account
+ * question open.
+ *
+ * This answers "does this flag need an account?", NOT "must login run first?".
+ * Login is lazy — it runs only after the provider choice is resolved — so this
+ * is consulted on the flag path, where the choice was made before the installer
+ * even started.
  *
  * Only `--provider claude` is exempt: it configures memory against the user's
  * own Anthropic plan and needs no claude-mem credentials. `gemini` and
  * `openrouter` are NOT exempt — openrouter is the transport for the cmem
  * gateway, so an explicit `openrouter` install may still be reaching cmem.ai.
- * With no flag at all the provider screen can still offer CMEM Pro, so login
- * must happen first.
+ * `undefined` (no flag) is likewise not exempt: it means the choice is still
+ * open, and it can still land on CMEM Pro — the interactive path narrows that
+ * to the actual selection before any login happens.
  */
 export function providerNeedsAccount(provider: InstallOptions['provider']): boolean {
   return provider !== 'claude';
@@ -2142,28 +2283,46 @@ async function runInstallCommandInner(options: InstallOptions, summary: InstallS
     log.info('Claude Code: leaving native auto-memory enabled unless you explicitly opt in to disabling it.');
   }
 
-  // Login is account-first for every install EXCEPT one that has already named
-  // a provider needing no claude-mem account. `--provider claude` runs memory
-  // on the user's own Anthropic plan and never touches cmem.ai, so gating it on
-  // browser OAuth made an unrelated cmem.ai outage fail an install that could
-  // have completed offline — and there is no account question left to ask,
-  // because the flag already answered it.
+  // Choice first, login second. The provider screen costs nothing to show — no
+  // network, no account — so the offer is read before anything is spent on it.
+  // Only then, and only for a choice that actually needs a claude-mem account,
+  // do we open a browser. A user who picks their own Anthropic plan (by flag or
+  // at the prompt) runs memory on that plan, never touches cmem.ai, and now
+  // never sees an OAuth screen — so an unrelated cmem.ai outage can no longer
+  // fail an install that could have completed offline.
   //
-  // Deliberately keyed on the explicit flag, not on reachability: a silent
+  // Deliberately keyed on the resolved choice, not on reachability: a silent
   // fallback to a local install whenever cmem.ai is down would quietly change
-  // what the user gets. This only skips a step the user's own flag made moot.
+  // what the user gets. This only skips a step the user's own choice made moot.
+  const providerChoice = await promptProviderChoice(options);
+  const choiceNeedsAccount = options.provider
+    ? providerNeedsAccount(options.provider)
+    : providerChoice === 'cmem';
+  // The two account paths differ in how many browser trips they cost. CMEM Pro
+  // is one trip that carries sign-in, the offer, checkout and device approval
+  // in a single visit. An explicit `--provider openrouter|gemini` needs only an
+  // account — it never enrolls in Pro — so it keeps the login-only trip and
+  // stops as soon as the account exists.
   let oauthPairing: InstallerOAuthPairing | null = null;
-  if (providerNeedsAccount(options.provider)) {
+  if (providerChoice === 'cmem') {
+    oauthPairing = await requireCmemProTrialPairing(version);
+  } else if (choiceNeedsAccount) {
     oauthPairing = await requireInstallerOAuthLogin(version);
-    if (!oauthPairing) {
-      if (isInteractive) p.cancel('OAuth login is required to finish installation.');
-      else console.error('OAuth login is required to finish installation.');
-      process.exit(1);
-    }
   } else {
-    log.info('Skipping claude-mem login: --provider claude runs memory on your own Anthropic plan.');
+    log.info('Skipping claude-mem login: this provider runs memory on your own Anthropic plan.');
   }
-  const selectedProvider = await promptProvider(options, oauthPairing, version);
+  if (choiceNeedsAccount && !oauthPairing) {
+    // Name the step that actually failed. The CMEM Pro path can fail anywhere in
+    // one browser visit — sign-in, checkout, or device approval — so blaming
+    // "OAuth login" there sends the user (and support) after the wrong thing.
+    const failure = providerChoice === 'cmem'
+      ? 'CMEM Pro setup was not completed. Run npx claude-mem install to try again.'
+      : 'OAuth login is required to finish installation.';
+    if (isInteractive) p.cancel(failure);
+    else console.error(failure);
+    process.exit(1);
+  }
+  const selectedProvider = await promptProvider(providerChoice, oauthPairing, version);
   const cloudSyncConfigured = [
     getSetting('CLAUDE_MEM_CLOUD_SYNC_TOKEN'),
     getSetting('CLAUDE_MEM_CLOUD_SYNC_USER_ID'),

--- a/src/npx-cli/commands/install.ts
+++ b/src/npx-cli/commands/install.ts
@@ -2398,7 +2398,16 @@ async function runInstallCommandInner(options: InstallOptions, summary: InstallS
     `Plugin dir:  ${styleText('cyan', marketplaceDir)}`,
     `IDEs:        ${styleText('cyan', selectedIDEs.join(', '))}`,
   ];
-  summaryLines.push(`Account:     ${styleText('cyan', 'OAuth login complete')}`);
+  // Report what actually happened. This line used to be hardcoded, which was
+  // true only while login was mandatory for every install — now that it runs
+  // solely for the paths that need an account, an offline Anthropic Max install
+  // would otherwise be told it completed a login it never performed.
+  const accountStatus = !oauthPairing
+    ? 'local only (no claude-mem account needed)'
+    : cloudSyncConfigured
+      ? 'signed in — CMEM Pro active'
+      : 'signed in';
+  summaryLines.push(`Account:     ${styleText('cyan', accountStatus)}`);
   summaryLines.push(`Cloud sync:  ${styleText('cyan', cloudSyncConfigured ? 'ON (CMEM Pro)' : 'OFF (local)')}`);
   if (autoMemoryStatus === 'disabled') {
     summaryLines.push(`Auto-memory: ${styleText('cyan', 'disabled')} (CLAUDE_CODE_DISABLE_AUTO_MEMORY=1)`);

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -91,7 +91,7 @@ export interface SettingsDefaults {
   CLAUDE_MEM_CLOUD_SYNC_DEVICE_NAME: string;
   CLAUDE_MEM_CLOUD_SYNC_WS: string;    // advisory WebSocket speed layer (Phase 4) — 'false' = HTTP polling only
   // claude-mem sign-in funnel state, written by the installer's browser-login
-  // step (install.ts promptBrowserLogin/completeTrialPairing). Declared here so
+  // step (install.ts requireInstallerOAuthLogin/completeCmemTrialPairing). Declared here so
   // loadFromFile round-trips them instead of dropping unknown keys.
   CLAUDE_MEM_PRO_TRIAL_EMAIL: string;
   CLAUDE_MEM_PRO_TRIAL_AT: string;

--- a/tests/npx-cli/install-trial-contract.test.ts
+++ b/tests/npx-cli/install-trial-contract.test.ts
@@ -129,8 +129,7 @@ describe('installer trial-ready contract', () => {
 
   it('uses the exact two-option provider copy', () => {
     expect(buildProviderLabels()).toEqual({
-      cmem: 'CMEM Pro (30 Day Free Trial: Tokens for Observations + Real-Time Cloud Sync '
-        + 'for Claude.ai, ChatGPT.com, anything that accepts an MCP Connector)',
+      cmem: 'CMEM Pro (30 Day Free Trial: cloud sync, tokens included)',
       cmemHint: '',
       claude: 'Use your Anthropic Max Plan (no cloud sync, uses tokens for observations)',
       claudeHint: '',
@@ -147,6 +146,12 @@ describe('installer trial-ready contract', () => {
     expect(labels.claudeHint).toBe('');
     expect(labels.cmem).toContain('30 Day Free Trial');
     expect(labels.claude).toContain('no cloud sync');
+    // Each row must stay on one line in an 80-column terminal, clack's row
+    // prefix included, so neither description wraps into the other.
+    for (const label of [labels.cmem, labels.claude]) {
+      expect(label).not.toContain('\n');
+      expect(label.length).toBeLessThan(74);
+    }
   });
 
   it('does not ask for the billing acknowledgement in the terminal', () => {
@@ -158,12 +163,25 @@ describe('installer trial-ready contract', () => {
     expect(source).not.toContain('CMEM_TRIAL_ACKNOWLEDGEMENT');
   });
 
-  it('requires OAuth before provider selection and contains no retired email path', () => {
+  it('resolves the provider choice before OAuth and contains no retired email path', () => {
+    // Login is LAZY. The provider screen is free — no network, no account — so
+    // it runs first, and OAuth is reached only once the resolved choice needs a
+    // claude-mem account. Picking the Anthropic Max path opens no browser.
     const source = readFileSync(join(repoRoot, 'src/npx-cli/commands/install.ts'), 'utf-8');
+    const choiceIndex = source.indexOf('await promptProviderChoice(options)');
+    const gateIndex = source.indexOf('if (choiceNeedsAccount) {');
     const oauthIndex = source.indexOf('await requireInstallerOAuthLogin(version)');
-    const providerIndex = source.indexOf('await promptProvider(options, oauthPairing, version)');
-    expect(oauthIndex).toBeGreaterThan(-1);
-    expect(providerIndex).toBeGreaterThan(oauthIndex);
+    const applyIndex = source.indexOf('await promptProvider(providerChoice, oauthPairing, version)');
+    expect(choiceIndex).toBeGreaterThan(-1);
+    expect(gateIndex).toBeGreaterThan(choiceIndex);
+    expect(oauthIndex).toBeGreaterThan(gateIndex);
+    expect(applyIndex).toBeGreaterThan(oauthIndex);
+    // The gate that makes login conditional on the CMEM branch.
+    expect(source).toMatch(
+      /const choiceNeedsAccount = options\.provider\s*\n\s*\? providerNeedsAccount\(options\.provider\)\s*\n\s*: providerChoice === 'cmem';/,
+    );
+    // promptProviderChoice takes no pairing and returns before any login.
+    expect(source).toContain('async function promptProviderChoice(options: InstallOptions): Promise<ProviderChoice>');
     expect(source).toContain('p.multiselect<ProviderChoice>');
     expect(source).not.toContain('promptBrowserLogin');
     expect(source).not.toContain('CMEM_PRO_TRIAL_START_URL');
@@ -173,7 +191,7 @@ describe('installer trial-ready contract', () => {
 
   it('stops any respawned worker after provider settings are persisted', () => {
     const source = readFileSync(join(repoRoot, 'src/npx-cli/commands/install.ts'), 'utf-8');
-    const providerIndex = source.indexOf('await promptProvider(options, oauthPairing, version)');
+    const providerIndex = source.indexOf('await promptProvider(providerChoice, oauthPairing, version)');
     const cutoverIndex = source.indexOf("'provider-cutover'", providerIndex);
     const workerStartIndex = source.indexOf('workerStartResult = await ensureWorkerStarted', cutoverIndex);
     expect(providerIndex).toBeGreaterThan(-1);

--- a/tests/npx-cli/provider-account-gate.test.ts
+++ b/tests/npx-cli/provider-account-gate.test.ts
@@ -11,7 +11,10 @@ describe('provider account gate', () => {
   });
 
   it('still requires an account when no provider was named', () => {
-    // The provider screen can still offer CMEM Pro, so login has to come first.
+    // `undefined` means the choice is still open and can still land on CMEM Pro,
+    // so this flag alone cannot exempt the install. It does NOT mean login runs
+    // first: the interactive path resolves the choice before any login, and only
+    // the CMEM branch reaches OAuth.
     expect(providerNeedsAccount(undefined)).toBe(true);
   });
 
@@ -32,13 +35,22 @@ describe('install flow wiring', () => {
     'utf-8',
   );
 
-  it('gates the OAuth login call behind providerNeedsAccount', () => {
-    // Pins the regression this fixes: the login call was previously
-    // unconditional, so any cmem.ai outage hard-blocked every install.
-    expect(source).toContain('if (providerNeedsAccount(options.provider)) {');
+  it('gates the OAuth login call behind the resolved provider choice', () => {
+    // Pins two regressions. The login call was once unconditional, so any
+    // cmem.ai outage hard-blocked every install. It was then made conditional
+    // but ran BEFORE the provider prompt, so every interactive user paid for a
+    // browser round trip regardless of what they went on to pick. The gate now
+    // reads the already-resolved choice: the flag path still defers to
+    // providerNeedsAccount, and the prompt path narrows to the CMEM branch.
+    expect(source).toContain('const providerChoice = await promptProviderChoice(options);');
     expect(source).toMatch(
-      /if \(providerNeedsAccount\(options\.provider\)\) \{\s*\n\s*oauthPairing = await requireInstallerOAuthLogin\(version\);/,
+      /const choiceNeedsAccount = options\.provider\s*\n\s*\? providerNeedsAccount\(options\.provider\)\s*\n\s*: providerChoice === 'cmem';/,
     );
+    expect(source).toMatch(
+      /if \(choiceNeedsAccount\) \{\s*\n\s*oauthPairing = await requireInstallerOAuthLogin\(version\);/,
+    );
+    // The choice step itself must stay free of the pairing entirely.
+    expect(source).toContain('async function promptProviderChoice(options: InstallOptions): Promise<ProviderChoice>');
   });
 
   it('refuses CMEM Pro enrollment without a pairing', () => {


### PR DESCRIPTION
## The story

The Aug 31 OAuth rewrite inverted the funnel. Mandatory browser login was placed **before** the value proposition, so a free, open-source plugin demanded GitHub/Google OAuth before it would finish installing. Having made login mandatory, the code then correctly noticed it couldn't pitch on a mandatory step — so the pitch moved *after* the wall, splitting one offer across three surfaces.

**The audit that drove that rewrite was misread.** It showed:

| Signal | Number |
|---|---|
| Installers who typed their email | **2,222** |
| Resend delivery acceptance | **96.6%** |
| `auth_callback_failed` pageviews | **2,537** (1,907 distinct) |
| Claimers who reached Stripe | 135, no claim→checkout loss |

The failure was the **browser callback**, not email capture and not price resistance. The rewrite deleted the step with 2,222 conversions and promoted the step with 1,907 failures to mandatory for 100% of installs.

Five consecutive fix commits to that rewrite landed in a single day. That's a design that isn't landing, not polish.

## What this does

Restores the old funnel's shape — **cheap, early, terminal-native commitment** — while keeping every security fix from the rewrite. **Email capture is NOT restored** (the forbid-list test still passes).

- **Provider choice runs first, costs nothing, and is the conversion event.** Picking CMEM Pro is the new "type your email": instant, terminal-native, zero context switch.
- **OAuth is lazy.** Only the CMEM Pro branch opens a browser. Anthropic Max installs fully offline, so a cmem.ai outage can't fail it.
- **One browser trip instead of two.** `claim/route.ts` already bounces a sessionless visitor through `/login` and back, so opening `checkout_url` does login → offer → Stripe in one unbroken visit.
- **Provider label trimmed 143 → 57 chars.** Dead `CMEM_TRIAL_ACKNOWLEDGEMENT` deleted.

### Measured effect

| Path | Browser opens | Switches |
|---|---|---|
| CMEM Pro | 2 → **1** | 5 → **4** |
| Anthropic Max | 1 → **0** | → **0** |
| `--provider claude` | 0 | 0 (works with cmem.ai unreachable) |
| `--provider openrouter` | 1 | unchanged |

**On the switch count:** an earlier draft of the plan claimed 5 → 2. That was wrong and is corrected. The device-approval step still sends the user back to the terminal for the code and returns them to the browser. The **delta is real** (one whole round trip, −2), but the absolute is **4**. Reaching 2 needs the deferred Phase 4 (device-code narrowing), which requires a DB migration and a security review.

## Two defects found while verifying this change

1. **Poll budget collapse.** `OAUTH_POLL_BUDGET_MS` was a single 240s window. It used to be spent *twice* — once per browser trip — so folding the trips together silently folded the budget together, leaving four minutes to cover OAuth + reading the offer + Stripe card entry + device approval, then exiting non-zero. Now phase-aware: 240s for login-only, 25 min for enrollment, bounded by the server's 30-min `PAIRING_TTL_SECONDS`.
2. **Misleading failure.** A CMEM Pro path failing at checkout or approval printed "OAuth login is required to finish installation", sending users and support after the wrong thing.

## Back-compat

`hasPairingAndTrialParams` and `parseInstallerOAuthStartBody` are **byte-identical to HEAD** (verified by diffing extracted function bodies). No URL shape changed. Installers already on npm keep working.

⚠️ Requires [claude-mem-pro#151](https://github.com/thedotmack/claude-mem-pro/pull/151) to deploy **first**.

## Testing

`npm run typecheck` clean

```
bun test tests/npx-cli/ tests/install-non-tty.test.ts
 100 pass / 0 fail / 264 expect()

npm test
 2866 pass / 27 skip / 2 fail
```

The 2 failures are pre-existing `worktree-adoption` tests, identical to baseline before this branch.

Anti-pattern greps all clean: no `promptBrowserLogin`, `CMEM_PRO_TRIAL_START_URL`, `CLAUDE_MEM_ONLINE_OPTIN`, `Your email:`, or `CMEM_TRIAL_ACKNOWLEDGEMENT` anywhere in `src/`.

## Contract flips (deliberate, not incidental)

The test literally named `'requires OAuth before provider selection'` asserted the inversion this PR fixes. It and the `provider-account-gate` adjacency regex were rewritten to pin the new contract. The forbid-list and `p.multiselect<ProviderChoice>` assertions are preserved byte-for-byte.

## Not verified

- **The back-compat gate was not run** — a published 13.21.2 from npm has not been exercised against the updated server. Static evidence is strong (frozen validators byte-identical, clean state-machine walk) but the gate is formally open.
- **stdin sequencing** — `waitForReturnToOpenBrowser` now runs after a clack multiselect. A pty repro passed, but the same harness also passed the ordering a code comment says previously stalled, so it has no demonstrated sensitivity. Structural argument says low risk. Only a live interactive run settles it.
- Manual walkthroughs (switch counts, `/etc/hosts`-blocked offline run).

## Known trade

Lazy login costs `pro_users` its `registered` rows — and more broadly than first stated: that row is inserted only on the `login_only` branch, which new installers never take. A user who signs in and abandons at the offer or at Stripe now leaves no row at all. Top-of-funnel visibility should move to anonymous installer telemetry (`captureCliEvent`, `installId`), which already exists and needs no account. Measurement should ride on telemetry, not on a login wall.

Plan: `plans/2026-08-31-funnel-immediacy-restore.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DD5YMaAiXXeY3zaitbGC6n