### PR TITLE
CCS Align Phase 3 — final verification / sign-off

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "claude-mem",
-      "version": "13.24.4",
+      "version": "13.24.5",
       "source": "./plugin",
       "description": "Persistent memory system for Claude Code - context compression across sessions"
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.24.4",
+  "version": "13.24.5",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "author": {
     "name": "Alex Newman"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.24.4",
+  "version": "13.24.5",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "author": {
     "name": "Alex Newman",

--- a/claude-mem-cursor/.cursor-plugin/plugin.json
+++ b/claude-mem-cursor/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem-cursor",
-  "version": "13.24.4",
+  "version": "13.24.5",
   "description": "Persistent memory for Cursor. Hooks ingest tool use; MCP searches past sessions. Works with a local worker or a remote cmem.ai worker, and a local host-login observer or remote inference.",
   "author": {
     "name": "Alex Newman"

--- a/claude-mem-grok-bot/.cursor-plugin/plugin.json
+++ b/claude-mem-grok-bot/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem-grok-bot",
-  "version": "13.24.4",
+  "version": "13.24.5",
   "description": "Persistent memory for Grok Bot. No host hooks: transcript watcher plus MCP. Local worker with host-login observer, or remote cmem.ai. Install without Cursor.",
   "author": {
     "name": "Alex Newman"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.24.4",
+  "version": "13.24.5",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "keywords": [
     "claude",

--- a/plans/2026-09-09-ccs-align.md
+++ b/plans/2026-09-09-ccs-align.md
@@ -1,7 +1,9 @@
 # CCS Align — standing-seat plan of record
 
 **Date:** 2026-09-09
-**Status:** PLAN ONLY — awaiting Prioritizer PASS before `/do`. Not a compiler. Not Focus. Not Grok Memory Phase 2.
+**Status:** PASSED & SHIPPING — Phases 0–2 merged; Phase 3 (final verification) in sign-off. Not a compiler. Not Focus. Not Grok Memory Phase 2.
+**Shipped:** Phase 0 [#3934](https://github.com/thedotmack/claude-mem/pull/3934) (`e03cf5f`) · Phase 1 [#3935](https://github.com/thedotmack/claude-mem/pull/3935) (`7abdf79`) · Phase 2 [#3936](https://github.com/thedotmack/claude-mem/pull/3936) (`c2d023d`). Defaults below applied as-is (no D-row overrides). Phase 3 verifies the boundary and closes the loop; it adds no new runtime surface.
+**Ops MISS (record, not fix here):** running worker plugin on the house box may still be `13.24.1` while repo/marketplace is `13.24.5` (this Phase 3 PATCH). Restarting the worker is a hard forbid for this seat — roll the version lag up to the Prioritizer for an out-of-band restart.
 **Seat this plan is for:** CCS Align (single-purpose, Worker Watch pattern). Prioritizer keeps the bird’s-eye.
 **Builds on:** merged [claude-mem#3931](https://github.com/thedotmack/claude-mem/pull/3931) (`b6741bdf`) — Grok Bot awareness breathing for LFG + Orifice.
 **PR:** [#3933](https://github.com/thedotmack/claude-mem/pull/3933) (draft, plan only)
@@ -534,4 +536,4 @@ One purpose. No watercooler. No “while I was here I also…”
 
 ---
 
-*Plan of record for Alex Newman / CMEM house. Prioritizer: PASS on defaults or send D-row overrides. CCS Align seat: do not start `/do` until PASS.*
+*Plan of record for Alex Newman / CMEM house. Prioritizer PASSed on defaults; Phases 0–2 shipped (#3934/#3935/#3936). Phase 3 is final verification / sign-off — regression tests green, anti-pattern greps clean, skill + plan honest about what this seat is not.*

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.24.4",
+  "version": "13.24.5",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "author": {
     "name": "Alex Newman"

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem",
-  "version": "13.24.4",
+  "version": "13.24.5",
   "description": "Memory compression system for Claude Code - persist context across sessions",
   "author": {
     "name": "Alex Newman",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mem-plugin",
-  "version": "13.24.4",
+  "version": "13.24.5",
   "private": true,
   "description": "Runtime dependencies for claude-mem bundled hooks",
   "type": "module",

--- a/plugin/skills/ccs-align/SKILL.md
+++ b/plugin/skills/ccs-align/SKILL.md
@@ -3,18 +3,34 @@ name: ccs-align
 description: Run the CCS Align seat's hourly breathing cycle — prove the local claude-mem worker is healthy, pull needle observations through search → timeline → get_observations, land them in a seat-owned middle cache via atomic grab → append → filter exclude-marks → replace, manage exclude marks, and walk house → project → seat rules to detect conflicts (SHADOW_HOUSE, DENY_ALLOW, DRIFT, CLOCK_HEADER) with an append-only rules-report.md. Use when asked to run CCS Align, breathe the alignment seat, refresh the middle cache, exclude or restore an observation, walk rules, check rules conflicts, or check the Worker Watch board.
 ---
 
-# CCS Align — Worker Watch seat (Phase 0 + Phase 1 + Phase 2: breathing slice + exclude marks + rules alignment)
+# CCS Align — Worker Watch seat (Phases 0–2 shipped; Phase 3 = verify / sign-off)
 
 CCS Align is a **standing seat**, not a bird's-eye planner. Its one job, once an hour: talk to the **local** claude-mem worker, pull recent needle observations through the existing three-layer disclosure ladder, and land them in a **seat-owned middle cache** using grab → append → replace.
 
-This skill implements the Phase 0 breathing slice, Phase 1 exclude marks, and Phase 2 rules alignment from the plan of record, `plans/2026-09-09-ccs-align.md`. It is **not** a context compiler, **not** Focus/mouth, and **not** Grok Memory Phase 2. When you speak to the human, address them as **Alex**.
+This skill implements the Phase 0 breathing slice, Phase 1 exclude marks, and Phase 2 rules alignment from the plan of record, `plans/2026-09-09-ccs-align.md`. Phases 0–2 are **shipped and merged** ([#3934](https://github.com/thedotmack/claude-mem/pull/3934), [#3935](https://github.com/thedotmack/claude-mem/pull/3935), [#3936](https://github.com/thedotmack/claude-mem/pull/3936)); Phase 3 is **verify / sign-off** (this loop) — no new product surface. It is **not** a context compiler, **not** Focus/mouth, and **not** Grok Memory Phase 2. When you speak to the human, address them as **Alex**.
 
-## What is implemented (Phase 0 + Phase 1 + Phase 2)
+## What is implemented (Phases 0–2 shipped)
 
-- **Phase 0 — Breathing slice:** health check → `search` → `timeline` → `get_observations` → append records to `~/.claude-mem/ccs-align/<viewerId>/middle.jsonl` (atomic, deduped).
-- **Phase 1 — Exclude marks:** mark observations (and linked tool-use ids) as excluded from the compiled middle cache. "Purge" means the compiled `middle.jsonl` no longer contains the record — the diary / SQLite stay authoritative. Unmarking + rebuild restores the observation. `DELETE /api/observation/:id` is **forbidden**.
-- **Phase 2 — Rules alignment:** walk house → project → seat layers, detect conflicts (`SHADOW_HOUSE`, `DENY_ALLOW`, `DRIFT`, `CLOCK_HEADER`), emit an append-only `rules-report.md`. Optionally dry-run/apply `SHADOW_HOUSE` leaf patches when `CLAUDE_MEM_CCS_ALIGN_PATCH_SHADOWS=true`. Runs every 6th hour of the hourly Worker Watch cycle (D4). This is a **checklist**, not a parser — no `.cas` compiler.
+- **Phase 0 — Breathing slice** ([#3934](https://github.com/thedotmack/claude-mem/pull/3934)): health check → `search` → `timeline` → `get_observations` → append records to `~/.claude-mem/ccs-align/<viewerId>/middle.jsonl` (atomic, deduped).
+- **Phase 1 — Exclude marks** ([#3935](https://github.com/thedotmack/claude-mem/pull/3935)): mark observations (and linked tool-use ids) as excluded from the compiled middle cache. "Purge" means the compiled `middle.jsonl` no longer contains the record — the diary / SQLite stay authoritative. Unmarking + rebuild restores the observation. `DELETE /api/observation/:id` is **forbidden**.
+- **Phase 2 — Rules alignment** ([#3936](https://github.com/thedotmack/claude-mem/pull/3936)): walk house → project → seat layers, detect conflicts (`SHADOW_HOUSE`, `DENY_ALLOW`, `DRIFT`, `CLOCK_HEADER`), emit an append-only `rules-report.md`. Optionally dry-run/apply `SHADOW_HOUSE` leaf patches when `CLAUDE_MEM_CCS_ALIGN_PATCH_SHADOWS=true`. Runs every 6th hour of the hourly Worker Watch cycle (D4). This is a **checklist**, not a parser — no `.cas` compiler.
+- **Phase 3 — Verify / sign-off** (this loop): re-run the regression tests and anti-pattern greps, prove the boundary (a scripted cycle dedupes, an exclude drops from the middle cache but not the diary, the rules report is produced or a MISS is recorded), and keep the skill + plan honest about what this seat is not. Phase 3 adds **no** new runtime behavior.
 - **Does not:** delete history, write `profile.md`, write LFG/Orifice `[awareness]` logs (that seam belongs to [#3931](https://github.com/thedotmack/claude-mem/pull/3931)), add a sixth `processAgentResponse` consumer, restart the worker, run a per-turn drip update, enforce Focus/mouth/standing rules, or copy house text into seats.
+
+## What this is NOT (honest boundary)
+
+CCS Align is deliberately small. It does **not** ship, and this loop does **not** add, any of the following — these are future work or a different agent, called out so no one reads more into the seat than is there:
+
+- **No context compiler.** There is no `.cas` parser, no `compileAwareness()`, no JIT compile, no computed-styles UI. The CCS Notion page types (`Bucket`, `canRead`) are teaching copy quoted as comments — never a runtime parser.
+- **No brainbeat product.** The "regenerate awareness once per finished unit of work" door is not built. Align *pulls* on an hourly cadence; it is not a per-turn drip and it is not a brainbeat.
+- **No attention trough / curse-salience.** No salience decay, no trough scoring. Explicitly out of every phase.
+- **No Focus / mouth enforcement.** Standing rules (always / never / danger) are never enforced or decayed here. Align may *list* a conflict; egress filtering belongs to a different agent.
+- **No second writer on LFG/Orifice `[awareness]` logs.** [#3931](https://github.com/thedotmack/claude-mem/pull/3931) owns `agents/**/memory/log/YYYY-MM.md`. Align writes only its seat-owned middle cache.
+- **No history rewrite.** Exclude marks filter the *compiled* cache; the diary / SQLite stay authoritative and rebuildable. No `DELETE /api/observation`, no A-MEM row rewrite.
+
+### Ops MISS — worker plugin version lag
+
+As of this sign-off, the repo (package, plugin, marketplace) is at **13.24.5** (this Phase 3 PATCH), but the **running worker plugin on the house box may still be 13.24.1**. That is an **operational MISS to record, not fix here**: this seat does not restart or upgrade the worker (a hard forbid). If the live box still shows 13.24.1, note it when rolling status up to the Prioritizer so the worker gets restarted onto the current plugin out-of-band. If the running worker already matches the package version, this MISS is closed.
 
 ## Prerequisites
 
@@ -348,11 +364,32 @@ const result = walkRules(config);
 // result.patchesApplied — number of SHADOW_HOUSE lines removed (0 if patchShadows=false)
 ```
 
-## Later phases (documented, not implemented here)
+## Phase 3 — Verify / sign-off (plan §3)
 
-- **Phase 3 — Verify:** two-cycle dedupe, rebuild-from-diary, #3931 tests still green.
+Phase 3 closes the plan loop. It proves the seat is hourly-runnable, documented, and honest about what it is not — it does **not** add runtime behavior.
 
-See `plans/2026-09-09-ccs-align.md` for the full contract.
+**Prove the boundary, not the code (§3.1):**
+
+- One scripted cycle: health → `search` → `timeline` → `get_observations` → `middle.jsonl`.
+- A second cycle produces no duplicate lines (dedupe holds).
+- Exclude one id → gone from the middle cache, still returned by the worker (`GET /api/observation/N`).
+- A rules report is produced (or an explicit `MISS` on a box with no agent-data tree).
+- User-facing strings say **Alex**, never "Az"; no "context compiler shipped / brainbeat is live / we compiled awareness" claims (only future / not-this-plan wording).
+
+**Prove nothing regressed (§3.2):** run the tests in the Verification section below, including the #3931 pusher and transcript tests. #3931 behavior must stay: LFG/Orifice still get `[awareness]` lines from the **worker pusher**, not from Align.
+
+**Anti-pattern grep (§3.3):** no `DELETE /api/observation`, no `notifyGrokBotAwareness`, no `processAgentResponse` reuse in the seat helpers (forbid/comment mentions are fine — the seat must not *use* them).
+
+**Sign-off (§3.4):** this skill can be run by a Worker Watch seat with no extra product context; the shipped defaults still match the D-rows; the Prioritizer can roll this up as "CCS Align Phase 0 green / Phase 1 marks / Phase 2 report."
+
+See `plans/2026-09-09-ccs-align.md` §3 for the full contract.
+
+## Later phases (documented, not implemented)
+
+- **Full brainbeat / context compiler / `.cas` runtime** — future work, paper scaffold, out of this plan.
+- **Attention trough / curse-salience, Focus/mouth egress enforcement** — different agents / backlog; hard forbids here.
+
+See `plans/2026-09-09-ccs-align.md` "Explicit non-goals" for the full list.
 
 ## Verification (Phase 0 + Phase 1 + Phase 2)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this is

Phase 3 (final verification / sign-off) for the CCS Align standing seat. It **closes the plan loop** — it does not add product surface. Phases 0–2 already shipped and merged (#3934, #3935, #3936); this PR proves the seat is hourly-runnable, documented, and honest about what it is not.

Branched fresh off `main` @ `c2d023d` (post-#3936).

## What changed

- **`plugin/skills/ccs-align/SKILL.md`**
  - Heading + "What is implemented" now say **Phases 0–2 shipped** (linked to #3934/#3935/#3936) and **Phase 3 = verify / sign-off** (adds no runtime behavior).
  - New **"What this is NOT"** section — honest boundary: no context compiler / `.cas` parser, no brainbeat product, no attention trough / curse-salience, no Focus/mouth enforcement, no second writer on LFG/Orifice `[awareness]` logs, no history rewrite.
  - New **Phase 3 sign-off** section mapping plan §3.1–§3.4 (prove the boundary, prove nothing regressed, anti-pattern greps, sign-off).
  - Records the **ops MISS**: the running worker plugin on the house box may still be `13.24.1` while the repo is `13.24.5`. Restarting the worker is a hard forbid for this seat, so this rolls **up** to the Prioritizer for an out-of-band restart rather than being "fixed" here.
  - Human is addressed as **Alex**.
- **`plans/2026-09-09-ccs-align.md`** — status `PLAN ONLY — awaiting PASS` → `PASSED & SHIPPING` (Phases 0–2 merged; Phase 3 verify). Locked-defaults table and history preserved; no rewrite.
- **Version** — PATCH bump `13.24.4` → `13.24.5` across the 9 synced manifest files (D10). `CHANGELOG.md` left untouched (generated).

No code behavior changed. The §5 "optional glue" was already satisfied — `walkRules` / `discoverLayerPaths` / `landObservationsInMiddleCache` / `loadCcsAlignConfig` are exported and documented for Worker Watch to import, so no CLI/fan-out was added (adding one would be new surface the plan forbids).

## Verification

**Regression tests (plan §3.2) — all green:**

```
bun test tests/integrations/grok-bot-awareness-pusher.test.ts   # 8 pass
bun test tests/integrations/ccs-align-middle-cache.test.ts       # part of 55 pass
bun test tests/integrations/ccs-align-rules-walker.test.ts       # part of 55 pass
bun test tests/transcripts/processor-agent-id.test.ts            # 5 pass
bun test tests/transcripts/grok-bot-config.test.ts               # 9 pass
```

Totals: **55 pass** across the three integration files, **14 pass** across the two transcript files. 0 fail. #3931 behavior intact (LFG/Orifice `[awareness]` lines still come from the worker pusher, not Align).

**Anti-pattern greps (plan §3.1 / §3.3) — clean.** The only hits for `DELETE /api/observation`, `context compiler shipped`, `Az`, and `processAgentResponse` are forbid/comment/description lines (docs forbidding the pattern), never actual use. `notifyGrokBotAwareness` → 0 hits. No real violation slipped in, so nothing was "fixed."

## Hard forbids honored

No attention trough, no Focus/mouth, no `.cas` parser / "compiler shipped" claim, no `DELETE /api/observation`, no second writer on LFG/Orifice logs, no `profile.md` writes.

Draft — plain-English Phase 3 sign-off; ready for Alex / Prioritizer review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f01736e0-9af3-4150-90af-64805982f72a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f01736e0-9af3-4150-90af-64805982f72a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

