### PR TITLE
docs: Grok mem README and install for Grok Bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,13 @@
   <a href="docs/i18n/README.no.md">🇳🇴 Norsk</a>
 </p>
 
-<h4 align="center">Persistent memory compression system built for <a href="https://claude.com/claude-code" target="_blank">Claude Code</a>.</h4>
+<h4 align="center"><a href="https://grok-mem.ai">Grok Mem</a> is how Grok Bots remember. Sits next to Grok's own memory. Does not replace it.</h4>
+
+<p align="center">
+  <a href="https://grok-mem.ai">
+    <img src="https://img.shields.io/badge/Grok%20mem-1A1A1A?style=for-the-badge" alt="Grok mem">
+  </a>
+</p>
 
 <p align="center">
   <a href="LICENSE">
@@ -123,12 +129,20 @@
 </p>
 
 <p align="center">
-  Claude-Mem seamlessly preserves context across sessions by automatically capturing tool usage observations, generating semantic summaries, and making them available to future sessions. This enables Claude to maintain continuity of knowledge about projects even after sessions end or reconnect.
+  <a href="https://grok-mem.ai">Grok Mem</a> is how Grok Bots remember the work. Grok already remembers you. Grok Mem remembers what the bot did, what we decided, what to do next. Those notes come back in the next chat.
 </p>
 
 ---
 
 ## Quick Start
+
+Install [Grok Mem](https://grok-mem.ai) for Grok Bot:
+
+```bash
+npx claude-mem install --ide grok-bot
+```
+
+Grok Bot has no host hooks, so we watch the chat log files. Default is CMEM Pro, the hosted memory. Local observer is opt-in: `--provider host`. Installing this plugin does not install Cursor.
 
 Install with a single command:
 

--- a/docs/public/installation.mdx
+++ b/docs/public/installation.mdx
@@ -5,9 +5,21 @@ description: "Install Claude-Mem plugin for persistent memory across sessions"
 
 # Installation Guide
 
+**[Grok mem](https://grok-mem.ai)** — Grok Mem is how Grok Bots remember. Sits next to Grok's own memory. Does not replace it.
+
 ## Quick Start
 
-### Option 1: npx (Recommended)
+### Option 1: Grok Bot
+
+Grok Bot has no host hooks. Install it independently of Cursor or Claude Code. Default is CMEM Pro, the hosted memory:
+
+```bash
+npx claude-mem install --ide grok-bot
+```
+
+Local host-login observer is opt-in: `--provider host`. `--ide` is a single string — a second host is a second install command. Installing this plugin does not install Cursor. See [Grok Bot Integration](/grok-bot).
+
+### Option 2: npx
 
 Install and configure Claude-Mem with a single command:
 
@@ -35,7 +47,7 @@ Headless or already signed in? See [CMEM Pro (manual / headless)](/cmem-pro-head
 
 `--provider claude` never touches cmem.ai and skips OAuth. You can finish a CMEM Pro pairing anytime by re-running `npx claude-mem install`, or by writing settings by hand ([manual / headless](/cmem-pro-headless)).
 
-### Option 2: Plugin Marketplace
+### Option 3: Plugin Marketplace
 
 Install Claude-Mem directly from the plugin marketplace inside Claude Code:
 
@@ -49,16 +61,6 @@ Both methods will automatically configure hooks and start the worker service. St
 > **Important:** Claude-Mem is published on npm, but running `npm install -g claude-mem` installs the
 > **SDK/library only**. It does **not** register plugin hooks or start the worker service.
 > Always install via `npx claude-mem install` or the `/plugin` commands above.
-
-### Grok Bot
-
-Grok Bot has no host hooks. Install it independently of Cursor or Claude Code. Default observer is CMEM Pro:
-
-```bash
-npx claude-mem install --ide grok-bot
-```
-
-Local host-login observer is opt-in: `--provider host`. `--ide` is a single string — a second host is a second install command. See [Grok Bot Integration](/grok-bot). This host ships in claude-mem **13.24** ([PR #3842](https://github.com/thedotmack/claude-mem/pull/3842)).
 
 ## System Requirements
 


### PR DESCRIPTION
Show page for tonight. Live URL grok-mem.ai. Stickers say Grok mem. Does not claim a version past 13.23.1. Install does not have to work.

Grok Mem is how Grok Bots remember. Sits next to Grok's own memory. Does not replace it.