### PR TITLE
fix(chroma): stop a backfill run after repeated batch failures

### DIFF
--- a/src/services/sync/ChromaSync.ts
+++ b/src/services/sync/ChromaSync.ts
@@ -101,6 +101,10 @@ export class ChromaSync {
   private collectionCreated = false;
   private collectionCreation: Promise<void> | null = null;
   private readonly BATCH_SIZE = 100;
+  // How many rows in a row may fail to write before a backfill run gives up
+  // (#3928). Set per run in ensureBackfilled and read by runBackfillPipeline.
+  private readonly MAX_CONSECUTIVE_BATCH_FAILURES = 3;
+  private backfillAborted = false;
 
   constructor(project: string) {
     this.project = project;
@@ -719,6 +723,7 @@ export class ChromaSync {
 
     await this.ensureCollectionExists();
 
+    this.backfillAborted = false;
     const watermarks = ChromaSyncState.get(project);
 
     try {
@@ -735,8 +740,17 @@ export class ChromaSync {
     watermarks: ProjectWatermarks
   ): Promise<void> {
     const observationDocs = await this.backfillObservations(db, backfillProject, watermarks.observations);
+    if (this.backfillAborted) {
+      return;
+    }
     const summaryDocs = await this.backfillSummaries(db, backfillProject, watermarks.summaries);
+    if (this.backfillAborted) {
+      return;
+    }
     const promptDocs = await this.backfillPrompts(db, backfillProject, watermarks.prompts);
+    if (this.backfillAborted) {
+      return;
+    }
 
     logger.info('CHROMA_SYNC', 'Smart backfill complete', {
       project: backfillProject,
@@ -764,8 +778,10 @@ export class ChromaSync {
     const rowsWithDocs = rows.map(row => ({ row, docs: formatDocs(row) }));
     const totalDocs = rowsWithDocs.reduce((sum, { docs }) => sum + docs.length, 0);
     let processedDocs = 0;
+    let consecutiveFailures = 0;
 
-    for (const { row, docs } of rowsWithDocs) {
+    for (let rowIndex = 0; rowIndex < rowsWithDocs.length; rowIndex += 1) {
+      const { row, docs } = rowsWithDocs[rowIndex];
       if (docs.length === 0) {
         continue;
       }
@@ -792,6 +808,7 @@ export class ChromaSync {
           break;
         }
 
+        consecutiveFailures = 0;
         logger.debug('CHROMA_SYNC', 'Backfill progress', {
           project: backfillProject,
           progress: `${Math.min(processedDocs, totalDocs)}/${totalDocs}`
@@ -799,6 +816,24 @@ export class ChromaSync {
       }
 
       if (!rowComplete) {
+        consecutiveFailures += 1;
+        // A write that fails for several rows in a row is not a per-row
+        // problem, it is Chroma refusing writes. Walking every remaining row
+        // through the same failure logs one identical error per row (millions
+        // of lines on a large store, #3928) and never advances anything, so
+        // stop this run here. Nothing is lost: the rows keep their pending
+        // marks or stay above the watermark and the next backfill retries them.
+        if (consecutiveFailures >= this.MAX_CONSECUTIVE_BATCH_FAILURES) {
+          this.backfillAborted = true;
+          logger.error('CHROMA_SYNC', 'Backfill stopped after repeated batch failures', {
+            project: backfillProject,
+            kind,
+            consecutiveFailures,
+            lastRowId: row.id,
+            remainingRows: rowsWithDocs.length - rowIndex - 1
+          });
+          return totalDocs;
+        }
         continue;
       }
 

--- a/tests/services/sync/chroma-sync-watermarks.test.ts
+++ b/tests/services/sync/chroma-sync-watermarks.test.ts
@@ -202,6 +202,64 @@ describe('ChromaSync watermark gap persistence', () => {
     expect(ChromaSyncState.get(project).observations).toBe(5);
   });
 
+  it('stops a backfill run after repeated batch failures instead of walking every row (#3928)', async () => {
+    ChromaSyncState.replace(project, {
+      observations: 0,
+      summaries: 0,
+      prompts: 0,
+      pending: {},
+    });
+    const sync = new ChromaSync(project) as ChromaSync & {
+      addDocuments: (documents: Array<{ id: string }>) => Promise<number>;
+    };
+    let attempts = 0;
+    sync.addDocuments = async () => {
+      attempts += 1;
+      return 0; // Chroma refuses every write
+    };
+
+    await sync.ensureBackfilled(project, makeStore(project, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]));
+
+    // Three failed rows, then the run stops; the other seven are never attempted.
+    expect(attempts).toBe(3);
+    expect(ChromaSyncState.get(project).observations).toBe(0);
+    expect(ChromaSyncState.getPending(project, 'observations')).toEqual([1, 2, 3]);
+
+    // Once Chroma writes again the same call finishes the whole backlog.
+    sync.addDocuments = async (documents) => {
+      addDocumentCalls.push(documents.map(document => document.id));
+      return documents.length;
+    };
+    await sync.ensureBackfilled(project, makeStore(project, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]));
+
+    expect(ChromaSyncState.get(project).observations).toBe(10);
+    expect(ChromaSyncState.getPending(project, 'observations')).toEqual([]);
+    expect(addDocumentCalls.flat()).toContain('obs_10_narrative');
+  });
+
+  it('resets the failure streak when a later row succeeds', async () => {
+    ChromaSyncState.replace(project, {
+      observations: 0,
+      summaries: 0,
+      prompts: 0,
+      pending: {},
+    });
+    const sync = new ChromaSync(project) as ChromaSync & {
+      addDocuments: (documents: Array<{ id: string }>) => Promise<number>;
+    };
+    let attempts = 0;
+    sync.addDocuments = async (documents) => {
+      attempts += 1;
+      // Rows 1-2 fail, row 3 succeeds, rows 4-5 fail, row 6 succeeds: never three in a row.
+      return attempts % 3 === 0 ? documents.length : 0;
+    };
+
+    await sync.ensureBackfilled(project, makeStore(project, [1, 2, 3, 4, 5, 6]));
+
+    expect(attempts).toBe(6);
+    expect(ChromaSyncState.getPending(project, 'observations')).toEqual([1, 2, 4, 5]);
+  });
+
   it('keeps a split observation row pending until every batch for that row lands', async () => {
     const splitRow = makeObservationRow(1, project, 101);
     ChromaSyncState.replace(project, {


### PR DESCRIPTION
Fixes #3928

**Problem:** when Chroma refuses writes (dead writer lock, unreachable server, …), `backfillKind()` keeps walking every remaining row of the backfill: each row's first batch fails inside `addDocuments()`, which logs `Batch add failed — watermark will not advance for this batch, continuing with remaining batches` and returns, and the loop simply moves to the next row. On a large store that is one identical error line per row per run — the 8.9M lines / 3.8 GB reported in the issue — while nothing ever advances (`batchStart=0` on every line: it is the first batch of every row, not the same batch retried).

**Change:**
- `backfillKind()` counts consecutive failed rows and stops the run after `MAX_CONSECUTIVE_BATCH_FAILURES = 3`, logging one `Backfill stopped after repeated batch failures` error with the kind, the last row id and the number of rows left. A later successful row resets the streak, so a single bad row still doesn't stop a healthy run.
- `runBackfillPipeline()` skips the remaining kinds (summaries, prompts) once a run aborted, instead of failing the same way three more times.
- Nothing is lost: the failed rows keep their pending marks or stay above the watermark, and the next backfill run picks them up exactly as before.

This also bounds the shutdown case in #3896 (a restart during backfill kept walking 26k rows against a manager that already refused mutations): the run now stops after three refused rows.

This is the retry-cap part of the issue. Exponential backoff between runs would need a scheduler for backfill (today it runs once per worker start), and log deduplication belongs in the logger; both are left out to keep this focused.

**Tests** (`tests/services/sync/chroma-sync-watermarks.test.ts`):
- with every write failing, 10 rows produce exactly 3 attempts, the watermark stays put, rows 1–3 are pending, and the next run with Chroma healthy syncs the whole backlog (fails on `main`: 10 attempts);
- a success in between resets the streak (6 rows, 6 attempts).

```
bun test tests/services/sync tests/integration/chroma-vector-sync.test.ts   # 64 pass
bun x tsc --noEmit                                                          # clean
```
