### PR TITLE
fix(search): hydrate Chroma matches in relevance order, not by date

### DIFF
--- a/src/services/worker/SearchManager.ts
+++ b/src/services/worker/SearchManager.ts
@@ -129,7 +129,7 @@ export class SearchManager {
 
   private async searchChromaForTimeline(query: string, project?: string, platformSource?: string): Promise<ObservationSearchResult[]> {
     return this.hybridSemanticHydrate(query, 'observation', project, platformSource, (ids) =>
-      this.sessionStore.getObservationsByIds(ids, { orderBy: 'date_desc', limit: 1, project, platformSource })
+      this.sessionStore.getObservationsByIds(ids, { orderBy: 'relevance', limit: 1, project, platformSource })
     );
   }
 
@@ -924,7 +924,7 @@ export class SearchManager {
       try {
         const limit = options.limit || 20;
         results = await this.hybridSemanticHydrate(query, 'observation', options.project, options.platformSource, (ids) =>
-          this.sessionStore.getObservationsByIds(ids, { orderBy: 'date_desc', limit, project: options.project, platformSource: options.platformSource })
+          this.sessionStore.getObservationsByIds(ids, { orderBy: 'relevance', limit, project: options.project, platformSource: options.platformSource })
         );
       } catch (chromaError) {
         const errorObject = chromaError instanceof Error ? chromaError : new Error(String(chromaError));
@@ -1103,7 +1103,7 @@ export class SearchManager {
       logger.debug('SEARCH', 'Using hybrid semantic search for timeline query', {});
       try {
         results = await this.hybridSemanticHydrate(query, 'observation', project, platformSource, (ids) =>
-          this.sessionStore.getObservationsByIds(ids, { orderBy: 'date_desc', limit, project, platformSource })
+          this.sessionStore.getObservationsByIds(ids, { orderBy: 'relevance', limit, project, platformSource })
         );
       } catch (chromaError) {
         const errorObject = chromaError instanceof Error ? chromaError : new Error(String(chromaError));

--- a/tests/worker/search-manager.test.ts
+++ b/tests/worker/search-manager.test.ts
@@ -102,6 +102,67 @@ describe('SearchManager platform-scoped Chroma hydration', () => {
     expect(result.observations).toEqual([observation]);
   });
 
+  it('hydrates Chroma observation matches in relevance order, not by date', async () => {
+    // Chroma returns up to 100 candidates already ranked by distance. Hydrating
+    // them with orderBy 'date_desc' discards that ranking and yields the N
+    // newest candidates instead of the N most relevant, so an older exact match
+    // loses to a newer vague one. 'relevance' preserves the caller-provided id
+    // order (tests/services/sqlite/get-observations-by-ids-relevance.test.ts).
+    // performChromaSemanticSearch already does this; these two paths did not.
+    const olderExactMatch = 11;
+    const newerVagueMatch = 22;
+    const now = Date.now();
+
+    const makeManager = (getObservationsByIds: any) => new SearchManager(
+      {
+        searchObservations: mock(() => []),
+        searchSessions: mock(() => []),
+        searchUserPrompts: mock(() => []),
+      } as any,
+      {
+        getObservationsByIds,
+        getSessionSummariesByIds: mock(() => []),
+        getUserPromptsByIds: mock(() => []),
+      } as any,
+      {
+        queryChroma: mock(() => Promise.resolve({
+          // Chroma's own order: the exact match ranks first despite being older.
+          ids: [olderExactMatch, newerVagueMatch],
+          distances: [0.05, 0.4],
+          metadatas: [
+            { sqlite_id: olderExactMatch, doc_type: 'observation', created_at_epoch: now - 86_400_000 },
+            { sqlite_id: newerVagueMatch, doc_type: 'observation', created_at_epoch: now },
+          ],
+        })),
+      } as any,
+      {} as any,
+      {} as any,
+    );
+
+    const searchHydrate = mock(() => []);
+    await makeManager(searchHydrate).searchObservations({ query: 'exact phrase', limit: 1 });
+    expect(searchHydrate).toHaveBeenCalledWith(
+      [olderExactMatch, newerVagueMatch],
+      expect.objectContaining({ orderBy: 'relevance' })
+    );
+
+    const timelineHydrate = mock(() => []);
+    await makeManager(timelineHydrate).getTimelineByQuery({ query: 'exact phrase', limit: 1 });
+    expect(timelineHydrate).toHaveBeenCalledWith(
+      [olderExactMatch, newerVagueMatch],
+      expect.objectContaining({ orderBy: 'relevance' })
+    );
+
+    // timeline() picks a single anchor via searchChromaForTimeline; the anchor
+    // should be the top-ranked match, not merely the most recent one.
+    const anchorHydrate = mock(() => []);
+    await makeManager(anchorHydrate).timeline({ query: 'exact phrase' });
+    expect(anchorHydrate).toHaveBeenCalledWith(
+      [olderExactMatch, newerVagueMatch],
+      expect.objectContaining({ orderBy: 'relevance' })
+    );
+  });
+
   it('passes platformSource into Chroma session where filter and SQLite hydration', async () => {
     const session = {
       id: 6,


### PR DESCRIPTION
## Symptom

A search returns **the N newest of up to 100 semantic candidates instead of the N most relevant**. An older observation that matches precisely loses to a newer, vaguely related one — including when the query is the older observation's own verbatim text. Raising `limit` surfaces the older one again, which shows it was a candidate all along and was dropped by the date cut, not by relevance.

Closes #3876 (the first of the three bugs reported there; the other two are separate and not touched here).

## Root cause

`hybridSemanticHydrate` asks Chroma for 100 matches, which arrive in distance order, and then hydrates them by date:

```ts
const chromaResults = await this.queryChroma(query, 100, whereFilter);
...
this.sessionStore.getObservationsByIds(ids, { orderBy: 'date_desc', limit, ... })
```

`ids` is already Chroma's ranking. Re-sorting by date throws it away *before* `limit` is applied, so the limit cuts the most relevant results rather than the least.

## The fix

`orderBy: 'relevance'` preserves the caller-provided id order — that is the documented contract in `tests/services/sqlite/get-observations-by-ids-relevance.test.ts` ("returns rows in caller-provided ID order"). The same file already relies on it: `performChromaSemanticSearch` hydrates observations with `orderBy: 'relevance'`.

So this changes the three call sites that pass ids straight from Chroma to use the mode the sibling path already uses:

| Call site | Effect |
| --- | --- |
| `searchObservations` | search results ranked by relevance |
| `getTimelineByQuery` | timeline results ranked by relevance |
| `searchChromaForTimeline` | the single timeline **anchor** becomes the top-ranked match, not the most recent one |

The third one is worth calling out: it selects one row with `limit: 1`, and the FTS fallback immediately beneath it returns the *best* match, so the two paths disagreed about what "top result" means. The variable that consumes it is even called `topResult`.

## Tests

One regression test in the existing `tests/worker/search-manager.test.ts`, using that file's mock harness. It feeds Chroma a ranking where the exact match is **older** than the vague one and asserts all three paths hydrate with `orderBy: 'relevance'`.

Confirmed it fails against unfixed code:

```
(fail) SearchManager platform-scoped Chroma hydration > hydrates Chroma
       observation matches in relevance order, not by date
+     "orderBy": "date_desc",
```

and passes after: `8 pass, 0 fail`.

`bun test tests/worker/` gives 15 fail / 15 errors both before and after — an identical pre-existing baseline (missing `@modelcontextprotocol/sdk` module in a fresh checkout), verified by stashing. My change adds one passing test and no new failures.

## One thing I did not change

In `performChromaSemanticSearch`, observations hydrate with `orderBy: 'relevance'` while **session summaries and user prompts from the same Chroma ranking** still hydrate with `orderBy: 'date_desc'` (`SearchManager.ts` lines 435 and 443). That looks like the same defect, but sessions and prompts may be intentionally chronological, and two existing tests pin the current behaviour — so I left it alone rather than widen this PR on a guess. Happy to send a follow-up if you want it changed.

## Rubric check

- **Actually sick** — incorrect behavior on `main` today; symptom stated above.
- **Root cause cured** — the ranking is now carried through hydration instead of being re-sorted away. No guards, retries, fallbacks, fail-open modes, or truncation; nothing is dropped.
- **Locally contained** — three arguments in the file that has the bug. No new processes, state files, lifecycle managers, or env-var escape hatches.
- **Perfectly dosed** — 3 changed lines plus a test.
