### PR TITLE
fix(oauth): honor CLAUDE_CONFIG_DIR for the Claude Code keychain entry and the SDK subprocess env

### DIFF
--- a/docs/public/configuration.mdx
+++ b/docs/public/configuration.mdx
@@ -64,6 +64,7 @@ Use [LiteLLM Gateway](configuration/litellm-gateway) when you want `CLAUDE_MEM_P
 | `CLAUDE_MEM_LOG_LEVEL`        | `INFO`                          | Log verbosity (DEBUG, INFO, WARN, ERROR, SILENT) |
 | `CLAUDE_MEM_PYTHON_VERSION`   | `3.13`                          | Python version for chroma-mcp         |
 | `CLAUDE_CODE_PATH`            | _(auto-detect)_                 | Path to Claude Code CLI (for Windows) |
+| `CLAUDE_MEM_CLAUDE_CONFIG_DIR`| _(unset — falls through to `CLAUDE_CONFIG_DIR`/`~/.claude`)_ | Override which `CLAUDE_CONFIG_DIR` profile's OAuth keychain entry to read, and which `CLAUDE_CONFIG_DIR` the spawned SDK subprocess sees. For running multiple named Claude Code profiles (e.g. `~/.claude-profiles/<name>`, each logged in separately) side by side on one machine. macOS only for the keychain lookup; Windows/Linux credential stores are not profile-aware yet. |
 
 ## Model Configuration
 

--- a/src/services/worker/http/routes/SettingsRoutes.ts
+++ b/src/services/worker/http/routes/SettingsRoutes.ts
@@ -97,6 +97,7 @@ export class SettingsRoutes extends BaseRouteHandler {
       'CLAUDE_MEM_LOG_LEVEL',
       'CLAUDE_MEM_PYTHON_VERSION',
       'CLAUDE_CODE_PATH',
+      'CLAUDE_MEM_CLAUDE_CONFIG_DIR',
       'CLAUDE_MEM_CONTEXT_SHOW_READ_TOKENS',
       'CLAUDE_MEM_CONTEXT_SHOW_WORK_TOKENS',
       'CLAUDE_MEM_CONTEXT_SHOW_SAVINGS_AMOUNT',
@@ -200,6 +201,21 @@ export class SettingsRoutes extends BaseRouteHandler {
       const pythonVersionRegex = /^3\.\d{1,2}$/;
       if (!pythonVersionRegex.test(settings.CLAUDE_MEM_PYTHON_VERSION)) {
         return { valid: false, error: 'CLAUDE_MEM_PYTHON_VERSION must be in format "3.X" or "3.XX" (e.g., "3.13")' };
+      }
+    }
+
+    // #2753 — CLAUDE_MEM_CLAUDE_CONFIG_DIR controls which keychain identity's
+    // OAuth token gets read (oauth-token.ts's deriveMacKeychainServiceName)
+    // and which CLAUDE_CONFIG_DIR gets stamped onto every spawned SDK
+    // subprocess (EnvManager.ts's buildIsolatedEnv), so — unlike most of this
+    // whitelist — a malformed value here has spawn/auth-identity consequences,
+    // not just a rejected form field. Empty string is valid (the documented
+    // "fall through to default" sentinel); a present value must be a
+    // non-empty-after-trim string so a type-confused payload (number, array,
+    // object) can't reach path.join/createHash downstream.
+    if (settings.CLAUDE_MEM_CLAUDE_CONFIG_DIR !== undefined && settings.CLAUDE_MEM_CLAUDE_CONFIG_DIR !== '') {
+      if (typeof settings.CLAUDE_MEM_CLAUDE_CONFIG_DIR !== 'string' || !settings.CLAUDE_MEM_CLAUDE_CONFIG_DIR.trim()) {
+        return { valid: false, error: 'CLAUDE_MEM_CLAUDE_CONFIG_DIR must be a non-empty path string, or "" to use the default' };
       }
     }
 

--- a/src/shared/EnvManager.ts
+++ b/src/shared/EnvManager.ts
@@ -1,14 +1,24 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from 'fs';
 import { parseEnv } from 'util';
+import { basename } from 'path';
 import { logger } from '../utils/logger.js';
-import { paths } from './paths.js';
+import { paths, DEFAULT_CLAUDE_CONFIG_DIR } from './paths.js';
+import { SettingsDefaultsManager } from './SettingsDefaultsManager.js';
 import {
   readClaudeOAuthToken,
   writeStaleMarker,
   clearStaleMarker,
+  resolveEffectiveClaudeConfigDir,
   type OAuthTokenResult,
 } from './oauth-token.js';
+
+/** #2753 — the effective config dir's profile label for logging (never the token itself): 'default' for ~/.claude, else its basename. */
+function resolveConfigDirProfileLabel(): string {
+  const settings = SettingsDefaultsManager.loadFromFile(paths.settings());
+  const effectiveConfigDir = resolveEffectiveClaudeConfigDir(settings.CLAUDE_MEM_CLAUDE_CONFIG_DIR);
+  return effectiveConfigDir === DEFAULT_CLAUDE_CONFIG_DIR ? 'default' : basename(effectiveConfigDir);
+}
 
 // Resolved lazily so tests (and any rare runtime path-overrides) can target a
 // temp file via CLAUDE_MEM_ENV_FILE without depending on module-load order.
@@ -182,6 +192,16 @@ export function buildIsolatedEnv(includeCredentials: boolean = true): Record<str
 
   isolatedEnv.CLAUDE_MEM_INTERNAL = '1';
 
+  // #2753 — override whatever the blanket copy above put in
+  // CLAUDE_CONFIG_DIR (the WORKER's own env) with the effective config dir
+  // for the SDK SUBPROCESS only: the CLAUDE_MEM_CLAUDE_CONFIG_DIR setting
+  // when set, else process.env.CLAUDE_CONFIG_DIR/default (unchanged from
+  // today). This never touches the worker's own paths.CLAUDE_CONFIG_DIR /
+  // MARKETPLACE_ROOT, which stay derived solely from
+  // process.env.CLAUDE_CONFIG_DIR at module load.
+  const configDirSettings = SettingsDefaultsManager.loadFromFile(paths.settings());
+  isolatedEnv.CLAUDE_CONFIG_DIR = resolveEffectiveClaudeConfigDir(configDirSettings.CLAUDE_MEM_CLAUDE_CONFIG_DIR);
+
   if (includeCredentials) {
     const credentials = loadClaudeMemEnv();
 
@@ -319,8 +339,12 @@ export function getAuthMethodDescription(): string {
   // Note: this is a quick sync hint for logging — the authoritative OAuth
   // path is buildIsolatedEnvWithFreshOAuth() which reads the keychain at
   // spawn time. process.env may or may not carry a token here.
+  // #2753: names the resolved profile (suffix/dir basename or 'default'),
+  // never the token itself — the profile is the whole point (which
+  // config-dir identity's keychain entry this worker will inject).
+  const profile = resolveConfigDirProfileLabel();
   if (process.env.CLAUDE_CODE_OAUTH_TOKEN) {
-    return 'Claude Code OAuth token (env, refreshed via keychain at spawn)';
+    return `Claude Code OAuth token (env, refreshed via keychain at spawn) profile=${profile}`;
   }
-  return 'Claude Code OAuth token (read from system keychain at spawn)';
+  return `Claude Code OAuth token (read from system keychain at spawn) profile=${profile}`;
 }

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -40,6 +40,8 @@ export interface SettingsDefaults {
   CLAUDE_MEM_LOG_LEVEL: string;
   CLAUDE_MEM_PYTHON_VERSION: string;
   CLAUDE_CODE_PATH: string;
+  /** #2753 — override the effective CLAUDE_CONFIG_DIR for the keychain lookup + SDK subprocess env only. Empty = fall through to process.env.CLAUDE_CONFIG_DIR / default. Never touches the worker's own MARKETPLACE_ROOT/paths. */
+  CLAUDE_MEM_CLAUDE_CONFIG_DIR: string;
   CLAUDE_MEM_MODE: string;
   CLAUDE_MEM_CONTEXT_SHOW_READ_TOKENS: string;
   CLAUDE_MEM_CONTEXT_SHOW_WORK_TOKENS: string;
@@ -162,6 +164,7 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_LOG_LEVEL: 'INFO',
     CLAUDE_MEM_PYTHON_VERSION: '3.13',
     CLAUDE_CODE_PATH: '', // Empty means auto-detect via 'which claude'
+    CLAUDE_MEM_CLAUDE_CONFIG_DIR: '', // #2753 — override CLAUDE_CONFIG_DIR for the keychain lookup + SDK subprocess only; empty = fall through to process.env.CLAUDE_CONFIG_DIR/default
     CLAUDE_MEM_MODE: 'code', // Default mode profile
     CLAUDE_MEM_CONTEXT_SHOW_READ_TOKENS: 'false',
     CLAUDE_MEM_CONTEXT_SHOW_WORK_TOKENS: 'false',

--- a/src/shared/oauth-token.ts
+++ b/src/shared/oauth-token.ts
@@ -11,16 +11,82 @@
 
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import { createHash } from 'crypto';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
 import { userInfo } from 'os';
 import { join } from 'path';
-import { paths } from './paths.js';
+import { paths, CLAUDE_CONFIG_DIR, DEFAULT_CLAUDE_CONFIG_DIR, expandTilde } from './paths.js';
+import { SettingsDefaultsManager } from './SettingsDefaultsManager.js';
 import { logger } from '../utils/logger.js';
 
 const execFileAsync = promisify(execFile);
 
 const KEYCHAIN_SERVICE_NAME = 'Claude Code-credentials';
 const READ_TIMEOUT_MS = 5000;
+
+/**
+ * #2753 — resolve the effective CLAUDE_CONFIG_DIR for the keychain lookup +
+ * SDK subprocess env, honoring the precedence: the
+ * CLAUDE_MEM_CLAUDE_CONFIG_DIR setting > process.env.CLAUDE_CONFIG_DIR >
+ * default (~/.claude). `paths.CLAUDE_CONFIG_DIR` already folds in
+ * process.env/default, so once the setting is empty this just returns that.
+ *
+ * The setting is human-typed (settings.json, or POSTed through the settings
+ * HTTP route), so a leading `~` is expanded the same way every other
+ * user-typed path setting in this codebase already is (CLAUDE_CODE_PATH via
+ * SettingsRoutes, CLAUDE_MEM_DATA_DIR via paths.ts's resolveDataDir) —
+ * otherwise a literal `~` reaches sha256() unexpanded in
+ * deriveMacKeychainServiceName, producing a suffix that never matches the
+ * real keychain entry Claude Code stores under the expanded absolute path.
+ * process.env.CLAUDE_CONFIG_DIR itself is left untouched: a shell-exported
+ * env var is already tilde-expanded by the shell before this process sees it.
+ *
+ * Round 3 fix: a trailing path separator is ALSO stripped, from both the
+ * setting branch and the CLAUDE_CONFIG_DIR fallback branch. `path.join`
+ * (which both `expandTilde` and `CLAUDE_CONFIG_DIR`'s own derivation in
+ * paths.ts route through) preserves a trailing separator rather than
+ * normalizing it away, so a very plausible human/shell-completion input like
+ * `~/.claude/` — typed to mean "my default profile" — survives expansion as
+ * "<home>/.claude/" and then fails deriveMacKeychainServiceName's bare
+ * `=== DEFAULT_CLAUDE_CONFIG_DIR` string comparison, silently deriving a
+ * WRONG suffixed keychain service name instead of the bare default one. The
+ * same divergence hits a `CLAUDE_CONFIG_DIR` shell export with a trailing
+ * slash. Stripping here — the single point every consumer (keychain lookup,
+ * the SDK-subprocess env, the profile label) resolves through — fixes all of
+ * them at once instead of re-normalizing at each comparison site.
+ */
+export function resolveEffectiveClaudeConfigDir(settingValue?: string): string {
+  const trimmed = settingValue?.trim();
+  if (trimmed) return stripTrailingSep(expandTilde(trimmed));
+  return stripTrailingSep(CLAUDE_CONFIG_DIR);
+}
+
+/**
+ * Strip one or more trailing `/` or `\` characters. Never reduces a bare
+ * separator-only string (e.g. "/") to "" — not a real config dir in
+ * practice, but a defensive no-op is cheaper than returning an empty path.
+ */
+function stripTrailingSep(dir: string): string {
+  const stripped = dir.replace(/[/\\]+$/, '');
+  return stripped.length > 0 ? stripped : dir;
+}
+
+/**
+ * #2753 — macOS derivation, empirically verified on the Studio (see #2756/
+ * #2753 background table): Claude Code stores per-config-dir credentials
+ * under 'Claude Code-credentials' for the default config dir, and under
+ * 'Claude Code-credentials-<suffix>' (suffix = first 8 hex chars of
+ * sha256(effectiveConfigDir path string)) for every other config dir.
+ *
+ * Windows/Linux are NOT covered by this function — see readWindowsCredentialManager /
+ * readLinuxLibsecret for why those two paths are left on the bare service
+ * name (no verified evidence in this repo of their suffix scheme).
+ */
+export function deriveMacKeychainServiceName(effectiveConfigDir: string): string {
+  if (effectiveConfigDir === DEFAULT_CLAUDE_CONFIG_DIR) return KEYCHAIN_SERVICE_NAME;
+  const suffix = createHash('sha256').update(effectiveConfigDir).digest('hex').slice(0, 8);
+  return `${KEYCHAIN_SERVICE_NAME}-${suffix}`;
+}
 
 // Grace window: even if expiresAt is in the past by less than this, allow the
 // token through. Claude Desktop typically refreshes shortly before expiry, so
@@ -74,31 +140,45 @@ function isExpired(expiresAtMs: number | undefined): boolean {
 }
 
 /**
- * macOS: read the JSON blob stored under "Claude Code-credentials" service in
- * the user's login keychain. The blob looks like:
+ * macOS: read the JSON blob stored under the given service name (the default
+ * "Claude Code-credentials", or a per-config-dir suffixed variant — see
+ * deriveMacKeychainServiceName, #2753) in the user's login keychain. The blob
+ * looks like:
  *   {"claudeAiOauth":{"accessToken":"...","refreshToken":"...","expiresAt":<ms>}}
+ *
+ * `execImpl` is an injectable seam for tests: promisify(execFile) is captured
+ * once at import time as the module-level `execFileAsync`, so tests cannot
+ * intercept the real one post-hoc (see tests/shared/oauth-token.test.ts for
+ * the fuller explanation) — passing a fake here lets a test fake two
+ * different keychain responses keyed by service-name argument without
+ * touching the real `security` binary. Exported (not just internal to
+ * readClaudeOAuthToken) specifically so tests can drive it directly with a
+ * fake execImpl.
  */
-async function readMacOsKeychain(): Promise<OAuthTokenResult> {
+export async function readMacOsKeychain(
+  serviceName: string,
+  execImpl: typeof execFileAsync = execFileAsync,
+): Promise<OAuthTokenResult> {
   const account = userInfo().username;
   let stdout: string;
   try {
-    ({ stdout } = await execFileAsync(
+    ({ stdout } = await execImpl(
       'security',
-      ['find-generic-password', '-s', KEYCHAIN_SERVICE_NAME, '-a', account, '-w'],
+      ['find-generic-password', '-s', serviceName, '-a', account, '-w'],
       { timeout: READ_TIMEOUT_MS, windowsHide: true },
     ));
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));
     // `security` exits non-zero when the entry doesn't exist — fail-fast as absent.
-    logger.warn('OAUTH', 'macOS keychain lookup failed', { service: KEYCHAIN_SERVICE_NAME, account }, err);
+    logger.warn('OAUTH', 'macOS keychain lookup failed', { service: serviceName, account }, err);
     return {
       kind: 'absent',
-      reason: `macOS keychain lookup failed for service "${KEYCHAIN_SERVICE_NAME}" (account=${account}): ${err.message}`,
+      reason: `macOS keychain lookup failed for service "${serviceName}" (account=${account}): ${err.message}`,
     };
   }
   const raw = stdout.trim();
   if (!raw) {
-    return { kind: 'absent', reason: 'macOS keychain returned empty value for "Claude Code-credentials"' };
+    return { kind: 'absent', reason: `macOS keychain returned empty value for "${serviceName}"` };
   }
   return parseKeychainPayload(raw);
 }
@@ -112,6 +192,13 @@ async function readMacOsKeychain(): Promise<OAuthTokenResult> {
  * secret requires PowerShell + the CredentialManager module OR the Win32
  * CredRead API. We use a PowerShell snippet that calls CredRead for the
  * common target name patterns Claude Desktop is known to use.
+ *
+ * #2753: deliberately NOT given a per-config-dir suffixed service/target
+ * name like the macOS branch (deriveMacKeychainServiceName). There is no
+ * verified evidence in this repo of whether Windows Credential Manager
+ * target names follow the same sha256(configDir)[:8] suffix scheme as
+ * macOS's keychain — this always reads the bare `KEYCHAIN_SERVICE_NAME`
+ * candidates until that is confirmed on an actual Windows box.
  */
 async function readWindowsCredentialManager(): Promise<OAuthTokenResult> {
   // PowerShell snippet enumerates likely target names and prints the JSON blob.
@@ -179,6 +266,11 @@ async function readWindowsCredentialManager(): Promise<OAuthTokenResult> {
  * Linux: libsecret via the `secret-tool` CLI. Claude Desktop on Linux stores
  * the credential under the same service name "Claude Code-credentials" with
  * the account attribute set to the OS username.
+ *
+ * #2753: same rationale as readWindowsCredentialManager above — left on the
+ * bare KEYCHAIN_SERVICE_NAME. No verified evidence in this repo of Linux's
+ * per-config-dir suffix scheme; do not guess-extend deriveMacKeychainServiceName's
+ * logic here without separate verification on an actual Linux box.
  */
 async function readLinuxLibsecret(): Promise<OAuthTokenResult> {
   const account = userInfo().username;
@@ -276,13 +368,29 @@ function readSidecarExpiresAt(): number | undefined {
  * store. Falls back to the CLAUDE_CODE_OAUTH_TOKEN environment variable only
  * when the keychain has no entry — env-as-primary is intended for CI/headless
  * setups where no keychain exists.
+ *
+ * `execImpl` is the same injectable seam `readMacOsKeychain` exposes (see its
+ * doc comment) — threaded through here, not just down at readMacOsKeychain,
+ * so a test can drive this function end-to-end and assert the darwin branch
+ * actually derives and passes the config-dir-suffixed service name, rather
+ * than only exercising deriveMacKeychainServiceName/readMacOsKeychain as
+ * standalone units. Defaults to the real execFileAsync for every production
+ * call site (only src/shared/EnvManager.ts calls this today, with no args).
  */
-export async function readClaudeOAuthToken(): Promise<OAuthTokenResult> {
+export async function readClaudeOAuthToken(
+  execImpl: typeof execFileAsync = execFileAsync,
+): Promise<OAuthTokenResult> {
   let keychainResult: OAuthTokenResult;
+
+  // #2753 — resolve the effective config dir (setting > env > default) once
+  // per call; only the macOS branch currently has a verified per-config-dir
+  // service-name suffix, so it's the only branch that consumes it.
+  const settings = SettingsDefaultsManager.loadFromFile(paths.settings());
+  const effectiveConfigDir = resolveEffectiveClaudeConfigDir(settings.CLAUDE_MEM_CLAUDE_CONFIG_DIR);
 
   switch (process.platform) {
     case 'darwin':
-      keychainResult = await readMacOsKeychain();
+      keychainResult = await readMacOsKeychain(deriveMacKeychainServiceName(effectiveConfigDir), execImpl);
       break;
     case 'win32':
       keychainResult = await readWindowsCredentialManager();

--- a/src/shared/paths.ts
+++ b/src/shared/paths.ts
@@ -40,7 +40,13 @@ export function resolveDataDir(): string {
 }
 
 export const DATA_DIR = resolveDataDir();
-export const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude');
+// #2753 — the literal default config dir, independent of process.env state.
+// Lets callers (oauth-token.ts) compare an *effective* config dir against the
+// TRUE default rather than against CLAUDE_CONFIG_DIR (which already folds in
+// process.env). Purely additive: does not change CLAUDE_CONFIG_DIR's own
+// derivation or MARKETPLACE_ROOT below.
+export const DEFAULT_CLAUDE_CONFIG_DIR = join(homedir(), '.claude');
+export const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR || DEFAULT_CLAUDE_CONFIG_DIR;
 
 export const MARKETPLACE_ROOT = join(CLAUDE_CONFIG_DIR, 'plugins', 'marketplaces', 'thedotmack');
 

--- a/tests/env-isolation.test.ts
+++ b/tests/env-isolation.test.ts
@@ -9,6 +9,8 @@ import {
 } from '../src/shared/EnvManager.js';
 import { sanitizeEnv } from '../src/supervisor/env-sanitizer.js';
 import * as oauthToken from '../src/shared/oauth-token.js';
+import { SettingsDefaultsManager } from '../src/shared/SettingsDefaultsManager.js';
+import { paths, CLAUDE_CONFIG_DIR, DEFAULT_CLAUDE_CONFIG_DIR, MARKETPLACE_ROOT } from '../src/shared/paths.js';
 // CJS interop: the check is a .cjs module exporting findViolations.
 import { createRequire } from 'module';
 const requireCjs = createRequire(import.meta.url);
@@ -236,5 +238,112 @@ describe('spawn-env discipline (CI guard)', () => {
   it('no spawn site hands raw process.env to a child without sanitizeEnv', () => {
     const violations = findViolations();
     expect(violations).toEqual([]);
+  });
+});
+
+/**
+ * #2753 — buildIsolatedEnv() must stamp the EFFECTIVE CLAUDE_CONFIG_DIR onto
+ * the isolated env it hands to the SDK subprocess (precedence: the
+ * CLAUDE_MEM_CLAUDE_CONFIG_DIR setting > process.env.CLAUDE_CONFIG_DIR >
+ * default), while never touching the WORKER's own module-level
+ * paths.CLAUDE_CONFIG_DIR / MARKETPLACE_ROOT constants.
+ *
+ * paths.ts's own CLAUDE_CONFIG_DIR is frozen at first module evaluation from
+ * process.env.CLAUDE_CONFIG_DIR at THAT time (same convention as DATA_DIR
+ * elsewhere in this codebase) — mutating process.env.CLAUDE_CONFIG_DIR at
+ * test runtime has no effect on it, so these tests exercise the "setting"
+ * side of the precedence (the only side that IS re-read live, via
+ * SettingsDefaultsManager.loadFromFile on every call) against whatever the
+ * frozen CLAUDE_CONFIG_DIR happens to resolve to in this process — the
+ * "process.env > default" half of the fallback is covered separately at the
+ * pure-function level in tests/shared/oauth-token.test.ts
+ * (resolveEffectiveClaudeConfigDir), where it doesn't depend on module-load
+ * timing.
+ *
+ * SettingsDefaultsManager.loadFromFile is a static method — spyOn mutates
+ * the class object every importer (including EnvManager.ts) calls through,
+ * so mocking it here is observed by buildIsolatedEnv() without touching the
+ * real ~/.claude-mem/settings.json. Always restored in afterEach.
+ */
+describe('#2753: buildIsolatedEnv resolves CLAUDE_CONFIG_DIR for the SDK subprocess only', () => {
+  let loadFromFileSpy: ReturnType<typeof spyOn> | undefined;
+
+  function stubConfigDirSetting(value: string): void {
+    loadFromFileSpy = spyOn(SettingsDefaultsManager, 'loadFromFile').mockImplementation(
+      () => ({ ...SettingsDefaultsManager.getAllDefaults(), CLAUDE_MEM_CLAUDE_CONFIG_DIR: value }) as any
+    );
+  }
+
+  afterEach(() => {
+    loadFromFileSpy?.mockRestore();
+    loadFromFileSpy = undefined;
+  });
+
+  it('the CLAUDE_MEM_CLAUDE_CONFIG_DIR setting wins over the frozen CLAUDE_CONFIG_DIR fallback', () => {
+    stubConfigDirSetting('/tmp/from-setting');
+
+    const result = buildIsolatedEnv();
+
+    expect(result.CLAUDE_CONFIG_DIR).toBe('/tmp/from-setting');
+    expect(result.CLAUDE_CONFIG_DIR).not.toBe(CLAUDE_CONFIG_DIR);
+  });
+
+  it('falls through to the frozen CLAUDE_CONFIG_DIR (env-or-default, resolved at module load) when the setting is empty', () => {
+    stubConfigDirSetting('');
+
+    const result = buildIsolatedEnv();
+
+    expect(result.CLAUDE_CONFIG_DIR).toBe(CLAUDE_CONFIG_DIR);
+  });
+
+  it('never touches the worker\'s own paths.CLAUDE_CONFIG_DIR / MARKETPLACE_ROOT module constants, nor the real process.env.CLAUDE_CONFIG_DIR', () => {
+    const beforeConfigDir = CLAUDE_CONFIG_DIR;
+    const beforeMarketplaceRoot = MARKETPLACE_ROOT;
+    // Captured before the call so a regression that ALSO promotes the
+    // resolved override onto the real process env (which would leak into
+    // every other paths.* consumer in this worker process, not just the
+    // isolated subprocess env) is actually caught — `CLAUDE_CONFIG_DIR` /
+    // `MARKETPLACE_ROOT` above are frozen module constants that TypeScript
+    // `const` semantics make impossible to mutate, so they can't detect that
+    // class of leak on their own.
+    const beforeProcessEnvConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+    stubConfigDirSetting('/tmp/subprocess-only-override');
+    const result = buildIsolatedEnv();
+
+    // The subprocess env got the override...
+    expect(result.CLAUDE_CONFIG_DIR).toBe('/tmp/subprocess-only-override');
+    // ...but the worker's own frozen module constants did not move at all...
+    expect(CLAUDE_CONFIG_DIR).toBe(beforeConfigDir);
+    expect(MARKETPLACE_ROOT).toBe(beforeMarketplaceRoot);
+    expect(paths.supervisorRegistry()).toContain(paths.dataDir());
+    // ...and neither did the real process environment.
+    expect(process.env.CLAUDE_CONFIG_DIR).toBe(beforeProcessEnvConfigDir);
+  });
+
+  it('buildIsolatedEnvWithFreshOAuth(false) inherits the same CLAUDE_CONFIG_DIR resolution as buildIsolatedEnv', async () => {
+    stubConfigDirSetting('/tmp/from-setting-via-fresh-oauth');
+
+    // includeCredentials=false short-circuits before any OAuth/keychain
+    // lookup (see buildIsolatedEnvWithFreshOAuth's own early return) — this
+    // isolates the CLAUDE_CONFIG_DIR assertion from platform-dependent
+    // keychain behavior.
+    const result = await buildIsolatedEnvWithFreshOAuth(false);
+
+    expect(result.CLAUDE_CONFIG_DIR).toBe('/tmp/from-setting-via-fresh-oauth');
+  });
+
+  // Round 3 fix: resolveEffectiveClaudeConfigDir strips a trailing separator,
+  // and buildIsolatedEnv resolves through it — so the SDK subprocess never
+  // sees a trailing-slash CLAUDE_CONFIG_DIR that would otherwise mismatch the
+  // worker's own no-trailing-slash value elsewhere (and, for the darwin
+  // keychain lookup, fail the default-vs-suffixed comparison in
+  // deriveMacKeychainServiceName).
+  it('strips a trailing separator from a CLAUDE_MEM_CLAUDE_CONFIG_DIR setting before stamping it onto the subprocess env', () => {
+    stubConfigDirSetting('/tmp/from-setting-with-slash/');
+
+    const result = buildIsolatedEnv();
+
+    expect(result.CLAUDE_CONFIG_DIR).toBe('/tmp/from-setting-with-slash');
   });
 });

--- a/tests/shared/oauth-token.test.ts
+++ b/tests/shared/oauth-token.test.ts
@@ -1,15 +1,19 @@
-import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test';
 import * as childProcess from 'child_process';
 import * as fs from 'fs';
 import { join } from 'path';
+import { homedir } from 'os';
 import {
   readClaudeOAuthToken,
   decodeJwtExpMs,
   writeStaleMarker,
   clearStaleMarker,
   readStaleMarker,
+  resolveEffectiveClaudeConfigDir,
+  deriveMacKeychainServiceName,
+  readMacOsKeychain,
 } from '../../src/shared/oauth-token.js';
-import { paths } from '../../src/shared/paths.js';
+import { paths, CLAUDE_CONFIG_DIR, DEFAULT_CLAUDE_CONFIG_DIR } from '../../src/shared/paths.js';
 import { buildIsolatedEnvWithFreshOAuth } from '../../src/shared/EnvManager.js';
 
 /**
@@ -288,5 +292,264 @@ describe('buildIsolatedEnvWithFreshOAuth — absent token clears stale marker', 
     }
 
     expect(readStaleMarker()).toBeUndefined();
+  });
+});
+
+/**
+ * #2753 — resolveEffectiveClaudeConfigDir precedence: the
+ * CLAUDE_MEM_CLAUDE_CONFIG_DIR setting wins when non-empty; an empty,
+ * whitespace-only, or absent setting falls through to paths.CLAUDE_CONFIG_DIR
+ * (which already folds in process.env.CLAUDE_CONFIG_DIR vs. the default —
+ * see the frozen-at-module-load note in tests/env-isolation.test.ts for why
+ * that half of the fallback isn't re-tested dynamically here).
+ */
+describe('resolveEffectiveClaudeConfigDir (#2753)', () => {
+  it('returns the trimmed setting when it is non-empty', () => {
+    expect(resolveEffectiveClaudeConfigDir('/custom/config/dir')).toBe('/custom/config/dir');
+    expect(resolveEffectiveClaudeConfigDir('  /padded/dir  ')).toBe('/padded/dir');
+  });
+
+  it('falls through to the frozen CLAUDE_CONFIG_DIR for an empty, whitespace-only, or absent setting', () => {
+    expect(resolveEffectiveClaudeConfigDir('')).toBe(CLAUDE_CONFIG_DIR);
+    expect(resolveEffectiveClaudeConfigDir('   ')).toBe(CLAUDE_CONFIG_DIR);
+    expect(resolveEffectiveClaudeConfigDir(undefined)).toBe(CLAUDE_CONFIG_DIR);
+  });
+
+  // Round 2 fix: a human-typed '~/...' setting value must expand to the same
+  // effective dir (and therefore the same keychain suffix) as its already-
+  // expanded absolute-path form — otherwise deriveMacKeychainServiceName
+  // hashes the literal tilde string and never matches the real keychain entry.
+  it('expands a leading ~ to the same effective dir as the equivalent absolute path', () => {
+    const absolute = join(homedir(), '.ccs', 'instances', 'nyeq50');
+    const tilde = '~/.ccs/instances/nyeq50';
+
+    const resolvedFromTilde = resolveEffectiveClaudeConfigDir(tilde);
+    const resolvedFromAbsolute = resolveEffectiveClaudeConfigDir(absolute);
+
+    expect(resolvedFromTilde).toBe(resolvedFromAbsolute);
+    expect(resolvedFromTilde).toBe(absolute);
+    // And the downstream keychain suffix derivation must therefore agree too —
+    // this is the actual failure mode a missing expansion produces.
+    expect(deriveMacKeychainServiceName(resolvedFromTilde)).toBe(
+      deriveMacKeychainServiceName(resolvedFromAbsolute),
+    );
+  });
+
+  it('expands a padded "~/..." setting value (trim then expand, not expand then trim)', () => {
+    const absolute = join(homedir(), '.ccs', 'instances', 'nyeq50');
+    expect(resolveEffectiveClaudeConfigDir('  ~/.ccs/instances/nyeq50  ')).toBe(absolute);
+  });
+
+  // Round 3 fix: a trailing separator must not survive into the effective
+  // dir — otherwise `~/.claude/` (a very plausible human/shell-completion
+  // typo for "my default profile") resolves to "<home>/.claude/", which
+  // fails deriveMacKeychainServiceName's bare `=== DEFAULT_CLAUDE_CONFIG_DIR`
+  // check and derives a WRONG suffixed service name for what the user meant
+  // as the default. Node's path.join (used by both expandTilde and
+  // DEFAULT_CLAUDE_CONFIG_DIR's own derivation) preserves a trailing
+  // separator rather than normalizing it away, so this is not hypothetical.
+  it('strips a trailing separator so "~/.claude/" resolves to the bare default, not a suffixed dir', () => {
+    const resolvedFromTildeSlash = resolveEffectiveClaudeConfigDir('~/.claude/');
+    expect(resolvedFromTildeSlash).toBe(DEFAULT_CLAUDE_CONFIG_DIR);
+    expect(deriveMacKeychainServiceName(resolvedFromTildeSlash)).toBe('Claude Code-credentials');
+  });
+
+  it('strips a trailing separator from an already-absolute setting value with a trailing slash', () => {
+    const absoluteWithSlash = `${DEFAULT_CLAUDE_CONFIG_DIR}/`;
+    const resolved = resolveEffectiveClaudeConfigDir(absoluteWithSlash);
+    expect(resolved).toBe(DEFAULT_CLAUDE_CONFIG_DIR);
+    expect(deriveMacKeychainServiceName(resolved)).toBe('Claude Code-credentials');
+  });
+
+  it('strips a trailing separator so an instance dir with a trailing slash matches its no-slash suffix', () => {
+    const noSlash = '/Users/matthewdnye/.ccs/instances/iveg50';
+    const withSlash = `${noSlash}/`;
+    const resolvedNoSlash = resolveEffectiveClaudeConfigDir(noSlash);
+    const resolvedWithSlash = resolveEffectiveClaudeConfigDir(withSlash);
+    expect(resolvedWithSlash).toBe(resolvedNoSlash);
+    expect(deriveMacKeychainServiceName(resolvedWithSlash)).toBe(
+      deriveMacKeychainServiceName(resolvedNoSlash),
+    );
+  });
+});
+
+/**
+ * #2753 — deriveMacKeychainServiceName suffix-derivation table, empirically
+ * verified 2026-09-06 on the Mac Studio (see the task background): Claude
+ * Code stores per-config-dir credentials under
+ * 'Claude Code-credentials-<sha256(configDirPath)[:8]>' for every config dir
+ * other than the literal default (~/.claude), which stays unsuffixed. These
+ * are pure sha256-of-a-literal-string computations — deterministic on any
+ * machine regardless of its actual $HOME, so the hardcoded Studio paths
+ * below are a legitimate portable fixture, not an environment dependency.
+ */
+describe('deriveMacKeychainServiceName (#2753) — suffix-derivation table', () => {
+  it('returns the bare "Claude Code-credentials" for the literal default config dir', () => {
+    expect(deriveMacKeychainServiceName(DEFAULT_CLAUDE_CONFIG_DIR)).toBe('Claude Code-credentials');
+  });
+
+  const studioTable: Array<{ instance: string; configDir: string; suffix: string }> = [
+    { instance: 'iveg50', configDir: '/Users/matthewdnye/.ccs/instances/iveg50', suffix: 'faf0d083' },
+    { instance: 'nyem50', configDir: '/Users/matthewdnye/.ccs/instances/nyem50', suffix: '7034a92a' },
+    { instance: 'qcom50', configDir: '/Users/matthewdnye/.ccs/instances/qcom50', suffix: '8bb48066' },
+    { instance: 'flee50', configDir: '/Users/matthewdnye/.ccs/instances/flee50', suffix: '53f0e97f' },
+    { instance: 'nyeq50', configDir: '/Users/matthewdnye/.ccs/instances/nyeq50', suffix: 'e38871d4' },
+    { instance: 'repl00', configDir: '/Users/matthewdnye/.ccs/instances/repl00', suffix: '2e1325ac' },
+  ];
+
+  for (const { instance, configDir, suffix } of studioTable) {
+    it(`suffixes ${instance} (${configDir}) as "Claude Code-credentials-${suffix}"`, () => {
+      expect(deriveMacKeychainServiceName(configDir)).toBe(`Claude Code-credentials-${suffix}`);
+    });
+  }
+});
+
+/**
+ * #2753 — readMacOsKeychain's injectable execImpl seam, exercised directly
+ * (not through readClaudeOAuthToken/process.platform dispatch — see the
+ * module-load comment on readMacOsKeychain for why the module-level
+ * execFileAsync can't be intercepted post-hoc). Because execImpl is fully
+ * injected here, this never shells out to the real `security` binary, so —
+ * unlike the platform-dispatch tests elsewhere in this file — it does NOT
+ * need a `if (process.platform !== 'darwin') return;` guard; it runs on any
+ * host OS and never touches the real keychain.
+ */
+describe('readMacOsKeychain with an injected execImpl (#2753)', () => {
+  it('the default service name returns absent while a per-config-dir suffixed service name returns present ("default item empty, instance item valid")', async () => {
+    const instanceServiceName = deriveMacKeychainServiceName('/Users/matthewdnye/.ccs/instances/iveg50');
+    const futureExpiresAt = Date.now() + 60 * 60 * 1000;
+    const instancePayload = JSON.stringify({
+      claudeAiOauth: { accessToken: 'sk-ant-oat01-instance-token', expiresAt: futureExpiresAt },
+    });
+
+    const fakeExecImpl = mock((_cmd: string, args: readonly string[]) => {
+      const serviceArgIndex = args.indexOf('-s');
+      const serviceName = serviceArgIndex >= 0 ? args[serviceArgIndex + 1] : undefined;
+      if (serviceName === instanceServiceName) {
+        return Promise.resolve({ stdout: instancePayload, stderr: '' });
+      }
+      // The default item is empty (no keychain entry) — `security` exits
+      // non-zero and execFile rejects, exactly like the real binary.
+      return Promise.reject(new Error(
+        'security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.'
+      ));
+    }) as any;
+
+    const defaultResult = await readMacOsKeychain('Claude Code-credentials', fakeExecImpl);
+    expect(defaultResult.kind).toBe('absent');
+
+    const instanceResult = await readMacOsKeychain(instanceServiceName, fakeExecImpl);
+    expect(instanceResult.kind).toBe('present');
+    if (instanceResult.kind === 'present') {
+      expect(instanceResult.token).toBe('sk-ant-oat01-instance-token');
+      expect(instanceResult.source).toBe('keychain');
+      expect(instanceResult.expiresAt).toBe(futureExpiresAt);
+    }
+
+    expect(fakeExecImpl).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * #2753 — the gap the tests above leave open: they only exercise
+ * resolveEffectiveClaudeConfigDir / deriveMacKeychainServiceName /
+ * readMacOsKeychain as standalone units. None of them assert what
+ * readClaudeOAuthToken() ITSELF passes to readMacOsKeychain on the darwin
+ * dispatch — so a future refactor or merge-conflict resolution could
+ * silently drop the `deriveMacKeychainServiceName(effectiveConfigDir)` call
+ * at that one call site (reverting to the pre-#2753 bug: always the bare
+ * default keychain item, regardless of CLAUDE_CONFIG_DIR) and every existing
+ * test would still pass. These tests close that gap by driving
+ * readClaudeOAuthToken() end-to-end with an injected execImpl (the same seam
+ * readMacOsKeychain already exposes, now threaded through
+ * readClaudeOAuthToken too) plus a spied paths.settings() pointing at a
+ * controlled temp settings.json, and asserting the actual `-s <name>`
+ * argument the darwin branch hands to the exec call.
+ *
+ * Like the "injected execImpl" describe above, this never shells out to the
+ * real `security` binary, so it spoofs platform to darwin unconditionally
+ * and runs on any host OS.
+ */
+describe('readClaudeOAuthToken (#2753) — darwin dispatch wires the derived service name through', () => {
+  let settingsPathSpy: ReturnType<typeof spyOn> | undefined;
+
+  beforeEach(() => {
+    setPlatform('darwin');
+  });
+
+  afterEach(() => {
+    settingsPathSpy?.mockRestore();
+    settingsPathSpy = undefined;
+  });
+
+  function stubSettingsFile(configDirSetting: string): void {
+    const settingsPath = join(tempDir, 'settings.json');
+    fs.writeFileSync(settingsPath, JSON.stringify({ CLAUDE_MEM_CLAUDE_CONFIG_DIR: configDirSetting }));
+    settingsPathSpy = spyOn(paths, 'settings').mockImplementation(() => settingsPath);
+  }
+
+  function fakeExecFor(expectedServiceName: string, payload: string): any {
+    return mock((_cmd: string, args: readonly string[]) => {
+      const serviceArgIndex = args.indexOf('-s');
+      const serviceName = serviceArgIndex >= 0 ? args[serviceArgIndex + 1] : undefined;
+      if (serviceName === expectedServiceName) {
+        return Promise.resolve({ stdout: payload, stderr: '' });
+      }
+      return Promise.reject(new Error(`unexpected keychain service name: ${serviceName}`));
+    });
+  }
+
+  it('passes deriveMacKeychainServiceName(effectiveConfigDir) through — not the bare default — when the setting is non-empty', async () => {
+    const instanceConfigDir = '/Users/matthewdnye/.ccs/instances/iveg50';
+    stubSettingsFile(instanceConfigDir);
+    const expectedServiceName = deriveMacKeychainServiceName(instanceConfigDir);
+    expect(expectedServiceName).not.toBe('Claude Code-credentials');
+
+    const futureExpiresAt = Date.now() + 60 * 60 * 1000;
+    const payload = JSON.stringify({
+      claudeAiOauth: { accessToken: 'sk-ant-oat01-wired-token', expiresAt: futureExpiresAt },
+    });
+    const fakeExecImpl = fakeExecFor(expectedServiceName, payload);
+
+    const result = await readClaudeOAuthToken(fakeExecImpl);
+
+    expect(fakeExecImpl).toHaveBeenCalledTimes(1);
+    const callArgs = fakeExecImpl.mock.calls[0][1] as string[];
+    expect(callArgs).toContain(expectedServiceName);
+    expect(callArgs).not.toContain('Claude Code-credentials');
+    expect(result.kind).toBe('present');
+    if (result.kind === 'present') {
+      expect(result.token).toBe('sk-ant-oat01-wired-token');
+      expect(result.source).toBe('keychain');
+    }
+  });
+
+  it('falls through to deriveMacKeychainServiceName(CLAUDE_CONFIG_DIR) when the setting is empty', async () => {
+    stubSettingsFile('');
+    // NOT hardcoded to the bare 'Claude Code-credentials': CLAUDE_CONFIG_DIR
+    // is frozen at module load from process.env.CLAUDE_CONFIG_DIR (or the
+    // default), and this suite itself may be running under a non-default
+    // CCS-instance config dir (e.g. iveg50) — exactly the "fleet" scenario
+    // the critical finding warned a silent regression would hit hardest. The
+    // expected value must track whatever this process's own CLAUDE_CONFIG_DIR
+    // actually is, the same way resolveEffectiveClaudeConfigDir's own
+    // fall-through tests do above.
+    const expectedServiceName = deriveMacKeychainServiceName(CLAUDE_CONFIG_DIR);
+
+    const futureExpiresAt = Date.now() + 60 * 60 * 1000;
+    const payload = JSON.stringify({
+      claudeAiOauth: { accessToken: 'sk-ant-oat01-default-token', expiresAt: futureExpiresAt },
+    });
+    const fakeExecImpl = fakeExecFor(expectedServiceName, payload);
+
+    const result = await readClaudeOAuthToken(fakeExecImpl);
+
+    expect(fakeExecImpl).toHaveBeenCalledTimes(1);
+    const callArgs = fakeExecImpl.mock.calls[0][1] as string[];
+    expect(callArgs).toContain(expectedServiceName);
+    expect(result.kind).toBe('present');
+    if (result.kind === 'present') {
+      expect(result.token).toBe('sk-ant-oat01-default-token');
+    }
   });
 });

--- a/tests/shared/settings-defaults-manager.test.ts
+++ b/tests/shared/settings-defaults-manager.test.ts
@@ -501,6 +501,15 @@ describe('SettingsDefaultsManager', () => {
       expect(defaults.CLAUDE_MEM_DATA_DIR).toBeDefined();
       expect(defaults.CLAUDE_MEM_LOG_LEVEL).toBeDefined();
     });
+
+    // #2753 — new key: empty by default (fall through to
+    // process.env.CLAUDE_CONFIG_DIR/default in oauth-token.ts's
+    // resolveEffectiveClaudeConfigDir), overridable via file or env like any
+    // other setting (the generic per-key loops in loadFromFile/
+    // applyEnvOverrides need no key-specific code).
+    it('CLAUDE_MEM_CLAUDE_CONFIG_DIR defaults to empty string', () => {
+      expect(SettingsDefaultsManager.getAllDefaults().CLAUDE_MEM_CLAUDE_CONFIG_DIR).toBe('');
+    });
   });
 
   describe('get', () => {
@@ -564,6 +573,28 @@ describe('SettingsDefaultsManager', () => {
       const result = SettingsDefaultsManager.loadFromFile(settingsPath);
 
       expect(result.CLAUDE_MEM_WORKER_PORT).toBe('99999');
+    });
+
+    // #2753 — CLAUDE_MEM_CLAUDE_CONFIG_DIR is overridable via the file and
+    // via CLAUDE_MEM_CLAUDE_CONFIG_DIR env, same as any other key (no
+    // key-specific code was added — the generic loops already handle it).
+    it('CLAUDE_MEM_CLAUDE_CONFIG_DIR: file value is honored, and env overrides the file', () => {
+      const originalConfigDirEnv = process.env.CLAUDE_MEM_CLAUDE_CONFIG_DIR;
+      try {
+        delete process.env.CLAUDE_MEM_CLAUDE_CONFIG_DIR;
+        writeFileSync(settingsPath, JSON.stringify({ CLAUDE_MEM_CLAUDE_CONFIG_DIR: '/from/file' }));
+
+        expect(SettingsDefaultsManager.loadFromFile(settingsPath).CLAUDE_MEM_CLAUDE_CONFIG_DIR).toBe('/from/file');
+
+        process.env.CLAUDE_MEM_CLAUDE_CONFIG_DIR = '/from/env';
+        expect(SettingsDefaultsManager.loadFromFile(settingsPath).CLAUDE_MEM_CLAUDE_CONFIG_DIR).toBe('/from/env');
+      } finally {
+        if (originalConfigDirEnv === undefined) {
+          delete process.env.CLAUDE_MEM_CLAUDE_CONFIG_DIR;
+        } else {
+          process.env.CLAUDE_MEM_CLAUDE_CONFIG_DIR = originalConfigDirEnv;
+        }
+      }
     });
 
     it('should use file setting when env var is not set', () => {

--- a/tests/worker/http/routes/settings-routes-config-dir.test.ts
+++ b/tests/worker/http/routes/settings-routes-config-dir.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import type { Request, Response } from 'express';
+import { existsSync, readFileSync, writeFileSync, rmSync } from 'fs';
+import { SettingsRoutes } from '../../../../src/services/worker/http/routes/SettingsRoutes.js';
+import { paths } from '../../../../src/shared/paths.js';
+
+/**
+ * #2753 round 2 — a review finding noted that CLAUDE_MEM_CLAUDE_CONFIG_DIR
+ * was added to the POST /api/settings write-whitelist with zero test
+ * coverage anywhere in the repo (`grep -rl "SettingsRoutes" tests/` returned
+ * nothing before this file). This exercises the actual route handler so a
+ * future silent removal of the whitelist entry — or a validation regression —
+ * is caught, without touching the real ~/.claude-mem (paths.settings()
+ * resolves under the per-run temp DATA_DIR that tests/preload.ts pins before
+ * any module loads).
+ */
+
+function createMockReqRes(body: any): {
+  req: Partial<Request>;
+  res: Partial<Response>;
+  jsonSpy: ReturnType<typeof mock>;
+  statusSpy: ReturnType<typeof mock>;
+} {
+  const jsonSpy = mock(() => {});
+  const statusSpy = mock(() => ({ json: jsonSpy }));
+  return {
+    req: { body, path: '/api/settings', params: {}, query: {} } as Partial<Request>,
+    res: { json: jsonSpy, status: statusSpy, headersSent: false } as unknown as Partial<Response>,
+    jsonSpy,
+    statusSpy,
+  };
+}
+
+function captureSettingsPostHandler(routes: SettingsRoutes): (req: Request, res: Response) => void {
+  let handler!: (req: Request, res: Response) => void;
+  const mockApp: any = {
+    get: mock(() => {}),
+    post: mock((path: string, ...handlers: Array<(req: Request, res: Response) => void>) => {
+      if (path === '/api/settings') {
+        handler = handlers[handlers.length - 1];
+      }
+    }),
+  };
+  routes.setupRoutes(mockApp);
+  return (req: Request, res: Response): void => handler(req, res);
+}
+
+describe('SettingsRoutes — CLAUDE_MEM_CLAUDE_CONFIG_DIR write whitelist (#2753 round 2)', () => {
+  const settingsPath = paths.settings();
+  let priorSettingsContent: string | undefined;
+  let handler: (req: Request, res: Response) => void;
+
+  beforeEach(() => {
+    priorSettingsContent = existsSync(settingsPath) ? readFileSync(settingsPath, 'utf-8') : undefined;
+    handler = captureSettingsPostHandler(new SettingsRoutes({} as any));
+  });
+
+  afterEach(() => {
+    if (priorSettingsContent === undefined) {
+      try {
+        rmSync(settingsPath, { force: true });
+      } catch {
+        // best effort
+      }
+    } else {
+      writeFileSync(settingsPath, priorSettingsContent, 'utf-8');
+    }
+  });
+
+  it('round-trips a valid path value through POST /api/settings', () => {
+    const { req, res, jsonSpy } = createMockReqRes({
+      CLAUDE_MEM_CLAUDE_CONFIG_DIR: '/Users/matthewdnye/.ccs/instances/iveg50',
+    });
+
+    handler(req as Request, res as Response);
+
+    expect(jsonSpy).toHaveBeenCalledWith({ success: true, message: 'Settings updated successfully' });
+    const persisted = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    expect(persisted.CLAUDE_MEM_CLAUDE_CONFIG_DIR).toBe('/Users/matthewdnye/.ccs/instances/iveg50');
+  });
+
+  it('accepts an empty string (the documented "use the default" sentinel)', () => {
+    const { req, res, jsonSpy } = createMockReqRes({ CLAUDE_MEM_CLAUDE_CONFIG_DIR: '' });
+
+    handler(req as Request, res as Response);
+
+    expect(jsonSpy).toHaveBeenCalledWith({ success: true, message: 'Settings updated successfully' });
+    const persisted = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+    expect(persisted.CLAUDE_MEM_CLAUDE_CONFIG_DIR).toBe('');
+  });
+
+  it('rejects a non-string value (e.g. a number) with 400 and does not persist it', () => {
+    const { req, res, statusSpy, jsonSpy } = createMockReqRes({ CLAUDE_MEM_CLAUDE_CONFIG_DIR: 42 });
+    const before = existsSync(settingsPath) ? readFileSync(settingsPath, 'utf-8') : undefined;
+
+    handler(req as Request, res as Response);
+
+    expect(statusSpy).toHaveBeenCalledWith(400);
+    expect(jsonSpy).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+    const after = existsSync(settingsPath) ? readFileSync(settingsPath, 'utf-8') : undefined;
+    expect(after).toBe(before);
+  });
+
+  it('rejects a whitespace-only value with 400', () => {
+    const { req, res, statusSpy } = createMockReqRes({ CLAUDE_MEM_CLAUDE_CONFIG_DIR: '   ' });
+
+    handler(req as Request, res as Response);
+
+    expect(statusSpy).toHaveBeenCalledWith(400);
+  });
+});


### PR DESCRIPTION
## Summary

When the worker runs under a non-default `CLAUDE_CONFIG_DIR` (a second Claude Code profile logged in separately), `readClaudeOAuthToken()` still reads the **default** keychain item. Claude Code stores per-profile credentials on macOS under `Claude Code-credentials-<suffix>`, where `suffix` is the first 8 hex characters of `sha256(<config dir path>)`; only the default `~/.claude` profile uses the bare `Claude Code-credentials` name. With the fixed constant in `oauth-token.ts`, the worker under a named profile either found no token (default item empty) or, worse, injected the wrong identity's token into the spawned SDK subprocess. Verified on the reporting machine against six real non-default config dirs (each derived suffix matched the keychain entry Claude Code had created).

The spawned SDK subprocess also inherited whatever `CLAUDE_CONFIG_DIR` the worker's own environment happened to carry, so there was no way to pin the subprocess to a specific profile from settings.

## What this changes

- **`paths.ts`:** adds `DEFAULT_CLAUDE_CONFIG_DIR` (the literal default, independent of `process.env`). `CLAUDE_CONFIG_DIR` and `MARKETPLACE_ROOT` keep their existing derivation.
- **`SettingsDefaultsManager.ts` / `SettingsRoutes.ts` / `docs/public/configuration.mdx`:** new setting `CLAUDE_MEM_CLAUDE_CONFIG_DIR` (default empty = fall through to `process.env.CLAUDE_CONFIG_DIR`, then `~/.claude`). Registered in the `POST /api/settings` allowlist with a non-empty-string validation (an empty string is the documented "use the default" sentinel); documented in the settings table.
- **`oauth-token.ts`:** `resolveEffectiveClaudeConfigDir(settingValue?)` applies the precedence setting > env > default, expands a leading `~` and strips a trailing path separator, so `~/.claude`, `~/.claude/` and the absolute form all resolve to the same string. `deriveMacKeychainServiceName(dir)` returns the bare service name for the literal default and the `-<sha256[:8]>` variant otherwise. `readMacOsKeychain(serviceName, execImpl)` takes the service name and an injectable exec seam; `readClaudeOAuthToken(execImpl?)` threads the seam through so the darwin dispatch can be tested end to end. **Only the darwin branch consumes the derived name** — the Windows and Linux readers stay on the bare name, with a comment saying their per-profile scheme is unverified rather than guessed.
- **`EnvManager.ts`:** `buildIsolatedEnv` stamps the effective config dir onto the isolated env handed to the SDK subprocess (this is the only env it touches; the worker's own `paths.*` constants and `process.env` are untouched). Note the subprocess env now always carries an explicit `CLAUDE_CONFIG_DIR`, `~/.claude` when nothing overrides it — the same directory Claude Code resolves when the variable is absent. `getAuthMethodDescription()` appends `profile=<basename|default>` so `/api/health` names the profile whose keychain entry will be read; it never includes the token.

## Test evidence

- `npx tsc --noEmit`: clean.
- `bun test tests/shared/oauth-token.test.ts tests/env-isolation.test.ts tests/shared/settings-defaults-manager.test.ts tests/worker/http/routes/settings-routes-config-dir.test.ts tests/logger-usage-standards.test.ts`: **102 pass, 0 fail** (up from 71 on a clean checkout of the same base; the new `settings-routes-config-dir.test.ts` is the first test to drive `SettingsRoutes` directly). `--rerun-each=5` over the three new-behaviour files: 260 runs, 0 fail.
- Full `bun test`: the same pre-existing failing set as a clean checkout of the same base (`tests/infrastructure/cleanup-v12_4_3` and the legacy migration-chain test), nothing new.
- New tests cover: the precedence and normalisation of `resolveEffectiveClaudeConfigDir`; the suffix table for six real config dirs plus the default; `readMacOsKeychain` with an injected exec proving "default item empty, profile item present" without touching a real keychain; `readClaudeOAuthToken`'s darwin dispatch passing the derived `-s <name>` argument (and falling through to the frozen `CLAUDE_CONFIG_DIR` when the setting is empty); `buildIsolatedEnv` / `buildIsolatedEnvWithFreshOAuth(false)` stamping the subprocess env per precedence while `paths.CLAUDE_CONFIG_DIR`, `MARKETPLACE_ROOT` and `process.env` stay put; the settings key's default and file/env override; the route allowlist round-trip and its 400 paths.
- Live: this change has run on the reporting machine's worker (built from source on a v13.9.3-based branch) since 2026-09-07 10:31 PDT; `/api/health` reports `profile=<named profile>` and the subprocess authenticates with that profile's token.

Refs #3868 (sibling local patch from the same install; independent of this one).

---
Opened by Gwen Ives, Virtual COO (an AI assistant operating on behalf of Matt Nye), from the install where the defect was measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJEKSU5eVwnvBf4irjtP4E
