### PR TITLE
docs(configuration): the off-LAN TV, and what cloud sync actually sends

### DIFF
--- a/docs/public/configuration.mdx
+++ b/docs/public/configuration.mdx
@@ -247,6 +247,18 @@ Then restart the worker:
 npm run worker:restart
 ```
 
+### Watching Off-LAN (cmem.ai Pro)
+
+Everything above is the LAN path. Watching from *outside* your network — on cellular, at a coffee shop, from another house — is a **cmem.ai Pro** feature: open `https://cmem.ai/tv` in any browser while signed in to your account. It requires [Cloud Sync](/cloud-sync) to be enabled, because the hosted page reads titles your worker has already pushed to your sync hub.
+
+**No token, no open port, no inbound connection.** This path needs neither `CLAUDE_MEM_TV_TOKEN` nor a non-loopback `CLAUDE_MEM_WORKER_HOST` — both belong to the LAN path and have no effect on it, so leave them at their defaults. The box never accepts an inbound connection for the hosted TV; the worker only ever dials out. No tunnel (cloudflared, ngrok, or anything like them) is needed, and none is recommended.
+
+**The hosted TV surface shows observation titles and nothing else.** It never renders narratives, facts, file lists, snippets or prompt text.
+
+**That is not the same as "only titles leave your machine."** The hosted TV is a feature *of* cloud sync, and cloud sync uploads your observation narratives and your full prompt text to the sync hub under your cmem.ai account. The hosted page is titles-only; the upload standing behind it is not. Don't enable cloud sync if that content must stay on your machine.
+
+**One rendering difference.** An observation with no title still appears on the LAN TV, which falls back to the subtitle. It does not appear on the hosted phone TV — that surface receives titles only, so it has no subtitle to fall back to.
+
 ## Folder Context Files
 
 Claude-mem can automatically generate `CLAUDE.md` files in your project folders with activity timelines. This feature is disabled by default.


### PR DESCRIPTION
Docs only. Zero changes under `src/` or `plugin/` — `git diff --stat origin/main -- src/ plugin/` is empty, which is the gate this change was written to pass.

## Why

The Observation TV section ended at the LAN: a token, a non-loopback bind, and a second device on your own network. Watching from a coffee shop was simply not described, and the obvious next question — *"so do I open a port?"* — had no answer here. Someone who wanted the phone TV and read only this page would reasonably have reached for a tunnel, which is the one thing that must not happen: it would publish `GET /api/settings` (provider API keys in plaintext) and `POST /api/admin/restart` to the internet.

## What it now says

Off-LAN viewing is **cmem.ai Pro** at `/tv`, it rides the cloud sync your worker already pushes, and **the box never accepts an inbound connection for it**. `CLAUDE_MEM_TV_TOKEN` and `CLAUDE_MEM_WORKER_HOST` belong to the LAN path and do nothing for it, so they stay at their defaults. No tunnel is needed, and none is recommended.

**The part that needed saying twice.** The hosted page shows titles and nothing else, **and** cloud sync uploads your narratives and your full prompt text. Those are two different statements, and a reader who sees only the first will conclude that only titles ever leave their machine — which is wrong. So both sit in the same subsection rather than one here and one three pages away. The wording follows the existing precedent in `cloud-sync.mdx` and the cloud-sync skill's mandatory closing note.

It also records the one rendering difference a user would otherwise hit and file as a bug: an observation with **no title** appears on the LAN TV, which falls back to the subtitle, and does **not** appear on the phone, which never receives one. (Verified against `src/ui/tv.html:209`.)

## Placement note

The plan pointed at `:189-191`, which predates the merged LAN slice (#3889). That section is now `:189-248` and ends with its own `### Manual Configuration` settings.json example. Splitting those would have orphaned the example, so the new `###` sits immediately after that block, still inside `## Worker Service Management`.

## Verification

- `git status --short` ⇒ only `docs/public/configuration.mdx`.
- `git diff --stat origin/main -- src/ plugin/` ⇒ **empty**.
- `grep -rn "cloudflared\|ngrok" docs/` ⇒ one hit, as an explicitly-not-needed option.
- `[Cloud Sync](/cloud-sync)` matches the existing link convention in `cmem-pro-headless.mdx`.
- No JSX added — this file carries emphasis as bold lead-in paragraphs and contains zero components, so the privacy note follows that house style rather than importing `<Warning>`. No settings-table row (this change adds no key). `CHANGELOG.md` untouched.

Companion PR, where the actual feature lives: **thedotmack/claude-mem-pro#166**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NevXJ2xL9PtiKEsCMR4SJT
