### PR TITLE
feat(telemetry): report subscription usage-limit hits to PostHog

### DIFF
--- a/docs/public/telemetry.mdx
+++ b/docs/public/telemetry.mdx
@@ -114,6 +114,10 @@ Every event property passes through a strict whitelist scrubber — any key not 
 | `process_rss_mb` | `187` | Worker process resident memory, integer megabytes |
 | `heap_used_mb` | `92` | Worker JS heap in use, integer megabytes |
 | `hook_type` | `observation` | Which hook kind failed: context / session-init / observation / summarize / file-context — our handler names |
+| `limit_window` | `five_hour` | Which subscription window was exhausted on `usage_limit_hit`: five_hour / seven_day / seven_day_opus / seven_day_sonnet / overage / unknown — a closed enum |
+| `overage_status` | `rejected` | Whether extra-usage credits could cover the request: allowed / allowed_warning / rejected / unknown — a closed enum |
+| `is_using_overage` | `false` | Whether the request was already being billed to extra usage |
+| `resets_in_minutes` | `112` | Whole minutes until the exhausted window resets, floored at 0 — never the provider's message text |
 | `error_mode` | `worker_unavailable` | Coarse hook failure mode: worker_unavailable / blocking_error — never an error message |
 | `consecutive_failures` | `3` | How many hook failures occurred in a row (the fail-loud counter) |
 | `threshold_tripped` | `true` | Whether the consecutive-failure count reached the fail-loud threshold |
@@ -137,6 +141,7 @@ One value is derived server-side rather than sent by the client: PostHog resolve
 | `context_injected_rollup` | A 5-minute time-window rollup of context injections (stored memory injected into new sessions) | aggregated `outcomes_ok` / `outcomes_error` counts, `count`, `total_tokens`, `avg_tokens`, `total_observations_injected` (sum of observations served from cache into prompts), `total_tokens_saved_vs_naive`, `window_start_ts` |
 | `search_performed` | A memory search runs (never the query text) | `endpoint`, `outcome`, `duration_ms`, `result_count`, `search_strategy`, `chroma_available`, `fallback_reason` |
 | `worker_stopped` | The background worker shuts down gracefully | `uptime_seconds`, `shutdown_reason` (stop / restart / signal) |
