### PR TITLE
docs: CMEM Pro manual/headless setup

### DIFF
--- a/docs/public/cmem-pro-headless.mdx
+++ b/docs/public/cmem-pro-headless.mdx
@@ -1,0 +1,129 @@
+---
+title: "CMEM Pro (manual / headless)"
+description: "What npx claude-mem install writes for CMEM Pro — OAuth pairing, settings.json keys, and how to verify without the interactive installer"
+---
+
+# CMEM Pro (manual / headless)
+
+Use this when you already have a [cmem.ai](https://cmem.ai) account and need to wire CMEM Pro without the interactive installer (CI, a second machine, or a box you SSH into). The usual path is still [`npx claude-mem install`](/installation).
+
+<Warning>
+Never paste real `cm_pro_…` keys, setup tokens, or OpenRouter `sk-or-` keys into chat, tickets, or docs. The examples below are placeholders only. Keep `~/.claude-mem/settings.json` mode `0600`.
+</Warning>
+
+## What the installer does
+
+Three stages:
+
+1. **Runtime** — Bun/uv if needed, IDE plugin files, worker deps.
+2. **Sign in** — skipped only for `--provider claude` (that path never talks to cmem.ai). Otherwise the CLI does **not** ask for an email:
+   - `POST https://cmem.ai/api/installer/oauth/start` with `{ source: "npx-installer", device_name: <hostname> }`
+   - prints a device code `XXXX-XXXX` and opens `authorization_url`
+   - polls `https://cmem.ai/api/pro/trial/poll` until authenticated
+3. **Provider** — **CMEM Pro is pre-selected.** Choosing it opens `checkout_url` (trial/claim), polls until `status: "ready"`, then writes settings and restarts the worker.
+
+`--provider openrouter` with a **personal** key is a different path: empty `CLAUDE_MEM_OPENROUTER_BASE_URL` (or `https://openrouter.ai/api/v1`). Never send a personal `sk-or-` key to `https://cmem.ai/api/inference`.
+
+## Settings the installer writes
+
+Credentials are **staged**, then **activated**. File: `~/.claude-mem/settings.json`.
+
+### Staged (sync + trial metadata)
+
+| Key | From the ready poll |
+| --- | --- |
+| `CLAUDE_MEM_CLOUD_SYNC_TOKEN` | `setup_token` |
+| `CLAUDE_MEM_CLOUD_SYNC_USER_ID` | `user_id` |
+| `CLAUDE_MEM_CLOUD_SYNC_HUB_URL` | `hub_url` |
+| `CLAUDE_MEM_CLOUD_SYNC_DEVICE_ID` | `""` (worker mints on first start) |
+| `CLAUDE_MEM_CLOUD_SYNC_DEVICE_NAME` | hostname |
+| `CLAUDE_MEM_PRO_TRIAL_STATE` | `active` |
+| `CLAUDE_MEM_PRO_TRIAL_ENDS_AT` | `trial.ends_at` or `""` |
+| `CLAUDE_MEM_PRO_PLAN` | `trial` / `pro` / `none` |
+| `CLAUDE_MEM_PRO_MEMORY_KEY` | `memory_key`, or `setup_token` if omitted |
+| `CLAUDE_MEM_PRO_MEMORY_BASE_URL` | `memory_base_url`, or `https://cmem.ai/api/inference/v1` |
+| `CLAUDE_MEM_PRO_MEMORY_MODEL` | `memory_model`, or `cmem-observer` |
+| `CLAUDE_MEM_PRO_FALLBACK_AT` | `""` |
+
+Cloud sync is on only when the token, user id, **and** hub URL are all non-empty. See [Cloud Sync](/cloud-sync).
+
+### Activated (this is what makes observations run)
+
+The worker talks to cmem.ai through the generic OpenRouter client. There is no separate CMEM provider implementation.
+
+```json
+{
+  "CLAUDE_MEM_PROVIDER": "openrouter",
+  "CLAUDE_MEM_OPENROUTER_BASE_URL": "https://cmem.ai/api/inference/v1",
+  "CLAUDE_MEM_OPENROUTER_MODEL": "cmem-observer",
+  "CLAUDE_MEM_OPENROUTER_API_KEY": "cm_pro_YOUR_MEMORY_KEY",
+  "CLAUDE_MEM_PRO_MEMORY_KEY": "",
+  "CLAUDE_MEM_PRO_MEMORY_BASE_URL": "",
+  "CLAUDE_MEM_PRO_MEMORY_MODEL": ""
+}
+```
+
+Keep the cloud-sync trio from staging. `memory_key` and `setup_token` are often the same (`cm_pro_…`). If the poll returns a distinct `memory_key`, use that for `CLAUDE_MEM_OPENROUTER_API_KEY` and keep `setup_token` only on `CLAUDE_MEM_CLOUD_SYNC_TOKEN`.
+
+## Manual recipe (you already have tokens)
+
+1. From **cmem.ai → Connect** (or an installer pairing), copy `setup_token`, `user_id`, `hub_url`, and `memory_key` (if missing, use `setup_token`).
+2. Merge staged + activated keys into `~/.claude-mem/settings.json`. Placeholders only:
+
+```json
+{
+  "CLAUDE_MEM_CLOUD_SYNC_TOKEN": "cm_pro_YOUR_SETUP_TOKEN",
+  "CLAUDE_MEM_CLOUD_SYNC_USER_ID": "YOUR_USER_ID",
+  "CLAUDE_MEM_CLOUD_SYNC_HUB_URL": "https://YOUR_HUB_URL",
+  "CLAUDE_MEM_CLOUD_SYNC_DEVICE_ID": "",
+  "CLAUDE_MEM_CLOUD_SYNC_DEVICE_NAME": "my-machine",
+  "CLAUDE_MEM_PRO_TRIAL_STATE": "active",
+  "CLAUDE_MEM_PRO_TRIAL_ENDS_AT": "",
+  "CLAUDE_MEM_PRO_PLAN": "trial",
+  "CLAUDE_MEM_PRO_FALLBACK_AT": "",
+  "CLAUDE_MEM_PROVIDER": "openrouter",
+  "CLAUDE_MEM_OPENROUTER_BASE_URL": "https://cmem.ai/api/inference/v1",
+  "CLAUDE_MEM_OPENROUTER_MODEL": "cmem-observer",
+  "CLAUDE_MEM_OPENROUTER_API_KEY": "cm_pro_YOUR_MEMORY_KEY"
+}
+```
+
+3. `chmod 600 ~/.claude-mem/settings.json`
+4. Restart the worker so it is not holding old in-memory provider/sync state:
+
+```bash
+npx claude-mem restart
+```
+
+The interactive installer stops the worker after it persists the provider for the same reason.
+
+5. Verify (port is `CLAUDE_MEM_WORKER_PORT` or `~/.claude-mem/.worker.port`):
+
+```bash
+curl -s "http://127.0.0.1:${CLAUDE_MEM_WORKER_PORT}/api/health"
+curl -s "http://127.0.0.1:${CLAUDE_MEM_WORKER_PORT}/api/sync/status"
+```
+
+Expect health with provider `openrouter`, and sync `configured: true` plus `hub.reachable: true`.
+
+6. First real observation should store via model `cmem-observer`. Gateway success **clears** `CLAUDE_MEM_PRO_FALLBACK_AT`. A terminal quota/key error from the gateway **sets** that timestamp and memory falls back to the Anthropic plan.
+
+<Info>
+Fallback is **event-driven**, not a calendar date. Do not treat `CLAUDE_MEM_PRO_TRIAL_ENDS_AT` as the switch. The switch is `CLAUDE_MEM_PRO_FALLBACK_AT`.
+</Info>
+
+## What not to mix
+
+| Path | OpenRouter base URL | Key |
+| --- | --- | --- |
+| CMEM Pro (this page) | `https://cmem.ai/api/inference/v1` | `cm_pro_…` memory key |
+| Personal OpenRouter | empty, or `https://openrouter.ai/api/v1` | your `sk-or-…` |
+| Anthropic plan | n/a | `--provider claude` — local Max; cloud sync and CMEM keys cleared |
+
+Never send a personal OpenRouter key to the cmem gateway.
+
+## Next steps
+
+- [Installation](/installation) — interactive three-stage installer
+- [Cloud Sync](/cloud-sync) — what the sync trio replicates
+- [OpenRouter provider](/usage/openrouter-provider) — personal OpenRouter keys (not cmem.ai)

--- a/docs/public/docs.json
+++ b/docs/public/docs.json
@@ -94,7 +94,8 @@
         "icon": "cloud",
         "pages": [
           "hosted-server",
-          "cloud-sync"
+          "cloud-sync",
+          "cmem-pro-headless"
         ]
       },
       {

--- a/docs/public/installation.mdx
+++ b/docs/public/installation.mdx
@@ -15,28 +15,24 @@ Install and configure Claude-Mem with a single command:
 npx claude-mem install
 ```
 
-The interactive installer runs in three stages — install first, sign in second, then pick your memory provider:
+The interactive installer runs in three stages — runtime first, sign in second, then pick your memory provider:
 
-1. **Install everything.** Runs a runtime check (auto-installs Bun and uv if missing), detects your installed IDEs (Claude Code, Cursor, Windsurf, OpenCode, Codex CLI, Antigravity CLI) and lets you multi-select which ones to wire up, offers to install Claude Code if it isn't found, then copies plugin files into the marketplace directory, registers the plugin, and installs dependencies.
-2. **Sign in to claude-mem.** The installer asks for your email and sends a sign-in link; your browser opens to complete it. Every sign-in provisions a memory key for your account — no card required.
-3. **Choose your memory provider.** After sign-in you pick where observation extraction runs (see below), then the worker service auto-starts with your choice.
+1. **Install runtime.** Runs a runtime check (auto-installs Bun and uv if missing), detects your installed IDEs (Claude Code, Cursor, Windsurf, OpenCode, Codex CLI, Antigravity CLI) and lets you multi-select which ones to wire up, offers to install Claude Code if it isn't found, then copies plugin files into the marketplace directory, registers the plugin, and installs dependencies.
+2. **Sign in.** Skipped only for `--provider claude` (that path never talks to cmem.ai). The CLI does **not** ask for an email. It starts an OAuth pairing (`POST https://cmem.ai/api/installer/oauth/start`), prints a device code `XXXX-XXXX`, opens `authorization_url` in your browser, and polls until you are authenticated. No card required.
+3. **Choose your memory provider.** **CMEM Pro is pre-selected.** Picking it opens a checkout/trial URL, polls until the account is `ready`, writes `~/.claude-mem/settings.json`, and restarts the worker. Other choices: personal OpenRouter, Gemini, or your Anthropic plan.
+
+Headless or already signed in? See [CMEM Pro (manual / headless)](/cmem-pro-headless) for the exact settings the installer writes.
 
 ### Memory Provider Options
 
-- **claude-mem observer (recommended)** — memory runs off-plan: get up to 100% more usage from your plan. Free for 30 days; when the free trial ends, memory automatically falls back to your Anthropic plan unless you subscribe.
-- **Your OpenRouter key** — memory runs off-plan on your OpenRouter credit.
+- **CMEM Pro / claude-mem observer (pre-selected)** — memory runs off-plan through `https://cmem.ai/api/inference/v1` with model `cmem-observer`. Free trial, then subscribe or fall back. Fallback is **event-driven** (`CLAUDE_MEM_PRO_FALLBACK_AT` after a terminal gateway quota/key error), not the trial end date. See [CMEM Pro (manual / headless)](/cmem-pro-headless).
+- **Your OpenRouter key** — memory runs off-plan on your OpenRouter credit. Empty base URL (or `https://openrouter.ai/api/v1`). **Never** send a personal `sk-or-` key to the cmem.ai inference gateway.
 - **Gemini API key** — memory runs off-plan on your Gemini key.
-- **Anthropic plan** — memory shares your Claude plan usage. Prompts for the Claude model used to compress observations (Haiku / Sonnet / Opus).
+- **Anthropic plan** (`--provider claude`) — memory shares your Claude plan usage. Skips cmem.ai entirely. Prompts for the Claude model used to compress observations (Haiku / Sonnet / Opus).
 
 ### Skipping the Sign-In
 
-The sign-in step is skipped automatically when any of these apply:
-
-- You pass an explicit `--provider` flag (e.g. `npx claude-mem install --provider claude`)
-- `CLAUDE_MEM_ONLINE_OPTIN=false` is set in your environment
-- The install runs in CI or a non-interactive (non-TTY) shell
-
-You can finish signing in anytime by re-running `npx claude-mem install`.
+`--provider claude` never touches cmem.ai and skips OAuth. You can finish a CMEM Pro pairing anytime by re-running `npx claude-mem install`, or by writing settings by hand ([manual / headless](/cmem-pro-headless)).
 
 ### Option 2: Plugin Marketplace
 
@@ -125,6 +121,15 @@ npm run worker:logs
 npm run test:context
 ```
 
+#### 6. CMEM Pro / sync
+
+```bash
+curl -s "http://127.0.0.1:${CLAUDE_MEM_WORKER_PORT}/api/health"
+curl -s "http://127.0.0.1:${CLAUDE_MEM_WORKER_PORT}/api/sync/status"
+```
+
+See [CMEM Pro (manual / headless)](/cmem-pro-headless).
+
 ## Upgrading
 
 Upgrades are automatic when updating via the plugin marketplace. After an external upgrade (for example `claude plugin update`), the Setup hook detects a version-marker mismatch and asks you to run `npx claude-mem repair`, which installs any missing runtime dependencies and refreshes the marker.
@@ -134,5 +139,6 @@ See [CHANGELOG](https://github.com/thedotmack/claude-mem/blob/main/CHANGELOG.md)
 ## Next Steps
 
 - [Getting Started Guide](usage/getting-started) - Learn how Claude-Mem works automatically
+- [CMEM Pro (manual / headless)](/cmem-pro-headless) - Exact settings.json keys and headless setup
 - [MCP Search Tools](usage/search-tools) - Query your project history
 - [Configuration](configuration) - Customize Claude-Mem behavior


### PR DESCRIPTION
## Summary
- New page [CMEM Pro (manual / headless)](docs/public/cmem-pro-headless.mdx): exact `settings.json` keys the installer stages then activates (sync trio + OpenRouter pointed at `https://cmem.ai/api/inference/v1` with model `cmem-observer`). Placeholders only.
- Verify with `/api/health` and `/api/sync/status`. Fallback is event-driven (`CLAUDE_MEM_PRO_FALLBACK_AT`), not `trial.ends_at`.
- Fix [installation.mdx](docs/public/installation.mdx): three-stage flow is runtime → **device-code OAuth** (no email in the CLI) → provider. **CMEM Pro is pre-selected.** `--provider claude` skips cmem.ai. Personal OpenRouter keys must not be sent to the cmem gateway.
- Nav: Hosted Server group.

Does **not** document Grok Bot / Cursor store plugins or `--ide grok-bot` (those stay on #3843 until #3842 merges).

## Test plan
- [ ] Mintlify preview: `/cmem-pro-headless` renders, nav shows it, Installation links work
- [ ] Example JSON uses only placeholders (`cm_pro_YOUR_…`)
- [ ] No personal `sk-or-` key pointed at `cmem.ai/api/inference`
- [ ] Copy matches installer: device code, CMEM Pro pre-selected, event-driven fallback
