### PR TITLE
feat(ccs-align): Phase 0 breathing slice — worker health + three-layer pull + atomic middle cache

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "claude-mem",
-      "version": "13.24.1",
+      "version": "13.24.2",
       "source": "./plugin",
       "description": "Persistent memory system for Claude Code - context compression across sessions"
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.24.1",
+  "version": "13.24.2",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "author": {
     "name": "Alex Newman"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.24.1",
+  "version": "13.24.2",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "author": {
     "name": "Alex Newman",

--- a/claude-mem-cursor/.cursor-plugin/plugin.json
+++ b/claude-mem-cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem-cursor",
-  "version": "13.24.1",
+  "version": "13.24.2",
   "description": "Persistent memory for Cursor. Hooks ingest tool use; MCP searches past sessions. Works with a local worker or a remote cmem.ai worker, and a local host-login observer or remote inference.",
   "author": {
     "name": "Alex Newman"

--- a/claude-mem-grok-bot/.cursor-plugin/plugin.json
+++ b/claude-mem-grok-bot/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem-grok-bot",
-  "version": "13.24.1",
+  "version": "13.24.2",
   "description": "Persistent memory for Grok Bot. No host hooks: transcript watcher plus MCP. Local worker with host-login observer, or remote cmem.ai. Install without Cursor.",
   "author": {
     "name": "Alex Newman"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.24.1",
+  "version": "13.24.2",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "keywords": [
     "claude",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.24.1",
+  "version": "13.24.2",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "author": {
     "name": "Alex Newman"

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.24.1",
+  "version": "13.24.2",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "author": {
     "name": "Alex Newman",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem-plugin",
-  "version": "13.24.1",
+  "version": "13.24.2",
   "private": true,
   "description": "Runtime dependencies for claude-mem bundled hooks",
   "type": "module",

--- a/plugin/skills/ccs-align/SKILL.md
+++ b/plugin/skills/ccs-align/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: ccs-align
+description: Run the CCS Align seat's hourly breathing cycle — prove the local claude-mem worker is healthy, pull needle observations through search → timeline → get_observations, and land them in a seat-owned middle cache via an atomic grab → append → replace. Use when asked to run CCS Align, breathe the alignment seat, refresh the middle cache, or check the Worker Watch board.
+---
+
+# CCS Align — Worker Watch seat (Phase 0: breathing slice)
+
+CCS Align is a **standing seat**, not a bird's-eye planner. Its one job, once an hour: talk to the **local** claude-mem worker, pull recent needle observations through the existing three-layer disclosure ladder, and land them in a **seat-owned middle cache** using grab → append → replace.
+
+This skill is the Phase 0 breathing slice of the plan of record, `plans/2026-09-09-ccs-align.md`. It is **not** a context compiler, **not** Focus/mouth, and **not** Grok Memory Phase 2. When you speak to the human, address them as **Alex**.
+
+## What Phase 0 is (and is not)
+
+Phase 0 proves the boundary, not a product:
+
+- **Does:** health check → `search` → `timeline` → `get_observations` → append records to `~/.claude-mem/ccs-align/<viewerId>/middle.jsonl` (atomic, deduped).
+- **Does not:** delete history, write `profile.md`, write LFG/Orifice `[awareness]` logs (that seam belongs to [#3931](https://github.com/thedotmack/claude-mem/pull/3931)), add a sixth `processAgentResponse` consumer, restart the worker, or run a per-turn drip update.
+
+Later phases (exclude marks, rules alignment) are documented in the plan of record and are **not** implemented here.
+
+## Prerequisites
+
+The claude-mem worker must be running locally. This seat talks to the **local worker** (per-UID port ~`37700`), never the cloud CMEM MCP — cloud `observation:<base64>` ids are a different API and must not be mixed in.
+
+**Resolve the worker port** once and reuse `$WORKER_PORT` in every curl below. This snippet is copied from the `timeline-report` skill and honors `CLAUDE_MEM_WORKER_PORT` → `~/.claude-mem/settings.json` → the per-UID default `37700 + (uid % 100)`:
+
+```bash
+WORKER_PORT="${CLAUDE_MEM_WORKER_PORT:-$(node -e "const fs=require('fs'),p=require('path'),os=require('os');const uid=(typeof process.getuid==='function'?process.getuid():77);const fallback=String(37700+(uid%100));try{const s=JSON.parse(fs.readFileSync(p.join(os.homedir(),'.claude-mem','settings.json'),'utf-8'));process.stdout.write(String(s.CLAUDE_MEM_WORKER_PORT||fallback));}catch{process.stdout.write(fallback);}" 2>/dev/null)}"
+```
+
+Do **not** hardcode port `37777` — ports are per-UID.
+
+## Settings
+
+Defaults live in `SettingsDefaultsManager.ts`; override in `~/.claude-mem/settings.json`:
+
+| Key | Default | Meaning |
+|---|---|---|
+| `CLAUDE_MEM_CCS_ALIGN_ENABLED` | `true` | Master switch for the seat. |
+| `CLAUDE_MEM_CCS_ALIGN_VIEWER_IDS` | `ccs-align` | Comma-separated viewer ids the seat maintains a cache for. |
+| `CLAUDE_MEM_CCS_ALIGN_TRIGGER_TYPES` | `decision,bugfix,security_alert,sensitive` | Needle observation types to pull (copied from #3931's list, D6). |
+| `CLAUDE_MEM_CCS_ALIGN_PATCH_SHADOWS` | `false` | Phase 2 rules-shadow patch gate. **Off** in Phase 0; documented only. |
+
+Pilot viewer id is `ccs-align`. The seat **may read** LFG observations (agent id `521e962d-2ec3-4488-bfbc-54d5209ce118`) as a project filter, but **must not write** LFG/Orifice monthly logs or any `profile.md`.
+
+## Hourly cycle (Appendix A runbook)
+
+Run this every hour on a weekday house board. One purpose. No watercooler. No "while I was here I also…".
+
+```
+every hour (weekday house board):
+  1. Resolve WORKER_PORT (snippet above)
+  2. GET /api/health || GET /health   → abort with a one-line miss if down
+  3. search(obs_type=needles, limit=20) since cursor.lastObservationId
+  4. timeline(anchor=newest)          → collect neighbor ids
+  5. get_observations(ids=…)
+  6. grab middle.jsonl → append new → filter exclude-marks → replace atomic
+  7. if original-cache path set and not writable: append-only to middle.jsonl (already done)
+  8. update cursor.json
+  9. every 6th hour: rules walk → append rules-report.md   (Phase 2 — not in this slice)
+ 10. Speak to Alex only on red (worker down, write refused, unexpected profile.md touch)
+```
+
+### Step 1 — Resolve the port
+
+Use the `$WORKER_PORT` snippet above.
+
+### Step 2 — Prove worker health (prefer `/api/health`)
+
+Prefer `GET /api/health`; also accept the viewer alias `GET /health`. The public worker docs still show `GET /health` and a `port` field — both are stale. Health does **not** return a port; use `GET /api/stats` (`worker.port`) if you need it.
+
+```bash
+curl -sS "http://127.0.0.1:${WORKER_PORT}/api/health" || curl -sS "http://127.0.0.1:${WORKER_PORT}/health"
+# expect a JSON body with "status":"ok". If the worker is down, abort with a
+# one-line miss — do NOT start it, do NOT retry aggressively.
+```
+
+If health cannot be proven (e.g. no live worker in a cloud VM), record a **MISS** and stop. Do not fabricate a cache cycle.
+
+### Step 3 — Pull through the three-layer ladder (in order)
+
+The disclosure order is **`search` → `timeline` → `get_observations`**. Never jump straight to `get_observations`, and do **not** call `get_tool_uses` in Phase 0 (that is Phase 1).
+
+1. **`search`** with the needle `obs_type` list (`CLAUDE_MEM_CCS_ALIGN_TRIGGER_TYPES`), `limit` ≤ 20, optionally scoped by `project`. Use the cursor's `lastObservationId` to avoid re-pulling the whole diary.
+
+   ```bash
+   curl -sS "http://127.0.0.1:${WORKER_PORT}/api/search?query=*&type=decision&limit=20&format=json"
+   ```
+
+2. **`timeline`** anchored on the newest hit. The worker's **code default depth is 10** (`SearchManager.ts`) — the MCP text that says "3" is stale, so omit the depths (worker applies 10) or pass `10` explicitly.
+
+   ```bash
+   curl -sS "http://127.0.0.1:${WORKER_PORT}/api/timeline?anchor=<newestObservationId>"
+   ```
+
+3. **`get_observations`** for the ids you will actually cache.
+
+   ```bash
+   curl -sS -X POST "http://127.0.0.1:${WORKER_PORT}/api/observations/batch" \
+     -H 'content-type: application/json' \
+     -d '{"ids":[12345,12346]}'
+   ```
+
+The MCP twins are `search` → `timeline` → `get_observations`. Worker `get_observations` ids are **numbers**; do not pass cloud `observation:<base64>` ids into `/api/observations/batch`.
+
+### Step 4 — Grab → append → replace (atomic middle cache)
+
+Land the observations with the seat helper `src/services/integrations/CcsAlignMiddleCache.ts`
+(`landObservationsInMiddleCache`). It copies the #3931 atomic primitive
+(`appendAwarenessLineAtomic` + `awarenessLineBody`) with exactly three changes:
+the tag is `[ccs-align]`, the path root is `~/.claude-mem/ccs-align/<viewerId>/`,
+and the file is `middle.jsonl`.
+
+```
+grab:    read middle.jsonl if it exists, else empty
+append:  for each new observation id not already present, append one record
+replace: write temp + rename (copy appendAwarenessLineAtomic; never appendFileSync)
+fallback: if an OPTIONAL original-cache path is set and not writable, skip grab/replace
+          on that path and append timeline items to middle.jsonl only
+```
+
+There is **no compiled laminate file in-repo**, so the fallback resolves to
+"append to the seat file" — never invent a laminate.
+
+Each line of `middle.jsonl` is one record. The shape is **locked** for Phase 0 (do not add fields):
+
+```json
+{
+  "v": 1,
+  "id": 12345,
+  "type": "decision",
+  "title": "…",
+  "created_at": "2026-09-09T00:00:00.000Z",
+  "project": "claude-mem",
+  "agent_id": null,
+  "source": "worker",
+  "line": "- 2026-09-09 [ccs-align] decision — …"
+}
+```
+
+`line` is `formatCcsAlignLine` — the #3931 `formatAwarenessLine` with the tag
+swapped and the same 500-char truncation. Dedupe is by observation `id` **and**
+by body (the line from `[ccs-align]` onward, date excluded), so the same fact on
+a new day is still skipped and the file does not grow on a repeat cycle.
+
+A minimal invocation (bun/node):
+
+```ts
+import { landObservationsInMiddleCache } from '../../src/services/integrations/CcsAlignMiddleCache.js';
+
+landObservationsInMiddleCache({
+  viewerId: 'ccs-align',
+  observations: rowsFromGetObservations, // [{ id, type, title, subtitle, facts, created_at, project, agent_id }]
+});
+```
+
+It **never throws** into the caller — a broken write path is logged and swallowed.
+
+### Step 5 — Update the cursor
+
+Write `~/.claude-mem/ccs-align/<viewerId>/cursor.json` so the next hour does not re-pull the whole diary:
+
+```json
+{ "lastRunAt": "…", "lastObservationId": 12345, "healthPath": "/api/health", "workerPort": 37700 }
+```
+
+Use `writeCursor` from the helper (atomic temp + rename).
+
+### Step 6 — Speak only on red
+
+Roll status **up** to the Prioritizer. Only speak to Alex on red: worker down, a write was refused, or an unexpected `profile.md` touch. Otherwise stay quiet.
+
+## Hard forbids (every phase)
+
+- ❌ `DELETE /api/observation/:id` — tombstone ≠ exclude mark; breaks rebuild-from-history.
+- ❌ Writing LFG/Orifice `[awareness]` logs, or into any `agents/**/memory/log/` path.
+- ❌ Writing `profile.md`, user-memory, or project memory.
+- ❌ A top-of-prompt clock (timestamps belong on facts, not a cache header).
+- ❌ `POST /api/context/semantic` (per-turn drip the awareness design forbids).
+- ❌ A sixth `processAgentResponse` consumer — CCS Align **pulls**; #3931 owns that seam.
+- ❌ Restarting the worker, or `POST /api/settings`.
+- ❌ Addressing the human as "Az". Always **Alex**.
+- ❌ Claiming a context compiler / brainbeat shipped. Those are future work.
+
+## Later phases (documented, not implemented here)
+
+- **Phase 1 — Exclude marks:** compile-time omit of observations + linked tool-use ids from the middle cache; history stays; no `DELETE`. Marks file `exclude-marks.json`.
+- **Phase 2 — Rules alignment:** house → project → seat conflict/drift **report** (`rules-report.md`). Report-only unless `CLAUDE_MEM_CCS_ALIGN_PATCH_SHADOWS=true`.
+- **Phase 3 — Verify:** two-cycle dedupe, rebuild-from-diary, #3931 tests still green.
+
+See `plans/2026-09-09-ccs-align.md` for the full contract.
+
+## Verification (Phase 0)
+
+```bash
+bun test tests/integrations/ccs-align-middle-cache.test.ts
+# format/truncate, needle match, append, dedupe, path safety, never-throw, cursor round-trip
+
+# #3931 must not regress — LFG/Orifice still get [awareness] lines from the worker pusher, not Align
+bun test tests/integrations/grok-bot-awareness-pusher.test.ts
+```
+
+Live-box checks (house, not CI — a cloud VM may have no live worker; record a MISS if so):
+
+- `curl -sS "http://127.0.0.1:$WORKER_PORT/api/health"` returns `status: ok`
+- After one cycle, `~/.claude-mem/ccs-align/ccs-align/middle.jsonl` exists
+- A second cycle with the same observations does **not** grow the file (dedupe)
+- `profile.md` under any `agents/` path is byte-identical to before
+- LFG/Orifice `memory/log/YYYY-MM.md` unchanged by Align

--- a/src/services/integrations/CcsAlignMiddleCache.ts
+++ b/src/services/integrations/CcsAlignMiddleCache.ts
@@ -1,0 +1,369 @@
+import { accessSync, constants, existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'fs';
+import path from 'path';
+import { homedir } from 'os';
+import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js';
+import { USER_SETTINGS_PATH, DATA_DIR } from '../../shared/paths.js';
+import { logger } from '../../utils/logger.js';
+
+// CCS Align — Phase 0 breathing slice.
+//
+// This is a deliberate copy of the #3931 atomic append primitive
+// (`appendAwarenessLineAtomic` / `awarenessLineBody` / `formatAwarenessLine`
+// in `GrokBotAwarenessPusher.ts`) with three — and only three — changes locked
+// by the plan of record (`plans/2026-09-09-ccs-align.md`, D1/D2/§0.1):
+//   1. Tag is `[ccs-align]`, NOT a second `[awareness]` writer.
+//   2. Path root is seat-owned `~/.claude-mem/ccs-align/<viewerId>/`, never
+//      `agents/<id>/memory/log/`.
+//   3. File is `middle.jsonl` (one JSON record per line).
+//
+// It does NOT delete history, does NOT write `profile.md`, and does NOT add a
+// sixth `processAgentResponse` consumer. It is a seat-owned middle cache the
+// hourly CCS Align seat lands observations into via grab -> append -> replace.
+
+const MAX_LINE_CHARS = 500;
+const CCS_ALIGN_TAG = '[ccs-align]';
+const CCS_ALIGN_DIRNAME = 'ccs-align';
+const MIDDLE_CACHE_FILENAME = 'middle.jsonl';
+const CURSOR_FILENAME = 'cursor.json';
+const RECORD_VERSION = 1;
+
+/**
+ * The subset of an observation the middle cache lands. `id`/`created_at`/
+ * `project`/`agent_id` come from the worker's full observation row
+ * (`get_observations` / `POST /api/observations/batch`); the text fields mirror
+ * `ParsedObservation`.
+ */
+export interface CcsAlignObservationInput {
+  id: number;
+  type: string;
+  title?: string | null;
+  subtitle?: string | null;
+  facts?: string[];
+  created_at?: string | null;
+  project?: string | null;
+  agent_id?: string | null;
+  source?: string;
+}
+
+/** One line of `middle.jsonl`. Shape is LOCKED for Phase 0 — do not add fields. */
+export interface CcsAlignMiddleRecord {
+  v: number;
+  id: number;
+  type: string;
+  title: string | null;
+  created_at: string | null;
+  project: string | null;
+  agent_id: string | null;
+  source: string;
+  line: string;
+}
+
+/** Contents of `cursor.json`. Prevents re-pulling the whole diary every hour. */
+export interface CcsAlignCursor {
+  lastRunAt: string;
+  lastObservationId: number | null;
+  healthPath: string;
+  workerPort: number | null;
+}
+
+export interface CcsAlignConfig {
+  enabled: boolean;
+  viewerIds: string[];
+  triggerTypes: string[];
+  triggerConcepts: string[];
+  dataRoot: string;
+}
+
+function splitCsv(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map(entry => entry.trim())
+    .filter(entry => entry.length > 0);
+}
+
+export function loadCcsAlignConfig(
+  settingsPath: string = USER_SETTINGS_PATH,
+  env: NodeJS.ProcessEnv = process.env,
+): CcsAlignConfig {
+  const settings = SettingsDefaultsManager.loadFromFile(settingsPath);
+  const dataRoot = env.CLAUDE_MEM_DATA_DIR
+    ? env.CLAUDE_MEM_DATA_DIR
+    : (settings.CLAUDE_MEM_DATA_DIR || path.join(homedir(), '.claude-mem'));
+  return {
+    enabled: settings.CLAUDE_MEM_CCS_ALIGN_ENABLED === 'true',
+    viewerIds: splitCsv(settings.CLAUDE_MEM_CCS_ALIGN_VIEWER_IDS),
+    triggerTypes: splitCsv(settings.CLAUDE_MEM_CCS_ALIGN_TRIGGER_TYPES),
+    triggerConcepts: [],
+    dataRoot,
+  };
+}
+
+/**
+ * Needle match — copied from `observationMatchesAwarenessNeedle` (#3931). An
+ * empty filter set never matches (fail closed).
+ */
+export function observationMatchesCcsAlignNeedle(
+  obs: { type: string; concepts?: string[] },
+  triggerTypes: string[],
+  triggerConcepts: string[] = [],
+): boolean {
+  if (triggerTypes.length === 0 && triggerConcepts.length === 0) {
+    return false;
+  }
+  const matchesType = triggerTypes.includes(obs.type);
+  const matchesConcept = (obs.concepts ?? []).some(concept => triggerConcepts.includes(concept));
+  return matchesType || matchesConcept;
+}
+
+function collapseWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * `- YYYY-MM-DD [ccs-align] <type> — <title>: <subtitle>. <fact>`, truncated to
+ * 500 chars. Copied verbatim from `formatAwarenessLine` (#3931) with the tag
+ * swapped.
+ */
+export function formatCcsAlignLine(obs: CcsAlignObservationInput, now: Date = new Date()): string {
+  const date = now.toISOString().slice(0, 10);
+  const title = collapseWhitespace(obs.title ?? '');
+  const subtitle = collapseWhitespace(obs.subtitle ?? '');
+  const fact = collapseWhitespace((obs.facts ?? [])[0] ?? '');
+  const headline = [title, subtitle].filter(Boolean).join(': ');
+  const detail = [headline, fact].filter(Boolean).join('. ');
+  const body = collapseWhitespace(`${obs.type}${detail ? ` — ${detail}` : ''}`);
+  const line = `- ${date} ${CCS_ALIGN_TAG} ${body}`.trimEnd();
+  if (line.length <= MAX_LINE_CHARS) return line;
+  return `${line.slice(0, MAX_LINE_CHARS - 1)}…`;
+}
+
+/**
+ * Dedupe key: the line from `[ccs-align]` onward (date excluded), so the same
+ * fact on a new day is still skipped. Scope is one file. Copied from
+ * `awarenessLineBody` (#3931).
+ */
+export function ccsAlignLineBody(line: string): string {
+  const idx = line.indexOf(CCS_ALIGN_TAG);
+  return idx >= 0 ? line.slice(idx).trim() : line.trim();
+}
+
+export function ccsAlignViewerDir(dataRoot: string, viewerId: string): string {
+  return path.join(dataRoot, CCS_ALIGN_DIRNAME, viewerId);
+}
+
+export function ccsAlignMiddleCachePath(dataRoot: string, viewerId: string): string {
+  return path.join(ccsAlignViewerDir(dataRoot, viewerId), MIDDLE_CACHE_FILENAME);
+}
+
+export function ccsAlignCursorPath(dataRoot: string, viewerId: string): string {
+  return path.join(ccsAlignViewerDir(dataRoot, viewerId), CURSOR_FILENAME);
+}
+
+/**
+ * Refuse any write that escapes the seat-owned CCS Align root, targets
+ * `profile.md`, or lands inside an `agents/.../memory/log` tree (that is the
+ * #3931 pusher's seam, never Align's). Shape copied from
+ * `assertSafeAwarenessLogPath` (#3931).
+ */
+export function assertSafeMiddleCachePath(dataRoot: string, viewerId: string, filePath: string): void {
+  const expectedRoot = path.resolve(ccsAlignViewerDir(dataRoot, viewerId));
+  const resolved = path.resolve(filePath);
+  if (!resolved.startsWith(expectedRoot + path.sep) && resolved !== expectedRoot) {
+    throw new Error('Refusing CCS Align write outside the seat-owned ccs-align root');
+  }
+  if (path.basename(resolved) === 'profile.md') {
+    throw new Error('Refusing CCS Align write to profile.md');
+  }
+  if (/(^|[\\/])agents[\\/].*[\\/]memory[\\/]log([\\/]|$)/.test(resolved)) {
+    throw new Error('Refusing CCS Align write into agents/**/memory/log (that seam belongs to #3931)');
+  }
+}
+
+export function buildCcsAlignRecord(obs: CcsAlignObservationInput, now: Date = new Date()): CcsAlignMiddleRecord {
+  return {
+    v: RECORD_VERSION,
+    id: obs.id,
+    type: obs.type,
+    title: obs.title ?? null,
+    created_at: obs.created_at ?? null,
+    project: obs.project ?? null,
+    agent_id: obs.agent_id ?? null,
+    source: obs.source ?? 'worker',
+    line: formatCcsAlignLine(obs, now),
+  };
+}
+
+function parseRecordLine(rawLine: string): CcsAlignMiddleRecord | null {
+  const trimmed = rawLine.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed) as CcsAlignMiddleRecord;
+    if (parsed && typeof parsed === 'object' && typeof parsed.line === 'string') {
+      return parsed;
+    }
+  } catch {
+    // Not a valid record line — ignore for dedupe purposes.
+  }
+  return null;
+}
+
+/** Read and parse the existing middle cache (empty array if it does not exist). */
+export function readMiddleCache(cachePath: string): CcsAlignMiddleRecord[] {
+  if (!existsSync(cachePath)) return [];
+  const raw = readFileSync(cachePath, 'utf8');
+  const records: CcsAlignMiddleRecord[] = [];
+  for (const rawLine of raw.split('\n')) {
+    const record = parseRecordLine(rawLine);
+    if (record) records.push(record);
+  }
+  return records;
+}
+
+/**
+ * Grab -> append -> replace, atomically.
+ *
+ * grab:    read `middle.jsonl` if it exists, else empty.
+ * append:  keep only records whose observation id AND body are not already
+ *          present (body key excludes the date, matching #3931).
+ * replace: write a temp file + `renameSync` (never `appendFileSync`).
+ *
+ * Returns the records actually appended. A no-op returns `[]` and does not
+ * rewrite the file.
+ */
+export function appendMiddleCacheRecordsAtomic(
+  cachePath: string,
+  records: CcsAlignMiddleRecord[],
+): CcsAlignMiddleRecord[] {
+  const dir = path.dirname(cachePath);
+  mkdirSync(dir, { recursive: true });
+
+  const existing = existsSync(cachePath) ? readFileSync(cachePath, 'utf8') : '';
+  const seenIds = new Set<number>();
+  const seenBodies = new Set<string>();
+  for (const rawLine of existing.split('\n')) {
+    const record = parseRecordLine(rawLine);
+    if (!record) continue;
+    seenIds.add(record.id);
+    seenBodies.add(ccsAlignLineBody(record.line));
+  }
+
+  const toAppend: CcsAlignMiddleRecord[] = [];
+  for (const record of records) {
+    const body = ccsAlignLineBody(record.line);
+    if (seenIds.has(record.id) || seenBodies.has(body)) continue;
+    seenIds.add(record.id);
+    seenBodies.add(body);
+    toAppend.push(record);
+  }
+
+  if (toAppend.length === 0) {
+    return [];
+  }
+
+  const appended = toAppend.map(record => JSON.stringify(record)).join('\n');
+  const prefix = existing.length === 0 || existing.endsWith('\n') ? existing : `${existing}\n`;
+  const next = `${prefix}${appended}\n`;
+  const tmpPath = `${cachePath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    writeFileSync(tmpPath, next, 'utf8');
+    renameSync(tmpPath, cachePath);
+  } catch (error) {
+    try { unlinkSync(tmpPath); } catch { /* ignore cleanup */ }
+    throw error;
+  }
+  return toAppend;
+}
+
+export function readCursor(cursorPath: string): CcsAlignCursor | null {
+  if (!existsSync(cursorPath)) return null;
+  try {
+    return JSON.parse(readFileSync(cursorPath, 'utf8')) as CcsAlignCursor;
+  } catch {
+    return null;
+  }
+}
+
+/** Write `cursor.json` atomically (temp + rename), same primitive as the cache. */
+export function writeCursor(cursorPath: string, cursor: CcsAlignCursor): void {
+  const dir = path.dirname(cursorPath);
+  mkdirSync(dir, { recursive: true });
+  const tmpPath = `${cursorPath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    writeFileSync(tmpPath, `${JSON.stringify(cursor, null, 2)}\n`, 'utf8');
+    renameSync(tmpPath, cursorPath);
+  } catch (error) {
+    try { unlinkSync(tmpPath); } catch { /* ignore cleanup */ }
+    throw error;
+  }
+}
+
+/**
+ * D2 fallback probe. There is NO compiled laminate in-repo, so this helper
+ * exists only so the seat can honor an OPTIONAL original-cache path if a later
+ * PASS names one: if that path is missing or not writable, the seat appends to
+ * the middle cache only (which it does anyway) and never invents a laminate.
+ */
+export function isOriginalCacheWritable(originalCachePath: string | null | undefined): boolean {
+  if (!originalCachePath) return false;
+  try {
+    if (existsSync(originalCachePath)) {
+      accessSync(originalCachePath, constants.W_OK);
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+export interface LandObservationsInput {
+  viewerId: string;
+  observations: CcsAlignObservationInput[];
+  dataRoot?: string;
+  now?: Date;
+  /** OPTIONAL. Only honored if writable; never created. See {@link isOriginalCacheWritable}. */
+  originalCachePath?: string | null;
+}
+
+export interface LandObservationsResult {
+  appended: CcsAlignMiddleRecord[];
+  cachePath: string;
+}
+
+/**
+ * Land needle observations into the seat's middle cache. Never throws into the
+ * caller — a broken write path is logged and swallowed, matching the #3931
+ * pusher's never-throw contract.
+ */
+export function landObservationsInMiddleCache(input: LandObservationsInput): LandObservationsResult {
+  const dataRoot = input.dataRoot ?? DATA_DIR;
+  const now = input.now ?? new Date();
+  const cachePath = ccsAlignMiddleCachePath(dataRoot, input.viewerId);
+  try {
+    assertSafeMiddleCachePath(dataRoot, input.viewerId, cachePath);
+
+    if (input.originalCachePath && !isOriginalCacheWritable(input.originalCachePath)) {
+      logger.debug('AWARENESS', 'CCS Align original cache missing or not writable; append-only to seat file', {
+        viewerId: input.viewerId,
+        originalCachePath: input.originalCachePath,
+      });
+    }
+
+    const records = input.observations.map(obs => buildCcsAlignRecord(obs, now));
+    const appended = appendMiddleCacheRecordsAtomic(cachePath, records);
+    if (appended.length > 0) {
+      logger.debug('AWARENESS', 'CCS Align landed observations in middle cache', {
+        viewerId: input.viewerId,
+        appended: appended.length,
+      });
+    }
+    return { appended, cachePath };
+  } catch (error) {
+    const err = error instanceof Error ? error : new Error(String(error));
+    logger.warn('AWARENESS', 'CCS Align middle-cache write skipped', {
+      viewerId: input.viewerId,
+    }, err);
+    return { appended: [], cachePath };
+  }
+}

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -121,6 +121,13 @@ export interface SettingsDefaults {
   CLAUDE_MEM_GROK_BOT_AWARENESS_AGENT_IDS: string;
   CLAUDE_MEM_GROK_BOT_AWARENESS_TRIGGER_TYPES: string;
   CLAUDE_MEM_GROK_BOT_AWARENESS_TRIGGER_CONCEPTS: string;
+  // CCS Align (Worker Watch seat, Phase 0 breathing slice). Seat-owned middle
+  // cache under ~/.claude-mem/ccs-align/<viewerId>/; pull-only, never a second
+  // writer on LFG/Orifice logs. See plans/2026-09-09-ccs-align.md.
+  CLAUDE_MEM_CCS_ALIGN_ENABLED: string;
+  CLAUDE_MEM_CCS_ALIGN_VIEWER_IDS: string;
+  CLAUDE_MEM_CCS_ALIGN_TRIGGER_TYPES: string;
+  CLAUDE_MEM_CCS_ALIGN_PATCH_SHADOWS: string;
   CLAUDE_MEM_QUEUE_ENGINE: string;
   CLAUDE_MEM_REDIS_URL: string;
   CLAUDE_MEM_REDIS_HOST: string;
@@ -240,6 +247,12 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_GROK_BOT_AWARENESS_AGENT_IDS: '521e962d-2ec3-4488-bfbc-54d5209ce118,95601360-61f7-4fd9-bb3a-2c976b2b85c0',
     CLAUDE_MEM_GROK_BOT_AWARENESS_TRIGGER_TYPES: 'decision,bugfix,security_alert,sensitive',
     CLAUDE_MEM_GROK_BOT_AWARENESS_TRIGGER_CONCEPTS: '',
+    CLAUDE_MEM_CCS_ALIGN_ENABLED: 'true',
+    CLAUDE_MEM_CCS_ALIGN_VIEWER_IDS: 'ccs-align',
+    // Copy of the Grok needle list (D6). Same episodic needles, seat-owned cache.
+    CLAUDE_MEM_CCS_ALIGN_TRIGGER_TYPES: 'decision,bugfix,security_alert,sensitive',
+    // Phase 2 rules-shadow patch stays a Prioritizer flag, not a silent /do (D8).
+    CLAUDE_MEM_CCS_ALIGN_PATCH_SHADOWS: 'false',
     CLAUDE_MEM_QUEUE_ENGINE: 'sqlite',
     CLAUDE_MEM_REDIS_URL: '',
     CLAUDE_MEM_REDIS_HOST: '127.0.0.1',

--- a/tests/integrations/ccs-align-middle-cache.test.ts
+++ b/tests/integrations/ccs-align-middle-cache.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import {
+  appendMiddleCacheRecordsAtomic,
+  assertSafeMiddleCachePath,
+  buildCcsAlignRecord,
+  ccsAlignCursorPath,
+  ccsAlignLineBody,
+  ccsAlignMiddleCachePath,
+  formatCcsAlignLine,
+  isOriginalCacheWritable,
+  landObservationsInMiddleCache,
+  observationMatchesCcsAlignNeedle,
+  readCursor,
+  readMiddleCache,
+  writeCursor,
+  type CcsAlignObservationInput,
+} from '../../src/services/integrations/CcsAlignMiddleCache.js';
+
+const VIEWER = 'ccs-align';
+const now = new Date('2026-09-09T15:04:05.000Z');
+
+function makeObs(overrides: Partial<CcsAlignObservationInput> = {}): CcsAlignObservationInput {
+  return {
+    id: 12345,
+    type: 'decision',
+    title: 'Land the middle cache',
+    subtitle: 'Phase 0 only',
+    facts: ['Write dated fact lines into the seat-owned middle cache'],
+    created_at: '2026-09-09T00:00:00.000Z',
+    project: 'claude-mem',
+    agent_id: null,
+    source: 'worker',
+    ...overrides,
+  };
+}
+
+describe('CCS Align middle cache', () => {
+  const temps: string[] = [];
+
+  afterEach(() => {
+    for (const dir of temps.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function tempRoot(): string {
+    const dir = mkdtempSync(path.join(tmpdir(), 'ccs-align-'));
+    temps.push(dir);
+    return dir;
+  }
+
+  it('formats a dated fact line tagged [ccs-align] and truncates to 500 chars', () => {
+    const short = formatCcsAlignLine(makeObs(), now);
+    expect(short).toBe(
+      '- 2026-09-09 [ccs-align] decision — Land the middle cache: Phase 0 only. Write dated fact lines into the seat-owned middle cache',
+    );
+
+    const long = formatCcsAlignLine(makeObs({
+      title: 'x'.repeat(600),
+      subtitle: '',
+      facts: [],
+    }), now);
+    expect(long.startsWith('- 2026-09-09 [ccs-align] decision — ')).toBe(true);
+    expect(long.length).toBe(500);
+    expect(long.endsWith('…')).toBe(true);
+  });
+
+  it('matches needle types or concepts and rejects empty filters', () => {
+    expect(observationMatchesCcsAlignNeedle({ type: 'decision' }, ['decision'], [])).toBe(true);
+    expect(observationMatchesCcsAlignNeedle({ type: 'discovery' }, ['decision'], [])).toBe(false);
+    expect(observationMatchesCcsAlignNeedle({ type: 'discovery', concepts: ['gotcha'] }, [], ['gotcha'])).toBe(true);
+    expect(observationMatchesCcsAlignNeedle({ type: 'decision' }, [], [])).toBe(false);
+  });
+
+  it('lands a record into the seat-owned middle.jsonl and never touches profile.md', () => {
+    const root = tempRoot();
+    const { appended, cachePath } = landObservationsInMiddleCache({
+      viewerId: VIEWER,
+      observations: [makeObs()],
+      dataRoot: root,
+      now,
+    });
+
+    expect(appended).toHaveLength(1);
+    expect(cachePath).toBe(path.join(root, 'ccs-align', VIEWER, 'middle.jsonl'));
+
+    const records = readMiddleCache(cachePath);
+    expect(records).toHaveLength(1);
+    expect(records[0].id).toBe(12345);
+    expect(records[0].v).toBe(1);
+    expect(records[0].source).toBe('worker');
+    expect(records[0].line.includes('[ccs-align]')).toBe(true);
+
+    // Never a second [awareness] writer, never profile.md, never agents/**/memory/log.
+    expect(existsSync(path.join(root, 'ccs-align', VIEWER, 'profile.md'))).toBe(false);
+    expect(existsSync(path.join(root, 'agents'))).toBe(false);
+  });
+
+  it('dedupes by observation id and body so the same fact is not landed twice', () => {
+    const root = tempRoot();
+    const first = landObservationsInMiddleCache({ viewerId: VIEWER, observations: [makeObs()], dataRoot: root, now });
+    expect(first.appended).toHaveLength(1);
+
+    // Same observation on a later day: date differs but body dedupe still skips.
+    const second = landObservationsInMiddleCache({
+      viewerId: VIEWER,
+      observations: [makeObs()],
+      dataRoot: root,
+      now: new Date('2026-09-10T00:00:00.000Z'),
+    });
+    expect(second.appended).toHaveLength(0);
+
+    const records = readMiddleCache(first.cachePath);
+    expect(records).toHaveLength(1);
+  });
+
+  it('appends new observations onto an existing cache without rewriting earlier lines', () => {
+    const root = tempRoot();
+    const cachePath = ccsAlignMiddleCachePath(root, VIEWER);
+
+    const r1 = appendMiddleCacheRecordsAtomic(cachePath, [buildCcsAlignRecord(makeObs({ id: 1 }), now)]);
+    expect(r1).toHaveLength(1);
+    const r2 = appendMiddleCacheRecordsAtomic(cachePath, [buildCcsAlignRecord(makeObs({ id: 2, title: 'second' }), now)]);
+    expect(r2).toHaveLength(1);
+    // Re-appending id 1 is a no-op that must not rewrite/grow the file.
+    const r3 = appendMiddleCacheRecordsAtomic(cachePath, [buildCcsAlignRecord(makeObs({ id: 1 }), now)]);
+    expect(r3).toHaveLength(0);
+
+    const lines = readFileSync(cachePath, 'utf8').trim().split('\n').filter(Boolean);
+    expect(lines).toHaveLength(2);
+    expect((JSON.parse(lines[0]) as { id: number }).id).toBe(1);
+    expect((JSON.parse(lines[1]) as { id: number }).id).toBe(2);
+  });
+
+  it('refuses writes to profile.md, agents/**/memory/log, and outside the seat root', () => {
+    const root = tempRoot();
+    expect(() => assertSafeMiddleCachePath(root, VIEWER, ccsAlignMiddleCachePath(root, VIEWER))).not.toThrow();
+    expect(() => assertSafeMiddleCachePath(root, VIEWER, path.join(root, 'ccs-align', VIEWER, 'profile.md'))).toThrow();
+    expect(() => assertSafeMiddleCachePath(root, VIEWER, path.join(root, 'agents', 'x', 'memory', 'log', '2026-09.md'))).toThrow();
+    expect(() => assertSafeMiddleCachePath(root, VIEWER, path.join(root, 'somewhere-else', 'middle.jsonl'))).toThrow();
+  });
+
+  it('never throws into the caller when the write path is broken', () => {
+    const root = tempRoot();
+    // Make the middle.jsonl target a directory so the atomic rename fails.
+    const cachePath = ccsAlignMiddleCachePath(root, VIEWER);
+    mkdirSync(cachePath, { recursive: true });
+
+    expect(() => landObservationsInMiddleCache({
+      viewerId: VIEWER,
+      observations: [makeObs()],
+      dataRoot: root,
+      now,
+    })).not.toThrow();
+  });
+
+  it('treats a missing original laminate path as append-only (D2): never invents one', () => {
+    const root = tempRoot();
+    const missing = path.join(root, 'nope', 'laminate.jsonl');
+    expect(isOriginalCacheWritable(missing)).toBe(false);
+    expect(isOriginalCacheWritable(null)).toBe(false);
+
+    const { appended, cachePath } = landObservationsInMiddleCache({
+      viewerId: VIEWER,
+      observations: [makeObs()],
+      dataRoot: root,
+      now,
+      originalCachePath: missing,
+    });
+    // Still lands in the seat file; the laminate path is not created.
+    expect(appended).toHaveLength(1);
+    expect(existsSync(cachePath)).toBe(true);
+    expect(existsSync(missing)).toBe(false);
+  });
+
+  it('round-trips the cursor file at the seat path', () => {
+    const root = tempRoot();
+    const cursorPath = ccsAlignCursorPath(root, VIEWER);
+    expect(readCursor(cursorPath)).toBeNull();
+
+    writeCursor(cursorPath, {
+      lastRunAt: now.toISOString(),
+      lastObservationId: 12345,
+      healthPath: '/api/health',
+      workerPort: 37700,
+    });
+
+    const cursor = readCursor(cursorPath);
+    expect(cursor?.lastObservationId).toBe(12345);
+    expect(cursor?.healthPath).toBe('/api/health');
+    expect(cursor?.workerPort).toBe(37700);
+  });
+
+  it('dedupe body key excludes the date so line bodies compare stably', () => {
+    const a = formatCcsAlignLine(makeObs(), new Date('2026-09-09T00:00:00.000Z'));
+    const b = formatCcsAlignLine(makeObs(), new Date('2026-12-25T00:00:00.000Z'));
+    expect(a).not.toBe(b);
+    expect(ccsAlignLineBody(a)).toBe(ccsAlignLineBody(b));
+    expect(ccsAlignLineBody(a).startsWith('[ccs-align] decision')).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this is

CCS Align **Phase 0 only** — the breathing slice of the plan of record (`plans/2026-09-09-ccs-align.md`, merged in #3933, builds on #3931). It gives the standing CCS Align seat exactly one capability: talk to the **local** claude-mem worker, pull recent needle observations through the existing `search → timeline → get_observations` ladder, and land them in a **seat-owned middle cache** via an atomic grab → append → replace.

This is **not** a context compiler, **not** Focus/mouth, **not** Grok Memory Phase 2. Phases 1–3 (exclude marks, rules alignment, final verify) are documented as later work but **not implemented here**.

## What shipped

- **`src/services/integrations/CcsAlignMiddleCache.ts`** — copies the #3931 atomic primitive (`appendAwarenessLineAtomic` / `awarenessLineBody` / `formatAwarenessLine`) with the three locked Phase 0 changes and nothing else:
  1. Tag `[ccs-align]` (never a second `[awareness]` writer)
  2. Path root `~/.claude-mem/ccs-align/<viewerId>/` (never `agents/<id>/memory/log/`)
  3. File `middle.jsonl` (one JSON record per line)
  - Grab → append → replace is atomic (temp file + `renameSync`), deduped by observation `id` **and** by date-excluded body (so the same fact on a new day does not grow the file).
  - Path safety refuses `profile.md`, `agents/**/memory/log`, and any write outside the seat root. The lander never throws into the caller.
  - Cursor helpers read/write `cursor.json` (`{ lastRunAt, lastObservationId, healthPath, workerPort }`).
  - `isOriginalCacheWritable` implements the D2 fallback: if an optional original laminate path is missing/not writable, append-only to the seat file — no laminate is ever invented (there is none in-repo).
- **`plugin/skills/ccs-align/SKILL.md`** — the hourly Worker Watch runbook (Appendix A of the plan): resolve port (timeline-report snippet, per-UID `37700+(uid%100)`), prefer `GET /api/health`, pull the three-layer ladder (timeline depth default **10** from source, not the stale MCP "3"), land + dedupe, update the cursor, speak to **Alex** only on red. Documents settings, hard forbids, and the later-phase stubs.
- **Settings** (`SettingsDefaultsManager.ts`): `CLAUDE_MEM_CCS_ALIGN_ENABLED=true`, `CLAUDE_MEM_CCS_ALIGN_VIEWER_IDS=ccs-align`, `CLAUDE_MEM_CCS_ALIGN_TRIGGER_TYPES=decision,bugfix,security_alert,sensitive` (copied from the Grok needle list, D6), `CLAUDE_MEM_CCS_ALIGN_PATCH_SHADOWS=false` (Phase 2 gate, documented only).
- **Tests** (`tests/integrations/ccs-align-middle-cache.test.ts`) — 10 tests copying the #3931 patterns: format/500-char truncate, needle match, atomic append, id+body dedupe across days, path safety, never-throw, D2 fallback, cursor round-trip.
- **Version**: PATCH bump `13.24.1 → 13.24.2` (code ships, D10). Manifest versions synced. `CHANGELOG.md` untouched (generated).

## Locked defaults honored

D1 seat path · D2 append-only fallback (no invented laminate) · D3 pull-only, no sixth `processAgentResponse` consumer · D5 `ccs-align` viewer, no LFG/Orifice/`profile.md` writes · D6 needle list · D9 skill + tests artifact · D10 PATCH + address **Alex**, never Az.

## Hard forbids verified

No `DELETE /api/observation`, no LFG/Orifice `[awareness]` writes, no `profile.md`/user/project memory writes, no top-of-prompt clock, no `CHANGELOG.md` edit, no Phase 1/2 implementation, no sixth response-processor fan-out. The plan's anti-pattern greps (`DELETE /api/observation`, `processAgentResponse`, `agents/**/memory/log`, `Az`) now match **only** forbid/guard documentation lines and the runtime path-safety guard — never a write path, call, or consumer.

## How to verify

```bash
bun test tests/integrations/ccs-align-middle-cache.test.ts        # 10 pass
bun test tests/integrations/grok-bot-awareness-pusher.test.ts     # #3931 unchanged, 8 pass
bun test tests/transcripts/grok-bot-config.test.ts tests/transcripts/processor-agent-id.test.ts
tsc --noEmit                                                       # clean
```

Local box (not CI): `curl -sS "http://127.0.0.1:$WORKER_PORT/api/health"` → `status: ok`; run one cycle → `~/.claude-mem/ccs-align/ccs-align/middle.jsonl` exists; a second cycle with the same observations does not grow it.

**MISS (documented):** a live local worker was not available in this cloud VM, so the live-box health/pull checklist from plan §0.3 is proven via fixture/unit tests rather than a running worker. Everything CI/unit tests can cover is green (typecheck clean; 39 integration + regression tests pass; 194 shared/worker tests including `settings-defaults-manager` pass).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b27bd2e-54b5-4c37-b8a3-48f1a115781d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b27bd2e-54b5-4c37-b8a3-48f1a115781d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

