### PR TITLE
fix(ci): validate committed plugin versions before rebuilding

### DIFF
--- a/.github/workflows/committed-plugin-versions.yml
+++ b/.github/workflows/committed-plugin-versions.yml
@@ -1,0 +1,26 @@
+name: Committed plugin versions
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  committed-plugin-versions:
+    name: Validate marketplace artifacts before build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # Marketplace installs use the committed bundles. A build here would
+      # repair stale artifacts and hide the mismatch that caused #3857.
+      # This suite uses only Bun and Node built-ins; no install is necessary.
+      - name: Check committed manifests and bundle versions
+        run: bun test tests/infrastructure/version-consistency.test.ts

--- a/.github/workflows/committed-plugin-versions.yml
+++ b/.github/workflows/committed-plugin-versions.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v7
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 

--- a/tests/infrastructure/version-consistency.test.ts
+++ b/tests/infrastructure/version-consistency.test.ts
@@ -7,7 +7,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '../..');
 
 describe('Version Consistency', () => {
-  let rootVersion: string;
+  const rootVersion: string = JSON.parse(
+    readFileSync(path.join(projectRoot, 'package.json'), 'utf-8')
+  ).version;
 
   it('should read version from root package.json', () => {
     const packageJsonPath = path.join(projectRoot, 'package.json');
@@ -16,8 +18,6 @@ describe('Version Consistency', () => {
     const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
     expect(packageJson.version).toBeDefined();
     expect(packageJson.version).toMatch(/^\d+\.\d+\.\d+$/);
-    
-    rootVersion = packageJson.version;
   });
 
   it('should have matching version in plugin/package.json', () => {
@@ -74,34 +74,26 @@ describe('Version Consistency', () => {
     ]);
   });
 
-  it('should have version injected into built worker-service.cjs', () => {
-    const workerServicePath = path.join(projectRoot, 'plugin/scripts/worker-service.cjs');
-    
-    if (!existsSync(workerServicePath)) {
-      console.log('⚠️  worker-service.cjs not found - run npm run build first');
-      return;
-    }
-    
-    const workerServiceContent = readFileSync(workerServicePath, 'utf-8');
+  // Marketplace installs execute these committed bundles without rebuilding.
+  // Run this suite on the pristine checkout as well as after npm run build.
+  for (const bundle of [
+    'worker-service.cjs',
+    'mcp-server.cjs',
+    'server-service.cjs',
+    'transcript-watcher.cjs',
+  ]) {
+    it(`should ship ${bundle} with the manifest version`, () => {
+      const bundlePath = path.join(projectRoot, 'plugin/scripts', bundle);
+      expect(existsSync(bundlePath), `${bundle} is missing; run npm run build and commit the artifacts`).toBe(true);
 
-    const versionPattern = new RegExp(`"${rootVersion.replace(/\./g, '\\.')}"`, 'g');
-    const matches = workerServiceContent.match(versionPattern);
-    
-    expect(matches).toBeTruthy();
-    expect(matches!.length).toBeGreaterThan(0);
-  });
-
-  it('should have built mcp-server.cjs', () => {
-    const mcpServerPath = path.join(projectRoot, 'plugin/scripts/mcp-server.cjs');
-
-    if (!existsSync(mcpServerPath)) {
-      console.log('⚠️  mcp-server.cjs not found - run npm run build first');
-      return;
-    }
-
-    const mcpServerContent = readFileSync(mcpServerPath, 'utf-8');
-    expect(mcpServerContent.length).toBeGreaterThan(0);
-  });
+      const content = readFileSync(bundlePath, 'utf-8');
+      // Match the full quoted value so a longer version cannot match a prefix.
+      expect(
+        content.includes(JSON.stringify(rootVersion)),
+        `${bundle} lacks version ${rootVersion}; run npm run build and commit the artifacts`
+      ).toBe(true);
+    });
+  }
 
   it('should validate version format is semver compliant', () => {
     expect(rootVersion).toMatch(/^\d+\.\d+\.\d+$/);


### PR DESCRIPTION
Marketplace installs execute committed plugin bundles, but the existing CI rebuilds them before checking versions. This lets a manifest-only version bump pass CI while shipping bundles stamped with the previous version, as in #3857.

The bundle rebuild is already merged in #3878. This follow-up adds a separate check on the untouched checkout, with no dependency installation or build. It also makes the version-consistency suite fail when any of the worker, MCP server, server, or transcript-watcher bundles is missing or lacks the quoted manifest version. Expected-version setup no longer depends on another test running first.

The new workflow pins full commit SHAs of the verified latest stable releases: actions/checkout v7.0.1 and oven-sh/setup-bun v2.2.0, with version comments retained. Checkout v7 differs from the v4 pins in neighboring workflows; existing workflows are unchanged.

Validation:
- `bun test tests/infrastructure/version-consistency.test.ts`: 13 passed, 0 failed in a checkout without node_modules.
- Eight temporary mutation checks: removing each of the four bundles or replacing its embedded current-version strings with a stale version failed with the intended diagnostic. All artifacts were restored afterward.
- Before this change, the suite incorrectly passed with the worker bundle missing and with stale server bundle versions.
- Workflow YAML parsed successfully; `git diff --check` passed; independent code review found no actionable issues.

This checks committed artifact presence and embedded version strings. It does not change runtime version reporting or the worker recycle policy, and it does not attest that every version assignment in a mixed bundle is consistent.
