### PR TITLE
fix(windows): reclaim ghost listeners left by out-of-band worker deaths

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -201,6 +201,19 @@ jobs:
           $bun = Join-Path $env:USERPROFILE '.bun\\bin\\bun.exe'
           & $bun test tests/integration/worker-recycle-orphans.test.ts --timeout 600000
 
+      # Ghost-listener recovery gate (plan-15 #3603). Fails on main: a worker
+      # killed OUT-OF-BAND (taskkill /F without /T) leaves its chroma sidecar
+      # chain holding the inherited listening socket, and no launcher reclaims
+      # the port — ensureWorkerStarted returns 'dead' forever. Passes once the
+      # spawn path reclaims the dead owner's sidecar descendants and starts.
+      - name: Ghost-listener recovery gate (#3603)
+        shell: pwsh
+        env:
+          CLAUDE_MEM_DATA_DIR: ${{ runner.temp }}\claude-mem-ghost-data
+        run: |
+          $bun = Join-Path $env:USERPROFILE '.bun\\bin\\bun.exe'
+          & $bun test tests/integration/worker-ghost-port-recovery.test.ts --timeout 600000
+
       # Diagnostic only — never fails the job. Ancestry/identity filtering is
       # done inside the tests; this is just a human-readable postmortem for
       # when the gate above goes red.

--- a/src/services/infrastructure/HealthMonitor.ts
+++ b/src/services/infrastructure/HealthMonitor.ts
@@ -15,12 +15,22 @@ function formatHostForUrl(host: string): string {
   return host.includes(':') ? `[${host}]` : host;
 }
 
+// Probes against a ghost listener (plan-15 #3603) can connect — the kernel
+// completes handshakes on the inherited socket — but never receive a response,
+// because no application is reading. An unbounded fetch would hang the probe
+// forever, so every HTTP probe is aborted after this budget. 5s is above a
+// healthy worker's sub-100ms response and below every caller's retry budget.
+const HEALTH_PROBE_TIMEOUT_MS = 5_000;
+
 async function httpRequestToWorker(
   port: number,
   endpointPath: string,
   method: string = 'GET'
 ): Promise<{ ok: boolean; statusCode: number; body: string }> {
-  const response = await fetch(`http://${formatHostForUrl(getWorkerHost())}:${port}${endpointPath}`, { method });
+  const response = await fetch(`http://${formatHostForUrl(getWorkerHost())}:${port}${endpointPath}`, {
+    method,
+    signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
+  });
   let body = '';
   try {
     body = await response.text();

--- a/src/services/worker-service.ts
+++ b/src/services/worker-service.ts
@@ -48,6 +48,7 @@ import {
   touchPidFile
 } from './infrastructure/ProcessManager.js';
 import { runOneTimeV12_4_3Cleanup } from './infrastructure/CleanupV12_4_3.js';
+import { reclaimGhostListeningPort } from '../shared/port-reclaim.js';
 import {
   isPortInUse,
   waitForHealth,
@@ -1451,8 +1452,28 @@ async function main() {
       // port — the port cannot be faked by a stale or clobbered file. Exit 0:
       // duplicate suppression is a success, not a failure.
       if (await isPortInUse(port)) {
-        logger.info('SYSTEM', 'Port already in use, refusing to start duplicate', { port });
-        process.exit(0);
+        // A live worker answers health — this is a genuine duplicate.
+        if (await waitForHealth(port, getPlatformTimeout(HOOK_TIMEOUTS.HEALTH_CHECK))) {
+          logger.info('SYSTEM', 'Worker already running (health verified), refusing to start duplicate', { port });
+          process.exit(0);
+        }
+        // Bound but silent: likely a ghost listener — a dead worker whose
+        // surviving chroma sidecar chain holds the inherited socket
+        // (plan-15 #3603). Reclaim when the owner is provably dead; a live
+        // owner (wedged worker, foreign process) keeps the duplicate refusal.
+        const reclaim = await reclaimGhostListeningPort(port);
+        if (reclaim.reclaimed) {
+          logger.info('SYSTEM', 'Reclaimed ghost listener left by a dead worker — starting anyway', {
+            port,
+            killedPids: reclaim.killedPids,
+          });
+        } else {
+          logger.info('SYSTEM', 'Port already in use, refusing to start duplicate', {
+            port,
+            reclaimReason: reclaim.reason,
+          });
+          process.exit(0);
+        }
       }
 
       // PID file second, ADVISORY only: it covers a dying-but-still-alive

--- a/src/services/worker-spawner.ts
+++ b/src/services/worker-spawner.ts
@@ -17,6 +17,7 @@ import {
 } from './infrastructure/HealthMonitor.js';
 import { acquireSpawnLock, releaseSpawnLock } from '../shared/worker-spawn-gate.js';
 import { isPidAlive } from '../supervisor/process-registry.js';
+import { reclaimGhostListeningPort } from '../shared/port-reclaim.js';
 
 const WINDOWS_SPAWN_COOLDOWN_MS = 2 * 60 * 1000;
 
@@ -125,8 +126,31 @@ export async function ensureWorkerStarted(
       logger.info('SYSTEM', 'Worker is now healthy');
       return ready ? 'ready' : 'warming';
     }
-    logger.error('SYSTEM', 'Port in use but worker not responding to health checks');
-    return 'dead';
+    // The port is bound but nothing answers health. Usually this is a dead
+    // worker whose surviving chroma sidecar chain (uvx -> uv -> python) holds
+    // the inherited listening socket — a ghost listener under a dead PID
+    // (plan-15 #3603). Without a reclaim the launcher returns 'dead' forever
+    // and the port stays blocked until a human tree-kills the chain by hand.
+    // Reclaim only fires when the owner is provably dead and the survivors
+    // are chroma sidecars; a live owner keeps the old 'dead' behavior.
+    const reclaim = await reclaimGhostListeningPort(port);
+    if (reclaim.reclaimed) {
+      logger.info('SYSTEM', 'Reclaimed ghost listener left by a dead worker — proceeding to spawn', {
+        port,
+        killedPids: reclaim.killedPids,
+      });
+      // The cooldown marker may have been written by the very spawn attempts
+      // this ghost blocked; the reason for those failures is now gone, so a
+      // time-based cooldown would only delay the recovery that just became
+      // possible (the plan-15 "cooldowns keyed to evidence, not time" rule).
+      clearWorkerSpawnAttempted();
+    } else {
+      logger.error('SYSTEM', 'Port in use but worker not responding to health checks', {
+        port,
+        reclaimReason: reclaim.reason,
+      });
+      return 'dead';
+    }
   }
 
   if (shouldSkipSpawnOnWindows()) {

--- a/src/shared/port-reclaim.ts
+++ b/src/shared/port-reclaim.ts
@@ -1,0 +1,368 @@
+/**
+ * Ghost-listener reclaim on Windows.
+ *
+ * WHY THIS EXISTS — the 2026-09-07 reproduction (and #3482 / #3300 / plan-15
+ * #3603): the worker daemon's listening socket is inherited by the chroma-mcp
+ * sidecar tree (uvx -> uv -> python) it spawns. When the worker is killed
+ * OUT-OF-BAND — crash, `taskkill /F` without `/T`, a kill that runs no
+ * shutdown code — nothing tree-kills the sidecar, so the descendants stay
+ * alive holding the inherited socket handle. Windows keeps the port LISTENING
+ * under the DEAD worker's PID (netstat shows an owner that no longer exists),
+ * and every launcher treats "port in use" as proof of a live worker:
+ *
+ *   - the daemon duplicate gate logs "Port already in use, refusing to start
+ *     duplicate" and exit(0)s;
+ *   - ensureWorkerStarted() logs "Port in use but worker not responding to
+ *     health checks" and returns 'dead'.
+ *
+ * Neither ever reclaims, so the port stays bound until a human tree-kills the
+ * chroma chain by hand (the recovery manual). This module automates that
+ * recovery with the same evidence the manual uses:
+ *
+ *   1. netstat finds the LISTENING owner PID(s) for the port;
+ *   2. if EVERY owner is dead, the surviving sidecar is located two ways:
+ *      a. walking down the process table's parent chain from the dead PID
+ *         (Windows preserves the parent link after the parent exits);
+ *      b. a full-table scan for processes whose command line points at THIS
+ *         install's chroma store (`--data-dir <DATA_DIR>`), which catches the
+ *         broken-chain case: when the worker dies, its uvx/uv stdio parents
+ *         read EOF and exit, leaving the chroma-mcp/python sidecar orphaned
+ *         one or two links BELOW a dead PID — unreachable by walk (a), but
+ *         still carrying our data-dir argument;
+ *   3. only processes that are chroma sidecars by executable name (walk a)
+ *      or by data-dir fingerprint (scan b) are killed, so a reused PID whose
+ *      new owner happens to have children cannot pull unrelated processes
+ *      into the kill;
+ *   4. every kill goes through killProcessTree with the start token from the
+ *      SAME table read that discovered the target, so a PID that exits and is
+ *      reissued between discovery and kill is never signalled.
+ *
+ * A live owner — a wedged-but-alive worker, a foreign service, another
+ * install — is never touched: those are plan-15 liveness-authority cases and
+ * must keep the current "in use" behavior, not get killed by a launcher.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { logger } from '../utils/logger.js';
+import { killProcessTree } from './kill-process-tree.js';
+import { isPidAlive } from '../supervisor/process-registry.js';
+import { DATA_DIR } from './paths.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Executable names of the chroma-mcp sidecar chain the worker spawns
+ * (uvx -> uv -> python -> chroma-mcp). Only descendants matching these are
+ * reclaim targets: they are the only processes in the tree that can hold the
+ * inherited listening socket, and the whitelist is what makes the kill safe
+ * against PID reuse.
+ */
+const CHROMA_SIDECAR_NAME_PATTERN = /^(uv|uvx|python|chroma-mcp)(\.exe)?$/i;
+
+/** Whitelist check for a process-table Name column value. */
+export function isChromaSidecarName(name: string): boolean {
+  return CHROMA_SIDECAR_NAME_PATTERN.test(name.trim());
+}
+
+export interface WindowsProcessRow {
+  pid: number;
+  ppid: number;
+  name: string;
+  startToken: string | null;
+  /** Full command line; null when the OS did not expose it. */
+  cmdline: string | null;
+}
+
+/**
+ * Does a command line point at THIS install's chroma store?
+ *
+ * chroma-mcp is always spawned with `--data-dir <DATA_DIR>/chroma`, so the
+ * argument is a reliable ownership fingerprint. Matching it matters for the
+ * broken-chain case (see reclaimGhostListeningPort): when the uvx/uv layers
+ * exit after the worker dies, the surviving chroma-mcp/python sidecar is no
+ * longer reachable by walking down from the dead owner's PID — but its
+ * command line still names our data dir, which is how we know it is ours.
+ */
+export function chromaCmdlineMatchesDataDir(cmdline: string | null, dataDir: string): boolean {
+  if (!cmdline) return false;
+  const normalizedCmdline = cmdline.toLowerCase().replace(/\\/g, '/');
+  const flagIndex = normalizedCmdline.indexOf('--data-dir');
+  if (flagIndex < 0) return false;
+  let value = normalizedCmdline.slice(flagIndex + '--data-dir'.length).trim();
+  // A value containing spaces is double-quoted by the spawner.
+  if (value.startsWith('"')) {
+    const endQuote = value.indexOf('"', 1);
+    value = endQuote < 0 ? value.slice(1) : value.slice(1, endQuote);
+  }
+  const normalizedDir = dataDir.toLowerCase().replace(/\\/g, '/');
+  return (
+    value === normalizedDir ||
+    (value.startsWith(normalizedDir) && value[normalizedDir.length] === '/')
+  );
+}
+
+/**
+ * One CIM query returning pid, parent pid, executable name, command line and
+ * creation token per row. Identity and ancestry come from the SAME
+ * observation, so the discovery-to-kill gap never revalidates a target
+ * against a different read (same atomicity rule as readProcessTable in
+ * kill-process-tree.ts). Command lines may contain commas and quotes, so the
+ * rows are transported as JSON rather than CSV.
+ */
+async function readWindowsProcessTableWithNames(): Promise<WindowsProcessRow[] | null> {
+  try {
+    const result = await execFileAsync(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,CommandLine,@{Name='StartToken';Expression={$_.CreationDate.ToString('yyyyMMddHHmmss.ffffff')}} | ConvertTo-Json -Compress",
+      ],
+      { timeout: 30_000, windowsHide: true, maxBuffer: 32 * 1024 * 1024 }
+    );
+    const parsed = JSON.parse(result.stdout) as unknown;
+    const rawRows = Array.isArray(parsed) ? parsed : parsed === null ? [] : [parsed];
+    const rows: WindowsProcessRow[] = [];
+    for (const row of rawRows as Array<Record<string, unknown>>) {
+      const name = typeof row.Name === 'string' ? row.Name.trim() : '';
+      if (!name) continue;
+      const pid = typeof row.ProcessId === 'number' ? row.ProcessId : Number.parseInt(String(row.ProcessId), 10);
+      const ppid = typeof row.ParentProcessId === 'number' ? row.ParentProcessId : Number.parseInt(String(row.ParentProcessId), 10);
+      if (!Number.isInteger(pid) || !Number.isInteger(ppid)) continue;
+      rows.push({
+        pid,
+        ppid,
+        name,
+        cmdline: typeof row.CommandLine === 'string' ? row.CommandLine : null,
+        startToken: typeof row.StartToken === 'string' && row.StartToken.length > 0 ? row.StartToken : null,
+      });
+    }
+    return rows;
+  } catch (error) {
+    logger.warn(
+      'PROCESS',
+      'Cannot enumerate the Windows process table with names — ghost-port reclaim disabled',
+      { error: error instanceof Error ? error.message : String(error) }
+    );
+    return null;
+  }
+}
+
+/** Owner PIDs currently LISTENING on `port`, or null when netstat failed. */
+async function listListeningOwnerPids(port: number): Promise<number[] | null> {
+  try {
+    const result = await execFileAsync('netstat', ['-ano'], {
+      timeout: 15_000,
+      windowsHide: true,
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    return parseNetstatListeningPids(result.stdout, port);
+  } catch (error) {
+    logger.warn(
+      'PROCESS',
+      'netstat failed — ghost-port reclaim disabled for this attempt',
+      { port, error: error instanceof Error ? error.message : String(error) }
+    );
+    return null;
+  }
+}
+
+/**
+ * Parse `netstat -ano` output for every process LISTENING on `port`.
+ *
+ * Pure and exported for tests: feed it a captured netstat transcript and
+ * assert on the parsed owners without touching the real process table.
+ */
+export function parseNetstatListeningPids(netstatOutput: string, port: number): number[] {
+  const pids = new Set<number>();
+  const addressSuffix = `:${port}`;
+  for (const rawLine of netstatOutput.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    // Proto LocalAddress ForeignAddress State PID
+    if (!/^TCP\b/i.test(line)) continue;
+    const fields = line.split(/\s+/);
+    const localAddress = fields[1];
+    if (!localAddress?.endsWith(addressSuffix)) continue;
+    if (fields[3] !== 'LISTENING') continue;
+    const pid = Number.parseInt(fields[4] ?? '', 10);
+    if (Number.isInteger(pid) && pid > 0) pids.add(pid);
+  }
+  return [...pids];
+}
+
+export type GhostPortReclaimResult =
+  | { reclaimed: true; killedPids: number[] }
+  | {
+      reclaimed: false;
+      reason:
+        | 'not-supported' // non-Windows — no inheritable-handle ghost mechanism
+        | 'netstat-unreadable'
+        | 'no-listener' // port is not bound by anything
+        | 'owner-alive' // a live process owns the port — never touch it
+        | 'table-unreadable' // could not enumerate processes — refuse to guess
+        | 'no-chroma-descendants' // owner dead but nothing reclaimable found
+        | 'kill-failed' // a tree-kill genuinely failed
+        | 'still-bound'; // everything reclaimable was killed, port stayed bound
+      killedPids?: number[];
+    };
+
+interface KillTreeOptions {
+  expectedStartToken?: string | null;
+  signalMode: 'immediate';
+}
+
+/**
+ * Injectable seams for tests. Defaults are the real Windows implementations;
+ * the suite injects fakes to exercise every decision branch on every CI
+ * platform (the real netstat/CIM/taskkill path is covered by the Windows
+ * integration gate).
+ */
+export interface GhostPortReclaimDeps {
+  isWin32?: () => boolean;
+  listOwners?: (port: number) => Promise<number[] | null>;
+  readTable?: () => Promise<WindowsProcessRow[] | null>;
+  killTree?: (pid: number, options: KillTreeOptions) => Promise<void>;
+  dataDir?: () => string | null;
+}
+
+/**
+ * Reclaim a port held by a ghost listener — one whose owning PID is dead but
+ * whose socket stays bound because the dead owner's surviving descendants
+ * inherited the handle (Windows). Returns reclaimed:true only when the port
+ * is verified free again after the kill.
+ *
+ * Safety rules (all must hold before anything is signalled):
+ *   - Windows only; POSIX sockets die with their owner, so there is nothing
+ *     to reclaim (the function is still exported for POSIX callers to invoke
+ *     unconditionally — it resolves to not-supported).
+ *   - A LIVE owner means "leave it alone": a wedged worker or a foreign
+ *     process is not ours to kill from a spawn path.
+ *   - Every kill target is (a) a chroma sidecar reachable down the dead
+ *     owner's parent chain, or (b) a chroma sidecar whose command line names
+ *     THIS install's data dir — PID reuse cannot pull in strangers, and a
+ *     chain that broke between the dead owner and the survivor is still
+ *     identified by its data-dir argument.
+ *   - Each kill goes through killProcessTree() with the start token captured
+ *     in the same table read that discovered the target.
+ */
+export async function reclaimGhostListeningPort(
+  port: number,
+  deps: GhostPortReclaimDeps = {}
+): Promise<GhostPortReclaimResult> {
+  const isWin32 = deps.isWin32 ?? (() => process.platform === 'win32');
+  const listOwners = deps.listOwners ?? listListeningOwnerPids;
+  const readTable = deps.readTable ?? readWindowsProcessTableWithNames;
+  const killTree = deps.killTree ?? ((pid, options) => killProcessTree(pid, options));
+  const dataDir = deps.dataDir ?? (() => DATA_DIR);
+
+  if (!isWin32()) {
+    return { reclaimed: false, reason: 'not-supported', killedPids: [] };
+  }
+
+  const owners = await listOwners(port);
+  if (owners === null) return { reclaimed: false, reason: 'netstat-unreadable', killedPids: [] };
+  if (owners.length === 0) return { reclaimed: false, reason: 'no-listener', killedPids: [] };
+
+  const table = await readTable();
+  if (table === null) return { reclaimed: false, reason: 'table-unreadable', killedPids: [] };
+
+  // A live owner is authoritative: something real owns the port. Killing or
+  // reclaiming here could take down a wedged-but-alive worker that still
+  // owns its socket — the launcher must keep reporting it as in use.
+  const aliveOwners = owners.filter(owner => isPidAlive(owner));
+  if (aliveOwners.length > 0) {
+    return { reclaimed: false, reason: 'owner-alive', killedPids: [] };
+  }
+
+  const childrenByParent = new Map<number, WindowsProcessRow[]>();
+  for (const row of table) {
+    const siblings = childrenByParent.get(row.ppid);
+    if (siblings) siblings.push(row);
+    else childrenByParent.set(row.ppid, [row]);
+  }
+
+  const killTargets = new Map<number, WindowsProcessRow>();
+
+  // (a) Walk every dead owner's surviving descendants. Windows keeps the
+  // parent link after the parent exits, so the chain the dead worker spawned
+  // is still reachable from its PID — when no intermediate link died.
+  const seen = new Set<number>();
+  const walk = (parentPid: number): void => {
+    for (const child of childrenByParent.get(parentPid) ?? []) {
+      if (seen.has(child.pid)) continue;
+      seen.add(child.pid);
+      walk(child.pid);
+      if (isChromaSidecarName(child.name)) killTargets.set(child.pid, child);
+    }
+  };
+  for (const owner of owners) walk(owner);
+
+  // (b) Broken-chain scan: the worker's uvx/uv layers read EOF on the MCP
+  // stdio pipes and exit when the worker dies, so the surviving
+  // chroma-mcp/python sidecar can sit one or two links BELOW a dead PID —
+  // invisible to the walk above. Its `--data-dir <DATA_DIR>` argument still
+  // proves it belongs to this install, so match every sidecar-named process
+  // against our data dir anywhere in the table. (Walk targets already carry
+  // their own evidence; a data-dir match is not required of them.)
+  const ownDataDir = dataDir();
+  if (ownDataDir) {
+    for (const row of table) {
+      if (killTargets.has(row.pid)) continue;
+      if (!isChromaSidecarName(row.name)) continue;
+      if (chromaCmdlineMatchesDataDir(row.cmdline, ownDataDir)) {
+        killTargets.set(row.pid, row);
+      }
+    }
+  }
+
+  if (killTargets.size === 0) {
+    logger.info('PROCESS', 'Ghost listener owner is dead but no chroma-sidecar descendants found', {
+      port,
+      deadOwners: owners,
+      processTableRows: table.length,
+      dataDir: ownDataDir ?? '(unresolved)',
+    });
+    return { reclaimed: false, reason: 'no-chroma-descendants', killedPids: [] };
+  }
+
+  logger.warn('PROCESS', 'Reclaiming ghost listener: killing dead worker\'s surviving chroma sidecar chain', {
+    port,
+    deadOwners: owners,
+    targets: [...killTargets.values()].map(target => ({ pid: target.pid, name: target.name })),
+  });
+
+  const killedPids: number[] = [];
+  for (const target of killTargets.values()) {
+    try {
+      await killTree(target.pid, {
+        // Identity from the discovery read — never re-probed against a
+        // different observation, and never self-captured after an await.
+        expectedStartToken: target.startToken,
+        signalMode: 'immediate',
+      });
+      killedPids.push(target.pid);
+    } catch (error) {
+      logger.error(
+        'PROCESS',
+        'Ghost-port reclaim tree-kill failed',
+        { port, pid: target.pid },
+        error instanceof Error ? error : new Error(String(error))
+      );
+      return { reclaimed: false, reason: 'kill-failed', killedPids };
+    }
+  }
+
+  const after = await listOwners(port);
+  if (after !== null && after.length === 0) {
+    logger.info('PROCESS', 'Ghost listener reclaimed — port is free again', { port, killedPids });
+    return { reclaimed: true, killedPids };
+  }
+  logger.warn('PROCESS', 'Ghost-port reclaim killed the sidecar chain but the port is still bound', {
+    port,
+    killedPids,
+    stillOwnedBy: after,
+  });
+  return { reclaimed: false, reason: 'still-bound', killedPids };
+}

--- a/tests/integration/fixtures/ghost-worker-host.ts
+++ b/tests/integration/fixtures/ghost-worker-host.ts
@@ -1,0 +1,99 @@
+/**
+ * Fixture host for worker-ghost-port-recovery.test.ts.
+ *
+ * Impersonates a WORKER THAT DIES OUT-OF-BAND while its chroma-mcp sidecar
+ * tree (uvx -> uv -> python) is alive — the exact shape of the ghost-listener
+ * bug (plan-15 #3603, reproduced 2026-09-07 and again by the probe that
+ * shaped this gate): the test kills THIS process with `taskkill /F /PID`
+ * (no `/T`), which runs no shutdown code. The uvx/uv layers read EOF on their
+ * MCP stdio pipes and exit, but the persistent chroma-mcp/python sidecar
+ * survives holding the inherited listening socket — the port stays LISTENING
+ * under this dead PID.
+ *
+ * IMPORTANT: the parent test must launch this fixture DETACHED (PowerShell
+ * Start-Process, the same way spawnDaemon() launches the real worker), NOT as
+ * a child of the bun test runner. The runner manages its children with
+ * process-tree teardown that does not exist in the production launch path,
+ * and the whole point is to reproduce the production shape.
+ *
+ * Contract with the parent test (stdout redirected to a file, one JSON
+ * object per line):
+ *   {"event":"ready","pid":N,"port":N,"chromaRootPid":N}
+ *   {"event":"error","message":"..."}
+ */
+
+import http from 'http';
+import fs from 'fs';
+import { ChromaMcpManager } from '../../../src/services/sync/ChromaMcpManager.js';
+import { getSupervisor } from '../../../src/supervisor/index.js';
+import { getWorkerPort, getWorkerHost } from '../../../src/shared/worker-utils.js';
+import { paths } from '../../../src/shared/paths.js';
+
+function emit(payload: Record<string, unknown>): void {
+  process.stdout.write(`${JSON.stringify(payload)}\n`);
+}
+
+async function main(): Promise<void> {
+  const port = getWorkerPort();
+  const host = getWorkerHost();
+
+  // 1. Bind the worker port FIRST — the chroma sidecar tree must be spawned
+  //    AFTER the listening socket exists, or there is no handle for it to
+  //    inherit. The ghost only forms when the socket predates the chain.
+  const server = http.createServer((req, res) => {
+    if (req.url?.startsWith('/api/health')) {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok', version: '0.0.1-ghost-fixture', pid: process.pid }));
+      return;
+    }
+    if (req.url?.startsWith('/api/readiness')) {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ready: true }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, host, resolve);
+  });
+
+  // 2. Build a real chroma-mcp subprocess tree owned by THIS process. Spawned
+  //    after the listen above, the chain inherits the listening socket the
+  //    way the production worker's sidecar does.
+  const manager = ChromaMcpManager.getInstance();
+  const collection = `ghost_fixture_${Date.now()}`;
+  await manager.callTool('chroma_create_collection', { collection_name: collection });
+  await manager.callTool('chroma_add_documents', {
+    collection_name: collection,
+    documents: ['ghost fixture document'],
+    ids: [`fixture_${Date.now()}`],
+  });
+
+  const chromaRecord = getSupervisor().getRegistry().getAll().find(r => r.id === 'chroma-mcp');
+  if (!chromaRecord?.pid) {
+    emit({ event: 'error', message: 'chroma-mcp did not register a pid with the supervisor' });
+    process.exit(1);
+  }
+
+  fs.mkdirSync(paths.dataDir(), { recursive: true });
+  fs.writeFileSync(
+    paths.workerPid(),
+    JSON.stringify({ pid: process.pid, port, startedAt: new Date().toISOString() }),
+    'utf-8'
+  );
+
+  emit({ event: 'ready', pid: process.pid, port, chromaRootPid: chromaRecord.pid });
+
+  // 3. Idle until the test kills us. No signal handlers on purpose: a handler
+  //    here would shut the tree down cleanly and mask the ghost — the point
+  //    is that NOTHING runs when this process dies.
+  setInterval(() => {}, 1 << 30);
+}
+
+main().catch((error: unknown) => {
+  emit({ event: 'error', message: error instanceof Error ? error.message : String(error) });
+  process.exit(1);
+});

--- a/tests/integration/worker-ghost-port-recovery.test.ts
+++ b/tests/integration/worker-ghost-port-recovery.test.ts
@@ -1,0 +1,299 @@
+/**
+ * THE fail-on-main gate for ghost-listener recovery (plan-15 #3603,
+ * reproduction of 2026-09-07 and siblings #2893/#2963/#3482/#3596).
+ *
+ * Scenario under test:
+ *   - a worker is killed OUT-OF-BAND (`taskkill /F /PID`, no `/T` — no
+ *     shutdown code runs), while its real chroma-mcp sidecar tree is alive;
+ *   - the sidecar descendants inherited the worker's listening socket, so the
+ *     port stays LISTENING under the DEAD worker PID (a ghost listener);
+ *   - the next launcher (ensureWorkerStarted — the MCP-server / CLI / install
+ *     spawn path) sees "port in use", waits for health, gets nothing, and on
+ *     MAIN returns 'dead': nothing reclaims, so the port is blocked until a
+ *     human tree-kills the sidecar chain by hand.
+ *
+ * What the gate asserts:
+ *   1. the fixture really leaves a ghost: after the out-of-band kill the port
+ *      is still bound, its owner PID no longer exists, and the chroma chain
+ *      snapshot survives;
+ *   2. the PRODUCTION ensureWorkerStarted() then returns 'ready'/'warming'
+ *      (NOT 'dead') — on main it returns 'dead' because no reclaim exists;
+ *   3. every snapshotted sidecar descendant is gone (the reclaim killed the
+ *      chain), matched on pid AND start token so a recycled PID cannot fake
+ *      success;
+ *   4. the port is served by a NEW live worker (health answers a different
+ *      pid than the dead fixture).
+ *
+ * The fixture is launched DETACHED (PowerShell Start-Process) — the same way
+ * spawnDaemon() launches the real worker — because a fixture child of the bun
+ * test runner does not reproduce the ghost: the runner's process-tree
+ * management takes the sidecar down with the fixture. The production launch
+ * path has no such management, which is exactly why the ghost exists there.
+ *
+ * Windows-only: POSIX sockets die with their owner (no inherited-handle
+ * ghost), so the scenario cannot be constructed there — the gate refuses to
+ * run rather than pass vacuously.
+ *
+ * Requires the same isolation contract as the other chroma gates:
+ * CLAUDE_MEM_DATA_DIR set in the environment before this process starts, and
+ * CLAUDE_MEM_TEST_CHROMA=1 to opt in (skipped otherwise).
+ */
+
+import { describe, it, expect, afterEach } from 'bun:test';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  snapshotDescendants,
+  survivingProcesses,
+  describeProcesses,
+  type ProcessIdentity,
+} from './helpers/process-tree.js';
+
+const RUN_GATE = process.env.CLAUDE_MEM_TEST_CHROMA === '1';
+
+// The ghost scenario is Windows-only (inheritable socket handles). This file
+// is also wired into the Linux chroma job for parity — there it must SKIP
+// entirely, because the fixture cannot produce a ghost on POSIX.
+const IS_WINDOWS = process.platform === 'win32';
+
+const FIXTURE_READY_TIMEOUT_MS = 600_000;
+const RECOVERY_TIMEOUT_MS = 600_000;
+const GHOST_SETTLE_TIMEOUT_MS = 30_000;
+const ORPHAN_SETTLE_TIMEOUT_MS = 30_000;
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(here, 'fixtures', 'ghost-worker-host.ts');
+
+interface FixtureHandle {
+  pid: number;
+  port: number;
+  chromaRootPid: number;
+}
+
+let active: FixtureHandle | null = null;
+
+function bunExecutable(): string {
+  return process.env.BUN_EXECUTABLE || process.execPath;
+}
+
+/** Kill exactly ONE process — never its descendants (`/T` deliberately omitted). */
+function killProcessOnly(pid: number): void {
+  execFileSync('taskkill', ['/F', '/PID', String(pid)], {
+    stdio: 'ignore',
+    windowsHide: true,
+  });
+}
+
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function listeningOwnerPids(port: number): number[] {
+  const stdout = execFileSync('netstat', ['-ano'], {
+    encoding: 'utf-8',
+    timeout: 15_000,
+    windowsHide: true,
+  });
+  const owners = new Set<number>();
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    const fields = line.split(/\s+/);
+    if (/^TCP\b/i.test(fields[0] ?? '')
+      && (fields[1] ?? '').endsWith(`:${port}`)
+      && fields[3] === 'LISTENING') {
+      const pid = Number.parseInt(fields[4] ?? '', 10);
+      if (Number.isInteger(pid) && pid > 0) owners.add(pid);
+    }
+  }
+  return [...owners];
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs: number, label: string): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for: ${label}`);
+    }
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+}
+
+/**
+ * Launch the fixture DETACHED, exactly like spawnDaemon() launches the real
+ * worker (PowerShell Start-Process with redirected output). Returns once the
+ * fixture's stdout reports ready.
+ */
+async function startFixture(): Promise<FixtureHandle> {
+  const stdoutFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'ghost-fixture-')), 'out.txt');
+  const stderrFile = stdoutFile.replace(/out\.txt$/, 'err.txt');
+
+  const command =
+    `$p = Start-Process -FilePath '${bunExecutable().replace(/'/g, "''")}' ` +
+    `-ArgumentList @('run', '${FIXTURE.replace(/'/g, "''")}') ` +
+    `-WorkingDirectory '${process.cwd().replace(/'/g, "''")}' ` +
+    `-RedirectStandardOutput '${stdoutFile.replace(/'/g, "''")}' ` +
+    `-RedirectStandardError '${stderrFile.replace(/'/g, "''")}' -PassThru; ` +
+    `Write-Output $p.Id`;
+
+  const spawnedPid = Number.parseInt(
+    execFileSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', command], {
+      encoding: 'utf-8',
+      windowsHide: true,
+    }).trim(),
+    10
+  );
+  if (!Number.isInteger(spawnedPid) || spawnedPid <= 0) {
+    throw new Error(`fixture Start-Process returned an invalid pid: ${spawnedPid}`);
+  }
+
+  const deadline = Date.now() + FIXTURE_READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (!processExists(spawnedPid)) {
+      const stderr = fs.existsSync(stderrFile) ? fs.readFileSync(stderrFile, 'utf-8') : '';
+      throw new Error(`fixture exited early (pid ${spawnedPid})\n${stderr}`);
+    }
+    if (fs.existsSync(stdoutFile)) {
+      const content = fs.readFileSync(stdoutFile, 'utf-8');
+      for (const rawLine of content.split(/\r?\n/)) {
+        const line = rawLine.trim();
+        if (!line.startsWith('{')) continue;
+        const payload = JSON.parse(line) as Record<string, unknown>;
+        if (payload.event === 'ready') {
+          const handle: FixtureHandle = {
+            pid: payload.pid as number,
+            port: payload.port as number,
+            chromaRootPid: payload.chromaRootPid as number,
+          };
+          active = handle;
+          return handle;
+        }
+        if (payload.event === 'error') {
+          throw new Error(`fixture failed: ${String(payload.message)}`);
+        }
+      }
+    }
+    await new Promise(resolve => setTimeout(resolve, 500));
+  }
+  throw new Error(`fixture did not become ready in ${FIXTURE_READY_TIMEOUT_MS}ms`);
+}
+
+function assertIsolatedDataDir(): void {  const dataDir = process.env.CLAUDE_MEM_DATA_DIR;
+  if (!dataDir) {
+    throw new Error(
+      'CLAUDE_MEM_DATA_DIR must be set before starting this process — refusing to run the ghost recovery gate against the default data dir'
+    );
+  }
+  fs.mkdirSync(dataDir, { recursive: true });
+}
+
+async function waitForOrphansToClear(
+  snapshot: ProcessIdentity[],
+  timeoutMs: number
+): Promise<ProcessIdentity[]> {
+  const deadline = Date.now() + timeoutMs;
+  let survivors = survivingProcesses(snapshot);
+  while (survivors.length > 0 && Date.now() < deadline) {
+    await new Promise(resolve => setTimeout(resolve, 500));
+    survivors = survivingProcesses(snapshot);
+  }
+  return survivors;
+}
+
+afterEach(async () => {
+  // Tear down whatever is left: the recovery may have spawned a real worker
+  // as the dead fixture's replacement, and the fixture's own chroma chain may
+  // still be alive if the gate failed before the reclaim ran.
+  const handle = active;
+  active = null;
+  if (!handle) return;
+
+  const { killProcessTree } = await import('../../src/shared/kill-process-tree.js');
+  await killProcessTree(handle.chromaRootPid).catch(() => {});
+  if (processExists(handle.pid)) {
+    killProcessOnly(handle.pid);
+  }
+
+  const { paths } = await import('../../src/shared/paths.js');
+  const pidFile = paths.workerPid();
+  if (fs.existsSync(pidFile)) {
+    const info = JSON.parse(fs.readFileSync(pidFile, 'utf-8')) as { pid?: number };
+    if (typeof info.pid === 'number' && info.pid !== handle.pid) {
+      await killProcessTree(info.pid).catch(() => {});
+    }
+    fs.rmSync(pidFile, { force: true });
+  }
+});
+
+describe.if(RUN_GATE && IS_WINDOWS)('worker recovers from a ghost listener left by an out-of-band kill', () => {
+  it('reclaims the dead worker\'s sidecar chain and starts a new worker', async () => {
+    assertIsolatedDataDir();
+    const fixture = await startFixture();
+
+    // Snapshot BEFORE the kill: once the root exits, identity is the only
+    // way to tell the survivors apart from anything that recycled its PID.
+    const snapshot = snapshotDescendants(fixture.pid);
+    expect(snapshot.length).toBeGreaterThan(0);
+    const names = snapshot.map(p => p.name.toLowerCase()).join(' ');
+    expect(names).toMatch(/uv|python/);
+
+    // Kill the fixture OUT-OF-BAND: taskkill /F /PID without /T, exactly the
+    // way a crash or a forced task-manager kill takes the worker down.
+    killProcessOnly(fixture.pid);
+    await waitFor(
+      () => !processExists(fixture.pid),
+      30_000,
+      `fixture process ${fixture.pid} to die`
+    );
+
+    // Ghost precondition: the port is still bound under the dead PID, and the
+    // sidecar chain survived (the uvx/uv layers exit on pipe EOF, but the
+    // persistent chroma-mcp/python sidecar holds the inherited socket). Wait
+    // briefly for that settled shape — without it the gate could pass by
+    // having nothing to recover.
+    let ownerUnderDeadPid = false;
+    const settleDeadline = Date.now() + GHOST_SETTLE_TIMEOUT_MS;
+    while (Date.now() < settleDeadline) {
+      const owners = listeningOwnerPids(fixture.port);
+      if (owners.length > 0 && owners.every(owner => owner === fixture.pid) && !processExists(fixture.pid)) {
+        ownerUnderDeadPid = true;
+        break;
+      }
+      await new Promise(resolve => setTimeout(resolve, 500));
+    }
+    expect(ownerUnderDeadPid, 'port must be LISTENING under the dead fixture PID (ghost)').toBe(true);
+    expect(processExists(fixture.pid)).toBe(false);
+    const survivorsAfterKill = survivingProcesses(snapshot);
+    expect(
+      survivorsAfterKill.length > 0,
+      `sidecar chain must survive the out-of-band kill: ${describeProcesses(snapshot)}`
+    ).toBe(true);
+
+    // Drive the PRODUCTION launcher. On main this returns 'dead' — no
+    // reclaim exists, so the ghost blocks every spawn forever.
+    const { ensureWorkerStarted } = await import('../../src/services/worker-spawner.js');
+    const { resolveWorkerScriptPath } = await import('../../src/shared/worker-utils.js');
+    const scriptPath = resolveWorkerScriptPath();
+    expect(scriptPath).not.toBeNull();
+    const result = await ensureWorkerStarted(fixture.port, scriptPath!);
+    expect(result, `ensureWorkerStarted must not give up on a reclaimable ghost (was: ${result})`).not.toBe('dead');
+
+    // The reclaim must have taken the sidecar chain down with the ghost.
+    const orphans = await waitForOrphansToClear(snapshot, ORPHAN_SETTLE_TIMEOUT_MS);
+    expect(
+      orphans.length === 0,
+      `sidecar descendants survived the ghost reclaim: ${describeProcesses(orphans)}`
+    ).toBe(true);
+
+    // A NEW worker must now be serving the port.
+    const { waitForHealth } = await import('../../src/services/infrastructure/HealthMonitor.js');
+    expect(await waitForHealth(fixture.port, 90_000), 'replacement worker must answer health').toBe(true);
+  }, RECOVERY_TIMEOUT_MS);
+});

