### PR TITLE
fix(installer): clarify non-interactive provider requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ npx claude-mem install
 
 The installer sets everything up first, then asks you to sign in to claude-mem in your browser (email magic link — no card required). Signing in provisions a memory key for your account and unlocks the **claude-mem observer**: memory that runs off-plan, free for your first 30 days, so you get up to 100% more usage from your plan. When the free trial ends, memory automatically falls back to your Anthropic plan unless you subscribe. After sign-in you pick your memory provider — the claude-mem observer, your own OpenRouter or Gemini key, or your Anthropic plan.
 
-Prefer to skip the sign-in? Pass an explicit `--provider` flag, set `CLAUDE_MEM_ONLINE_OPTIN=false`, or run in CI/non-interactive shells — the installer completes without any account interaction.
+Prefer to skip the sign-in? Pass an explicit `--provider` flag. For Claude Code and other IDEs in CI or any non-interactive shell, pass `--provider` so the installer can complete without account interaction; Grok Bot is the exception and defaults to CMEM Pro.
 
 Or install for OpenCode:
 

--- a/src/npx-cli/index.ts
+++ b/src/npx-cli/index.ts
@@ -75,7 +75,7 @@ function parseInstallOptions(argv: string[]): InstallOptions {
       'no-auto-start': { type: 'boolean' },
       'disable-auto-memory': { type: 'boolean' },
     },
-    strict: false,
+    strict: true,
     allowPositionals: true,
   });
   const flag = (name: string): string | undefined =>

--- a/src/npx-cli/install/error-taxonomy.ts
+++ b/src/npx-cli/install/error-taxonomy.ts
@@ -155,6 +155,22 @@ export const ERROR_CATEGORIES: ErrorCategory[] = [
       'An install command did not finish in time. Check network connectivity. On a slow host, raise the budget with CLAUDE_MEM_INSTALL_TIMEOUT_MS and re-run.',
   },
   {
+    id: 'non-interactive-provider-required',
+    severity: ErrorSeverity.ABORT,
+    match: (_cause, ctx) =>
+      ctx.component === 'provider-selection' && ctx.phase === 'non-interactive-validation',
+    remediation: () =>
+      'Pass an explicit provider with `--provider claude|gemini|openrouter|host`, or run the installer in an interactive terminal.',
+  },
+  {
+    id: 'non-interactive-provider-credentials-required',
+    severity: ErrorSeverity.ABORT,
+    match: (_cause, ctx) =>
+      ctx.component === 'provider-credentials' && ctx.phase === 'non-interactive-validation',
+    remediation: () =>
+      'Configure the selected provider credentials before running the installer non-interactively, or run it in an interactive terminal.',
+  },
+  {
     id: 'unknown-install-error',
     severity: ErrorSeverity.ABORT,
     match: () => true,

--- a/tests/install-error-matrix.test.ts
+++ b/tests/install-error-matrix.test.ts
@@ -72,6 +72,24 @@ describe('error taxonomy', () => {
     expect(cat.severity).toBe(ErrorSeverity.ABORT);
   });
 
+  it('classifies missing non-interactive providers separately from unknown errors', () => {
+    const cat = classifyError(new Error('A provider must be explicit when stdin is not interactive.'), {
+      component: 'provider-selection',
+      phase: 'non-interactive-validation',
+    });
+    expect(cat.id).toBe('non-interactive-provider-required');
+    expect(cat.severity).toBe(ErrorSeverity.ABORT);
+  });
+
+  it('classifies missing non-interactive provider credentials separately', () => {
+    const cat = classifyError(new Error('gemini requires a preconfigured personal API key when stdin is not interactive.'), {
+      component: 'provider-credentials',
+      phase: 'non-interactive-validation',
+    });
+    expect(cat.id).toBe('non-interactive-provider-credentials-required');
+    expect(cat.severity).toBe(ErrorSeverity.ABORT);
+  });
+
   it('defaults unknown errors to ABORT (fail-loud)', () => {
     const cat = classifyError(new Error('something we have never seen'), {
       component: 'mystery',
@@ -128,6 +146,18 @@ describe('installerError decision logic', () => {
     expect(record.categoryId).toBe('tree-sitter-eresolve');
     expect(record.severity).toBe('ABORT');
     expect(record.details).toContain('While resolving');
+  });
+
+  it('persists the dedicated category for a missing non-interactive provider', () => {
+    const summary = createInstallSummary();
+    expect(() => installerError(ErrorSeverity.ABORT, {
+      component: 'provider-selection',
+      phase: 'non-interactive-validation',
+      cause: new Error('A provider must be explicit when stdin is not interactive.'),
+    }, summary)).toThrow(InstallAbortError);
+
+    const record = JSON.parse(readFileSync(join(home, 'last-install-error.json'), 'utf-8'));
+    expect(record.categoryId).toBe('non-interactive-provider-required');
   });
 
   it('WARN_CONTINUE appends to summary and does not throw', () => {
@@ -250,7 +280,7 @@ function simulateInstall(_ide: string, scenario: Scenario): Outcome {
   return { status, aborted: false };
 }
 
-describe('cross-IDE failure matrix (11 IDEs x 4 scenarios)', () => {
+describe('cross-IDE failure matrix (12 IDEs x 4 scenarios)', () => {
   const scenarios: Scenario[] = ['happy', 'eresolve', 'missing-uv', 'missing-bun'];
 
   let prevMatrixDataDir: string | undefined;

--- a/tests/install-non-tty.test.ts
+++ b/tests/install-non-tty.test.ts
@@ -11,6 +11,7 @@ const installSourcePath = join(
   'install.ts',
 );
 const installSource = readFileSync(installSourcePath, 'utf-8');
+const readmeSource = readFileSync(join(__dirname, '..', 'README.md'), 'utf-8');
 const codexInstallerSourcePath = join(
   __dirname,
   '..',
@@ -100,6 +101,16 @@ describe('Install Non-TTY Support', () => {
       expect(validationIndex).toBeGreaterThan(-1);
       expect(validationIndex).toBeLessThan(oauthIndex);
       expect(installSource).toContain('A provider must be explicit when stdin is not interactive.');
+    });
+
+    it('rejects unknown install flags instead of silently swallowing them', () => {
+      expect(readFileSync(join(__dirname, '..', 'src', 'npx-cli', 'index.ts'), 'utf-8'))
+        .toContain('strict: true');
+    });
+
+    it('documents the explicit provider requirement and Grok Bot exception', () => {
+      expect(readmeSource).toContain('For Claude Code and other IDEs in CI or any non-interactive shell, pass `--provider`');
+      expect(readmeSource).toContain('Grok Bot is the exception and defaults to CMEM Pro.');
     });
 
     it('never opens an API-key prompt on non-interactive stdin', () => {


### PR DESCRIPTION
## Summary

Non-interactive installs without an explicit provider were documented incorrectly and reported as unknown installer errors. This updates the README, classifies missing providers and credentials separately, and rejects unknown install flags while preserving Grok Bot's CMEM Pro default.

Closes #3893