### PR TITLE
fix(quota): match the SDK's real rate_limit_event message shape

### DIFF
--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -20,8 +20,8 @@ import { sanitizeEnv } from '../../supervisor/env-sanitizer.js';
 import {
   globalRateLimitStore,
   buildUsageLimitHitProps,
+  extractRateLimitInfo,
   shouldAbortForQuota,
-  type RateLimitInfo,
 } from './RateLimitStore.js';
 
 // @ts-ignore - Agent SDK types may not be available
@@ -288,35 +288,31 @@ export class ClaudeProvider {
       });
 
       for await (const message of queryResult) {
-        // Quota-aware wall-clock guard (#2234): the SDK pushes `system` events
-        // with subtype `rate_limit` carrying live subscription quota state.
-        // Capture the snapshot, then bail out of the loop before issuing
-        // another request if we've crossed a per-window threshold. API-key
-        // users are exempt — they authorized per-call spend.
-        if (
-          (message as any)?.type === 'system' &&
-          (message as any)?.subtype === 'rate_limit'
-        ) {
-          const info = (message as any).rate_limit_info as RateLimitInfo | undefined;
-          if (info) {
-            // The observer runs on the same account as the observed session,
-            // so a `rejected` snapshot here means the user's own Claude Code
-            // session is out of usage too. set() dedupes: one event per
-            // exhausted window, not one per observer request against the wall.
-            if (globalRateLimitStore.set(info)) {
-              logger.warn('SDK', 'Subscription usage limit hit', {
-                sessionDbId: session.sessionDbId,
-                window: info.rateLimitType,
-                overageStatus: info.overageStatus,
-              });
-              captureEvent('usage_limit_hit', {
-                ...buildUsageLimitHitProps(info),
-                ide: session.platformSource,
-                provider: 'claude',
-                observed_model: session.observedModel,
-                observed_billing: session.observedBilling,
-              });
-            }
+        // Quota-aware wall-clock guard (#2234): the SDK pushes
+        // `rate_limit_event` messages carrying live subscription quota state
+        // (see extractRateLimitInfo for the shape). Capture the snapshot, then
+        // bail out of the loop before issuing another request if we've
+        // crossed a per-window threshold. API-key users are exempt — they
+        // authorized per-call spend.
+        const info = extractRateLimitInfo(message);
+        if (info) {
+          // The observer runs on the same account as the observed session,
+          // so a `rejected` snapshot here means the user's own Claude Code
+          // session is out of usage too. set() dedupes: one event per
+          // exhausted window, not one per observer request against the wall.
+          if (globalRateLimitStore.set(info)) {
+            logger.warn('SDK', 'Subscription usage limit hit', {
+              sessionDbId: session.sessionDbId,
+              window: info.rateLimitType,
+              overageStatus: info.overageStatus,
+            });
+            captureEvent('usage_limit_hit', {
+              ...buildUsageLimitHitProps(info),
+              ide: session.platformSource,
+              provider: 'claude',
+              observed_model: session.observedModel,
+              observed_billing: session.observedBilling,
+            });
           }
           const decision = shouldAbortForQuota(authMethod, globalRateLimitStore);
           if (decision.abort) {

--- a/src/services/worker/RateLimitStore.ts
+++ b/src/services/worker/RateLimitStore.ts
@@ -2,9 +2,10 @@
  * Rate limit store — captures `rate_limit` system events emitted by
  * `@anthropic-ai/claude-agent-sdk`'s `query()` stream.
  *
- * The SDK reports the live Claude subscription quota state as `system` events
- * with subtype `rate_limit`. The payload includes the (currently undocumented)
- * `rate_limit_info` shape:
+ * The SDK reports the live Claude subscription quota state as a top-level
+ * `rate_limit_event` message (`SDKRateLimitEvent` in sdk.d.ts). Older builds
+ * surfaced it as a `system` message with subtype `rate_limit`; both shapes
+ * are accepted by extractRateLimitInfo. The `rate_limit_info` payload:
  *
  *   {
  *     status: "allowed" | "allowed_warning" | "rejected",
@@ -98,6 +99,28 @@ export class RateLimitStore {
 
 /** Process-wide singleton. */
 export const globalRateLimitStore = new RateLimitStore();
+
+/**
+ * Pull the `rate_limit_info` payload out of an SDK stream message, or
+ * undefined when the message is not a quota snapshot.
+ *
+ * The SDK emits `{ type: 'rate_limit_event', rate_limit_info }` — a top-level
+ * message type in the SDKMessage union, NOT a `system` subtype. The original
+ * guard (#2234) matched `type === 'system' && subtype === 'rate_limit'`, which
+ * the SDK never sends, so the quota guard and every consumer of the store were
+ * dead until this extractor replaced it. The legacy shape is still accepted in
+ * case an older SDK build is on the path.
+ */
+export function extractRateLimitInfo(message: unknown): RateLimitInfo | undefined {
+  if (!message || typeof message !== 'object') return undefined;
+  const m = message as { type?: unknown; subtype?: unknown; rate_limit_info?: unknown };
+  const isRateLimitMessage =
+    m.type === 'rate_limit_event' || (m.type === 'system' && m.subtype === 'rate_limit');
+  if (!isRateLimitMessage) return undefined;
+  const info = m.rate_limit_info;
+  if (!info || typeof info !== 'object') return undefined;
+  return info as RateLimitInfo;
+}
 
 /**
  * A snapshot is a NEW rejection when it says `rejected` and the previous

--- a/tests/worker/rate-limit-store.test.ts
+++ b/tests/worker/rate-limit-store.test.ts
@@ -4,6 +4,7 @@ import {
   shouldAbortForQuota,
   isApiKeyAuth,
   isNewRejection,
+  extractRateLimitInfo,
   minutesUntilReset,
   buildUsageLimitHitProps,
   type RateLimitInfo,
@@ -302,5 +303,35 @@ describe('buildUsageLimitHitProps', () => {
       is_using_overage: false,
       resets_in_minutes: undefined,
     });
+  });
+});
+
+// The SDK emits `{ type: 'rate_limit_event', rate_limit_info }` (SDKRateLimitEvent
+// in sdk.d.ts). The original guard matched a `system` message with subtype
+// `rate_limit`, which the SDK never sends, so the whole quota path was dead.
+describe('extractRateLimitInfo', () => {
+  const info: RateLimitInfo = { status: 'rejected', rateLimitType: 'five_hour', resetsAt: FIXED_NOW + 60_000 };
+
+  it('accepts the SDK rate_limit_event message', () => {
+    expect(
+      extractRateLimitInfo({ type: 'rate_limit_event', rate_limit_info: info, uuid: 'u', session_id: 's' }),
+    ).toEqual(info);
+  });
+
+  it('still accepts the legacy system/rate_limit shape', () => {
+    expect(extractRateLimitInfo({ type: 'system', subtype: 'rate_limit', rate_limit_info: info })).toEqual(info);
+  });
+
+  it('ignores every other stream message', () => {
+    expect(extractRateLimitInfo({ type: 'system', subtype: 'init' })).toBeUndefined();
+    expect(extractRateLimitInfo({ type: 'assistant', message: {} })).toBeUndefined();
+    expect(extractRateLimitInfo({ type: 'result', subtype: 'success' })).toBeUndefined();
+    expect(extractRateLimitInfo(undefined)).toBeUndefined();
+    expect(extractRateLimitInfo('rate_limit_event')).toBeUndefined();
+  });
+
+  it('ignores a rate_limit_event with no payload', () => {
+    expect(extractRateLimitInfo({ type: 'rate_limit_event' })).toBeUndefined();
+    expect(extractRateLimitInfo({ type: 'rate_limit_event', rate_limit_info: null })).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

The quota guard (#2234) and the new `usage_limit_hit` event (#3837) both read the SDK stream for a `system` message with subtype `rate_limit`. The SDK has never sent that shape. `SDKRateLimitEvent` in `sdk.d.ts` (0.3.172, the version this repo pins) is a top-level `{ type: 'rate_limit_event', rate_limit_info }` member of the `SDKMessage` union, and no `system` subtype named `rate_limit` exists anywhere in the declarations.

Consequence: the guard never matched, `RateLimitStore` stayed empty, the quota abort never fired, and `usage_limit_hit` stayed at zero across 1,120 Claude-provider installs already running 13.23.0.

- `extractRateLimitInfo` in `RateLimitStore.ts` accepts the real `rate_limit_event` shape and still tolerates the legacy `system`/`rate_limit` form.
- `ClaudeProvider` routes the stream through it; the rest of the guard and the event emission are unchanged.
- Header comment on `RateLimitStore` corrected.

## Evidence

- `sdk.d.ts` line 3821: `type: 'rate_limit_event'` with `rate_limit_info: SDKRateLimitInfo`
- `SDKRateLimitInfo.status: 'allowed' | 'allowed_warning' | 'rejected'`, `rateLimitType: 'five_hour' | 'seven_day' | 'seven_day_opus' | 'seven_day_sonnet' | 'overage'`, matching the store's existing `RateLimitInfo`
- `SDKRateLimitEvent` is member 29 of the `SDKMessage` union, so `query()` yields it
- PostHog: 0 `usage_limit_hit` events in 6 hours from 1,120 Claude-provider installs on 13.23.0

## Test plan

- [x] `tsc --noEmit` clean
- [x] `extractRateLimitInfo` tests: real shape, legacy shape, every other message type, missing payload
- [x] rate-limit-store, quota-cooldown, ClaudeProvider, and scrub suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NoBPqpo7YaR3HKipExjAT