--- a/tests/services/worker-spawner.test.ts
+++ b/tests/services/worker-spawner.test.ts
@@ -4,6 +4,7 @@ import { HOOK_TIMEOUTS } from '../../src/shared/hook-constants.js';
 import * as realProcessManager from '../../src/services/infrastructure/ProcessManager.js';
 import * as realHealthMonitor from '../../src/services/infrastructure/HealthMonitor.js';
 import * as realWorkerSpawnGate from '../../src/shared/worker-spawn-gate.js';
+import * as realPortReclaim from '../../src/shared/port-reclaim.js';
 
 /**
  * The whole suite runs in one bun process and `mock.module` mutates the shared
@@ -17,6 +18,7 @@ import * as realWorkerSpawnGate from '../../src/shared/worker-spawn-gate.js';
 const realProcessManagerSnapshot = { ...realProcessManager };
 const realHealthMonitorSnapshot = { ...realHealthMonitor };
 const realWorkerSpawnGateSnapshot = { ...realWorkerSpawnGate };
+const realPortReclaimSnapshot = { ...realPortReclaim };
 
 const processManager = {
   cleanStalePidFile: mock(() => 'dead' as 'alive' | 'dead'),
@@ -36,14 +38,29 @@ const spawnGate = {
   releaseSpawnLock: mock(() => {}),
 };
 
+// port-reclaim must be stubbed like the rest of the module graph: its
+// production implementation shells out to netstat/Get-CimInstance/taskkill,
+// which would run for real inside the "port in use" branch of every test
+// below. The ghost-recovery behavior itself has dedicated unit coverage in
+// tests/shared/port-reclaim.test.ts and a Windows integration gate.
+const portReclaim = {
+  reclaimGhostListeningPort: mock(async () => ({
+    reclaimed: false,
+    reason: 'not-supported',
+    killedPids: [] as number[],
+  })),
+};
+
 mock.module('../../src/services/infrastructure/ProcessManager.js', () => processManager);
 mock.module('../../src/services/infrastructure/HealthMonitor.js', () => healthMonitor);
 mock.module('../../src/shared/worker-spawn-gate.js', () => spawnGate);
+mock.module('../../src/shared/port-reclaim.js', () => portReclaim);
 
 afterAll(() => {
   mock.module('../../src/services/infrastructure/ProcessManager.js', () => realProcessManagerSnapshot);
   mock.module('../../src/services/infrastructure/HealthMonitor.js', () => realHealthMonitorSnapshot);
   mock.module('../../src/shared/worker-spawn-gate.js', () => realWorkerSpawnGateSnapshot);
+  mock.module('../../src/shared/port-reclaim.js', () => realPortReclaimSnapshot);
 });
 
 const { ensureWorkerStarted } = await import('../../src/services/worker-spawner.js');
@@ -189,6 +206,40 @@ describe('ensureWorkerStarted startup readiness', () => {
     expect(healthMonitor.waitForHealth).toHaveBeenNthCalledWith(1, 39006, 1000);
     expect(healthMonitor.waitForHealth).toHaveBeenNthCalledWith(2, 39006, HOOK_TIMEOUTS.PORT_IN_USE_WAIT);
     expect(healthMonitor.waitForReadiness).not.toHaveBeenCalled();
+    expect(processManager.spawnDaemon).not.toHaveBeenCalled();
+  });
+
+  it('starts a worker after reclaiming a ghost listener from a dead worker', async () => {
+    resetMocks();
+    healthMonitor.isPortInUse.mockResolvedValue(true);
+    healthMonitor.waitForReadiness.mockResolvedValue(true);
+    portReclaim.reclaimGhostListeningPort.mockResolvedValue({
+      reclaimed: true,
+      killedPids: [3001, 3002],
+    });
+
+    const result = await ensureWorkerStarted(39008, import.meta.filename);
+
+    // The ghost is gone, so the launcher must NOT give up: it proceeds to the
+    // spawn path like a free port would.
+    expect(result).toBe('ready');
+    expect(portReclaim.reclaimGhostListeningPort).toHaveBeenCalledWith(39008);
+    expect(processManager.spawnDaemon).toHaveBeenCalledTimes(1);
+    expect(healthMonitor.waitForReadiness).toHaveBeenCalledWith(39008, HOOK_TIMEOUTS.READINESS_WAIT);
+  });
+
+  it('stays dead when the ghost port cannot be reclaimed', async () => {
+    resetMocks();
+    healthMonitor.isPortInUse.mockResolvedValue(true);
+    portReclaim.reclaimGhostListeningPort.mockResolvedValue({
+      reclaimed: false,
+      reason: 'owner-alive',
+      killedPids: [],
+    });
+
+    const result = await ensureWorkerStarted(39009, import.meta.filename);
+
+    expect(result).toBe('dead');
     expect(processManager.spawnDaemon).not.toHaveBeenCalled();
   });
 

--- a/tests/shared/port-reclaim.test.ts
+++ b/tests/shared/port-reclaim.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Ghost-listener reclaim unit tests.
+ *
+ * The production reclaim (reclaimGhostListeningPort) only runs on Windows and
+ * shells out to netstat / Get-CimInstance / taskkill, so its decision logic is
+ * exercised on every CI platform through injected fakes; the pure parsers run
+ * directly. The real end-to-end path — worker killed out-of-band, chroma
+ * sidecar chain holding the inherited socket, launcher reclaims and starts —
+ * is the Windows integration gate (tests/integration/worker-ghost-port-recovery
+ * .test.ts, CLAUDE_MEM_TEST_CHROMA=1 in the windows workflow).
+ */
+
+import { describe, it, expect } from 'bun:test';
+import {
+  parseNetstatListeningPids,
+  isChromaSidecarName,
+  chromaCmdlineMatchesDataDir,
+  reclaimGhostListeningPort,
+  type GhostPortReclaimDeps,
+  type WindowsProcessRow,
+} from '../../src/shared/port-reclaim.js';
+
+const SAMPLE_NETSTAT = [
+  'Active Connections',
+  '',
+  '  Proto  Local Address          Foreign Address        State           PID',
+  '  TCP    0.0.0.0:135            0.0.0.0:0              LISTENING       1100',
+  '  TCP    127.0.0.1:37777        0.0.0.0:0              LISTENING       57824',
+  '  TCP    127.0.0.1:37777        127.0.0.1:54321        ESTABLISHED     9999',
+  '  TCP    127.0.0.1:37778        0.0.0.0:0              LISTENING       22040',
+  '  TCP    [::1]:37777            [::]:0                 LISTENING       57824',
+  '  TCP    [::]:37001             [::]:0                 LISTENING       4',
+  '  UDP    0.0.0.0:37777          *:*                                    57824',
+].join('\r\n');
+
+describe('parseNetstatListeningPids', () => {
+  it('extracts every LISTENING owner for the exact port', () => {
+    const owners = parseNetstatListeningPids(SAMPLE_NETSTAT, 37777);
+    // IPv4 + IPv6 listeners dedupe to one owner PID.
+    expect(owners).toEqual([57824]);
+  });
+
+  it('ignores other ports, non-LISTENING states and UDP rows', () => {
+    const owners = parseNetstatListeningPids(SAMPLE_NETSTAT, 37777);
+    expect(owners).not.toContain(1100); // different port
+    expect(owners).not.toContain(22040); // 37778
+    expect(owners).not.toContain(9999); // ESTABLISHED, not a listener
+    expect(owners).not.toContain(4); // 37001
+  });
+
+  it('returns an empty list when nothing listens on the port', () => {
+    expect(parseNetstatListeningPids(SAMPLE_NETSTAT, 39999)).toEqual([]);
+    expect(parseNetstatListeningPids('', 37777)).toEqual([]);
+  });
+});
+
+describe('isChromaSidecarName', () => {
+  it('accepts the uvx -> uv -> python -> chroma-mcp chain, with or without .exe', () => {
+    for (const name of ['uv', 'uvx', 'python', 'chroma-mcp', 'uv.exe', 'uvx.exe', 'python.exe', 'chroma-mcp.exe']) {
+      expect(isChromaSidecarName(name), `expected ${name} to match`).toBe(true);
+    }
+  });
+
+  it('rejects case-insensitively so casing differences cannot cause a miss', () => {
+    expect(isChromaSidecarName('UV.EXE')).toBe(true);
+    expect(isChromaSidecarName('Python')).toBe(true);
+  });
+
+  it('rejects everything a reused PID could plausibly own', () => {
+    for (const name of ['bun.exe', 'node.exe', 'claude.exe', 'cmd.exe', 'powershell.exe', '', 'python3.13']) {
+      expect(isChromaSidecarName(name), `expected ${JSON.stringify(name)} not to match`).toBe(false);
+    }
+  });
+});
+
+describe('chromaCmdlineMatchesDataDir', () => {
+  const DATA = 'C:/Users/test/.claude-mem';
+
+  it('matches the chroma-mcp persistent command line, backslash or forward slash', () => {
+    expect(chromaCmdlineMatchesDataDir(
+      '"chroma-mcp.exe" --client-type persistent --data-dir C:/Users/test/.claude-mem/chroma',
+      DATA
+    )).toBe(true);
+    expect(chromaCmdlineMatchesDataDir(
+      '"chroma-mcp.exe" --client-type persistent --data-dir C:\\Users\\test\\.claude-mem\\chroma',
+      DATA
+    )).toBe(true);
+  });
+
+  it('matches case-insensitively (Windows paths are case-insensitive)', () => {
+    expect(chromaCmdlineMatchesDataDir(
+      '--data-dir c:/USERS/Test/.claude-mem/chroma',
+      DATA
+    )).toBe(true);
+  });
+
+  it('handles a double-quoted data-dir value containing spaces', () => {
+    expect(chromaCmdlineMatchesDataDir(
+      '--data-dir "C:/Users/Test User/.claude-mem/chroma"',
+      'C:/Users/Test User/.claude-mem'
+    )).toBe(true);
+  });
+
+  it('rejects a different data dir, including prefix lookalikes', () => {
+    expect(chromaCmdlineMatchesDataDir(
+      '--data-dir C:/Users/test/other-install/chroma',
+      DATA
+    )).toBe(false);
+    // Prefix lookalike: .claude-mem-other must not match .claude-mem
+    expect(chromaCmdlineMatchesDataDir(
+      '--data-dir C:/Users/test/.claude-mem-other/chroma',
+      DATA
+    )).toBe(false);
+    expect(chromaCmdlineMatchesDataDir('python.exe --version', DATA)).toBe(false);
+    expect(chromaCmdlineMatchesDataDir(null, DATA)).toBe(false);
+  });
+});
+
+/** A dead owner: a PID that cannot exist on this machine (max 32-bit PID space). */
+const DEAD_OWNER = 4_000_000_000;
+const DEAD_OWNER_2 = 4_000_000_001;
+/** A live owner: this test runner itself. */
+const LIVE_OWNER = process.pid;
+
+interface RowInput {
+  pid: number;
+  ppid: number;
+  name: string;
+  token?: string;
+  cmdline?: string | null;
+}
+
+function rows(inputs: RowInput[]): WindowsProcessRow[] {
+  return inputs.map(input => ({
+    pid: input.pid,
+    ppid: input.ppid,
+    name: input.name,
+    startToken: input.token ?? null,
+    cmdline: input.cmdline !== undefined ? input.cmdline : null,
+  }));
+}
+
+
+/**
+ * listOwners is invoked twice (probe + verify). A real ghost clears after the
+ * kill, so the fake returns the live owner list first and `afterOwners` on
+ * the verify call.
+ */
+function ghostDeps(overrides: {
+  owners?: number[] | null;
+  table?: RowInput[] | null;
+  killFails?: boolean;
+  afterOwners?: number[] | null;
+  dataDir?: string | null;
+}): { deps: GhostPortReclaimDeps; killed: Array<{ pid: number; token: string | null | undefined }> } {
+  const killed: Array<{ pid: number; token: string | null | undefined }> = [];
+  const firstOwners = overrides.owners === undefined ? [DEAD_OWNER] : overrides.owners;
+  const verifyOwners = overrides.afterOwners !== undefined ? overrides.afterOwners : [];
+  let probeCount = 0;
+  return {
+    killed,
+    deps: {
+      isWin32: () => true,
+      listOwners: async () => {
+        probeCount += 1;
+        return probeCount === 1 ? firstOwners : verifyOwners;
+      },
+      readTable: async () => (overrides.table === undefined ? [] : overrides.table === null ? null : rows(overrides.table)),
+      dataDir: () => (overrides.dataDir === undefined ? null : overrides.dataDir),
+      killTree: async (pid, options) => {
+        if (overrides.killFails) throw new Error('taskkill access denied');
+        killed.push({ pid, token: options.expectedStartToken });
+      },
+    },
+  };
+}
+
+describe('reclaimGhostListeningPort decision branches', () => {
+  it('resolves to not-supported off Windows (never touches a process)', async () => {
+    const result = await reclaimGhostListeningPort(37777, {
+      isWin32: () => false,
+      listOwners: async () => {
+        throw new Error('must not be called');
+      },
+    });
+    expect(result).toEqual({ reclaimed: false, reason: 'not-supported', killedPids: [] });
+  });
+
+  it('reports netstat-unreadable when the owner list cannot be read', async () => {
+    const { deps: testDeps } = ghostDeps({ owners: null });
+    const result = await reclaimGhostListeningPort(37777, testDeps);
+    expect(result.reclaimed).toBe(false);
+    expect((result as { reason: string }).reason).toBe('netstat-unreadable');
+  });
+
+  it('reports no-listener when nothing is bound to the port', async () => {
+    const { deps: testDeps } = ghostDeps({ owners: [] });
+    const result = await reclaimGhostListeningPort(37777, testDeps);
+    expect(result).toEqual({ reclaimed: false, reason: 'no-listener', killedPids: [] });
+  });
+
+  it('reports table-unreadable when the process table cannot be enumerated', async () => {
+    const { deps: testDeps } = ghostDeps({ owners: [DEAD_OWNER], table: null });
+    const result = await reclaimGhostListeningPort(37777, testDeps);
+    expect((result as { reason: string }).reason).toBe('table-unreadable');
+  });
+
+  it('never kills when a live owner holds the port (wedged worker / foreign process)', async () => {
+    const { deps: testDeps, killed } = ghostDeps({ owners: [LIVE_OWNER] });
+    const result = await reclaimGhostListeningPort(37777, testDeps);
+    expect(result).toEqual({ reclaimed: false, reason: 'owner-alive', killedPids: [] });
+    expect(killed).toEqual([]);
+  });
+
+  it('walks the dead owner\'s descendants and kills only chroma sidecars', async () => {
+    const { deps: testDeps, killed } = ghostDeps({
+      owners: [DEAD_OWNER],
+      table: [
+        { pid: 3001, ppid: DEAD_OWNER, name: 'uvx.exe', token: 't-uvx' },
+        { pid: 3002, ppid: 3001, name: 'uv.exe', token: 't-uv' },
+        { pid: 3003, ppid: 3002, name: 'python.exe', token: 't-py' },
+        { pid: 3004, ppid: 3003, name: 'chroma-mcp.exe', token: 't-cm' },
+        // A bun/node descendant of the dead worker is NOT a sidecar — a
+        // recycled-PID edge case must not pull it into the kill.
+        { pid: 3005, ppid: 3004, name: 'bun.exe', token: 't-bun' },
+        // Unrelated processes elsewhere in the table are untouched.
+        { pid: 4001, ppid: 1, name: 'explorer.exe' },
+      ],
+    });
+    const result = await reclaimGhostListeningPort(37777, testDeps);
+    expect(result.reclaimed).toBe(true);
+    expect((result as { killedPids: number[] }).killedPids).toEqual([3004, 3003, 3002, 3001]);
+    expect(killed.map(entry => entry.pid)).toEqual([3004, 3003, 3002, 3001]);
+    // Every kill carried the token from the SAME table read that discovered it.
+    expect(killed.map(entry => entry.token)).toEqual(['t-cm', 't-py', 't-uv', 't-uvx']);
+    expect(killed.map(entry => entry.pid)).not.toContain(3005);
+    expect(killed.map(entry => entry.pid)).not.toContain(4001);
+  });
+
+  it('reports no-chroma-descendants when the dead owner\'s survivors are unrelated', async () => {
+    const { deps: testDeps, killed } = ghostDeps({
+      owners: [DEAD_OWNER],
+      table: [
+        // PID-reuse worst case: the number now names a live process with
+        // children — but they are bun/node, so nothing may be killed.
+        { pid: 5001, ppid: DEAD_OWNER, name: 'bun.exe', token: 't-bun' },
+        { pid: 5002, ppid: 5001, name: 'node.exe', token: 't-node' },
+      ],
+    });
+    const result = await reclaimGhostListeningPort(37777, testDeps);
+    expect(result).toEqual({ reclaimed: false, reason: 'no-chroma-descendants', killedPids: [] });
+    expect(killed).toEqual([]);
+  });
+
+  it('reclaims a broken chain via the data-dir fingerprint when the walk cannot reach it', async () => {
+    const { deps: testDeps, killed } = ghostDeps({
+      owners: [DEAD_OWNER],
+      // The worker's uvx/uv stdio layers exited on pipe EOF after the worker
+      // died, so the surviving chroma-mcp/python sidecar hangs off a DEAD
+      // intermediate pid — unreachable by walking down from the dead owner.
+      // Its --data-dir argument is what identifies it as ours.
+      table: [
+        { pid: 6201, ppid: DEAD_OWNER, name: 'uvx.exe', token: 't-uvx' },
+        // 6202 (uv) and 6203 (uvx of a SECOND generation) both died; the table
+        // keeps no rows for them, and 6301's ppid points at the dead 6202.
+        { pid: 6301, ppid: 6202, name: 'chroma-mcp.exe', token: 't-cm',
+          cmdline: '"chroma-mcp.exe" --client-type persistent --data-dir C:/Users/test/.claude-mem/chroma' },
+        { pid: 6302, ppid: 6301, name: 'python.exe', token: 't-py',
+          cmdline: '"python.exe" "chroma-mcp.exe" --client-type persistent --data-dir C:/Users/test/.claude-mem/chroma' },
+        // Another install's chroma on the same machine must NOT be touched.
+        { pid: 6401, ppid: 1, name: 'chroma-mcp.exe', token: 't-other',
+          cmdline: '"chroma-mcp.exe" --client-type persistent --data-dir C:/Users/other/.claude-mem/chroma' },
+        // A sidecar-named process with no data-dir argument is not evidence.
+        { pid: 6402, ppid: 1, name: 'python.exe', token: 't-nodir', cmdline: 'python.exe -m http.server' },
+      ],
+      dataDir: 'C:/Users/test/.claude-mem',
+    });
+    const result = await reclaimGhostListeningPort(37777, testDeps);
+    expect(result.reclaimed).toBe(true);
+    // 6201 (uvx) is reachable by the walk; 6301/6302 (chroma-mcp/python)
+    // only by the data-dir scan — all three are legitimate targets.
+    expect((result as { killedPids: number[] }).killedPids).toEqual([6201, 6301, 6302]);
+    expect(killed.map(entry => entry.pid)).toEqual([6201, 6301, 6302]);
+    expect(killed.map(entry => entry.token)).toEqual(['t-uvx', 't-cm', 't-py']);
+  });
+
+  it('does not run the data-dir scan when the data dir is unresolved', async () => {
+    const { deps: testDeps, killed } = ghostDeps({
+      owners: [DEAD_OWNER],
+      table: [
+        { pid: 6301, ppid: DEAD_OWNER, name: 'bun.exe', token: 't-bun' },
+      ],
+      dataDir: null,
+    });
+    const result = await reclaimGhostListeningPort(37777, testDeps);
+    expect(result.reclaimed).toBe(false);
+    expect(killed).toEqual([]);
+  });
+
+  it('reports kill-failed when a tree-kill genuinely fails and stops', async () => {
+    const { deps: testDeps, killed } = ghostDeps({
+      owners: [DEAD_OWNER],
+      table: [
+        { pid: 3001, ppid: DEAD_OWNER, name: 'uvx.exe', token: 't-uvx' },
+        { pid: 3002, ppid: 3001, name: 'python.exe', token: 't-py' },
+      ],
+      killFails: true,
+    });
+    const result = await reclaimGhostListeningPort(37777, testDeps);
+    expect(result.reclaimed).toBe(false);
+    expect((result as { reason: string }).reason).toBe('kill-failed');
+    expect(killed).toEqual([]); // failed on the first target (deepest leaf)
+  });
+
+  it('reports still-bound when the port survives the kill (holder is elsewhere)', async () => {
+    const { deps: testDeps, killed } = ghostDeps({
+      owners: [DEAD_OWNER],
+      table: [{ pid: 3001, ppid: DEAD_OWNER, name: 'uvx.exe', token: 't-uvx' }],
+      afterOwners: [42], // something else still owns the port after the kill
+    });
+    const result = await reclaimGhostListeningPort(37777, testDeps);
+    expect(result.reclaimed).toBe(false);
+    expect((result as { reason: string }).reason).toBe('still-bound');
+    expect(killed.map(entry => entry.pid)).toEqual([3001]);
+  });
+
+  it('handles multiple dead owners (IPv4 + IPv6 listeners) without double kills', async () => {
+    const { deps: testDeps, killed } = ghostDeps({
+      owners: [DEAD_OWNER, DEAD_OWNER_2],
+      table: [
+        { pid: 3001, ppid: DEAD_OWNER, name: 'uvx.exe', token: 't-a' },
+        { pid: 3101, ppid: DEAD_OWNER_2, name: 'python.exe', token: 't-b' },
+      ],
+    });
+    const result = await reclaimGhostListeningPort(37777, testDeps);
+    expect(result.reclaimed).toBe(true);
+    expect(killed.map(entry => entry.pid).sort((a, b) => a - b)).toEqual([3001, 3101]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3899.

On Windows, a worker killed **out-of-band** (crash, `taskkill /F` without `/T`) leaves its chroma sidecar chain (`uvx -> uv -> chroma-mcp -> python`, spawned with piped stdio → inherited socket handles) alive holding the listening socket. The port stays `LISTENING` under the dead worker PID, and every launcher refuses to start forever:

```
Port already in use, refusing to start duplicate        (daemon gate)
Port in use but worker not responding to health checks  (ensureWorkerStarted -> 'dead')
```

Until now the only recovery was a human tree-kill of the chain by hand. This PR makes that recovery automatic at spawn time.

**Relationship to existing work (different layers, all complementary):**

| Work | Layer | Gap this PR covers |
|---|---|---|
| #3309 (open) | prevents inheritance (non-inheritable listener) | cannot help chains that already exist from a pre-fix / crash-then-upgrade world |
| #3416 (open) | routes around the ghost (relocate port) | never frees the original port/socket |
| #3405 → #3614 bundle | reclaims via `supervisor.json` start-token records | a registry entry overwritten by a later generation, or a chain whose registry root died, is invisible to it |

This PR proves ownership from the OS alone (no claude-mem records): the survivors of a dead listener still carry `--data-dir <DATA_DIR>` on their command line.

## What does this PR do?

### 1. `src/shared/port-reclaim.ts` (new) — ghost-listener reclaim

Detection + recovery ladder, all evidence OS-side, all safety conditions enforced before any signal:

1. **netstat** finds the LISTENING owner PID(s) for the port.
2. **Live owner → never touched** (`owner-alive`): a wedged-but-alive worker or a foreign process keeps the current "in use" behavior. Only *every-owner-dead* proceeds.
3. Targets are chroma sidecars, located two ways:
   - **walk** down the dead owner's parent chain (Windows preserves parent links after death);
   - **full-table scan** matching the sidecar's `--data-dir <DATA_DIR>` command-line fingerprint — this is the load-bearing case: when the worker dies, `uvx`/`uv` read EOF and exit, so the surviving `chroma-mcp`/`python` sits one or two links below a dead PID, unreachable by the walk. The `python.exe` links are matched by their `--data-dir` argument (their executable name alone would miss them).
4. Every kill goes through `killProcessTree` with the start token from the **same table read** that discovered the target (identity never re-probed after an await). PID reuse cannot pull in strangers: a reused owner PID whose new children are unrelated is filtered by name and by the data-dir fingerprint.
5. Post-kill netstat re-probe; `reclaimed:true` only when the port is verified free.

### 2. Reclaim wired into both spawn paths

- `ensureWorkerStarted()` (worker-spawner.ts): the "Port in use but worker not responding" branch now reclaims before giving up; a successful reclaim also clears the Windows spawn-cooldown marker (its reason — the ghost — is gone; the plan-15 "cooldowns keyed to evidence, not time" rule).
- daemon duplicate gate (worker-service.ts): bound-but-silent now reclaims before `exit(0)`; a live worker still exits 0 immediately, and a live-but-wedged owner still refuses (never killed from a spawn path).

### 3. Bounded health probes (HealthMonitor.ts)

Ghost listeners accept TCP (the kernel completes handshakes) but never respond. Probes were unbounded, so the new health check in the daemon gate — and the old ones — could hang forever on a ghost. All HTTP probes now abort at 5s (above a healthy worker's sub-100ms response, below every retry budget). `/api/admin/shutdown` responds before draining (flushResponseThen), so this does not truncate graceful shutdown.

## How verified?

**Unit (cross-platform, injected seams):** `tests/shared/port-reclaim.test.ts` — 16 tests: netstat parsing (IPv4/IPv6/dedupe), sidecar-name whitelist, data-dir fingerprint matcher (slash forms, case, quoted values, prefix lookalikes), and every reclaim branch (not-supported / owner-alive / no-listener / broken-chain via fingerprint / PID-reuse safety / kill-failed / still-bound / multi-owner). `tests/services/worker-spawner.test.ts` gains: ghost-reclaimed → proceeds to spawn; unreclaimable → stays dead. `bun run typecheck` clean.

**Real Windows end-to-end (fail-on-main integration gate):** `tests/integration/worker-ghost-port-recovery.test.ts` (wired into the `chroma-windows` job of `.github/workflows/windows.yml`, `CLAUDE_MEM_TEST_CHROMA=1`):

1. detached fixture worker (PowerShell Start-Process — the same way `spawnDaemon()` launches the real daemon; a bun-test child does NOT reproduce the ghost because the test runner manages its process tree) starts a real chroma-mcp chain and binds the port;
2. `taskkill /F /PID` (no `/T`) kills it;
3. asserts the ghost: port LISTENING under the dead PID, uvx/uv exited on EOF, chroma-mcp/python survivors alive;
4. drives the PRODUCTION `ensureWorkerStarted()` → on main it returns `'dead'` (no reclaim exists); with this PR it returns ready and a replacement worker serves health;
5. asserts every snapshotted sidecar descendant (pid + start token matched) is gone.

Result on Windows 11 (real chroma, isolated data dir): `1 pass, 0 fail` — ghost precondition asserted, reclaim freed the port, replacement worker healthy.

Also reproduced the exact broken-chain shape in isolation (bun server + real chroma chain, worker killed; survivors = chroma-mcp + two python under dead intermediate PIDs) and confirmed: v1 walk-only reclaim could NOT see them (`no-chroma-descendants`), the data-dir fingerprint scan kills exactly those three processes and the port frees (`reclaimed:true`).

## Checklist

- [x] Tests added/updated and passing (unit + Windows integration gate)
- [x] Typecheck passing
