### PR TITLE
fix: say why the worker died instead of listing suspects

### DIFF
--- a/src/services/infrastructure/ProcessManager.ts
+++ b/src/services/infrastructure/ProcessManager.ts
@@ -369,6 +369,101 @@ export function buildWindowsDaemonStartCommand(runtimePath: string, scriptPath: 
   return `Start-Process -FilePath '${psSingleQuote(runtimePath)}' -ArgumentList @('"${psSingleQuote(scriptPath)}"','--daemon') -WindowStyle Hidden`;
 }
 
+export const WORKER_BOOT_PROBE_TIMEOUT_MS = 5000;
+const WORKER_BOOT_PROBE_MAX_LINES = 8;
+
+/**
+ * Did the probe "time out" too early for that timeout to be real?
+ *
+ * Called from the worker-start failure path, the FIRST sync spawn comes back
+ * ETIMEDOUT in ~25ms — the child SIGTERMed before it could print a byte — no
+ * matter how generous the window is (measured identically at 8s and at 60s
+ * under Bun 1.3.13 on Windows). A second, identical spawn immediately after
+ * always answers in ~180ms, so the deadline is being resolved against something
+ * stale that the first call refreshes. A genuine timeout burns the whole window
+ * instead, which is what separates the two here.
+ */
+export function shouldRetryWorkerBootProbe(
+  error: Error | undefined,
+  elapsedMs: number,
+  timeoutMs: number
+): boolean {
+  if ((error as NodeJS.ErrnoException | undefined)?.code !== 'ETIMEDOUT') return false;
+  return elapsedMs < timeoutMs / 2;
+}
+
+/**
+ * Re-run the worker bundle in the foreground to recover the stderr spawnDaemon
+ * threw away.
+ *
+ * The daemon is detached with its stdio discarded (Start-Process -WindowStyle
+ * Hidden on Windows, stdio:'ignore' elsewhere), so a bundle that dies during
+ * module resolution — a truncated `bun install` in the plugin cache, a pruned
+ * dependency — leaves the caller with nothing but "worker exited", and the
+ * operator is left guessing between Bun, the bundle and the port. Running the
+ * same bundle where we CAN read stderr puts the actual error back in the log.
+ *
+ * `status` is the probe command: it executes every top-level require in the
+ * bundle — which is where these failures happen, long before argv is parsed —
+ * then exits 0 on every branch without starting a server, so a healthy bundle
+ * costs one silent subprocess. scripts/smoke-clean-room.cjs guards the same
+ * class of failure at build time with the same trick.
+ *
+ * Failure-path only, and never throws: a probe that cannot run tells us nothing
+ * about the bundle, so it stays quiet rather than blaming the wrong thing.
+ */
+export function probeWorkerBootFailure(
+  scriptPath: string,
+  timeoutMs: number = getPlatformTimeout(WORKER_BOOT_PROBE_TIMEOUT_MS)
+): string | undefined {
+  const runtimePath = resolveWorkerRuntimePath();
+  if (!runtimePath) return undefined;
+
+  const runProbe = (): { result: ReturnType<typeof spawnSync>; elapsedMs: number } | undefined => {
+    const startedAt = Date.now();
+    try {
+      const result = spawnSync(runtimePath, [scriptPath, 'status'], {
+        encoding: 'utf-8',
+        timeout: timeoutMs,
+        windowsHide: true,
+        env: sanitizeEnv({ ...process.env })
+      });
+      return { result, elapsedMs: Date.now() - startedAt };
+    } catch (error: unknown) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      logger.debug('SYSTEM', 'Worker boot probe could not be launched', { scriptPath }, err);
+      return undefined;
+    }
+  };
+
+  let attempt = runProbe();
+  if (attempt === undefined) return undefined;
+
+  // One retry when the window expired too early to be real — see
+  // shouldRetryWorkerBootProbe. Without it the probe stays silent on exactly
+  // the platform this fix exists for.
+  if (shouldRetryWorkerBootProbe(attempt.result.error, attempt.elapsedMs, timeoutMs)) {
+    logger.debug('SYSTEM', 'Worker boot probe timed out before it could run — retrying once', {
+      scriptPath,
+      elapsedMs: attempt.elapsedMs,
+      timeoutMs
+    });
+    attempt = runProbe();
+    if (attempt === undefined) return undefined;
+  }
+
+  const { result } = attempt;
+  // Timed out for real, or never launched at all — inconclusive either way.
+  if (result.error) return undefined;
+  // The bundle loaded and answered. Whatever killed the daemon, it was not this.
+  if (result.status === 0) return undefined;
+
+  const output = `${result.stdout ?? ''}${result.stderr ?? ''}`.trim();
+  if (!output) return undefined;
+
+  return output.split(/\r?\n/).slice(0, WORKER_BOOT_PROBE_MAX_LINES).join('\n');
+}
+
 export function spawnDaemon(
   scriptPath: string,
   port: number,

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -21,7 +21,7 @@ import { openConfiguredSqliteDatabase } from './sqlite/connection.js';
 import { configureSupervisorSignalHandlers, getSupervisor, startSupervisor } from '../supervisor/index.js';
 import { sanitizeEnv } from '../supervisor/env-sanitizer.js';
 
-import { ensureWorkerStarted as ensureWorkerStartedShared, type WorkerStartResult } from './worker-spawner.js';
+import { ensureWorkerStarted as ensureWorkerStartedShared, getLastWorkerBootFailure, type WorkerStartResult } from './worker-spawner.js';
 import { acquireSpawnLock, releaseSpawnLock } from '../shared/worker-spawn-gate.js';
 import { snapshotDependencyHealth, type DependencyHealthSnapshot } from '../shared/dependency-health.js';
 import { captureEvent, captureException, shutdownTelemetry, enableExceptionAutocaptureForWorker } from './telemetry/telemetry.js';
@@ -1114,7 +1114,14 @@ async function main() {
     case 'start': {
       const result = await ensureWorkerStarted(port);
       if (result === 'dead') {
-        exitWithStatus('error', 'Failed to start worker');
+        // Carry the boot probe's own words into the hook's status line — this
+        // is the one place a user reliably sees, and "Failed to start worker"
+        // on its own sends them to the log to find out nothing more.
+        const bootFailure = getLastWorkerBootFailure();
+        exitWithStatus(
+          'error',
+          bootFailure ? `Failed to start worker: ${bootFailure}` : 'Failed to start worker'
+        );
       } else {
         exitWithStatus('ready', result === 'warming' ? 'Worker started; still warming up' : undefined);
       }

--- a/src/services/worker-spawner.ts
+++ b/src/services/worker-spawner.ts
@@ -7,6 +7,7 @@ import { SettingsDefaultsManager } from '../shared/SettingsDefaultsManager.js';
 import {
   cleanStalePidFile,
   getPlatformTimeout,
+  probeWorkerBootFailure,
   spawnDaemon,
   touchPidFile,
 } from './infrastructure/ProcessManager.js';
@@ -69,10 +70,23 @@ function clearWorkerSpawnAttempted(): void {
 
 export type WorkerStartResult = 'ready' | 'warming' | 'dead';
 
+// Why the last spawn died, when we could prove it. ensureWorkerStarted returns
+// a three-state verdict that callers switch on, and widening that union to
+// carry a reason would churn every call site for a string only the failure
+// branch ever has. Set immediately before returning 'dead', cleared on entry so
+// a later failure can never be explained by an earlier one's diagnosis.
+let lastWorkerBootFailure: string | undefined;
+
+export function getLastWorkerBootFailure(): string | undefined {
+  return lastWorkerBootFailure;
+}
+
 export async function ensureWorkerStarted(
   port: number,
   workerScriptPath: string
 ): Promise<WorkerStartResult> {
+  lastWorkerBootFailure = undefined;
+
   if (!workerScriptPath) {
     logger.error('SYSTEM', 'ensureWorkerStarted called with empty workerScriptPath — caller bug');
     return 'dead';
@@ -162,9 +176,19 @@ export async function ensureWorkerStarted(
       const workerPidStillAlive = cleanStalePidFile() === 'alive';
       const spawnedProcessStillAlive = spawnedPid !== undefined && spawnedPid > 0 && isPidAlive(spawnedPid);
       if (!workerStillHealthy && !workerPidStillAlive && !spawnedProcessStillAlive) {
-        logger.error('SYSTEM', spawnLockHeld
-          ? 'Worker exited before readiness endpoint became available'
-          : 'Spawn-lock holder never produced a live worker before readiness timed out');
+        if (!spawnLockHeld) {
+          logger.error('SYSTEM', 'Spawn-lock holder never produced a live worker before readiness timed out');
+          return 'dead';
+        }
+        // We launched it and it is gone, so the bundle itself is the suspect —
+        // and its stderr went to a hidden window. Ask it again where we can
+        // hear the answer.
+        lastWorkerBootFailure = probeWorkerBootFailure(workerScriptPath);
+        logger.error(
+          'SYSTEM',
+          'Worker exited before readiness endpoint became available',
+          lastWorkerBootFailure ? { bootFailure: lastWorkerBootFailure } : {}
+        );
         return 'dead';
       }
       logger.warn('SYSTEM', spawnLockHeld

--- a/tests/infrastructure/process-manager.test.ts
+++ b/tests/infrastructure/process-manager.test.ts
@@ -26,6 +26,8 @@ const {
   isPidFileRecent,
   touchPidFile,
   spawnDaemon,
+  probeWorkerBootFailure,
+  shouldRetryWorkerBootProbe,
   buildWindowsDaemonStartCommand,
   resolveWorkerRuntimePath,
   captureProcessStartToken,
@@ -711,6 +713,93 @@ describe('ProcessManager', () => {
       expect(command).toBe(
         `Start-Process -FilePath 'C:\\Users\\O''Brien\\.bun\\bin\\bun.exe' -ArgumentList @('"C:\\Users\\O''Brien\\plugin\\scripts\\worker-service.cjs"','--daemon') -WindowStyle Hidden`
       );
+    });
+  });
+
+  describe('probeWorkerBootFailure', () => {
+    // spawnDaemon detaches the worker with its stdio discarded, so a bundle
+    // that dies during module resolution — the shape a truncated `bun install`
+    // in the plugin cache takes — used to leave nothing behind but "worker
+    // exited". These run real subprocesses against the same runtime resolution
+    // the probe uses in production; a stub would only prove the stub.
+    const PROBE_DIR = path.join(DATA_DIR, 'boot-probe');
+
+    const writeProbeScript = (name: string, body: string): string => {
+      mkdirSync(PROBE_DIR, { recursive: true });
+      const scriptPath = path.join(PROBE_DIR, name);
+      writeFileSync(scriptPath, body, 'utf-8');
+      return scriptPath;
+    };
+
+    afterAll(() => {
+      rmSync(PROBE_DIR, { recursive: true, force: true });
+    });
+
+    it('reports the error from a bundle that cannot resolve its dependencies', () => {
+      const scriptPath = writeProbeScript(
+        'unresolvable.cjs',
+        `require('./this-dependency-was-never-installed.cjs');\n`
+      );
+
+      const failure = probeWorkerBootFailure(scriptPath);
+
+      expect(failure).toBeDefined();
+      expect(failure!).toMatch(/this-dependency-was-never-installed/);
+    });
+
+    it('stays silent when the bundle loads and exits cleanly', () => {
+      const scriptPath = writeProbeScript(
+        'healthy.cjs',
+        `console.log('Worker is not running');\nprocess.exit(0);\n`
+      );
+
+      expect(probeWorkerBootFailure(scriptPath)).toBeUndefined();
+    });
+
+    it('stays silent when the bundle fails without saying anything', () => {
+      const scriptPath = writeProbeScript('mute.cjs', `process.exit(1);\n`);
+
+      expect(probeWorkerBootFailure(scriptPath)).toBeUndefined();
+    });
+
+    it('caps a runaway stack trace instead of pasting it whole into the log', () => {
+      const scriptPath = writeProbeScript(
+        'noisy.cjs',
+        `for (let i = 0; i < 200; i++) console.error('boot noise line ' + i);\nprocess.exit(1);\n`
+      );
+
+      const failure = probeWorkerBootFailure(scriptPath);
+
+      expect(failure).toBeDefined();
+      expect(failure!.split('\n').length).toBeLessThanOrEqual(8);
+      expect(failure!).toContain('boot noise line 0');
+    });
+
+    it('returns rather than throwing when the script does not exist at all', () => {
+      const missing = path.join(PROBE_DIR, 'no-such-worker-bundle.cjs');
+
+      expect(() => probeWorkerBootFailure(missing)).not.toThrow();
+    });
+
+    describe('shouldRetryWorkerBootProbe', () => {
+      const etimedout = (): Error => Object.assign(new Error('spawnSync ETIMEDOUT'), { code: 'ETIMEDOUT' });
+
+      it('retries a window that expired far too early to be real', () => {
+        // The measured shape of the bug: ETIMEDOUT after 25ms of a 5s window.
+        expect(shouldRetryWorkerBootProbe(etimedout(), 25, 5000)).toBe(true);
+      });
+
+      it('does not retry a timeout that burned its whole window', () => {
+        expect(shouldRetryWorkerBootProbe(etimedout(), 5001, 5000)).toBe(false);
+        expect(shouldRetryWorkerBootProbe(etimedout(), 2500, 5000)).toBe(false);
+      });
+
+      it('does not retry failures that are not timeouts', () => {
+        const enoent = Object.assign(new Error('spawnSync ENOENT'), { code: 'ENOENT' });
+
+        expect(shouldRetryWorkerBootProbe(enoent, 5, 5000)).toBe(false);
+        expect(shouldRetryWorkerBootProbe(undefined, 5, 5000)).toBe(false);
+      });
     });
   });
 


### PR DESCRIPTION
## The failure

A worker that dies during module resolution leaves nothing behind. `spawnDaemon` detaches it with its stdio discarded — `Start-Process -WindowStyle Hidden` on Windows, `stdio:'ignore'` elsewhere — so the only trace is:

```
[ERROR] [SYSTEM] Worker exited before readiness endpoint became available
[ERROR] [SYSTEM] Worker auto-start failed — ... Check earlier log lines for the
        specific failure reason (Bun not found, missing worker bundle, port conflict, etc.)
```

None of those three was the cause when this bit me. A truncated `bun install` in the plugin cache had left `zod@4.4.3` short 37 files (`v4/locales/be.cjs` among them), so the bundle died on `require`. Every claude-mem hook failed for hours with nothing in the log to say why; finding it took manually running the bundle in the foreground.

## The fix

Do that manual step automatically, on the failure path only.

- `probeWorkerBootFailure()` re-runs the bundle where its stderr can be read and logs what it says, as `bootFailure` on the existing error line.
- `status` is the probe command: it executes every top-level require — where these failures happen, long before argv is parsed — then exits 0 on every branch without starting a server, so a healthy bundle costs one silent subprocess. `scripts/smoke-clean-room.cjs` already guards the same class of failure at build time with the same trick.
- The reason also rides out through `getLastWorkerBootFailure()` into the `start` hook's status line, so `Failed to start worker` becomes `Failed to start worker: error: Cannot find module …`.

Before / after on the same reproduction:

```
- Worker exited before readiness endpoint became available
+ Worker exited before readiness endpoint became available {bootFailure=error:
+   Cannot find module './this-dependency-was-never-installed.cjs' from '…\worker-service.cjs'
+   Bun v1.3.13 (Windows x64)}
```

## Why there is a retry

The probe needs one to work at all where it matters most. Called from the failure path under Bun 1.3.13 on Windows, the **first** sync spawn returns `ETIMEDOUT` in ~25 ms with the child `SIGTERM`ed before printing a byte — measured identically at an 8 s and at a 60 s timeout — while a second, identical spawn immediately after answers in ~180 ms. A plain 50 s idle await, a preceding `execSync`, and pending timers each fail to reproduce it in isolation, so the retry is gated on the observation rather than on a theory: `shouldRetryWorkerBootProbe` fires only for a window that expired far too early to be real. A genuine timeout — the bundle loaded and kept running — burns the full window and is never retried.

## Verification

- `bun test tests/infrastructure/process-manager.test.ts` — 60 pass, 8 new (5 probe behaviours against real subprocesses, 3 retry-predicate). The one failure, `resolveWorkerRuntimePath > should look up Bun on non-Windows when caller is Node`, is pre-existing on `main` on a Windows host and untouched by this change.
- `bun test tests/worker-spawn.test.ts tests/worker-script-resolution.test.ts tests/infrastructure/` — 244 pass / 12 fail, against a `main` baseline of 239 pass / 12 fail: same 12, plus the new tests.
- `npm run typecheck:root`, `npm run build`, `npm run lint:spawn-env`, `npm run lint:hook-io` all clean.
- End-to-end: `ensureWorkerStarted` against a bundle that cannot resolve its dependencies now returns `dead` with the module error in both the log and `getLastWorkerBootFailure()`.

Source and tests only — no rebuilt bundles, since CI runs `npm run build` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
