### PR TITLE
fix: prevent stale observer health warnings

### DIFF
--- a/src/services/context/ContextBuilder.ts
+++ b/src/services/context/ContextBuilder.ts
@@ -197,7 +197,14 @@ function paintRed(text: string): string {
  * last thing rendered is the thing still on screen — and for the model, the
  * closest thing to its first reply.
  */
-export function withObserverHealthWarning(text: string, forHuman: boolean = false): string {
+export function withObserverHealthWarning(
+  text: string,
+  forHuman: boolean = false,
+  includeWarning: boolean = true,
+): string {
+  if (!includeWarning) {
+    return text;
+  }
   const health = readObserverHealth();
   if (!isObserverUnhealthy(health)) {
     return text;
@@ -213,6 +220,7 @@ export async function generateContextWithStats(
   input?: ContextInput,
   forHuman: boolean = false
 ): Promise<{ text: string; stats: ContextInjectStats | null }> {
+  const includeHealthWarning = input?.source !== 'compact';
   const config = loadContextConfig();
   const cwd = input?.cwd ?? process.cwd();
   const context = getProjectContext(cwd);
@@ -227,7 +235,7 @@ export async function generateContextWithStats(
 
   const rawDb = initializeDatabase();
   if (!rawDb) {
-    return { text: withObserverHealthWarning('', forHuman), stats: null };
+    return { text: withObserverHealthWarning('', forHuman, includeHealthWarning), stats: null };
   }
 
   try {
@@ -240,7 +248,10 @@ export async function generateContextWithStats(
     const summaries = querySummariesMulti(db, queryProjects, config, platformSource);
 
     if (observations.length === 0 && summaries.length === 0) {
-      return { text: withObserverHealthWarning(renderEmptyState(project, forHuman), forHuman), stats: null };
+      return {
+        text: withObserverHealthWarning(renderEmptyState(project, forHuman), forHuman, includeHealthWarning),
+        stats: null,
+      };
     }
 
     const output = buildContextOutput(
@@ -254,7 +265,7 @@ export async function generateContextWithStats(
     );
 
     return {
-      text: withObserverHealthWarning(output, forHuman),
+      text: withObserverHealthWarning(output, forHuman, includeHealthWarning),
       stats: buildInjectStats(observations, summaries, Boolean(input?.full)),
     };
   } finally {

--- a/src/shared/observer-health.ts
+++ b/src/shared/observer-health.ts
@@ -73,6 +73,8 @@ export const OBSERVER_HEALTH_FILENAME = 'observer-health.json';
 
 /** Warn only after repeated failures — a single blip self-heals on retry. */
 export const OBSERVER_UNHEALTHY_FAILURE_THRESHOLD = 3;
+/** A failure that has not been refreshed recently is no longer actionable. */
+export const OBSERVER_UNHEALTHY_MAX_ERROR_AGE_MS = 6 * 60 * 60_000;
 
 const MAX_ERROR_MESSAGE_LENGTH = 600;
 
@@ -257,10 +259,15 @@ export function recordObserverSuccess(filePath: string = defaultHealthFilePath()
   });
 }
 
-export function isObserverUnhealthy(state: ObserverHealthState | null): state is ObserverHealthState {
+export function isObserverUnhealthy(
+  state: ObserverHealthState | null,
+  nowMs: number = Date.now(),
+): state is ObserverHealthState {
   return state !== null
     && state.consecutiveFailures >= OBSERVER_UNHEALTHY_FAILURE_THRESHOLD
-    && (state.lastErrorAt ?? 0) > (state.lastSuccessAt ?? 0);
+    && (state.lastErrorAt ?? 0) > (state.lastSuccessAt ?? 0)
+    && (state.lastErrorAt ?? 0) <= nowMs
+    && nowMs - (state.lastErrorAt ?? 0) <= OBSERVER_UNHEALTHY_MAX_ERROR_AGE_MS;
 }
 
 /** "3 minutes" / "about 2 hours" / "about 3 days" for outage durations. */

--- a/tests/observer-health.test.ts
+++ b/tests/observer-health.test.ts
@@ -12,6 +12,7 @@ import {
   describeDuration,
   scrubErrorMessage,
   OBSERVER_UNHEALTHY_FAILURE_THRESHOLD,
+  OBSERVER_UNHEALTHY_MAX_ERROR_AGE_MS,
   type ObserverHealthState,
 } from '../src/shared/observer-health.ts';
 
@@ -213,10 +214,26 @@ describe('observer-health ledger', () => {
 describe('isObserverUnhealthy', () => {
   it('requires the failure threshold AND failures newer than the last success', () => {
     expect(isObserverUnhealthy(null)).toBe(false);
-    expect(isObserverUnhealthy(unhealthyState())).toBe(true);
-    expect(isObserverUnhealthy(unhealthyState({ consecutiveFailures: OBSERVER_UNHEALTHY_FAILURE_THRESHOLD - 1 }))).toBe(false);
+    expect(isObserverUnhealthy(unhealthyState(), 1_754_700_100_001)).toBe(true);
+    expect(isObserverUnhealthy(unhealthyState({ consecutiveFailures: OBSERVER_UNHEALTHY_FAILURE_THRESHOLD - 1 }), 1_754_700_100_001)).toBe(false);
     expect(isObserverUnhealthy(unhealthyState({ lastSuccessAt: Date.now() + 60_000 }))).toBe(false);
-    expect(isObserverUnhealthy(unhealthyState({ lastSuccessAt: null }))).toBe(true);
+    expect(isObserverUnhealthy(unhealthyState({ lastSuccessAt: null }), 1_754_700_100_001)).toBe(true);
+  });
+
+  it('does not report an outage after the last failure becomes stale', () => {
+    const lastErrorAt = 1_754_700_100_000;
+    expect(isObserverUnhealthy(
+      unhealthyState({ lastErrorAt }),
+      lastErrorAt + OBSERVER_UNHEALTHY_MAX_ERROR_AGE_MS + 1,
+    )).toBe(false);
+  });
+
+  it('does not trust a failure timestamp from the future', () => {
+    const nowMs = 1_754_700_100_000;
+    expect(isObserverUnhealthy(
+      unhealthyState({ lastErrorAt: nowMs + 1 }),
+      nowMs,
+    )).toBe(false);
   });
 });
 
@@ -325,19 +342,22 @@ describe('describeDuration', () => {
 describe('ContextBuilder observer-health injection', () => {
   interface ChildRender {
     emptyDbText: string;
+    observerText: string;
     agentText: string;
     humanText: string;
   }
 
   function runContextChild(childDataDir: string): ChildRender {
     const result = Bun.spawnSync(['bun', '-e', `
-      import { generateContext, withObserverHealthWarning } from './src/services/context/ContextBuilder.ts';
+      import { generateContext } from './src/services/context-generator.ts';
+      import { withObserverHealthWarning } from './src/services/context/ContextBuilder.ts';
       import { ModeManager } from './src/services/domain/ModeManager.ts';
       ModeManager.getInstance().loadMode('code');
       const emptyDbText = await generateContext({ projects: ['observer-health-test'] });
+      const observerText = await generateContext({ projects: ['observer-health-test'], source: 'compact' });
       const agentText = withObserverHealthWarning('TIMELINE_BODY', false);
       const humanText = withObserverHealthWarning('TIMELINE_BODY', true);
-      console.log(JSON.stringify({ emptyDbText, agentText, humanText }));
+      console.log(JSON.stringify({ emptyDbText, observerText, agentText, humanText }));
     `], {
       cwd: repoRoot,
       env: {
@@ -353,15 +373,24 @@ describe('ContextBuilder observer-health injection', () => {
     return JSON.parse(new TextDecoder().decode(result.stdout).trim());
   }
 
+  function writeFreshUnhealthyState(): void {
+    const now = Date.now();
+    writeFileSync(join(dataDir, 'observer-health.json'), JSON.stringify(unhealthyState({
+      failingSinceAt: now - 60_000,
+      lastErrorAt: now,
+      lastSuccessAt: now - 120_000,
+    })));
+  }
+
   it('shows the outage warning even when there is no database to render', () => {
-    writeFileSync(join(dataDir, 'observer-health.json'), JSON.stringify(unhealthyState()));
+    writeFreshUnhealthyState();
     const { emptyDbText } = runContextChild(dataDir);
     expect(emptyDbText).toContain("can't save memories");
     expect(emptyDbText).toContain('openrouter');
   });
 
   it('puts the warning BELOW the context, where a long timeline cannot scroll it away', () => {
-    writeFileSync(join(dataDir, 'observer-health.json'), JSON.stringify(unhealthyState()));
+    writeFreshUnhealthyState();
     const { agentText, humanText } = runContextChild(dataDir);
     for (const text of [agentText, humanText]) {
       expect(text).toContain('TIMELINE_BODY');
@@ -370,8 +399,14 @@ describe('ContextBuilder observer-health injection', () => {
     }
   });
 
+  it('does not feed the health warning into a recycled observer context', () => {
+    writeFreshUnhealthyState();
+    const { observerText } = runContextChild(dataDir);
+    expect(observerText).not.toContain("can't save memories");
+  });
+
   it('paints the warning red for the terminal and leaves the agent copy clean', () => {
-    writeFileSync(join(dataDir, 'observer-health.json'), JSON.stringify(unhealthyState()));
+    writeFreshUnhealthyState();
     const { agentText, humanText } = runContextChild(dataDir);
 
     expect(humanText).toContain(RED);
@@ -388,7 +423,7 @@ describe('ContextBuilder observer-health injection', () => {
   });
 
   it('leaves the context body itself unpainted', () => {
-    writeFileSync(join(dataDir, 'observer-health.json'), JSON.stringify(unhealthyState()));
+    writeFreshUnhealthyState();
     const { humanText } = runContextChild(dataDir);
     expect(humanText.slice(0, humanText.indexOf(RED))).toContain('TIMELINE_BODY');
     expect(humanText.slice(0, humanText.indexOf(RED))).not.toContain('\x1b[');


### PR DESCRIPTION
## Summary

Expire observer health warnings after six hours without a refreshed failure and keep the user-facing banner out of recycled observer context. This prevents transient quota outages from persisting across sessions or contaminating observer input.

Fixes #3902