+| `usage_limit_hit` | The Claude subscription behind the observer reports a window as `rejected` — since the observer shares the observed session's account, this is when the user's own Claude Code session ran out of usage. Emitted once per exhausted window (deduped on the window's reset time; a worker restart while still capped re-emits once). Only fires when the observer runs on Claude with a subscription login — API-key, Gemini, and OpenRouter observers never see it | `limit_window` (five_hour / seven_day / seven_day_opus / seven_day_sonnet / overage / unknown), `overage_status` (allowed / allowed_warning / rejected / unknown), `is_using_overage`, `resets_in_minutes`, `ide`, `provider`, `observed_model`, `observed_billing` |
 | `hook_failed` | A claude-mem hook fails hard — the worker is unreachable past the fail-loud threshold, or a blocking error occurs | `hook_type`, `error_mode`, `consecutive_failures`, `threshold_tripped` |
 | `error_occurred` | The worker returns an HTTP 5xx | `error_category` |
 | `$exception` | A real error is captured for [error tracking](#error-tracking) — consent-gated and independently kill-switchable | Redacted `error_type` / `error_message` / `error_stack`, `occurrence_count`, plus whitelisted context. See [Error tracking](#error-tracking) for exactly what is kept vs. redacted |

--- a/src/sdk/output-classifier.ts
+++ b/src/sdk/output-classifier.ts
@@ -59,9 +59,22 @@ export function isQuotaLimitedObserverOutput(raw: unknown): boolean {
     return false;
   }
 
+  if (/<(observation|summary)\b/i.test(raw) || /<skip_summary\b/i.test(raw)) {
+    return false;
+  }
+
   const text = raw.toLowerCase().replace(/\s+/g, ' ').trim();
 
   return (
+    // Wordings Claude Code actually writes when a subscription window or the
+    // credit balance is exhausted:
+    //   "You've hit your session limit · resets 5:50pm (America/Los_Angeles)"
+    //   "You've reached your Fable 5 limit. Run /usage-credits to continue…"
+    //   "You're out of usage credits. Run /usage-credits to keep using…"
+    /\byou'?ve (?:hit|reached) your\b.{0,40}\blimit\b/.test(text) ||
+    /\bsession limit\b/.test(text) ||
+    /\bout of (?:usage )?credits\b/.test(text) ||
+    /\/usage-credits\b/.test(text) ||
     /\bclaude\b.*\busage\b.*\blimit\b.*\b(reached|exceeded|exhausted|reset|resets|try again)\b/.test(text) ||
     /\b(reached|exceeded|exhausted)\b.*\bclaude\b.*\busage\b.*\blimit\b/.test(text) ||
     /\bweekly\b.*\b(limit|quota)\b.*\b(reached|exceeded|exhausted|reset|resets|try again)\b/.test(text) ||

--- a/src/services/telemetry/scrub.ts
+++ b/src/services/telemetry/scrub.ts
@@ -123,6 +123,15 @@ export const ALLOWED_PROPERTY_KEYS: Set<string> = new Set([
   'error_mode',
   'consecutive_failures',
   'threshold_tripped',
+  // usage_limit_hit — the SDK's rate_limit_info projected to closed enums:
+  // limit_window (five_hour | seven_day | seven_day_opus | seven_day_sonnet |
+  // overage | unknown), overage_status (allowed | allowed_warning | rejected |
+  // unknown), a boolean, and whole minutes until the window resets. Never the
+  // provider's limit message text.
+  'limit_window',
+  'overage_status',
+  'is_using_overage',
+  'resets_in_minutes',
   // Historical backfill (backfill.ts) — anonymous per-day rollup counters,
   // the backfilled:true flag, and the single inferred-install date string
   // (YYYY-MM-DD). Counts/sums and closed-enum buckets only — never project

--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -19,6 +19,7 @@ import {
 import { sanitizeEnv } from '../../supervisor/env-sanitizer.js';
 import {
   globalRateLimitStore,
+  buildUsageLimitHitProps,
   shouldAbortForQuota,
   type RateLimitInfo,
 } from './RateLimitStore.js';
@@ -36,6 +37,7 @@ import {
 import { recycleObserverConversation, loadSessionStartContext } from './session/recycle-conversation.js';
 import { optimizeObservationFields, buildFieldCompressionPrompt, type FieldCompressor } from './field-optimizer.js';
 import { telemetryBuffer } from '../telemetry/buffer.js';
+import { captureEvent } from '../telemetry/telemetry.js';
 import { clearDependencyStatus, recordClaudeCliSetupRequired } from '../../shared/dependency-health.js';
 
 /**
@@ -297,7 +299,24 @@ export class ClaudeProvider {
         ) {
           const info = (message as any).rate_limit_info as RateLimitInfo | undefined;
           if (info) {
-            globalRateLimitStore.set(info);
+            // The observer runs on the same account as the observed session,
+            // so a `rejected` snapshot here means the user's own Claude Code
+            // session is out of usage too. set() dedupes: one event per
+            // exhausted window, not one per observer request against the wall.
+            if (globalRateLimitStore.set(info)) {
+              logger.warn('SDK', 'Subscription usage limit hit', {
+                sessionDbId: session.sessionDbId,
+                window: info.rateLimitType,
+                overageStatus: info.overageStatus,
+              });
+              captureEvent('usage_limit_hit', {
+                ...buildUsageLimitHitProps(info),
+                ide: session.platformSource,
+                provider: 'claude',
+                observed_model: session.observedModel,
+                observed_billing: session.observedBilling,
+              });
+            }
           }
           const decision = shouldAbortForQuota(authMethod, globalRateLimitStore);
           if (decision.abort) {

--- a/src/services/worker/RateLimitStore.ts
+++ b/src/services/worker/RateLimitStore.ts
@@ -60,10 +60,12 @@ export class RateLimitStore {
    * Accepts both the literal `rate_limit_info` payload and a wrapping object;
    * callers should pass the inner info.
    */
-  set(info: RateLimitInfo | undefined | null): void {
-    if (!info || typeof info !== 'object') return;
+  set(info: RateLimitInfo | undefined | null): boolean {
+    if (!info || typeof info !== 'object') return false;
     const key: RateLimitBucketKey = info.rateLimitType ?? 'default';
+    const previous = this.entries.get(key);
     this.entries.set(key, { ...info, observedAt: Date.now() });
+    return isNewRejection(previous, info);
   }
 
   /** Snapshot a single bucket, or undefined if not yet seen. */
@@ -96,6 +98,50 @@ export class RateLimitStore {
 
 /** Process-wide singleton. */
 export const globalRateLimitStore = new RateLimitStore();
+
+/**
+ * A snapshot is a NEW rejection when it says `rejected` and the previous
+ * snapshot for the same window did not — or pointed at a different reset
+ * time, which means the window was exhausted again after a reset without an
+ * `allowed` snapshot in between. The SDK re-sends `rejected` on every request
+ * while the wall is up, so this is what keeps `usage_limit_hit` at one event
+ * per exhaustion instead of one per observer request.
+ */
+export function isNewRejection(
+  previous: RateLimitInfo | undefined,
+  next: RateLimitInfo,
+): boolean {
+  if (next.status !== 'rejected') return false;
+  if (!previous || previous.status !== 'rejected') return true;
+  return previous.resetsAt !== next.resetsAt;
+}
+
+/**
+ * Whole minutes until the window resets, floored at 0. Claude Code has been
+ * seen writing `resetsAt` as epoch seconds in transcripts while the SDK
+ * documents epoch ms, so anything too small to be ms is treated as seconds.
+ */
+export function minutesUntilReset(resetsAt: number | undefined, now: number = Date.now()): number | undefined {
+  if (typeof resetsAt !== 'number' || !Number.isFinite(resetsAt)) return undefined;
+  const resetsAtMs = resetsAt < 1e12 ? resetsAt * 1000 : resetsAt;
+  return Math.max(0, Math.round((resetsAtMs - now) / 60_000));
+}
+
+/**
+ * PostHog properties for one `usage_limit_hit` event. Closed enums, a
+ * boolean, and one integer — never the provider's message text.
+ */
+export function buildUsageLimitHitProps(
+  info: RateLimitInfo,
+  now: number = Date.now(),
+): Record<string, unknown> {
+  return {
+    limit_window: info.rateLimitType ?? 'unknown',
+    overage_status: info.overageStatus ?? 'unknown',
+    is_using_overage: info.isUsingOverage === true,
+    resets_in_minutes: minutesUntilReset(info.resetsAt, now),
+  };
+}
 
 /**
  * Per-window utilization thresholds for subscription users (cli/oauth).

--- a/tests/sdk/output-classifier.test.ts
+++ b/tests/sdk/output-classifier.test.ts
@@ -65,6 +65,30 @@ describe('isQuotaLimitedObserverOutput', () => {
     ).toBe(true);
   });
 
+  it('detects the wordings Claude Code actually writes on a limit hit', () => {
+    expect(
+      isQuotaLimitedObserverOutput("You've hit your session limit · resets 5:50pm (America/Los_Angeles)"),
+    ).toBe(true);
+    expect(
+      isQuotaLimitedObserverOutput(
+        "You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model.",
+      ),
+    ).toBe(true);
+    expect(
+      isQuotaLimitedObserverOutput(
+        "You're out of usage credits. Run /usage-credits to keep using Fable 5 or /model to switch models.",
+      ),
+    ).toBe(true);
+  });
+
+  it('does not treat XML that mentions a limit as quota prose', () => {
+    expect(
+      isQuotaLimitedObserverOutput(
+        '<observation><title>Hit the session limit while testing</title></observation>',
+      ),
+    ).toBe(false);
+  });
+
   it('does not treat context-window prose as quota prose', () => {
     expect(
       isQuotaLimitedObserverOutput('I hit the context window and cannot produce valid XML.'),

--- a/tests/worker/rate-limit-store.test.ts
+++ b/tests/worker/rate-limit-store.test.ts
@@ -3,6 +3,9 @@ import {
   RateLimitStore,
   shouldAbortForQuota,
   isApiKeyAuth,
+  isNewRejection,
+  minutesUntilReset,
+  buildUsageLimitHitProps,
   type RateLimitInfo,
 } from '../../src/services/worker/RateLimitStore.js';
 
@@ -205,5 +208,99 @@ describe('shouldAbortForQuota — cli/oauth auth', () => {
   it('does not abort with empty store', () => {
     const decision = shouldAbortForQuota(cliAuth, store, FIXED_NOW);
     expect(decision.abort).toBe(false);
+  });
+});
+
+// usage_limit_hit telemetry: one event per exhausted window, never one per
+// observer request against the wall.
+describe('RateLimitStore.set → new-rejection signal', () => {
+  it('reports the first rejected snapshot for a window', () => {
+    const store = freshStore();
+    expect(store.set({ rateLimitType: 'five_hour', status: 'allowed', utilization: 0.4 })).toBe(false);
+    expect(store.set({ rateLimitType: 'five_hour', status: 'rejected', resetsAt: FIXED_NOW + 60_000 })).toBe(true);
+  });
+
+  it('does not re-report the same rejection on later requests', () => {
+    const store = freshStore();
+    const rejected: RateLimitInfo = { rateLimitType: 'five_hour', status: 'rejected', resetsAt: FIXED_NOW + 60_000 };
+    expect(store.set(rejected)).toBe(true);
+    expect(store.set(rejected)).toBe(false);
+    expect(store.set({ ...rejected, utilization: 1 })).toBe(false);
+  });
+
+  it('reports again when the same window is exhausted after a reset', () => {
+    const store = freshStore();
+    expect(store.set({ rateLimitType: 'five_hour', status: 'rejected', resetsAt: FIXED_NOW + 60_000 })).toBe(true);
+    expect(store.set({ rateLimitType: 'five_hour', status: 'rejected', resetsAt: FIXED_NOW + 6 * 3_600_000 })).toBe(true);
+  });
+
+  it('reports again after an allowed snapshot in between', () => {
+    const store = freshStore();
+    const rejected: RateLimitInfo = { rateLimitType: 'seven_day', status: 'rejected', resetsAt: FIXED_NOW + 60_000 };
+    expect(store.set(rejected)).toBe(true);
+    expect(store.set({ rateLimitType: 'seven_day', status: 'allowed' })).toBe(false);
+    expect(store.set(rejected)).toBe(true);
+  });
+
+  it('tracks windows independently', () => {
+    const store = freshStore();
+    expect(store.set({ rateLimitType: 'five_hour', status: 'rejected', resetsAt: 1 })).toBe(true);
+    expect(store.set({ rateLimitType: 'seven_day', status: 'rejected', resetsAt: 1 })).toBe(true);
+  });
+
+  it('never reports allowed or warning snapshots', () => {
+    expect(isNewRejection(undefined, { status: 'allowed' })).toBe(false);
+    expect(isNewRejection(undefined, { status: 'allowed_warning', utilization: 0.99 })).toBe(false);
+    expect(isNewRejection(undefined, {})).toBe(false);
+  });
+
+  it('ignores malformed payloads', () => {
+    const store = freshStore();
+    expect(store.set(undefined)).toBe(false);
+    expect(store.set(null)).toBe(false);
+  });
+});
+
+describe('minutesUntilReset', () => {
+  it('handles epoch-ms and epoch-seconds resetsAt', () => {
+    expect(minutesUntilReset(FIXED_NOW + 30 * 60_000, FIXED_NOW)).toBe(30);
+    expect(minutesUntilReset(Math.floor(FIXED_NOW / 1000) + 30 * 60, FIXED_NOW)).toBe(30);
+  });
+
+  it('floors at zero and drops non-numbers', () => {
+    expect(minutesUntilReset(FIXED_NOW - 60_000, FIXED_NOW)).toBe(0);
+    expect(minutesUntilReset(undefined, FIXED_NOW)).toBeUndefined();
+    expect(minutesUntilReset(Number.NaN, FIXED_NOW)).toBeUndefined();
+  });
+});
+
+describe('buildUsageLimitHitProps', () => {
+  it('projects rate_limit_info to closed enums and one integer', () => {
+    expect(
+      buildUsageLimitHitProps(
+        {
+          status: 'rejected',
+          rateLimitType: 'five_hour',
+          resetsAt: FIXED_NOW + 112 * 60_000,
+          overageStatus: 'rejected',
+          isUsingOverage: false,
+        },
+        FIXED_NOW,
+      ),
+    ).toEqual({
+      limit_window: 'five_hour',
+      overage_status: 'rejected',
+      is_using_overage: false,
+      resets_in_minutes: 112,
+    });
+  });
+
+  it('fills unknown for missing enum fields', () => {
+    expect(buildUsageLimitHitProps({ status: 'rejected' }, FIXED_NOW)).toEqual({
+      limit_window: 'unknown',
+      overage_status: 'unknown',
+      is_using_overage: false,
+      resets_in_minutes: undefined,
+    });
   });
 });


### PR DESCRIPTION
## Summary

Tracks when a user runs out of Claude Code usage. Nothing reported this before: the only quota signal was `abort_reason: quota` on the observer rollup, which fires when claude-mem's own guard stops early, not when the user's session is blocked. The Stop hook never fires on a limit-hit turn (verified across five hits on five days in local hook logs), so the transcript path cannot carry it either.

- **New `usage_limit_hit` event.** The observer runs on the same account as the observed session, so the SDK's `rate_limit` stream reporting a window as `rejected` is the moment the user's own session ran out. `ClaudeProvider` captures the event there with `limit_window`, `overage_status`, `is_using_overage`, `resets_in_minutes`, plus `ide`, `provider`, `observed_model`, `observed_billing`. Closed enums, a boolean, and one integer. The provider's message text never leaves the machine.
- **Deduped in `RateLimitStore.set`.** Returns true only for a fresh rejection: one event per exhausted window, not one per observer request against the wall. Emits again after a reset or an allowed snapshot in between.
- **Reset-time handling** accepts epoch seconds or milliseconds. Claude Code writes seconds in transcripts while the SDK documents milliseconds.
- **Classifier fix.** `isQuotaLimitedObserverOutput` now matches the wordings Claude Code actually writes ("You've hit your session limit · resets …", "You've reached your Fable 5 limit…", "You're out of usage credits…"). Those turns were classified as prose and the batch dropped (seen in the worker log on Aug 26); they now pause the generator and preserve queued work like every other quota refusal. It also skips XML like the other two detectors.
- Whitelist entries and `telemetry.mdx` updated.

## Limits

- Fires only when the observer runs on Claude with a subscription login. API-key, Gemini, and OpenRouter observers never see the SDK rate_limit stream. Documented.
- A worker restart while still capped re-emits once (store is in-memory).
- Not verified live that the SDK emits a `rejected` snapshot before a capped request fails, since that needs an actually exhausted account. Transcript evidence and the SDK's documented shape both say it does.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `tests/worker/rate-limit-store.test.ts`: dedup rules, reset math, prop projection
- [x] `tests/sdk/output-classifier.test.ts`: the three real wordings, XML exclusion
- [x] telemetry scrub, provider classifier, quota-cooldown, and ClaudeProvider suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NoBPqpo7YaR3HKipExjAT
