### PR TITLE
fix(worker): honor field optimizer deadline and compact Edit observer view

### DIFF
--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -214,8 +214,8 @@ export class ClaudeProvider {
     session.lastResultTotalCostUsd = null;
 
     const activeResponseContext = { current: snapshotResponseContext(session) };
-    const compressField: FieldCompressor = (text, budgetChars) =>
-      this.compressField(text, budgetChars, session, modelId, claudePath);
+    const compressField: FieldCompressor = (text, budgetChars, signal) =>
+      this.compressField(text, budgetChars, session, modelId, claudePath, signal);
     const messageGenerator = this.createMessageGenerator(session, cwdTracker, activeResponseContext, worker, compressField);
 
     if (session.memorySessionId) {
@@ -510,35 +510,48 @@ export class ClaudeProvider {
     session: ActiveSession,
     modelId: string,
     claudePath: string,
+    signal: AbortSignal,
   ): Promise<string | null> {
     const isolatedEnv = sanitizeEnv(await buildIsolatedEnvWithFreshOAuth());
-    const result = query({
-      prompt: buildFieldCompressionPrompt(text, budgetChars),
-      options: {
-        ...buildHardenedSdkOptions({
-          source: 'Observer',
-          sessionDbId: session.sessionDbId,
-          contentSessionId: session.contentSessionId,
-          project: session.project,
-          model: modelId,
-          env: isolatedEnv,
-          pathToClaudeCodeExecutable: claudePath,
-          abortController: session.abortController,
-        }),
-        maxTurns: 1,
-      },
-    });
-
-    let out = '';
-    for await (const message of result) {
-      if (message.type === 'assistant') {
-        const content = (message as any).message.content;
-        out += Array.isArray(content)
-          ? content.filter((c: any) => c.type === 'text').map((c: any) => c.text).join('\n')
-          : typeof content === 'string' ? content : '';
-      }
+    const controller = new AbortController();
+    const abort = () => controller.abort();
+    const signals = [signal, session.abortController.signal];
+    for (const source of signals) {
+      source.addEventListener('abort', abort, { once: true });
+      if (source.aborted) abort();
     }
-    return out || null;
+    try {
+      if (controller.signal.aborted) return null;
+      const result = query({
+        prompt: buildFieldCompressionPrompt(text, budgetChars),
+        options: {
+          ...buildHardenedSdkOptions({
+            source: 'Observer',
+            sessionDbId: session.sessionDbId,
+            contentSessionId: session.contentSessionId,
+            project: session.project,
+            model: modelId,
+            env: isolatedEnv,
+            pathToClaudeCodeExecutable: claudePath,
+            abortController: controller,
+          }),
+          maxTurns: 1,
+        },
+      });
+
+      let out = '';
+      for await (const message of result) {
+        if (message.type === 'assistant') {
+          const content = (message as any).message.content;
+          out += Array.isArray(content)
+            ? content.filter((c: any) => c.type === 'text').map((c: any) => c.text).join('\n')
+            : typeof content === 'string' ? content : '';
+        }
+      }
+      return out || null;
+    } finally {
+      for (const source of signals) source.removeEventListener('abort', abort);
+    }
   }
 
   private async *createMessageGenerator(

--- a/src/services/worker/GeminiProvider.ts
+++ b/src/services/worker/GeminiProvider.ts
@@ -292,8 +292,8 @@ export class GeminiProvider extends OpenAICompatibleProvider<GeminiConfig> {
     return contents;
   }
 
-  protected async query(history: ConversationMessage[], config: GeminiConfig): Promise<ProviderQueryResult> {
-    return this.queryGeminiMultiTurn(history, config.apiKey, config.model, config.rateLimitingEnabled);
+  protected async query(history: ConversationMessage[], config: GeminiConfig, signal?: AbortSignal): Promise<ProviderQueryResult> {
+    return this.queryGeminiMultiTurn(history, config.apiKey, config.model, config.rateLimitingEnabled, signal);
   }
 
   private fetchGenerateContent(
@@ -323,7 +323,8 @@ export class GeminiProvider extends OpenAICompatibleProvider<GeminiConfig> {
     history: ConversationMessage[],
     apiKey: string,
     model: GeminiModel,
-    rateLimitingEnabled: boolean
+    rateLimitingEnabled: boolean,
+    signal?: AbortSignal
   ): Promise<ProviderQueryResult> {
     const contents = this.conversationToGeminiContents(history);
     const totalChars = history.reduce((sum, m) => sum + m.content.length, 0);
@@ -371,7 +372,7 @@ export class GeminiProvider extends OpenAICompatibleProvider<GeminiConfig> {
       }
 
       return await response.json() as GeminiResponse;
-    }, { label: `Gemini ${model}` });
+    }, { label: `Gemini ${model}`, abortSignal: signal, ...(signal ? { maxRetries: 0 } : {}) });
 
     if (!data.candidates?.[0]?.content?.parts?.[0]?.text) {
       logger.error('SDK', 'Empty response from Gemini');

--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -77,7 +77,7 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
   protected abstract missingApiKeyError(): Error;
 
   /** Issue the actual HTTP request and normalize its response. */
-  protected abstract query(history: ConversationMessage[], config: TConfig): Promise<ProviderQueryResult>;
+  protected abstract query(history: ConversationMessage[], config: TConfig, signal?: AbortSignal): Promise<ProviderQueryResult>;
 
   /**
    * One bounded, standalone call that condenses an oversized tool payload.
@@ -86,10 +86,11 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
    * `session.conversationHistory` would grow the very conversation the recycle
    * logic exists to bound.
    */
-  private async compressField(text: string, budgetChars: number, config: TConfig): Promise<string | null> {
+  private async compressField(text: string, budgetChars: number, config: TConfig, signal: AbortSignal): Promise<string | null> {
     const result = await this.query(
       [{ role: 'user', content: buildFieldCompressionPrompt(text, budgetChars) }],
       config,
+      signal,
     );
     return result.content || null;
   }
@@ -262,7 +263,7 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     // rather than a head/tail slice with the middle cut out (#3800).
     const optimized = await optimizeObservationFields(
       { toolInput: message.tool_input, toolOutput: message.tool_response },
-      (text, budgetChars) => this.compressField(text, budgetChars, config),
+      (text, budgetChars, signal) => this.compressField(text, budgetChars, config, signal),
       { sessionDbId: session.sessionDbId, toolName: message.tool_name },
     );
 

--- a/src/services/worker/OpenRouterProvider.ts
+++ b/src/services/worker/OpenRouterProvider.ts
@@ -348,8 +348,8 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
     }));
   }
 
-  protected async query(history: ConversationMessage[], config: OpenRouterConfig): Promise<ProviderQueryResult> {
-    return this.queryOpenRouterMultiTurn(history, config.apiKey, config.model, config.apiUrl, config.siteUrl, config.appName);
+  protected async query(history: ConversationMessage[], config: OpenRouterConfig, signal?: AbortSignal): Promise<ProviderQueryResult> {
+    return this.queryOpenRouterMultiTurn(history, config.apiKey, config.model, config.apiUrl, config.siteUrl, config.appName, signal);
   }
 
   /** POST the chat-completions request. Extracted so the retry try block stays narrow. */
@@ -391,7 +391,8 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
     model: string,
     apiUrl: string,
     siteUrl?: string,
-    appName?: string
+    appName?: string,
+    signal?: AbortSignal
   ): Promise<ProviderQueryResult> {
     const messages = this.conversationToOpenAIMessages(history);
     const totalChars = history.reduce((sum, m) => sum + m.content.length, 0);
@@ -446,7 +447,7 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
       }
 
       return responseData;
-    }, { label: `OpenRouter ${model}` });
+    }, { label: `OpenRouter ${model}`, abortSignal: signal, ...(signal ? { maxRetries: 0 } : {}) });
 
     // A successful cmem-gateway response proves the delivered key is funded
     // again (resubscribed) — clear the trial-expiry fallback marker so

