### PR TITLE
fix: handle closed bun-runner stdin pipes

### DIFF
--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -175,6 +175,7 @@ if (needsCmdShell) {
 const child = spawn(spawnCmd, spawnArgs, spawnOptions);
 
 if (child.stdin) {
+  child.stdin.on('error', () => {});
   if (stdinData && stdinData.length > 0) {
     child.stdin.write(stdinData);
     child.stdin.end();

--- a/tests/bun-runner.test.ts
+++ b/tests/bun-runner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { chmodSync, cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { spawnSync } from 'child_process';
 import { dirname, join, win32 } from 'path';
@@ -261,5 +261,29 @@ describe('bun-runner.js spawn: no cmd.exe for .exe targets (#3196)', () => {
     const shellAssignments = source.match(/spawnOptions\.shell = true/g) ?? [];
     expect(shellAssignments.length).toBe(1);
     expect(source).not.toMatch(/if \(IS_WINDOWS\) \{\s*const quote/);
+  });
+});
+
+describe('bun-runner.js stdin pipe errors', () => {
+  it('does not crash when the child closes stdin before the payload is written', () => {
+    const fixtureDir = mkdtempSync(join(tmpdir(), 'bun-runner-epipe-'));
+    const bunPath = join(fixtureDir, 'bun');
+
+    try {
+      writeFileSync(bunPath, '#!/bin/sh\nexec 0<&-\nsleep 0.1\n');
+      chmodSync(bunPath, 0o755);
+
+      const result = spawnSync(process.execPath, [BUN_RUNNER_PATH, 'worker-service.cjs', 'hook'], {
+        encoding: 'utf-8',
+        env: { ...process.env, PATH: `${fixtureDir}:${process.env.PATH || ''}` },
+        input: Buffer.alloc(1024 * 1024, 'x')
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).not.toContain('Unhandled');
+      expect(result.stderr).not.toContain('write EPIPE');
+    } finally {
+      rmSync(fixtureDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

The Bun runner can crash with an unhandled EPIPE when a child exits before a hook payload write completes. Handle stdin stream errors and add regression coverage for a child that closes stdin early.

Fixes #3895