### PR TITLE
feat(telemetry): report observed model, source, and billing tier to PostHog

### DIFF
--- a/docs/public/telemetry.mdx
+++ b/docs/public/telemetry.mdx
@@ -32,6 +32,8 @@ When enabled, events are anonymous and identified only by a random install UUID 
 
 Low-volume lifecycle events (`install_*`, `uninstall_completed`, `worker_started`) build an analytics profile keyed to that random UUID so aggregate retention and cohort statistics are computable — the profile contains nothing beyond the whitelisted fields below (platform, version, IDE/provider choice). It is not, and cannot be, connected to you: there is no name, email, IP, hardware ID, or any other identifier. All high-volume activity is sent with `$process_person_profile: false` and builds no profile at all.
 
+About the observed IDE session's identity, claude-mem collects only its model id (`observed_model`) and a billing tier (`observed_billing`) — never account ids, emails, or tokens.
+
 **High-volume events are rolled up, not streamed.** Rather than emit one event per compression or context injection, claude-mem aggregates them locally and sends one summary:
 
 - **`observer_turn_rollup`** — a **per-session** accumulator. Every compression in a session folds into one running rollup that is emitted **once, at session end** (instead of one `session_compressed` event per turn). It carries a `rollup_reason` explaining why it flushed (`session_end` | `worker_shutdown` | `safety_flush`) and a `window_seq` partial-flush counter (`0` for a normal one-shot session; `0,1,2,…` only when a long-lived session trips the periodic safety sweep).
@@ -59,7 +61,7 @@ Every event property passes through a strict whitelist scrubber — any key not 
 | `locale` | `en-US` | Language tag |
 | `is_ci` | `false` | Whether running in CI |
 | `endpoint` | `by-file` | Which claude-mem search route — always one of our route names, never a query |
