### PR TITLE
server: let CLAUDE_MEM_SERVER_MAX_OUTPUT_TOKENS set the generation output cap

### DIFF
--- a/src/server/runtime/create-server-service.ts
+++ b/src/server/runtime/create-server-service.ts
@@ -253,29 +253,54 @@ function buildServerGenerationProviderFromEnv(): ServerGenerationProvider | null
   }
 }
 
+/**
+ * Optional cap on generated tokens for the server generation providers (#3829).
+ * All three providers already accept `maxOutputTokens`; nothing populated it, so
+ * every request went out with the constructor default of 4096. On a model that
+ * answers at length the reply is truncated mid-structure, the observation parser
+ * rejects it, and the job settles as a non-retryable parse_error — the work is
+ * lost silently. Unset keeps the 4096 default, so behavior is unchanged.
+ */
+export function resolveServerMaxOutputTokens(): number | undefined {
+  const raw = process.env.CLAUDE_MEM_SERVER_MAX_OUTPUT_TOKENS;
+  if (!raw) return undefined;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    logger.warn('SYSTEM', 'server: ignoring invalid CLAUDE_MEM_SERVER_MAX_OUTPUT_TOKENS', { value: raw });
+    return undefined;
+  }
+  return parsed;
+}
+
 function instantiateServerGenerationProvider(provider: string): ServerGenerationProvider | null {
   if (provider === 'claude' || provider === 'anthropic') {
     const apiKey = process.env.ANTHROPIC_API_KEY ?? process.env.CLAUDE_MEM_ANTHROPIC_API_KEY ?? '';
     if (!apiKey) return null;
-    const opts: { apiKey: string; model?: string } = { apiKey };
+    const opts: { apiKey: string; model?: string; maxOutputTokens?: number } = { apiKey };
     if (process.env.CLAUDE_MEM_SERVER_MODEL) opts.model = process.env.CLAUDE_MEM_SERVER_MODEL;
+    const maxOutputTokens = resolveServerMaxOutputTokens();
+    if (maxOutputTokens !== undefined) opts.maxOutputTokens = maxOutputTokens;
     return new ClaudeObservationProvider(opts);
   }
   if (provider === 'gemini') {
     const apiKey = process.env.GEMINI_API_KEY ?? process.env.CLAUDE_MEM_GEMINI_API_KEY ?? '';
     if (!apiKey) return null;
-    const opts: { apiKey: string; model?: string } = { apiKey };
+    const opts: { apiKey: string; model?: string; maxOutputTokens?: number } = { apiKey };
     if (process.env.CLAUDE_MEM_SERVER_MODEL) opts.model = process.env.CLAUDE_MEM_SERVER_MODEL;
+    const maxOutputTokens = resolveServerMaxOutputTokens();
+    if (maxOutputTokens !== undefined) opts.maxOutputTokens = maxOutputTokens;
     return new GeminiObservationProvider(opts);
   }
   if (provider === 'openrouter') {
     const apiKey = process.env.OPENROUTER_API_KEY ?? process.env.CLAUDE_MEM_OPENROUTER_API_KEY ?? '';
     if (!apiKey) return null;
-    const opts: { apiKey: string; model?: string; baseUrl?: string } = { apiKey };
+    const opts: { apiKey: string; model?: string; baseUrl?: string; maxOutputTokens?: number } = { apiKey };
     if (process.env.CLAUDE_MEM_SERVER_MODEL) opts.model = process.env.CLAUDE_MEM_SERVER_MODEL;
     // #2382/#2590/#2622/#2393 — optional OpenAI-compatible base URL.
     const baseUrl = process.env.CLAUDE_MEM_OPENROUTER_BASE_URL ?? process.env.OPENROUTER_BASE_URL;
     if (baseUrl) opts.baseUrl = baseUrl;
+    const maxOutputTokens = resolveServerMaxOutputTokens();
+    if (maxOutputTokens !== undefined) opts.maxOutputTokens = maxOutputTokens;
     return new OpenRouterObservationProvider(opts);
   }
   return null;

--- a/tests/server/runtime/server-max-output-tokens.test.ts
+++ b/tests/server/runtime/server-max-output-tokens.test.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it } from 'bun:test';
+import { resolveServerMaxOutputTokens } from '../../../src/server/runtime/create-server-service.js';
+import { OpenRouterObservationProvider } from '../../../src/server/generation/providers/OpenRouterObservationProvider.js';
+
+const KEY = 'CLAUDE_MEM_SERVER_MAX_OUTPUT_TOKENS';
+
+afterEach(() => {
+  delete process.env[KEY];
+});
+
+describe('resolveServerMaxOutputTokens', () => {
+  it('is undefined when unset, so the provider default is unchanged', () => {
+    expect(resolveServerMaxOutputTokens()).toBeUndefined();
+  });
+
+  it('reads a positive integer', () => {
+    process.env[KEY] = '16384';
+    expect(resolveServerMaxOutputTokens()).toBe(16384);
+  });
+
+  it('ignores values that are not positive integers rather than sending NaN', () => {
+    for (const bad of ['0', '-1', 'lots', '1.5', '']) {
+      process.env[KEY] = bad;
+      expect(resolveServerMaxOutputTokens()).toBeUndefined();
+    }
+  });
+});
+
+describe('OpenRouterObservationProvider max_tokens', () => {
+  async function capture(maxOutputTokens?: number): Promise<number> {
+    let body: { max_tokens?: number } = {};
+    const provider = new OpenRouterObservationProvider({
+      apiKey: 'k',
+      ...(maxOutputTokens === undefined ? {} : { maxOutputTokens }),
+      fetchImpl: (async (_url: string, init: { body: string }) => {
+        body = JSON.parse(init.body);
+        return new Response(
+          JSON.stringify({ choices: [{ message: { content: '<skip_summary />' } }] }),
+          { status: 200 },
+        );
+      }) as unknown as typeof fetch,
+    });
+    await provider.generate({
+      job: {
+        id: 'job-1', projectId: 'p', teamId: 't', agentEventId: 'e', sourceType: 'agent_event',
+        sourceId: 'e', serverSessionId: null, jobType: 'observation_generate_for_event',
+        status: 'processing', idempotencyKey: 'k', bullmqJobId: null, attempts: 1,
+        maxAttempts: 3, nextAttemptAtEpoch: null, lockedAtEpoch: null,
+      },
+      events: [],
+      project: { projectId: 'p', teamId: 't' },
+    } as never);
+    return body.max_tokens as number;
+  }
+
+  it('defaults to 4096', async () => {
+    expect(await capture()).toBe(4096);
+  });
+
+  it('sends the configured cap instead', async () => {
+    expect(await capture(16384)).toBe(16384);
+  });
+});


### PR DESCRIPTION
Closes #3829 (the max_tokens half).

All three server generation providers already take a `maxOutputTokens` option, but `instantiateServerGenerationProvider` never populates it, so every request goes out with the constructor default of 4096.

On a model that answers at length that truncates the reply mid-structure. The observation parser then finds no complete `<observation>` block, returns `{valid:false}`, and `processGenerationResult` settles the job as `parse_error` with `retryable:false` — one attempt of three, and the observation is gone. It looks like a model problem rather than a configuration one, which is what made it hard to spot: we lost 20 observations to it before working out the reply was simply being cut off at exactly 4096 completion tokens.

This reads `CLAUDE_MEM_SERVER_MAX_OUTPUT_TOKENS` and passes it to whichever provider is selected. Unset keeps 4096, so nothing changes unless you set it. Non-integer or non-positive values are ignored with a warning rather than sent as `NaN`.

Tests in `tests/server/runtime/server-max-output-tokens.test.ts`: the parsing cases, plus two that capture the outgoing request body and assert `max_tokens` is 4096 by default and the configured value when set. They fail without the change. `bun test tests/server/` is 170 pass / 13 skip / 0 fail.

I've left the worker-side providers alone — same shape, but it's a separate concern and I didn't want to widen this.