--- a/src/services/worker/field-optimizer.ts
+++ b/src/services/worker/field-optimizer.ts
@@ -29,7 +29,7 @@ import { logger } from '../../utils/logger.js';
  * Returns null when the provider cannot do it. Supplied by each provider so
  * this module stays free of provider wiring and is testable on its own.
  */
-export type FieldCompressor = (text: string, budgetChars: number) => Promise<string | null>;
+export type FieldCompressor = (text: string, budgetChars: number, signal: AbortSignal) => Promise<string | null>;
 
 /** How long one compression pass may run before the observer gives up on it. */
 export const FIELD_OPTIMIZE_TIMEOUT_MS = 30_000;
@@ -57,13 +57,14 @@ ${text}
 </payload>`;
 }
 
-async function withTimeout<T>(work: Promise<T>, ms: number): Promise<T | null> {
+async function withTimeout<T>(work: (signal: AbortSignal) => Promise<T>, ms: number): Promise<T | null> {
+  const controller = new AbortController();
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     return await Promise.race([
-      work,
+      work(controller.signal),
       new Promise<null>(resolve => {
-        timer = setTimeout(() => resolve(null), ms);
+        timer = setTimeout(() => { controller.abort(); resolve(null); }, ms);
         timer.unref?.();
       }),
     ]);
@@ -93,7 +94,7 @@ export async function optimizeField(
   const budget = Math.floor(maxChars * FIELD_OPTIMIZE_TARGET_RATIO);
   let condensed: string | null = null;
   try {
-    condensed = await withTimeout(compress(raw, budget), FIELD_OPTIMIZE_TIMEOUT_MS);
+    condensed = await withTimeout(signal => compress(raw, budget, signal), FIELD_OPTIMIZE_TIMEOUT_MS);
   } catch (error) {
     logger.warn('SDK', 'Oversized field compression failed; falling back to truncation', {
       sessionId: context.sessionDbId,
@@ -134,6 +135,44 @@ export async function optimizeField(
  * Condense whichever of an observation's two payload fields are over budget,
  * so the observation can then be built and sent at full fidelity-per-token.
  */
+function compactEditOutput(fields: { toolInput: unknown; toolOutput: unknown }, maxChars: number): unknown {
+  try {
+    const input: any = typeof fields.toolInput === 'string' ? JSON.parse(fields.toolInput) : fields.toolInput;
+    const output: any = typeof fields.toolOutput === 'string' ? JSON.parse(fields.toolOutput) : fields.toolOutput;
+    if (!input || !output || Array.isArray(output) || output.userModified !== false
+        || typeof input.file_path !== 'string' || !input.file_path
+        || typeof input.old_string !== 'string' || !input.old_string || typeof input.new_string !== 'string'
+        || output.filePath !== input.file_path || output.oldString !== input.old_string || output.newString !== input.new_string
+        || (output.originalFile !== null && typeof output.originalFile !== 'string')
+        || Object.keys(output).some(k => !['filePath', 'oldString', 'newString', 'originalFile', 'structuredPatch', 'userModified', 'replaceAll'].includes(k))
+        || (input.replace_all !== undefined && typeof input.replace_all !== 'boolean')
+        || (output.replaceAll !== undefined && output.replaceAll !== (input.replace_all ?? false))
+        || !Array.isArray(output.structuredPatch) || !output.structuredPatch.length) return fields.toolOutput;
+    const rawLength = JSON.stringify(output).length;
+    if (rawLength <= maxChars) return fields.toolOutput;
+    for (const h of output.structuredPatch) {
+      if (!h || Object.keys(h).some(k => !['oldStart', 'oldLines', 'newStart', 'newLines', 'lines'].includes(k))
+          || !['oldStart', 'oldLines', 'newStart', 'newLines'].every(k => Number.isSafeInteger(h[k]) && h[k] >= 0)
+          || !Array.isArray(h.lines) || !h.lines.every((line: unknown) => typeof line === 'string' && (/^[ +\-]/.test(line) || line === '\\ No newline at end of file'))
+          || h.lines.filter((l: string) => l[0] === ' ' || l[0] === '-').length !== h.oldLines
+          || h.lines.filter((l: string) => l[0] === ' ' || l[0] === '+').length !== h.newLines) return fields.toolOutput;
+      const before = h.lines.filter((l: string) => l[0] === ' ' || l[0] === '-').map((l: string) => l.slice(1)).join('\n');
+      const after = h.lines.filter((l: string) => l[0] === ' ' || l[0] === '+').map((l: string) => l.slice(1)).join('\n');
+      const replaced = input.replace_all ? before.split(input.old_string).join(input.new_string)
+        : before.replace(input.old_string, () => input.new_string);
+      if (!before.includes(input.old_string) || replaced !== after) return fields.toolOutput;
+    }
+    // Observer-only view: canonical native replacements survive, raw capture is untouched.
+    const view = { ...output,
+      originalFile: output.originalFile === null ? null : `[omitted ${output.originalFile.length} source characters]`,
+      structuredPatch: output.structuredPatch.map(({ lines, ...h }: any) => ({ ...h, omitted_lines: lines.length })),
+      observer_note: 'Redundant full-source and patch lines omitted; exact native oldString/newString and hunk locations retained. Raw tool payload unchanged.' };
+    return JSON.stringify(view).length <= maxChars ? view : fields.toolOutput;
+  } catch {
+    return fields.toolOutput; // Unknown/non-JSON shapes retain the existing bounded model/fallback path.
+  }
+}
+
 export async function optimizeObservationFields(
   fields: { toolInput: unknown; toolOutput: unknown },
   compress: FieldCompressor,
@@ -142,7 +181,8 @@ export async function optimizeObservationFields(
 ): Promise<{ toolInput: unknown; toolOutput: unknown }> {
   const [toolInput, toolOutput] = await Promise.all([
     optimizeField(fields.toolInput, compress, { ...context, field: 'parameters' }, maxChars),
-    optimizeField(fields.toolOutput, compress, { ...context, field: 'outcome' }, maxChars),
+    optimizeField(context.toolName === 'Edit' ? compactEditOutput(fields, maxChars) : fields.toolOutput,
+      compress, { ...context, field: 'outcome' }, maxChars),
   ]);
   return { toolInput, toolOutput };
 }

--- a/src/services/worker/field-optimizer.ts
+++ b/src/services/worker/field-optimizer.ts
@@ -148,7 +148,7 @@ function compactEditOutput(fields: { toolInput: unknown; toolOutput: unknown }, 
         || (input.replace_all !== undefined && typeof input.replace_all !== 'boolean')
         || (output.replaceAll !== undefined && output.replaceAll !== (input.replace_all ?? false))
         || !Array.isArray(output.structuredPatch) || !output.structuredPatch.length) return fields.toolOutput;
-    const rawLength = JSON.stringify(output).length;
+    const rawLength = JSON.stringify(fields.toolOutput, null, 2).length;
     if (rawLength <= maxChars) return fields.toolOutput;
     for (const h of output.structuredPatch) {
       if (!h || Object.keys(h).some(k => !['oldStart', 'oldLines', 'newStart', 'newLines', 'lines'].includes(k))
@@ -167,7 +167,7 @@ function compactEditOutput(fields: { toolInput: unknown; toolOutput: unknown }, 
       originalFile: output.originalFile === null ? null : `[omitted ${output.originalFile.length} source characters]`,
       structuredPatch: output.structuredPatch.map(({ lines, ...h }: any) => ({ ...h, omitted_lines: lines.length })),
       observer_note: 'Redundant full-source and patch lines omitted; exact native oldString/newString and hunk locations retained. Raw tool payload unchanged.' };
-    return JSON.stringify(view).length <= maxChars ? view : fields.toolOutput;
+    return JSON.stringify(view, null, 2).length <= maxChars ? view : fields.toolOutput;
   } catch {
     return fields.toolOutput; // Unknown/non-JSON shapes retain the existing bounded model/fallback path.
   }

--- a/tests/worker/edit-observer-view.test.ts
+++ b/tests/worker/edit-observer-view.test.ts
@@ -59,6 +59,25 @@ test('native Edit observer view removes redundant patch bytes for objects and HT
   }
 });
 
+test('Edit budget uses the same escaped representation as optimizeField', async () => {
+  const lines = [...Array(1800).fill(' "'), '-old()', '+new()'];
+  const raw = { ...output, structuredPatch: [{ oldStart: 1, oldLines: 1801,
+    newStart: 1, newLines: 1801, lines }] };
+  expect(JSON.stringify(raw).length).toBeLessThan(16000);
+  for (const value of [raw, JSON.stringify(raw)]) {
+    expect(JSON.stringify(value, null, 2).length).toBeGreaterThan(16000);
+    const fields = { toolInput: JSON.stringify(input), toolOutput: value };
+    const before = JSON.stringify(fields);
+    let calls = 0;
+    const result = await optimizeObservationFields(fields, async () => { calls++; return null; },
+      { sessionDbId: 0, toolName: 'Edit' });
+    expect(calls).toBe(0);
+    expect(JSON.stringify(result.toolOutput, null, 2).length).toBeLessThan(16000);
+    expect(result.toolOutput).toMatchObject({ oldString: 'old()', newString: 'new()' });
+    expect(JSON.stringify(fields)).toBe(before);
+  }
+});
+
 test('unknown, inconsistent, modified, or failed Edit results keep the normal path', async () => {
   for (const change of [{ userModified: true }, { oldString: 'different' }, { error: 'failed' },
     { extraNativeField: true }, { structuredPatch: [{ ...output.structuredPatch[0], oldLines: 2 }] },

--- a/tests/worker/edit-observer-view.test.ts
+++ b/tests/worker/edit-observer-view.test.ts
@@ -1,0 +1,72 @@
+import { test, expect } from 'bun:test';
+import { optimizeObservationFields } from '../../src/services/worker/field-optimizer.js';
+import { ingestObservation, setIngestContext } from '../../src/services/worker/http/shared.js';
+import { createServer } from 'node:http';
+
+const input = { file_path: '/fixture/huge.ts', old_string: 'old()', new_string: 'new()', replace_all: false };
+const prefix = 'x'.repeat(100_000);
+const output = { filePath: input.file_path, oldString: input.old_string, newString: input.new_string,
+  originalFile: null, userModified: false,
+  structuredPatch: [{ oldStart: 1, oldLines: 1, newStart: 1, newLines: 1,
+    lines: ['-' + prefix + 'old()', '+' + prefix + 'new()'] }] };
+
+test('HTTP ingestion preserves raw strings while the native observer view shrinks', async () => {
+  let queued: any;
+  let optimized: any;
+  let calls = 0;
+  setIngestContext({
+    dbManager: { getSessionStore: () => ({ createSDKSession: () => 1,
+      getPromptNumberFromUserPrompts: () => 1, getUserPrompt: () => 'public fixture' }) } as any,
+    sessionManager: { queueObservation: async (_id: number, observation: any) => { queued = observation; } } as any,
+    eventBroadcaster: { broadcastObservationQueued: () => {} } as any,
+    ensureGeneratorRunning: async () => {
+      optimized = await optimizeObservationFields({ toolInput: queued.tool_input, toolOutput: queued.tool_response },
+        async () => { calls++; return null; }, { sessionDbId: 1, toolName: queued.tool_name });
+    },
+  });
+  const server = createServer(async (req, res) => {
+    let body = ''; for await (const chunk of req) body += chunk;
+    res.end(JSON.stringify(await ingestObservation(JSON.parse(body))));
+  });
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+  try {
+    const port = (server.address() as { port: number }).port;
+    const result = await fetch(`http://127.0.0.1:${port}/observation`, { method: 'POST',
+      body: JSON.stringify({ contentSessionId: 'isolated-edit-test', toolName: 'Edit', toolInput: input, toolResponse: output, cwd: '/fixture' }) });
+    expect((await result.json() as any).ok).toBe(true);
+    expect(JSON.parse(queued.tool_response)).toEqual(output);
+    expect(JSON.parse(queued.tool_input)).toEqual(input);
+    expect(calls).toBe(0);
+    expect(JSON.stringify(optimized.toolOutput).length).toBeLessThan(2000);
+    console.log('EDIT_VIEW_BYTES', queued.tool_response.length, JSON.stringify(optimized.toolOutput).length);
+  } finally {
+    server.closeAllConnections();
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
+});
+
+test('native Edit observer view removes redundant patch bytes for objects and HTTP JSON strings', async () => {
+  for (const encoded of [false, true]) {
+    const fields = { toolInput: encoded ? JSON.stringify(input) : input, toolOutput: encoded ? JSON.stringify(output) : output };
+    const before = JSON.stringify(fields);
+    let calls = 0;
+    const optimized = await optimizeObservationFields(fields, async () => { calls++; return null; }, { sessionDbId: 0, toolName: 'Edit' });
+    expect(calls).toBe(0);
+    expect(JSON.stringify(optimized.toolOutput).length).toBeLessThan(2000);
+    expect(optimized.toolOutput).toMatchObject({ filePath: input.file_path, oldString: 'old()', newString: 'new()', userModified: false });
+    expect(JSON.stringify(optimized.toolOutput)).toContain('omitted');
+    expect(JSON.stringify(fields)).toBe(before);
+  }
+});
+
+test('unknown, inconsistent, modified, or failed Edit results keep the normal path', async () => {
+  for (const change of [{ userModified: true }, { oldString: 'different' }, { error: 'failed' },
+    { extraNativeField: true }, { structuredPatch: [{ ...output.structuredPatch[0], oldLines: 2 }] },
+    { structuredPatch: [{ ...output.structuredPatch[0], lines: ['-' + prefix + 'other()', '+' + prefix + 'new()'] }] }]) {
+    const raw = { ...output, ...change };
+    let calls = 0;
+    const result = await optimizeObservationFields({ toolInput: input, toolOutput: raw }, async () => { calls++; return null; }, { sessionDbId: 0, toolName: 'Edit' });
+    expect(calls).toBe(1);
+    expect(result.toolOutput).toBe(raw);
+  }
+});

