### PR TITLE
fix(observer): don't store observations parsed from the init reply

### DIFF
--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -135,7 +135,6 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     const initPrompt = session.lastPromptNumber === 1
       ? buildInitPrompt(session.project, session.contentSessionId, session.userPrompt, mode, priorContext)
       : buildContinuationPrompt(session.userPrompt, session.lastPromptNumber, session.contentSessionId, mode, priorContext);
-    const initContext = snapshotResponseContext(session);
 
     session.conversationHistory.push({ role: 'user', content: initPrompt });
 
@@ -143,7 +142,7 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
       session.lastPromptSentAt = Date.now();
       session.lastGeneratorSource = 'init';
       const initResponse = await this.query(session.conversationHistory, config);
-      await this.handleInitResponse(initResponse, session, worker, model, initContext);
+      this.handleInitResponse(initResponse, session, model);
     } catch (error: unknown) {
       // Classified errors are logged once, at SessionRoutes' `Observer failed`
       // line; here they're debug-level so one failure isn't five error lines.
@@ -203,28 +202,27 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     }
   }
 
-  private async handleInitResponse(
+  private handleInitResponse(
     initResponse: ProviderQueryResult,
     session: ActiveSession,
-    worker: WorkerRef | undefined,
-    model: string,
-    responseContext: ReturnType<typeof snapshotResponseContext>
-  ): Promise<void> {
-    if (initResponse.content) {
-      // Appended once, by processAgentResponse below — see processObservationMessage.
-      const tokensUsed = initResponse.tokensUsed || 0;
-      session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
-      session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
-      session.lastUsage = this.buildLastUsage(initResponse);
-      await processAgentResponse(
-        initResponse.content, session, this.dbManager, this.sessionManager,
-        worker, tokensUsed, null, this.providerName, undefined, initResponse.servedModel ?? model, responseContext
-      );
-    } else {
+    model: string
+  ): void {
+    if (!initResponse.content) {
       logger.error('SDK', `Empty ${this.providerName} init response - session may lack context`, {
         sessionId: session.sessionDbId, model
       });
+      return;
     }
+
+    const tokensUsed = initResponse.tokensUsed || 0;
+    session.cumulativeInputTokens += Math.floor(tokensUsed * 0.7);
+    session.cumulativeOutputTokens += Math.floor(tokensUsed * 0.3);
+    // The init prompt carries the user's request and no tool call, so nothing in
+    // its reply can be an observation of this session — an <observation> here was
+    // invented from <user_request> alone and would be stored as memory for work
+    // that never happened. Keep the turn so role alternation holds, but never
+    // hand it to the storage path.
+    session.conversationHistory.push({ role: 'assistant', content: initResponse.content });
   }
 
   private async processObservationMessage(

--- a/tests/gemini_provider.test.ts
+++ b/tests/gemini_provider.test.ts
@@ -9,6 +9,15 @@ import { ModeManager } from '../src/services/domain/ModeManager';
 import { SettingsDefaultsManager } from '../src/shared/SettingsDefaultsManager';
 
 let rateLimitingEnabled = 'false';
+let queuedMessages: Array<Record<string, unknown>> = [];
+
+const toolObservationMessage = {
+  type: 'observation',
+  tool_name: 'Read',
+  tool_input: { file_path: 'src/main.ts' },
+  tool_response: 'file contents',
+  prompt_number: 1,
+};
 
 const mockMode = {
   name: 'code',
@@ -91,6 +100,7 @@ describe('GeminiProvider', () => {
 
   beforeEach(() => {
     rateLimitingEnabled = 'false';
+    queuedMessages = [];
 
     modeManagerSpy = spyOn(ModeManager, 'getInstance').mockImplementation(() => ({
       getActiveMode: () => mockMode,
@@ -156,7 +166,7 @@ describe('GeminiProvider', () => {
     };
 
     mockSessionManager = {
-      getMessageIterator: async function* () { yield* []; },
+      getMessageIterator: async function* () { yield* queuedMessages; },
       getClaimedMessages: mock(() => []),
       confirmClaimedMessages: mock(() => Promise.resolve(0)),
       resetProcessingToPending: mock(() => Promise.resolve(0)),
@@ -318,6 +328,7 @@ describe('GeminiProvider', () => {
       </observation>
     `;
 
+    queuedMessages = [toolObservationMessage];
     global.fetch = mock(() => Promise.resolve(new Response(JSON.stringify({
       candidates: [{ content: { parts: [{ text: observationXml }] } }],
       usageMetadata: { totalTokenCount: 50 }
@@ -325,12 +336,12 @@ describe('GeminiProvider', () => {
 
     await agent.startSession(session);
 
-    expect(mockStoreObservations).toHaveBeenCalled();
+    expect(mockStoreObservations).toHaveBeenCalledTimes(1);
     expect(mockSyncObservation).toHaveBeenCalled();
     expect(session.cumulativeInputTokens).toBeGreaterThan(0);
   });
 
-  it('stores a deferred init response under the original prompt project after the live session advances', async () => {
+  it('stores a deferred observation response under the original prompt project after the live session advances', async () => {
     const session = makeSession({
       project: 'repo-a',
       userPrompt: 'prompt 1',
@@ -339,7 +350,7 @@ describe('GeminiProvider', () => {
     const observationXml = `
       <observation>
         <type>discovery</type>
-        <title>Late init response</title>
+        <title>Late observation response</title>
         <narrative>Should stay on the original prompt project.</narrative>
         <facts></facts>
         <concepts></concepts>
@@ -348,10 +359,23 @@ describe('GeminiProvider', () => {
       </observation>
     `;
 
+    queuedMessages = [toolObservationMessage];
     let resolveFetch!: (response: Response) => void;
-    global.fetch = mock(() => new Promise<Response>(resolve => {
-      resolveFetch = resolve;
-    }));
+    let sends = 0;
+    global.fetch = mock(() => {
+      sends++;
+      // Only the observation query is held open; the init query has to complete
+      // for the message loop to reach it.
+      if (sends === 1) {
+        return Promise.resolve(new Response(JSON.stringify({
+          candidates: [{ content: { parts: [{ text: 'Ready.' }] } }],
+          usageMetadata: { totalTokenCount: 10 }
+        })));
+      }
+      return new Promise<Response>(resolve => {
+        resolveFetch = resolve;
+      });
+    });
 
     const pending = agent.startSession(session);
     // Wait for the request to actually be in flight rather than assuming it

--- a/tests/worker/openai-compatible-init-response.test.ts
+++ b/tests/worker/openai-compatible-init-response.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import { ModeManager } from '../../src/services/domain/ModeManager.js';
+import { OpenAICompatibleProvider, type ProviderQueryResult } from '../../src/services/worker/OpenAICompatibleProvider.js';
+import type { DatabaseManager } from '../../src/services/worker/DatabaseManager.js';
+import type { SessionManager } from '../../src/services/worker/SessionManager.js';
+import type { ActiveSession, ConversationMessage } from '../../src/services/worker-types.js';
+
+const mockMode = {
+  name: 'code',
+  prompts: {
+    init: 'init prompt',
+    observation: 'obs prompt',
+    summary: 'summary prompt',
+  },
+  observation_types: [{ id: 'discovery' }],
+  observation_concepts: [],
+};
+
+const observationXml = `
+  <observation>
+    <type>discovery</type>
+    <title>Invented from the user request</title>
+    <narrative>No tool call had been observed when this was produced.</narrative>
+    <facts></facts>
+    <concepts></concepts>
+    <files_read></files_read>
+    <files_modified></files_modified>
+  </observation>
+`;
+
+function makeSession(overrides: Partial<ActiveSession> = {}): ActiveSession {
+  return {
+    sessionDbId: 1,
+    contentSessionId: 'test-session',
+    memorySessionId: 'mem-session-123',
+    project: 'test-project',
+    platformSource: 'claude',
+    userPrompt: 'test prompt',
+    abortController: new AbortController(),
+    generatorPromise: null,
+    lastPromptNumber: 1,
+    startTime: Date.now(),
+    cumulativeInputTokens: 0,
+    cumulativeOutputTokens: 0,
+    earliestPendingTimestamp: null,
+    claimedMessageIds: [],
+    conversationHistory: [],
+    currentProvider: null,
+    consecutiveRestarts: 0,
+    consecutiveInvalidOutputs: 0,
+    lastGeneratorActivity: Date.now(),
+    ...overrides,
+  };
+}
+
+/** Answers every prompt — the init prompt included — with a valid observation. */
+class TestProvider extends OpenAICompatibleProvider<{ apiKey: string; model: string }> {
+  protected readonly providerName = 'TestProvider';
+  protected readonly syntheticIdPrefix = 'test';
+  protected readonly forwardEmptyMessageResponse = false;
+  queries = 0;
+
+  protected getConfig() {
+    return { apiKey: 'test-api-key', model: 'session-model' };
+  }
+
+  protected missingApiKeyError(): Error {
+    return new Error('missing key');
+  }
+
+  protected async query(_history: ConversationMessage[], _config: { apiKey: string; model: string }): Promise<ProviderQueryResult> {
+    this.queries++;
+    return { content: observationXml, tokensUsed: 100 };
+  }
+
+  protected estimateTokens(): number {
+    return 0;
+  }
+
+  protected buildLastUsage(): ActiveSession['lastUsage'] {
+    return null;
+  }
+}
+
+describe('OpenAICompatibleProvider init response', () => {
+  let modeManagerSpy: ReturnType<typeof spyOn>;
+  let storeObservations: ReturnType<typeof mock>;
+  let dbManager: DatabaseManager;
+  let sessionManager: SessionManager;
+
+  beforeEach(() => {
+    modeManagerSpy = spyOn(ModeManager, 'getInstance').mockImplementation(() => ({
+      getActiveMode: () => mockMode,
+      loadMode: () => {},
+    } as unknown as ModeManager));
+
+    storeObservations = mock(() => ({ observationIds: [1], summaryId: null, createdAtEpoch: Date.now() }));
+
+    dbManager = {
+      getSessionStore: () => ({
+        storeObservations,
+        ensureMemorySessionIdRegistered: mock(() => {}),
+        updateMemorySessionId: mock(() => {}),
+      }),
+      getChromaSync: () => ({
+        syncObservation: mock(() => Promise.resolve()),
+        syncSummary: mock(() => Promise.resolve()),
+      }),
+      getCloudSync: () => null,
+    } as unknown as DatabaseManager;
+
+    sessionManager = {
+      getMessageIterator: async function* () {
+        yield { type: 'observation', tool_name: 'Read', tool_input: { file_path: 'src/main.ts' }, tool_response: 'file contents', prompt_number: 1 };
+      },
+      getClaimedMessages: mock(() => []),
+      confirmClaimedMessages: mock(() => Promise.resolve(0)),
+      resetProcessingToPending: mock(() => Promise.resolve(0)),
+    } as unknown as SessionManager;
+  });
+
+  afterEach(() => {
+    modeManagerSpy.mockRestore();
+    mock.restore();
+  });
+
+  it('does not store observations parsed out of the init response', async () => {
+    const provider = new TestProvider(dbManager, sessionManager);
+    const session = makeSession();
+
+    await provider.startSession(session);
+
+    // Both queries were answered with an observation, but only the reply to a
+    // real tool call is an observation of this session.
+    expect(provider.queries).toBe(2);
+    expect(storeObservations).toHaveBeenCalledTimes(1);
+    // The init reply still occupies its assistant turn, so roles alternate.
+    expect(session.conversationHistory.map(message => message.role)).toEqual(['user', 'assistant', 'user', 'assistant']);
+  });
+});


### PR DESCRIPTION
## Symptom

An observation can be stored asserting work that never happened.

A session that had made no tool calls yet got this stored a few seconds in, before its only `Edit` was processed:

- title: *"Provider credit exhaustion detection"*
- narrative: *"Provider behavior was extended so exhausted credits are recognized as a distinct condition"*
- `files_modified: []`

Nothing had been observed at that point. The observation is a paraphrase of the user's prompt, stored as memory. It then feeds cross-session context injection like any real one — which is worse than a missing observation, because the next session reads it as something that happened.

## Mechanism

`OpenAICompatibleProvider.startSession` sends the briefing prompt as a standalone query and hands the reply straight to the storage path:

- `src/services/worker/OpenAICompatibleProvider.ts:135-137` builds `buildInitPrompt` / `buildContinuationPrompt`
- `:145` sends it as its own query
- `:146` → `handleInitResponse` (`:206-228`), which at `:213` checks only `if (initResponse.content)` and at `:219` calls `processAgentResponse` unconditionally
- `src/services/worker/agents/ResponseProcessor.ts:311-320` parses it, `:445` stores whatever `<observation>` it found

The brief cannot legitimately contain one. `src/sdk/prompts.ts:64-90` shows the model the observation output format and an `<observed_from_primary_session>` block holding only `<user_request>` and `<requested_at>` — there is no `<what_happened>`, no tool call, nothing observed — and then ends with the `MEMORY PROCESSING START` header. The mode's own `skip_guidance` says to return an empty response when skipping. Most of the time the model does. Sometimes it fills in the format from the user request instead, and that gets stored.

`files_modified: []` is the fingerprint: `sanitizeObservationFiles` (`ResponseProcessor.ts:249-258`) strips file claims that no claimed message supports, and at init there are none.

## Evidence

Measured on a non-Anthropic provider: **2 of 12 sessions** produced a well-formed `<observation>` in reply to the brief, and both were stored. One landed in a real corpus, with the content above.

Reproduced offline, no API calls, driven through the real base class: a stub subclass overriding only `query()` to return an `<observation>` for the init call, with an empty message iterator, stores one observation. The same holds with the real `GeminiProvider` and `OpenRouterProvider` and `fetch` mocked, because `startSession` and `handleInitResponse` are base-class private — `GeminiProvider.ts:223-226` and `OpenRouterProvider.ts:301-304` only supply `getConfig`/`query`/`estimateTokens`/`buildLastUsage`. Control: an empty init reply stores nothing.

Not a regression — `git show 4ad2383f` shows `handleInitResponse` already called `processAgentResponse` before #3217.

**You can measure the rate on your own fleet without trusting the number above:** every `session_compressed` event with `hook='init'` and `count>0` is an init-derived observation (`ResponseProcessor.ts:493` is the count, `:506` stamps `hook: session.lastGeneratorSource`, set to `'init'` at `OpenAICompatibleProvider.ts:144`). The 2/12 is one model on one provider; I have not measured Gemini, OpenRouter or the Claude path.

## The fix

`handleInitResponse` keeps the reply's token accounting and appends it as the assistant turn itself, instead of routing it through `processAgentResponse`. +16/-18 in one file.

The assistant turn is still pushed, so role alternation is byte-for-byte what it was — this only removes the storage call. `session.lastUsage` is deliberately no longer set at init: `ResponseProcessor.ts:485-487` reads and nulls it, so with no consumer on this path it would have leaked the init call's usage into the next real observation's telemetry.

## What it leaves alone

- **`ClaudeProvider` is exposed the same way and is not fixed here.** `ClaudeProvider.ts:566-568` builds the same brief, `:575-584` yields it as the first user message, and `:359-429` treats every `assistant` message identically — `:416` passes it to `processAgentResponse` with no notion of which prompt it answers. Fixing it needs a different mechanism (the SDK streams, so it turns on the one-reply-per-turn invariant rather than a return value) and deserves its own change. Happy to follow up. It also means the telemetry query above keeps working as a measurement of the remaining exposure after this merges.
- **The prompt text.** A line telling the model no tool use has been observed yet would help the Claude path too, but it is probabilistic and untestable, and the mode text is yours.
- **One deliberate loss, stated plainly:** the init reply no longer reaches the prose-rejection recovery paths in `ResponseProcessor` (context overflow → recycle, quota prose → pause and preserve the batch, auth prose → abort). Those now trigger one query later, on the first observation, which goes through `processAgentResponse` as before — so the recovery still happens, at the cost of one wasted request in those failure cases. If you would rather keep it at init, the alternative is a `store: false` parameter on `processAgentResponse`; I picked the smaller diff.

## Tests

- **New** `tests/worker/openai-compatible-init-response.test.ts`, in the idiom of `tests/worker/openai-compatible-summary-tier.test.ts`: a provider that answers every prompt with a valid observation, one tool call in the iterator. Asserts two queries, `storeObservations` called once, and history roles `['user','assistant','user','assistant']`. On `main` it fails with `Expected number of calls: 1 / Received number of calls: 2`.
- **Re-targeted, two tests in `tests/gemini_provider.test.ts`.** Both stored through the init query rather than through a tool call, because the init query is the only one that needs no message iterator — they were exercising the store pipeline, not asserting that a brief reply is memory. Both now queue one tool call: `should process observations and store them` (also tightened to `toHaveBeenCalledTimes(1)`, so it is now a guard for this bug too) and the #3217 deferred-attribution test, whose `fetch` mock now completes the brief and holds the observation query open instead. Its attribution assertions are unchanged.

Green: `npm run typecheck`; `bun test tests/worker tests/shared tests/env-isolation.test.ts` → 790 pass, 1 skip, 0 fail; `npm run lint:spawn-env`; `npm run lint:hook-io`; `tests/gemini_provider.test.ts` 12/12.

---

Unrelated note, no change proposed: `CLAUDE_MEM_TIER_SUMMARY_MODEL` reaches non-Claude providers as a literal model id (`model-aliases.ts:36-42` → `OpenAICompatibleProvider.ts:334-336`), which is what #3257 was for, so setting it to an id the active provider does not serve makes every summary fail with a 4xx while observations keep working. The default is `''` (`SettingsDefaultsManager.ts:186`), so a default install is unaffected and this is a misconfiguration, not a bug — the comment there could just say "otherwise a model id the active provider serves" if you think it is worth the character.