### PR TITLE
docs: add npm claude-mem package handout

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@
 
 ## Quick Start
 
-Install [Grok Mem](https://grok-mem.ai) for Grok Bot:
+Install [Grok Mem](https://grok-mem.ai) for Grok Bot. The package name is still [`claude-mem`](https://www.npmjs.com/package/claude-mem).
 
 ```bash
 npx claude-mem install --ide grok-bot

--- a/docs/public/installation.mdx
+++ b/docs/public/installation.mdx
@@ -5,7 +5,7 @@ description: "Install Claude-Mem plugin for persistent memory across sessions"
 
 # Installation Guide
 
-**[Grok mem](https://grok-mem.ai)** — Grok Mem is how Grok Bots remember. Sits next to Grok's own memory. Does not replace it.
+**[Grok mem](https://grok-mem.ai)** — Grok Mem is how Grok Bots remember. Sits next to Grok's own memory. Does not replace it. The package name is still [`claude-mem`](https://www.npmjs.com/package/claude-mem).
 
 ## Quick Start
 


### PR DESCRIPTION
Surgical public-docs fix. Site URL stays https://grok-mem.ai. Working handout is the npm package https://www.npmjs.com/package/claude-mem. Product is Grok Mem; package name remains claude-mem.

- README Quick Start: add the npm package handout next to the Grok Mem install line
- docs/public/installation.mdx banner: same npm handout

Does not add vercel.app. Does not add grok-bot.ai as a live site URL. Does not bump the version badge.