### PR TITLE
chore: bump version to 13.24.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "claude-mem",
-      "version": "13.23.1",
+      "version": "13.24.0",
       "source": "./plugin",
       "description": "Persistent memory system for Claude Code - context compression across sessions"
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.23.1",
+  "version": "13.24.0",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "author": {
     "name": "Alex Newman"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.23.1",
+  "version": "13.24.0",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "author": {
     "name": "Alex Newman",

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.23.1",
+  "version": "13.24.0",
   "description": "Persistent memory for coding agents. Cursor and Grok Bot install independently; worker and observer can be local or remote.",
   "homepage": "https://github.com/thedotmack/claude-mem",
   "skills": "./claude-mem-grok-bot/skills/",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,46 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [13.24.0] - 2026-09-03
+
+## Independent Cursor and Grok Bot marketplace plugins
+
+### Ship claude-mem as two store plugins plus a host-observer install path (#3842)
+
+claude-mem now installs as two independent Cursor marketplace plugins — `claude-mem-cursor` and `claude-mem-grok-bot` — instead of one glued listing. Each host can be installed alone. Grok Bot does not require Cursor hooks, the Claude CLI, or an xAI API key.
+
+**Install matrix**
+
+- `npx claude-mem install --ide cursor`
+- `npx claude-mem install --ide grok-bot`
+- both flags together is optional
+
+**Observer**
+
+- `--provider host` uses a local OpenAI-compat loopback so the already-logged-in host agent writes observations. No API key. Alias of OpenRouter + loopback URL + dummy key + host model.
+- `--provider openrouter` remains the remote path (cmem.ai inference or any OpenAI-compat URL)
+- Claude and Gemini providers stay
+
+**Worker**
+
+- Default stays local. Existing `--runtime server --server-url` still points at a remote worker.
+- The host-observer shim never binds the worker port. If 37777 is taken, the shim uses 37778 (or `CLAUDE_MEM_HOST_OBSERVER_PORT`). A healthy worker is not restarted.
+
+**Ingest**
+
+- Cursor: existing `hook cursor` events with `platformSource=cursor`
+- Grok Bot: no hooks. Transcript watcher on `agent-transcripts/*/*.jsonl` with `platformSource=grok-bot`
+- `POST /api/memory/save` honors `metadata.platformSource`
+
+**CLI**
+
+- `npx claude-mem mcp` stdio entry
+- `npx claude-mem hook cursor`
+
+Docs: `docs/store-plugins.md` install matrix and public Mintlify page `docs/public/grok-bot/index.mdx`. Plugin ids locked: `claude-mem-cursor`, `claude-mem-grok-bot`.
+
+**Full Changelog**: https://github.com/thedotmack/claude-mem/compare/v13.23.1...v13.24.0
+
 ## [13.23.1] - 2026-09-01
 
 ## Fix: the quota guard and `usage_limit_hit` never fired

--- a/claude-mem-cursor/.cursor-plugin/plugin.json
+++ b/claude-mem-cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem-cursor",
-  "version": "13.23.1",
+  "version": "13.24.0",
   "description": "Persistent memory for Cursor. Hooks ingest tool use; MCP searches past sessions. Works with a local worker or a remote cmem.ai worker, and a local host-login observer or remote inference.",
   "author": { "name": "Alex Newman" },
   "homepage": "https://github.com/thedotmack/claude-mem",

--- a/claude-mem-grok-bot/.cursor-plugin/plugin.json
+++ b/claude-mem-grok-bot/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem-grok-bot",
-  "version": "13.23.1",
+  "version": "13.24.0",
   "description": "Persistent memory for Grok Bot. No host hooks: transcript watcher plus MCP. Local worker with host-login observer, or remote cmem.ai. Install without Cursor.",
   "author": { "name": "Alex Newman" },
   "homepage": "https://github.com/thedotmack/claude-mem",

--- a/openclaw/openclaw.plugin.json
+++ b/openclaw/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "name": "Claude-Mem (Persistent Memory)",
   "description": "OpenClaw plugin for Claude-Mem. Records observations from embedded runner sessions and streams them to messaging channels.",
   "kind": "memory",
-  "version": "13.23.1",
+  "version": "13.24.0",
   "license": "Apache-2.0",
   "author": "thedotmack",
   "homepage": "https://claude-mem.ai",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.23.1",
+  "version": "13.24.0",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "keywords": [
     "claude",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.23.1",
+  "version": "13.24.0",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "author": {
     "name": "Alex Newman"

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.23.1",
+  "version": "13.24.0",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "author": {
     "name": "Alex Newman",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem-plugin",
-  "version": "13.23.1",
+  "version": "13.24.0",
   "private": true,
   "description": "Runtime dependencies for claude-mem bundled hooks",
   "type": "module",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Catch GitHub up to the already-published npm **13.24.0**. This is a version-file + changelog sync only.

## Why

`claude-mem@13.24.0` is already live on npm. GitHub was still on 13.23.1: no `v13.24.0` tag, latest GitHub release still `v13.23.1`, and every version manifest on `main` still said 13.23.1.

This PR does **not** publish to npm and does **not** bump past 13.24.0.

## Changes

- Bump every version manifest to `13.24.0`:
  - `package.json`
  - `plugin/package.json`
  - `.claude-plugin/marketplace.json`
  - `.claude-plugin/plugin.json`
  - `.codex-plugin/plugin.json`
  - `plugin/.claude-plugin/plugin.json`
  - `plugin/.codex-plugin/plugin.json`
  - `.grok-plugin/plugin.json`
  - `claude-mem-cursor/.cursor-plugin/plugin.json`
  - `claude-mem-grok-bot/.cursor-plugin/plugin.json`
  - `openclaw/openclaw.plugin.json`
- Add `CHANGELOG.md` section for 13.24.0 covering PR #3842 (squash `1c7aaff` already on main)
- Merged latest `main` (`5237b3a` docs: Cursor install is npx, not git clone) so this is a fast-forwardable merge

## After merge

Create git tag `v13.24.0` and GitHub release `v13.24.0` with the changelog notes. Do not run `npm publish` / `np` / `npm run release:*`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e6cdd24-34bc-46ff-81e7-41a8d4523abb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e6cdd24-34bc-46ff-81e7-41a8d4523abb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

