### PR TITLE
fix(observer): preserve persisted memory session id across fresh spawns

### DIFF
--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -218,11 +218,9 @@ export class ClaudeProvider {
       this.compressField(text, budgetChars, session, modelId, claudePath);
     const messageGenerator = this.createMessageGenerator(session, cwdTracker, activeResponseContext, worker, compressField);
 
+    // Fresh observer spawns must not persist NULL: the FK cascade would violate
+    // child rows' NOT NULL memory_session_id. Clear only the in-memory ID.
     if (session.memorySessionId) {
-      // Observer spawns intentionally opt out of Claude transcript persistence.
-      // A carried session_id from an earlier no-persist spawn is therefore not
-      // safe to feed back into `resume` on a later fresh process.
-      this.dbManager.getSessionStore().updateMemorySessionId(session.sessionDbId, null);
       session.memorySessionId = null;
     }
 

--- a/tests/fk-constraint-fix.test.ts
+++ b/tests/fk-constraint-fix.test.ts
@@ -1,6 +1,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { SessionStore } from '../src/services/sqlite/SessionStore.js';
+import { ClaudeProvider } from '../src/services/worker/ClaudeProvider.js';
 
 describe('FK Constraint Fix (Issue #846)', () => {
   let store: SessionStore;
@@ -105,5 +106,59 @@ describe('FK Constraint Fix (Issue #846)', () => {
     );
 
     expect(result.id).toBeGreaterThan(0);
+  });
+
+  it('preserves the persisted memory session id when starting a fresh observer session', async () => {
+    const sessionDbId = store.createSDKSession('provider-reset-id', 'test-project', 'test prompt');
+    const memorySessionId = 'carried-memory-id';
+
+    store.ensureMemorySessionIdRegistered(sessionDbId, memorySessionId);
+    store.storeObservation(
+      memorySessionId,
+      'test-project',
+      {
+        type: 'discovery',
+        title: 'Existing child row',
+        subtitle: null,
+        facts: [],
+        narrative: null,
+        concepts: [],
+        files_read: [],
+        files_modified: []
+      }
+    );
+
+    const updateCalls: Array<{ id: number; value: string | null }> = [];
+    store.updateMemorySessionId = (id, value) => {
+      updateCalls.push({ id, value });
+    };
+
+    const provider = new ClaudeProvider({ getSessionStore: () => store } as any, {} as any);
+    const abortController = new AbortController();
+    abortController.abort();
+    const session = {
+      sessionDbId,
+      contentSessionId: 'content-session',
+      memorySessionId,
+      project: 'test-project',
+      userPrompt: 'test prompt',
+      modelOverride: 'test-model',
+      abortController,
+      lastPromptNumber: 1,
+      conversationHistory: [],
+      pendingAgentId: null,
+      pendingAgentType: null,
+      forceInit: false,
+      startTime: Date.now(),
+      cumulativeInputTokens: 0,
+      cumulativeOutputTokens: 0,
+      lastResultTotalCostUsd: null,
+    } as any;
+
+    await expect(provider.startSession(session)).rejects.toThrow();
+
+    expect(updateCalls).toEqual([]);
+    expect(session.memorySessionId).toBeNull();
+    expect(store.getSessionById(sessionDbId)?.memory_session_id).toBe(memorySessionId);
   });
 });


### PR DESCRIPTION
## Summary

Fresh observer spawns no longer persist `NULL` over an existing memory session ID. The startup path clears only the in-memory ID, preserving child-row foreign keys during recycle and restart handling.

Fixes #3840