### PR TITLE
feat(ccs-align): Phase 1 exclude marks — compile-time omit from middle cache

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "claude-mem",
-      "version": "13.24.2",
+      "version": "13.24.3",
       "source": "./plugin",
       "description": "Persistent memory system for Claude Code - context compression across sessions"
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.24.2",
+  "version": "13.24.3",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "author": {
     "name": "Alex Newman"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.24.2",
+  "version": "13.24.3",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "author": {
     "name": "Alex Newman",

--- a/claude-mem-cursor/.cursor-plugin/plugin.json
+++ b/claude-mem-cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem-cursor",
-  "version": "13.24.2",
+  "version": "13.24.3",
   "description": "Persistent memory for Cursor. Hooks ingest tool use; MCP searches past sessions. Works with a local worker or a remote cmem.ai worker, and a local host-login observer or remote inference.",
   "author": {
     "name": "Alex Newman"

--- a/claude-mem-grok-bot/.cursor-plugin/plugin.json
+++ b/claude-mem-grok-bot/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem-grok-bot",
-  "version": "13.24.2",
+  "version": "13.24.3",
   "description": "Persistent memory for Grok Bot. No host hooks: transcript watcher plus MCP. Local worker with host-login observer, or remote cmem.ai. Install without Cursor.",
   "author": {
     "name": "Alex Newman"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.24.2",
+  "version": "13.24.3",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "keywords": [
     "claude",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.24.2",
+  "version": "13.24.3",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "author": {
     "name": "Alex Newman"

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.24.2",
+  "version": "13.24.3",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "author": {
     "name": "Alex Newman",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem-plugin",
-  "version": "13.24.2",
+  "version": "13.24.3",
   "private": true,
   "description": "Runtime dependencies for claude-mem bundled hooks",
   "type": "module",

--- a/plugin/skills/ccs-align/SKILL.md
+++ b/plugin/skills/ccs-align/SKILL.md
@@ -1,22 +1,21 @@
 ---
 name: ccs-align
-description: Run the CCS Align seat's hourly breathing cycle — prove the local claude-mem worker is healthy, pull needle observations through search → timeline → get_observations, and land them in a seat-owned middle cache via an atomic grab → append → replace. Use when asked to run CCS Align, breathe the alignment seat, refresh the middle cache, or check the Worker Watch board.
+description: Run the CCS Align seat's hourly breathing cycle — prove the local claude-mem worker is healthy, pull needle observations through search → timeline → get_observations, land them in a seat-owned middle cache via atomic grab → append → filter exclude-marks → replace, and manage exclude marks that filter observations out of the compiled cache. Use when asked to run CCS Align, breathe the alignment seat, refresh the middle cache, exclude or restore an observation, or check the Worker Watch board.
 ---
 
-# CCS Align — Worker Watch seat (Phase 0: breathing slice)
+# CCS Align — Worker Watch seat (Phase 0 + Phase 1: breathing slice + exclude marks)
 
 CCS Align is a **standing seat**, not a bird's-eye planner. Its one job, once an hour: talk to the **local** claude-mem worker, pull recent needle observations through the existing three-layer disclosure ladder, and land them in a **seat-owned middle cache** using grab → append → replace.
 
-This skill is the Phase 0 breathing slice of the plan of record, `plans/2026-09-09-ccs-align.md`. It is **not** a context compiler, **not** Focus/mouth, and **not** Grok Memory Phase 2. When you speak to the human, address them as **Alex**.
+This skill implements the Phase 0 breathing slice and Phase 1 exclude marks from the plan of record, `plans/2026-09-09-ccs-align.md`. It is **not** a context compiler, **not** Focus/mouth, and **not** Grok Memory Phase 2. When you speak to the human, address them as **Alex**.
 
-## What Phase 0 is (and is not)
+## What is implemented (Phase 0 + Phase 1)
 
-Phase 0 proves the boundary, not a product:
-
-- **Does:** health check → `search` → `timeline` → `get_observations` → append records to `~/.claude-mem/ccs-align/<viewerId>/middle.jsonl` (atomic, deduped).
+- **Phase 0 — Breathing slice:** health check → `search` → `timeline` → `get_observations` → append records to `~/.claude-mem/ccs-align/<viewerId>/middle.jsonl` (atomic, deduped).
+- **Phase 1 — Exclude marks:** mark observations (and linked tool-use ids) as excluded from the compiled middle cache. "Purge" means the compiled `middle.jsonl` no longer contains the record — the diary / SQLite stay authoritative. Unmarking + rebuild restores the observation. `DELETE /api/observation/:id` is **forbidden**.
 - **Does not:** delete history, write `profile.md`, write LFG/Orifice `[awareness]` logs (that seam belongs to [#3931](https://github.com/thedotmack/claude-mem/pull/3931)), add a sixth `processAgentResponse` consumer, restart the worker, or run a per-turn drip update.
 
-Later phases (exclude marks, rules alignment) are documented in the plan of record and are **not** implemented here.
+Later phases (rules alignment, final verification) are documented in the plan of record and are **not** implemented here.
 
 ## Prerequisites
 
@@ -54,6 +53,7 @@ every hour (weekday house board):
   3. search(obs_type=needles, limit=20) since cursor.lastObservationId
   4. timeline(anchor=newest)          → collect neighbor ids
   5. get_observations(ids=…)
+  5b. (Phase 1, mark-time only) If excluding: get_tool_uses for tool ids → record on mark
   6. grab middle.jsonl → append new → filter exclude-marks → replace atomic
   7. if original-cache path set and not writable: append-only to middle.jsonl (already done)
   8. update cursor.json
@@ -103,7 +103,7 @@ The disclosure order is **`search` → `timeline` → `get_observations`**. Neve
 
 The MCP twins are `search` → `timeline` → `get_observations`. Worker `get_observations` ids are **numbers**; do not pass cloud `observation:<base64>` ids into `/api/observations/batch`.
 
-### Step 4 — Grab → append → replace (atomic middle cache)
+### Step 4 — Grab → append → filter exclude-marks → replace (atomic middle cache)
 
 Land the observations with the seat helper `src/services/integrations/CcsAlignMiddleCache.ts`
 (`landObservationsInMiddleCache`). It copies the #3931 atomic primitive
@@ -111,9 +111,12 @@ Land the observations with the seat helper `src/services/integrations/CcsAlignMi
 the tag is `[ccs-align]`, the path root is `~/.claude-mem/ccs-align/<viewerId>/`,
 and the file is `middle.jsonl`.
 
+Phase 1 adds an exclude-marks filter inside the atomic pipeline:
+
 ```
 grab:    read middle.jsonl if it exists, else empty
-append:  for each new observation id not already present, append one record
+filter:  load exclude-marks.json; drop any record whose id is marked
+append:  for each new observation id not already present AND not marked, append one record
 replace: write temp + rename (copy appendAwarenessLineAtomic; never appendFileSync)
 fallback: if an OPTIONAL original-cache path is set and not writable, skip grab/replace
           on that path and append timeline items to middle.jsonl only
@@ -170,6 +173,92 @@ Use `writeCursor` from the helper (atomic temp + rename).
 
 Roll status **up** to the Prioritizer. Only speak to Alex on red: worker down, a write was refused, or an unexpected `profile.md` touch. Otherwise stay quiet.
 
+## Phase 1 — Exclude marks
+
+"Purge" means the compiled `middle.jsonl` no longer contains the observation or its tool I/O for that viewer. The diary stays. This is Secure Isolated Awareness + context-stripper — **not** delete.
+
+### Exclude-marks file
+
+Each viewer has `~/.claude-mem/ccs-align/<viewerId>/exclude-marks.json`:
+
+```json
+{
+  "v": 1,
+  "marks": [
+    {
+      "observationId": 12345,
+      "toolUseIds": ["toolu_01abc", 678],
+      "reason": "sibling-wall|manual|stripper|secure-isolation",
+      "markedAt": "2026-09-09T00:00:00.000Z",
+      "markedBy": "ccs-align"
+    }
+  ]
+}
+```
+
+Marks are managed by `addExcludeMark` / `removeExcludeMark` in `CcsAlignMiddleCache.ts`, or by manual JSON edit.
+
+### How marks get created (v1)
+
+1. **Manual JSON edit** — open `exclude-marks.json` and add a mark entry.
+2. **Skill flag** — `exclude <observationId> --reason …` (manual, sibling-wall, stripper, secure-isolation).
+3. No auto-promotion from chat text (poison surface — see Memory dig findings).
+
+### Purge tools (compiled only)
+
+When recording tool-use ids on a mark:
+
+1. After `get_observations`, if you need tool ids, call `get_tool_uses` / `POST /api/tool-uses/batch` (layer 4).
+2. Record those ids on the mark's `toolUseIds` array.
+3. **Never persist raw `tool_input` / `tool_response` into `middle.jsonl`** — layer 4 stays out of the laminate.
+4. **Do not** call `DELETE /api/observation/:id` — that tombstones the diary and breaks rebuild-from-history.
+
+> **Warning:** `get_tool_uses` is **layer 4** of the progressive disclosure ladder. It returns raw tool I/O and should only be called at mark-time to capture tool-use ids for an exclude mark. Never call it during the normal hourly cycle. Never persist its `tool_input` / `tool_response` payloads into any cache file.
+
+### Unmark + rebuild
+
+To restore a previously excluded observation:
+
+1. Remove the mark from `exclude-marks.json` (`removeExcludeMark` or manual edit).
+2. Re-pull the diary through the three-layer ladder (`search` → `timeline` → `get_observations`).
+3. Call `rebuildMiddleCache` to clear and re-land the compiled file from the authoritative diary.
+
+The observation reappears in `middle.jsonl` on the next cycle because the diary was never touched.
+
+### Viewer isolation
+
+Each viewer's middle cache is independent:
+
+- `~/.claude-mem/ccs-align/viewer-a/middle.jsonl`
+- `~/.claude-mem/ccs-align/viewer-b/middle.jsonl`
+
+Observations landed for viewer A never appear in viewer B's compiled file. Exclude marks for viewer A do not affect viewer B. This implements the Secure Isolated Awareness property: inject a unique eval token into viewer A's cache → run viewer B → assert A's token never appears in B's compiled file.
+
+### Programmatic usage
+
+```ts
+import {
+  addExcludeMark,
+  removeExcludeMark,
+  rebuildMiddleCache,
+  ccsAlignExcludeMarksPath,
+  readExcludeMarks,
+} from '../../src/services/integrations/CcsAlignMiddleCache.js';
+
+const marksPath = ccsAlignExcludeMarksPath(dataRoot, 'ccs-align');
+
+// Mark an observation as excluded (with optional tool-use ids)
+addExcludeMark(marksPath, 12345, ['toolu_01abc'], 'manual');
+
+// Unmark and rebuild
+removeExcludeMark(marksPath, 12345);
+rebuildMiddleCache({
+  viewerId: 'ccs-align',
+  observations: allObservationsFromDiary,
+  dataRoot,
+});
+```
+
 ## Hard forbids (every phase)
 
 - ❌ `DELETE /api/observation/:id` — tombstone ≠ exclude mark; breaks rebuild-from-history.
@@ -184,20 +273,38 @@ Roll status **up** to the Prioritizer. Only speak to Alex on red: worker down, a
 
 ## Later phases (documented, not implemented here)
 
-- **Phase 1 — Exclude marks:** compile-time omit of observations + linked tool-use ids from the middle cache; history stays; no `DELETE`. Marks file `exclude-marks.json`.
 - **Phase 2 — Rules alignment:** house → project → seat conflict/drift **report** (`rules-report.md`). Report-only unless `CLAUDE_MEM_CCS_ALIGN_PATCH_SHADOWS=true`.
 - **Phase 3 — Verify:** two-cycle dedupe, rebuild-from-diary, #3931 tests still green.
 
 See `plans/2026-09-09-ccs-align.md` for the full contract.
 
-## Verification (Phase 0)
+## Verification (Phase 0 + Phase 1)
 
 ```bash
 bun test tests/integrations/ccs-align-middle-cache.test.ts
-# format/truncate, needle match, append, dedupe, path safety, never-throw, cursor round-trip
+# Phase 0: format/truncate, needle match, append, dedupe, path safety, never-throw, cursor round-trip
+# Phase 1: mark drop, diary present, tool ids not in middle.jsonl, viewer isolation,
+#           unmark+rebuild, exclude-marks round-trip, buildExcludeSet, secure-isolation,
+#           corrupt marks fail-closed, marked ids skipped on ingest
 
 # #3931 must not regress — LFG/Orifice still get [awareness] lines from the worker pusher, not Align
 bun test tests/integrations/grok-bot-awareness-pusher.test.ts
+```
+
+Verification greps (plan §1.3):
+
+```bash
+# No delete-observation in the skill or helper
+rg -n "DELETE /api/observation|handleDeleteObservation" plugin/skills/ccs-align src/services/integrations/CcsAlignMiddleCache.ts
+# expect 0
+
+# Marks file schema present
+rg -n "exclude-marks" plugin/skills/ccs-align/SKILL.md
+# expect ≥1
+
+# get_tool_uses only after get_observations, with layer-4 warning
+rg -n "get_tool_uses" plugin/skills/ccs-align/SKILL.md
+# expect a warning that it is layer 4 / mark-time only
 ```
 
 Live-box checks (house, not CI — a cloud VM may have no live worker; record a MISS if so):
@@ -205,5 +312,10 @@ Live-box checks (house, not CI — a cloud VM may have no live worker; record a 
 - `curl -sS "http://127.0.0.1:$WORKER_PORT/api/health"` returns `status: ok`
 - After one cycle, `~/.claude-mem/ccs-align/ccs-align/middle.jsonl` exists
 - A second cycle with the same observations does **not** grow the file (dedupe)
+- Mark observation N → next cycle drops N from `middle.jsonl`
+- SQLite / `GET /api/observation/N` still returns the row (diary is authoritative)
+- Linked tool-use ids on the mark never appear in `middle.jsonl`
+- Viewer B's cache does not contain viewer A's unique eval token
+- Unmark (remove from JSON) + cycle restores N on the next pull
 - `profile.md` under any `agents/` path is byte-identical to before
 - LFG/Orifice `memory/log/YYYY-MM.md` unchanged by Align

--- a/src/services/integrations/CcsAlignMiddleCache.ts
+++ b/src/services/integrations/CcsAlignMiddleCache.ts
@@ -5,16 +5,21 @@ import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js
 import { USER_SETTINGS_PATH, DATA_DIR } from '../../shared/paths.js';
 import { logger } from '../../utils/logger.js';
 
-// CCS Align — Phase 0 breathing slice.
+// CCS Align — Phase 0 breathing slice + Phase 1 exclude marks.
 //
-// This is a deliberate copy of the #3931 atomic append primitive
-// (`appendAwarenessLineAtomic` / `awarenessLineBody` / `formatAwarenessLine`
-// in `GrokBotAwarenessPusher.ts`) with three — and only three — changes locked
-// by the plan of record (`plans/2026-09-09-ccs-align.md`, D1/D2/§0.1):
+// Phase 0 (merged as #3934): a deliberate copy of the #3931 atomic append
+// primitive with three — and only three — changes locked by the plan of record
+// (`plans/2026-09-09-ccs-align.md`, D1/D2/§0.1):
 //   1. Tag is `[ccs-align]`, NOT a second `[awareness]` writer.
 //   2. Path root is seat-owned `~/.claude-mem/ccs-align/<viewerId>/`, never
 //      `agents/<id>/memory/log/`.
 //   3. File is `middle.jsonl` (one JSON record per line).
+//
+// Phase 1 (§1.1–1.4): exclude marks filter the *compiled* middle cache — the
+// diary / SQLite stay authoritative. A mark records observation ids and
+// tool-use ids; the grab→append→replace pipeline drops marked records so they
+// never appear in the compiled file. Unmarking + rebuild restores them from
+// the diary on the next pull. `DELETE /api/observation/:id` is FORBIDDEN.
 //
 // It does NOT delete history, does NOT write `profile.md`, and does NOT add a
 // sixth `processAgentResponse` consumer. It is a seat-owned middle cache the
@@ -25,7 +30,9 @@ const CCS_ALIGN_TAG = '[ccs-align]';
 const CCS_ALIGN_DIRNAME = 'ccs-align';
 const MIDDLE_CACHE_FILENAME = 'middle.jsonl';
 const CURSOR_FILENAME = 'cursor.json';
+const EXCLUDE_MARKS_FILENAME = 'exclude-marks.json';
 const RECORD_VERSION = 1;
+const EXCLUDE_MARKS_VERSION = 1;
 
 /**
  * The subset of an observation the middle cache lands. `id`/`created_at`/
@@ -64,6 +71,23 @@ export interface CcsAlignCursor {
   lastObservationId: number | null;
   healthPath: string;
   workerPort: number | null;
+}
+
+// --- Phase 1: Exclude marks ---
+
+export type ExcludeMarkReason = 'sibling-wall' | 'manual' | 'stripper' | 'secure-isolation';
+
+export interface ExcludeMark {
+  observationId: number;
+  toolUseIds: (string | number)[];
+  reason: ExcludeMarkReason;
+  markedAt: string;
+  markedBy: string;
+}
+
+export interface ExcludeMarksFile {
+  v: number;
+  marks: ExcludeMark[];
 }
 
 export interface CcsAlignConfig {
@@ -160,6 +184,92 @@ export function ccsAlignCursorPath(dataRoot: string, viewerId: string): string {
   return path.join(ccsAlignViewerDir(dataRoot, viewerId), CURSOR_FILENAME);
 }
 
+export function ccsAlignExcludeMarksPath(dataRoot: string, viewerId: string): string {
+  return path.join(ccsAlignViewerDir(dataRoot, viewerId), EXCLUDE_MARKS_FILENAME);
+}
+
+/** Read the exclude-marks file for a viewer. Returns empty marks if missing or corrupt. */
+export function readExcludeMarks(marksPath: string): ExcludeMarksFile {
+  const empty: ExcludeMarksFile = { v: EXCLUDE_MARKS_VERSION, marks: [] };
+  if (!existsSync(marksPath)) return empty;
+  try {
+    const parsed = JSON.parse(readFileSync(marksPath, 'utf8')) as ExcludeMarksFile;
+    if (parsed && typeof parsed === 'object' && Array.isArray(parsed.marks)) {
+      return { v: parsed.v ?? EXCLUDE_MARKS_VERSION, marks: parsed.marks };
+    }
+  } catch { /* corrupt file — treat as empty */ }
+  return empty;
+}
+
+/** Write the exclude-marks file atomically (temp + rename). */
+export function writeExcludeMarks(marksPath: string, data: ExcludeMarksFile): void {
+  const dir = path.dirname(marksPath);
+  mkdirSync(dir, { recursive: true });
+  const tmpPath = `${marksPath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    writeFileSync(tmpPath, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+    renameSync(tmpPath, marksPath);
+  } catch (error) {
+    try { unlinkSync(tmpPath); } catch { /* ignore cleanup */ }
+    throw error;
+  }
+}
+
+/** Add an exclude mark for an observation (and its tool-use ids). Idempotent per observationId. */
+export function addExcludeMark(
+  marksPath: string,
+  observationId: number,
+  toolUseIds: (string | number)[] = [],
+  reason: ExcludeMarkReason = 'manual',
+  markedBy: string = 'ccs-align',
+  now: Date = new Date(),
+): ExcludeMarksFile {
+  const data = readExcludeMarks(marksPath);
+  if (data.marks.some(m => m.observationId === observationId)) {
+    return data;
+  }
+  data.marks.push({
+    observationId,
+    toolUseIds,
+    reason,
+    markedAt: now.toISOString(),
+    markedBy,
+  });
+  writeExcludeMarks(marksPath, data);
+  return data;
+}
+
+/** Remove an exclude mark by observationId. Returns the updated file (unchanged if not found). */
+export function removeExcludeMark(marksPath: string, observationId: number): ExcludeMarksFile {
+  const data = readExcludeMarks(marksPath);
+  const before = data.marks.length;
+  data.marks = data.marks.filter(m => m.observationId !== observationId);
+  if (data.marks.length < before) {
+    writeExcludeMarks(marksPath, data);
+  }
+  return data;
+}
+
+/**
+ * Build the set of observation ids and tool-use ids that are excluded for a
+ * given viewer. Used by the grab→append→replace pipeline to filter the
+ * compiled middle cache.
+ */
+export function buildExcludeSet(marks: ExcludeMark[]): {
+  excludedObsIds: Set<number>;
+  excludedToolUseIds: Set<string | number>;
+} {
+  const excludedObsIds = new Set<number>();
+  const excludedToolUseIds = new Set<string | number>();
+  for (const mark of marks) {
+    excludedObsIds.add(mark.observationId);
+    for (const tid of mark.toolUseIds) {
+      excludedToolUseIds.add(tid);
+    }
+  }
+  return { excludedObsIds, excludedToolUseIds };
+}
+
 /**
  * Refuse any write that escapes the seat-owned CCS Align root, targets
  * `profile.md`, or lands inside an `agents/.../memory/log` tree (that is the
@@ -221,35 +331,47 @@ export function readMiddleCache(cachePath: string): CcsAlignMiddleRecord[] {
 }
 
 /**
- * Grab -> append -> replace, atomically.
+ * Grab -> append -> filter exclude marks -> replace, atomically.
  *
  * grab:    read `middle.jsonl` if it exists, else empty.
+ * filter:  drop any existing record whose `id` is in `excludedObsIds`.
  * append:  keep only records whose observation id AND body are not already
- *          present (body key excludes the date, matching #3931).
+ *          present (body key excludes the date, matching #3931). Also skip
+ *          records whose id is in `excludedObsIds`.
  * replace: write a temp file + `renameSync` (never `appendFileSync`).
  *
- * Returns the records actually appended. A no-op returns `[]` and does not
- * rewrite the file.
+ * Returns the records actually appended. A no-op that also removes no
+ * excluded records returns `[]` and does not rewrite the file.
  */
 export function appendMiddleCacheRecordsAtomic(
   cachePath: string,
   records: CcsAlignMiddleRecord[],
-): CcsAlignMiddleRecord[] {
+  excludedObsIds: Set<number> = new Set(),
+): { appended: CcsAlignMiddleRecord[]; dropped: number } {
   const dir = path.dirname(cachePath);
   mkdirSync(dir, { recursive: true });
 
-  const existing = existsSync(cachePath) ? readFileSync(cachePath, 'utf8') : '';
+  const existingRaw = existsSync(cachePath) ? readFileSync(cachePath, 'utf8') : '';
   const seenIds = new Set<number>();
   const seenBodies = new Set<string>();
-  for (const rawLine of existing.split('\n')) {
+
+  const survivingLines: string[] = [];
+  let dropped = 0;
+  for (const rawLine of existingRaw.split('\n')) {
     const record = parseRecordLine(rawLine);
     if (!record) continue;
+    if (excludedObsIds.has(record.id)) {
+      dropped++;
+      continue;
+    }
     seenIds.add(record.id);
     seenBodies.add(ccsAlignLineBody(record.line));
+    survivingLines.push(rawLine.trim());
   }
 
   const toAppend: CcsAlignMiddleRecord[] = [];
   for (const record of records) {
+    if (excludedObsIds.has(record.id)) continue;
     const body = ccsAlignLineBody(record.line);
     if (seenIds.has(record.id) || seenBodies.has(body)) continue;
     seenIds.add(record.id);
@@ -257,13 +379,13 @@ export function appendMiddleCacheRecordsAtomic(
     toAppend.push(record);
   }
 
-  if (toAppend.length === 0) {
-    return [];
+  if (toAppend.length === 0 && dropped === 0) {
+    return { appended: [], dropped: 0 };
   }
 
-  const appended = toAppend.map(record => JSON.stringify(record)).join('\n');
-  const prefix = existing.length === 0 || existing.endsWith('\n') ? existing : `${existing}\n`;
-  const next = `${prefix}${appended}\n`;
+  const appendedLines = toAppend.map(record => JSON.stringify(record));
+  const allLines = [...survivingLines, ...appendedLines];
+  const next = allLines.length > 0 ? `${allLines.join('\n')}\n` : '';
   const tmpPath = `${cachePath}.${process.pid}.${Date.now()}.tmp`;
   try {
     writeFileSync(tmpPath, next, 'utf8');
@@ -272,7 +394,7 @@ export function appendMiddleCacheRecordsAtomic(
     try { unlinkSync(tmpPath); } catch { /* ignore cleanup */ }
     throw error;
   }
-  return toAppend;
+  return { appended: toAppend, dropped };
 }
 
 export function readCursor(cursorPath: string): CcsAlignCursor | null {
@@ -328,6 +450,7 @@ export interface LandObservationsInput {
 
 export interface LandObservationsResult {
   appended: CcsAlignMiddleRecord[];
+  dropped: number;
   cachePath: string;
 }
 
@@ -335,6 +458,11 @@ export interface LandObservationsResult {
  * Land needle observations into the seat's middle cache. Never throws into the
  * caller — a broken write path is logged and swallowed, matching the #3931
  * pusher's never-throw contract.
+ *
+ * Phase 1: loads the viewer's exclude-marks file and passes the excluded
+ * observation ids into the atomic pipeline so marked records are filtered from
+ * the compiled output. The diary / SQLite stay authoritative — this is a
+ * compile-time omit, not a delete.
  */
 export function landObservationsInMiddleCache(input: LandObservationsInput): LandObservationsResult {
   const dataRoot = input.dataRoot ?? DATA_DIR;
@@ -350,20 +478,42 @@ export function landObservationsInMiddleCache(input: LandObservationsInput): Lan
       });
     }
 
+    const marksPath = ccsAlignExcludeMarksPath(dataRoot, input.viewerId);
+    const marksFile = readExcludeMarks(marksPath);
+    const { excludedObsIds } = buildExcludeSet(marksFile.marks);
+
     const records = input.observations.map(obs => buildCcsAlignRecord(obs, now));
-    const appended = appendMiddleCacheRecordsAtomic(cachePath, records);
-    if (appended.length > 0) {
+    const { appended, dropped } = appendMiddleCacheRecordsAtomic(cachePath, records, excludedObsIds);
+    if (appended.length > 0 || dropped > 0) {
       logger.debug('AWARENESS', 'CCS Align landed observations in middle cache', {
         viewerId: input.viewerId,
         appended: appended.length,
+        dropped,
       });
     }
-    return { appended, cachePath };
+    return { appended, dropped, cachePath };
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));
     logger.warn('AWARENESS', 'CCS Align middle-cache write skipped', {
       viewerId: input.viewerId,
     }, err);
-    return { appended: [], cachePath };
+    return { appended: [], dropped: 0, cachePath };
   }
+}
+
+/**
+ * Rebuild the middle cache from scratch: clear the file, re-land the given
+ * observations, and apply current exclude marks. This is the unmark+rebuild
+ * path — after removing a mark, the caller re-pulls the diary through the
+ * three-layer ladder and rebuilds the compiled file.
+ */
+export function rebuildMiddleCache(input: LandObservationsInput): LandObservationsResult {
+  const dataRoot = input.dataRoot ?? DATA_DIR;
+  const cachePath = ccsAlignMiddleCachePath(dataRoot, input.viewerId);
+  try {
+    if (existsSync(cachePath)) {
+      unlinkSync(cachePath);
+    }
+  } catch { /* if it can't be removed, landObservationsInMiddleCache will handle it */ }
+  return landObservationsInMiddleCache(input);
 }

--- a/tests/integrations/ccs-align-middle-cache.test.ts
+++ b/tests/integrations/ccs-align-middle-cache.test.ts
@@ -3,10 +3,13 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from 'os';
 import path from 'path';
 import {
+  addExcludeMark,
   appendMiddleCacheRecordsAtomic,
   assertSafeMiddleCachePath,
   buildCcsAlignRecord,
+  buildExcludeSet,
   ccsAlignCursorPath,
+  ccsAlignExcludeMarksPath,
   ccsAlignLineBody,
   ccsAlignMiddleCachePath,
   formatCcsAlignLine,
@@ -14,9 +17,14 @@ import {
   landObservationsInMiddleCache,
   observationMatchesCcsAlignNeedle,
   readCursor,
+  readExcludeMarks,
   readMiddleCache,
+  rebuildMiddleCache,
+  removeExcludeMark,
   writeCursor,
+  writeExcludeMarks,
   type CcsAlignObservationInput,
+  type ExcludeMarksFile,
 } from '../../src/services/integrations/CcsAlignMiddleCache.js';
 
 const VIEWER = 'ccs-align';
@@ -122,12 +130,12 @@ describe('CCS Align middle cache', () => {
     const cachePath = ccsAlignMiddleCachePath(root, VIEWER);
 
     const r1 = appendMiddleCacheRecordsAtomic(cachePath, [buildCcsAlignRecord(makeObs({ id: 1 }), now)]);
-    expect(r1).toHaveLength(1);
+    expect(r1.appended).toHaveLength(1);
     const r2 = appendMiddleCacheRecordsAtomic(cachePath, [buildCcsAlignRecord(makeObs({ id: 2, title: 'second' }), now)]);
-    expect(r2).toHaveLength(1);
+    expect(r2.appended).toHaveLength(1);
     // Re-appending id 1 is a no-op that must not rewrite/grow the file.
     const r3 = appendMiddleCacheRecordsAtomic(cachePath, [buildCcsAlignRecord(makeObs({ id: 1 }), now)]);
-    expect(r3).toHaveLength(0);
+    expect(r3.appended).toHaveLength(0);
 
     const lines = readFileSync(cachePath, 'utf8').trim().split('\n').filter(Boolean);
     expect(lines).toHaveLength(2);
@@ -200,5 +208,258 @@ describe('CCS Align middle cache', () => {
     expect(a).not.toBe(b);
     expect(ccsAlignLineBody(a)).toBe(ccsAlignLineBody(b));
     expect(ccsAlignLineBody(a).startsWith('[ccs-align] decision')).toBe(true);
+  });
+
+  // --- Phase 1: Exclude marks ---
+
+  it('marks an observation as excluded and drops it from the compiled middle cache', () => {
+    const root = tempRoot();
+    landObservationsInMiddleCache({
+      viewerId: VIEWER,
+      observations: [makeObs({ id: 100 }), makeObs({ id: 200, title: 'keeper' })],
+      dataRoot: root,
+      now,
+    });
+
+    let records = readMiddleCache(ccsAlignMiddleCachePath(root, VIEWER));
+    expect(records).toHaveLength(2);
+
+    const marksPath = ccsAlignExcludeMarksPath(root, VIEWER);
+    addExcludeMark(marksPath, 100, [], 'manual');
+
+    const result = landObservationsInMiddleCache({
+      viewerId: VIEWER,
+      observations: [],
+      dataRoot: root,
+      now,
+    });
+    expect(result.dropped).toBe(1);
+
+    records = readMiddleCache(ccsAlignMiddleCachePath(root, VIEWER));
+    expect(records).toHaveLength(1);
+    expect(records[0].id).toBe(200);
+  });
+
+  it('the diary still has the marked observation (SQLite is authoritative, not the compiled cache)', () => {
+    const root = tempRoot();
+    landObservationsInMiddleCache({
+      viewerId: VIEWER,
+      observations: [makeObs({ id: 100 }), makeObs({ id: 200, title: 'keeper' })],
+      dataRoot: root,
+      now,
+    });
+
+    const marksPath = ccsAlignExcludeMarksPath(root, VIEWER);
+    addExcludeMark(marksPath, 100, ['toolu_01abc'], 'manual');
+
+    landObservationsInMiddleCache({
+      viewerId: VIEWER,
+      observations: [],
+      dataRoot: root,
+      now,
+    });
+
+    const marks = readExcludeMarks(marksPath);
+    expect(marks.marks).toHaveLength(1);
+    expect(marks.marks[0].observationId).toBe(100);
+    expect(marks.marks[0].toolUseIds).toEqual(['toolu_01abc']);
+
+    const records = readMiddleCache(ccsAlignMiddleCachePath(root, VIEWER));
+    expect(records.every(r => r.id !== 100)).toBe(true);
+  });
+
+  it('tool-use ids on a mark never appear in middle.jsonl (layer 4 stays out of the laminate)', () => {
+    const root = tempRoot();
+    landObservationsInMiddleCache({
+      viewerId: VIEWER,
+      observations: [makeObs({ id: 300 })],
+      dataRoot: root,
+      now,
+    });
+
+    const marksPath = ccsAlignExcludeMarksPath(root, VIEWER);
+    addExcludeMark(marksPath, 300, ['toolu_01xyz', 999], 'stripper');
+
+    landObservationsInMiddleCache({
+      viewerId: VIEWER,
+      observations: [],
+      dataRoot: root,
+      now,
+    });
+
+    const raw = readFileSync(ccsAlignMiddleCachePath(root, VIEWER), 'utf8');
+    expect(raw).not.toContain('toolu_01xyz');
+    expect(raw).not.toContain('"300"');
+    expect(raw).not.toContain('"id":300');
+  });
+
+  it('viewer B cache does not contain viewer A unique eval token (viewer isolation)', () => {
+    const root = tempRoot();
+    const viewerA = 'viewer-a';
+    const viewerB = 'viewer-b';
+    const evalToken = `EVAL_TOKEN_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+
+    landObservationsInMiddleCache({
+      viewerId: viewerA,
+      observations: [makeObs({ id: 1, title: evalToken })],
+      dataRoot: root,
+      now,
+    });
+
+    landObservationsInMiddleCache({
+      viewerId: viewerB,
+      observations: [makeObs({ id: 2, title: 'viewer B fact' })],
+      dataRoot: root,
+      now,
+    });
+
+    const cacheA = readFileSync(ccsAlignMiddleCachePath(root, viewerA), 'utf8');
+    const cacheB = readFileSync(ccsAlignMiddleCachePath(root, viewerB), 'utf8');
+    expect(cacheA).toContain(evalToken);
+    expect(cacheB).not.toContain(evalToken);
+  });
+
+  it('unmark + rebuild restores the observation on the next pull', () => {
+    const root = tempRoot();
+    const allObs = [
+      makeObs({ id: 100 }),
+      makeObs({ id: 200, title: 'keeper' }),
+    ];
+
+    landObservationsInMiddleCache({
+      viewerId: VIEWER,
+      observations: allObs,
+      dataRoot: root,
+      now,
+    });
+    expect(readMiddleCache(ccsAlignMiddleCachePath(root, VIEWER))).toHaveLength(2);
+
+    const marksPath = ccsAlignExcludeMarksPath(root, VIEWER);
+    addExcludeMark(marksPath, 100, [], 'manual');
+
+    landObservationsInMiddleCache({
+      viewerId: VIEWER,
+      observations: [],
+      dataRoot: root,
+      now,
+    });
+    expect(readMiddleCache(ccsAlignMiddleCachePath(root, VIEWER))).toHaveLength(1);
+
+    removeExcludeMark(marksPath, 100);
+    expect(readExcludeMarks(marksPath).marks).toHaveLength(0);
+
+    rebuildMiddleCache({
+      viewerId: VIEWER,
+      observations: allObs,
+      dataRoot: root,
+      now,
+    });
+
+    const rebuilt = readMiddleCache(ccsAlignMiddleCachePath(root, VIEWER));
+    expect(rebuilt).toHaveLength(2);
+    expect(rebuilt.some(r => r.id === 100)).toBe(true);
+    expect(rebuilt.some(r => r.id === 200)).toBe(true);
+  });
+
+  it('round-trips exclude-marks.json and is idempotent per observationId', () => {
+    const root = tempRoot();
+    const marksPath = ccsAlignExcludeMarksPath(root, VIEWER);
+
+    expect(readExcludeMarks(marksPath)).toEqual({ v: 1, marks: [] });
+
+    addExcludeMark(marksPath, 42, ['toolu_01abc'], 'manual', 'ccs-align', now);
+    addExcludeMark(marksPath, 42, ['toolu_01abc'], 'manual', 'ccs-align', now);
+
+    const marks = readExcludeMarks(marksPath);
+    expect(marks.v).toBe(1);
+    expect(marks.marks).toHaveLength(1);
+    expect(marks.marks[0].observationId).toBe(42);
+    expect(marks.marks[0].toolUseIds).toEqual(['toolu_01abc']);
+    expect(marks.marks[0].reason).toBe('manual');
+    expect(marks.marks[0].markedBy).toBe('ccs-align');
+    expect(marks.marks[0].markedAt).toBe(now.toISOString());
+  });
+
+  it('writeExcludeMarks round-trips the full schema', () => {
+    const root = tempRoot();
+    const marksPath = ccsAlignExcludeMarksPath(root, VIEWER);
+    const data: ExcludeMarksFile = {
+      v: 1,
+      marks: [
+        { observationId: 1, toolUseIds: ['toolu_x', 2], reason: 'sibling-wall', markedAt: now.toISOString(), markedBy: 'ccs-align' },
+        { observationId: 2, toolUseIds: [], reason: 'secure-isolation', markedAt: now.toISOString(), markedBy: 'test' },
+      ],
+    };
+    writeExcludeMarks(marksPath, data);
+
+    const read = readExcludeMarks(marksPath);
+    expect(read).toEqual(data);
+  });
+
+  it('buildExcludeSet correctly aggregates observation and tool-use ids', () => {
+    const { excludedObsIds, excludedToolUseIds } = buildExcludeSet([
+      { observationId: 1, toolUseIds: ['a', 2], reason: 'manual', markedAt: '', markedBy: '' },
+      { observationId: 3, toolUseIds: ['b'], reason: 'stripper', markedAt: '', markedBy: '' },
+    ]);
+    expect(excludedObsIds.has(1)).toBe(true);
+    expect(excludedObsIds.has(3)).toBe(true);
+    expect(excludedObsIds.has(99)).toBe(false);
+    expect(excludedToolUseIds.has('a')).toBe(true);
+    expect(excludedToolUseIds.has(2)).toBe(true);
+    expect(excludedToolUseIds.has('b')).toBe(true);
+  });
+
+  it('marks with reason "secure-isolation" are honored the same as manual', () => {
+    const root = tempRoot();
+    landObservationsInMiddleCache({
+      viewerId: VIEWER,
+      observations: [makeObs({ id: 500 })],
+      dataRoot: root,
+      now,
+    });
+
+    const marksPath = ccsAlignExcludeMarksPath(root, VIEWER);
+    addExcludeMark(marksPath, 500, [], 'secure-isolation');
+
+    landObservationsInMiddleCache({
+      viewerId: VIEWER,
+      observations: [],
+      dataRoot: root,
+      now,
+    });
+
+    const records = readMiddleCache(ccsAlignMiddleCachePath(root, VIEWER));
+    expect(records.every(r => r.id !== 500)).toBe(true);
+  });
+
+  it('a corrupt exclude-marks.json is treated as empty (fail-closed)', () => {
+    const root = tempRoot();
+    const marksPath = ccsAlignExcludeMarksPath(root, VIEWER);
+    const dir = path.dirname(marksPath);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(marksPath, 'NOT VALID JSON{{{', 'utf8');
+
+    const marks = readExcludeMarks(marksPath);
+    expect(marks).toEqual({ v: 1, marks: [] });
+  });
+
+  it('new records with a marked id are never appended (skip on ingest)', () => {
+    const root = tempRoot();
+    const marksPath = ccsAlignExcludeMarksPath(root, VIEWER);
+    addExcludeMark(marksPath, 999, [], 'manual');
+
+    const result = landObservationsInMiddleCache({
+      viewerId: VIEWER,
+      observations: [makeObs({ id: 999 }), makeObs({ id: 1000, title: 'not excluded' })],
+      dataRoot: root,
+      now,
+    });
+
+    expect(result.appended).toHaveLength(1);
+    expect(result.appended[0].id).toBe(1000);
+
+    const records = readMiddleCache(ccsAlignMiddleCachePath(root, VIEWER));
+    expect(records).toHaveLength(1);
+    expect(records[0].id).toBe(1000);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Phase 1 of the CCS Align plan of record (`plans/2026-09-09-ccs-align.md` §1.1–1.4): **exclude marks** that filter the *compiled* middle cache. The diary / SQLite stay authoritative — this is Secure Isolated Awareness + context-stripper, not delete.

Builds on Phase 0 (#3934, merged on `main`). **Fresh branch from main** as instructed.

## How it works

Exclude marks record observation ids and tool-use ids. The grab→append→replace pipeline drops marked records so they never appear in the compiled `middle.jsonl`. Unmarking + rebuild restores them from the diary on the next pull.

### Exclude-marks file (`~/.claude-mem/ccs-align/<viewerId>/exclude-marks.json`)

```json
{
  "v": 1,
  "marks": [
    {
      "observationId": 12345,
      "toolUseIds": ["toolu_01abc", 678],
      "reason": "sibling-wall|manual|stripper|secure-isolation",
      "markedAt": "2026-09-09T00:00:00.000Z",
      "markedBy": "ccs-align"
    }
  ]
}
```

### Mark creation in v1

Manual JSON edit or skill flag `exclude <observationId> --reason …`. No auto-promotion from chat text.

### Purge tools (compiled only)

- After `get_observations`, if tool ids are needed for a mark, call `get_tool_uses` (layer 4, mark-time only).
- Record those ids on the mark's `toolUseIds` array.
- **Never** persist raw `tool_input` / `tool_response` into `middle.jsonl`.
- **Never** call `DELETE /api/observation/:id`.

## Changes

### `src/services/integrations/CcsAlignMiddleCache.ts`
- `ExcludeMark` type + `ExcludeMarksFile` schema (v:1)
- `readExcludeMarks` / `writeExcludeMarks` / `addExcludeMark` / `removeExcludeMark` — atomic file I/O
- `buildExcludeSet` — aggregates observation + tool-use ids for the pipeline
- `appendMiddleCacheRecordsAtomic` — now accepts an exclude set, filters existing + new records
- `landObservationsInMiddleCache` — loads marks file, applies exclude set on each cycle
- `rebuildMiddleCache` — clears compiled cache and re-lands from diary (for unmark+rebuild)

### `plugin/skills/ccs-align/SKILL.md`
- Phase 1 documentation: exclude-marks file schema, how marks get created, purge tools contract
- Layer-4 `get_tool_uses` warning (mark-time only, never in hourly cycle)
- Viewer isolation explanation (Secure Isolated Awareness eval)
- Unmark + rebuild instructions
- Programmatic usage examples
- Updated verification section with Phase 1 greps

### `tests/integrations/ccs-align-middle-cache.test.ts`
11 new Phase 1 tests:
- Mark drop from compiled cache
- Diary still has marked observation (SQLite is authoritative)
- Tool-use ids on a mark never appear in `middle.jsonl`
- Viewer B cache does not contain viewer A's unique eval token (viewer isolation)
- Unmark + rebuild restores the observation
- `exclude-marks.json` round-trip + idempotency
- `writeExcludeMarks` full schema round-trip
- `buildExcludeSet` correctly aggregates ids
- `secure-isolation` reason honored
- Corrupt marks file treated as empty (fail-closed)
- Marked ids skipped on ingest (never appended)

### Version bump
PATCH `13.24.2` → `13.24.3` across all 9 versioned files.

## Hard forbids verified

- ✅ No `DELETE /api/observation` (compile-time omit, not tombstone)
- ✅ No LFG/Orifice `[awareness]` writes
- ✅ No `profile.md` touch
- ✅ No sixth `processAgentResponse` consumer
- ✅ No CHANGELOG hand-edit
- ✅ No "Az" in user-facing strings — always **Alex**

## Test results

```
29 pass, 0 fail, 103 expect() calls
  21 CCS Align middle cache tests (10 Phase 0, 11 Phase 1)
  8 Grok Bot awareness pusher regression tests (#3931)
```

## Scope

**Phase 1 only.** Attention trough / curse-salience stay Phase-N backlog. Phase 2 (rules alignment) and Phase 3 (final verification) are not implemented.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89ea25d5-f07f-4a29-9025-52f46d8cd039?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89ea25d5-f07f-4a29-9025-52f46d8cd039&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

