### PR TITLE
fix(quota): ignore inactive overage utilization

### DIFF
--- a/src/services/worker/RateLimitStore.ts
+++ b/src/services/worker/RateLimitStore.ts
@@ -150,6 +150,8 @@ export function shouldAbortForQuota(
 
     const util = entry.utilization;
     const threshold = UTILIZATION_THRESHOLDS[window];
+    const appliesUtilizationThreshold =
+      window !== 'overage' || entry.isUsingOverage !== false;
 
     // Provider-side rejection trumps utilization heuristics. A snapshot with
     // status='rejected' (or overageStatus='rejected' on the overage window)
@@ -167,7 +169,7 @@ export function shouldAbortForQuota(
       };
     }
 
-    if (typeof util === 'number' && util >= threshold) {
+    if (appliesUtilizationThreshold && typeof util === 'number' && util >= threshold) {
       return {
         abort: true,
         window,

--- a/tests/worker/rate-limit-store.test.ts
+++ b/tests/worker/rate-limit-store.test.ts
@@ -119,6 +119,17 @@ describe('shouldAbortForQuota — cli/oauth auth', () => {
     store = freshStore();
   });
 
+  it('does not abort on inactive overage at 100% utilization', () => {
+    store.set({
+      rateLimitType: 'overage',
+      utilization: 1,
+      isUsingOverage: false,
+      status: 'allowed_warning',
+    });
+    const decision = shouldAbortForQuota(cliAuth, store, FIXED_NOW);
+    expect(decision.abort).toBe(false);
+  });
+
   it('aborts on five_hour at 0.96 with reason mentioning "five_hour"', () => {
     store.set({ rateLimitType: 'five_hour', utilization: 0.96 });
     const decision = shouldAbortForQuota(cliAuth, store, FIXED_NOW);


### PR DESCRIPTION
An inactive overage snapshot with `isUsingOverage: false` could still trigger the utilization threshold and abort allowed work. Skip that heuristic for explicitly inactive overage while preserving provider rejection handling and existing behavior for active or unspecified overage.

Fixes #3903