--- a/tests/worker/field-deadline-wire.test.ts
+++ b/tests/worker/field-deadline-wire.test.ts
@@ -1,0 +1,44 @@
+import { test, expect } from 'bun:test';
+import { createServer } from 'node:http';
+import { optimizeField } from '../../src/services/worker/field-optimizer.js';
+import { OpenRouterProvider } from '../../src/services/worker/OpenRouterProvider.js';
+
+test('field deadline cancels real OpenRouter fetch and prevents retries', async () => {
+  let requests = 0;
+  let disconnected = false;
+  const server = createServer((req, res) => {
+    requests++;
+    req.resume();
+    res.on('close', () => { disconnected = true; });
+    // Deliberately never send headers: cancellation must reach the socket.
+  });
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address() as { port: number };
+  const nativeTimeout = globalThis.setTimeout;
+  let budgetTimers = 0;
+  // query() arms its attempt timeout before optimizeField arms the field deadline.
+  // Keep the attempt alive longer so this test exercises field cancellation, not a timer tie.
+  globalThis.setTimeout = ((fn: any, ms: number, ...args: any[]) =>
+    nativeTimeout(fn, ms === 30_000 ? (++budgetTimers === 1 ? 1000 : 100) : ms, ...args)) as typeof setTimeout;
+  const provider = new OpenRouterProvider({} as any, {} as any);
+  const raw = JSON.stringify({ oldString: 'a', newString: 'b', content: 'x'.repeat(20_000) });
+  let signal: AbortSignal | undefined;
+  try {
+    const result = await optimizeField(raw, (text, budget, abortSignal) => {
+      signal = abortSignal;
+      return (provider as any).compressField(text, budget, {
+        apiKey: 'fixture-not-a-secret', model: 'fixture',
+        apiUrl: `http://127.0.0.1:${address.port}/v1/chat/completions`,
+      }, abortSignal);
+    }, { sessionDbId: 0, field: 'outcome', toolName: 'Edit' });
+    await new Promise(resolve => nativeTimeout(resolve, 450));
+    expect(result).toBe(raw);
+    expect(signal?.aborted).toBe(true);
+    expect(requests).toBe(1);
+    expect(disconnected).toBe(true);
+  } finally {
+    globalThis.setTimeout = nativeTimeout;
+    server.closeAllConnections();
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
+}, 5000);

--- a/tests/worker/field-deadline-wire.test.ts
+++ b/tests/worker/field-deadline-wire.test.ts
@@ -8,8 +8,13 @@ test('field deadline cancels real OpenRouter fetch and prevents retries', async 
   let disconnected = false;
   const server = createServer((req, res) => {
     requests++;
-    req.resume();
-    res.on('close', () => { disconnected = true; });
+    // Do not resume() the body: on older Bun versions that keeps the keep-alive
+    // socket open and `res.on('close')` does not fire within the observation
+    // window. The request's own abort/error and socket-close events are the
+    // event-driven, runtime-agnostic signal that the client disconnected.
+    req.on('error', () => { disconnected = true; });
+    req.on('close', () => { if ((req as any).aborted || (req as any).destroyed) disconnected = true; });
+    req.socket.on('close', () => { disconnected = true; });
     // Deliberately never send headers: cancellation must reach the socket.
   });
   await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));


### PR DESCRIPTION
## Summary

Plumbs an AbortSignal through the field-compression path so a field-level timeout can cancel the real provider request and stop retries instead of leaking a background attempt. Also adds a conservative `Edit` observer view that removes redundant `originalFile` and patch-line bytes while preserving the canonical replacement metadata; the raw tool payload stored in the DB is unchanged.

## Changes

- `src/services/worker/field-optimizer.ts`: `withTimeout` now creates an `AbortController`, hands its signal to the compressor, and aborts on timeout.
- `OpenAICompatibleProvider.ts`, `GeminiProvider.ts`, `OpenRouterProvider.ts`, `ClaudeProvider.ts`: thread the signal into `query`/`compressField` and forward it to `withRetry` / the SDK query, disabling retries when a caller-supplied signal is present.
- `field-optimizer.ts`: adds `compactEditOutput` for `Edit` tool outcomes.
- `tests/worker/field-deadline-wire.test.ts`, `tests/worker/edit-observer-view.test.ts`: new targeted tests.

## Test evidence

`bun test tests/worker/field-deadline-wire.test.ts tests/worker/edit-observer-view.test.ts tests/worker/field-optimizer.test.ts`

Result: **14 pass / 0 fail** on UM (Bun v1.4.1).