### PR TITLE
feat(ccs-align): Phase 2 rules alignment — house → project → seat conflict walk

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "claude-mem",
-      "version": "13.24.3",
+      "version": "13.24.4",
       "source": "./plugin",
       "description": "Persistent memory system for Claude Code - context compression across sessions"
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.24.3",
+  "version": "13.24.4",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "author": {
     "name": "Alex Newman"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.24.3",
+  "version": "13.24.4",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "author": {
     "name": "Alex Newman",

--- a/claude-mem-cursor/.cursor-plugin/plugin.json
+++ b/claude-mem-cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem-cursor",
-  "version": "13.24.3",
+  "version": "13.24.4",
   "description": "Persistent memory for Cursor. Hooks ingest tool use; MCP searches past sessions. Works with a local worker or a remote cmem.ai worker, and a local host-login observer or remote inference.",
   "author": {
     "name": "Alex Newman"

--- a/claude-mem-grok-bot/.cursor-plugin/plugin.json
+++ b/claude-mem-grok-bot/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem-grok-bot",
-  "version": "13.24.3",
+  "version": "13.24.4",
   "description": "Persistent memory for Grok Bot. No host hooks: transcript watcher plus MCP. Local worker with host-login observer, or remote cmem.ai. Install without Cursor.",
   "author": {
     "name": "Alex Newman"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.24.3",
+  "version": "13.24.4",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "keywords": [
     "claude",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.24.3",
+  "version": "13.24.4",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "author": {
     "name": "Alex Newman"

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.24.3",
+  "version": "13.24.4",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "author": {
     "name": "Alex Newman",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem-plugin",
-  "version": "13.24.3",
+  "version": "13.24.4",
   "private": true,
   "description": "Runtime dependencies for claude-mem bundled hooks",
   "type": "module",

--- a/plugin/skills/ccs-align/SKILL.md
+++ b/plugin/skills/ccs-align/SKILL.md
@@ -1,21 +1,20 @@
 ---
 name: ccs-align
-description: Run the CCS Align seat's hourly breathing cycle — prove the local claude-mem worker is healthy, pull needle observations through search → timeline → get_observations, land them in a seat-owned middle cache via atomic grab → append → filter exclude-marks → replace, and manage exclude marks that filter observations out of the compiled cache. Use when asked to run CCS Align, breathe the alignment seat, refresh the middle cache, exclude or restore an observation, or check the Worker Watch board.
+description: Run the CCS Align seat's hourly breathing cycle — prove the local claude-mem worker is healthy, pull needle observations through search → timeline → get_observations, land them in a seat-owned middle cache via atomic grab → append → filter exclude-marks → replace, manage exclude marks, and walk house → project → seat rules to detect conflicts (SHADOW_HOUSE, DENY_ALLOW, DRIFT, CLOCK_HEADER) with an append-only rules-report.md. Use when asked to run CCS Align, breathe the alignment seat, refresh the middle cache, exclude or restore an observation, walk rules, check rules conflicts, or check the Worker Watch board.
 ---
 
-# CCS Align — Worker Watch seat (Phase 0 + Phase 1: breathing slice + exclude marks)
+# CCS Align — Worker Watch seat (Phase 0 + Phase 1 + Phase 2: breathing slice + exclude marks + rules alignment)
 
 CCS Align is a **standing seat**, not a bird's-eye planner. Its one job, once an hour: talk to the **local** claude-mem worker, pull recent needle observations through the existing three-layer disclosure ladder, and land them in a **seat-owned middle cache** using grab → append → replace.
 
-This skill implements the Phase 0 breathing slice and Phase 1 exclude marks from the plan of record, `plans/2026-09-09-ccs-align.md`. It is **not** a context compiler, **not** Focus/mouth, and **not** Grok Memory Phase 2. When you speak to the human, address them as **Alex**.
+This skill implements the Phase 0 breathing slice, Phase 1 exclude marks, and Phase 2 rules alignment from the plan of record, `plans/2026-09-09-ccs-align.md`. It is **not** a context compiler, **not** Focus/mouth, and **not** Grok Memory Phase 2. When you speak to the human, address them as **Alex**.
 
-## What is implemented (Phase 0 + Phase 1)
+## What is implemented (Phase 0 + Phase 1 + Phase 2)
 
 - **Phase 0 — Breathing slice:** health check → `search` → `timeline` → `get_observations` → append records to `~/.claude-mem/ccs-align/<viewerId>/middle.jsonl` (atomic, deduped).
 - **Phase 1 — Exclude marks:** mark observations (and linked tool-use ids) as excluded from the compiled middle cache. "Purge" means the compiled `middle.jsonl` no longer contains the record — the diary / SQLite stay authoritative. Unmarking + rebuild restores the observation. `DELETE /api/observation/:id` is **forbidden**.
-- **Does not:** delete history, write `profile.md`, write LFG/Orifice `[awareness]` logs (that seam belongs to [#3931](https://github.com/thedotmack/claude-mem/pull/3931)), add a sixth `processAgentResponse` consumer, restart the worker, or run a per-turn drip update.
-
-Later phases (rules alignment, final verification) are documented in the plan of record and are **not** implemented here.
+- **Phase 2 — Rules alignment:** walk house → project → seat layers, detect conflicts (`SHADOW_HOUSE`, `DENY_ALLOW`, `DRIFT`, `CLOCK_HEADER`), emit an append-only `rules-report.md`. Optionally dry-run/apply `SHADOW_HOUSE` leaf patches when `CLAUDE_MEM_CCS_ALIGN_PATCH_SHADOWS=true`. Runs every 6th hour of the hourly Worker Watch cycle (D4). This is a **checklist**, not a parser — no `.cas` compiler.
+- **Does not:** delete history, write `profile.md`, write LFG/Orifice `[awareness]` logs (that seam belongs to [#3931](https://github.com/thedotmack/claude-mem/pull/3931)), add a sixth `processAgentResponse` consumer, restart the worker, run a per-turn drip update, enforce Focus/mouth/standing rules, or copy house text into seats.
 
 ## Prerequisites
 
@@ -38,7 +37,7 @@ Defaults live in `SettingsDefaultsManager.ts`; override in `~/.claude-mem/settin
 | `CLAUDE_MEM_CCS_ALIGN_ENABLED` | `true` | Master switch for the seat. |
 | `CLAUDE_MEM_CCS_ALIGN_VIEWER_IDS` | `ccs-align` | Comma-separated viewer ids the seat maintains a cache for. |
 | `CLAUDE_MEM_CCS_ALIGN_TRIGGER_TYPES` | `decision,bugfix,security_alert,sensitive` | Needle observation types to pull (copied from #3931's list, D6). |
-| `CLAUDE_MEM_CCS_ALIGN_PATCH_SHADOWS` | `false` | Phase 2 rules-shadow patch gate. **Off** in Phase 0; documented only. |
+| `CLAUDE_MEM_CCS_ALIGN_PATCH_SHADOWS` | `false` | Phase 2 rules-shadow patch gate. When `true`, the rules walker removes `SHADOW_HOUSE` duplicate lines from leaf files (atomic temp+rename). Default **off** — report-only. |
 
 Pilot viewer id is `ccs-align`. The seat **may read** LFG observations (agent id `521e962d-2ec3-4488-bfbc-54d5209ce118`) as a project filter, but **must not write** LFG/Orifice monthly logs or any `profile.md`.
 
@@ -57,7 +56,7 @@ every hour (weekday house board):
   6. grab middle.jsonl → append new → filter exclude-marks → replace atomic
   7. if original-cache path set and not writable: append-only to middle.jsonl (already done)
   8. update cursor.json
-  9. every 6th hour: rules walk → append rules-report.md   (Phase 2 — not in this slice)
+  9. every 6th hour: rules walk → append rules-report.md   (Phase 2 — see below)
  10. Speak to Alex only on red (worker down, write refused, unexpected profile.md touch)
 ```
 
@@ -270,15 +269,92 @@ rebuildMiddleCache({
 - ❌ Restarting the worker, or `POST /api/settings`.
 - ❌ Addressing the human as "Az". Always **Alex**.
 - ❌ Claiming a context compiler / brainbeat shipped. Those are future work.
+- ❌ "Fixing" deny/allow by flipping rules — report only.
+- ❌ Copying house text into seats — that is the bug this phase detects.
+- ❌ Building a `.cas` compiler so the report looks smarter.
+- ❌ Patching standing / Focus / always / never / danger files.
+- ❌ Attention trough / curse-salience experiments (Phase-N backlog only).
+
+## Phase 2 — Rules alignment (house → project → seat)
+
+Every 6th hour of the hourly Worker Watch cycle (D4), the seat walks house → project → seat layers to detect and report rules conflicts. This is a **checklist**, not a parser. No `.cas` compiler.
+
+### Cascade rules (from Notion CCS)
+
+- Write once at HOUSE; seats inherit
+- A leaf copy **shadows** the cascade (bug, not feature)
+- Deny beats allow
+- Siblings deny heavy buckets (`obs`, `note`, `person`) by default
+- Fail closed: if no rule exists, deny
+
+### Layer walk
+
+| Layer | Where to look (house box) | Bucket |
+|---|---|---|
+| House | `user-memory/` shared profile; Notion CCS `:root` | `profile`, `standing`, `owns` |
+| Project | `.cmem-projects/<project>/`, repo `CLAUDE.md` | project overrides |
+| Seat | `agents/<uuid>/profile.md`, `agents/<uuid>/memory/` | leaf — must not duplicate house |
+
+On a box with no agent-data tree, the report records `MISS: house-box paths` and exits cleanly.
+
+### Conflict classes (v1)
+
+| Code | Pattern | Agency |
+|---|---|---|
+| `SHADOW_HOUSE` | Leaf file contains a line that also exists at house (or starts with `House rule`) | Dry-run remove-from-leaf; apply only if `CLAUDE_MEM_CCS_ALIGN_PATCH_SHADOWS=true` |
+| `DENY_ALLOW` | Same bucket allow at one layer, deny at another | Report only |
+| `DRIFT` | House text changed; leaf still has old wording (partial prefix match) | Report only |
+| `CLOCK_HEADER` | Top-of-prompt clock / "current time is" in a profile | Report only (house rule: no clock in the prefix) |
+
+### Rules report
+
+Output: `~/.claude-mem/ccs-align/<viewerId>/rules-report.md` — dated, append-only sections. Each run appends a new section with a timestamp, a table of conflicts, any MISS entries, and a patches-applied count. Status rolls **up** to Prioritizer (never peer spam).
+
+### Limited patch (D8 default off)
+
+When `CLAUDE_MEM_CCS_ALIGN_PATCH_SHADOWS=true`:
+
+1. Only `SHADOW_HOUSE` conflicts are patched — never `DENY_ALLOW`, `DRIFT`, or `CLOCK_HEADER`.
+2. The would-be diff is written into the report **before** any patch is applied.
+3. The leaf file is copied, duplicate lines are stripped, and the file is replaced atomically (temp + rename, same primitive as `CcsAlignMiddleCache`).
+4. **Never patches `standing` / Focus / `always.md` / `never.md` / `danger.md` / `profile.md`.**
+5. House files are never modified.
+
+### Programmatic usage
+
+```ts
+import {
+  walkRules,
+  discoverLayerPaths,
+  type RulesWalkerConfig,
+} from '../../src/services/integrations/CcsAlignRulesWalker.js';
+
+// Discover paths on the current box
+const paths = discoverLayerPaths({ project: 'claude-mem' });
+
+const config: RulesWalkerConfig = {
+  dataRoot: '~/.claude-mem',
+  viewerId: 'ccs-align',
+  patchShadows: false,  // report-only by default
+  housePaths: paths.housePaths,
+  projectPaths: paths.projectPaths,
+  seatPaths: paths.seatPaths,
+};
+
+const result = walkRules(config);
+// result.conflicts — array of detected conflicts
+// result.misses — paths that were not found
+// result.reportPath — path to the appended rules-report.md
+// result.patchesApplied — number of SHADOW_HOUSE lines removed (0 if patchShadows=false)
+```
 
 ## Later phases (documented, not implemented here)
 
-- **Phase 2 — Rules alignment:** house → project → seat conflict/drift **report** (`rules-report.md`). Report-only unless `CLAUDE_MEM_CCS_ALIGN_PATCH_SHADOWS=true`.
 - **Phase 3 — Verify:** two-cycle dedupe, rebuild-from-diary, #3931 tests still green.
 
 See `plans/2026-09-09-ccs-align.md` for the full contract.
 
-## Verification (Phase 0 + Phase 1)
+## Verification (Phase 0 + Phase 1 + Phase 2)
 
 ```bash
 bun test tests/integrations/ccs-align-middle-cache.test.ts
@@ -287,24 +363,27 @@ bun test tests/integrations/ccs-align-middle-cache.test.ts
 #           unmark+rebuild, exclude-marks round-trip, buildExcludeSet, secure-isolation,
 #           corrupt marks fail-closed, marked ids skipped on ingest
 
+bun test tests/integrations/ccs-align-rules-walker.test.ts
+# Phase 2: SHADOW_HOUSE detection (exact dup + "House rule" prefix), default report-only
+#           (leaf unchanged), patchShadows=true (leaf loses duplicates, house unchanged),
+#           never patches standing/always/never, MISS on absent paths, CLOCK_HEADER detection,
+#           DENY_ALLOW detection, DRIFT detection, append-only report, atomic patch,
+#           full walkRules integration, edge cases
+
 # #3931 must not regress — LFG/Orifice still get [awareness] lines from the worker pusher, not Align
 bun test tests/integrations/grok-bot-awareness-pusher.test.ts
 ```
 
-Verification greps (plan §1.3):
+Verification greps (plan §2.3):
 
 ```bash
-# No delete-observation in the skill or helper
-rg -n "DELETE /api/observation|handleDeleteObservation" plugin/skills/ccs-align src/services/integrations/CcsAlignMiddleCache.ts
-# expect 0
-
-# Marks file schema present
-rg -n "exclude-marks" plugin/skills/ccs-align/SKILL.md
+# Report path documented
+rg -n "rules-report" plugin/skills/ccs-align/SKILL.md
 # expect ≥1
 
-# get_tool_uses only after get_observations, with layer-4 warning
-rg -n "get_tool_uses" plugin/skills/ccs-align/SKILL.md
-# expect a warning that it is layer 4 / mark-time only
+# Patch gated
+rg -n "CCS_ALIGN_PATCH_SHADOWS" plugin/skills/ccs-align/SKILL.md
+# expect ≥1
 ```
 
 Live-box checks (house, not CI — a cloud VM may have no live worker; record a MISS if so):

--- a/src/services/integrations/CcsAlignRulesWalker.ts
+++ b/src/services/integrations/CcsAlignRulesWalker.ts
@@ -1,0 +1,697 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, statSync, unlinkSync, writeFileSync } from 'fs';
+import path from 'path';
+import { homedir } from 'os';
+import { SettingsDefaultsManager } from '../../shared/SettingsDefaultsManager.js';
+import { USER_SETTINGS_PATH, DATA_DIR } from '../../shared/paths.js';
+import { logger } from '../../utils/logger.js';
+
+// CCS Align — Phase 2: rules alignment (house → project → seat).
+//
+// A periodic walk over house, project, and seat layers to detect conflicts and
+// priority drift. Output is an append-only `rules-report.md`. Limited patch
+// agency on SHADOW_HOUSE only, gated by CLAUDE_MEM_CCS_ALIGN_PATCH_SHADOWS.
+//
+// This is a CHECKLIST, not a parser. Fail closed; deny beats allow; write-once
+// at HOUSE; leaf copy shadows. The .cas compiler is NOT shipped here.
+//
+// Cascade rules (from Notion CCS, plan §2.1):
+//   - Write once at HOUSE; seats inherit
+//   - A leaf copy SHADOWS the cascade (bug, not feature)
+//   - Deny beats allow
+//   - Siblings deny heavy buckets (obs, note, person) by default
+//
+// Hard constraints:
+//   - Never write profile.md, user-memory, or project memory
+//   - Never patch standing / Focus / always.md / never.md
+//   - Never "fix" deny/allow by flipping rules
+//   - Never copy house text into seats (that is the bug)
+//   - On a box with no agent-data tree: report MISS and exit 0
+
+const CCS_ALIGN_DIRNAME = 'ccs-align';
+const RULES_REPORT_FILENAME = 'rules-report.md';
+
+// Conflict class codes (v1 only — do not invent more)
+export type ConflictCode = 'SHADOW_HOUSE' | 'DENY_ALLOW' | 'DRIFT' | 'CLOCK_HEADER';
+
+export interface RulesConflict {
+  code: ConflictCode;
+  layer: 'house' | 'project' | 'seat';
+  file: string;
+  line: string;
+  detail: string;
+  /** The matching house line, if applicable. */
+  houseMatch?: string;
+}
+
+export interface LayerEntry {
+  layer: 'house' | 'project' | 'seat';
+  file: string;
+  lines: string[];
+  /** True if the file was found; false for a MISS. */
+  found: boolean;
+}
+
+export interface RulesWalkResult {
+  conflicts: RulesConflict[];
+  layers: LayerEntry[];
+  misses: string[];
+  reportPath: string;
+  patchesApplied: number;
+}
+
+export interface RulesWalkerConfig {
+  dataRoot: string;
+  viewerId: string;
+  patchShadows: boolean;
+  /** House-layer paths to check (user-memory shared profile, etc.). */
+  housePaths: string[];
+  /** Project-layer paths (.cmem-projects/<project>/, repo CLAUDE.md). */
+  projectPaths: string[];
+  /** Seat-layer paths (agents/<uuid>/profile.md, agents/<uuid>/memory/). */
+  seatPaths: string[];
+}
+
+// Forbidden patch targets: standing, Focus, always/never/danger files.
+const FORBIDDEN_PATCH_BASENAMES = new Set([
+  'standing.md',
+  'always.md',
+  'never.md',
+  'danger.md',
+]);
+
+const FORBIDDEN_PATCH_PATH_PATTERNS = [
+  /standing/i,
+  /(^|[\\/])focus([\\/]|$)/i,
+];
+
+function splitCsv(value: string | undefined): string[] {
+  if (!value) return [];
+  return value.split(',').map(s => s.trim()).filter(s => s.length > 0);
+}
+
+export function loadRulesWalkerConfig(
+  settingsPath: string = USER_SETTINGS_PATH,
+  env: NodeJS.ProcessEnv = process.env,
+): RulesWalkerConfig {
+  const settings = SettingsDefaultsManager.loadFromFile(settingsPath);
+  const dataRoot = env.CLAUDE_MEM_DATA_DIR
+    ? env.CLAUDE_MEM_DATA_DIR
+    : (settings.CLAUDE_MEM_DATA_DIR || path.join(homedir(), '.claude-mem'));
+
+  const patchShadows = (
+    env.CLAUDE_MEM_CCS_ALIGN_PATCH_SHADOWS ??
+    settings.CLAUDE_MEM_CCS_ALIGN_PATCH_SHADOWS ??
+    'false'
+  ) === 'true';
+
+  const viewerIds = splitCsv(settings.CLAUDE_MEM_CCS_ALIGN_VIEWER_IDS);
+  const viewerId = viewerIds[0] || 'ccs-align';
+
+  return {
+    dataRoot,
+    viewerId,
+    patchShadows,
+    housePaths: [],
+    projectPaths: [],
+    seatPaths: [],
+  };
+}
+
+export function rulesReportPath(dataRoot: string, viewerId: string): string {
+  return path.join(dataRoot, CCS_ALIGN_DIRNAME, viewerId, RULES_REPORT_FILENAME);
+}
+
+/**
+ * Read all non-empty trimmed lines from a file. Returns empty array if the
+ * file does not exist or cannot be read.
+ */
+export function readFileLines(filePath: string): string[] {
+  try {
+    if (!existsSync(filePath)) return [];
+    return readFileSync(filePath, 'utf8')
+      .split('\n')
+      .map(l => l.trimEnd())
+      .filter(l => l.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Collect all readable files under a directory, recursively. Returns absolute
+ * paths. Silently returns empty if the dir is missing.
+ */
+function collectFiles(dirPath: string): string[] {
+  const result: string[] = [];
+  if (!existsSync(dirPath)) return result;
+  try {
+    const entries = readdirSync(dirPath, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        result.push(...collectFiles(full));
+      } else if (entry.isFile()) {
+        result.push(full);
+      }
+    }
+  } catch { /* unreadable dir */ }
+  return result;
+}
+
+/**
+ * Detect CLOCK_HEADER: a top-of-prompt clock or "current time is" line in a
+ * profile. House rule says timestamps belong on facts, not as a header.
+ */
+export function detectClockHeader(line: string): boolean {
+  const lower = line.toLowerCase();
+  const trimmed = line.trim();
+  return (
+    /^(#\s*)?current (time|date|datetime)\b/i.test(trimmed) ||
+    lower.includes('current time is') ||
+    lower.includes('current date is') ||
+    /^(#\s*)?(today|now)\s*(is\s*:|:\s*)\s*\d{4}/i.test(trimmed)
+  );
+}
+
+/**
+ * Detect whether a leaf line shadows a house line (SHADOW_HOUSE).
+ * A match is: exact duplicate, or the leaf line starts with "House rule".
+ */
+export function detectShadowHouse(
+  leafLine: string,
+  houseLines: Set<string>,
+): { isShadow: boolean; matchedHouseLine?: string } {
+  const trimmed = leafLine.trim();
+  if (houseLines.has(trimmed)) {
+    return { isShadow: true, matchedHouseLine: trimmed };
+  }
+  if (/^House rule\b/i.test(trimmed)) {
+    for (const houseLine of houseLines) {
+      if (trimmed.includes(houseLine) || houseLine.includes(trimmed.replace(/^House rule[:\s]*/i, '').trim())) {
+        return { isShadow: true, matchedHouseLine: houseLine };
+      }
+    }
+    return { isShadow: true, matchedHouseLine: undefined };
+  }
+  return { isShadow: false };
+}
+
+/**
+ * Detect DENY_ALLOW: same bucket allow at one layer, deny at another.
+ * Looks for lines containing "allow" or "deny" that reference similar buckets.
+ */
+export function detectDenyAllow(
+  line: string,
+  otherLayerLines: string[],
+): { isDenyAllow: boolean; detail: string } {
+  const lower = line.toLowerCase().trim();
+  const hasDeny = /\bdeny\b/.test(lower);
+  const hasAllow = /\ballow\b/.test(lower);
+  if (!hasDeny && !hasAllow) return { isDenyAllow: false, detail: '' };
+
+  for (const other of otherLayerLines) {
+    const otherLower = other.toLowerCase().trim();
+    const otherHasDeny = /\bdeny\b/.test(otherLower);
+    const otherHasAllow = /\ballow\b/.test(otherLower);
+    if ((hasDeny && otherHasAllow) || (hasAllow && otherHasDeny)) {
+      return {
+        isDenyAllow: true,
+        detail: `Line "${line.trim()}" conflicts with "${other.trim()}" — deny/allow on same bucket`,
+      };
+    }
+  }
+  return { isDenyAllow: false, detail: '' };
+}
+
+/**
+ * Detect DRIFT: house text changed; leaf still has old wording. We detect this
+ * by checking if a leaf line is "close but not exact" to a house line — shares
+ * a significant prefix but differs.
+ */
+export function detectDrift(
+  leafLine: string,
+  houseLines: string[],
+  threshold: number = 0.7,
+): { isDrift: boolean; matchedHouseLine?: string } {
+  const trimmed = leafLine.trim();
+  if (trimmed.length < 10) return { isDrift: false };
+  for (const houseLine of houseLines) {
+    const hTrimmed = houseLine.trim();
+    if (hTrimmed === trimmed) continue; // exact match is SHADOW_HOUSE, not DRIFT
+    if (hTrimmed.length < 10) continue;
+
+    const shorter = Math.min(trimmed.length, hTrimmed.length);
+    let common = 0;
+    for (let i = 0; i < shorter; i++) {
+      if (trimmed[i] === hTrimmed[i]) common++;
+      else break;
+    }
+    if (common / shorter >= threshold) {
+      return { isDrift: true, matchedHouseLine: hTrimmed };
+    }
+  }
+  return { isDrift: false };
+}
+
+/**
+ * Check whether a file path is safe to patch (SHADOW_HOUSE removal only).
+ * Never patch standing, Focus, always.md, never.md, danger.md, or profile.md.
+ */
+export function isSafePatchTarget(filePath: string): boolean {
+  const basename = path.basename(filePath);
+  if (FORBIDDEN_PATCH_BASENAMES.has(basename)) return false;
+  if (basename === 'profile.md') return false;
+  for (const pattern of FORBIDDEN_PATCH_PATH_PATTERNS) {
+    if (pattern.test(filePath)) return false;
+  }
+  return true;
+}
+
+/**
+ * Apply SHADOW_HOUSE patch: remove duplicate lines from a leaf file.
+ * Uses atomic temp+rename. Returns the number of lines removed.
+ * Never patches standing / Focus / always / never files.
+ */
+export function applyShadowPatch(
+  leafFilePath: string,
+  linesToRemove: Set<string>,
+): number {
+  if (!isSafePatchTarget(leafFilePath)) {
+    logger.warn('AWARENESS', 'CCS Align refusing shadow patch on forbidden target', {
+      path: leafFilePath,
+    });
+    return 0;
+  }
+
+  if (!existsSync(leafFilePath)) return 0;
+
+  const original = readFileSync(leafFilePath, 'utf8');
+  const originalLines = original.split('\n');
+  let removed = 0;
+
+  const patchedLines: string[] = [];
+  for (const line of originalLines) {
+    if (linesToRemove.has(line.trim()) && line.trim().length > 0) {
+      removed++;
+    } else {
+      patchedLines.push(line);
+    }
+  }
+
+  if (removed === 0) return 0;
+
+  const patched = patchedLines.join('\n');
+  const tmpPath = `${leafFilePath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    writeFileSync(tmpPath, patched, 'utf8');
+    renameSync(tmpPath, leafFilePath);
+  } catch (error) {
+    try { unlinkSync(tmpPath); } catch { /* ignore cleanup */ }
+    throw error;
+  }
+  return removed;
+}
+
+/**
+ * Format a dated section for the append-only rules report.
+ */
+export function formatReportSection(
+  now: Date,
+  conflicts: RulesConflict[],
+  misses: string[],
+  patchesApplied: number,
+): string {
+  const date = now.toISOString().slice(0, 19).replace('T', ' ');
+  const lines: string[] = [];
+  lines.push(`## ${date} — CCS Align Phase 2 rules walk`);
+  lines.push('');
+
+  if (misses.length > 0) {
+    for (const miss of misses) {
+      lines.push(`MISS: ${miss}`);
+    }
+    lines.push('');
+  }
+
+  if (conflicts.length === 0 && misses.length === 0) {
+    lines.push('No conflicts detected. All layers walked clean.');
+    lines.push('');
+    return lines.join('\n');
+  }
+
+  if (conflicts.length > 0) {
+    lines.push(`| Code | Layer | File | Detail |`);
+    lines.push(`|------|-------|------|--------|`);
+    for (const c of conflicts) {
+      const shortFile = c.file.length > 60 ? `…${c.file.slice(-57)}` : c.file;
+      const escapedDetail = c.detail.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+      lines.push(`| ${c.code} | ${c.layer} | ${shortFile} | ${escapedDetail} |`);
+    }
+    lines.push('');
+  }
+
+  if (patchesApplied > 0) {
+    lines.push(`Patches applied: ${patchesApplied} SHADOW_HOUSE lines removed from leaf files.`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Write (append) a report section to the rules-report.md file.
+ * Uses atomic temp+rename for the full file (append-only sections).
+ */
+export function appendRulesReport(reportPath: string, section: string): void {
+  const dir = path.dirname(reportPath);
+  mkdirSync(dir, { recursive: true });
+
+  let existing = '';
+  if (existsSync(reportPath)) {
+    existing = readFileSync(reportPath, 'utf8');
+  }
+
+  if (existing.length === 0) {
+    existing = '# CCS Align — Rules Report\n\nAppend-only. Status rolls up to Prioritizer.\n\n';
+  }
+
+  const next = existing.endsWith('\n')
+    ? `${existing}${section}\n`
+    : `${existing}\n${section}\n`;
+
+  const tmpPath = `${reportPath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    writeFileSync(tmpPath, next, 'utf8');
+    renameSync(tmpPath, reportPath);
+  } catch (error) {
+    try { unlinkSync(tmpPath); } catch { /* ignore cleanup */ }
+    throw error;
+  }
+}
+
+/**
+ * Gather all files from layer paths, reading lines from each found file and
+ * recording misses for absent paths.
+ */
+export function gatherLayerEntries(
+  layerPaths: string[],
+  layer: 'house' | 'project' | 'seat',
+): { entries: LayerEntry[]; misses: string[] } {
+  const entries: LayerEntry[] = [];
+  const misses: string[] = [];
+
+  for (const p of layerPaths) {
+    if (!existsSync(p)) {
+      misses.push(`${layer} — ${p}`);
+      continue;
+    }
+
+    try {
+      const stat = statSync(p);
+      if (stat.isDirectory()) {
+        const files = collectFiles(p);
+        if (files.length === 0) {
+          misses.push(`${layer} — ${p} (empty directory)`);
+        }
+        for (const file of files) {
+          entries.push({
+            layer,
+            file,
+            lines: readFileLines(file),
+            found: true,
+          });
+        }
+      } else {
+        entries.push({
+          layer,
+          file: p,
+          lines: readFileLines(p),
+          found: true,
+        });
+      }
+    } catch {
+      misses.push(`${layer} — ${p} (unreadable)`);
+    }
+  }
+
+  return { entries, misses };
+}
+
+/**
+ * Main rules walk: house → project → seat. Detects conflicts, writes report,
+ * optionally applies SHADOW_HOUSE patches.
+ *
+ * On a box with no agent-data tree: report says "MISS: house-box paths" and
+ * exits cleanly (returns with zero conflicts, non-zero misses).
+ */
+export function walkRules(config: RulesWalkerConfig, now: Date = new Date()): RulesWalkResult {
+  const reportFile = rulesReportPath(config.dataRoot, config.viewerId);
+  const conflicts: RulesConflict[] = [];
+  const allMisses: string[] = [];
+  let patchesApplied = 0;
+
+  // Gather layers
+  const house = gatherLayerEntries(config.housePaths, 'house');
+  const project = gatherLayerEntries(config.projectPaths, 'project');
+  const seat = gatherLayerEntries(config.seatPaths, 'seat');
+
+  allMisses.push(...house.misses, ...project.misses, ...seat.misses);
+
+  // If every layer path is missing, record a top-level miss
+  if (house.entries.length === 0 && project.entries.length === 0 && seat.entries.length === 0) {
+    if (config.housePaths.length > 0 || config.projectPaths.length > 0 || config.seatPaths.length > 0) {
+      allMisses.push('house-box paths');
+    }
+  }
+
+  // Build the consolidated house line set for shadow/drift detection
+  const houseLineSet = new Set<string>();
+  const allHouseLines: string[] = [];
+  for (const entry of house.entries) {
+    for (const line of entry.lines) {
+      const trimmed = line.trim();
+      if (trimmed.length > 0) {
+        houseLineSet.add(trimmed);
+        allHouseLines.push(trimmed);
+      }
+    }
+  }
+
+  // Build all house+project lines for deny/allow cross-layer comparison
+  const houseProjectLines: string[] = [...allHouseLines];
+  for (const entry of project.entries) {
+    for (const line of entry.lines) {
+      const trimmed = line.trim();
+      if (trimmed.length > 0) houseProjectLines.push(trimmed);
+    }
+  }
+
+  const allLayers = [...house.entries, ...project.entries, ...seat.entries];
+
+  // Walk all entries, detecting conflicts
+  for (const entry of allLayers) {
+    for (const line of entry.lines) {
+      // CLOCK_HEADER: any layer
+      if (detectClockHeader(line)) {
+        conflicts.push({
+          code: 'CLOCK_HEADER',
+          layer: entry.layer,
+          file: entry.file,
+          line,
+          detail: 'Top-of-prompt clock or "current time is" in a profile (house rule: no clock in prefix)',
+        });
+      }
+    }
+  }
+
+  // Seat-layer specific conflict detection (against house)
+  const shadowPatchesByFile = new Map<string, Set<string>>();
+
+  for (const entry of seat.entries) {
+    for (const line of entry.lines) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) continue;
+
+      // SHADOW_HOUSE: leaf line also at house (or starts with "House rule")
+      const shadow = detectShadowHouse(trimmed, houseLineSet);
+      if (shadow.isShadow) {
+        conflicts.push({
+          code: 'SHADOW_HOUSE',
+          layer: 'seat',
+          file: entry.file,
+          line: trimmed,
+          detail: shadow.matchedHouseLine
+            ? `Leaf duplicates house line: "${shadow.matchedHouseLine}"`
+            : 'Leaf starts with "House rule" — shadows the cascade',
+          houseMatch: shadow.matchedHouseLine,
+        });
+
+        if (!shadowPatchesByFile.has(entry.file)) {
+          shadowPatchesByFile.set(entry.file, new Set());
+        }
+        shadowPatchesByFile.get(entry.file)!.add(trimmed);
+      }
+
+      // DRIFT: leaf line is close-but-not-exact to a house line
+      if (!shadow.isShadow) {
+        const drift = detectDrift(trimmed, allHouseLines);
+        if (drift.isDrift) {
+          conflicts.push({
+            code: 'DRIFT',
+            layer: 'seat',
+            file: entry.file,
+            line: trimmed,
+            detail: drift.matchedHouseLine
+              ? `House text may have changed; leaf still has old wording. House: "${drift.matchedHouseLine}"`
+              : 'Possible drift from house text',
+          });
+        }
+      }
+
+      // DENY_ALLOW: check seat line against house+project lines
+      const denyAllow = detectDenyAllow(trimmed, houseProjectLines);
+      if (denyAllow.isDenyAllow) {
+        conflicts.push({
+          code: 'DENY_ALLOW',
+          layer: 'seat',
+          file: entry.file,
+          line: trimmed,
+          detail: denyAllow.detail,
+        });
+      }
+    }
+  }
+
+  // Project-layer deny/allow (against house)
+  for (const entry of project.entries) {
+    for (const line of entry.lines) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) continue;
+
+      const denyAllow = detectDenyAllow(trimmed, allHouseLines);
+      if (denyAllow.isDenyAllow) {
+        conflicts.push({
+          code: 'DENY_ALLOW',
+          layer: 'project',
+          file: entry.file,
+          line: trimmed,
+          detail: denyAllow.detail,
+        });
+      }
+    }
+  }
+
+  // Write the would-be diff into the report BEFORE applying any patches
+  const section = formatReportSection(now, conflicts, allMisses, 0);
+
+  // Apply SHADOW_HOUSE patches only if gated on
+  if (config.patchShadows && shadowPatchesByFile.size > 0) {
+    for (const [filePath, linesToRemove] of shadowPatchesByFile) {
+      try {
+        const removed = applyShadowPatch(filePath, linesToRemove);
+        patchesApplied += removed;
+      } catch (error) {
+        logger.warn('AWARENESS', 'CCS Align shadow patch failed', {
+          file: filePath,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    // If patches were applied, re-format the section with the count
+    if (patchesApplied > 0) {
+      const patchedSection = formatReportSection(now, conflicts, allMisses, patchesApplied);
+      try {
+        appendRulesReport(reportFile, patchedSection);
+      } catch (error) {
+        logger.warn('AWARENESS', 'CCS Align rules report write failed', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+
+      return { conflicts, layers: allLayers, misses: allMisses, reportPath: reportFile, patchesApplied };
+    }
+  }
+
+  // Write report (no patches or patches disabled)
+  try {
+    appendRulesReport(reportFile, section);
+  } catch (error) {
+    logger.warn('AWARENESS', 'CCS Align rules report write failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  return { conflicts, layers: allLayers, misses: allMisses, reportPath: reportFile, patchesApplied };
+}
+
+/**
+ * Discover house-box paths that may exist on the current machine.
+ * Returns paths that should be checked — caller passes them as housePaths,
+ * projectPaths, seatPaths.
+ */
+export function discoverLayerPaths(opts: {
+  dataRoot?: string;
+  project?: string;
+  agentIds?: string[];
+} = {}): {
+  housePaths: string[];
+  projectPaths: string[];
+  seatPaths: string[];
+} {
+  const home = homedir();
+  const dataRoot = opts.dataRoot || path.join(home, '.claude-mem');
+
+  const housePaths: string[] = [];
+  const projectPaths: string[] = [];
+  const seatPaths: string[] = [];
+
+  // House: user-memory/ shared profile
+  const userMemory = path.join(home, 'user-memory');
+  housePaths.push(userMemory);
+
+  // House: also check home-based agent data
+  const agentDataRoot = path.join(home, 'agent-data');
+  if (existsSync(agentDataRoot)) {
+    housePaths.push(agentDataRoot);
+  }
+
+  // Project: .cmem-projects/<project>/
+  if (opts.project) {
+    const cmemProjects = path.join(dataRoot, '.cmem-projects', opts.project);
+    projectPaths.push(cmemProjects);
+  }
+
+  // Project: repo CLAUDE.md (workspace root)
+  const workspaceClaude = path.join(process.cwd(), 'CLAUDE.md');
+  projectPaths.push(workspaceClaude);
+
+  // Seat: agents/<uuid>/profile.md, agents/<uuid>/memory/
+  const agentsDir = path.join(agentDataRoot);
+  if (opts.agentIds && opts.agentIds.length > 0 && existsSync(agentsDir)) {
+    for (const agentId of opts.agentIds) {
+      const agentProfile = path.join(agentsDir, 'agents', agentId, 'profile.md');
+      const agentMemory = path.join(agentsDir, 'agents', agentId, 'memory');
+      seatPaths.push(agentProfile);
+      seatPaths.push(agentMemory);
+    }
+  } else {
+    // Discover agent dirs if they exist
+    const agentsRoot = path.join(agentDataRoot, 'agents');
+    if (existsSync(agentsRoot)) {
+      try {
+        const entries = readdirSync(agentsRoot, { withFileTypes: true });
+        for (const entry of entries) {
+          if (entry.isDirectory()) {
+            const agentProfile = path.join(agentsRoot, entry.name, 'profile.md');
+            const agentMemory = path.join(agentsRoot, entry.name, 'memory');
+            seatPaths.push(agentProfile);
+            seatPaths.push(agentMemory);
+          }
+        }
+      } catch { /* unreadable agents dir */ }
+    }
+  }
+
+  return { housePaths, projectPaths, seatPaths };
+}

--- a/tests/integrations/ccs-align-rules-walker.test.ts
+++ b/tests/integrations/ccs-align-rules-walker.test.ts
@@ -1,0 +1,504 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import {
+  applyShadowPatch,
+  appendRulesReport,
+  detectClockHeader,
+  detectDenyAllow,
+  detectDrift,
+  detectShadowHouse,
+  formatReportSection,
+  gatherLayerEntries,
+  isSafePatchTarget,
+  readFileLines,
+  rulesReportPath,
+  walkRules,
+  type RulesConflict,
+  type RulesWalkerConfig,
+} from '../../src/services/integrations/CcsAlignRulesWalker.js';
+
+const VIEWER = 'ccs-align';
+const now = new Date('2026-09-09T18:00:00.000Z');
+
+describe('CCS Align Phase 2 — rules walker', () => {
+  const temps: string[] = [];
+
+  afterEach(() => {
+    for (const dir of temps.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function tempRoot(): string {
+    const dir = mkdtempSync(path.join(tmpdir(), 'ccs-align-rules-'));
+    temps.push(dir);
+    return dir;
+  }
+
+  function writeFile(root: string, relPath: string, content: string): string {
+    const full = path.join(root, relPath);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(full, content, 'utf8');
+    return full;
+  }
+
+  // --- Fixture: duplicated "House rule" → SHADOW_HOUSE in report ---
+
+  it('detects SHADOW_HOUSE when a leaf file duplicates a house line', () => {
+    const root = tempRoot();
+    const housePath = writeFile(root, 'house/profile.txt', [
+      'Always address the human as Alex.',
+      'Never delete observation history.',
+      'Timestamps belong on facts, not headers.',
+    ].join('\n'));
+
+    const seatPath = writeFile(root, 'seat/agent-1/rules.md', [
+      'Always address the human as Alex.',
+      'Some agent-specific rule here.',
+      'Never delete observation history.',
+    ].join('\n'));
+
+    const config: RulesWalkerConfig = {
+      dataRoot: root,
+      viewerId: VIEWER,
+      patchShadows: false,
+      housePaths: [housePath],
+      projectPaths: [],
+      seatPaths: [seatPath],
+    };
+
+    const result = walkRules(config, now);
+    const shadows = result.conflicts.filter(c => c.code === 'SHADOW_HOUSE');
+    expect(shadows.length).toBeGreaterThanOrEqual(2);
+    expect(shadows.some(c => c.line.includes('Always address the human as Alex.'))).toBe(true);
+    expect(shadows.some(c => c.line.includes('Never delete observation history.'))).toBe(true);
+  });
+
+  it('detects SHADOW_HOUSE when a leaf line starts with "House rule"', () => {
+    const root = tempRoot();
+    const housePath = writeFile(root, 'house/shared.md', 'Do not write profile.md from Align.');
+
+    const seatPath = writeFile(root, 'seat/agent-1/config.md', [
+      'House rule: do not write profile.md from Align.',
+      'Another local rule.',
+    ].join('\n'));
+
+    const config: RulesWalkerConfig = {
+      dataRoot: root,
+      viewerId: VIEWER,
+      patchShadows: false,
+      housePaths: [housePath],
+      projectPaths: [],
+      seatPaths: [seatPath],
+    };
+
+    const result = walkRules(config, now);
+    const shadows = result.conflicts.filter(c => c.code === 'SHADOW_HOUSE');
+    expect(shadows.length).toBeGreaterThanOrEqual(1);
+    expect(shadows[0].line).toContain('House rule');
+  });
+
+  // --- Default settings leave leaf unchanged ---
+
+  it('default settings (patchShadows=false) leave the leaf file unchanged', () => {
+    const root = tempRoot();
+    const housePath = writeFile(root, 'house/rules.md', 'Never delete observation history.');
+
+    const seatContent = 'Never delete observation history.\nSome other rule.';
+    const seatPath = writeFile(root, 'seat/agent-1/rules.md', seatContent);
+
+    const config: RulesWalkerConfig = {
+      dataRoot: root,
+      viewerId: VIEWER,
+      patchShadows: false,
+      housePaths: [housePath],
+      projectPaths: [],
+      seatPaths: [seatPath],
+    };
+
+    const result = walkRules(config, now);
+    expect(result.patchesApplied).toBe(0);
+
+    const afterContent = readFileSync(seatPath, 'utf8');
+    expect(afterContent).toBe(seatContent);
+  });
+
+  // --- With patch flag on, leaf loses only duplicates; house unchanged ---
+
+  it('with patchShadows=true, leaf loses only duplicate lines and house is unchanged', () => {
+    const root = tempRoot();
+    const houseContent = 'Always address the human as Alex.\nNever delete observation history.';
+    const housePath = writeFile(root, 'house/rules.md', houseContent);
+
+    const seatContent = [
+      'Always address the human as Alex.',
+      'Some agent-specific rule.',
+      'Never delete observation history.',
+      'Another agent rule.',
+    ].join('\n');
+    const seatPath = writeFile(root, 'seat/agent-1/rules.md', seatContent);
+
+    const config: RulesWalkerConfig = {
+      dataRoot: root,
+      viewerId: VIEWER,
+      patchShadows: true,
+      housePaths: [housePath],
+      projectPaths: [],
+      seatPaths: [seatPath],
+    };
+
+    const result = walkRules(config, now);
+    expect(result.patchesApplied).toBe(2);
+
+    const patchedContent = readFileSync(seatPath, 'utf8');
+    expect(patchedContent).not.toContain('Always address the human as Alex.');
+    expect(patchedContent).not.toContain('Never delete observation history.');
+    expect(patchedContent).toContain('Some agent-specific rule.');
+    expect(patchedContent).toContain('Another agent rule.');
+
+    const houseAfter = readFileSync(housePath, 'utf8');
+    expect(houseAfter).toBe(houseContent);
+  });
+
+  // --- No write to standing / always.md / never.md ---
+
+  it('never patches standing, always.md, or never.md even when patchShadows=true', () => {
+    const root = tempRoot();
+    const housePath = writeFile(root, 'house/rules.md', 'House shared rule.');
+
+    const standingContent = 'House shared rule.\nStanding order.';
+    const standingPath = writeFile(root, 'seat/standing.md', standingContent);
+    const alwaysContent = 'House shared rule.\nAlways do X.';
+    const alwaysPath = writeFile(root, 'seat/always.md', alwaysContent);
+    const neverContent = 'House shared rule.\nNever do Y.';
+    const neverPath = writeFile(root, 'seat/never.md', neverContent);
+
+    const config: RulesWalkerConfig = {
+      dataRoot: root,
+      viewerId: VIEWER,
+      patchShadows: true,
+      housePaths: [housePath],
+      projectPaths: [],
+      seatPaths: [standingPath, alwaysPath, neverPath],
+    };
+
+    walkRules(config, now);
+
+    expect(readFileSync(standingPath, 'utf8')).toBe(standingContent);
+    expect(readFileSync(alwaysPath, 'utf8')).toBe(alwaysContent);
+    expect(readFileSync(neverPath, 'utf8')).toBe(neverContent);
+  });
+
+  // --- MISS on box with no agent-data tree ---
+
+  it('on a box with no agent-data tree, report says MISS and exits 0', () => {
+    const root = tempRoot();
+    const config: RulesWalkerConfig = {
+      dataRoot: root,
+      viewerId: VIEWER,
+      patchShadows: false,
+      housePaths: [path.join(root, 'nonexistent', 'house')],
+      projectPaths: [path.join(root, 'nonexistent', 'project')],
+      seatPaths: [path.join(root, 'nonexistent', 'seat')],
+    };
+
+    const result = walkRules(config, now);
+    expect(result.conflicts).toHaveLength(0);
+    expect(result.misses.length).toBeGreaterThan(0);
+    expect(result.misses.some(m => m.includes('house-box paths'))).toBe(true);
+
+    const reportContent = readFileSync(result.reportPath, 'utf8');
+    expect(reportContent).toContain('MISS');
+  });
+
+  // --- CLOCK_HEADER detection ---
+
+  it('detects CLOCK_HEADER in profile files', () => {
+    expect(detectClockHeader('# Current time is 2026-09-09T18:00:00Z')).toBe(true);
+    expect(detectClockHeader('Current date is 2026-09-09')).toBe(true);
+    expect(detectClockHeader('Today is: 2026-09-09')).toBe(true);
+    expect(detectClockHeader('current time is now')).toBe(true);
+    expect(detectClockHeader('Some normal rule about time management')).toBe(false);
+    expect(detectClockHeader('Remember to check the time')).toBe(false);
+  });
+
+  it('reports CLOCK_HEADER conflicts from walkRules', () => {
+    const root = tempRoot();
+    const seatPath = writeFile(root, 'seat/agent-1/profile.md', [
+      '# Current time is 2026-09-09T18:00:00Z',
+      'Some other rule.',
+    ].join('\n'));
+
+    const config: RulesWalkerConfig = {
+      dataRoot: root,
+      viewerId: VIEWER,
+      patchShadows: false,
+      housePaths: [],
+      projectPaths: [],
+      seatPaths: [seatPath],
+    };
+
+    const result = walkRules(config, now);
+    const clockHeaders = result.conflicts.filter(c => c.code === 'CLOCK_HEADER');
+    expect(clockHeaders.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // --- DENY_ALLOW detection ---
+
+  it('detects DENY_ALLOW when same bucket has allow at one layer and deny at another', () => {
+    const result = detectDenyAllow('allow reading obs bucket', [
+      'deny reading obs bucket',
+      'some unrelated rule',
+    ]);
+    expect(result.isDenyAllow).toBe(true);
+    expect(result.detail).toContain('deny/allow');
+  });
+
+  it('does not flag DENY_ALLOW when no conflict exists', () => {
+    const result = detectDenyAllow('some rule about foo', ['another rule about bar']);
+    expect(result.isDenyAllow).toBe(false);
+  });
+
+  // --- DRIFT detection ---
+
+  it('detects DRIFT when leaf has old wording that partially matches house', () => {
+    const result = detectDrift(
+      'Always address the human as Alexander.',
+      ['Always address the human as Alex.'],
+      0.7,
+    );
+    expect(result.isDrift).toBe(true);
+    expect(result.matchedHouseLine).toBe('Always address the human as Alex.');
+  });
+
+  it('does not flag DRIFT on exact matches (those are SHADOW_HOUSE)', () => {
+    const result = detectDrift(
+      'Always address the human as Alex.',
+      ['Always address the human as Alex.'],
+      0.7,
+    );
+    expect(result.isDrift).toBe(false);
+  });
+
+  // --- Report generation ---
+
+  it('generates a dated, append-only rules report', () => {
+    const root = tempRoot();
+    const reportFile = rulesReportPath(root, VIEWER);
+    const conflicts: RulesConflict[] = [
+      {
+        code: 'SHADOW_HOUSE',
+        layer: 'seat',
+        file: '/some/path/rules.md',
+        line: 'Always address the human as Alex.',
+        detail: 'Leaf duplicates house line: "Always address the human as Alex."',
+      },
+    ];
+
+    appendRulesReport(reportFile, formatReportSection(now, conflicts, [], 0));
+    const content = readFileSync(reportFile, 'utf8');
+    expect(content).toContain('CCS Align — Rules Report');
+    expect(content).toContain('2026-09-09 18:00:00');
+    expect(content).toContain('SHADOW_HOUSE');
+    expect(content).toContain('Prioritizer');
+
+    // Append a second section — the file should grow, not overwrite
+    const later = new Date('2026-09-10T06:00:00.000Z');
+    appendRulesReport(reportFile, formatReportSection(later, [], ['house-box paths'], 0));
+    const content2 = readFileSync(reportFile, 'utf8');
+    expect(content2).toContain('2026-09-09 18:00:00');
+    expect(content2).toContain('2026-09-10 06:00:00');
+    expect(content2).toContain('MISS: house-box paths');
+  });
+
+  // --- isSafePatchTarget ---
+
+  it('refuses to patch standing.md, always.md, never.md, danger.md, and profile.md', () => {
+    expect(isSafePatchTarget('/foo/standing.md')).toBe(false);
+    expect(isSafePatchTarget('/foo/always.md')).toBe(false);
+    expect(isSafePatchTarget('/foo/never.md')).toBe(false);
+    expect(isSafePatchTarget('/foo/danger.md')).toBe(false);
+    expect(isSafePatchTarget('/foo/profile.md')).toBe(false);
+    expect(isSafePatchTarget('/foo/focus/bar.md')).toBe(false);
+    expect(isSafePatchTarget('/foo/rules.md')).toBe(true);
+    expect(isSafePatchTarget('/foo/config.md')).toBe(true);
+  });
+
+  // --- applyShadowPatch ---
+
+  it('removes only specified duplicate lines from a leaf file atomically', () => {
+    const root = tempRoot();
+    const content = 'Line A\nLine B\nLine C\nLine D\n';
+    const filePath = writeFile(root, 'leaf.md', content);
+
+    const removed = applyShadowPatch(filePath, new Set(['Line B', 'Line D']));
+    expect(removed).toBe(2);
+
+    const result = readFileSync(filePath, 'utf8');
+    expect(result).toContain('Line A');
+    expect(result).toContain('Line C');
+    expect(result).not.toContain('Line B');
+    expect(result).not.toContain('Line D');
+  });
+
+  it('returns 0 and does not touch the file when no lines match', () => {
+    const root = tempRoot();
+    const content = 'Line A\nLine B\n';
+    const filePath = writeFile(root, 'leaf.md', content);
+
+    const removed = applyShadowPatch(filePath, new Set(['Line X']));
+    expect(removed).toBe(0);
+    expect(readFileSync(filePath, 'utf8')).toBe(content);
+  });
+
+  // --- readFileLines ---
+
+  it('reads non-empty trimmed lines from a file', () => {
+    const root = tempRoot();
+    const filePath = writeFile(root, 'test.txt', 'Line 1\n\n  Line 2  \nLine 3\n');
+    const lines = readFileLines(filePath);
+    expect(lines).toEqual(['Line 1', '  Line 2', 'Line 3']);
+  });
+
+  it('returns empty array for missing files', () => {
+    expect(readFileLines('/nonexistent/path')).toEqual([]);
+  });
+
+  // --- gatherLayerEntries ---
+
+  it('gathers files from a directory recursively and records misses', () => {
+    const root = tempRoot();
+    writeFile(root, 'layer/a.md', 'rule A');
+    writeFile(root, 'layer/sub/b.md', 'rule B');
+
+    const { entries, misses } = gatherLayerEntries([path.join(root, 'layer')], 'house');
+    expect(entries).toHaveLength(2);
+    expect(entries.every(e => e.found)).toBe(true);
+    expect(misses).toHaveLength(0);
+  });
+
+  it('records misses for non-existent paths', () => {
+    const { entries, misses } = gatherLayerEntries(['/nonexistent/path'], 'house');
+    expect(entries).toHaveLength(0);
+    expect(misses).toHaveLength(1);
+    expect(misses[0]).toContain('house');
+  });
+
+  // --- detectShadowHouse ---
+
+  it('detects exact duplicate lines as SHADOW_HOUSE', () => {
+    const houseLines = new Set(['Always be kind.', 'Never lie.']);
+    expect(detectShadowHouse('Always be kind.', houseLines).isShadow).toBe(true);
+    expect(detectShadowHouse('Something else.', houseLines).isShadow).toBe(false);
+  });
+
+  it('detects "House rule:" prefix as SHADOW_HOUSE', () => {
+    const houseLines = new Set(['Never lie.']);
+    const result = detectShadowHouse('House rule: Never lie.', houseLines);
+    expect(result.isShadow).toBe(true);
+  });
+
+  // --- Full integration: walkRules end-to-end ---
+
+  it('walkRules produces a complete report with all conflict types', () => {
+    const root = tempRoot();
+    const housePath = writeFile(root, 'house/shared.md', [
+      'Always address the human as Alex.',
+      'allow reading profile bucket',
+    ].join('\n'));
+
+    const seatPath = writeFile(root, 'seat/agent/rules.md', [
+      'Always address the human as Alex.',
+      'House rule: some old copy',
+      '# Current time is 2026-01-01',
+      'deny reading profile bucket',
+    ].join('\n'));
+
+    const config: RulesWalkerConfig = {
+      dataRoot: root,
+      viewerId: VIEWER,
+      patchShadows: false,
+      housePaths: [housePath],
+      projectPaths: [],
+      seatPaths: [seatPath],
+    };
+
+    const result = walkRules(config, now);
+    const codes = result.conflicts.map(c => c.code);
+    expect(codes).toContain('SHADOW_HOUSE');
+    expect(codes).toContain('CLOCK_HEADER');
+    expect(codes).toContain('DENY_ALLOW');
+
+    expect(existsSync(result.reportPath)).toBe(true);
+    const report = readFileSync(result.reportPath, 'utf8');
+    expect(report).toContain('SHADOW_HOUSE');
+    expect(report).toContain('CLOCK_HEADER');
+    expect(report).toContain('DENY_ALLOW');
+  });
+
+  it('walkRules with patchShadows writes diff into report then patches', () => {
+    const root = tempRoot();
+    const housePath = writeFile(root, 'house/rules.md', 'Shared house rule.');
+    const seatContent = 'Shared house rule.\nLocal seat rule.';
+    const seatPath = writeFile(root, 'seat/agent/rules.md', seatContent);
+
+    const config: RulesWalkerConfig = {
+      dataRoot: root,
+      viewerId: VIEWER,
+      patchShadows: true,
+      housePaths: [housePath],
+      projectPaths: [],
+      seatPaths: [seatPath],
+    };
+
+    const result = walkRules(config, now);
+    expect(result.patchesApplied).toBe(1);
+
+    const patched = readFileSync(seatPath, 'utf8');
+    expect(patched).not.toContain('Shared house rule.');
+    expect(patched).toContain('Local seat rule.');
+
+    const report = readFileSync(result.reportPath, 'utf8');
+    expect(report).toContain('SHADOW_HOUSE');
+    expect(report).toContain('Patches applied: 1');
+  });
+
+  // --- Edge cases ---
+
+  it('handles empty layer paths gracefully', () => {
+    const root = tempRoot();
+    const config: RulesWalkerConfig = {
+      dataRoot: root,
+      viewerId: VIEWER,
+      patchShadows: false,
+      housePaths: [],
+      projectPaths: [],
+      seatPaths: [],
+    };
+
+    const result = walkRules(config, now);
+    expect(result.conflicts).toHaveLength(0);
+    expect(result.misses).toHaveLength(0);
+    expect(existsSync(result.reportPath)).toBe(true);
+  });
+
+  it('handles files with only empty lines', () => {
+    const root = tempRoot();
+    const housePath = writeFile(root, 'house/empty.md', '\n\n\n');
+    const seatPath = writeFile(root, 'seat/empty.md', '\n\n\n');
+
+    const config: RulesWalkerConfig = {
+      dataRoot: root,
+      viewerId: VIEWER,
+      patchShadows: false,
+      housePaths: [housePath],
+      projectPaths: [],
+      seatPaths: [seatPath],
+    };
+
+    const result = walkRules(config, now);
+    expect(result.conflicts).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

CCS Align Phase 2: a periodic rules walk over house → project → seat layers that detects conflicts and priority drift, emits an append-only `rules-report.md`, and optionally applies limited SHADOW_HOUSE leaf patches — gated by `CLAUDE_MEM_CCS_ALIGN_PATCH_SHADOWS=true` (default off, report-only).

Implements `plans/2026-09-09-ccs-align.md` §2.1–2.3. Phase 0 (#3934) and Phase 1 (#3935) are already on main.

## Why

Memory dig findings revealed that house rules copied into leaf profiles shadow the cascade (the CCC leak). Align's job is a periodic conflict/priority-drift report, plus limited agency on one known pattern (SHADOW_HOUSE). This is a checklist, not a parser — no `.cas` compiler.

## What changed

### New: `src/services/integrations/CcsAlignRulesWalker.ts`
- Cascade rules checklist: fail closed, deny beats allow, write-once at HOUSE, leaf copy shadows
- Layer walk: house (user-memory, shared profile) → project (.cmem-projects, repo CLAUDE.md) → seat (agents/*/profile.md, agents/*/memory/) with MISS recording
- Four conflict classes (v1 only):
  - `SHADOW_HOUSE`: leaf line also at house or starts with "House rule"
  - `DENY_ALLOW`: same bucket allow at one layer, deny at another
  - `DRIFT`: house text changed; leaf still has old wording (prefix match)
  - `CLOCK_HEADER`: top-of-prompt clock / "current time is" in a profile
- Append-only `rules-report.md` output (`~/.claude-mem/ccs-align/<viewerId>/rules-report.md`)
- SHADOW_HOUSE patch: gated by `CLAUDE_MEM_CCS_ALIGN_PATCH_SHADOWS`, atomic temp+rename, forbidden-target guards (standing, Focus, always/never/danger/profile.md)
- `discoverLayerPaths()` for discovering house-box paths at runtime
- On a box with no agent-data tree: records `MISS: house-box paths` and exits 0

### Updated: `plugin/skills/ccs-align/SKILL.md`
- Phase 2 documentation: cascade rules, layer walk table, conflict classes table, rules-report path, limited patch docs, programmatic usage
- Updated description, "What is implemented", hourly cycle step 9, hard forbids, verification section
- Cadence: Phase 2 runs every 6th hour of the hourly Worker Watch cycle (D4)

### New: `tests/integrations/ccs-align-rules-walker.test.ts`
- 26 tests covering all plan §2.3 verification criteria:
  - Fixture with duplicated "House rule" → SHADOW_HOUSE in report
  - Default settings leave leaf unchanged
  - With patch flag on: leaf loses only duplicates; house unchanged
  - No write to standing / always.md / never.md
  - MISS on box with no agent-data tree
  - CLOCK_HEADER, DENY_ALLOW, DRIFT detection
  - Append-only report, atomic patch, integration, edge cases

### Version bump: 13.24.3 → 13.24.4 (PATCH, D10)

## Hard constraints honored
- ✅ NO attention trough / curse-salience
- ✅ NO Focus / mouth / standing enforcement
- ✅ NO .cas compiler
- ✅ NO profile.md writes from Align
- ✅ NO DELETE /api/observation
- ✅ NO CHANGELOG.md edit
- ✅ Default is report-only; patch gated by `CLAUDE_MEM_CCS_ALIGN_PATCH_SHADOWS`
- ✅ Deny/allow conflicts are reported, never "fixed" by flipping rules
- ✅ House text is never copied into seats

## Verification

```bash
bun test tests/integrations/ccs-align-rules-walker.test.ts  # 26 pass
bun test tests/integrations/ccs-align-middle-cache.test.ts   # 21 pass (no regression)
```

Plan §2.3 greps:
```bash
rg -n "rules-report" plugin/skills/ccs-align/SKILL.md       # ≥1 ✓
rg -n "CCS_ALIGN_PATCH_SHADOWS" plugin/skills/ccs-align/SKILL.md  # ≥1 ✓
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50086b60-1f52-4d5a-a93f-bee14e65308f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50086b60-1f52-4d5a-a93f-bee14e65308f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

