### PR TITLE
fix(parser): unwrap a label-wrapped observation title

### DIFF
--- a/src/sdk/parser.ts
+++ b/src/sdk/parser.ts
@@ -94,7 +94,7 @@ function parseObservationBlocks(text: string, correlationId?: string | number): 
     const obsContent = match[1];
 
     const type = extractField(obsContent, 'type');
-    const title = extractField(obsContent, 'title');
+    const title = unwrapLabelWrappedTitle(extractField(obsContent, 'title'));
     const subtitle = extractField(obsContent, 'subtitle');
     const narrative = extractField(obsContent, 'narrative');
     const facts = extractArrayElements(obsContent, 'facts', 'fact');
@@ -184,6 +184,20 @@ function parseSummaryBlock(text: string, correlationId?: string | number): Parse
     next_steps,
     notes,
   };
+}
+
+// Some local observers echo the field label into the value, producing
+// `<title>[**title**: Example observation]</title>`. Only this complete,
+// unambiguous wrapper is unwrapped; partial forms and legitimately bracketed
+// titles are stored as-is (#3907).
+const LABEL_WRAPPED_TITLE = /^\[\*\*title\*\*:\s*([\s\S]+?)\s*\]$/;
+
+function unwrapLabelWrappedTitle(title: string | null): string | null {
+  if (title === null) return null;
+  const match = LABEL_WRAPPED_TITLE.exec(title);
+  if (!match) return title;
+  const inner = match[1].trim();
+  return inner === '' ? title : inner;
 }
 
 function extractField(content: string, fieldName: string): string | null {

--- a/tests/sdk/parser.test.ts
+++ b/tests/sdk/parser.test.ts
@@ -49,6 +49,30 @@ describe('parseAgentXml — observations', () => {
     expect(result[0].narrative).toBe('The token refresh logic skips expired tokens.');
   });
 
+  it('unwraps a label-wrapped title echoed by a local observer (#3907)', () => {
+    const xml = `<observation>
+      <type>discovery</type>
+      <title>[**title**: Example observation]</title>
+      <narrative>Some narrative.</narrative>
+    </observation>`;
+
+    const result = expectObservation(xml);
+
+    expect(result[0].title).toBe('Example observation');
+  });
+
+  it('leaves bracketed and partially wrapped titles untouched (#3907)', () => {
+    for (const title of ['[Example observation]', '**title**: Example', '[**title**: ]', '[**subtitle**: x]']) {
+      const xml = `<observation>
+        <type>discovery</type>
+        <title>${title}</title>
+        <narrative>Some narrative.</narrative>
+      </observation>`;
+
+      expect(expectObservation(xml)[0].title).toBe(title);
+    }
+  });
+
   it('returns a populated observation when only narrative is present (no title)', () => {
     const xml = `<observation>
       <type>bugfix</type>


### PR DESCRIPTION
Fixes #3907

**Problem:** local observers sometimes echo the field label into the value, producing `<title>[**title**: Example observation]</title>`. `extractField()` only trims whitespace, so the complete wrapper was persisted as the observation title (603 rows in the reporter's corpus).

**Change:** `parseAgentXml` now unwraps exactly that complete, nonempty `[**title**: …]` wrapper before the title is stored. Because this happens at parse time, everything derived from the title (content hash, search index, UI) sees the plain text consistently. Partial forms (`**title**: x`), legitimately bracketed titles (`[Example]`), an empty wrapper (`[**title**: ]`) and other field labels are left untouched, matching the issue's "narrow, unambiguous form only" scope. No migration of existing rows is included.

**Tests** (`tests/sdk/parser.test.ts`): the wrapped title is unwrapped (fails on `main`); the ambiguous forms above are stored as-is.

```
bun test tests/sdk/parser.test.ts   # 23 pass
bun x tsc --noEmit                  # clean
```
