### PR TITLE
fix(observer): don't confirm the queued batch on mid-stream empty SDK chunks

### DIFF
--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -287,6 +287,11 @@ export class ClaudeProvider {
         }),
       });
 
+      // A single SDK turn streams several assistant messages; thinking-only
+      // and tool_use-only chunks carry no text block. Tracked per turn so an
+      // empty batch is forwarded once, after the turn ends.
+      let sawTextResponse = false;
+
       for await (const message of queryResult) {
         // Quota-aware wall-clock guard (#2234): the SDK pushes
         // `rate_limit_event` messages carrying live subscription quota state
@@ -413,19 +418,22 @@ export class ClaudeProvider {
             throw new Error('Invalid API key: check your API key configuration in ~/.claude-mem/settings.json or ~/.claude-mem/.env');
           }
 
-          await processAgentResponse(
-            textContent,
-            session,
-            this.dbManager,
-            this.sessionManager,
-            worker,
-            discoveryTokens,
-            originalTimestamp,
-            'SDK',
-            cwdTracker.lastCwd,
-            modelId,
-            activeResponseContext.current
-          );
+          if (responseSize > 0) {
+            sawTextResponse = true;
+            await processAgentResponse(
+              textContent,
+              session,
+              this.dbManager,
+              this.sessionManager,
+              worker,
+              discoveryTokens,
+              originalTimestamp,
+              'SDK',
+              cwdTracker.lastCwd,
+              modelId,
+              activeResponseContext.current
+            );
+          }
         }
 
         if (message.type === 'result') {
@@ -471,6 +479,26 @@ export class ClaudeProvider {
                   : undefined,
             });
           }
