### PR TITLE
fix(openrouter): bound the observer context and anchor the schema in a system message (#3606)

### DIFF
--- a/src/services/worker-types.ts
+++ b/src/services/worker-types.ts
@@ -25,14 +25,16 @@ export interface ActiveSession {
   currentProvider: 'claude' | 'gemini' | 'openrouter' | null;
   consecutiveRestarts: number;
   /**
-   * Legacy invalid-output counter, intentionally always 0: ordinary non-XML
-   * observer output is confirmed as a no-op and resets this so benign skip
-   * acknowledgements never accumulate respawn debt.
+   * Real invalid-output counter (#3606): incremented on a dropped batch
+   * (non-XML output that is not a designed empty skip), reset to 0 on a
+   * valid parse or a designed empty skip (idle output with a non-'length'
+   * finish reason — the prompt allows an empty reply to signal "nothing to
+   * report").
    *
    * It is deliberately NOT the breaker for repeated hard rejections — counting
-   * skips and rejections on one counter is what produced the respawn storm this
-   * reset was added to stop. Hard rejections are counted by
-   * `consecutiveContextOverflows` instead.
+   * skips and rejections on one counter is what produced the respawn storm the
+   * write-only reset this replaces was added to stop. Hard rejections are
+   * counted by `consecutiveContextOverflows` instead.
    */
   consecutiveInvalidOutputs: number;
   /**
@@ -82,6 +84,8 @@ export interface ActiveSession {
   pendingCompressionEvent?: Record<string, unknown> | null;
   /** Cumulative total_cost_usd from the SDK's latest result message — per-compression cost is the delta between results. */
   lastResultTotalCostUsd?: number | null;
+  /** finish_reason from the latest OpenAI-compatible provider response — 'length' flags a truncated (not just empty/prose) observer output (#3606). */
+  lastFinishReason?: string | null;
 }
 
 export interface PendingMessage {

--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -38,6 +38,8 @@ export interface ProviderQueryResult {
   costUsd?: number;
   /** The model that actually served the request, when reported. */
   servedModel?: string;
+  /** finish_reason from the provider response, when reported — 'length' flags a truncated (not just empty/prose) output (#3606). */
+  finishReason?: string;
 }
 
 /**
@@ -216,6 +218,7 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
       session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
       session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
       session.lastUsage = this.buildLastUsage(initResponse);
+      session.lastFinishReason = initResponse.finishReason ?? null;
       await processAgentResponse(
         initResponse.content, session, this.dbManager, this.sessionManager,
         worker, tokensUsed, null, this.providerName, undefined, initResponse.servedModel ?? model, responseContext
@@ -295,6 +298,7 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     }
 
     if (obsResponse.content || this.forwardEmptyMessageResponse) {
+      session.lastFinishReason = obsResponse.finishReason ?? null;
       await processAgentResponse(
         obsResponse.content || '', session, this.dbManager, this.sessionManager,
         worker, tokensUsed, originalTimestamp, this.providerName, lastCwd, obsResponse.servedModel ?? config.model, responseContext
@@ -351,6 +355,7 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     }
 
     if (summaryResponse.content || this.forwardEmptyMessageResponse) {
+      session.lastFinishReason = summaryResponse.finishReason ?? null;
       await processAgentResponse(
         summaryResponse.content || '', session, this.dbManager, this.sessionManager,
         worker, tokensUsed, originalTimestamp, this.providerName, lastCwd, summaryResponse.servedModel ?? summaryConfig.model, responseContext

--- a/src/services/worker/OpenRouterProvider.ts
+++ b/src/services/worker/OpenRouterProvider.ts
@@ -12,6 +12,7 @@ import { SessionManager } from './SessionManager.js';
 import { ClassifiedProviderError, type ProviderErrorClass } from './provider-errors.js';
 import { withRetry, parseRetryAfterMs } from './retry.js';
 import { OpenAICompatibleProvider, type ProviderQueryResult } from './OpenAICompatibleProvider.js';
+import { buildBoundedMessages, type BoundedMessage } from './context-window.js';
 
 /**
  * OpenAI-compatible client configuration.
@@ -176,11 +177,6 @@ export function classifyOpenRouterError(input: {
 
 const CHARS_PER_TOKEN_ESTIMATE = 4;
 
-interface OpenAIMessage {
-  role: 'user' | 'assistant' | 'system';
-  content: string;
-}
-
 interface OpenRouterResponse {
   /** The model that actually served the request — not the configured string. */
   model?: string;
@@ -214,10 +210,30 @@ export interface OpenRouterConfig {
   apiUrl: string;
   siteUrl?: string;
   appName?: string;
+  /** max_tokens in the request body (#3606/#3490). */
+  maxTokens: number;
+  /** Max history turns sent after the system anchor; 0 = unbounded (#3606). */
+  maxContextMessages: number;
+  /** Max total chars of that windowed history; 0 = unbounded (#3606). */
+  maxContextChars: number;
+  /** withRetry per-attempt timeout for this provider (#3606). */
+  attemptTimeoutMs: number;
 }
 
 function hasProcessEnvOverride(key: string): boolean {
   return Object.prototype.hasOwnProperty.call(process.env, key);
+}
+
+/**
+ * NaN or below `min` (corrupt settings.json / bad env override) falls back to
+ * `fallback` rather than producing an unbounded-by-accident or invalid
+ * request value. `min` is 1 for keys where 0 would be a broken request value
+ * (maxTokens, attemptTimeoutMs) and 0 for keys where 0 is the documented
+ * "unbounded" sentinel (maxContextMessages, maxContextChars).
+ */
+function parseOpenRouterInt(raw: unknown, fallback: number, min: number): number {
+  const parsed = parseInt(String(raw), 10);
+  return Number.isNaN(parsed) || parsed < min ? fallback : parsed;
 }
 
 function normalizeOpenRouterModel(rawModel: unknown): string {
@@ -295,7 +311,22 @@ export function resolveOpenRouterConfig(
   const siteUrl = settings.CLAUDE_MEM_OPENROUTER_SITE_URL || '';
   const appName = settings.CLAUDE_MEM_OPENROUTER_APP_NAME || OPENROUTER_APP_TITLE;
 
-  return { apiKey, model, apiUrl, siteUrl, appName };
+  // #3606 — a corrupt/non-numeric settings value falls back to the shipped
+  // default rather than propagating NaN/negative limits. Fallbacks are the
+  // literal SettingsDefaultsManager DEFAULTS values (parseInt(defaults.X) was
+  // redundant — SettingsDefaultsManager already backfills missing keys before
+  // this code ever runs). maxTokens and attemptTimeoutMs are request-shape/
+  // timing values a 0 would break (an OpenAI-compatible max_tokens: 0 or a
+  // zero-length retry timeout is not a meaningful "unbounded"), so they
+  // require >= 1; maxContextMessages and maxContextChars keep 0 as the
+  // documented "unbounded" sentinel — only a negative value (never a
+  // legitimate setting) falls back there.
+  const maxTokens = parseOpenRouterInt(settings.CLAUDE_MEM_OPENROUTER_MAX_TOKENS, 4096, 1);
+  const maxContextMessages = parseOpenRouterInt(settings.CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES, 40, 0);
+  const maxContextChars = parseOpenRouterInt(settings.CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_CHARS, 200000, 0);
+  const attemptTimeoutMs = parseOpenRouterInt(settings.CLAUDE_MEM_OPENROUTER_ATTEMPT_TIMEOUT_MS, 30000, 1);
+
+  return { apiKey, model, apiUrl, siteUrl, appName, maxTokens, maxContextMessages, maxContextChars, attemptTimeoutMs };
 }
 
 export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfig> {
@@ -341,15 +372,8 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
     };
   }
 
-  private conversationToOpenAIMessages(history: ConversationMessage[]): OpenAIMessage[] {
-    return history.map(msg => ({
-      role: msg.role === 'assistant' ? 'assistant' : 'user',
-      content: msg.content
-    }));
-  }
-
   protected async query(history: ConversationMessage[], config: OpenRouterConfig): Promise<ProviderQueryResult> {
-    return this.queryOpenRouterMultiTurn(history, config.apiKey, config.model, config.apiUrl, config.siteUrl, config.appName);
+    return this.queryOpenRouterMultiTurn(history, config);
   }
 
   /** POST the chat-completions request. Extracted so the retry try block stays narrow. */
@@ -357,13 +381,18 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
     apiUrl: string,
     apiKey: string,
     model: string,
-    messages: OpenAIMessage[],
+    messages: BoundedMessage[],
+    maxTokens: number,
     siteUrl: string | undefined,
     appName: string | undefined,
     priorRequestId: string | null,
     attemptSignal: AbortSignal
   ): Promise<Response> {
-    return fetch(apiUrl, {
+    // `timeout` isn't in the DOM fetch/RequestInit types — Bun's fetch has a
+    // built-in ~300s cap that overrides any AbortSignal-based per-attempt
+    // timeout, so it must be disabled explicitly for withRetry's
+    // perAttemptTimeoutMs to be authoritative (#3606).
+    const requestInit = {
       method: 'POST',
       headers: {
         'Authorization': `Bearer ${apiKey}`,
@@ -375,31 +404,33 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
         model,
         messages,
         temperature: 0.3,  // Lower temperature for structured extraction
-        max_tokens: 4096,
+        max_tokens: maxTokens,
         // Ask openrouter.ai for usage accounting (token counts + cost).
         // Only sent to openrouter.ai — strict custom gateways may reject
         // unknown body fields.
         ...(apiUrl.includes('openrouter.ai') ? { usage: { include: true } } : {}),
       }),
       signal: attemptSignal,
-    });
+      timeout: false,
+    } as unknown as Record<string, unknown>;
+
+    return fetch(apiUrl, requestInit as RequestInit);
   }
 
   private async queryOpenRouterMultiTurn(
     history: ConversationMessage[],
-    apiKey: string,
-    model: string,
-    apiUrl: string,
-    siteUrl?: string,
-    appName?: string
+    config: OpenRouterConfig
   ): Promise<ProviderQueryResult> {
-    const messages = this.conversationToOpenAIMessages(history);
-    const totalChars = history.reduce((sum, m) => sum + m.content.length, 0);
-    const estimatedTokens = this.estimateTokens(history.map(m => m.content).join(''));
+    const { apiKey, model, apiUrl, siteUrl, appName, maxTokens, maxContextMessages, maxContextChars, attemptTimeoutMs } = config;
+
+    const messages = buildBoundedMessages(history, { maxMessages: maxContextMessages, maxChars: maxContextChars });
+    const promptChars = messages.reduce((sum, m) => sum + m.content.length, 0);
+    const estimatedTokens = this.estimateTokens(messages.map(m => m.content).join(''));
 
     logger.debug('SDK', `Querying OpenRouter multi-turn (${model})`, {
       turns: history.length,
-      totalChars,
+      messagesSent: messages.length,
+      promptChars,
       estimatedTokens
     });
 
@@ -408,7 +439,7 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
     const data = await withRetry<OpenRouterResponse>(async (attemptSignal) => {
       let response: Response;
       try {
-        response = await this.fetchChatCompletion(apiUrl, apiKey, model, messages, siteUrl, appName, priorRequestId, attemptSignal);
+        response = await this.fetchChatCompletion(apiUrl, apiKey, model, messages, maxTokens, siteUrl, appName, priorRequestId, attemptSignal);
       } catch (networkError: unknown) {
         const err = networkError instanceof Error ? networkError : new Error(String(networkError));
         throw classifyOpenRouterError({ cause: err });
@@ -446,22 +477,63 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
       }
 
       return responseData;
-    }, { label: `OpenRouter ${model}` });
+    }, { label: `OpenRouter ${model}`, perAttemptTimeoutMs: attemptTimeoutMs });
 
     // A successful cmem-gateway response proves the delivered key is funded
     // again (resubscribed) — clear the trial-expiry fallback marker so
     // dispatch returns to the gateway. No-op for every other endpoint.
     clearProFallbackOnGatewaySuccess(apiUrl);
 
