### PR TITLE
fix(codex): re-inject memory after compact and clear

### DIFF
--- a/plugin/hooks/codex-hooks.json
+++ b/plugin/hooks/codex-hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup|resume",
+        "matcher": "startup|resume|clear|compact",
         "hooks": [
           {
             "type": "command",

--- a/tests/infrastructure/plugin-distribution.test.ts
+++ b/tests/infrastructure/plugin-distribution.test.ts
@@ -115,6 +115,20 @@ describe('Plugin Distribution - Codex Marketplace', () => {
     expect(Object.keys(codexHooks).sort()).toEqual(['hooks']);
   });
 
+  it('re-injects Codex memory on every SessionStart source that starts a fresh context', () => {
+    // Codex emits startup, resume, clear and compact (SessionStartSource in
+    // codex-rs/hooks/src/events/session_start.rs). clear and compact both hand
+    // the model an empty context, so the injection hook has to run for them or
+    // the session continues with no memory.
+    const codexHooks = readJson('plugin/hooks/codex-hooks.json');
+    const matchers = codexHooks.hooks.SessionStart.map((entry: any) => entry.matcher);
+
+    expect(matchers).toHaveLength(1);
+    for (const source of ['startup', 'resume', 'clear', 'compact']) {
+      expect(matchers[0].split('|')).toContain(source);
+    }
+  });
+
   it('sets the Codex hook marker on every Codex command', () => {
     for (const command of commandHooksFrom('plugin/hooks/codex-hooks.json')) {
       expect(command).toContain('CLAUDE_MEM_CODEX_HOOK=1');


### PR DESCRIPTION
## Symptom

In Codex, memory is never re-injected after a context compaction. After a manual `/compact` or an auto-compaction, the session continues with an empty context, and a long-running Codex session loses all injected memory at its first compaction and never gets it back.

Closes #3862.

## Root cause

`plugin/hooks/codex-hooks.json` matches only two of the four SessionStart sources Codex emits:

```json
"SessionStart": [{ "matcher": "startup|resume", ... }]
```

Codex has four. From `codex-rs/hooks/src/events/session_start.rs`:

```rust
pub enum SessionStartSource {
    Startup,
    Resume,
    Clear,
    Compact,
}
```

`clear` and `compact` are precisely the sources that hand the model a fresh context, so those are the ones the injection hook most needs to run for — and they are the two that are missing. The Claude Code config already matches `startup|clear|compact` for the same reason.

## The fix

One string:

```diff
-        "matcher": "startup|resume",
+        "matcher": "startup|resume|clear|compact",
```

The hook command is untouched. It runs `hook codex context` and does not branch on the source at all, so it injects on `compact` and `clear` exactly as it already does on `startup` and `resume`.

## Why this is safe

- **The matcher syntax supports it.** `matches_matcher` in `codex-rs/hooks/src/events/common.rs` handles a pipe-separated matcher two ways — exact alternation (`matcher.split('|').any(|c| c == input)`) or regex — and `"startup|resume|clear|compact"` matches `"compact"` under both.
- **The build does not overwrite it.** `scripts/build-hooks.js` patches only `command` and `commandWindows` on `SessionStart.0.0`; it never writes `matcher`, so this file is the source of truth for it.
- **The build validation does not reject it.** The Codex checks in `build-hooks.js` validate root keys and event names only — there is no matcher whitelist.

## Tests

Added one regression test to `tests/infrastructure/plugin-distribution.test.ts`, next to the existing Codex hook assertions. Confirmed it fails against the old matcher before the fix:

```
(fail) Plugin Distribution - Codex Marketplace > re-injects Codex memory on every
       SessionStart source that starts a fresh context
error: expect(received).toContain(expected)
```

and passes after:

```
68 pass, 0 fail
```

`bun test tests/infrastructure/` gives 209 pass / 1 fail, where that failure is a pre-existing missing-module error (`@modelcontextprotocol/sdk`) also present on a clean checkout of `main` — verified by stashing.

## Rubric check

- **Actually sick** — incorrect behavior on `main` today (13.24.1); symptom stated above.
- **Root cause cured** — the matcher now lists the sources the host actually emits. No guards, retries, fallbacks, fail-open modes, or truncation.
- **Locally contained** — one string in the existing config. No new processes, state files, lifecycle managers, or env-var escape hatches.
- **Perfectly dosed** — one wrong string, one changed string, plus a test.