+
+          // The turn is over and the model never emitted text: this is the
+          // intentional-skip response, forwarded once so the claimed batch is
+          // acknowledged instead of being retried forever.
+          if (!sawTextResponse) {
+            await processAgentResponse(
+              '',
+              session,
+              this.dbManager,
+              this.sessionManager,
+              worker,
+              0,
+              session.earliestPendingTimestamp,
+              'SDK',
+              cwdTracker.lastCwd,
+              modelId,
+              activeResponseContext.current
+            );
+          }
+          sawTextResponse = false;
         }
       }
     } finally {

--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -291,6 +291,8 @@ export class ClaudeProvider {
       // and tool_use-only chunks carry no text block. Tracked per turn so an
       // empty batch is forwarded once, after the turn ends.
       let sawTextResponse = false;
+      // One re-queue per generator pass for a batch a failed turn never read.
+      let retriedAfterErrorResult = false;
 
       for await (const message of queryResult) {
         // Quota-aware wall-clock guard (#2234): the SDK pushes
@@ -480,19 +482,25 @@ export class ClaudeProvider {
             });
           }
 
+          const resultSubtype = (message as any).subtype as string | undefined;
+          const resultIsError = (message as any).is_error === true || resultSubtype !== 'success';
+
           // The turn is over and the model never emitted text. Only a
           // successful turn means "the model read the batch and chose to skip
           // it" — forward the empty response once so the claim is acknowledged
-          // instead of being retried forever. An error result never reached
-          // that judgement, so its batch stays claimed and the next generator
-          // pass re-yields it (SessionManager.getMessageIterator).
+          // instead of being retried forever. A failed turn never reached that
+          // judgement, so its batch goes back to the buffer for the drain to
+          // re-yield. Exactly one such retry per generator pass: a message is
+          // always pending while a batch is re-queued, so the buffer never
+          // idles out, and an endlessly failing turn would spin on it.
           if (!sawTextResponse) {
-            const resultSubtype = (message as any).subtype as string | undefined;
-            if ((message as any).is_error === true || resultSubtype !== 'success') {
-              logger.warn('SDK', 'SDK turn failed before emitting text, leaving queue intact', {
+            if (resultIsError && !retriedAfterErrorResult) {
+              retriedAfterErrorResult = true;
+              logger.warn('SDK', 'SDK turn failed before emitting text, re-queueing the claimed batch', {
                 sessionId: session.sessionDbId,
                 subtype: resultSubtype,
               });
+              await this.sessionManager.resetProcessingToPending(session.sessionDbId);
             } else {
               await processAgentResponse(
                 '',
@@ -508,6 +516,9 @@ export class ClaudeProvider {
                 activeResponseContext.current
               );
             }
+          }
+          if (!resultIsError) {
+            retriedAfterErrorResult = false;
           }
           sawTextResponse = false;
         }

--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -480,23 +480,34 @@ export class ClaudeProvider {
             });
           }
 
-          // The turn is over and the model never emitted text: this is the
-          // intentional-skip response, forwarded once so the claimed batch is
-          // acknowledged instead of being retried forever.
+          // The turn is over and the model never emitted text. Only a
+          // successful turn means "the model read the batch and chose to skip
+          // it" — forward the empty response once so the claim is acknowledged
+          // instead of being retried forever. An error result never reached
+          // that judgement, so its batch stays claimed and the next generator
+          // pass re-yields it (SessionManager.getMessageIterator).
           if (!sawTextResponse) {
-            await processAgentResponse(
-              '',
-              session,
-              this.dbManager,
-              this.sessionManager,
-              worker,
-              0,
-              session.earliestPendingTimestamp,
-              'SDK',
-              cwdTracker.lastCwd,
-              modelId,
-              activeResponseContext.current
-            );
+            const resultSubtype = (message as any).subtype as string | undefined;
+            if ((message as any).is_error === true || resultSubtype !== 'success') {
+              logger.warn('SDK', 'SDK turn failed before emitting text, leaving queue intact', {
+                sessionId: session.sessionDbId,
+                subtype: resultSubtype,
+              });
+            } else {
+              await processAgentResponse(
+                '',
+                session,
+                this.dbManager,
+                this.sessionManager,
+                worker,
+                0,
+                session.earliestPendingTimestamp,
+                'SDK',
+                cwdTracker.lastCwd,
+                modelId,
+                activeResponseContext.current
+              );
+            }
           }
           sawTextResponse = false;
         }


### PR DESCRIPTION
## What happens

A Claude Agent SDK turn streams **several** `assistant` messages. Thinking-only and tool_use-only chunks carry no `text` content block, so `textContent` is `''` for them.

`ClaudeProvider` called `processAgentResponse` on every one of those chunks. An empty string classifies as `idle` in `ResponseProcessor`, which takes the no-op-batch path:

```ts
await sessionManager.confirmClaimedMessages(session.sessionDbId);
session.earliestPendingTimestamp = null;
return;
```

That runs while the model is still thinking. `claimedMessageIds` and `earliestPendingTimestamp` are cleared, and when the real `<observation>` arrives a few seconds later in the same turn it is written against a batch that has already been acknowledged and detached.

## Evidence

Instrumenting the call site to log the content-block types of every empty chunk, on claude-mem 13.24.0 against a live worker — every sample was a mid-stream thinking block:

```
[WARN] [SDK] [session-1597] {blocks=thinking, stop_reason=null}
```

The drop and the model's actual answer are the same turn, ~8.5s apart:

```
14:45:28.649 [WARN ] [PARSER] [session-1591] SDK returned non-XML idle response — ignoring queued batch
14:45:37.204 [DATA ] [SDK   ] [session-1591] Response received (1356 chars)  <observation>…
```

It is not rare. `PARSER … ignoring queued batch` over two days of normal use:

```
outputClass=idle   3463
outputClass=prose   128
outputClass=xml      14
```

The `idle` bucket is almost entirely this, not model skips.

## The fix

`processAgentResponse` is called for a turn's text as before, and the empty response is forwarded once at the `result` boundary when the turn produced no text at all. A turn the model genuinely skips still reaches the confirm path exactly once, so no batch is retried forever; mid-stream thinking chunks no longer acknowledge a batch the model has not answered yet.

This is the call-site distinction @danemil asked for in #3454 — "SDK returned empty string" and "no SDK response received" are now different events, and only the second one confirms.

## Relation to existing issues

- #3454 (closed as not-planned) reports this symptom. The two theories in that thread are a generator start-up race and deliberate model skips; the intra-turn empty-chunk path is a third mechanism, and it accounts for the volume above.
- #3606 / plan-18 routes `idle` to `resetProcessingToPending`. That change and this one compose: without this guard, preserving the batch on `idle` turns every thinking chunk into a re-queue, so the same batch is resent throughout the turn. The empty chunk is not a model output and is better not classified as one at all.
- `OpenAICompatibleProvider` already gates the same call on `obsResponse.content || this.forwardEmptyMessageResponse`; the streaming provider had no equivalent gate.

## Testing

No automated test. `tests/` has no Agent SDK stream harness to drive multi-chunk turns through, and building one for a per-turn flag looked disproportionate — happy to add it if you would rather have it. Verified against a live 13.24.0 worker with the equivalent patch applied to the shipped bundle: `PARSER … ignoring queued batch` went to 0 over an equal-length window that previously logged 5, with observations continuing to store normally.