-    if (!data.choices?.[0]?.message?.content) {
-      logger.error('SDK', 'Empty response from OpenRouter');
-      return { content: '' };
-    }
-
-    const content = data.choices[0].message.content;
-    const tokensUsed = data.usage?.total_tokens;
+    const firstChoice = data.choices?.[0];
+    const finishReason = firstChoice?.finish_reason;
     const realInputTokens = data.usage?.prompt_tokens;
     const realOutputTokens = data.usage?.completion_tokens;
+
+    if (!firstChoice?.message?.content) {
+      // Malformed (no choices at all, or a choice with no message) is a
+      // different failure than a designed empty completion (message.content
+      // === '' or undefined with choices present) — the latter is the
+      // prompt's documented way to say "nothing to report"; the former means
+      // the response body doesn't even have the shape the parser expects
+      // (#3606).
+      const malformed = !data.choices || data.choices.length === 0 || !firstChoice?.message;
+      if (malformed) {
+        logger.error('SDK', 'Malformed response from OpenRouter — no choices/message in body', {
+          keys: Object.keys(data),
+          finishReason,
+        });
+        return { content: '', finishReason: 'malformed' };
+      }
+
+      const logFields = {
+        finishReason,
+        promptTokens: realInputTokens,
+        completionTokens: realOutputTokens,
+        messagesSent: messages.length,
+        promptChars,
+      };
+      // A DESIGNED empty completion is exactly: message present, content
+      // empty, finish_reason === 'stop' — the prompt's documented way to say
+      // "nothing to report". 'length' is a real truncation (context/output
+      // budget exhausted) and stays an error. Any OTHER finish_reason
+      // (content_filter, tool_calls, function_call, or absent) is neither —
+      // the model did not reach the designed no-op path, so it must not be
+      // logged (or, downstream in ResponseProcessor, counted) as a benign
+      // skip: warn and hand the real reason to the parser layer (#3606).
+      if (finishReason === 'length') {
+        logger.error('SDK', 'Empty response from OpenRouter — context or output budget exhausted', logFields);
+        return { content: '', finishReason };
+      }
+      if (finishReason === 'stop') {
+        logger.info('SDK', `Empty response from OpenRouter (finish_reason=${finishReason}) — observer skipped the batch`, logFields);
+        return { content: '', finishReason };
+      }
+      logger.warn('SDK', `Empty response from OpenRouter with finish_reason=${finishReason ?? 'missing'} — not a designed skip`, logFields);
+      return { content: '', finishReason: finishReason ?? 'missing' };
+    }
+
+    const content = firstChoice.message.content;
+    const tokensUsed = data.usage?.total_tokens;
     // usage.cost is what openrouter.ai charged in credits (~USD); with BYOK the
     // model spend is reported separately as upstream_inference_cost. Custom
     // gateways usually omit both — costUsd stays undefined (never estimated).
@@ -481,6 +553,9 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
         outputTokens: realOutputTokens || 0,
         totalTokens: tokensUsed,
         ...(costUsd !== undefined ? { costUSD: costUsd.toFixed(6) } : {}),
+        finishReason,
+        messagesSent: messages.length,
+        promptChars,
         messagesInContext: history.length
       });
 
@@ -492,7 +567,7 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
       }
     }
 
-    return { content, tokensUsed, inputTokens: realInputTokens, outputTokens: realOutputTokens, costUsd, servedModel };
+    return { content, tokensUsed, inputTokens: realInputTokens, outputTokens: realOutputTokens, costUsd, servedModel, finishReason };
   }
 
 }

--- a/src/services/worker/OpenRouterProvider.ts
+++ b/src/services/worker/OpenRouterProvider.ts
@@ -225,15 +225,53 @@ function hasProcessEnvOverride(key: string): boolean {
 }
 
 /**
- * NaN or below `min` (corrupt settings.json / bad env override) falls back to
- * `fallback` rather than producing an unbounded-by-accident or invalid
- * request value. `min` is 1 for keys where 0 would be a broken request value
+ * Only a complete decimal integer is accepted: a finite, integral `number`,
+ * or a `string` that — after trimming surrounding whitespace — matches an
+ * optional leading sign followed by one or more digits and nothing else.
+ * `parseInt` was rejected here because it parses a numeric *prefix*, so a
+ * settings/env value like `"1e3"` silently became `1` (parseInt stops at
+ * `e`) instead of the intended 1000, turning a 1000ms timeout into 1ms.
+ * Anything that isn't a fully-numeric value this way — `"42.5"`, `"0x10"`,
+ * `""`, `"abc"`, `NaN`, `Infinity`, objects — falls back to `fallback`, and
+ * so does a value outside `[min, max]` (corrupt settings.json / bad env
+ * override). `min` is 1 for keys where 0 would be a broken request value
  * (maxTokens, attemptTimeoutMs) and 0 for keys where 0 is the documented
  * "unbounded" sentinel (maxContextMessages, maxContextChars).
+ *
+ * `max` closes the same "silently becomes ~1ms" failure at the other end of
+ * the range: an all-digit `string` long enough to overflow `Number()`
+ * (~309+ digits) becomes `Infinity` rather than throwing, and an ordinary
+ * fat-fingered value (e.g. an extra zero on `attemptTimeoutMs`) can still be
+ * a perfectly valid, finite integer that is nonetheless too large for
+ * `setTimeout`, which silently clamps any delay over 2^31-1 ms (~24.8 days)
+ * to fire after ~1ms instead of the intended delay. Both cases must fall
+ * back rather than pass through, so `max` defaults to
+ * `Number.MAX_SAFE_INTEGER` and the caller whose value reaches `setTimeout`
+ * (attemptTimeoutMs) passes the 32-bit signed-int ceiling explicitly.
  */
