### PR TITLE
docs: Grok Mem README and install

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
   <a href="docs/i18n/README.no.md">🇳🇴 Norsk</a>
 </p>
 
-<h4 align="center">Persistent memory compression system built for <a href="https://claude.com/claude-code" target="_blank">Claude Code</a>.</h4>
+<h4 align="center"><a href="https://www.npmjs.com/package/claude-mem">Grok Mem</a> — persistent memory for Grok Bot. Sits next to Grok's own memory. Does not replace it.</h4>
 
 <p align="center">
   <a href="LICENSE">
@@ -62,6 +62,9 @@
   </a>
   <a href="https://github.com/thedotmack/awesome-claude-code">
     <img src="https://awesome.re/mentioned-badge.svg" alt="Mentioned in Awesome Claude Code">
+  </a>
+  <a href="https://www.npmjs.com/package/claude-mem">
+    <img src="https://img.shields.io/badge/Grok-mem-111111?style=for-the-badge" alt="Grok mem">
   </a>
 </p>
 
@@ -123,14 +126,22 @@
 </p>
 
 <p align="center">
-  Claude-Mem seamlessly preserves context across sessions by automatically capturing tool usage observations, generating semantic summaries, and making them available to future sessions. This enables Claude to maintain continuity of knowledge about projects even after sessions end or reconnect.
+  Grok Mem is how Grok Bots remember the work. Grok already remembers you. Grok Mem remembers what the bot did, what we decided, what to do next. Those notes come back in the next chat. It sits next to Grok's own memory. It does not replace it. The package is still <a href="https://www.npmjs.com/package/claude-mem">claude-mem</a>. Site: <a href="https://grok-mem.vercel.app">grok-mem.vercel.app</a>.
 </p>
 
 ---
 
 ## Quick Start
 
-Install with a single command:
+**Grok Mem** for Grok Bot. The package name is still `claude-mem`. Handout: [npmjs.com/package/claude-mem](https://www.npmjs.com/package/claude-mem). Site: [grok-mem.vercel.app](https://grok-mem.vercel.app).
+
+```bash
+npx claude-mem install --ide grok-bot
+```
+
+Grok Bot has no host hooks, so we watch the chat log files. Default is CMEM Pro, the hosted memory. Local observer is opt-in: `--provider host`. Installing this plugin does not install Cursor.
+
+Or install with a single command:
 
 ```bash
 npx claude-mem install

--- a/docs/public/installation.mdx
+++ b/docs/public/installation.mdx
@@ -1,11 +1,23 @@
 ---
 title: "Installation"
-description: "Install Claude-Mem plugin for persistent memory across sessions"
+description: "Grok Mem install. Package name is still claude-mem."
 ---
 
 # Installation Guide
 
+**Grok Mem.** Persistent memory for Grok Bot. Sits next to Grok's own memory. It does not replace it. The package name is still `claude-mem`. Handout: [npmjs.com/package/claude-mem](https://www.npmjs.com/package/claude-mem). Site: [grok-mem.vercel.app](https://grok-mem.vercel.app).
+
 ## Quick Start
+
+### Grok Bot
+
+Grok Bot has no host hooks. We watch the chat log files. Install it independently of Cursor or Claude Code. Default memory is CMEM Pro, the hosted memory.
+
+```bash
+npx claude-mem install --ide grok-bot
+```
+
+Local host-login observer is opt-in: `--provider host`. `--ide` is a single string — a second host is a second install command. Installing this plugin does not install Cursor. See [Grok Bot Integration](/grok-bot).
 
 ### Option 1: npx (Recommended)
 
@@ -49,16 +61,6 @@ Both methods will automatically configure hooks and start the worker service. St
 > **Important:** Claude-Mem is published on npm, but running `npm install -g claude-mem` installs the
 > **SDK/library only**. It does **not** register plugin hooks or start the worker service.
 > Always install via `npx claude-mem install` or the `/plugin` commands above.
-
-### Grok Bot
-
-Grok Bot has no host hooks. Install it independently of Cursor or Claude Code. Default observer is CMEM Pro:
-
-```bash
-npx claude-mem install --ide grok-bot
-```
-
-Local host-login observer is opt-in: `--provider host`. `--ide` is a single string — a second host is a second install command. See [Grok Bot Integration](/grok-bot). This host ships in claude-mem **13.24** ([PR #3842](https://github.com/thedotmack/claude-mem/pull/3842)).
 
 ## System Requirements
 


### PR DESCRIPTION
Product is Grok Mem. Package stays claude-mem. Stickers say Grok mem. Working handouts: https://grok-mem.vercel.app and https://www.npmjs.com/package/claude-mem. Do not link grok-bot.ai as live. Install does not have to work.