### PR TITLE
docs: Cursor install is npx, not git clone

### DIFF
--- a/docs/public/cursor/gemini-setup.mdx
+++ b/docs/public/cursor/gemini-setup.mdx
@@ -1,69 +1,31 @@
 ---
 title: "Cursor + Gemini Setup"
-description: "Use Claude-Mem in Cursor with Google's Gemini API"
+description: "Use Claude-Mem in Cursor with your Gemini API key"
 ---
 
 # Cursor + Gemini Setup
 
-This guide walks you through setting up Claude-Mem in Cursor using Google's Gemini API. Memory runs off-plan on your Gemini key; rate limits depend on the selected model and your Google Cloud project's billing status.
+Use your Google Gemini key so memory notes run off-plan (they do not spend your Claude subscription). You do **not** clone the repo.
 
-<Info>
-**No billing required:** You can create a Gemini API key without enabling billing. Projects without billing use Google's model-specific rate limits.
-</Info>
+## Install
 
-## Step 1: Get a Gemini API Key
-
-1. Go to [Google AI Studio](https://aistudio.google.com/apikey)
-2. Sign in with your Google account
-3. Accept the Terms of Service
-4. Click **Create API key**
-5. Choose or create a Google Cloud project
-6. Copy your API key - you'll need it in Step 3
-
-<Tip>
-**Higher rate limits:** Enabling billing on your Google Cloud project can increase the available RPM. Review Google's current quota and billing terms before doing so.
-</Tip>
-
-## Step 2: Clone and Build Claude-Mem
+1. Get a key at [Google AI Studio](https://aistudio.google.com/apikey).
+2. Run:
 
 ```bash
-# Clone the repository
-git clone https://github.com/thedotmack/claude-mem.git
-cd claude-mem
-
-# Install dependencies
-bun install
-
-# Build the project
-bun run build
+npx claude-mem install
 ```
 
-## Step 3: Configure Gemini Provider
+Pick **Cursor**, then pick **Gemini** as the memory provider and paste the key.
 
-### Option A: Interactive Setup (Recommended)
+<Warning>
+`npm install -g claude-mem` is the library only. Always install with `npx claude-mem install`.
+</Warning>
 
-Run the setup wizard which guides you through everything:
-
-```bash
-bun run cursor:setup
-```
-
-The wizard will:
-1. Detect you don't have Claude Code
-2. Ask you to choose Gemini as your provider
-3. Prompt for your API key
-4. Install hooks automatically
-5. Start the worker
-
-### Option B: Manual Configuration
-
-Create the settings file manually:
+### Settings by hand (optional)
 
 ```bash
-# Create settings directory
 mkdir -p ~/.claude-mem
-
-# Create settings file with Gemini configuration
 cat > ~/.claude-mem/settings.json << 'EOF'
 {
   "CLAUDE_MEM_PROVIDER": "gemini",
@@ -72,42 +34,26 @@ cat > ~/.claude-mem/settings.json << 'EOF'
 EOF
 ```
 
-Replace `YOUR_GEMINI_API_KEY` with your actual API key.
+Then re-run `npx claude-mem install` so Cursor hooks and the worker are in place. Do not restart a healthy worker.
 
-Then install hooks and start the worker:
+## Restart Cursor
 
-```bash
-bun run cursor:install
-bun run worker:start
-```
+Close and reopen Cursor so hooks load.
 
-## Step 4: Restart Cursor
+## Verify
 
-Close and reopen Cursor IDE for the hooks to take effect.
+Health: `curl -s "http://127.0.0.1:${CLAUDE_MEM_WORKER_PORT}/api/health"` (port also in `~/.claude-mem/.worker.port`). Open the worker URL from install to see notes.
 
-## Step 5: Verify Installation
+## Models
 
-```bash
-# Check worker is running
-bun run worker:status
+| Model | Notes |
+|-------|-------|
+| `gemini-flash-latest` | **Default.** Current GA Flash |
+| `gemini-flash-lite-latest` | Current GA Flash-Lite |
+| `gemini-3.5-flash` | Pinned GA Flash |
+| `gemini-3.1-flash-lite` | Pinned GA Flash-Lite |
 
-# Check hooks are installed
-bun run cursor:status
-```
-
-Open the worker URL printed on startup to see the memory viewer.
-
-## Available Gemini Models
-
-| Model | RPM without billing | Notes |
-|-------|---------------------|-------|
-| `gemini-flash-latest` | 10 (1,000 with billing) | **Default.** Google alias tracking the current GA Flash model |
-| `gemini-flash-lite-latest` | 15 (4,000 with billing) | Google alias tracking the current GA Flash-Lite model |
-| `gemini-3.5-flash` | 10 (1,000 with billing) | Pinned GA Flash model |
-| `gemini-3.1-flash-lite` | 15 (4,000 with billing) | Pinned GA Flash-Lite model |
-| `gemini-3-flash-preview` | 5 (1,000 with billing) | Preview model |
-
-To change the model, update your settings:
+To pin a model:
 
 ```json
 {
@@ -117,15 +63,7 @@ To change the model, update your settings:
 }
 ```
 
-## Rate Limiting
-
-Claude-mem automatically handles rate limiting for keys without billing enabled:
-
-- Requests are spaced to stay within limits
-- Processing may be slightly slower but stays within quota
-- Provider errors leave observations pending for retry
-
-**To use billing-enabled limits:** Enable billing on your Google Cloud project, then add to settings:
+Rate limits depend on the model and whether billing is on in Google Cloud. Claude-mem spaces requests when billing is off. To turn off that extra throttle after you enable Google billing:
 
 ```json
 {
@@ -133,61 +71,16 @@ Claude-mem automatically handles rate limiting for keys without billing enabled:
 }
 ```
 
-This disables claude-mem's conservative no-billing throttle; Google's provider-side quota still applies.
-
 ## Troubleshooting
 
-### "Gemini API key not configured"
+**Key not configured** — `cat ~/.claude-mem/settings.json` should show `CLAUDE_MEM_PROVIDER` `gemini` and your key.
 
-Ensure your settings file exists and has the correct format:
+**HTTP 429** — wait, enable Google billing, or use [OpenRouter](/cursor/openrouter-setup).
 
-```bash
-cat ~/.claude-mem/settings.json
-```
+**Worker idle** — read `~/.claude-mem/logs/worker-YYYY-MM-DD.log`. Do not restart a healthy worker (the note queue is in memory).
 
-Should output something like:
-```json
-{
-  "CLAUDE_MEM_PROVIDER": "gemini",
-  "CLAUDE_MEM_GEMINI_API_KEY": "AIza..."
-}
-```
+## Next steps
 
-### Rate limit errors (HTTP 429)
-
-You're exceeding the no-billing rate limits. Options:
-1. Wait a few minutes for the rate limit to reset
-2. Enable billing on Google Cloud to unlock higher limits
-3. Switch to OpenRouter for higher volume needs
-
-### API key invalid
-
-1. Verify your key at [Google AI Studio](https://aistudio.google.com/apikey)
-2. Ensure there are no extra spaces or newlines in your settings.json
-3. Try generating a new API key
-
-### Worker not processing observations
-
-Check the worker logs:
-
-```bash
-bun run worker:logs
-```
-
-Look for error messages related to Gemini API calls.
-
-## Switching Providers Later
-
-You can switch between Gemini, OpenRouter, and Claude SDK at any time by updating your settings. No restart required - changes take effect on the next observation.
-
-```json
-{
-  "CLAUDE_MEM_PROVIDER": "openrouter"
-}
-```
-
-## Next Steps
-
-- [Cursor Integration Overview](/cursor/index) - All Cursor features
-- [OpenRouter Setup](/cursor/openrouter-setup) - Alternative provider with 100+ models
-- [Configuration Reference](../configuration) - All settings options
+- [Cursor Integration](/cursor) — default CMEM Pro install
+- [OpenRouter](/cursor/openrouter-setup)
+- [Configuration](/configuration)

--- a/docs/public/cursor/index.mdx
+++ b/docs/public/cursor/index.mdx
@@ -1,180 +1,79 @@
 ---
 title: "Cursor Integration"
-description: "Persistent AI memory for Cursor IDE - memory runs off-plan on the provider of your choice"
+description: "Persistent memory for Cursor — install with npx, no git clone"
 ---
 
 # Cursor Integration
 
-> **Your AI stops forgetting. Give Cursor persistent memory.**
-
-Every Cursor session starts fresh - your AI doesn't remember what it worked on yesterday. Claude-mem changes that. Your agent builds cumulative knowledge about your codebase, decisions, and patterns over time.
+Give Cursor a memory that lasts across chats. The installer wires Cursor hooks (small scripts Cursor runs when a session starts, a file is read, or a tool runs), starts the local worker (the program that stores notes), and uses **CMEM Pro** (the hosted memory service) unless you pick another provider.
 
 <CardGroup cols={2}>
-  <Card title="Runs Off-Plan" icon="dollar-sign">
-    Memory work runs on Gemini or OpenRouter - no Claude subscription required
+  <Card title="One command" icon="terminal">
+    `npx claude-mem install` — do not clone the repo to install.
   </Card>
-  <Card title="Automatic Capture" icon="bolt">
-    MCP tools, shell commands, and file edits logged without effort
+  <Card title="CMEM Pro default" icon="cloud">
+    Memory notes are written off-plan through the hosted service unless you pick Gemini, OpenRouter, or your Anthropic plan.
   </Card>
-  <Card title="Smart Context" icon="brain">
-    Relevant history injected into every chat session
+  <Card title="Cursor hooks" icon="bolt">
+    Cursor has hooks. Grok Bot does not — that host is a [different guide](/grok-bot).
   </Card>
-  <Card title="Works Everywhere" icon="check">
-    With or without Claude Code subscription
+  <Card title="Memory viewer" icon="eye">
+    Open the worker URL printed at install to browse saved notes.
   </Card>
 </CardGroup>
 
-<Info>
-**No Claude Code subscription required.** Use Gemini or OpenRouter as your AI provider — memory runs off-plan on your own key.
-</Info>
-
-## How It Works
-
-Claude-mem integrates with Cursor through native hooks:
-
-1. **Session hooks** capture tool usage, file edits, and shell commands
-2. **AI extraction** compresses observations into semantic summaries
-3. **Context injection** loads relevant history into each new session
-4. **Memory viewer** at the worker URL shows your knowledge base
-
-## Installation Paths
-
-Choose the installation method that fits your setup:
-
-### Path A: Cursor-Only Users (No Claude Code)
-
-If you're using Cursor without a Claude Code subscription:
+## Install
 
 ```bash
-# Clone and build
-git clone https://github.com/thedotmack/claude-mem.git
-cd claude-mem && bun install && bun run build
-
-# Run interactive setup wizard
-bun run cursor:setup
+npx claude-mem install
 ```
 
-The setup wizard will:
-- Detect you don't have Claude Code
-- Help you choose and configure a free AI provider (Gemini recommended)
-- Install hooks automatically
-- Start the worker service
+When the installer lists your apps, pick **Cursor**. The three stages are: install runtime, sign in (device code, no email in the CLI), then pick a memory provider. **CMEM Pro is pre-selected.**
 
-**Detailed guides:**
-- [Gemini Setup](/cursor/gemini-setup) - Recommended free option (1500 req/day)
-- [OpenRouter Setup](/cursor/openrouter-setup) - 100+ models including free options
+Other provider choices: your Gemini key, your OpenRouter key, or your Anthropic plan (`--provider claude`, which skips cmem.ai). Details: [Installation](/installation).
 
-### Path B: Claude Code Users
+<Warning>
+`npm install -g claude-mem` installs the library only. It does **not** register Cursor hooks or start the worker. Always use `npx claude-mem install`.
+</Warning>
 
-If you have Claude Code installed:
+Do not clone this repository to install. Clone is for people changing the code.
 
-```bash
-# Install the plugin (if not already)
-/plugin marketplace add thedotmack/claude-mem
-/plugin install claude-mem
+## How it works
 
-# Install Cursor hooks
-claude-mem cursor install
-```
+1. **Hooks** record what the agent does in Cursor.
+2. **Worker** stores those notes on your machine (default `127.0.0.1`, port in `~/.claude-mem/.worker.port`).
+3. **Next chat** gets relevant past notes.
+4. **Viewer** at the worker URL shows the knowledge base.
 
-The plugin uses Claude's SDK by default but you can switch to Gemini or OpenRouter anytime.
+Never restart a healthy worker. The note queue sits in memory; a restart drops it.
 
-## Prerequisites
+## Gemini or OpenRouter instead of CMEM Pro
 
-<AccordionGroup>
-  <Accordion title="macOS">
-    - [Bun](https://bun.sh): `curl -fsSL https://bun.sh/install | bash`
-    - Cursor IDE
-    - jq and curl: `brew install jq curl`
-  </Accordion>
-  <Accordion title="Linux">
-    - [Bun](https://bun.sh): `curl -fsSL https://bun.sh/install | bash`
-    - Cursor IDE
-    - jq and curl: `apt install jq curl` or `dnf install jq curl`
-  </Accordion>
-  <Accordion title="Windows">
-    - [Bun](https://bun.sh): `powershell -c "irm bun.sh/install.ps1 | iex"`
-    - Cursor IDE
-    - PowerShell 5.1+ (included in Windows 10/11)
-    - Git for Windows
-  </Accordion>
-</AccordionGroup>
+- [Gemini](/cursor/gemini-setup) — your Google key, memory off-plan
+- [OpenRouter](/cursor/openrouter-setup) — your OpenRouter key. **Never** send a personal `sk-or-` key to `https://cmem.ai/api/inference`
 
-## Quick Commands Reference
+## Verify it worked
 
-After installation, these commands are available from the claude-mem directory:
-
-| Command | Description |
-|---------|-------------|
-| `bun run cursor:setup` | Interactive setup wizard |
-| `bun run cursor:install` | Install Cursor hooks |
-| `bun run cursor:uninstall` | Remove Cursor hooks |
-| `bun run cursor:status` | Check hook installation status |
-| `bun run worker:start` | Start the worker service |
-| `bun run worker:stop` | Stop the worker service |
-| `bun run worker:status` | Check worker status |
-
-## Verifying Installation
-
-After setup, verify everything is working:
-
-1. **Check worker status:**
-   ```bash
-   bun run worker:status
-   ```
-
-2. **Check hook installation:**
-   ```bash
-   bun run cursor:status
-   ```
-
-3. **Open the memory viewer:**
-   Open the worker URL in your browser
-
-4. **Restart Cursor** and start a coding session - you should see context being captured
-
-## Provider Comparison
-
-| Provider | Plan Usage | Rate Limit | Best For |
-|----------|------------|------------|----------|
-| Gemini | Off-plan (your Gemini key) | 1500 req/day | Individual use, getting started |
-| OpenRouter | Off-plan (your OpenRouter credit; free models available) | Varies by model | Model variety, high volume |
-| Claude SDK | Shares your Claude plan | Unlimited | Claude Code subscribers |
-
-<Tip>
-**Recommendation:** Start with Gemini — it keeps memory off-plan and handles typical individual usage well. Switch to OpenRouter or Claude SDK if you need higher limits.
-</Tip>
+1. Restart Cursor after install so hooks load.
+2. Health: `curl -s "http://127.0.0.1:${CLAUDE_MEM_WORKER_PORT}/api/health"` (or the port in `~/.claude-mem/.worker.port`).
+3. Do a small unit of work, then open the worker URL. New notes should appear.
 
 ## Troubleshooting
 
-### Worker not starting
+### Nothing is being stored
 
-```bash
-# Check if port is in use
-lsof -i :YOUR_WORKER_PORT
-
-# Force restart
-bun run worker:stop && bun run worker:start
-
-# Check logs
-bun run worker:logs
-```
+- Confirm the worker is up. Do **not** restart it if it is already healthy.
+- Confirm you used `npx claude-mem install`, not a global `npm install`.
+- Restart Cursor once after install.
+- Logs: `~/.claude-mem/logs/worker-YYYY-MM-DD.log`
 
 ### Hooks not firing
 
-1. Restart Cursor IDE after installation
-2. Check hooks are installed: `bun run cursor:status`
-3. Verify hooks.json exists in `.cursor/` directory
+Restart Cursor. Hooks live under `.cursor/` in the project or your user Cursor config after install.
 
-### No context appearing
+## Next steps
 
-1. Ensure worker is running: `bun run worker:status`
-2. Check that you have observations by opening the worker URL
-3. Verify your API key is configured correctly
-
-## Next Steps
-
-- [Gemini Setup Guide](/cursor/gemini-setup) - Detailed off-plan setup with Gemini
-- [OpenRouter Setup Guide](/cursor/openrouter-setup) - Configure OpenRouter
-- [Configuration Reference](../configuration) - All settings options
-- [Troubleshooting](../troubleshooting) - Common issues and solutions
+- [Installation](/installation) — installer stages and CMEM Pro
+- [CMEM Pro (manual / headless)](/cmem-pro-headless) — settings the installer writes
+- [Gemini](/cursor/gemini-setup) / [OpenRouter](/cursor/openrouter-setup)
+- [Search Tools](/usage/search-tools) — query project history

--- a/docs/public/cursor/openrouter-setup.mdx
+++ b/docs/public/cursor/openrouter-setup.mdx
@@ -1,63 +1,35 @@
 ---
 title: "Cursor + OpenRouter Setup"
-description: "Use Claude-Mem in Cursor with OpenRouter's 100+ AI models"
+description: "Use Claude-Mem in Cursor with your OpenRouter key"
 ---
 
 # Cursor + OpenRouter Setup
 
-This guide walks you through setting up Claude-Mem in Cursor using OpenRouter. OpenRouter provides access to 100+ AI models from various providers, including several free options.
+Use your OpenRouter key so memory notes run off-plan on your OpenRouter credit. You do **not** clone the repo.
 
-<Info>
-**Model variety:** Access Claude, GPT-4, Gemini, Llama, Mistral, and many more through a single API key.
-</Info>
+<Warning>
+**Never** send a personal `sk-or-` key to `https://cmem.ai/api/inference`. For your own OpenRouter account, leave the base URL empty (or `https://openrouter.ai/api/v1`). CMEM Pro uses the cmem.ai inference URL with a **CMEM Pro** key, not your OpenRouter key.
+</Warning>
 
-## Step 1: Get an OpenRouter API Key
+## Install
 
-1. Go to [OpenRouter](https://openrouter.ai)
-2. Sign up or sign in
-3. Navigate to [API Keys](https://openrouter.ai/keys)
-4. Click **Create Key**
-5. Copy your API key - you'll need it in Step 3
-
-<Tip>
-**Free models available:** OpenRouter offers free versions of several models including Gemini Flash and others. Check the [model list](https://openrouter.ai/models?show_free=true) for current free options.
-</Tip>
-
-## Step 2: Clone and Build Claude-Mem
+1. Create a key at [OpenRouter API Keys](https://openrouter.ai/keys).
+2. Run:
 
 ```bash
-# Clone the repository
-git clone https://github.com/thedotmack/claude-mem.git
-cd claude-mem
-
-# Install dependencies
-bun install
-
-# Build the project
-bun run build
+npx claude-mem install
 ```
 
-## Step 3: Configure OpenRouter Provider
+Pick **Cursor**, then pick **your OpenRouter key** as the memory provider.
 
-### Option A: Interactive Setup (Recommended)
+<Warning>
+`npm install -g claude-mem` is the library only. Always install with `npx claude-mem install`.
+</Warning>
 
-Run the setup wizard which guides you through everything:
-
-```bash
-bun run cursor:setup
-```
-
-When prompted for provider, select **OpenRouter**.
-
-### Option B: Manual Configuration
-
-Create the settings file manually:
+### Settings by hand (optional)
 
 ```bash
-# Create settings directory
 mkdir -p ~/.claude-mem
-
-# Create settings file with OpenRouter configuration
 cat > ~/.claude-mem/settings.json << 'EOF'
 {
   "CLAUDE_MEM_PROVIDER": "openrouter",
@@ -66,51 +38,19 @@ cat > ~/.claude-mem/settings.json << 'EOF'
 EOF
 ```
 
-Replace `YOUR_OPENROUTER_API_KEY` with your actual API key.
+Leave `CLAUDE_MEM_OPENROUTER_BASE_URL` unset for OpenRouter itself. Then re-run `npx claude-mem install` so Cursor hooks and the worker are in place. Do not restart a healthy worker.
 
-Then install hooks and start the worker:
+## Restart Cursor
 
-```bash
-bun run cursor:install
-bun run worker:start
-```
+Close and reopen Cursor so hooks load.
 
-## Step 4: Restart Cursor
+## Verify
 
-Close and reopen Cursor IDE for the hooks to take effect.
+Health: `curl -s "http://127.0.0.1:${CLAUDE_MEM_WORKER_PORT}/api/health"`. Open the worker URL from install to see notes.
 
-## Step 5: Verify Installation
+## Models
 
-```bash
-# Check worker is running
-bun run worker:status
-
-# Check hooks are installed
-bun run cursor:status
-```
-
-Open the worker URL printed on startup to see the memory viewer.
-
-## Recommended Models
-
-### Free Models
-
-| Model | Provider | Notes |
-|-------|----------|-------|
-| `google/gemini-2.0-flash-exp:free` | Google | Fast, capable |
-| `xiaomi/mimo-v2-flash:free` | Xiaomi | Good general purpose |
-
-### Paid Models
-
-Paid models draw on your OpenRouter credit — memory stays off-plan either way.
-
-| Model | Notes |
-|-------|-------|
-| `anthropic/claude-3-haiku` | Fast, efficient |
-| `google/gemini-flash-1.5` | Fast, strong quality |
-| `mistralai/mistral-7b-instruct` | Lightweight option |
-
-To specify a model, add to your settings:
+Set `CLAUDE_MEM_OPENROUTER_MODEL` if you do not want the default. Free model ids on OpenRouter often end in `:free` — check the [model list](https://openrouter.ai/models?show_free=true).
 
 ```json
 {
@@ -120,13 +60,9 @@ To specify a model, add to your settings:
 }
 ```
 
-## Custom OpenAI-Compatible Endpoints
+## Other OpenAI-shaped servers
 
-The OpenRouter provider is a generic OpenAI-compatible client. Set `CLAUDE_MEM_OPENROUTER_BASE_URL` to point it at any endpoint that speaks the OpenAI `/chat/completions` API — DeepSeek, a local LM Studio server, or any custom gateway. The model id you set in `CLAUDE_MEM_OPENROUTER_MODEL` is sent verbatim.
-
-<Info>
-**Base URL resolution:** When `CLAUDE_MEM_OPENROUTER_BASE_URL` is empty (default), requests go to OpenRouter unchanged. When set, claude-mem POSTs to `<base_url>/chat/completions` — you can supply either a base like `https://api.deepseek.com/v1` (the `/chat/completions` path is appended automatically) or a full `.../chat/completions` URL (used verbatim). Trailing slashes are normalized. The environment variable `OPENROUTER_BASE_URL` is honored as a fallback.
-</Info>
+The OpenRouter provider is a generic OpenAI-compatible client. Set `CLAUDE_MEM_OPENROUTER_BASE_URL` to DeepSeek, LM Studio, or any gateway that speaks `/chat/completions`. The model id is sent as-is.
 
 ### DeepSeek
 
@@ -139,9 +75,7 @@ The OpenRouter provider is a generic OpenAI-compatible client. Set `CLAUDE_MEM_O
 }
 ```
 
-### LM Studio (local model)
-
-LM Studio exposes an OpenAI-compatible server. No API key is required for local use, and you can use any model id you have loaded.
+### LM Studio (local)
 
 ```json
 {
@@ -151,87 +85,16 @@ LM Studio exposes an OpenAI-compatible server. No API key is required for local 
 }
 ```
 
-### Generic custom endpoint
-
-Any OpenAI-compatible gateway works the same way:
-
-```json
-{
-  "CLAUDE_MEM_PROVIDER": "openrouter",
-  "CLAUDE_MEM_OPENROUTER_BASE_URL": "https://my-gateway.example.com/v1",
-  "CLAUDE_MEM_OPENROUTER_MODEL": "model-id",
-  "CLAUDE_MEM_OPENROUTER_API_KEY": "YOUR_KEY"
-}
-```
-
-## Cost Management
-
-OpenRouter charges per token. To manage costs:
-
-1. **Use free models:** Several high-quality free models are available
-2. **Monitor usage:** Check your [OpenRouter dashboard](https://openrouter.ai/activity)
-3. **Set spending limits:** Configure limits in OpenRouter settings
-
-<Warning>
-**Credit awareness:** OpenRouter paid models draw on your OpenRouter credit per request. Monitor your usage if using paid models.
-</Warning>
-
 ## Troubleshooting
 
-### "OpenRouter API key not configured"
+**Key not configured** — `cat ~/.claude-mem/settings.json` should show provider `openrouter` and your key.
 
-Ensure your settings file exists with the correct format:
+**Model not found** — check the id at [OpenRouter Models](https://openrouter.ai/models).
 
-```bash
-cat ~/.claude-mem/settings.json
-```
+**Worker idle** — read `~/.claude-mem/logs/worker-YYYY-MM-DD.log`. Do not restart a healthy worker.
 
-Should output something like:
-```json
-{
-  "CLAUDE_MEM_PROVIDER": "openrouter",
-  "CLAUDE_MEM_OPENROUTER_API_KEY": "sk-or-..."
-}
-```
+## Next steps
 
-### Model not found
-
-1. Check the model ID is correct at [OpenRouter Models](https://openrouter.ai/models)
-2. Some models may require payment - check if you have credits
-3. Free models have `:free` suffix in their ID
-
-### Rate limits
-
-OpenRouter rate limits vary by model and your account tier. If you hit limits:
-1. Wait briefly and retry
-2. Consider upgrading your OpenRouter account tier
-3. Switch to a less popular model
-
-### API errors
-
-Check the worker logs for details:
-
-```bash
-bun run worker:logs
-```
-
-Common issues:
-- Invalid API key (regenerate at OpenRouter)
-- Insufficient credits for paid models
-- Model temporarily unavailable
-
-## Switching Providers Later
-
-You can switch between OpenRouter, Gemini, and Claude SDK at any time by updating your settings. No restart required - changes take effect on the next observation.
-
-```json
-{
-  "CLAUDE_MEM_PROVIDER": "gemini"
-}
-```
-
-## Next Steps
-
-- [Cursor Integration Overview](/cursor/index) - All Cursor features
-- [Gemini Setup](/cursor/gemini-setup) - Alternative free provider
-- [Configuration Reference](../configuration) - All settings options
+- [Cursor Integration](/cursor) — default CMEM Pro install
+- [Gemini](/cursor/gemini-setup)
+- [Configuration](/configuration)


### PR DESCRIPTION
## Summary
The public Cursor pages still told people to `git clone` and `bun run cursor:setup`. That is the old path.

- Default install is now `npx claude-mem install` (pick Cursor). CMEM Pro is the default memory provider.
- Gemini / OpenRouter pages keep the key-setup detail, drop the clone wizard.
- Does **not** document `--ide cursor` — that flag waits on #3842 / npm.
- Tells people not to restart a healthy worker.
- Warns not to send a personal `sk-or-` key to cmem.ai inference.

Docs-only. Does not block Harry on #3842.

## Test plan
- [ ] Cursor overview, Gemini, and OpenRouter pages no longer mention clone / `bun run cursor:setup`
- [ ] Install command is `npx claude-mem install`
- [ ] No `--ide cursor` or `--ide grok-bot` claimed as on current npm
