### PR TITLE
fix(corpus): preserve observation type filters

### DIFF
--- a/src/services/worker/knowledge/CorpusBuilder.ts
+++ b/src/services/worker/knowledge/CorpusBuilder.ts
@@ -39,7 +39,7 @@ export class CorpusBuilder {
 
     const searchArgs: Record<string, unknown> = {};
     if (filter.project) searchArgs.project = filter.project;
-    if (filter.types && filter.types.length > 0) searchArgs.type = filter.types.join(',');
+    if (filter.types && filter.types.length > 0) searchArgs.obs_type = filter.types.join(',');
     if (filter.concepts && filter.concepts.length > 0) searchArgs.concepts = filter.concepts.join(',');
     if (filter.files && filter.files.length > 0) searchArgs.files = filter.files.join(',');
     if (filter.query) searchArgs.query = filter.query;

--- a/tests/worker/knowledge/corpus-builder.test.ts
+++ b/tests/worker/knowledge/corpus-builder.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { SearchOrchestrator } from '../../../src/services/worker/search/SearchOrchestrator.js';
+import { CorpusBuilder } from '../../../src/services/worker/knowledge/CorpusBuilder.js';
+
+const bugfixObservation = {
+  id: 42,
+  memory_session_id: 'session-bugfix',
+  project: 'corpus-project',
+  text: null,
+  type: 'bugfix' as const,
+  title: 'Preserve corpus observation filters',
+  subtitle: null,
+  facts: '[]',
+  narrative: 'The corpus search keeps the selected observation type.',
+  concepts: '[]',
+  files_read: '[]',
+  files_modified: '[]',
+  prompt_number: 1,
+  discovery_tokens: 0,
+  created_at: '2025-01-01T00:00:00.000Z',
+  created_at_epoch: 1735689600000,
+};
+
+const featureObservation = {
+  ...bugfixObservation,
+  id: 43,
+  memory_session_id: 'session-feature',
+  type: 'feature' as const,
+  title: 'Unrelated feature observation',
+};
+
+describe('CorpusBuilder observation type filters', () => {
+  it('passes types through the search layer before phase-two hydration', async () => {
+    const searchObservations = mock((_query: string | undefined, options: { type?: string[] }) => {
+      // Model the default search page: without the observation-type filter the
+      // requested bugfix is beyond the page and is never available to hydrate.
+      return options.type?.includes('bugfix') ? [bugfixObservation] : [featureObservation];
+    });
+    const searchOrchestrator = new SearchOrchestrator(
+      {
+        searchObservations,
+        searchSessions: mock(() => []),
+        searchUserPrompts: mock(() => []),
+      } as any,
+      {} as any,
+      null,
+    );
+    const getObservationsByIds = mock((ids: number[], options: { type?: string[] }) => {
+      const rows = ids.includes(bugfixObservation.id) ? [bugfixObservation] : [];
+      return options.type?.includes('bugfix') ? rows : [];
+    });
+    const write = mock(() => undefined);
+    const builder = new CorpusBuilder(
+      { getObservationsByIds } as any,
+      searchOrchestrator,
+      { write } as any,
+    );
+
+    const corpus = await builder.build('bugfixes', 'Bugfix observations', {
+      types: ['bugfix'],
+    });
+
+    expect(searchObservations).toHaveBeenCalledWith(undefined, expect.objectContaining({
+      type: ['bugfix'],
+    }));
+    expect(getObservationsByIds).toHaveBeenCalledWith([bugfixObservation.id], expect.objectContaining({
+      type: ['bugfix'],
+    }));
+    expect(corpus.observations).toHaveLength(1);
+    expect(corpus.observations[0]?.id).toBe(bugfixObservation.id);
+    expect(write).toHaveBeenCalledWith(corpus);
+  });
+});


### PR DESCRIPTION
Fixes #3892

`CorpusBuilder.build()` passed `filter.types` as `type`, but `SearchOrchestrator` treats `type` as the search scope and only forwards `obs_type` to observation filtering. Route selected observation types through `obs_type` so phase-one search applies the filter before hydration.

Verification:
- `bun test tests/worker/knowledge/corpus-builder.test.ts` (1 pass, 5 assertions)
- `bun test tests/worker/knowledge tests/worker/search` (61 pass, 143 assertions)
- `npm run lint:hook-io` and `npm run lint:spawn-env` passed
- `git diff --check` passed
- `bun run typecheck:root` currently reports existing errors in `src/npx-cli/commands/install.ts`; this PR does not touch that file.
