### PR TITLE
fix: reuse Chroma writer owner within process

### DIFF
--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -109,6 +109,11 @@ interface ChromaWriterLockPayload {
   startToken?: string | null;
 }
 
+// Keep one writer identity for the lifetime of this process. Multiple manager
+// instances can be created during reconnects/tests, and they must be able to
+// re-acquire a lock that this process already owns.
+const CHROMA_WRITER_OWNER_ID = `${process.pid}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
+
 export class ChromaMcpManager {
   private static instance: ChromaMcpManager | null = null;
   private client: Client | null = null;
@@ -121,7 +126,7 @@ export class ChromaMcpManager {
   private activePrewarmTracked: TrackedChild | null = null;
   private connectionGeneration: number = 0;
   private intentionallyClosingTransports = new WeakSet<object>();
-  private readonly chromaWriterOwnerId = `${process.pid}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
+  private readonly chromaWriterOwnerId = CHROMA_WRITER_OWNER_ID;
   private chromaWriterLock: { path: string; dataDir: string; ownerId: string } | null = null;
   private unexpectedCloseCleanup: Promise<void> | null = null;
   private mutationTail: Promise<void> = Promise.resolve();

--- a/tests/services/sync/chroma-mcp-manager-singleton.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-singleton.test.ts
@@ -882,6 +882,21 @@ describe('ChromaMcpManager singleton enforcement (#2313)', () => {
     expect(transportInstances.length).toBe(1);
   });
 
+  it('allows a new manager instance in this process to re-acquire its writer lock', async () => {
+    const firstManager = ChromaMcpManager.getInstance();
+    await firstManager.callTool('chroma_list_collections', { limit: 1 });
+    const firstOwnerId = (firstManager as unknown as { chromaWriterOwnerId: string }).chromaWriterOwnerId;
+
+    await ChromaMcpManager.reset();
+    writeChromaWriterLock(process.pid, firstOwnerId);
+
+    const secondManager = ChromaMcpManager.getInstance();
+    await secondManager.callTool('chroma_list_collections', { limit: 1 });
+
+    expect(transportInstances.length).toBe(2);
+    expect(existsSync(chromaWriterLockPath())).toBe(true);
+  });
+
   it('preserves remote mutation concurrency', async () => {
     mockedSettings = {
       CLAUDE_MEM_CHROMA_MODE: 'remote',


### PR DESCRIPTION
## Summary

Fixes #3919.

A `ChromaMcpManager` recreated in the same process can now re-acquire a Chroma writer lock left by its earlier instance. The owner token is generated once at module load instead of once per manager instance, so the existing owner comparison remains valid for the lifetime of the process.

## Problem and reproduction

The lock stores a PID and an `ownerId`. Previously, `ownerId` included a new random value for every manager instance. If a lock remained after the manager was recreated, the new instance could neither match the old owner ID nor reclaim the lock: the PID was still alive because it was the same process. The resulting error was `Chroma data dir ... is already owned by PID ...; refusing to start a second writer`, leaving local vector search unavailable.

The regression test connects one manager, records its owner token, resets the singleton, restores a lock with that token, and connects a new manager in the same process. Against the parent commit it fails with `ChromaUnavailableError`; with this change it successfully creates the replacement transport and retains the lock.

## Changes

- Generate `CHROMA_WRITER_OWNER_ID` once per process/module lifetime and reuse it for each manager instance.
- Add a regression test for same-process manager recreation with a remaining writer lock.
- Preserve the existing live-PID, stale-lock, owner-token, shutdown, and remote-mode behavior.

## Validation

- Baseline regression on parent commit: **1 failed** with the expected `ChromaUnavailableError` (23 filtered out).
- `bun test tests/services/sync/chroma-mcp-manager-singleton.test.ts`: **24 passed**, 0 failed, 95 assertions.
- `git diff --check`: passed.
- A targeted Biome check was also run. It reports existing import ordering, implicit-any, and formatting/lint issues elsewhere in these files; no unrelated formatting changes are included.

No real Chroma database or external service is required by the regression test; it uses the existing transport/process mocks and temporary lock files.