-function parseOpenRouterInt(raw: unknown, fallback: number, min: number): number {
-  const parsed = parseInt(String(raw), 10);
-  return Number.isNaN(parsed) || parsed < min ? fallback : parsed;
+const DECIMAL_INTEGER_PATTERN = /^[+-]?\d+$/;
+
+/** Node's `setTimeout` treats any delay above this (2^31 - 1) as invalid and
+ *  fires almost immediately instead (with a TimeoutOverflowWarning) — see the
+ *  `max` note on {@link parseOpenRouterInt}. */
+const SETTIMEOUT_MAX_MS = 2_147_483_647;
+
+export function parseOpenRouterInt(
+  raw: unknown,
+  fallback: number,
+  min: number,
+  max: number = Number.MAX_SAFE_INTEGER,
+): number {
+  let parsed: number;
+  if (typeof raw === 'number') {
+    if (!Number.isFinite(raw) || !Number.isInteger(raw)) return fallback;
+    parsed = raw;
+  } else if (typeof raw === 'string' && DECIMAL_INTEGER_PATTERN.test(raw.trim())) {
+    parsed = Number(raw.trim());
+  } else {
+    return fallback;
+  }
+  return !Number.isFinite(parsed) || parsed < min || parsed > max ? fallback : parsed;
 }
 
 function normalizeOpenRouterModel(rawModel: unknown): string {
@@ -320,11 +358,19 @@ export function resolveOpenRouterConfig(
   // zero-length retry timeout is not a meaningful "unbounded"), so they
   // require >= 1; maxContextMessages and maxContextChars keep 0 as the
   // documented "unbounded" sentinel — only a negative value (never a
-  // legitimate setting) falls back there.
+  // legitimate setting) falls back there. attemptTimeoutMs additionally caps
+  // at SETTIMEOUT_MAX_MS because it is handed to `setTimeout` (see retry.ts)
+  // — anything larger silently fires after ~1ms instead of the intended
+  // delay, the same failure mode this whole guard exists to prevent.
   const maxTokens = parseOpenRouterInt(settings.CLAUDE_MEM_OPENROUTER_MAX_TOKENS, 4096, 1);
   const maxContextMessages = parseOpenRouterInt(settings.CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES, 40, 0);
   const maxContextChars = parseOpenRouterInt(settings.CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_CHARS, 200000, 0);
-  const attemptTimeoutMs = parseOpenRouterInt(settings.CLAUDE_MEM_OPENROUTER_ATTEMPT_TIMEOUT_MS, 30000, 1);
+  const attemptTimeoutMs = parseOpenRouterInt(
+    settings.CLAUDE_MEM_OPENROUTER_ATTEMPT_TIMEOUT_MS,
+    30000,
+    1,
+    SETTIMEOUT_MAX_MS,
+  );
 
   return { apiKey, model, apiUrl, siteUrl, appName, maxTokens, maxContextMessages, maxContextChars, attemptTimeoutMs };
 }

--- a/src/services/worker/agents/ResponseProcessor.ts
+++ b/src/services/worker/agents/ResponseProcessor.ts
@@ -294,6 +294,22 @@ export async function processAgentResponse(
   session.lastGeneratorActivity = Date.now();
   const context = responseContext ?? snapshotResponseContext(session);
 
+  // Consume-and-clear immediately, unconditionally, on every call: this field
+  // is scoped to the single response that produced `text` (each OpenAI-
+  // compatible call site sets it right before invoking this function — see
+  // OpenAICompatibleProvider's handleInitResponse/processObservationMessage/
+  // processSummaryMessage). Reading and clearing it here, before branching on
+  // parse validity below, guarantees the NEXT call — from any provider,
+  // whether or not this response happened to parse as valid XML — starts
+  // from null instead of inheriting a finish reason an OpenAI-compatible
+  // turn set several responses ago. Without the clear, a session that fails
+  // over from OpenRouter to Claude (e.g. the cmem-gateway trial-expiry
+  // fallback in provider-dispatch.ts) would have a later empty Claude reply
+  // misread the OpenRouter turn's leftover 'length', mistaking a designed
+  // skip for a truncation.
+  const finishReason = session.lastFinishReason ?? null;
+  session.lastFinishReason = null;
+
   // Classify rejections BEFORE growing the window. "Prompt is too long", quota
   // prose and auth prose are refusals, not conversational turns; appending them
   // makes the next request strictly larger than the one that just failed, which
@@ -388,13 +404,15 @@ export async function processAgentResponse(
     // reading consecutiveInvalidOutputs. `truncated` is always false on the
     // other two paths: ClaudeProvider never assigns session.lastFinishReason
     // at all, and GeminiProvider's query() result never populates a
-    // finishReason, so the `?? null` fallback it inherits from
-    // OpenAICompatibleProvider always lands on null. This branch therefore
-    // degrades for Claude/Gemini to exactly its prior behavior, just with a
-    // real (no longer write-only) counter.
+    // finishReason, so the OpenAICompatibleProvider call sites that set it
+    // write `null` for Gemini on every response — and `finishReason` above
+    // was already consumed-and-cleared for THIS response at the top of this
+    // function, so neither path can observe a value an earlier OpenRouter
+    // turn left behind. This branch therefore degrades for Claude/Gemini to
+    // exactly its prior behavior, just with a real (no longer write-only)
+    // counter.
     const outputClass = classifyObserverOutput(text);
     const preview = previewOutput(text);
-    const finishReason = session.lastFinishReason ?? null;
     const truncated = finishReason === 'length';
     // A designed skip is exactly: idle output AND a finish reason that is
     // either null (Claude/Gemini never report one — their behavior is

--- a/src/services/worker/agents/ResponseProcessor.ts
+++ b/src/services/worker/agents/ResponseProcessor.ts
@@ -373,11 +373,38 @@ export async function processAgentResponse(
     }
 
     // Classify the non-XML output so a dropped batch is visible, not silent.
-    // Ordinary idle/prose is a claimed no-op batch: confirm it and do not build
-    // any respawn debt from repeated skip acknowledgements.
+    // A truly idle (empty) reply with a normal finish reason is the prompt's
+    // designed way to say "nothing to report" — confirm it as a no-op and do
+    // not build respawn debt. Everything else (prose, malformed XML, or an
+    // idle reply that is actually a 'length' truncation) is a real dropped
+    // batch and counts toward consecutiveInvalidOutputs (#3606 — the counter
+    // was previously write-only/always-0, hiding every one of these).
+    //
+    // This function is shared by every provider (Claude/SDK, Gemini,
+    // OpenRouter/OpenAI-compatible) — the counter fix and the truncated/
+    // logger.error-vs-warn split below apply uniformly to all of them, not
+    // just OpenRouter, and that is intentional rather than an accidental
+    // blast radius: nothing downstream branches on provider identity when
+    // reading consecutiveInvalidOutputs. `truncated` is always false on the
+    // other two paths: ClaudeProvider never assigns session.lastFinishReason
+    // at all, and GeminiProvider's query() result never populates a
+    // finishReason, so the `?? null` fallback it inherits from
+    // OpenAICompatibleProvider always lands on null. This branch therefore
+    // degrades for Claude/Gemini to exactly its prior behavior, just with a
+    // real (no longer write-only) counter.
     const outputClass = classifyObserverOutput(text);
     const preview = previewOutput(text);
-    session.consecutiveInvalidOutputs = 0;
+    const finishReason = session.lastFinishReason ?? null;
+    const truncated = finishReason === 'length';
+    // A designed skip is exactly: idle output AND a finish reason that is
+    // either null (Claude/Gemini never report one — their behavior is
+    // unchanged) or 'stop' (the OpenAI-compatible provider's designed
+    // no-op). Every other finish reason — 'length' (truncation),
+    // 'content_filter', 'tool_calls', 'function_call', 'missing', or
+    // 'malformed' — is a real dropped batch even though the text itself is
+    // idle/empty, because the provider never reached the designed no-op path.
+    const isDesignedSkip = outputClass === 'idle' && (finishReason === null || finishReason === 'stop');
+
     // The overflow/quota/auth rejections returned above, so reaching here means
     // the provider accepted this prompt and answered it. That is proof the
     // conversation fits, whether or not the answer parsed — so the recycle
@@ -385,16 +412,25 @@ export async function processAgentResponse(
     // that answered "idle" twice in a row trip the exhausted branch and wedge.
     session.consecutiveContextOverflows = 0;
 
-    // consecutiveInvalidOutputs is deliberately always 0 here (see worker-types),
-    // so logging it read as "the breaker is fine" on every rejection and hid
-    // #3800 for a full day of failures. Report the counter that can actually be
-    // non-zero instead.
-    logger.warn('PARSER', `${agentName} returned non-XML ${outputClass} response — ignoring queued batch`, {
-      sessionId: session.sessionDbId,
-      outputClass,
-      preview,
-      consecutiveContextOverflows: session.consecutiveContextOverflows,
-    });
+    if (isDesignedSkip) {
+      session.consecutiveInvalidOutputs = 0;
+      logger.info('PARSER', `${agentName} returned an empty response — observer skipped the batch`, {
+        sessionId: session.sessionDbId,
+        outputClass,
+        finishReason,
+      });
+    } else {
+      session.consecutiveInvalidOutputs += 1;
+      const log = (truncated || outputClass === 'xml') ? logger.error : logger.warn;
+      log.call(logger, 'PARSER', `${agentName} returned non-XML ${outputClass} response — ignoring queued batch`, {
+        sessionId: session.sessionDbId,
+        outputClass,
+        preview,
+        finishReason,
+        truncated,
+        consecutiveInvalidOutputs: session.consecutiveInvalidOutputs,
+      });
+    }
 
     // Plain-text skip responses are intentionally ignored. Re-queueing them
     // creates an observer loop where the same low-signal batch is retried.

--- a/src/services/worker/context-window.ts
+++ b/src/services/worker/context-window.ts
@@ -1,0 +1,77 @@
+
+import type { ConversationMessage } from '../worker-types.js';
+
+/**
+ * Bound the OpenAI-compatible message list sent to the model on the
+ * OpenRouter path. Root cause of #3606: `session.conversationHistory` was
+ * sent in full, with no `system` role, on every call. Against a bounded
+ * local context (llama.cpp / Ollama) that either fills the context window
+ * (truncation → empty content) or scrolls the observation schema — stated
+ * once in the init prompt — out of view (model degrades to bare prose). This
+ * module fixes both: the init/continuation prompt is always pinned as
+ * `system` so the schema survives regardless of history length, and the rest
+ * of the turns are capped by count and total chars.
+ */
+
+/** 0 = unbounded for either field. */
+export interface ContextWindowLimits {
+  /** Max history turns kept AFTER the system anchor. */
+  maxMessages: number;
+  /** Max total chars of that windowed history. */
+  maxChars: number;
+}
+
+export interface BoundedMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+/**
+ * `history[0]` is always the init or continuation prompt (see
+ * OpenAICompatibleProvider.startSession) and carries `system_identity` +
+ * `observer_role` + the full `<observation>` skeleton — it is pinned as the
+ * `system` message so the schema is never at risk of scrolling out of
+ * context. The remaining turns are windowed by count, then by total chars,
+ * then leading `assistant` turns are dropped so the first non-system message
+ * is a `user` turn (strict OpenAI-compatible gateways reject assistant-first;
+ * this also drops the orphaned init acknowledgement a front-trim can leave
+ * behind).
+ */
+export function buildBoundedMessages(
+  history: ConversationMessage[],
+  limits: ContextWindowLimits
+): BoundedMessage[] {
+  if (history.length === 0) {
+    return [];
+  }
+
+  const system: BoundedMessage = { role: 'system', content: history[0].content };
+  let rest = history.slice(1);
+
+  if (limits.maxMessages > 0 && rest.length > limits.maxMessages) {
+    rest = rest.slice(rest.length - limits.maxMessages);
+  }
+
+  if (limits.maxChars > 0) {
+    let totalChars = rest.reduce((sum, m) => sum + m.content.length, 0);
+    // The final message is always sent even if it alone exceeds the budget —
+    // that's the batch actually being asked about; dropping it would leave
+    // nothing for the model to respond to.
+    while (totalChars > limits.maxChars && rest.length > 1) {
+      totalChars -= rest[0].content.length;
+      rest = rest.slice(1);
+    }
+  }
+
+  while (rest.length > 0 && rest[0].role === 'assistant') {
+    rest = rest.slice(1);
+  }
+
+  return [
+    system,
+    ...rest.map(m => ({
+      role: (m.role === 'assistant' ? 'assistant' : 'user') as 'assistant' | 'user',
+      content: m.content,
+    })),
+  ];
+}

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -36,6 +36,10 @@ export interface SettingsDefaults {
   CLAUDE_MEM_OPENROUTER_BASE_URL: string;
   CLAUDE_MEM_OPENROUTER_SITE_URL: string;
   CLAUDE_MEM_OPENROUTER_APP_NAME: string;
+  CLAUDE_MEM_OPENROUTER_MAX_TOKENS: string;
+  CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES: string;
+  CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_CHARS: string;
+  CLAUDE_MEM_OPENROUTER_ATTEMPT_TIMEOUT_MS: string;
   CLAUDE_MEM_DATA_DIR: string;
   CLAUDE_MEM_LOG_LEVEL: string;
   CLAUDE_MEM_PYTHON_VERSION: string;
@@ -152,6 +156,10 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_OPENROUTER_BASE_URL: '',  // #2382/#2590/#2622/#2393 — optional OpenAI-compatible base URL (e.g. https://api.deepseek.com, http://localhost:1234/v1). Empty = default OpenRouter endpoint.
     CLAUDE_MEM_OPENROUTER_SITE_URL: '',  // Optional: for OpenRouter analytics
     CLAUDE_MEM_OPENROUTER_APP_NAME: 'claude-mem',  // App name for OpenRouter analytics
+    CLAUDE_MEM_OPENROUTER_MAX_TOKENS: '4096',  // #3606/#3490 — max_tokens in the request body (was hard-coded)
+    CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES: '40',  // #3606 — max history turns sent after the system anchor; 0 = unbounded
+    CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_CHARS: '200000',  // #3606 — max total chars of that windowed history; 0 = unbounded
+    CLAUDE_MEM_OPENROUTER_ATTEMPT_TIMEOUT_MS: '30000',  // #3606 — withRetry per-attempt timeout for this provider (was the hard-coded 30s default)
     CLAUDE_MEM_DATA_DIR: join(homedir(), '.claude-mem'),
     CLAUDE_MEM_LOG_LEVEL: 'INFO',
     CLAUDE_MEM_PYTHON_VERSION: '3.13',

--- a/tests/logger-usage-standards.test.ts
+++ b/tests/logger-usage-standards.test.ts
@@ -45,6 +45,7 @@ const EXCLUDED_PATTERNS = [
   /build\/hook-shell-template\.ts$/,  // Pure build-time shell-string generator (no runtime/observability surface); drift is enforced by build-hooks.js + plugin-distribution.test.ts
   /worker\/model-aliases\.ts$/,  // Pure $TIER alias resolver (#2289); side-effect-free passthrough, logging happens at the request-time call site
   /worker\/TimelineService\.ts$/,  // Pure filterByDepth helper after dead-code removal; no side effects (mirrors FallbackErrorHandler)
+  /worker\/context-window\.ts$/,  // Pure history-bounding transform (#3606); no side effects, logging happens at the OpenRouterProvider call site (mirrors output-classifier.ts)
 ];
 
 const HIGH_PRIORITY_PATTERNS = [

--- a/tests/shared/settings-openrouter-keys.test.ts
+++ b/tests/shared/settings-openrouter-keys.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { SettingsDefaultsManager, type SettingsDefaults } from '../../src/shared/SettingsDefaultsManager.js';
+
+// #3606 — the four OpenRouter context-window settings. Distinct from
+// settings-defaults-manager.test.ts's generic file/env-precedence coverage:
+// this asserts the specific keys and their documented default values, plus
+// that an env override wins per-key.
+
+const OPENROUTER_CONTEXT_KEYS = [
+  'CLAUDE_MEM_OPENROUTER_MAX_TOKENS',
+  'CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES',
+  'CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_CHARS',
+  'CLAUDE_MEM_OPENROUTER_ATTEMPT_TIMEOUT_MS',
+] as const satisfies ReadonlyArray<keyof SettingsDefaults>;
+
+describe('SettingsDefaultsManager — OpenRouter context-window keys', () => {
+  let tempDir: string;
+  let settingsPath: string;
+  const prevEnv: Partial<Record<(typeof OPENROUTER_CONTEXT_KEYS)[number], string | undefined>> = {};
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `settings-openrouter-keys-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tempDir, { recursive: true });
+    settingsPath = join(tempDir, 'settings.json');
+
+    for (const key of OPENROUTER_CONTEXT_KEYS) {
+      prevEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of OPENROUTER_CONTEXT_KEYS) {
+      if (prevEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = prevEnv[key];
+    }
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it('ships the documented defaults', () => {
+    const defaults = SettingsDefaultsManager.getAllDefaults();
+    expect(defaults.CLAUDE_MEM_OPENROUTER_MAX_TOKENS).toBe('4096');
+    expect(defaults.CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES).toBe('40');
+    expect(defaults.CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_CHARS).toBe('200000');
+    expect(defaults.CLAUDE_MEM_OPENROUTER_ATTEMPT_TIMEOUT_MS).toBe('30000');
+  });
+
+  it('loads values from settings.json when no env override is set', () => {
+    writeFileSync(settingsPath, JSON.stringify({
+      CLAUDE_MEM_OPENROUTER_MAX_TOKENS: '2048',
+      CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES: '10',
+      CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_CHARS: '50000',
+      CLAUDE_MEM_OPENROUTER_ATTEMPT_TIMEOUT_MS: '5000',
+    }), 'utf-8');
+
+    const result = SettingsDefaultsManager.loadFromFile(settingsPath);
+
+    expect(result.CLAUDE_MEM_OPENROUTER_MAX_TOKENS).toBe('2048');
+    expect(result.CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES).toBe('10');
+    expect(result.CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_CHARS).toBe('50000');
+    expect(result.CLAUDE_MEM_OPENROUTER_ATTEMPT_TIMEOUT_MS).toBe('5000');
+  });
+
+  it('falls back to defaults for keys absent from the file entirely', () => {
+    writeFileSync(settingsPath, JSON.stringify({ CLAUDE_MEM_MODEL: 'some-other-key' }), 'utf-8');
+
+    const result = SettingsDefaultsManager.loadFromFile(settingsPath);
+
+    expect(result.CLAUDE_MEM_OPENROUTER_MAX_TOKENS).toBe('4096');
+    expect(result.CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES).toBe('40');
+    expect(result.CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_CHARS).toBe('200000');
+    expect(result.CLAUDE_MEM_OPENROUTER_ATTEMPT_TIMEOUT_MS).toBe('30000');
+  });
+
+  it('an env override wins over the file value, per key', () => {
+    writeFileSync(settingsPath, JSON.stringify({
+      CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES: '10',
+      CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_CHARS: '50000',
+    }), 'utf-8');
+    process.env.CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES = '99';
+
+    const result = SettingsDefaultsManager.loadFromFile(settingsPath);
+
+    expect(result.CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES).toBe('99'); // env wins
+    expect(result.CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_CHARS).toBe('50000'); // file wins (no env set)
+  });
+
+  it('an env override wins even when the file has no OpenRouter keys at all', () => {
+    writeFileSync(settingsPath, JSON.stringify({}), 'utf-8');
+    process.env.CLAUDE_MEM_OPENROUTER_MAX_TOKENS = '512';
+    process.env.CLAUDE_MEM_OPENROUTER_ATTEMPT_TIMEOUT_MS = '9999';
+
+    const result = SettingsDefaultsManager.loadFromFile(settingsPath);
+
+    expect(result.CLAUDE_MEM_OPENROUTER_MAX_TOKENS).toBe('512');
+    expect(result.CLAUDE_MEM_OPENROUTER_ATTEMPT_TIMEOUT_MS).toBe('9999');
+  });
+});

--- a/tests/worker/agents/response-processor.test.ts
+++ b/tests/worker/agents/response-processor.test.ts
@@ -542,7 +542,9 @@ describe('ResponseProcessor', () => {
         confirmClaimedMessages,
       } as unknown as SessionManager;
 
-      const session = createMockSession();
+      // #3606: the real counter now increments on any dropped batch that
+      // isn't a designed empty skip — prose is not idle, so it counts.
+      const session = createMockSession({ consecutiveInvalidOutputs: 0 });
       const responseText = 'Skipping — repeated log scan with no new findings.';
 
       await processAgentResponse(
@@ -559,11 +561,229 @@ describe('ResponseProcessor', () => {
       expect(logger.warn).toHaveBeenCalledWith(
         'PARSER',
         expect.stringMatching(/^TestAgent returned non-XML prose response/),
-        expect.objectContaining({ sessionId: 1, outputClass: 'prose' })
+        expect.objectContaining({ sessionId: 1, outputClass: 'prose', finishReason: null, truncated: false })
       );
       expect(confirmClaimedMessages).toHaveBeenCalledWith(1);
       expect(session.earliestPendingTimestamp).toBeNull();
       expect(mockStoreObservations).not.toHaveBeenCalled();
+      expect(session.consecutiveInvalidOutputs).toBe(1);
+    });
+
+    it('logs an error (not a warning) for malformed XML output', async () => {
+      const confirmClaimedMessages = mock(() => Promise.resolve(0));
+      mockSessionManager = {
+        getMessageIterator: async function* () { yield* []; },
+        getPendingMessageStore: () => ({ confirmProcessed: mock(() => {}) }),
+        confirmClaimedMessages,
+      } as unknown as SessionManager;
+
+      const session = createMockSession({ consecutiveInvalidOutputs: 0 });
+      // Has an <observation> root tag (classifies as 'xml') but never closes,
+      // so parseAgentXml still rejects it as invalid.
+      const responseText = 'I hit the context window and cannot continue <observation>';
+
+      await processAgentResponse(
+        responseText,
+        session,
+        mockDbManager,
+        mockSessionManager,
+        mockWorker,
+        100,
+        null,
+        'TestAgent'
+      );
+
+      expect(logger.error).toHaveBeenCalledWith(
+        'PARSER',
+        expect.stringMatching(/^TestAgent returned non-XML xml response/),
+        expect.objectContaining({ outputClass: 'xml', truncated: false, consecutiveInvalidOutputs: 1 })
+      );
+      expect(confirmClaimedMessages).toHaveBeenCalledWith(1);
+      expect(session.consecutiveInvalidOutputs).toBe(1);
+    });
+
+    it('increments consecutiveInvalidOutputs across repeated dropped batches (1 then 2)', async () => {
+      mockSessionManager = {
+        getMessageIterator: async function* () { yield* []; },
+        getPendingMessageStore: () => ({ confirmProcessed: mock(() => {}) }),
+        confirmClaimedMessages: mock(() => Promise.resolve(0)),
+      } as unknown as SessionManager;
+
+      const session = createMockSession({ consecutiveInvalidOutputs: 0 });
+
+      await processAgentResponse('Skipping, nothing new here.', session, mockDbManager, mockSessionManager, mockWorker, 100, null, 'TestAgent');
+      expect(session.consecutiveInvalidOutputs).toBe(1);
+
+      await processAgentResponse('Still nothing new to report here.', session, mockDbManager, mockSessionManager, mockWorker, 100, null, 'TestAgent');
+      expect(session.consecutiveInvalidOutputs).toBe(2);
+    });
+
+    it('a valid parse resets consecutiveInvalidOutputs to 0', async () => {
+      // Uses the default mockSessionManager from beforeEach — it needs
+      // getClaimedMessages() (the valid-parse path calls it), unlike the
+      // invalid-branch tests above, which return before reaching it.
+      const session = createMockSession({ consecutiveInvalidOutputs: 3 });
+      const responseText = `
+        <observation>
+          <type>discovery</type>
+          <title>Test</title>
+          <facts></facts>
+          <concepts></concepts>
+          <files_read></files_read>
+          <files_modified></files_modified>
+        </observation>
+      `;
+
+      await processAgentResponse(responseText, session, mockDbManager, mockSessionManager, mockWorker, 100, null, 'TestAgent');
+
+      expect(session.consecutiveInvalidOutputs).toBe(0);
+    });
+  });
+
+  describe('finishReason-aware truncation handling (#3606)', () => {
+    it('idle output with finishReason null/undefined is a designed empty skip: logger.info, counter resets to 0', async () => {
+      const confirmClaimedMessages = mock(() => Promise.resolve(0));
+      mockSessionManager = {
+        getMessageIterator: async function* () { yield* []; },
+        getPendingMessageStore: () => ({ confirmProcessed: mock(() => {}) }),
+        confirmClaimedMessages,
+      } as unknown as SessionManager;
+
+      const session = createMockSession({ consecutiveInvalidOutputs: 2, lastFinishReason: null });
+
+      await processAgentResponse('', session, mockDbManager, mockSessionManager, mockWorker, 100, null, 'TestAgent');
+
+      expect(logger.info).toHaveBeenCalledWith(
+        'PARSER',
+        expect.stringMatching(/^TestAgent returned an empty response — observer skipped the batch$/),
+        expect.objectContaining({ sessionId: 1, outputClass: 'idle', finishReason: null })
+      );
+      expect(confirmClaimedMessages).toHaveBeenCalledWith(1);
+      expect(session.consecutiveInvalidOutputs).toBe(0);
+    });
+
+    it("idle output with finishReason 'stop' is also a designed empty skip: logger.info, counter resets to 0", async () => {
+      mockSessionManager = {
+        getMessageIterator: async function* () { yield* []; },
+        getPendingMessageStore: () => ({ confirmProcessed: mock(() => {}) }),
+        confirmClaimedMessages: mock(() => Promise.resolve(0)),
+      } as unknown as SessionManager;
+
+      const session = createMockSession({ consecutiveInvalidOutputs: 2, lastFinishReason: 'stop' });
+
+      await processAgentResponse('', session, mockDbManager, mockSessionManager, mockWorker, 100, null, 'TestAgent');
+
+      expect(logger.info).toHaveBeenCalledWith(
+        'PARSER',
+        expect.any(String),
+        expect.objectContaining({ outputClass: 'idle', finishReason: 'stop' })
+      );
+      expect(session.consecutiveInvalidOutputs).toBe(0);
+    });
+
+    it("idle output with finishReason 'missing' is NOT a designed skip: logger.warn, counter increments to 1, batch still confirmed (dropped, not requeued)", async () => {
+      const confirmClaimedMessages = mock(() => Promise.resolve(0));
+      mockSessionManager = {
+        getMessageIterator: async function* () { yield* []; },
+        getPendingMessageStore: () => ({ confirmProcessed: mock(() => {}) }),
+        confirmClaimedMessages,
+      } as unknown as SessionManager;
+
+      const session = createMockSession({ consecutiveInvalidOutputs: 0, lastFinishReason: 'missing' });
+
+      await processAgentResponse('', session, mockDbManager, mockSessionManager, mockWorker, 100, null, 'TestAgent');
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'PARSER',
+        expect.stringMatching(/^TestAgent returned non-XML idle response — ignoring queued batch$/),
+        expect.objectContaining({ outputClass: 'idle', finishReason: 'missing', truncated: false, consecutiveInvalidOutputs: 1 })
+      );
+      expect(logger.info).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(confirmClaimedMessages).toHaveBeenCalledWith(1);
+      expect(session.consecutiveInvalidOutputs).toBe(1);
+    });
+
+    it("idle output with finishReason 'malformed' is NOT a designed skip: logger.warn, counter increments to 1", async () => {
+      mockSessionManager = {
+        getMessageIterator: async function* () { yield* []; },
+        getPendingMessageStore: () => ({ confirmProcessed: mock(() => {}) }),
+        confirmClaimedMessages: mock(() => Promise.resolve(0)),
+      } as unknown as SessionManager;
+
+      const session = createMockSession({ consecutiveInvalidOutputs: 0, lastFinishReason: 'malformed' });
+
+      await processAgentResponse('', session, mockDbManager, mockSessionManager, mockWorker, 100, null, 'TestAgent');
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'PARSER',
+        expect.stringMatching(/^TestAgent returned non-XML idle response — ignoring queued batch$/),
+        expect.objectContaining({ outputClass: 'idle', finishReason: 'malformed', truncated: false, consecutiveInvalidOutputs: 1 })
+      );
+      expect(logger.info).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(session.consecutiveInvalidOutputs).toBe(1);
+    });
+
+    it("idle output with finishReason 'content_filter' is NOT a designed skip: logger.warn, counter increments to 1", async () => {
+      mockSessionManager = {
+        getMessageIterator: async function* () { yield* []; },
+        getPendingMessageStore: () => ({ confirmProcessed: mock(() => {}) }),
+        confirmClaimedMessages: mock(() => Promise.resolve(0)),
+      } as unknown as SessionManager;
+
+      const session = createMockSession({ consecutiveInvalidOutputs: 0, lastFinishReason: 'content_filter' });
+
+      await processAgentResponse('', session, mockDbManager, mockSessionManager, mockWorker, 100, null, 'TestAgent');
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'PARSER',
+        expect.stringMatching(/^TestAgent returned non-XML idle response — ignoring queued batch$/),
+        expect.objectContaining({ outputClass: 'idle', finishReason: 'content_filter', truncated: false, consecutiveInvalidOutputs: 1 })
+      );
+      expect(logger.info).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
+      expect(session.consecutiveInvalidOutputs).toBe(1);
+    });
+
+    it("empty output with finishReason 'length' is a real truncation: logger.error with truncated:true, counter increments", async () => {
+      const confirmClaimedMessages = mock(() => Promise.resolve(0));
+      mockSessionManager = {
+        getMessageIterator: async function* () { yield* []; },
+        getPendingMessageStore: () => ({ confirmProcessed: mock(() => {}) }),
+        confirmClaimedMessages,
+      } as unknown as SessionManager;
+
+      const session = createMockSession({ consecutiveInvalidOutputs: 0, lastFinishReason: 'length' });
+
+      await processAgentResponse('', session, mockDbManager, mockSessionManager, mockWorker, 100, null, 'TestAgent');
+
+      expect(logger.error).toHaveBeenCalledWith(
+        'PARSER',
+        expect.stringMatching(/^TestAgent returned non-XML idle response — ignoring queued batch$/),
+        expect.objectContaining({ outputClass: 'idle', finishReason: 'length', truncated: true, consecutiveInvalidOutputs: 1 })
+      );
+      expect(confirmClaimedMessages).toHaveBeenCalledWith(1);
+      expect(session.consecutiveInvalidOutputs).toBe(1);
+    });
+
+    it("prose output with finishReason 'length' logs an error (truncated overrides the normal prose→warn level)", async () => {
+      mockSessionManager = {
+        getMessageIterator: async function* () { yield* []; },
+        getPendingMessageStore: () => ({ confirmProcessed: mock(() => {}) }),
+        confirmClaimedMessages: mock(() => Promise.resolve(0)),
+      } as unknown as SessionManager;
+
+      const session = createMockSession({ consecutiveInvalidOutputs: 0, lastFinishReason: 'length' });
+
+      await processAgentResponse('mid-sentence prose that got cut off befo', session, mockDbManager, mockSessionManager, mockWorker, 100, null, 'TestAgent');
+
+      expect(logger.error).toHaveBeenCalledWith(
+        'PARSER',
+        expect.stringMatching(/^TestAgent returned non-XML prose response — ignoring queued batch$/),
+        expect.objectContaining({ outputClass: 'prose', truncated: true })
+      );
+      expect(session.consecutiveInvalidOutputs).toBe(1);
     });
   });
 
@@ -911,7 +1131,9 @@ describe('ResponseProcessor', () => {
         confirmClaimedMessages,
       } as unknown as SessionManager;
 
-      const session = createMockSession();
+      // #3606: an empty reply with no finish-reason truncation is the
+      // designed empty skip — logger.info, counter resets to 0 (not warn).
+      const session = createMockSession({ consecutiveInvalidOutputs: 2 });
       const responseText = '';
 
       await processAgentResponse(
@@ -922,6 +1144,12 @@ describe('ResponseProcessor', () => {
       expect(mockStoreObservations).not.toHaveBeenCalled();
       expect(confirmClaimedMessages).toHaveBeenCalledWith(1);
       expect(session.earliestPendingTimestamp).toBeNull();
+      expect(logger.info).toHaveBeenCalledWith(
+        'PARSER',
+        expect.stringMatching(/^TestAgent returned an empty response — observer skipped the batch$/),
+        expect.objectContaining({ outputClass: 'idle' })
+      );
+      expect(session.consecutiveInvalidOutputs).toBe(0);
     });
 
     it('clears pending work and does NOT call storeObservations on plain-text response', async () => {
@@ -932,7 +1160,10 @@ describe('ResponseProcessor', () => {
         confirmClaimedMessages,
       } as unknown as SessionManager;
 
-      const session = createMockSession();
+      // #3606: prose is not a designed skip — it's a real dropped batch,
+      // logged at warn (not error, since it's not truncated/xml) and counted
+      // toward consecutiveInvalidOutputs.
+      const session = createMockSession({ consecutiveInvalidOutputs: 0 });
       const responseText = 'This is just plain text without any XML tags.';
 
       await processAgentResponse(
@@ -943,6 +1174,12 @@ describe('ResponseProcessor', () => {
       expect(mockStoreObservations).not.toHaveBeenCalled();
       expect(confirmClaimedMessages).toHaveBeenCalledWith(1);
       expect(session.earliestPendingTimestamp).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        'PARSER',
+        expect.stringMatching(/^TestAgent returned non-XML prose response — ignoring queued batch$/),
+        expect.objectContaining({ outputClass: 'prose' })
+      );
+      expect(session.consecutiveInvalidOutputs).toBe(1);
     });
   });
 

--- a/tests/worker/agents/response-processor.test.ts
+++ b/tests/worker/agents/response-processor.test.ts
@@ -785,6 +785,47 @@ describe('ResponseProcessor', () => {
       );
       expect(session.consecutiveInvalidOutputs).toBe(1);
     });
+
+    it("does not leak an OpenRouter turn's finishReason into a later Claude-path empty reply on the same session (#3868)", async () => {
+      mockSessionManager = {
+        getMessageIterator: async function* () { yield* []; },
+        getPendingMessageStore: () => ({ confirmProcessed: mock(() => {}) }),
+        confirmClaimedMessages: mock(() => Promise.resolve(0)),
+      } as unknown as SessionManager;
+
+      // Turn 1: an OpenRouter reply. OpenAICompatibleProvider sets
+      // session.lastFinishReason = 'length' immediately before this call, so
+      // an empty reply here is a real truncation, not a designed skip.
+      const session = createMockSession({ consecutiveInvalidOutputs: 0, lastFinishReason: 'length' });
+
+      await processAgentResponse('', session, mockDbManager, mockSessionManager, mockWorker, 100, null, 'TestAgent');
+
+      expect(logger.error).toHaveBeenCalledWith(
+        'PARSER',
+        expect.stringMatching(/^TestAgent returned non-XML idle response — ignoring queued batch$/),
+        expect.objectContaining({ outputClass: 'idle', finishReason: 'length', truncated: true, consecutiveInvalidOutputs: 1 })
+      );
+
+      // The finish reason must be consumed by that read, not merely observed:
+      // it has to be cleared so the NEXT caller — regardless of provider —
+      // starts from null instead of inheriting this turn's 'length'.
+      expect(session.lastFinishReason).toBeNull();
+
+      // Turn 2: a later Claude-path reply on the SAME session object (e.g.
+      // the cmem-gateway trial-expiry fallback dropped this session back to
+      // Claude). ClaudeProvider never assigns session.lastFinishReason at
+      // all, so without the fix above this idle reply would still read
+      // Turn 1's leftover 'length' and be misclassified as a truncation
+      // instead of the designed empty-reply skip.
+      await processAgentResponse('', session, mockDbManager, mockSessionManager, mockWorker, 100, null, 'TestAgent');
+
+      expect(logger.info).toHaveBeenCalledWith(
+        'PARSER',
+        expect.stringMatching(/^TestAgent returned an empty response — observer skipped the batch$/),
+        expect.objectContaining({ outputClass: 'idle', finishReason: null })
+      );
+      expect(session.consecutiveInvalidOutputs).toBe(0);
+    });
   });
 
   describe('context-window overflow recovery (#3800)', () => {

--- a/tests/worker/context-window.test.ts
+++ b/tests/worker/context-window.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'bun:test';
+import { buildBoundedMessages } from '../../src/services/worker/context-window.js';
+import type { ConversationMessage } from '../../src/services/worker-types.js';
+
+function turn(role: 'user' | 'assistant', content: string): ConversationMessage {
+  return { role, content };
+}
+
+describe('buildBoundedMessages', () => {
+  it('returns [] for empty history', () => {
+    expect(buildBoundedMessages([], { maxMessages: 0, maxChars: 0 })).toEqual([]);
+  });
+
+  it('returns just the system anchor for a single-message history', () => {
+    const history = [turn('user', 'init prompt with the observation schema')];
+    const result = buildBoundedMessages(history, { maxMessages: 40, maxChars: 200000 });
+    expect(result).toEqual([{ role: 'system', content: 'init prompt with the observation schema' }]);
+  });
+
+  it('pins history[0] as system regardless of its original role', () => {
+    const history = [turn('user', 'init'), turn('assistant', 'ack')];
+    const result = buildBoundedMessages(history, { maxMessages: 0, maxChars: 0 });
+    expect(result[0]).toEqual({ role: 'system', content: 'init' });
+  });
+
+  it('maxMessages=0 means unbounded — keeps every turn after the anchor', () => {
+    const history = [turn('user', 'init'), ...Array.from({ length: 50 }, (_, i) => turn('user', `turn ${i}`))];
+    const result = buildBoundedMessages(history, { maxMessages: 0, maxChars: 0 });
+    expect(result).toHaveLength(51);
+  });
+
+  it('count cap keeps only the last N turns after the system anchor', () => {
+    // All 'user' so the count cap is the only thing under test — the
+    // leading-assistant-drop rule is covered separately below.
+    const history = [
+      turn('user', 'init'),
+      ...Array.from({ length: 10 }, (_, i) => turn('user', `turn ${i}`)),
+    ];
+    const result = buildBoundedMessages(history, { maxMessages: 4, maxChars: 0 });
+    // system + last 4 of the 10 trailing turns
+    expect(result).toHaveLength(5);
+    expect(result.slice(1).map(m => m.content)).toEqual(['turn 6', 'turn 7', 'turn 8', 'turn 9']);
+  });
+
+  it('maxChars=0 means unbounded — no char-based trimming', () => {
+    const history = [turn('user', 'init'), turn('user', 'x'.repeat(500000))];
+    const result = buildBoundedMessages(history, { maxMessages: 0, maxChars: 0 });
+    expect(result).toHaveLength(2);
+  });
+
+  it('char cap drops from the front, keeping the most recent turns and the final message', () => {
+    // All 'user' so the char cap is the only thing under test — the
+    // leading-assistant-drop rule is covered separately below.
+    const history = [
+      turn('user', 'init'),
+      turn('user', 'a'.repeat(100)),
+      turn('user', 'b'.repeat(100)),
+      turn('user', 'c'.repeat(100)),
+    ];
+    // budget only fits the last two trailing turns (200 chars)
+    const result = buildBoundedMessages(history, { maxMessages: 0, maxChars: 200 });
+    expect(result.map(m => m.content)).toEqual(['init', 'b'.repeat(100), 'c'.repeat(100)]);
+  });
+
+  it('keeps the final message even when it alone exceeds the char budget', () => {
+    const history = [
+      turn('user', 'init'),
+      turn('user', 'a'.repeat(50)),
+      turn('user', 'z'.repeat(500)),
+    ];
+    const result = buildBoundedMessages(history, { maxMessages: 0, maxChars: 10 });
+    expect(result).toEqual([
+      { role: 'system', content: 'init' },
+      { role: 'user', content: 'z'.repeat(500) },
+    ]);
+  });
+
+  it('drops leading assistant turns left over after count/char trimming', () => {
+    const history = [
+      turn('user', 'init'),
+      turn('user', 'earlier user turn'),
+      turn('assistant', 'orphaned init ack'),
+      turn('user', 'latest user turn'),
+    ];
+    // count cap of 2 lands exactly on [assistant ack, latest user turn]
+    const result = buildBoundedMessages(history, { maxMessages: 2, maxChars: 0 });
+    expect(result).toEqual([
+      { role: 'system', content: 'init' },
+      { role: 'user', content: 'latest user turn' },
+    ]);
+  });
+
+  it('drops ALL leading assistant turns, not just one', () => {
+    const history = [
+      turn('user', 'init'),
+      turn('assistant', 'ack 1'),
+      turn('assistant', 'ack 2'),
+      turn('user', 'real turn'),
+    ];
+    const result = buildBoundedMessages(history, { maxMessages: 0, maxChars: 0 });
+    expect(result).toEqual([
+      { role: 'system', content: 'init' },
+      { role: 'user', content: 'real turn' },
+    ]);
+  });
+
+  it('an all-assistant trailing window (after trimming) collapses to just the system anchor', () => {
+    const history = [turn('user', 'init'), turn('assistant', 'only ack')];
+    const result = buildBoundedMessages(history, { maxMessages: 1, maxChars: 0 });
+    expect(result).toEqual([{ role: 'system', content: 'init' }]);
+  });
+
+  it('maps ConversationMessage roles onto BoundedMessage roles (assistant stays assistant, anything else becomes user)', () => {
+    // The assistant turn is not leading (there's a user turn ahead of it),
+    // so it survives the leading-assistant-drop rule and its role mapping
+    // can be observed directly.
+    const history = [turn('user', 'init'), turn('user', 'u1'), turn('assistant', 'a1'), turn('user', 'u2')];
+    const result = buildBoundedMessages(history, { maxMessages: 0, maxChars: 0 });
+    expect(result.map(m => m.role)).toEqual(['system', 'user', 'assistant', 'user']);
+  });
+});

--- a/tests/worker/openai-compatible-history.test.ts
+++ b/tests/worker/openai-compatible-history.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test';
+import { OpenRouterProvider } from '../../src/services/worker/OpenRouterProvider.js';
+import { SettingsDefaultsManager } from '../../src/shared/SettingsDefaultsManager.js';
+import { ModeManager } from '../../src/services/domain/ModeManager.js';
+import { logger } from '../../src/utils/logger.js';
+import type { DatabaseManager } from '../../src/services/worker/DatabaseManager.js';
+import type { SessionManager } from '../../src/services/worker/SessionManager.js';
+import type { ActiveSession } from '../../src/services/worker-types.js';
+
+/**
+ * Regression guard for the duplicate-assistant-history bug fixed upstream at
+ * #3619 (predates #3606; OpenAICompatibleProvider no longer pushes the
+ * assistant reply itself — processAgentResponse in ResponseProcessor.ts
+ * already does). Exercises the full startSession() flow (init + two
+ * observation rounds) through OpenRouterProvider — the only concrete
+ * OpenAICompatibleProvider subclass this change touches — with a mocked
+ * fetch, and asserts conversationHistory ends up with exactly one assistant
+ * entry per reply, alternating roles.
+ */
+
+const mockMode = {
+  name: 'code',
+  prompts: { init: 'init prompt', observation: 'obs prompt', summary: 'summary prompt' },
+  observation_types: [{ id: 'discovery' }],
+  observation_concepts: [],
+};
+
+function observationXml(title: string): string {
+  return `<observation><type>discovery</type><title>${title}</title><facts></facts><concepts></concepts><files_read></files_read><files_modified></files_modified></observation>`;
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } });
+}
+
+describe('OpenAICompatibleProvider — no duplicate assistant history entries (#3606/#3619)', () => {
+  let loadFromFileSpy: ReturnType<typeof spyOn>;
+  let modeManagerSpy: ReturnType<typeof spyOn>;
+  let originalFetch: typeof global.fetch;
+  let loggerSpies: ReturnType<typeof spyOn>[];
+
+  beforeEach(() => {
+    loadFromFileSpy = spyOn(SettingsDefaultsManager, 'loadFromFile').mockImplementation(() => ({
+      ...SettingsDefaultsManager.getAllDefaults(),
+      CLAUDE_MEM_OPENROUTER_API_KEY: 'test-key',
+      CLAUDE_MEM_OPENROUTER_MODEL: 'mock-model',
+    }));
+    modeManagerSpy = spyOn(ModeManager, 'getInstance').mockImplementation(() => ({
+      getActiveMode: () => mockMode,
+      loadMode: () => {},
+    } as any));
+    loggerSpies = [
+      spyOn(logger, 'debug').mockImplementation(() => {}),
+      spyOn(logger, 'info').mockImplementation(() => {}),
+      spyOn(logger, 'warn').mockImplementation(() => {}),
+      spyOn(logger, 'error').mockImplementation(() => {}),
+      spyOn(logger, 'success').mockImplementation(() => {}),
+      spyOn(logger, 'failure').mockImplementation(() => {}),
+    ];
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    loadFromFileSpy.mockRestore();
+    modeManagerSpy.mockRestore();
+    loggerSpies.forEach(s => s.mockRestore());
+    mock.restore();
+  });
+
+  it('records exactly one assistant entry per reply across init + two observation rounds', async () => {
+    let call = 0;
+    const replies = [observationXml('init'), observationXml('obs-1'), observationXml('obs-2')];
+    const fetchMock = mock(() => {
+      const content = replies[Math.min(call, replies.length - 1)];
+      call += 1;
+      return Promise.resolve(jsonResponse({
+        choices: [{ message: { role: 'assistant', content }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      }));
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const observationMessages = [
+      { type: 'observation', tool_name: 'Read', tool_input: { file: 'a.ts' }, tool_response: 'r1', prompt_number: 1, cwd: '/tmp' },
+      { type: 'observation', tool_name: 'Read', tool_input: { file: 'b.ts' }, tool_response: 'r2', prompt_number: 1, cwd: '/tmp' },
+    ];
+
+    const mockStoreObservations = mock(() => ({ observationIds: [1], summaryId: null, createdAtEpoch: Date.now() }));
+    const mockDbManager = {
+      getSessionStore: () => ({
+        storeObservations: mockStoreObservations,
+        ensureMemorySessionIdRegistered: mock(() => {}),
+        getSessionById: mock(() => ({ memory_session_id: 'mem-session-123' })),
+        updateMemorySessionId: mock(() => {}),
+      }),
+      getChromaSync: () => ({
+        syncObservation: mock(() => Promise.resolve()),
+        syncSummary: mock(() => Promise.resolve()),
+      }),
+      getCloudSync: () => null,
+    } as unknown as DatabaseManager;
+
+    const mockSessionManager = {
+      getMessageIterator: async function* () {
+        for (const m of observationMessages) yield m as any;
+      },
+      getClaimedMessages: mock(() => []),
+      confirmClaimedMessages: mock(() => Promise.resolve(0)),
+      resetProcessingToPending: mock(() => Promise.resolve(0)),
+    } as unknown as SessionManager;
+
+    const provider = new OpenRouterProvider(mockDbManager, mockSessionManager);
+
+    const session = {
+      sessionDbId: 1,
+      contentSessionId: 'test-session',
+      memorySessionId: null,
+      project: 'test-project',
+      platformSource: 'claude',
+      userPrompt: 'test prompt',
+      conversationHistory: [],
+      lastPromptNumber: 1,
+      cumulativeInputTokens: 0,
+      cumulativeOutputTokens: 0,
+      abortController: new AbortController(),
+      generatorPromise: null,
+      currentProvider: null,
+      consecutiveRestarts: 0,
+      consecutiveInvalidOutputs: 0,
+      consecutiveContextOverflows: 0,
+      claimedMessageIds: [],
+      earliestPendingTimestamp: null,
+      lastGeneratorActivity: Date.now(),
+      startTime: Date.now(),
+    } as unknown as ActiveSession;
+
+    await provider.startSession(session);
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    const roles = session.conversationHistory.map(m => m.role);
+    expect(roles).toEqual(['user', 'assistant', 'user', 'assistant', 'user', 'assistant']);
+
+    for (let i = 1; i < roles.length; i++) {
+      const consecutiveAssistants = roles[i] === 'assistant' && roles[i - 1] === 'assistant';
+      expect(consecutiveAssistants).toBe(false);
+    }
+
+    // Each assistant entry is the exact reply text once, not twice.
+    expect(session.conversationHistory[1].content).toBe(replies[0]);
+    expect(session.conversationHistory[3].content).toBe(replies[1]);
+    expect(session.conversationHistory[5].content).toBe(replies[2]);
+  });
+});

--- a/tests/worker/openrouter-config-source.test.ts
+++ b/tests/worker/openrouter-config-source.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import {
   isOpenRouterAvailable,
+  parseOpenRouterInt,
   resolveOpenRouterConfig,
 } from '../../src/services/worker/OpenRouterProvider.js';
 import { DEFAULT_OPENROUTER_API_URL } from '../../src/shared/openrouter-base-url.js';
@@ -153,5 +154,145 @@ describe('OpenRouter credential tuple source coherence', () => {
       apiUrl: 'https://cmem.ai.evil.example/v1/chat/completions',
       model: 'custom-model',
     });
+  });
+});
+
+describe('OpenRouter numeric setting parsing (#3868)', () => {
+  let tempDir: string;
+  let settingsPath: string;
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `openrouter-int-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tempDir, { recursive: true });
+    settingsPath = join(tempDir, 'settings.json');
+    savedEnv = {};
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    process.env.CLAUDE_MEM_ENV_FILE = join(tempDir, '.env');
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  /**
+   * attemptTimeoutMs (min 1, default 30000) exercises the min>=1 fallback
+   * cases; maxContextMessages (min 0, default 40) exercises the "0 is a
+   * legitimate value, only negative falls back" cases documented beside
+   * parseOpenRouterInt.
+   */
+  function configFor(attemptTimeoutMsRaw: unknown, maxContextMessagesRaw?: unknown): { attemptTimeoutMs: number; maxContextMessages: number } {
+    writeFileSync(settingsPath, JSON.stringify({
+      CLAUDE_MEM_OPENROUTER_ATTEMPT_TIMEOUT_MS: attemptTimeoutMsRaw,
+      ...(maxContextMessagesRaw !== undefined ? { CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES: maxContextMessagesRaw } : {}),
+    }));
+    const config = resolveOpenRouterConfig(settingsPath);
+    return { attemptTimeoutMs: config.attemptTimeoutMs, maxContextMessages: config.maxContextMessages };
+  }
+
+  it('rejects a numeric-prefix string like "1e3" instead of silently truncating it to 1 (the reported 1ms-timeout bug)', () => {
+    // parseInt("1e3", 10) === 1, which used to pass the min-1 check and turn
+    // a 1000ms timeout into a 1ms one. The fixed parser must reject the whole
+    // string as non-integral and fall back to the documented default.
+    expect(configFor('1e3').attemptTimeoutMs).toBe(30000);
+  });
+
+  it('rejects a non-integral decimal string like "42.5"', () => {
+    expect(configFor('42.5').attemptTimeoutMs).toBe(30000);
+  });
+
+  it('rejects a hex-looking string like "0x10"', () => {
+    expect(configFor('0x10').attemptTimeoutMs).toBe(30000);
+  });
+
+  it('accepts a valid integer string with surrounding whitespace trimmed', () => {
+    expect(configFor(' 5000 ').attemptTimeoutMs).toBe(5000);
+  });
+
+  it('rejects a negative value below the minimum and falls back to the default', () => {
+    expect(configFor('-5').attemptTimeoutMs).toBe(30000);
+  });
+
+  it('rejects an empty string', () => {
+    expect(configFor('').attemptTimeoutMs).toBe(30000);
+  });
+
+  it('rejects a non-numeric string like "abc"', () => {
+    expect(configFor('abc').attemptTimeoutMs).toBe(30000);
+  });
+
+  it('rejects "0" for a min-1 key (attemptTimeoutMs) but accepts "0" for a min-0 key (maxContextMessages)', () => {
+    const config = configFor('0', '0');
+    expect(config.attemptTimeoutMs).toBe(30000);
+    expect(config.maxContextMessages).toBe(0);
+  });
+
+  it('accepts a plain valid integer value unchanged', () => {
+    expect(configFor('12345').attemptTimeoutMs).toBe(12345);
+  });
+
+  it('accepts an actual finite integral JSON number, not just a string', () => {
+    expect(configFor(5000).attemptTimeoutMs).toBe(5000);
+  });
+
+  it('rejects a non-integral JSON number like 42.5', () => {
+    expect(configFor(42.5).attemptTimeoutMs).toBe(30000);
+  });
+
+  it('rejects an object value', () => {
+    expect(configFor({ not: 'a number' }).attemptTimeoutMs).toBe(30000);
+  });
+
+  // NaN/Infinity can't round-trip through settings.json (JSON.stringify
+  // coerces both to `null`, and literal `NaN`/`Infinity` tokens aren't valid
+  // JSON), so these call parseOpenRouterInt directly rather than through the
+  // file-backed resolveOpenRouterConfig used above.
+  it('rejects non-finite numbers (NaN, Infinity) passed directly', () => {
+    expect(parseOpenRouterInt(NaN, 30000, 1)).toBe(30000);
+    expect(parseOpenRouterInt(Infinity, 30000, 1)).toBe(30000);
+    expect(parseOpenRouterInt(-Infinity, 30000, 1)).toBe(30000);
+  });
+
+  // A JSON string, unlike a literal NaN/Infinity token, round-trips through
+  // settings.json without issue — this is the realistic path (a corrupt
+  // settings value or an env var) that reaches parseOpenRouterInt's string
+  // branch. `Number('999…9')` for a numeral this long overflows to
+  // `Infinity` rather than throwing, so without a finiteness check on the
+  // parsed result, `Infinity < min` is false and the huge value would pass
+  // straight through instead of falling back — reintroducing the same
+  // "silently becomes ~1ms once it hits setTimeout" failure this guard
+  // exists to prevent.
+  it('rejects a numeral long enough to overflow Number() to Infinity', () => {
+    const overflowingNumeral = '9'.repeat(320);
+    expect(configFor(overflowingNumeral).attemptTimeoutMs).toBe(30000);
+    expect(parseOpenRouterInt(overflowingNumeral, 30000, 1)).toBe(30000);
+  });
+
+  // attemptTimeoutMs is handed to `setTimeout` (retry.ts), which silently
+  // clamps any delay over 2^31-1 ms to fire after ~1ms instead — so an
+  // ordinary finite, in-range-per-`min` value that is still too large for
+  // `setTimeout` (e.g. a fat-fingered extra zero) must fall back too, not
+  // just non-numeric or overflowing-to-Infinity input.
+  it("rejects a finite value that exceeds setTimeout's 32-bit ceiling and falls back to the default", () => {
+    expect(configFor(5_000_000_000).attemptTimeoutMs).toBe(30000);
+    expect(configFor('5000000000').attemptTimeoutMs).toBe(30000);
+  });
+
+  it("accepts a finite value at exactly setTimeout's 32-bit ceiling", () => {
+    expect(configFor(2_147_483_647).attemptTimeoutMs).toBe(2_147_483_647);
+  });
+
+  it('has no upper bound on a key with no explicit max (maxContextMessages), only on attemptTimeoutMs', () => {
+    // maxContextMessages never reaches setTimeout, so parseOpenRouterInt's
+    // default max (Number.MAX_SAFE_INTEGER) is the only ceiling — an
+    // ordinary large-but-safe integer must pass through unchanged.
+    expect(parseOpenRouterInt(5_000_000_000, 40, 0)).toBe(5_000_000_000);
   });
 });

--- a/tests/worker/openrouter-provider.test.ts
+++ b/tests/worker/openrouter-provider.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test';
+import { OpenRouterProvider } from '../../src/services/worker/OpenRouterProvider.js';
+import { SettingsDefaultsManager } from '../../src/shared/SettingsDefaultsManager.js';
+import { logger } from '../../src/utils/logger.js';
+import type { ConversationMessage } from '../../src/services/worker-types.js';
+import type { DatabaseManager } from '../../src/services/worker/DatabaseManager.js';
+import type { SessionManager } from '../../src/services/worker/SessionManager.js';
+
+// #3606 — the bounded-context-window fix on the OpenRouter path.
+// `query()`/`getConfig()` are `protected`, which TypeScript enforces only at
+// compile time; casting to `any` (the same trick used to unit-test other
+// protected provider internals) reaches them directly so these tests can
+// assert on the actual request body without standing up the full
+// startSession()/message-loop machinery.
+
+function makeHistory(turns: number): ConversationMessage[] {
+  const history: ConversationMessage[] = [
+    { role: 'user', content: 'INIT PROMPT carrying the <observation> schema' },
+  ];
+  for (let i = 0; i < turns; i++) {
+    history.push({
+      role: i % 2 === 0 ? 'assistant' : 'user',
+      content: `turn-${i}-${'x'.repeat(200)}`,
+    });
+  }
+  return history;
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } });
+}
+
+describe('OpenRouterProvider — bounded context window (#3606)', () => {
+  let loadFromFileSpy: ReturnType<typeof spyOn>;
+  let originalFetch: typeof global.fetch;
+  let provider: OpenRouterProvider;
+  let loggerSpies: ReturnType<typeof spyOn>[];
+
+  beforeEach(() => {
+    loadFromFileSpy = spyOn(SettingsDefaultsManager, 'loadFromFile').mockImplementation(() => ({
+      ...SettingsDefaultsManager.getAllDefaults(),
+      CLAUDE_MEM_OPENROUTER_API_KEY: 'test-key',
+      CLAUDE_MEM_OPENROUTER_MODEL: 'mock-model',
+      CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES: '4',
+      CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_CHARS: '3000',
+      CLAUDE_MEM_OPENROUTER_MAX_TOKENS: '777',
+      CLAUDE_MEM_OPENROUTER_ATTEMPT_TIMEOUT_MS: '1234',
+    }));
+
+    loggerSpies = [
+      spyOn(logger, 'debug').mockImplementation(() => {}),
+      spyOn(logger, 'info').mockImplementation(() => {}),
+      spyOn(logger, 'warn').mockImplementation(() => {}),
+      spyOn(logger, 'error').mockImplementation(() => {}),
+    ];
+
+    originalFetch = global.fetch;
+    provider = new OpenRouterProvider({} as DatabaseManager, {} as SessionManager);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    loadFromFileSpy.mockRestore();
+    loggerSpies.forEach(s => s.mockRestore());
+    mock.restore();
+  });
+
+  it('parses the four context-window settings into getConfig()', () => {
+    const config = (provider as any).getConfig();
+    expect(config.maxContextMessages).toBe(4);
+    expect(config.maxContextChars).toBe(3000);
+    expect(config.maxTokens).toBe(777);
+    expect(config.attemptTimeoutMs).toBe(1234);
+  });
+
+  it("falls back to the numeric default (4096 / 30000) when MAX_TOKENS or ATTEMPT_TIMEOUT_MS is '0' or '-5' — both must stay >= 1", () => {
+    for (const bad of ['0', '-5']) {
+      loadFromFileSpy.mockImplementation(() => ({
+        ...SettingsDefaultsManager.getAllDefaults(),
+        CLAUDE_MEM_OPENROUTER_API_KEY: 'test-key',
+        CLAUDE_MEM_OPENROUTER_MODEL: 'mock-model',
+        CLAUDE_MEM_OPENROUTER_MAX_TOKENS: bad,
+        CLAUDE_MEM_OPENROUTER_ATTEMPT_TIMEOUT_MS: bad,
+      }));
+      const config = (provider as any).getConfig();
+      expect(config.maxTokens).toBe(4096);
+      expect(config.attemptTimeoutMs).toBe(30000);
+    }
+  });
+
+  it("keeps '0' as unbounded for MAX_CONTEXT_MESSAGES and MAX_CONTEXT_CHARS (they don't share the >= 1 floor)", () => {
+    loadFromFileSpy.mockImplementation(() => ({
+      ...SettingsDefaultsManager.getAllDefaults(),
+      CLAUDE_MEM_OPENROUTER_API_KEY: 'test-key',
+      CLAUDE_MEM_OPENROUTER_MODEL: 'mock-model',
+      CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES: '0',
+      CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_CHARS: '0',
+    }));
+    const config = (provider as any).getConfig();
+    expect(config.maxContextMessages).toBe(0);
+    expect(config.maxContextChars).toBe(0);
+  });
+
+  it('falls back to the numeric default (40 / 200000) when MAX_CONTEXT_MESSAGES or MAX_CONTEXT_CHARS is negative — only 0 means unbounded', () => {
+    loadFromFileSpy.mockImplementation(() => ({
+      ...SettingsDefaultsManager.getAllDefaults(),
+      CLAUDE_MEM_OPENROUTER_API_KEY: 'test-key',
+      CLAUDE_MEM_OPENROUTER_MODEL: 'mock-model',
+      CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_MESSAGES: '-5',
+      CLAUDE_MEM_OPENROUTER_MAX_CONTEXT_CHARS: '-5',
+    }));
+    const config = (provider as any).getConfig();
+    expect(config.maxContextMessages).toBe(40);
+    expect(config.maxContextChars).toBe(200000);
+  });
+
+  it('sends a bounded, system-anchored request: max_tokens, timeout:false, and finishReason propagation', async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(jsonResponse({
+        choices: [{
+          message: { role: 'assistant', content: '<observation><type>discovery</type><title>t</title></observation>' },
+          finish_reason: 'stop',
+        }],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      }))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const history = makeHistory(30);
+    const config = (provider as any).getConfig();
+    const result = await (provider as any).query(history, config);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit & Record<string, unknown>];
+    const body = JSON.parse(init.body as string);
+
+    expect(body.messages[0].role).toBe('system');
+    expect(body.messages[0].content).toBe(history[0].content);
+    // maxContextMessages=4 -> system + at most 4 trailing turns.
+    expect(body.messages.length).toBeLessThanOrEqual(5);
+    const sentChars = body.messages
+      .slice(1)
+      .reduce((sum: number, m: { content: string }) => sum + m.content.length, 0);
+    expect(sentChars).toBeLessThanOrEqual(3000);
+    expect(body.max_tokens).toBe(777);
+    expect(init.timeout).toBe(false);
+
+    expect(result.finishReason).toBe('stop');
+    expect(result.content).toContain('<observation>');
+  });
+
+  it('keeps the final message even when char-bounding would otherwise drop it', async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(jsonResponse({
+        choices: [{ message: { role: 'assistant', content: 'ack' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      }))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const history: ConversationMessage[] = [
+      { role: 'user', content: 'INIT' },
+      { role: 'user', content: 'a'.repeat(50) },
+      { role: 'user', content: 'z'.repeat(5000) }, // alone exceeds the 3000-char budget
+    ];
+    const config = (provider as any).getConfig();
+    await (provider as any).query(history, config);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit & Record<string, unknown>];
+    const body = JSON.parse(init.body as string);
+    expect(body.messages).toHaveLength(2);
+    expect(body.messages[1].content).toBe('z'.repeat(5000));
+  });
+
+  it("empty content with finish_reason='length' logs an error and returns { content: '', finishReason: 'length' }", async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(jsonResponse({
+        choices: [{ message: { role: 'assistant', content: '' }, finish_reason: 'length' }],
+        usage: { prompt_tokens: 100, completion_tokens: 0, total_tokens: 100 },
+      }))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const history = makeHistory(5);
+    const config = (provider as any).getConfig();
+    const result = await (provider as any).query(history, config);
+
+    expect(result).toEqual({ content: '', finishReason: 'length' });
+    expect(logger.error).toHaveBeenCalledWith(
+      'SDK',
+      'Empty response from OpenRouter — context or output budget exhausted',
+      expect.objectContaining({ finishReason: 'length' })
+    );
+    expect(logger.info).not.toHaveBeenCalledWith('SDK', expect.stringContaining('observer skipped the batch'), expect.anything());
+  });
+
+  it("malformed response (data.choices missing) logs the malformed-body error and returns { content: '', finishReason: 'malformed' } — not the designed-empty logging", async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(jsonResponse({ usage: { prompt_tokens: 5, completion_tokens: 0, total_tokens: 5 } }))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const history = makeHistory(5);
+    const config = (provider as any).getConfig();
+    const result = await (provider as any).query(history, config);
+
+    expect(result).toEqual({ content: '', finishReason: 'malformed' });
+    expect(logger.error).toHaveBeenCalledWith(
+      'SDK',
+      'Malformed response from OpenRouter — no choices/message in body',
+      expect.objectContaining({ keys: ['usage'] })
+    );
+    expect(logger.error).not.toHaveBeenCalledWith(
+      'SDK',
+      'Empty response from OpenRouter — context or output budget exhausted',
+      expect.anything()
+    );
+    expect(logger.info).not.toHaveBeenCalledWith('SDK', expect.stringContaining('observer skipped the batch'), expect.anything());
+  });
+
+  it("malformed response (choices[0].message missing) also logs the malformed-body error, distinct from a designed empty completion, and returns finishReason: 'malformed' so downstream never treats it as a designed skip", async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(jsonResponse({
+        choices: [{ finish_reason: 'stop' }],
+        usage: { prompt_tokens: 5, completion_tokens: 0, total_tokens: 5 },
+      }))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const history = makeHistory(5);
+    const config = (provider as any).getConfig();
+    const result = await (provider as any).query(history, config);
+
+    expect(result).toEqual({ content: '', finishReason: 'malformed' });
+    expect(logger.error).toHaveBeenCalledWith(
+      'SDK',
+      'Malformed response from OpenRouter — no choices/message in body',
+      expect.objectContaining({ finishReason: 'stop' })
+    );
+    expect(logger.info).not.toHaveBeenCalled();
+  });
+
+  it("empty content with no finish_reason at all ({message:{}}) is NOT a designed skip: logs warn and returns finishReason: 'missing'", async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(jsonResponse({
+        choices: [{ message: {} }],
+        usage: { prompt_tokens: 12, completion_tokens: 0, total_tokens: 12 },
+      }))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const history = makeHistory(5);
+    const config = (provider as any).getConfig();
+    const result = await (provider as any).query(history, config);
+
+    expect(result).toEqual({ content: '', finishReason: 'missing' });
+    expect(logger.warn).toHaveBeenCalledWith(
+      'SDK',
+      'Empty response from OpenRouter with finish_reason=missing — not a designed skip',
+      expect.objectContaining({
+        finishReason: undefined,
+        messagesSent: expect.any(Number),
+        promptChars: expect.any(Number),
+        promptTokens: 12,
+        completionTokens: 0,
+      })
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalledWith('SDK', expect.stringContaining('observer skipped the batch'), expect.anything());
+  });
+
+  it("empty content with finish_reason='content_filter' is NOT a designed skip: logs warn, not info, and returns the real finishReason", async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(jsonResponse({
+        choices: [{ message: { content: '' }, finish_reason: 'content_filter' }],
+        usage: { prompt_tokens: 20, completion_tokens: 0, total_tokens: 20 },
+      }))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const history = makeHistory(5);
+    const config = (provider as any).getConfig();
+    const result = await (provider as any).query(history, config);
+
+    expect(result).toEqual({ content: '', finishReason: 'content_filter' });
+    expect(logger.warn).toHaveBeenCalledWith(
+      'SDK',
+      'Empty response from OpenRouter with finish_reason=content_filter — not a designed skip',
+      expect.objectContaining({ finishReason: 'content_filter' })
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalledWith('SDK', expect.stringContaining('observer skipped the batch'), expect.anything());
+  });
+
+  it("empty content with finish_reason='stop' is a designed no-op: logs info, not error", async () => {
+    const fetchMock = mock(() =>
+      Promise.resolve(jsonResponse({
+        choices: [{ message: { role: 'assistant', content: '' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 100, completion_tokens: 0, total_tokens: 100 },
+      }))
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const history = makeHistory(5);
+    const config = (provider as any).getConfig();
+    const result = await (provider as any).query(history, config);
+
+    expect(result).toEqual({ content: '', finishReason: 'stop' });
+    expect(logger.info).toHaveBeenCalledWith(
+      'SDK',
+      'Empty response from OpenRouter (finish_reason=stop) — observer skipped the batch',
+      expect.objectContaining({ finishReason: 'stop' })
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/tests/worker/poison-respawn.test.ts
+++ b/tests/worker/poison-respawn.test.ts
@@ -88,12 +88,16 @@ describe('observer invalid-output handling (Phase 3 recovery)', () => {
     expect(sm.getMessageBuffer().getPendingCount(1)).toBe(0);
     expect(session.claimedMessageIds).toEqual([]);
     expect(session.earliestPendingTimestamp).toBeNull();
-    expect(session.consecutiveInvalidOutputs).toBe(0);
+    // #3606: consecutiveInvalidOutputs is now a real counter — this text
+    // classifies structurally as 'xml' (has an <observation> root tag) but
+    // fails to parse (no closing tag), so it's a genuine dropped batch and
+    // increments (2 -> 3) instead of resetting.
+    expect(session.consecutiveInvalidOutputs).toBe(3);
     expect(session.abortController.signal.aborted).toBe(false);
     expect(session.abortReason ?? null).toBeNull();
   });
 
-  it('repeated "No observations to record" acknowledgements confirm and never build respawn debt', async () => {
+  it('repeated "No observations to record" acknowledgements confirm and drop the queue each time', async () => {
     const sm = new SessionManager(makeDbManager());
     const session = sm.initializeSession(2, 'do the thing', 1);
     session.memorySessionId = 'mem-2';
@@ -113,7 +117,12 @@ describe('observer invalid-output handling (Phase 3 recovery)', () => {
         null,
         'TestAgent',
       );
-      expect(session.consecutiveInvalidOutputs).toBe(0);
+      // #3606: this prose ("No observations to record.") is not idle — it's
+      // a real dropped batch (not the designed empty-reply skip), so the
+      // real counter climbs each call rather than staying pinned at 0. The
+      // queue-level guarantee this test is really about — confirmed, never
+      // aborted, never re-queued — is asserted below.
+      expect(session.consecutiveInvalidOutputs).toBe(i + 1);
       expect(session.abortController.signal.aborted).toBe(false);
     }
 


### PR DESCRIPTION
## Summary

On the OpenRouter / OpenAI-compatible path the observer sends the **entire per-session conversation history on every call, with no `system` role**. Against a bounded context (a local Ollama/llama.cpp model here, 16,384 tokens) that produces exactly the discard pattern tracked in #3606, in two flavours:

- the prompt fills the window → llama.cpp truncates (`truncated=1`, `n_tokens=16383`) → the reply is empty → `outputClass=idle` → `confirmClaimedMessages` drops the batch. In our logs **99.1 % of idle discards (663/669) sat at exactly the context ceiling**.
- the history grows (median 235 turns) → the `<observation>` schema, stated once in the init prompt, scrolls out of view → the model emits bare `<observation>free text</observation>` → `parseObservationBlocks` finds no fields → `outputClass=xml`, dropped. **94 % of xml-class discards (492/522) were schema-less prose**, strongly correlated with history length; the remaining 6 % were cut mid-tag at exactly the ceiling.

Net effect on one install: **818 successful HTTP calls → 26 observations written over 15 hours (~96 % discarded)**, with the write-only `consecutiveInvalidOutputs` counter reading 0 throughout.

## What this changes

- **`context-window.ts` (new):** `history[0]` (the init/continuation prompt, which carries the full schema) is pinned as the `system` message; the rest is windowed by turn count and total chars, the final message is always kept, and leading `assistant` turns are dropped after trimming so strict gateways still see a user-first conversation.
- **Four settings declared and honoured** on this path (they previously did nothing because `SettingsDefaultsManager.loadFromFile` only copies keys present in `DEFAULTS`): `CLAUDE_MEM_OPENROUTER_MAX_TOKENS` (was hard-coded `4096`, see #3490), `_MAX_CONTEXT_MESSAGES` (default 40), `_MAX_CONTEXT_CHARS` (default 200000; `0` = unbounded for both caps), `_ATTEMPT_TIMEOUT_MS` (was the hard-coded 30 s `withRetry` default). Corrupt values fall back to the defaults; `max_tokens` and the timeout require ≥ 1.
- **`finish_reason` is read and propagated.** A designed empty completion is exactly: message present, empty content, `finish_reason === 'stop'` (info). `'length'` is a real truncation (error). Any other reason, an absent one, or a body with no `choices`/`message` (`malformed`) is not a designed skip and is logged as such.
- **`consecutiveInvalidOutputs` becomes a real counter** in the shared fall-through branch of `ResponseProcessor`: incremented on any real dropped batch, reset on a valid parse or a designed skip (`idle` with `finish_reason` `null` or `'stop'`; `null` covers Claude/Gemini, which never report one, so their behaviour is unchanged). Dropped batches log at `error` when truncated or xml-classified, `warn` otherwise. The newer overflow/quota/auth branches above it (#3800) are untouched. No retry is introduced: the drop-on-invalid design stays; the root cause is fixed upstream of it.
- Bun's `fetch` has a built-in ~300 s cap that overrides any `AbortSignal` per-attempt timeout; the request init now sets `timeout: false` so the configured timeout is authoritative.
- The duplicate assistant-history push this fix also targeted was already removed at #3619; `tests/worker/openai-compatible-history.test.ts` is added as a regression guard.

## Test evidence

- `tsc --noEmit` clean. `bun test tests/worker tests/sdk tests/shared`: 882 pass, 0 fail (+44 new). Full `bun test`: identical failing-test set and tallies to a clean `origin/main` checkout at the same commit (`be44b6c8`), verified side by side.
- The same logic was built into a worker bundle (on a v13.9.3-based branch) and driven end to end against a mock OpenAI-compatible server on a scratch port: every request system-first, ≤ cap messages, char cap with the final-message rule, alternating roles, observations stored; the `length` / `stop`-empty / `content_filter` / `malformed` paths logged and counted as designed.
- Live, after install on the affected machine (`MAX_CONTEXT_MESSAGES=12`, `MAX_CONTEXT_CHARS=28000`, `MAX_TOKENS=1500` for a 16k lane): prompt size median 7,463 tokens (was 12,800, p90 15,400), zero `truncated=1`, **97 observations + 2 summaries from 99 successful calls in the first 46 minutes, 2 batches dropped** (one output at the token cap, one prose reply).

Refs #3606 (umbrella), #3490 (`max_tokens`), #3624 (the preserve-and-retry approach; this PR removes the cause instead), #3619.

---
Opened by Gwen Ives, Virtual COO (an AI assistant operating on behalf of Matt Nye), from the install where the defect was measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwVTb8AbAAQZjxsrewXc83
