### PR TITLE
fix(chroma): record failed live writes as pending so the watermark cannot orphan them

### DIFF
--- a/src/services/sync/ChromaSync.ts
+++ b/src/services/sync/ChromaSync.ts
@@ -471,9 +471,14 @@ export class ChromaSync {
     // #2282).
     const written = await this.addDocuments(documents);
     if (written === documents.length) {
+      ChromaSyncState.clearPending(project, 'observations', [observationId]);
       ChromaSyncState.bump(project, 'observations', observationId);
     } else {
-      logger.warn('CHROMA_SYNC', 'Observation watermark bump skipped — partial write', {
+      // Not bumping is not enough: the watermark is a high-water mark, so the
+      // next row that does write would skip past this one for good (#3917).
+      // Record it as pending so the backfill retries it, like backfillKind().
+      ChromaSyncState.markPending(project, 'observations', [observationId]);
+      logger.warn('CHROMA_SYNC', 'Observation watermark bump skipped — partial write, row marked pending', {
         observationId,
         project,
         requested: documents.length,
@@ -518,9 +523,11 @@ export class ChromaSync {
     // Only bump on a confirmed full write — see syncObservation() for rationale.
     const written = await this.addDocuments(documents);
     if (written === documents.length) {
+      ChromaSyncState.clearPending(project, 'summaries', [summaryId]);
       ChromaSyncState.bump(project, 'summaries', summaryId);
     } else {
-      logger.warn('CHROMA_SYNC', 'Summary watermark bump skipped — partial write', {
+      ChromaSyncState.markPending(project, 'summaries', [summaryId]);
+      logger.warn('CHROMA_SYNC', 'Summary watermark bump skipped — partial write, row marked pending', {
         summaryId,
         project,
         requested: documents.length,
@@ -575,9 +582,11 @@ export class ChromaSync {
     // Only bump on a confirmed full write — see syncObservation() for rationale.
     const written = await this.addDocuments([document]);
     if (written === 1) {
+      ChromaSyncState.clearPending(project, 'prompts', [promptId]);
       ChromaSyncState.bump(project, 'prompts', promptId);
     } else {
-      logger.warn('CHROMA_SYNC', 'Prompt watermark bump skipped — write failed', {
+      ChromaSyncState.markPending(project, 'prompts', [promptId]);
+      logger.warn('CHROMA_SYNC', 'Prompt watermark bump skipped — write failed, row marked pending', {
         promptId,
         project,
         written

--- a/tests/services/sync/chroma-sync-watermarks.test.ts
+++ b/tests/services/sync/chroma-sync-watermarks.test.ts
@@ -151,6 +151,100 @@ describe('ChromaSync watermark gap persistence', () => {
     expect(ChromaSyncState.getPending(project, 'observations')).toEqual([2]);
   });
 
+  it('marks a failed live observation write pending so a later write cannot orphan it (#3917)', async () => {
+    ChromaSyncState.replace(project, {
+      observations: 4,
+      summaries: 0,
+      prompts: 0,
+      pending: {},
+    });
+    const sync = new ChromaSync(project) as ChromaSync & {
+      addDocuments: (documents: Array<{ id: string }>) => Promise<number>;
+    };
+    const observation = {
+      type: 'discovery',
+      title: 'Observation',
+      subtitle: null,
+      facts: [],
+      narrative: 'Narrative',
+      concepts: [],
+      files_read: [],
+      files_modified: [],
+    };
+
+    // Chroma is down while observation 5 is written.
+    sync.addDocuments = async () => 0;
+    await sync.syncObservation(5, 'mem-5', project, observation, 5, 1_700_000_000_005, 'claude');
+    expect(ChromaSyncState.get(project).observations).toBe(4);
+    expect(ChromaSyncState.getPending(project, 'observations')).toEqual([5]);
+
+    // Chroma is back for observation 6: the watermark moves past 5, but 5 stays reachable.
+    sync.addDocuments = async (documents) => {
+      addDocumentCalls.push(documents.map(document => document.id));
+      return documents.length;
+    };
+    await sync.syncObservation(6, 'mem-6', project, observation, 6, 1_700_000_000_006, 'claude');
+    expect(ChromaSyncState.get(project).observations).toBe(6);
+    expect(ChromaSyncState.getPending(project, 'observations')).toEqual([5]);
+
+    // The next backfill picks the orphan up through the pending list.
+    await sync.ensureBackfilled(project, makeStore(project, [1, 2, 3, 4, 5, 6]));
+    expect(addDocumentCalls.flat()).toContain('obs_5_narrative');
+    expect(ChromaSyncState.getPending(project, 'observations')).toEqual([]);
+  });
+
+  it('marks a failed live prompt write pending and clears it once the prompt lands (#3917)', async () => {
+    ChromaSyncState.replace(project, {
+      observations: 0,
+      summaries: 0,
+      prompts: 2,
+      pending: {},
+    });
+    const sync = new ChromaSync(project) as ChromaSync & {
+      addDocuments: (documents: Array<{ id: string }>) => Promise<number>;
+    };
+
+    sync.addDocuments = async () => 0;
+    await sync.syncUserPrompt(3, 'mem-3', project, 'prompt text', 3, 1_700_000_000_003, 'claude');
+    expect(ChromaSyncState.get(project).prompts).toBe(2);
+    expect(ChromaSyncState.getPending(project, 'prompts')).toEqual([3]);
+
+    sync.addDocuments = async (documents) => documents.length;
+    await sync.syncUserPrompt(3, 'mem-3', project, 'prompt text', 3, 1_700_000_000_003, 'claude');
+    expect(ChromaSyncState.get(project).prompts).toBe(3);
+    expect(ChromaSyncState.getPending(project, 'prompts')).toEqual([]);
+  });
+
+  it('marks a failed live summary write pending (#3917)', async () => {
+    ChromaSyncState.replace(project, {
+      observations: 0,
+      summaries: 7,
+      prompts: 0,
+      pending: {},
+    });
+    const sync = new ChromaSync(project) as ChromaSync & {
+      addDocuments: (documents: Array<{ id: string }>) => Promise<number>;
+    };
+    const summary = {
+      request: 'request',
+      investigated: 'investigated',
+      learned: 'learned',
+      completed: 'completed',
+      next_steps: null,
+      notes: null,
+    };
+
+    sync.addDocuments = async () => 0;
+    await sync.syncSummary(8, 'mem-8', project, summary, 8, 1_700_000_000_008, 'claude');
+    expect(ChromaSyncState.get(project).summaries).toBe(7);
+    expect(ChromaSyncState.getPending(project, 'summaries')).toEqual([8]);
+
+    sync.addDocuments = async (documents) => documents.length;
+    await sync.syncSummary(9, 'mem-9', project, summary, 9, 1_700_000_000_009, 'claude');
+    expect(ChromaSyncState.get(project).summaries).toBe(9);
+    expect(ChromaSyncState.getPending(project, 'summaries')).toEqual([8]);
+  });
+
   it('keeps pending observation ids when live sync advances past the gap', async () => {
     ChromaSyncState.replace(project, {
       observations: 4,


### PR DESCRIPTION
Fixes #3917

**Problem:** `syncObservation`, `syncSummary` and `syncUserPrompt` skip the watermark bump when `addDocuments()` reports a failed or partial write, but they record nothing for the row. `ChromaSyncState.bump()` is a monotonic high-water mark, so the next row that does write moves the watermark past every row that failed before it, and recovery only ever looks at `id > watermark` ∪ `pending`. Those rows become unreachable to every future backfill, silently, the moment a Chroma outage clears; the issue reports 1,900 observations lost this way, a second user 9.4% of their store.

**Change:** the three live paths now mirror what `backfillKind()` already does:
- a failed or partial write calls `ChromaSyncState.markPending(project, kind, [id])` (the warn line now says so), so the next backfill retries the row through the pending list;
- a successful write clears the row's pending mark before bumping, so a row that failed once and was written later doesn't stay in the retry list.

Existing orphans from before this change are not reindexed automatically by this PR: deleting `chroma-sync-state.json` makes the next start run `bootstrapWatermarks()`, which rebuilds the pending list from the ids actually present in Chroma; a dedicated reconciliation pass is out of scope here.

**Tests** (`tests/services/sync/chroma-sync-watermarks.test.ts`): a failed observation write is pending, a later successful write moves the watermark past it without dropping it, and the following backfill indexes it; the same for summaries; and a prompt that fails and then lands is cleared from pending. All three fail on `main`.

```
bun test tests/services/sync tests/integration/chroma-vector-sync.test.ts tests/worker/session-manager-project.test.ts   # 71 pass
bun x tsc --noEmit                                                                                                    # clean
```
