### PR TITLE
fix(windows): validate Bun paths returned by where

### DIFF
--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -43,11 +43,15 @@ function findBun() {
       const firstInstallPaths = firstBunDir
         ? bunPaths.filter(line => dirname(line).toLowerCase() === firstBunDir)
         : [];
-      const bunExePath = firstInstallPaths.find(line => line.toLowerCase().endsWith('bun.exe'));
+      const bunExePath = firstInstallPaths.find(line =>
+        line.toLowerCase().endsWith('bun.exe') && existsSync(line)
+      );
       if (bunExePath) {
         return bunExePath;
       }
-      const bunCmdPath = firstInstallPaths.find(line => line.toLowerCase().endsWith('bun.cmd'));
+      const bunCmdPath = firstInstallPaths.find(line =>
+        line.toLowerCase().endsWith('bun.cmd') && existsSync(line)
+      );
       if (bunCmdPath) {
         return bunCmdPath;
       }
@@ -55,12 +59,14 @@ function findBun() {
       // the resolved absolute path instead of falling through to the bare
       // name: resolving a bare `bun` later relies on the child's PATH, which
       // cmd.exe drops entirely when it exceeds ~8191 chars (issue #3196).
-      const firstWherePath = pathCheck.stdout.split(/\r?\n/).map(line => line.trim()).find(Boolean);
+      const firstWherePath = bunPaths.find(line => existsSync(line));
       if (firstWherePath) {
         return firstWherePath;
       }
     }
-    return 'bun';
+    if (!IS_WINDOWS) {
+      return 'bun';
+    }
   }
 
   const bunPaths = IS_WINDOWS

--- a/tests/bun-runner.test.ts
+++ b/tests/bun-runner.test.ts
@@ -30,8 +30,9 @@ interface WhereResult {
 
 function runFindBun(
   whereResult: WhereResult,
-  { isWindows = true, existingPaths = [] as string[] } = {}
+  { isWindows = true, existingPaths = [] as string[], wherePathsExist = true } = {}
 ): string | null {
+  const wherePaths = whereResult.stdout.split(/\r?\n/).map(path => path.trim()).filter(Boolean);
   const factory = new Function(
     'spawnSync',
     'IS_WINDOWS',
@@ -47,7 +48,7 @@ function runFindBun(
     isWindows ? win32.join : join,
     isWindows ? win32.dirname : dirname,
     () => (isWindows ? 'C:\\Users\\test' : '/home/test'),
-    (p: string) => existingPaths.includes(p)
+    (p: string) => existingPaths.includes(p) || (wherePathsExist && wherePaths.includes(p))
   );
 }
 
@@ -79,7 +80,7 @@ function findBunForWhereOutput(stdout: string) {
   return createFindBun({
     IS_WINDOWS: true,
     dirname: win32.dirname,
-    existsSync: () => false,
+    existsSync: path => stdout.split(/\r?\n/).map(line => line.trim()).includes(path),
     homedir: () => 'C:\\Users\\fixture',
     join,
     spawnSync: (() => ({
@@ -232,6 +233,18 @@ describe('bun-runner.js findBun: absolute bun.exe resolution (#3196)', () => {
       { status: 1, stdout: '' },
       { existingPaths: [expected] }
     );
+    expect(result).toBe(expected);
+  });
+
+  it('falls back when where.exe returns a path corrupted by the active code page', () => {
+    const expected = win32.join('C:\\Users\\test', '.bun', 'bin', 'bun.exe');
+    const corruptedWherePath = 'C:\\Users\\\ufffdR\\\ufffdc\\.bun\\bin\\bun.exe';
+
+    const result = runFindBun(
+      { status: 0, stdout: `${corruptedWherePath}\r\n` },
+      { existingPaths: [expected], wherePathsExist: false }
+    );
+
     expect(result).toBe(expected);
   });
 


### PR DESCRIPTION
## What
Validate Windows Bun paths returned by `where` before using them.

## Why
On non-UTF-8 Windows code pages, `where.exe` can return a decoded path with replacement characters, causing Bun hooks to fail with `ENOENT`. Reject invalid candidates so the resolver reaches the existing profile-based fallback.

Fixes #3865