-| `ide` | `claude-code` | Installer IDE choice (the installer's own id list) |
+| `ide` | `claude-code` | Installer IDE choice (the installer's own id list) or, on `observer_turn_rollup`, the observed session's platform source (`claude` / `codex` / `cursor` / …) |
 | `provider` | `claude` | LLM provider choice: claude / gemini / openrouter |
 | `runtime_mode` | `worker` | worker or server runtime |
 | `trigger` | `heartbeat` | Whether `worker_started` was a real start or the daily heartbeat |
@@ -76,6 +78,8 @@ Every event property passes through a strict whitelist scrubber — any key not 
 | `stage` | `awaiting_checkout` | Installer trial polling stage: awaiting_login / awaiting_checkout / awaiting_approval |
 | `mode` | `code` | Active claude-mem mode id (our mode list) |
 | `model` | `claude-haiku-4-5` | Model id used for compression |
+| `observed_model` | `claude-fable-5-1` | Model id the observed IDE session itself was running (read from its transcript) — distinct from `model`, which is the compression model. `unknown` when not determinable |
+| `observed_billing` | `max` | Billing posture of the observed session — a closed enum: max / pro / team / enterprise / subscription / api_key / bedrock / vertex / foundry / unknown. Never an account id, email, or token |
 | `hook` | `ingest` | What triggered a compression: init / ingest / summarize |
 | `observation_type`, `obs_type_*` | `bugfix`, `3` | Observation type buckets (bugfix / discovery / decision / refactor / other) — counts only |
 | `compression_ms` | `2140` | Latency of the compression model call |
@@ -129,7 +133,7 @@ One value is derived server-side rather than sent by the client: PostHog resolve
 | `trial_poll_timeout` | Browser completion polling is cancelled, expires, times out, or becomes unreachable | `version`, `stage`, `outcome`, `duration_ms` |
 | `uninstall_completed` | `npx claude-mem uninstall` finishes | — |
 | `worker_started` | The background worker starts, plus one heartbeat per 24h of uptime | `trigger` (start / heartbeat), `duration_ms`, `ide`, `provider`, `mode`, `runtime_mode`, process memory (`process_rss_mb`, `heap_used_mb`), the install snapshot: `db_observation_count`, `db_session_count`, `db_summary_count`, `db_project_count`, `db_size_mb`, `install_age_days`, `obs_count_7d`, `obs_count_30d`, `days_since_last_obs`; on a real start also crash detection: `previous_shutdown` (crash / clean / unknown) and, after a clean shutdown, `previous_uptime_seconds` |
-| `observer_turn_rollup` | Emitted **once per session, at session end** — a per-session rollup that aggregates every compression in that session (stored observations, invalid-output drops, failures, aborts) instead of one event per turn | `rollup_reason` (session_end / worker_shutdown / safety_flush), `window_seq`, aggregated `outcomes_*` counts, `total_tokens_input`, `total_tokens_output`, `total_cost_usd`, `avg_duration_ms`, `avg_compression_ms`, `top_model`, `observations_created` (sum of observations generated in the session — pairs with `total_cost_usd` to derive cost per observation), summed `obs_type_*` buckets, `window_start_ts`, plus the per-turn fields it summarizes (`provider`, `ide`, `hook`) |
+| `observer_turn_rollup` | Emitted **once per session, at session end** — a per-session rollup that aggregates every compression in that session (stored observations, invalid-output drops, failures, aborts) instead of one event per turn | `rollup_reason` (session_end / worker_shutdown / safety_flush), `window_seq`, aggregated `outcomes_*` counts, `total_tokens_input`, `total_tokens_output`, `total_cost_usd`, `avg_duration_ms`, `avg_compression_ms`, `top_model`, `observed_model`, `observed_billing`, `observations_created` (sum of observations generated in the session — pairs with `total_cost_usd` to derive cost per observation), summed `obs_type_*` buckets, `window_start_ts`, plus the per-turn fields it summarizes (`provider`, `ide`) |
 | `context_injected_rollup` | A 5-minute time-window rollup of context injections (stored memory injected into new sessions) | aggregated `outcomes_ok` / `outcomes_error` counts, `count`, `total_tokens`, `avg_tokens`, `total_observations_injected` (sum of observations served from cache into prompts), `total_tokens_saved_vs_naive`, `window_start_ts` |
 | `search_performed` | A memory search runs (never the query text) | `endpoint`, `outcome`, `duration_ms`, `result_count`, `search_strategy`, `chroma_available`, `fallback_reason` |
 | `worker_stopped` | The background worker shuts down gracefully | `uptime_seconds`, `shutdown_reason` (stop / restart / signal) |

--- a/plans/2026-09-01-posthog-observed-model.md
+++ b/plans/2026-09-01-posthog-observed-model.md
@@ -1,0 +1,312 @@
+# PostHog: report the observed model, source, and billing type
+
+**Branch:** `posthog-observed-model` (worktree at repo root of this file). **Base:** `main`.
+
+## Goal
+
+PostHog currently reports only the *observer* model (the model claude-mem uses to write
+observations: `model` / `top_model`). We need to also know, per observed session:
+
+1. **`observed_model`** — the model the user is running in their IDE session (e.g. `claude-fable-5-1`).
+2. **`ide`** (already exists per-turn but is dropped from the rollup) — the source platform (`claude`, `codex`, `cursor`, …).
+3. **`observed_billing`** — Max / Pro / Team / API credits / Bedrock / Vertex / Foundry / unknown, when determinable.
+
+These are **new, separate** properties. Do not touch `model` / `top_model` / `provider` semantics — those stay observer-side.
+
+## Phase 0: Documentation Discovery (DONE — consolidated findings)
+
+### 0.1 Where the observed model is available
+
+| Source | Fact | Evidence |
+|---|---|---|
+| Claude Code hook stdin | `model` (canonical id string) is present on **SessionStart only**; absent on UserPromptSubmit / PostToolUse / Stop. | https://code.claude.com/docs/en/hooks.md (SessionStart input table) |
+| Transcript JSONL | Every assistant entry carries `message.model` (verified on a real transcript: `"model":"claude-fable-5-1"`), alongside `message.role`, `message.content`. Line role is `line.type` (Claude Code) or `line.role` (Cursor). | Real transcript under `~/.claude/projects/…/*.jsonl`; `src/shared/transcript-parser.ts:61` |
+| Our hook types | `NormalizedHookInput` already declares `model?`, `permissionMode?`, `sessionSource?` (`src/cli/types.ts:13-15`). Only the codex adapter fills them (`src/cli/adapters/codex.ts:99-101`). The claude-code adapter drops them (`src/cli/adapters/claude-code.ts:15-25`). No downstream consumer reads `input.model` anywhere in `src/`. | grep |
+| Stop hook path | `summarize` handler already reads the transcript: `extractLastMessage(transcriptPath, 'assistant', true)` at `src/cli/handlers/summarize.ts:93`, then POSTs `/api/sessions/summarize` with `{ contentSessionId, last_assistant_message, agentId?, platformSource }` (`summarize.ts:138-147`). | read |
+
+**Decision:** read the observed model from the transcript in the Stop hook (`summarize` handler). It is platform-generic, needs no new hook wiring, and refreshes every turn (covers `/model` switches). The SessionStart `model` field is *not* used (it would need a new transport through the `context` handler, which only GETs `/api/context/inject`).
+
+### 0.2 Where billing / plan is available
+
+| Signal | Location | Evidence |
+|---|---|---|
+| Subscription account | `~/.claude.json` → `oauthAccount.organizationType` (observed: `"claude_max"`), `oauthAccount.billingType` (`"stripe_subscription"`), `oauthAccount.organizationRateLimitTier` (`"default_claude_max_20x"`). Top-level copies of those keys are `null` on this machine — read from `oauthAccount`. | `jq '.oauthAccount' ~/.claude.json` (verified 2026-09-01) |
+| API key billing | `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` in the **hook process env** (hooks inherit Claude Code's environment; the worker daemon does NOT have the user's shell env). When a logged-in user also exports a key, Claude Code asks to approve it and records approvals under `customApiKeyResponses.approved` (last 20 chars of the key) in `~/.claude.json`. | https://code.claude.com/docs/en/hooks.md (hook execution environment); `~/.claude.json` key inventory |
+| Cloud providers | `CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_USE_VERTEX`, `CLAUDE_CODE_USE_FOUNDRY` env vars. | https://code.claude.com/docs/en/settings-reference.md |
+| Long-lived OAuth token | `CLAUDE_CODE_OAUTH_TOKEN` env → subscription of unknown tier. | same |
+| Config dir | `.claude.json` lives at `$CLAUDE_CONFIG_DIR/.claude.json` when `CLAUDE_CONFIG_DIR` is set, else `~/.claude.json`. Existing constant: `CLAUDE_CONFIG_DIR` in `src/shared/paths.ts:43`. | read |
+
+`~/.claude.json` is Claude Code specific → billing detection runs only when `input.platform === 'claude-code'`.
+
+**Decision:** compute billing in the hook process (it has the env), in the same `summarize` handler, and send it alongside the observed model.
+
+Detection order (closed enum, low cardinality):
+
+```
+1. CLAUDE_CODE_USE_BEDROCK set (non-empty, not '0'/'false') → 'bedrock'
+   CLAUDE_CODE_USE_VERTEX  → 'vertex'
+   CLAUDE_CODE_USE_FOUNDRY → 'foundry'
+2. key = ANTHROPIC_API_KEY || ANTHROPIC_AUTH_TOKEN (non-empty)
+   if key && (no oauthAccount || customApiKeyResponses.approved includes key.slice(-20)) → 'api_key'
+3. oauthAccount.organizationType is a string → strip leading 'claude_' → value
+   (e.g. 'max', 'pro', 'team', 'enterprise'); sanitize to /^[a-z0-9_]{1,40}$/ else 'subscription'
+4. oauthAccount present || CLAUDE_CODE_OAUTH_TOKEN set → 'subscription'
+5. else → 'unknown'
+```
+
+### 0.3 How telemetry flows (what must change for a property to reach PostHog)
+
+| Fact | Evidence |
+|---|---|
+| Per-turn `session_compressed` records are **never sent**; they are aggregated into `observer_turn_rollup` by `computeSessionCompressedRollup` (`src/services/telemetry/buffer.ts:124-241`). Only numeric aggregates and `top_model` survive; `ide`, `provider`, `hook` are dropped. The docs (`docs/public/telemetry.mdx:132`) claim `provider`, `ide`, `hook` are carried — currently false. | read |
+| Per-turn records are created at: `src/services/worker/agents/ResponseProcessor.ts:490-511` (`compressionProps`, success), `src/services/worker/http/routes/SessionRoutes.ts:328-336` (error), `SessionRoutes.ts:374-381` (abort). Claude path re-emits `...pending` in `src/services/worker/ClaudeProvider.ts:448-460` and `:469` — spreads the stashed props, so no change needed there. | read |
+| Every property must be in `ALLOWED_PROPERTY_KEYS` (`src/services/telemetry/scrub.ts:8-184`) or the scrubber drops it silently. `ide`, `provider`, `model`, `top_model` are already whitelisted (`scrub.ts:30,73,162`). | read |
+| In-memory session state type: `ActiveSession` in `src/services/worker-types.ts:9-…` (has `platformSource`, `lastModelId?`, `lastGeneratorSource?`). Built in `SessionManager.initializeSession` (`src/services/worker/SessionManager.ts:23-130`) from `dbManager.getSessionById(sessionDbId)` (`src/services/worker/DatabaseManager.ts:97-113` → `SessionStore.getSessionById`, `src/services/sqlite/SessionStore.ts:2321-2332`, row type `SdkSessionDetailRow` `SessionStore.ts:63-72`). | read |
+| Rollup flush points: `SessionManager.ts:260` and `:324` (`flushSession(sessionDbId, 'session_end')`), plus safety sweep and shutdown in `buffer.ts`. | read |
+| Summarize route: `handleSummarizeByClaudeId` `SessionRoutes.ts:504-539`; body schema `summarizeByClaudeIdSchema` `SessionRoutes.ts:456-461` (`.passthrough()`); it upserts the session via `store.createSDKSession(contentSessionId, '', '', undefined, platformSource)` (`:514`) then `queueSummarize` → `ensureGeneratorRunning` (`:532-534`). | read |
+| SQLite migration pattern: idempotent private method on `SessionStore`, `PRAGMA table_info`, `ALTER TABLE … ADD COLUMN`, `INSERT OR IGNORE INTO schema_versions`, appended to the constructor chain `SessionStore.ts:102-122`. Copy-ready template: `addObservationModelColumns` `SessionStore.ts:1688-1704`. Highest existing version stamp: 49 (`normalizeConceptTags`) → use **50** (the constructor chain is not in stamp order; 34 is already `ensureUserPromptsSessionDbId`). | read |
+
+### 0.4 Allowed APIs (only these — do not invent others)
+
+- `readFileSync`, `existsSync` from `fs`; `join` from `path`; `homedir` from `os`.
+- `extractLastMessage` / `extractLastMessageFromJsonl` pattern in `src/shared/transcript-parser.ts` (backward line scan, `JSON.parse` per line in try/catch, `line.type ?? line.role`).
+- `telemetryBuffer.record(event, sessionDbId, props)` (`buffer.ts:309`).
+- `SessionStore` methods use `this.db.prepare(sql).run(...)` / `.get(...)` (bun:sqlite).
+- `sessionManager.getSession(sessionDbId)` (used at `SessionRoutes.ts:621`).
+- Zod `z.string().optional()` inside the existing `.passthrough()` schema.
+- Logger: `logger.debug('HOOK', msg, ctx)` / `logger.warn(...)`.
+
+### 0.5 Anti-patterns to avoid
+
+- Do NOT put anything free-form into telemetry props (no paths, no prompts). `observed_model` is a model id; `observed_billing` is a closed enum.
+- Do NOT send `~/.claude.json` fields other than those named above; never read or log tokens.
+- Do NOT reuse `observations.generated_by_model`, `session.lastModelId`, `model`, or `top_model` — those are observer-side.
+- Do NOT read the transcript in the PostToolUse (`observation`) handler — it fires per tool call; Stop is once per turn.
+- Do NOT add try/catch around new happy-path code except the per-line `JSON.parse` in the transcript scan (existing, documented pattern). Errors must surface.
+- Do NOT touch `plugin/scripts/*.cjs` (build artifacts are rebuilt at version-bump time, not in feature PRs — see `git log -- plugin/scripts/worker-service.cjs`).
+- Tests that `mock.module('../../../src/shared/transcript-parser.js', …)` (e.g. `tests/cli/handlers/summarize-tag-stripping.test.ts:35-40`) must be extended to export the new function, or the handler import becomes `undefined` at call time.
+- Do not add a settings key; telemetry consent is env/`telemetry.json` only (`src/services/telemetry/consent.ts`).
+
+---
+
+## Phase 1: Hook side — extract observed model + billing, send on Stop
+
+### 1.1 `src/shared/transcript-parser.ts` — add `extractLastAssistantModel`
+
+Copy the shape of `extractLastMessage` (`transcript-parser.ts:5-22`) and the backward scan of `extractLastMessageFromJsonl` (`:40-58`):
+
+```ts
+export function extractLastAssistantModel(transcriptPath: string): string | undefined {
+  if (!transcriptPath || !existsSync(transcriptPath)) return undefined;
+  const content = readFileSync(transcriptPath, 'utf-8').trim();
+  if (!content) return undefined;
+  return extractLastAssistantModelFromJsonl(content);
+}
+
+export function extractLastAssistantModelFromJsonl(content: string): string | undefined {
+  const lines = content.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const rawLine = lines[i];
+    if (!rawLine) continue;
+    let line: any;
+    try { line = JSON.parse(rawLine); } catch { continue; } // same tolerated condition as extractLastMessageFromJsonl
+    if ((line.type ?? line.role) !== 'assistant') continue;
+    const model = line.message?.model;
+    if (typeof model === 'string' && model) return model;
+  }
+  return undefined;
+}
+```
+
+### 1.2 New `src/shared/observed-billing.ts`
+
+```ts
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+export type ObservedBilling = string; // closed set documented in docs/public/telemetry.mdx
+
+export function claudeJsonPath(env: NodeJS.ProcessEnv = process.env): string {
+  return env.CLAUDE_CONFIG_DIR ? join(env.CLAUDE_CONFIG_DIR, '.claude.json') : join(homedir(), '.claude.json');
+}
+
+export function detectObservedBilling(
+  env: NodeJS.ProcessEnv = process.env,
+  claudeJsonFile: string = claudeJsonPath(env),
+): ObservedBilling { … order from §0.2 … }
+```
+
+- `isTruthyEnv(v)`: non-empty and not `'0'`/`'false'` (case-insensitive).
+- Read `.claude.json` with `existsSync` + `readFileSync` + `JSON.parse`. A missing file → treat as no account. (Malformed JSON: let `JSON.parse` throw — fail fast; the Stop handler's existing outer behavior is acceptable. NOTE: `summarize.ts` has no try/catch around this section; if a throw here would abort summarization for users with a corrupt `.claude.json`, wrap ONLY the file read in a guard that returns `null` account and add a `logger.debug` — decide during implementation and document in the code comment.)
+- Only inspect: `oauthAccount.organizationType`, `oauthAccount` presence, `customApiKeyResponses.approved` (array of strings). Never read token-like fields.
+
+### 1.3 `src/cli/handlers/summarize.ts` — send the two new fields
+
+After `lastAssistantMessage` is resolved (post `:104`) and before the worker POST (`:138-147`):
+
+```ts
+const observedModel = transcriptPath ? extractLastAssistantModel(transcriptPath) : undefined;
+const observedBilling = input.platform === 'claude-code' ? detectObservedBilling() : undefined;
+```
+
+Add `observedModel`, `observedBilling` to the `/api/sessions/summarize` body (`:141-146`). Leave the server-runtime path (`summarizeViaServer`) untouched.
+
+### 1.4 Tests (Phase 1)
+
+- `tests/transcripts/observed-model-extraction.test.ts` — `extractLastAssistantModelFromJsonl`: returns model of last assistant line (Claude Code `type` form), returns model when a Cursor `role` form carries `message.model`, skips user lines and malformed lines, returns `undefined` when no assistant line has a model.
+- `tests/shared/observed-billing.test.ts` — full matrix from §0.2 using an injected `env` object and a temp `.claude.json` written to the scratchpad/tmp dir (`mkdtempSync`): bedrock/vertex/foundry; api key with no account; api key with account but unapproved → account tier; api key approved (last 20 chars) → `api_key`; `organizationType: 'claude_max'` → `max`; account without organizationType → `subscription`; `CLAUDE_CODE_OAUTH_TOKEN` only → `subscription`; nothing → `unknown`; missing file → `unknown`.
+- Update `tests/cli/handlers/summarize-tag-stripping.test.ts:35-40` mock to also export `extractLastAssistantModel: () => 'claude-test-model'`, and grep other tests mocking `transcript-parser.js` (`grep -rl "transcript-parser.js" tests`) — extend each.
+- New assertion in `tests/cli/handlers/` (add to `summarize-tag-stripping.test.ts` or a new `summarize-observed-fields.test.ts`): the POST body to `/api/sessions/summarize` includes `observedModel` and, for platform `claude-code`, `observedBilling` as a string.
+
+### 1.5 Verification checklist (Phase 1)
+
+```
+npm run typecheck
+bun test tests/transcripts tests/shared tests/cli
+npm run lint:hook-io
+grep -n "observedModel\|observedBilling" src/cli/handlers/summarize.ts   # both present in the body
+grep -rn "accessToken\|refreshToken" src/shared/observed-billing.ts       # must be EMPTY
+```
+
+---
+
+## Phase 2: Worker persistence — store on the session, load into `ActiveSession`
+
+### 2.1 `src/services/sqlite/SessionStore.ts`
+
+- Add `ensureSDKSessionsObservedColumns()` — copy `addObservationModelColumns` (`:1688-1704`), table `sdk_sessions`, columns `observed_model TEXT`, `observed_billing TEXT`, version stamp **50**. Append the call at the end of the constructor chain (`:102-122`, after `normalizeConceptTags()`).
+- Extend `SdkSessionDetailRow` (`:63-72`) with `observed_model: string | null; observed_billing: string | null;` and add both columns to the `SELECT` in `getSessionById` (`:2321-2332`).
+- Add:
+
+```ts
+setSessionObservedMetadata(sessionDbId: number, observedModel?: string, observedBilling?: string): void {
+  this.db.prepare(`
+    UPDATE sdk_sessions
+    SET observed_model = COALESCE(?, observed_model),
+        observed_billing = COALESCE(?, observed_billing)
+    WHERE id = ?
+  `).run(observedModel ?? null, observedBilling ?? null, sessionDbId);
+}
+```
+
+### 2.2 `src/services/worker/DatabaseManager.ts:97-106`
+
+Extend the inline return type of `getSessionById` with `observed_model: string | null; observed_billing: string | null;`.
+
+### 2.3 `src/services/worker-types.ts` (`ActiveSession`)
+
+Add, next to `lastModelId?` (`:69`), with the same doc-comment style:
+
+```ts
+/** Model the OBSERVED IDE session is running (from its transcript) — telemetry observed_model. Not the observer model. */
+observedModel?: string;
+/** Billing posture of the observed Claude Code session (closed enum, see observed-billing.ts) — telemetry observed_billing. */
+observedBilling?: string;
+```
+
+### 2.4 `src/services/worker/SessionManager.ts:23-130`
+
+- New-session object (`:103-…`): `observedModel: dbSession.observed_model ?? undefined, observedBilling: dbSession.observed_billing ?? undefined`.
+- Cached-session branch (`:57-59` pattern): if `dbSession.observed_model` and it differs, update `session.observedModel`; same for billing.
+
+### 2.5 `src/services/worker/http/routes/SessionRoutes.ts`
+
+- `summarizeByClaudeIdSchema` (`:456-461`): add `observedModel: z.string().max(200).optional(), observedBilling: z.string().max(40).optional()`.
+- `handleSummarizeByClaudeId` (`:504-539`): destructure the two fields; after `createSDKSession` (`:514`) and **before** `queueSummarize` (`:532`):
+
+```ts
+if (observedModel || observedBilling) {
+  store.setSessionObservedMetadata(sessionDbId, observedModel, observedBilling);
+  const active = this.sessionManager.getSession(sessionDbId);
+  if (active) {
+    if (observedModel) active.observedModel = observedModel;
+    if (observedBilling) active.observedBilling = observedBilling;
+  }
+}
+```
+
+Note the subagent early-return at `:507-510` stays above this (subagent Stop hooks are skipped).
+
+### 2.6 Tests (Phase 2)
+
+- `tests/sqlite/session-store-sessions.test.ts` (or new `session-store-observed-metadata.test.ts`): fresh `SessionStore(new Database(':memory:'))` → `PRAGMA table_info(sdk_sessions)` has both columns; `createSDKSession` then `setSessionObservedMetadata(id, 'claude-x', 'max')` → `getSessionById(id)` returns them; a second call with `undefined` model keeps the previous model (COALESCE).
+- Migration test: seed a legacy `sdk_sessions` table without the columns (pattern in `tests/sqlite/session-store-migrations.test.ts:9-33`), construct `SessionStore`, assert columns exist and `schema_versions` contains 50.
+
+### 2.7 Verification checklist (Phase 2)
+
+```
+npm run typecheck
+bun test tests/sqlite tests/worker
+grep -n "observed_model" src/services/sqlite/SessionStore.ts | wc -l   # ≥ 4 (migration, row type, select, update)
+```
+
+---
+
+## Phase 3: Telemetry emission — records, rollup, whitelist, docs
+
+### 3.1 Per-turn records
+
+Add to each record (omit when unknown — the scrubber drops `undefined`; the rollup fills `'unknown'`):
+
+- `src/services/worker/agents/ResponseProcessor.ts:490-511` `compressionProps`: `observed_model: session.observedModel, observed_billing: session.observedBilling`.
+- `SessionRoutes.ts:328-336` (error) and `:374-381` (abort): same two fields.
+
+### 3.2 Rollup carries source + observed fields — `src/services/telemetry/buffer.ts:124-241`
+
+Inside the record loop, track last-seen non-empty strings for `ide`, `provider`, `observed_model`, `observed_billing`. After the `rollup` object is built (`:199-226`):
+
+```ts
+if (lastIde) rollup.ide = lastIde;
+if (lastProvider) rollup.provider = lastProvider;
+rollup.observed_model = lastObservedModel ?? 'unknown';
+rollup.observed_billing = lastObservedBilling ?? 'unknown';
+```
+
+`ide`/`provider` fix the documented-but-missing behavior (`docs/public/telemetry.mdx:132`). `hook` varies per turn and is intentionally not carried.
+
+### 3.3 Whitelist — `src/services/telemetry/scrub.ts`
+
+Add after `'top_model'` (`:162`), with the house comment style:
+
+```ts
+// Observed-session identity (NOT the observer): the model id the user's IDE
+// session ran (from its transcript) and a closed-enum billing posture
+// (max | pro | team | enterprise | subscription | api_key | bedrock | vertex | foundry | unknown).
+'observed_model',
+'observed_billing',
+```
+
+### 3.4 Docs — `docs/public/telemetry.mdx`
+
+- `observer_turn_rollup` row (`:132`): add `observed_model`, `observed_billing`, and change "plus the per-turn fields it summarizes (`provider`, `ide`, `hook`)" to "(`provider`, `ide`)".
+- If a "what we collect / never collect" list exists above the events table (grep `top_model` and `never` in the file), add one sentence: the observed session's model id and a closed-set billing tier are collected; never account ids, emails, or tokens.
+
+### 3.5 Tests (Phase 3)
+
+- `tests/telemetry/buffer.test.ts`: rollup carries last-seen `ide`, `provider`, `observed_model`, `observed_billing`; `observed_*` default to `'unknown'` when no record had them; a later record overrides an earlier one (last-seen semantics). Follow the existing `top_model` test at `:116`/`:175-181`.
+- `tests/telemetry/scrub.test.ts`: `observed_model` and `observed_billing` survive `scrubProperties`.
+
+### 3.6 Verification checklist (Phase 3)
+
+```
+npm run typecheck
+bun test tests/telemetry
+grep -n "observed_model" src/services/telemetry/scrub.ts src/services/telemetry/buffer.ts src/services/worker/agents/ResponseProcessor.ts src/services/worker/http/routes/SessionRoutes.ts
+grep -n "observed_model\|observed_billing" docs/public/telemetry.mdx
+```
+
+---
+
+## Phase 4: Verification (final)
+
+1. `npm run typecheck && npm run build && bun test tests` (mirrors `.github/workflows/ci.yml`).
+2. `npm run lint:hook-io && npm run lint:spawn-env`.
+3. Anti-pattern greps:
+   - `grep -rn "accessToken\|refreshToken\|emailAddress\|accountUuid" src/shared/observed-billing.ts` → empty.
+   - `grep -rn "extractLastAssistantModel" src/cli/handlers/observation.ts` → empty (not in the per-tool path).
+   - `git status --porcelain plugin/scripts` → empty (no build artifacts in the feature PR).
+   - `grep -rln "transcript-parser.js" tests | xargs grep -L extractLastAssistantModel` → only files that don't mock the module.
+4. Live smoke (this machine): `npm run build-and-sync`, then after the next Stop hook fires in any Claude Code session:
+   `sqlite3 ~/.claude-mem/claude-mem.db "select id, platform_source, observed_model, observed_billing from sdk_sessions order by id desc limit 3"` → expect a real model id and `max`.
+5. Open PR against `main`, babysit (CI + review bots), merge, then version-bump **MINOR** (13.21.2 → 13.22.0) per the version-bump skill.

--- a/src/cli/handlers/summarize.ts
+++ b/src/cli/handlers/summarize.ts
@@ -5,7 +5,8 @@
 import type { EventHandler, NormalizedHookInput, HookResult } from '../types.js';
 import { executeWithWorkerFallback, isWorkerFallback } from '../../shared/worker-utils.js';
 import { logger } from '../../utils/logger.js';
-import { extractLastMessage } from '../../shared/transcript-parser.js';
+import { extractLastAssistantTurn, extractLastAssistantModel } from '../../shared/transcript-parser.js';
+import { detectObservedBilling } from '../../shared/observed-billing.js';
 import { stripMemoryTags } from '../../utils/tag-stripping.js';
 import { HOOK_EXIT_CODES } from '../../shared/hook-constants.js';
 import { normalizePlatformSource } from '../../shared/platform-source.js';
@@ -80,9 +81,13 @@ export const summarizeHandler: EventHandler = {
     }
 
     let lastAssistantMessage = '';
+    // Observed-session model for telemetry (NOT the observer model): the model
+    // the user's IDE session is running, read from its transcript.
+    let observedModel: string | undefined;
 
     if (input.lastAssistantMessage !== undefined) {
       lastAssistantMessage = stripMemoryTags(input.lastAssistantMessage);
+      observedModel = transcriptPath ? extractLastAssistantModel(transcriptPath) : undefined;
     } else {
       if (!transcriptPath) {
         logger.debug('HOOK', `No transcriptPath in Stop hook input for session ${sessionId} - skipping summary`);
@@ -90,8 +95,10 @@ export const summarizeHandler: EventHandler = {
       }
 
       try {
-        lastAssistantMessage = extractLastMessage(transcriptPath, 'assistant', true);
-        lastAssistantMessage = stripMemoryTags(lastAssistantMessage);
+        // One read of the transcript yields both the text and the model.
+        const turn = extractLastAssistantTurn(transcriptPath, true);
+        lastAssistantMessage = stripMemoryTags(turn.text);
+        observedModel = turn.model;
       } catch (err) {
         logger.warn('HOOK', `Stop hook: failed to extract last assistant message for session ${sessionId}: ${err instanceof Error ? err.message : err}`);
         return { continue: true, suppressOutput: true, exitCode: HOOK_EXIT_CODES.SUCCESS };
@@ -111,6 +118,11 @@ export const summarizeHandler: EventHandler = {
     });
 
     const platformSource = normalizePlatformSource(input.platform);
+
+    // Observed-session billing posture for telemetry (NOT the observer
+    // provider). `.claude.json` is Claude Code specific, so billing detection
+    // is skipped on other platforms.
+    const observedBilling = input.platform === 'claude-code' ? detectObservedBilling() : undefined;
 
     const runtime = resolveRuntimeContext();
     // Phase 1a (cmem-sdk rename): `runtime.runtime` is the canonical `'server'`
@@ -142,6 +154,8 @@ export const summarizeHandler: EventHandler = {
         contentSessionId: sessionId,
         last_assistant_message: lastAssistantMessage,
         platformSource,
+        observedModel,
+        observedBilling,
       },
     );
     if (isWorkerFallback(queueResult)) {

--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -69,6 +69,8 @@ interface SdkSessionDetailRow {
   user_prompt: string;
   custom_title: string | null;
   status: string;
+  observed_model: string | null;
+  observed_billing: string | null;
 }
 
 export class SessionStore {
@@ -120,6 +122,7 @@ export class SessionStore {
     this.ensureSyncRevisionTextAffinity();
     this.initializeSyncHubLaunchBaseline();
     this.normalizeConceptTags();
+    this.ensureSDKSessionsObservedColumns();
   }
 
   private getIndexColumns(indexName: string): string[] {
@@ -1702,6 +1705,26 @@ export class SessionStore {
     this.db.prepare('INSERT OR IGNORE INTO schema_versions (version, applied_at) VALUES (?, ?)').run(26, new Date().toISOString());
   }
 
+  // Identity of the OBSERVED IDE session (the model the user ran and its
+  // billing posture), reported by the Stop hook. Distinct from
+  // observations.generated_by_model, which is the observer model.
+  private ensureSDKSessionsObservedColumns(): void {
+    const columns = this.db.query('PRAGMA table_info(sdk_sessions)').all() as TableColumnInfo[];
+    const hasObservedModel = columns.some(col => col.name === 'observed_model');
+    const hasObservedBilling = columns.some(col => col.name === 'observed_billing');
+
+    if (hasObservedModel && hasObservedBilling) return;
+
+    if (!hasObservedModel) {
+      this.db.run('ALTER TABLE sdk_sessions ADD COLUMN observed_model TEXT');
+    }
+    if (!hasObservedBilling) {
+      this.db.run('ALTER TABLE sdk_sessions ADD COLUMN observed_billing TEXT');
+    }
+
+    this.db.prepare('INSERT OR IGNORE INTO schema_versions (version, applied_at) VALUES (?, ?)').run(50, new Date().toISOString());
+  }
+
   private ensureMergedIntoProjectColumns(): void {
     const obsCols = this.db
       .query('PRAGMA table_info(observations)')
@@ -2322,13 +2345,28 @@ export class SessionStore {
     const stmt = this.db.prepare(`
       SELECT id, content_session_id, memory_session_id, project,
              COALESCE(platform_source, '${DEFAULT_PLATFORM_SOURCE}') as platform_source,
-             user_prompt, custom_title, status
+             user_prompt, custom_title, status,
+             observed_model, observed_billing
       FROM sdk_sessions
       WHERE id = ?
       LIMIT 1
     `);
 
     return (stmt.get(id) as SdkSessionDetailRow | null) || null;
+  }
+
+  /**
+   * Record the observed IDE session's model id and billing posture (from the
+   * Stop hook). Each field only overwrites when supplied, so a turn that could
+   * not determine one of them keeps the previously stored value.
+   */
+  setSessionObservedMetadata(sessionDbId: number, observedModel?: string, observedBilling?: string): void {
+    this.db.prepare(`
+      UPDATE sdk_sessions
+      SET observed_model = COALESCE(?, observed_model),
+          observed_billing = COALESCE(?, observed_billing)
+      WHERE id = ?
+    `).run(observedModel || null, observedBilling || null, sessionDbId);
   }
 
   getSdkSessionsBySessionIds(memorySessionIds: string[]): {

--- a/src/services/telemetry/buffer.ts
+++ b/src/services/telemetry/buffer.ts
@@ -41,6 +41,12 @@ interface SessionCompressedRecord {
   compression_ms?: number;
   outcome?: string;
   model?: string;
+  // Source + observed-session identity, carried per turn and surfaced on the
+  // rollup with last-seen semantics (see computeSessionCompressedRollup).
+  ide?: string;
+  provider?: string;
+  observed_model?: string;
+  observed_billing?: string;
   // Per-turn observation accounting (ResponseProcessor compressionProps):
   // `count` is the number of observations created in this compression turn,
   // and obs_type_* is that turn's type breakdown. Summing these across the
@@ -146,6 +152,18 @@ function computeSessionCompressedRollup(
   let obsTypeRefactor = 0;
   let obsTypeOther = 0;
   const modelFrequency: Map<string, number> = new Map();
+  // Last-seen non-empty string per session for the source/observed fields.
+  // `ide` is constant within a session. `provider` is NOT: it can change
+  // mid-session on provider fallback or a quota cooldown, so last-seen reports
+  // the provider that finished the session. The observed model/billing only
+  // change on a /model switch, in which case the latest value is the one we
+  // want. `hook` is deliberately NOT carried: it varies per turn
+  // (init / ingest / summarize) so a single value would misrepresent the
+  // session. Records omit observed_* when unknown; the rollup fills 'unknown'.
+  let lastIde: string | undefined;
+  let lastProvider: string | undefined;
+  let lastObservedModel: string | undefined;
+  let lastObservedBilling: string | undefined;
 
   for (const r of records) {
     if (typeof r.tokens_input === 'number' && Number.isFinite(r.tokens_input)) {
@@ -173,6 +191,10 @@ function computeSessionCompressedRollup(
     if (typeof r.model === 'string' && r.model) {
       modelFrequency.set(r.model, (modelFrequency.get(r.model) ?? 0) + 1);
     }
+    if (typeof r.ide === 'string' && r.ide) lastIde = r.ide;
+    if (typeof r.provider === 'string' && r.provider) lastProvider = r.provider;
+    if (typeof r.observed_model === 'string' && r.observed_model) lastObservedModel = r.observed_model;
+    if (typeof r.observed_billing === 'string' && r.observed_billing) lastObservedBilling = r.observed_billing;
     // Generation-side observation volume. r.count is observations created in
     // this turn (NOT the rollup's turn count); sum it so the rollup carries
     // observations_created alongside total_cost_usd.
@@ -237,6 +259,14 @@ function computeSessionCompressedRollup(
     }
     rollup.top_model = topModel;
   }
+
+  // Source fields: only present if at least one record carried them (matches
+  // top_model). Observed-session fields: always present so PostHog can filter
+  // on 'unknown' explicitly rather than on a missing property.
+  if (lastIde) rollup.ide = lastIde;
+  if (lastProvider) rollup.provider = lastProvider;
+  rollup.observed_model = lastObservedModel ?? 'unknown';
+  rollup.observed_billing = lastObservedBilling ?? 'unknown';
 
   return rollup;
 }

--- a/src/services/telemetry/scrub.ts
+++ b/src/services/telemetry/scrub.ts
@@ -160,6 +160,11 @@ export const ALLOWED_PROPERTY_KEYS: Set<string> = new Set([
   'outcomes_aborted',
   'outcomes_invalid_output',
   'top_model',
+  // Observed-session identity (NOT the observer): the model id the user's IDE
+  // session ran (from its transcript) and a closed-enum billing posture
+  // (max | pro | team | enterprise | subscription | api_key | bedrock | vertex | foundry | unknown).
+  'observed_model',
+  'observed_billing',
   'window_start_ts',
   // Phase 2 per-session rollup: rollup_reason is a closed enum
   // (session_end | worker_shutdown | safety_flush) explaining why the session's

--- a/src/services/worker-types.ts
+++ b/src/services/worker-types.ts
@@ -67,6 +67,10 @@ export interface ActiveSession {
   lastGeneratorSource?: string;
   /** Model id resolved when the generator started — error-path telemetry, where no response model exists. */
   lastModelId?: string;
+  /** Model the OBSERVED IDE session is running (from its transcript) — telemetry observed_model. Not the observer model. */
+  observedModel?: string;
+  /** Billing posture of the observed Claude Code session (closed enum, see observed-billing.ts) — telemetry observed_billing. */
+  observedBilling?: string;
   /** Whether the OpenRouter provider targets openrouter.ai or a custom OpenAI-compatible gateway — telemetry endpoint_class. */
   endpointClass?: 'openrouter' | 'custom';
   /**

--- a/src/services/worker/DatabaseManager.ts
+++ b/src/services/worker/DatabaseManager.ts
@@ -103,6 +103,8 @@ export class DatabaseManager {
     user_prompt: string;
     custom_title: string | null;
     status: string;
+    observed_model: string | null;
+    observed_billing: string | null;
   } {
     const session = this.getSessionStore().getSessionById(sessionDbId);
     if (!session) {

--- a/src/services/worker/SessionManager.ts
+++ b/src/services/worker/SessionManager.ts
@@ -57,6 +57,12 @@ export class SessionManager {
       if (dbSession.platform_source && dbSession.platform_source !== session.platformSource) {
         session.platformSource = dbSession.platform_source;
       }
+      if (dbSession.observed_model && dbSession.observed_model !== session.observedModel) {
+        session.observedModel = dbSession.observed_model;
+      }
+      if (dbSession.observed_billing && dbSession.observed_billing !== session.observedBilling) {
+        session.observedBilling = dbSession.observed_billing;
+      }
 
       if (currentUserPrompt) {
         logger.debug('SESSION', 'Updating userPrompt for continuation', {
@@ -115,6 +121,8 @@ export class SessionManager {
       memorySessionId: null,  // Always start fresh - SDK will capture new ID
       project: suppliedProject || dbSession.project,
       platformSource: dbSession.platform_source,
+      observedModel: dbSession.observed_model ?? undefined,
+      observedBilling: dbSession.observed_billing ?? undefined,
       userPrompt,
       abortController: new AbortController(),
       generatorPromise: null,

--- a/src/services/worker/agents/ResponseProcessor.ts
+++ b/src/services/worker/agents/ResponseProcessor.ts
@@ -498,6 +498,11 @@ export async function processAgentResponse(
     // as "no model" in PostHog — stamp 'unknown' instead.
     model: typeof modelId === 'string' && modelId ? modelId : 'unknown',
     ide: session.platformSource,
+    // Observed-session identity (NOT the observer): the model the user's IDE
+    // session ran and its billing posture, stamped by the Stop hook. Omitted
+    // when unknown — the rollup fills 'unknown' at flush time.
+    observed_model: session.observedModel,
+    observed_billing: session.observedBilling,
     hook: session.lastGeneratorSource,
     endpoint_class: session.endpointClass,
     compression_ms: compressionMs,

--- a/src/services/worker/http/routes/SessionRoutes.ts
+++ b/src/services/worker/http/routes/SessionRoutes.ts
@@ -334,6 +334,8 @@ export class SessionRoutes extends BaseRouteHandler {
           error_category: 'provider_error',
           hook: session.lastGeneratorSource,
           ide: session.platformSource,
+          observed_model: session.observedModel,
+          observed_billing: session.observedBilling,
         });
       })
       .finally(async () => {
@@ -378,6 +380,8 @@ export class SessionRoutes extends BaseRouteHandler {
             abort_reason: normalizeAbortReason(reason),
             hook: session.lastGeneratorSource,
             ide: session.platformSource,
+            observed_model: session.observedModel,
+            observed_billing: session.observedBilling,
           });
         }
         // Every generator exit releases any probe this run claimed. Success
@@ -459,6 +463,8 @@ export class SessionRoutes extends BaseRouteHandler {
     last_assistant_message: z.string().optional(),
     agentId: z.string().optional(),
     platformSource: z.string().optional(),
+    observedModel: z.string().min(1).max(200).optional(),
+    observedBilling: z.string().min(1).max(40).optional(),
   }).passthrough();
 
   private handleObservationsByClaudeId = this.wrapHandler(async (req: Request, res: Response): Promise<void> => {
@@ -501,7 +507,7 @@ export class SessionRoutes extends BaseRouteHandler {
   });
 
   private handleSummarizeByClaudeId = this.wrapHandler(async (req: Request, res: Response): Promise<void> => {
-    const { contentSessionId, last_assistant_message, agentId } = req.body;
+    const { contentSessionId, last_assistant_message, agentId, observedModel, observedBilling } = req.body;
     const platformSource = this.getPlatformSourceFromRequest(req);
 
     if (agentId) {
@@ -512,6 +518,16 @@ export class SessionRoutes extends BaseRouteHandler {
     const store = this.dbManager.getSessionStore();
 
     const sessionDbId = store.createSDKSession(contentSessionId, '', '', undefined, platformSource);
+
+    if (observedModel || observedBilling) {
+      store.setSessionObservedMetadata(sessionDbId, observedModel, observedBilling);
+      const active = this.sessionManager.getSession(sessionDbId);
+      if (active) {
+        if (observedModel) active.observedModel = observedModel;
+        if (observedBilling) active.observedBilling = observedBilling;
+      }
+    }
+
     const promptNumber = store.getPromptNumberFromUserPrompts(contentSessionId, sessionDbId);
 
     const privacy = PrivacyCheckValidator.checkUserPromptPrivacy(

--- a/src/shared/observed-billing.ts
+++ b/src/shared/observed-billing.ts
@@ -1,0 +1,139 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Billing posture of the OBSERVED Claude Code session (the user's IDE session,
+ * not the observer claude-mem uses to write observations).
+ *
+ * Closed set, kept low-cardinality for telemetry. `max`/`pro`/`team`/`enterprise`
+ * come from `oauthAccount.organizationType` with the `claude_` prefix stripped;
+ * any other organizationType collapses to `subscription` so an unexpected value
+ * can never widen the set (documented in docs/public/telemetry.mdx).
+ */
+export type ObservedBilling =
+  | 'max'
+  | 'pro'
+  | 'team'
+  | 'enterprise'
+  | 'subscription'
+  | 'api_key'
+  | 'bedrock'
+  | 'vertex'
+  | 'foundry'
+  | 'unknown';
+
+type SubscriptionTier = 'max' | 'pro' | 'team' | 'enterprise';
+
+const KNOWN_SUBSCRIPTION_TIERS = new Set<string>(['max', 'pro', 'team', 'enterprise']);
+
+function isKnownSubscriptionTier(tier: string): tier is SubscriptionTier {
+  return KNOWN_SUBSCRIPTION_TIERS.has(tier);
+}
+
+/**
+ * The only `.claude.json` fields we keep. The parsed file is projected onto this
+ * shape immediately after JSON.parse, so token, email, and account-id fields on
+ * `oauthAccount` never exist past that line — nothing downstream can read or log them.
+ */
+interface ClaudeJsonBillingFields {
+  oauthAccount?: { organizationType?: unknown };
+  customApiKeyResponses?: { approved?: unknown };
+}
+
+export function claudeJsonPath(env: NodeJS.ProcessEnv = process.env): string {
+  return env.CLAUDE_CONFIG_DIR
+    ? join(env.CLAUDE_CONFIG_DIR, '.claude.json')
+    : join(homedir(), '.claude.json');
+}
+
+function isTruthyEnv(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized !== '' && normalized !== '0' && normalized !== 'false';
+}
+
+/** Keep only the billing fields; drop everything else from the parsed file. */
+function projectBillingFields(parsed: unknown): ClaudeJsonBillingFields {
+  if (!parsed || typeof parsed !== 'object') return {};
+  const { oauthAccount, customApiKeyResponses } = parsed as {
+    oauthAccount?: { organizationType?: unknown } | null;
+    customApiKeyResponses?: { approved?: unknown } | null;
+  };
+  return {
+    oauthAccount: oauthAccount ? { organizationType: oauthAccount.organizationType } : undefined,
+    customApiKeyResponses: customApiKeyResponses
+      ? { approved: customApiKeyResponses.approved }
+      : undefined,
+  };
+}
+
+function readClaudeJsonBillingFields(claudeJsonFile: string): ClaudeJsonBillingFields {
+  if (!existsSync(claudeJsonFile)) return {};
+  // The Stop hook has no guard around billing detection, so a corrupt
+  // `.claude.json` would otherwise abort summarization for that user. We wrap
+  // ONLY the read+parse: a corrupt file degrades to "no account" (the same
+  // result as a missing file) and the rest of detection proceeds.
+  //
+  // The error text is deliberately NOT logged: a JSON.parse SyntaxError quotes
+  // the offending input, and this file holds OAuth tokens. Only the error class
+  // name is recorded.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(claudeJsonFile, 'utf-8'));
+  } catch (error) {
+    logger.debug('HOOK', 'observed-billing: could not read or parse .claude.json, treating as no account', {
+      errorName: error instanceof Error ? error.name : 'unknown',
+    });
+    return {};
+  }
+  return projectBillingFields(parsed);
+}
+
+function isApiKeyApproved(fields: ClaudeJsonBillingFields, apiKey: string): boolean {
+  const approved = fields.customApiKeyResponses?.approved;
+  return Array.isArray(approved) && approved.includes(apiKey.slice(-20));
+}
+
+function organizationTier(fields: ClaudeJsonBillingFields): ObservedBilling | undefined {
+  const organizationType = fields.oauthAccount?.organizationType;
+  if (typeof organizationType !== 'string') return undefined;
+  const tier = organizationType.replace(/^claude_/, '');
+  return isKnownSubscriptionTier(tier) ? tier : 'subscription';
+}
+
+/**
+ * Detection order (first match wins):
+ *   1. CLAUDE_CODE_USE_BEDROCK / _VERTEX / _FOUNDRY  → bedrock | vertex | foundry
+ *   2. ANTHROPIC_API_KEY || ANTHROPIC_AUTH_TOKEN, and either no oauthAccount or
+ *      the key is in customApiKeyResponses.approved       → api_key
+ *   3. oauthAccount.organizationType                        → max | pro | team | enterprise,
+ *      or subscription for any other value
+ *   4. oauthAccount present || CLAUDE_CODE_OAUTH_TOKEN      → subscription
+ *   5. otherwise                                            → unknown
+ *
+ * Runs in the hook process because it needs Claude Code's environment; the
+ * worker daemon does not inherit the user's shell env.
+ */
+export function detectObservedBilling(
+  env: NodeJS.ProcessEnv = process.env,
+  claudeJsonFile: string = claudeJsonPath(env),
+): ObservedBilling {
+  if (isTruthyEnv(env.CLAUDE_CODE_USE_BEDROCK)) return 'bedrock';
+  if (isTruthyEnv(env.CLAUDE_CODE_USE_VERTEX)) return 'vertex';
+  if (isTruthyEnv(env.CLAUDE_CODE_USE_FOUNDRY)) return 'foundry';
+
+  const fields = readClaudeJsonBillingFields(claudeJsonFile);
+  const hasAccount = !!fields.oauthAccount;
+
+  const apiKey = env.ANTHROPIC_API_KEY || env.ANTHROPIC_AUTH_TOKEN;
+  if (apiKey && (!hasAccount || isApiKeyApproved(fields, apiKey))) return 'api_key';
+
+  const tier = organizationTier(fields);
+  if (tier) return tier;
+
+  if (hasAccount || isTruthyEnv(env.CLAUDE_CODE_OAUTH_TOKEN)) return 'subscription';
+
+  return 'unknown';
+}

--- a/src/shared/transcript-parser.ts
+++ b/src/shared/transcript-parser.ts
@@ -2,11 +2,11 @@ import { readFileSync, existsSync } from 'fs';
 import { logger } from '../utils/logger.js';
 import { SYSTEM_REMINDER_REGEX } from '../utils/tag-stripping.js';
 
-export function extractLastMessage(
-  transcriptPath: string,
-  role: 'user' | 'assistant',
-  stripSystemReminders: boolean = false
-): string {
+/**
+ * Read a transcript file once, trimmed. Returns '' (after a warn) when the
+ * path is missing, the file does not exist, or the file is empty.
+ */
+function readTranscriptOrWarn(transcriptPath: string): string {
   if (!transcriptPath || !existsSync(transcriptPath)) {
     logger.warn('PARSER', `Transcript path missing or file does not exist: ${transcriptPath}`);
     return '';
@@ -18,7 +18,59 @@ export function extractLastMessage(
     return '';
   }
 
+  return content;
+}
+
+/**
+ * Yield parsed JSONL entries from the last line to the first. Blank lines and
+ * lines that fail to parse are skipped so callers only ever see objects.
+ */
+function* parseJsonlLinesBackward(content: string): Generator<any> {
+  const lines = content.split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const rawLine = lines[i];
+    if (!rawLine) continue;
+    // Tolerate truncated/malformed JSONL lines (crash mid-write, partial flush).
+    // A bad line shouldn't crash the summarization pipeline — skip and move on.
+    let line: any;
+    try {
+      line = JSON.parse(rawLine);
+    } catch {
+      // [ANTI-PATTERN IGNORED]: malformed/truncated JSONL lines are expected (crash mid-write,
+      // partial flush) and this fires per bad line while scanning backwards over the whole
+      // transcript; recovery is to skip the line and keep scanning, so logging each one would
+      // flood the log with noise for a documented, tolerated condition.
+      continue;
+    }
+    yield line;
+  }
+}
+
+export function extractLastMessage(
+  transcriptPath: string,
+  role: 'user' | 'assistant',
+  stripSystemReminders: boolean = false
+): string {
+  const content = readTranscriptOrWarn(transcriptPath);
+  if (!content) return '';
   return extractLastMessageFromJsonl(content, role, stripSystemReminders);
+}
+
+/**
+ * Read the transcript ONCE and extract both the last assistant text and the
+ * model that assistant turn was running. The Stop hook needs both, and a
+ * long transcript should not be read from disk twice for it.
+ */
+export function extractLastAssistantTurn(
+  transcriptPath: string,
+  stripSystemReminders: boolean = false
+): { text: string; model?: string } {
+  const content = readTranscriptOrWarn(transcriptPath);
+  if (!content) return { text: '' };
+  return {
+    text: extractLastMessageFromJsonl(content, 'assistant', stripSystemReminders),
+    model: extractLastAssistantModelFromJsonl(content),
+  };
 }
 
 /**
@@ -39,25 +91,10 @@ export function extractLastMessageFromJsonl(
   role: 'user' | 'assistant',
   stripSystemReminders: boolean
 ): string {
-  const lines = content.split('\n');
   let foundMatchingRole = false;
   let lastEmptyText: string | null = null;
 
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const rawLine = lines[i];
-    if (!rawLine) continue;
-    // Tolerate truncated/malformed JSONL lines (crash mid-write, partial flush).
-    // A bad line shouldn't crash the summarization pipeline — skip and move on.
-    let line: any;
-    try {
-      line = JSON.parse(rawLine);
-    } catch {
-      // [ANTI-PATTERN IGNORED]: malformed/truncated JSONL lines are expected (crash mid-write,
-      // partial flush) and this fires per bad line while scanning backwards over the whole
-      // transcript; recovery is to skip the line and keep scanning, so logging each one would
-      // flood the log with noise for a documented, tolerated condition.
-      continue;
-    }
+  for (const line of parseJsonlLinesBackward(content)) {
     const lineRole = line.type ?? line.role;
     if (lineRole !== role) continue;
     foundMatchingRole = true;
@@ -79,8 +116,8 @@ export function extractLastMessageFromJsonl(
     } else {
       // Unknown content shape (null, number, plain object, etc.) — skip rather
       // than throw. A single weird line should not crash the entire summary
-      // pipeline; we already tolerate malformed JSONL via the parse-catch
-      // above, and this is the same class of defensive forward compat
+      // pipeline; we already tolerate malformed JSONL in parseJsonlLinesBackward,
+      // and this is the same class of defensive forward compat
       // (CodeRabbit / Greptile review on PR #2282).
       continue;
     }
@@ -105,4 +142,30 @@ export function extractLastMessageFromJsonl(
     return '';
   }
   return lastEmptyText ?? '';
+}
+
+/**
+ * Extract the model id the OBSERVED session is running from its transcript.
+ *
+ * Every assistant entry in a Claude Code / Cursor transcript carries
+ * `message.model` (e.g. `"claude-fable-5-1"`). We scan backwards so the value
+ * reflects the most recent turn — this covers mid-session `/model` switches.
+ *
+ * This is the observed-session model (what the user's IDE is running), NOT the
+ * observer model claude-mem uses to write observations.
+ */
+export function extractLastAssistantModel(transcriptPath: string): string | undefined {
+  if (!transcriptPath || !existsSync(transcriptPath)) return undefined;
+  const content = readFileSync(transcriptPath, 'utf-8').trim();
+  if (!content) return undefined;
+  return extractLastAssistantModelFromJsonl(content);
+}
+
+export function extractLastAssistantModelFromJsonl(content: string): string | undefined {
+  for (const line of parseJsonlLinesBackward(content)) {
+    if ((line.type ?? line.role) !== 'assistant') continue;
+    const model = line.message?.model;
+    if (typeof model === 'string' && model) return model;
+  }
+  return undefined;
 }

--- a/tests/cli/handlers/summarize-observed-fields.test.ts
+++ b/tests/cli/handlers/summarize-observed-fields.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, spyOn, mock } from 'bun:test';
+import { homedir } from 'os';
+import { join } from 'path';
+
+// Capture real exports before mock.module mutates the live namespace, then
+// re-register the snapshots in afterAll so these mocks do not leak into later
+// test files (bun's mock.module is process-global; mock.restore() does NOT undo it).
+import * as realSettingsDefaultsManager from '../../../src/shared/SettingsDefaultsManager.js';
+import * as realHookSettings from '../../../src/shared/hook-settings.js';
+import * as realTranscriptParser from '../../../src/shared/transcript-parser.js';
+import * as realObservedBilling from '../../../src/shared/observed-billing.js';
+import * as realWorkerUtils from '../../../src/shared/worker-utils.js';
+const realSettingsSnapshot = { ...realSettingsDefaultsManager };
+const realHookSettingsSnapshot = { ...realHookSettings };
+const realTranscriptParserSnapshot = { ...realTranscriptParser };
+const realObservedBillingSnapshot = { ...realObservedBilling };
+const realWorkerUtilsSnapshot = { ...realWorkerUtils };
+
+mock.module('../../../src/shared/SettingsDefaultsManager.js', () => ({
+  SettingsDefaultsManager: {
+    get: (key: string) => {
+      if (key === 'CLAUDE_MEM_DATA_DIR') return join(homedir(), '.claude-mem');
+      return '';
+    },
+    getInt: () => 0,
+    loadFromFile: () => ({ CLAUDE_MEM_EXCLUDED_PROJECTS: '' }),
+  },
+}));
+
+mock.module('../../../src/shared/hook-settings.js', () => ({
+  loadFromFileOnce: () => ({ CLAUDE_MEM_EXCLUDED_PROJECTS: '' }),
+}));
+
+// Counts every transcript read that can yield an observed model: the combined
+// extractLastAssistantTurn (transcript branch) and the model-only
+// extractLastAssistantModel (inline lastAssistantMessage branch). The Stop
+// hook must read the transcript exactly once per invocation.
+let modelExtractCallCount = 0;
+mock.module('../../../src/shared/transcript-parser.js', () => ({
+  extractLastMessage: () => 'A normal assistant turn.',
+  extractLastAssistantTurn: () => {
+    modelExtractCallCount += 1;
+    return { text: 'A normal assistant turn.', model: 'claude-test-model' };
+  },
+  extractLastAssistantModel: () => {
+    modelExtractCallCount += 1;
+    return 'claude-test-model';
+  },
+}));
+
+let billingDetectCallCount = 0;
+mock.module('../../../src/shared/observed-billing.js', () => ({
+  claudeJsonPath: () => '/tmp/fake/.claude.json',
+  detectObservedBilling: () => {
+    billingDetectCallCount += 1;
+    return 'max';
+  },
+}));
+
+const workerCallLog: Array<{ path: string; method: string; body: any }> = [];
+mock.module('../../../src/shared/worker-utils.js', () => ({
+  ensureWorkerRunning: () => Promise.resolve(true),
+  getWorkerPort: () => 37777,
+  workerHttpRequest: (apiPath: string, options?: any) => {
+    workerCallLog.push({ path: apiPath, method: options?.method ?? 'GET', body: options?.body });
+    return Promise.resolve(new Response('{"status":"queued"}', { status: 200 }));
+  },
+  executeWithWorkerFallback: async (apiPath: string, method: string, body: unknown) => {
+    workerCallLog.push({ path: apiPath, method, body });
+    return { status: 'queued' };
+  },
+  isWorkerFallback: (_result: unknown) => false,
+}));
+
+import { logger } from '../../../src/utils/logger.js';
+
+let loggerSpies: ReturnType<typeof spyOn>[] = [];
+
+beforeEach(() => {
+  workerCallLog.length = 0;
+  modelExtractCallCount = 0;
+  billingDetectCallCount = 0;
+  loggerSpies = [
+    spyOn(logger, 'info').mockImplementation(() => {}),
+    spyOn(logger, 'debug').mockImplementation(() => {}),
+    spyOn(logger, 'warn').mockImplementation(() => {}),
+    spyOn(logger, 'error').mockImplementation(() => {}),
+    spyOn(logger, 'failure').mockImplementation(() => {}),
+    spyOn(logger, 'dataIn').mockImplementation(() => {}),
+  ];
+});
+
+afterEach(() => {
+  loggerSpies.forEach(spy => spy.mockRestore());
+});
+
+afterAll(() => {
+  mock.module('../../../src/shared/SettingsDefaultsManager.js', () => realSettingsSnapshot);
+  mock.module('../../../src/shared/hook-settings.js', () => realHookSettingsSnapshot);
+  mock.module('../../../src/shared/transcript-parser.js', () => realTranscriptParserSnapshot);
+  mock.module('../../../src/shared/observed-billing.js', () => realObservedBillingSnapshot);
+  mock.module('../../../src/shared/worker-utils.js', () => realWorkerUtilsSnapshot);
+});
+
+function postedBody(): any {
+  expect(workerCallLog).toHaveLength(1);
+  expect(workerCallLog[0].path).toBe('/api/sessions/summarize');
+  const { body } = workerCallLog[0];
+  return typeof body === 'string' ? JSON.parse(body) : body;
+}
+
+describe('summarizeHandler — observed model + billing in the summarize body', () => {
+  it('sends observedModel and observedBilling for a claude-code Stop hook', async () => {
+    const { summarizeHandler } = await import('../../../src/cli/handlers/summarize.js');
+    const result = await summarizeHandler.execute({
+      sessionId: 'sess-observed',
+      cwd: '/tmp',
+      platform: 'claude-code',
+      transcriptPath: '/tmp/fake.jsonl',
+    });
+
+    expect(result.continue).toBe(true);
+    const body = postedBody();
+    expect(body.observedModel).toBe('claude-test-model');
+    expect(typeof body.observedBilling).toBe('string');
+    expect(body.observedBilling).toBe('max');
+    expect(modelExtractCallCount).toBe(1);
+    expect(billingDetectCallCount).toBe(1);
+  });
+
+  it('skips billing detection on non-claude-code platforms but still sends observedModel', async () => {
+    const { summarizeHandler } = await import('../../../src/cli/handlers/summarize.js');
+    await summarizeHandler.execute({
+      sessionId: 'sess-cursor',
+      cwd: '/tmp',
+      platform: 'cursor',
+      transcriptPath: '/tmp/cursor.jsonl',
+    });
+
+    const body = postedBody();
+    expect(body.observedModel).toBe('claude-test-model');
+    expect(body.observedBilling).toBeUndefined();
+    expect(billingDetectCallCount).toBe(0);
+    expect(modelExtractCallCount).toBe(1);
+  });
+
+  it('reads only the model (one transcript read) when an inline lastAssistantMessage comes with a transcriptPath', async () => {
+    const { summarizeHandler } = await import('../../../src/cli/handlers/summarize.js');
+    await summarizeHandler.execute({
+      sessionId: 'sess-inline-with-transcript',
+      cwd: '/tmp',
+      platform: 'codex',
+      transcriptPath: '/tmp/codex.jsonl',
+      lastAssistantMessage: 'Codex answer',
+    });
+
+    const body = postedBody();
+    expect(body.last_assistant_message).toBe('Codex answer');
+    expect(body.observedModel).toBe('claude-test-model');
+    expect(modelExtractCallCount).toBe(1);
+  });
+
+  it('omits observedModel when there is no transcript (Codex inline message path)', async () => {
+    const { summarizeHandler } = await import('../../../src/cli/handlers/summarize.js');
+    await summarizeHandler.execute({
+      sessionId: 'sess-codex',
+      cwd: '/tmp',
+      platform: 'codex',
+      lastAssistantMessage: 'Codex answer',
+    });
+
+    const body = postedBody();
+    expect(body.observedModel).toBeUndefined();
+    expect(body.observedBilling).toBeUndefined();
+    expect(modelExtractCallCount).toBe(0);
+    expect(billingDetectCallCount).toBe(0);
+  });
+});

--- a/tests/cli/handlers/summarize-tag-stripping.test.ts
+++ b/tests/cli/handlers/summarize-tag-stripping.test.ts
@@ -30,12 +30,16 @@ mock.module('../../../src/shared/hook-settings.js', () => ({
 }));
 
 let mockExtractedMessage: string = '';
+// Counts transcript reads: the Stop hook reads the transcript exactly once via
+// extractLastAssistantTurn (text + model together), never via extractLastMessage.
 let extractCallCount = 0;
 mock.module('../../../src/shared/transcript-parser.js', () => ({
-  extractLastMessage: () => {
+  extractLastMessage: () => mockExtractedMessage,
+  extractLastAssistantTurn: () => {
     extractCallCount += 1;
-    return mockExtractedMessage;
+    return { text: mockExtractedMessage, model: 'claude-test-model' };
   },
+  extractLastAssistantModel: () => 'claude-test-model',
 }));
 
 const workerCallLog: Array<{ path: string; method: string; body: any }> = [];
@@ -136,6 +140,7 @@ describe('summarizeHandler — privacy tag stripping', () => {
     const result = await summarizeHandler.execute(baseInput as any);
 
     expect(result.continue).toBe(true);
+    expect(extractCallCount).toBe(1);
     const body = postedBody();
     expect(body.last_assistant_message).not.toContain('SECRET-VALUE-42');
     expect(body.last_assistant_message).not.toContain('<private>');

--- a/tests/shared/observed-billing.test.ts
+++ b/tests/shared/observed-billing.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { claudeJsonPath, detectObservedBilling } from '../../src/shared/observed-billing.js';
+
+// A realistic key shape; only its last 20 chars are ever compared.
+const API_KEY = 'sk-ant-api03-AAAAAAAAAAAAAAAAAAAA-BBBBBBBBBBBBBBBBBBBB';
+const API_KEY_SUFFIX = API_KEY.slice(-20);
+
+let tempDir: string;
+let claudeJsonFile: string;
+
+function writeClaudeJson(contents: unknown): void {
+  writeFileSync(claudeJsonFile, typeof contents === 'string' ? contents : JSON.stringify(contents));
+}
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'observed-billing-'));
+  claudeJsonFile = join(tempDir, '.claude.json');
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('claudeJsonPath', () => {
+  it('honors CLAUDE_CONFIG_DIR', () => {
+    expect(claudeJsonPath({ CLAUDE_CONFIG_DIR: '/custom/cfg' })).toBe(join('/custom/cfg', '.claude.json'));
+  });
+
+  it('falls back to the home directory', () => {
+    expect(claudeJsonPath({})).toMatch(/\.claude\.json$/);
+    expect(claudeJsonPath({})).not.toContain('/custom/cfg');
+  });
+});
+
+describe('detectObservedBilling — cloud providers', () => {
+  it('reports bedrock / vertex / foundry from their env flags', () => {
+    writeClaudeJson({ oauthAccount: { organizationType: 'claude_max' } });
+    expect(detectObservedBilling({ CLAUDE_CODE_USE_BEDROCK: '1' }, claudeJsonFile)).toBe('bedrock');
+    expect(detectObservedBilling({ CLAUDE_CODE_USE_VERTEX: 'true' }, claudeJsonFile)).toBe('vertex');
+    expect(detectObservedBilling({ CLAUDE_CODE_USE_FOUNDRY: 'yes' }, claudeJsonFile)).toBe('foundry');
+  });
+
+  it('ignores "0" / "false" / empty provider flags', () => {
+    writeClaudeJson({ oauthAccount: { organizationType: 'claude_max' } });
+    expect(
+      detectObservedBilling(
+        { CLAUDE_CODE_USE_BEDROCK: '0', CLAUDE_CODE_USE_VERTEX: 'FALSE', CLAUDE_CODE_USE_FOUNDRY: '' },
+        claudeJsonFile,
+      ),
+    ).toBe('max');
+  });
+});
+
+describe('detectObservedBilling — API key', () => {
+  it('reports api_key when a key is set and there is no account', () => {
+    expect(detectObservedBilling({ ANTHROPIC_API_KEY: API_KEY }, claudeJsonFile)).toBe('api_key');
+  });
+
+  it('accepts ANTHROPIC_AUTH_TOKEN as the key source', () => {
+    expect(detectObservedBilling({ ANTHROPIC_AUTH_TOKEN: API_KEY }, claudeJsonFile)).toBe('api_key');
+  });
+
+  it('falls back to the account tier when the key is set but not approved', () => {
+    writeClaudeJson({
+      oauthAccount: { organizationType: 'claude_max' },
+      customApiKeyResponses: { approved: ['00000000000000000000'] },
+    });
+    expect(detectObservedBilling({ ANTHROPIC_API_KEY: API_KEY }, claudeJsonFile)).toBe('max');
+  });
+
+  it('reports api_key when the key suffix is in customApiKeyResponses.approved', () => {
+    writeClaudeJson({
+      oauthAccount: { organizationType: 'claude_max' },
+      customApiKeyResponses: { approved: [API_KEY_SUFFIX] },
+    });
+    expect(detectObservedBilling({ ANTHROPIC_API_KEY: API_KEY }, claudeJsonFile)).toBe('api_key');
+  });
+});
+
+describe('detectObservedBilling — subscription account', () => {
+  it('strips the claude_ prefix from organizationType', () => {
+    writeClaudeJson({ oauthAccount: { organizationType: 'claude_max' } });
+    expect(detectObservedBilling({}, claudeJsonFile)).toBe('max');
+
+    writeClaudeJson({ oauthAccount: { organizationType: 'claude_pro' } });
+    expect(detectObservedBilling({}, claudeJsonFile)).toBe('pro');
+  });
+
+  it('recognizes every known tier: max / pro / team / enterprise', () => {
+    for (const tier of ['max', 'pro', 'team', 'enterprise']) {
+      writeClaudeJson({ oauthAccount: { organizationType: `claude_${tier}` } });
+      expect(detectObservedBilling({}, claudeJsonFile)).toBe(tier);
+    }
+  });
+
+  it('collapses an unknown organizationType to "subscription" (closed set)', () => {
+    writeClaudeJson({ oauthAccount: { organizationType: 'Weird Tier/With Spaces' } });
+    expect(detectObservedBilling({}, claudeJsonFile)).toBe('subscription');
+
+    // Well-formed but not in the closed set — must not widen the enum.
+    writeClaudeJson({ oauthAccount: { organizationType: 'claude_startup' } });
+    expect(detectObservedBilling({}, claudeJsonFile)).toBe('subscription');
+  });
+
+  it('ignores token-shaped fields on oauthAccount and still reports the tier', () => {
+    writeClaudeJson({
+      oauthAccount: {
+        organizationType: 'claude_team',
+        accountUuid: 'acct-uuid',
+        emailAddress: 'someone@example.com',
+        accessToken: 'sk-ant-oat01-secret',
+      },
+    });
+    expect(detectObservedBilling({}, claudeJsonFile)).toBe('team');
+  });
+
+  it('reports subscription for an account without organizationType', () => {
+    writeClaudeJson({ oauthAccount: {} });
+    expect(detectObservedBilling({}, claudeJsonFile)).toBe('subscription');
+  });
+
+  it('reports subscription when only CLAUDE_CODE_OAUTH_TOKEN is set', () => {
+    expect(detectObservedBilling({ CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-xyz' }, claudeJsonFile)).toBe('subscription');
+  });
+});
+
+describe('detectObservedBilling — unknown', () => {
+  it('reports unknown when nothing is set and the file is missing', () => {
+    expect(detectObservedBilling({}, claudeJsonFile)).toBe('unknown');
+  });
+
+  it('reports unknown when the file exists but has no account', () => {
+    writeClaudeJson({ oauthAccount: null, customApiKeyResponses: { approved: [] } });
+    expect(detectObservedBilling({}, claudeJsonFile)).toBe('unknown');
+  });
+
+  it('treats a corrupt .claude.json as no account instead of throwing', () => {
+    writeClaudeJson('{ not json');
+    expect(() => detectObservedBilling({}, claudeJsonFile)).not.toThrow();
+    expect(detectObservedBilling({}, claudeJsonFile)).toBe('unknown');
+    expect(detectObservedBilling({ ANTHROPIC_API_KEY: API_KEY }, claudeJsonFile)).toBe('api_key');
+  });
+});

--- a/tests/sqlite/session-store-observed-metadata.test.ts
+++ b/tests/sqlite/session-store-observed-metadata.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SessionStore } from '../../src/services/sqlite/SessionStore.js';
+
+interface TableColumnInfo {
+  name: string;
+}
+
+function sdkSessionColumns(db: Database): string[] {
+  return (db.query('PRAGMA table_info(sdk_sessions)').all() as TableColumnInfo[]).map(col => col.name);
+}
+
+/**
+ * Seed a pre-v50 database: sdk_sessions without the observed_* columns and a
+ * schema_versions table without the v50 stamp. The rest of the constructor
+ * chain fills in what it needs.
+ */
+function seedLegacySdkSessions(db: Database): void {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS schema_versions (
+      id INTEGER PRIMARY KEY,
+      version INTEGER UNIQUE NOT NULL,
+      applied_at TEXT NOT NULL
+    )
+  `);
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS sdk_sessions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      content_session_id TEXT NOT NULL,
+      memory_session_id TEXT UNIQUE,
+      project TEXT NOT NULL,
+      platform_source TEXT NOT NULL DEFAULT 'claude',
+      user_prompt TEXT,
+      started_at TEXT NOT NULL,
+      started_at_epoch INTEGER NOT NULL,
+      completed_at TEXT,
+      completed_at_epoch INTEGER,
+      status TEXT CHECK(status IN ('active', 'completed', 'failed')) NOT NULL DEFAULT 'active'
+    )
+  `);
+
+  const now = new Date().toISOString();
+  db.prepare(`
+    INSERT INTO sdk_sessions (content_session_id, memory_session_id, project, started_at, started_at_epoch, status)
+    VALUES (?, ?, ?, ?, ?, 'completed')
+  `).run('legacy-content', 'legacy-memory', 'legacy-project', now, Date.now());
+}
+
+describe('SessionStore observed session metadata', () => {
+  let store: SessionStore | undefined;
+
+  afterEach(() => {
+    store?.close();
+    store = undefined;
+  });
+
+  describe('fresh database', () => {
+    it('creates sdk_sessions with observed_model and observed_billing columns', () => {
+      store = new SessionStore(new Database(':memory:'));
+
+      const columns = sdkSessionColumns(store.db);
+      expect(columns).toContain('observed_model');
+      expect(columns).toContain('observed_billing');
+    });
+
+    it('returns null observed fields for a session that never reported them', () => {
+      store = new SessionStore(new Database(':memory:'));
+      const id = store.createSDKSession('content-unreported', 'project', 'prompt');
+
+      const session = store.getSessionById(id);
+      expect(session?.observed_model).toBeNull();
+      expect(session?.observed_billing).toBeNull();
+    });
+  });
+
+  describe('setSessionObservedMetadata', () => {
+    it('stores both fields and getSessionById returns them', () => {
+      store = new SessionStore(new Database(':memory:'));
+      const id = store.createSDKSession('content-observed', 'project', 'prompt');
+
+      store.setSessionObservedMetadata(id, 'claude-x', 'max');
+
+      const session = store.getSessionById(id);
+      expect(session?.observed_model).toBe('claude-x');
+      expect(session?.observed_billing).toBe('max');
+    });
+
+    it('keeps the previous model when a later call omits it (COALESCE)', () => {
+      store = new SessionStore(new Database(':memory:'));
+      const id = store.createSDKSession('content-coalesce-model', 'project', 'prompt');
+
+      store.setSessionObservedMetadata(id, 'claude-x', 'max');
+      store.setSessionObservedMetadata(id, undefined, 'pro');
+
+      const session = store.getSessionById(id);
+      expect(session?.observed_model).toBe('claude-x');
+      expect(session?.observed_billing).toBe('pro');
+    });
+
+    it('keeps the previous billing when a later call omits it (COALESCE)', () => {
+      store = new SessionStore(new Database(':memory:'));
+      const id = store.createSDKSession('content-coalesce-billing', 'project', 'prompt');
+
+      store.setSessionObservedMetadata(id, 'claude-x', 'max');
+      store.setSessionObservedMetadata(id, 'claude-y', undefined);
+
+      const session = store.getSessionById(id);
+      expect(session?.observed_model).toBe('claude-y');
+      expect(session?.observed_billing).toBe('max');
+    });
+
+    it('keeps the previous model when a later call passes an empty string', () => {
+      store = new SessionStore(new Database(':memory:'));
+      const id = store.createSDKSession('content-empty-model', 'project', 'prompt');
+
+      store.setSessionObservedMetadata(id, 'claude-x', 'max');
+      store.setSessionObservedMetadata(id, '', 'pro');
+
+      const session = store.getSessionById(id);
+      expect(session?.observed_model).toBe('claude-x');
+      expect(session?.observed_billing).toBe('pro');
+    });
+
+    it('overwrites the model when a later turn reports a different one', () => {
+      store = new SessionStore(new Database(':memory:'));
+      const id = store.createSDKSession('content-switch', 'project', 'prompt');
+
+      store.setSessionObservedMetadata(id, 'claude-x', 'max');
+      store.setSessionObservedMetadata(id, 'claude-y', 'max');
+
+      expect(store.getSessionById(id)?.observed_model).toBe('claude-y');
+    });
+
+    it('does not touch other sessions', () => {
+      store = new SessionStore(new Database(':memory:'));
+      const a = store.createSDKSession('content-a', 'project', 'prompt');
+      const b = store.createSDKSession('content-b', 'project', 'prompt');
+
+      store.setSessionObservedMetadata(a, 'claude-x', 'max');
+
+      expect(store.getSessionById(b)?.observed_model).toBeNull();
+      expect(store.getSessionById(b)?.observed_billing).toBeNull();
+    });
+  });
+
+  describe('migration v50 (legacy sdk_sessions without observed columns)', () => {
+    it('adds both columns and stamps schema version 50', () => {
+      const db = new Database(':memory:');
+      seedLegacySdkSessions(db);
+      expect(sdkSessionColumns(db)).not.toContain('observed_model');
+      expect(sdkSessionColumns(db)).not.toContain('observed_billing');
+
+      store = new SessionStore(db);
+
+      const columns = sdkSessionColumns(db);
+      expect(columns).toContain('observed_model');
+      expect(columns).toContain('observed_billing');
+
+      const stamp = db.prepare('SELECT version FROM schema_versions WHERE version = 50').get() as { version: number } | null;
+      expect(stamp?.version).toBe(50);
+    });
+
+    it('preserves the legacy row and reads it back with null observed fields', () => {
+      const db = new Database(':memory:');
+      seedLegacySdkSessions(db);
+
+      store = new SessionStore(db);
+
+      const legacy = db.prepare("SELECT id FROM sdk_sessions WHERE content_session_id = 'legacy-content'").get() as { id: number };
+      const session = store.getSessionById(legacy.id);
+      expect(session?.project).toBe('legacy-project');
+      expect(session?.observed_model).toBeNull();
+      expect(session?.observed_billing).toBeNull();
+    });
+
+    it('is idempotent when re-run against an already-migrated database', () => {
+      const db = new Database(':memory:');
+      seedLegacySdkSessions(db);
+
+      store = new SessionStore(db);
+      const versionsBefore = (db.prepare('SELECT COUNT(*) AS n FROM schema_versions').get() as { n: number }).n;
+
+      // Constructing a second store over the same connection replays the
+      // whole migration chain; the observed-columns step must be a no-op.
+      const again = new SessionStore(db);
+      const versionsAfter = (db.prepare('SELECT COUNT(*) AS n FROM schema_versions').get() as { n: number }).n;
+
+      expect(versionsAfter).toBe(versionsBefore);
+      expect(sdkSessionColumns(db).filter(name => name === 'observed_model')).toHaveLength(1);
+      expect(again.getSessionById(1)?.observed_model).toBeNull();
+    });
+  });
+});

--- a/tests/telemetry/buffer.test.ts
+++ b/tests/telemetry/buffer.test.ts
@@ -181,6 +181,77 @@ describe('flushSession() — observer_turn_rollup', () => {
     expect(p.top_model).toBeUndefined();
   });
 
+  it('carries last-seen ide, provider, observed_model, observed_billing on the rollup', () => {
+    const SID = 10;
+    telemetryBuffer.record('session_compressed', SID, {
+      outcome: 'ok',
+      ide: 'claude-code',
+      provider: 'claude',
+      observed_model: 'claude-fable-5-1',
+      observed_billing: 'max',
+      hook: 'ingest',
+    });
+    telemetryBuffer.record('session_compressed', SID, {
+      outcome: 'ok',
+      ide: 'claude-code',
+      provider: 'claude',
+      observed_model: 'claude-fable-5-1',
+      observed_billing: 'max',
+      hook: 'summarize',
+    });
+    telemetryBuffer.flushSession(SID, 'session_end');
+
+    const p = (postHogCaptureCalls[0] as { properties: Record<string, unknown> }).properties;
+    expect(p.ide).toBe('claude-code');
+    expect(p.provider).toBe('claude');
+    expect(p.observed_model).toBe('claude-fable-5-1');
+    expect(p.observed_billing).toBe('max');
+    // hook varies per turn and is intentionally not carried on the rollup
+    expect(p.hook).toBeUndefined();
+  });
+
+  it('defaults observed_* to "unknown" and omits ide/provider when no record had them', () => {
+    const SID = 11;
+    telemetryBuffer.record('session_compressed', SID, { outcome: 'error' });
+    telemetryBuffer.flushSession(SID, 'session_end');
+
+    const p = (postHogCaptureCalls[0] as { properties: Record<string, unknown> }).properties;
+    expect(p.observed_model).toBe('unknown');
+    expect(p.observed_billing).toBe('unknown');
+    expect(p.ide).toBeUndefined();
+    expect(p.provider).toBeUndefined();
+  });
+
+  it('uses last-seen semantics: a later record overrides an earlier one, and empty/missing values do not clobber', () => {
+    const SID = 12;
+    telemetryBuffer.record('session_compressed', SID, {
+      outcome: 'ok',
+      ide: 'cursor',
+      provider: 'openrouter',
+      observed_model: 'claude-sonnet-4-5',
+      observed_billing: 'pro',
+    });
+    // Mid-session /model switch: the newest value wins.
+    telemetryBuffer.record('session_compressed', SID, {
+      outcome: 'ok',
+      observed_model: 'claude-fable-5-1',
+      observed_billing: 'max',
+    });
+    // A trailing record with no / empty values must NOT reset what was seen.
+    telemetryBuffer.record('session_compressed', SID, {
+      outcome: 'aborted',
+      observed_model: '',
+      observed_billing: undefined,
+    });
+    telemetryBuffer.flushSession(SID, 'session_end');
+
+    const p = (postHogCaptureCalls[0] as { properties: Record<string, unknown> }).properties;
+    expect(p.ide).toBe('cursor');
+    expect(p.provider).toBe('openrouter');
+    expect(p.observed_model).toBe('claude-fable-5-1');
+    expect(p.observed_billing).toBe('max');
+  });
+
   it('two sessions accumulate independently and each emits its own rollup', () => {
     const A = 100;
     const B = 200;

--- a/tests/telemetry/scrub.test.ts
+++ b/tests/telemetry/scrub.test.ts
@@ -216,6 +216,20 @@ describe('scrubProperties', () => {
     });
   });
 
+  it('keeps the observed-session identity keys with primitive values', () => {
+    const result = scrubProperties({
+      top_model: 'claude-haiku-4-5',
+      observed_model: 'claude-fable-5-1',
+      observed_billing: 'max',
+    });
+
+    expect(result).toEqual({
+      top_model: 'claude-haiku-4-5',
+      observed_model: 'claude-fable-5-1',
+      observed_billing: 'max',
+    });
+  });
+
   it('drops unknown keys silently', () => {
     const result = scrubProperties({
       version: '1.0.0',

--- a/tests/transcripts/observed-model-extraction.test.ts
+++ b/tests/transcripts/observed-model-extraction.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  extractLastAssistantModel,
+  extractLastAssistantModelFromJsonl,
+  extractLastAssistantTurn,
+} from '../../src/shared/transcript-parser.js';
+
+function claudeCodeLine(type: string, message: Record<string, unknown>): string {
+  return JSON.stringify({ type, message });
+}
+
+describe('extractLastAssistantModelFromJsonl', () => {
+  it('returns the model of the last assistant line (Claude Code `type` form)', () => {
+    const content = [
+      claudeCodeLine('user', { role: 'user', content: 'hi' }),
+      claudeCodeLine('assistant', { role: 'assistant', model: 'claude-old-model', content: [] }),
+      claudeCodeLine('user', { role: 'user', content: 'switch' }),
+      claudeCodeLine('assistant', { role: 'assistant', model: 'claude-fable-5-1', content: [] }),
+    ].join('\n');
+
+    expect(extractLastAssistantModelFromJsonl(content)).toBe('claude-fable-5-1');
+  });
+
+  it('returns the model when a Cursor `role` form carries message.model', () => {
+    const content = [
+      JSON.stringify({ role: 'user', message: { content: 'hi' } }),
+      JSON.stringify({ role: 'assistant', message: { model: 'cursor-model-x', content: 'yo' } }),
+    ].join('\n');
+
+    expect(extractLastAssistantModelFromJsonl(content)).toBe('cursor-model-x');
+  });
+
+  it('skips user lines and malformed lines while scanning backwards', () => {
+    const content = [
+      claudeCodeLine('assistant', { role: 'assistant', model: 'claude-real', content: [] }),
+      claudeCodeLine('user', { role: 'user', model: 'not-an-assistant-model', content: 'x' }),
+      '{"type":"assistant","message":{"model":"trunc',
+      '',
+    ].join('\n');
+
+    expect(extractLastAssistantModelFromJsonl(content)).toBe('claude-real');
+  });
+
+  it('returns undefined when no assistant line has a model', () => {
+    const content = [
+      claudeCodeLine('user', { role: 'user', content: 'hi' }),
+      claudeCodeLine('assistant', { role: 'assistant', content: [] }),
+      claudeCodeLine('assistant', { role: 'assistant', model: 42, content: [] }),
+      claudeCodeLine('assistant', { role: 'assistant', model: '', content: [] }),
+    ].join('\n');
+
+    expect(extractLastAssistantModelFromJsonl(content)).toBeUndefined();
+  });
+});
+
+describe('extractLastAssistantModel', () => {
+  it('reads the transcript file and returns the last assistant model', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'observed-model-'));
+    const transcriptPath = join(dir, 'transcript.jsonl');
+    writeFileSync(
+      transcriptPath,
+      claudeCodeLine('assistant', { role: 'assistant', model: 'claude-from-file', content: [] }) + '\n',
+    );
+
+    expect(extractLastAssistantModel(transcriptPath)).toBe('claude-from-file');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns undefined for a missing or empty path', () => {
+    expect(extractLastAssistantModel('')).toBeUndefined();
+    expect(extractLastAssistantModel(join(tmpdir(), 'does-not-exist-observed-model.jsonl'))).toBeUndefined();
+  });
+});
+
+describe('extractLastAssistantTurn', () => {
+  it('returns both the last assistant text and its model from a single file read', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'observed-turn-'));
+    const transcriptPath = join(dir, 'transcript.jsonl');
+    writeFileSync(
+      transcriptPath,
+      [
+        claudeCodeLine('user', { role: 'user', content: 'hi' }),
+        claudeCodeLine('assistant', {
+          role: 'assistant',
+          model: 'claude-turn-model',
+          content: [{ type: 'text', text: 'Final answer' }],
+        }),
+      ].join('\n') + '\n',
+    );
+
+    expect(extractLastAssistantTurn(transcriptPath)).toEqual({
+      text: 'Final answer',
+      model: 'claude-turn-model',
+    });
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('strips system reminders from the text when asked, still returning the model', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'observed-turn-strip-'));
+    const transcriptPath = join(dir, 'transcript.jsonl');
+    writeFileSync(
+      transcriptPath,
+      claudeCodeLine('assistant', {
+        role: 'assistant',
+        model: 'claude-turn-model',
+        content: [{ type: 'text', text: 'Kept <system-reminder>dropped</system-reminder>' }],
+      }) + '\n',
+    );
+
+    const turn = extractLastAssistantTurn(transcriptPath, true);
+    expect(turn.text).toBe('Kept');
+    expect(turn.model).toBe('claude-turn-model');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns { text: "" } for a missing or empty path', () => {
+    expect(extractLastAssistantTurn('')).toEqual({ text: '' });
+    expect(extractLastAssistantTurn(join(tmpdir(), 'does-not-exist-observed-turn.jsonl'))).toEqual({ text: '' });
+  });
+});


### PR DESCRIPTION
## Summary

PostHog only knew the *observer* model (`model` / `top_model`). This adds the **observed** session's identity to `observer_turn_rollup`:

- `observed_model` — the model the user's IDE session is running (from the transcript's last assistant entry, read once per Stop hook)
- `observed_billing` — closed enum `max | pro | team | enterprise | subscription | api_key | bedrock | vertex | foundry | unknown`, detected in the hook process from Claude Code's env (`CLAUDE_CODE_USE_BEDROCK/VERTEX/FOUNDRY`, `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`) and `~/.claude.json` `oauthAccount.organizationType`
- `ide` and `provider` now actually reach PostHog on the rollup (docs claimed they did; `computeSessionCompressedRollup` was dropping them)

## How it flows

Stop hook (`summarize` handler) → `/api/sessions/summarize` body gains `observedModel` / `observedBilling` → worker persists on `sdk_sessions` (new nullable columns, schema version 50) and mirrors onto `ActiveSession` → every per-turn `session_compressed` record carries them → rollup emits last-seen value or `'unknown'`.

## Privacy

- Only `oauthAccount.organizationType`, `oauthAccount` presence, and `customApiKeyResponses.approved` are read from `.claude.json`, projected immediately after `JSON.parse`; parse errors log only the error class name.
- Both keys are closed/low-cardinality, added to `ALLOWED_PROPERTY_KEYS`, and documented in `docs/public/telemetry.mdx`.
- No build artifacts in this PR (rebuilt at version bump).

## Test plan

- [x] `npm run typecheck`, `npm run build`, `npm run lint:hook-io`, `npm run lint:spawn-env`
- [x] `bun test tests` — 38 new tests across transcript extraction, billing detection matrix, summarize handler body, SessionStore migration/COALESCE, rollup last-seen semantics, scrub whitelist. The 2 failures in `tests/worker/sync/mutation-sites.test.ts` and `tests/services/infrastructure/worktree-adoption-chroma.test.ts` are pre-existing order-dependent flakes that fail identically on a clean `main`.
- [ ] After merge + version bump: `sqlite3 ~/.claude-mem/claude-mem.db "select observed_model, observed_billing from sdk_sessions order by id desc limit 3"` shows a real model id and `max`.

Plan: `plans/2026-09-01-posthog-observed-model.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NoBPqpo7YaR3HKipExjAT
