### PR TITLE
docs(plans): CCS scenario research brief + lock-next specs (conflict dedupe, not-in-group)

### DIFF
--- a/plans/2026-09-09-ccs-lock-conflict-dedupe.md
+++ b/plans/2026-09-09-ccs-lock-conflict-dedupe.md
@@ -1,0 +1,158 @@
+# CCS Lock — deny-beats-allow + node-identity dedupe (two-bucket conflict)
+
+**Date:** 2026-09-09 (overnight lock-next work, written 2026-09-10)
+**Status:** RESEARCH / SPEC ONLY. No code, no `/do`, no compiler, no settings changes.
+**Parent brief:** [`plans/2026-09-09-ccs-scenario-research.md`](./2026-09-09-ccs-scenario-research.md) — this locks item 1 of its "Lock next" list (scenario 6).
+**Seat:** CCS Align (leaf). **Audience:** Prioritizer first, then Alex and the house.
+
+---
+
+## TLDR for Prioritizer (≤6 lines)
+
+1. One underlying fact = **one node with one identity** in the DOM. Applies attach labels to that identity; they never mint a copy. Copies are the anti-pattern this lock exists to kill.
+2. Buckets get a **restricting** flag. A normal bucket label is an *allow* (OR — any match shows the node). A restricting bucket label is a *gate* (AND — only its members see the node, no matter what broader labels the node also carries). Deny beats allow; empty result fails closed.
+3. "Stripped view" is **not** compiler magic: it's a second, explicitly authored node (a *derived node*) carrying its own labels and a `derived-from` edge back to the full node. The edge is what makes drift detectable instead of silent.
+4. Scenario 6 resolved: Alex + Prioritizer see the full email node; Barb + Admin see the authored ticket-facts node; everyone else sees nothing. Each viewer's cache packs its matching node **once**, in the band the node lives in.
+5. No new levels, no new mechanism beyond one flag and one edge type. Per-viewer automatic renderings stay Phase-N.
+6. Ask: PASS this as the conflict rule; parent brief's scenario 6 stops being OPEN.
+
+---
+
+## 1. The problem being locked
+
+Scenario 6 of the parent brief: a customer email is both a support ticket and board-sensitive (the customer is a potential acquirer complaining about a bug). Barb's intake applies `bucket:support-inbox` (Barb + group Admin). Alex applies `bucket:board-private` (Alex + Prioritizer). Same underlying content, two applies with different intents — one is "route this to the people who work tickets," the other is "this is sensitive, keep it close."
+
+Naive union-of-matches shows the full email — board framing included — to everyone in either audience. Naive copying makes two emails that drift. Both are wrong. This spec locks the third path.
+
+Everything here stays inside the four locks of the parent brief: three levels only (seat / sidebar-group / house), XML/DOM spine, bucket-assign → apply-targets ACL, packing with live work after the pending timeline squeezed toward the tip.
+
+---
+
+## 2. What a node identity is
+
+A **node identity** is the durable, unique ID a chunk gets when it enters the DOM — minted once, at intake, and never re-minted for the same underlying fact.
+
+In plain terms: when the acquirer's email arrives, the intake op creates **one node** with an ID (call it `node:email-4471`). That ID is the handle for everything that ever happens to the email afterward:
+
+- **Labels attach to the identity.** `bucket:support-inbox` and `bucket:board-private` are both attached to `node:email-4471`. Two applies, one node.
+- **Annotations attach as child nodes.** Barb's triage note is a child of the email node with its own labels (`bucket:support-inbox`); the board's "handle with care, acquisition context" note is a child with `bucket:board-private`. The email text itself is never edited by either side.
+- **Edges reference the identity.** A derived node (section 5), a timeline entry, a status line — all point at `node:email-4471`, not at a pasted copy of its text.
+
+The identity is what makes "one fact appears once" checkable rather than aspirational. If two nodes exist whose content is the same fact, that's a bug in intake (or someone pasted — see anti-patterns), and the fix is: pick one identity, re-attach the other's labels and children to it, retire the duplicate.
+
+**Dedupe rule at intake:** before minting a node, the intake op asks "does this fact already have an identity?" (same source message, same artifact, same event). If yes, attach the new labels to the existing node instead of minting. The second apply in scenario 6 — Alex marking the email board-private — is exactly this: Alex's op finds `node:email-4471` already exists and attaches a label, it does not create a board copy of the email.
+
+---
+
+## 3. One fact, once in the DOM
+
+Consequences of section 2, spelled out:
+
+- **The DOM holds the email once.** Both buckets' membership sees *the same bytes* (or an authored derivative — section 5), so there is no version skew to reconcile.
+- **Applies are cheap and reversible.** Adding or removing a bucket label touches label metadata on one node. It never rewrites content, and removing an apply cleanly removes visibility — nothing to chase down and delete.
+- **Multiple matches don't multiply packing.** If an agent matches a node through two tokens (say a future Prioritizer enrolled in both buckets), the node still packs **once** in that agent's cache. Match count is a boolean, not a multiplier.
+- **Compile is per-viewer selection, not per-viewer rewriting.** Each agent's cache is compiled by selecting the nodes that agent's token set matches (after the deny pass, section 4) and packing each selected node once into its band. The compiler selects; it does not paraphrase. (Automatic per-viewer renderings are explicitly Phase-N — see section 8.)
+
+---
+
+## 4. Deny beats allow: the restricting flag
+
+### 4.1 Two kinds of bucket label
+
+Today every label on a node is an **allow**: visibility = "does the agent share *any* token with the node" (OR semantics). That's right for the common case and wrong for scenario 6, where the board apply carries restriction intent, not broadcast intent.
+
+The lock: a bucket can be marked **restricting** at apply time.
+
+- **Normal (allow) label** — OR. Any agent sharing the token sees the node.
+- **Restricting label** — AND. The node is visible **only** to agents carrying that bucket's token, regardless of any other, broader labels on the node.
+
+`bucket:board-private` is restricting. `bucket:support-inbox`, `group:building`, `house:status` are normal.
+
+### 4.2 Evaluation order
+
+For each node, at compile time:
+
+1. **Allow pass:** collect every agent that matches at least one normal label on the node (plain token match, unchanged from the parent brief).
+2. **Deny pass:** for each *restricting* label on the node, intersect the allow set with that bucket's members.
+3. **Result:** whoever survives sees the node. If the result is empty — for example, a node carrying two restricting buckets with disjoint memberships — **nobody** sees it and the compile flags it for its owner. Fail closed, never fail open.
+
+This is "deny beats allow" in one sentence: **one restricting label outranks any number of broad allows.** A node labeled `[house:all, bucket:board-private]` is visible to exactly the board bucket's members — the house label buys nothing against the gate. It also composes with the existing seat > group > house precedence without touching it: precedence orders *rules* in the cascade; the restricting flag gates *visibility of a node*. They answer different questions and never race.
+
+### 4.3 Scenario 6 under this rule
+
+`node:email-4471` carries `[bucket:support-inbox, bucket:board-private(restricting)]`.
+
+- Allow pass: Barb, Admin members (via `bucket:support-inbox`), Alex, Prioritizer (via `bucket:board-private`).
+- Deny pass: intersect with `bucket:board-private` members → **Alex + Prioritizer**.
+- Barb and Admin lose the full node. They are served by the derived node instead (next section).
+
+---
+
+## 5. Stripped vs full vs nothing
+
+The parent brief flagged "stripped/summary variant per viewer" as compiler territory and recommended absence. This lock keeps that recommendation but gives the stripped view an honest, no-compiler home:
+
+**A stripped view is a second node, authored on purpose.** When Alex (or whoever the board delegates) marks the email restricting, and support still needs the facts, someone writes a **derived node**: the ticket facts — bug report, customer-visible details, needed action — with none of the board framing (no acquirer context, no negotiation posture). That node:
+
+- has its **own identity** (`node:email-4471-ticket`),
+- carries **only** the labels its audience should match (`bucket:support-inbox`),
+- carries a **`derived-from` edge** pointing at `node:email-4471`.
+
+The `derived-from` edge is the whole trick. It's what separates a derived node from a drifting copy: when the parent node changes (customer sends a follow-up, board updates the facts), the edge lets the house *flag the derivative stale* instead of letting it silently rot. Who acts on that flag is an open question (section 8), but with the edge the drift is at least visible; without it, drift is invisible until Barb replies to the customer with old facts — the parent brief's exact failure story.
+
+**The resulting visibility table for scenario 6:**
+
+| Viewer | Sees | Why |
+|---|---|---|
+| Alex, Prioritizer | **Full node** (email + board children) | Members of the restricting bucket |
+| Barb, Admin members | **Derived node only** (ticket facts) | Match `bucket:support-inbox` on the derivative; denied on the full node |
+| Pepper, CCS Align, Orifice*, Grok Memory, everyone else | **Nothing** | Match neither node's labels |
+
+\* Orifice sees the ticket-facts node only if Orifice is in Admin; otherwise nothing.
+
+Two properties worth stating plainly, Alex:
+
+- **Nothing means absence, not redaction.** Barb's cache contains no marker saying "a board note exists about this ticket." A redaction marker is itself a leak (it advertises that something sensitive exists and roughly where). The wall is that the bytes were never packed — same principle as the sibling wall in scenario 8.
+- **If nobody authors a derivative, Barb sees nothing at all.** That is the correct default. A restricting apply with no derivative means the restrictor decided support doesn't need it (or hasn't gotten to it yet). Fail closed; the fix is authoring the derivative, not weakening the gate.
+
+---
+
+## 6. Packing: once per matching cache
+
+Nothing new is invented here — this section just confirms the parent brief's packing lock survives the conflict rule:
+
+- The **full node** packs once into Alex's and Prioritizer's caches. It's an open, sensitive deliberation → **pending timeline** band.
+- The **derived node** packs once into Barb's and each Admin member's cache. It's an open ticket → **pending timeline** of those caches.
+- If the ticket becomes active work ("Barb drafting reply now"), that's a **live-work band** status line in `house:status` — a separate roll-up chunk, written as roll-up (no board detail), sitting after the pending timeline, squeezed toward the tip, per the packing lock.
+- No cache ever contains both the full and derived node — the deny pass removes the full node from exactly the caches that hold the derivative, so there's no double-packing and no diff for a curious agent to compute.
+- Label changes (adding the restricting bucket, retiring the ticket) invalidate cache from the node's band down, in the affected caches only. Cheap for pending-timeline entries, by design.
+
+---
+
+## 7. Anti-patterns (what this lock forbids)
+
+1. **Two drifting copies.** One email pasted into two bucket "folders," each side annotating its own. This is the flat-concat failure wearing a bucket costume. Forbidden: any second node with the same underlying fact and no `derived-from` edge. Detection heuristic: intake dedupe (section 2); remedy: merge to one identity.
+2. **Share-by-paste.** Quoting a restricted node's content into a normal-bucket chunk to route around the gate. Mechanism can't fully stop a voluntary paste (same norms boundary as scenario 8's sibling wall), but the derived-node path makes the *legitimate* version of this cheap, so the paste has no excuse. One line in house rules, not new mechanism.
+3. **Redaction markers.** "\[Board-restricted content removed\]" in a non-member's cache. Forbidden — absence only, see section 5.
+4. **Deny as commentary.** Marking a bucket restricting to signal importance rather than to gate visibility. Restricting is an access decision with real fail-closed consequences (empty intersection = invisible node); using it as a highlighter creates accidental blackouts.
+5. **Compiler-written derivatives.** Auto-summarizing the full node into the stripped view. That's the per-viewer-rendering territory the parent brief marked OPEN and this lock parks at Phase-N. Overnight rule: derivatives are authored by someone accountable, or they don't exist.
+6. **Restricting-by-default.** If every bucket is restricting, the OR fabric that makes groups and house scopes work collapses into pairwise silos. Restricting is the exception, applied at apply time, by someone allowed to (section 8, Q1).
+
+---
+
+## 8. Open questions
+
+Carried honestly, not solved here:
+
+1. **Who may mark a bucket restricting?** Recommendation to lock later: Alex always; Prioritizer for board matters; a seat may restrict only buckets it owns. Needs a PASS, not assumed here.
+2. **Who authors and audits derived nodes?** The `derived-from` edge makes staleness flaggable — but who watches the flags? Natural owner is whoever applied the restriction (they created the need for the derivative). Unowned as of this writing.
+3. **Restricting: per-bucket or per-apply?** This spec treats it as a property set at apply time on the bucket. If the same bucket must be restricting on one node and normal on another, that's evidence it should be two buckets — but the house hasn't hit the case yet.
+4. **Double-restricted nodes.** Two restricting buckets with disjoint members → empty intersection → invisible to everyone, flagged to owner. Is silent-until-flagged good enough, or should the *apply op itself* refuse to create an always-invisible node? Leaning refuse-at-apply; needs a decision.
+5. **Derivative freshness contract.** How stale may a derived node be before the flag escalates (a line in `house:status`? a block on replies?)? Related to — but not the same as — the usage-left freshness question owned by Skillex in scenario 9.
+6. **Membership listing.** Who may *list* a restricting bucket's members remains the parent brief's lock-next item 5 (recommendation there: Alex + Prioritizer only, listing itself board-private). Not re-argued here; noting the two locks should land together.
+
+**Phase-N, mention only:** per-viewer automatic renderings / compiled variants of one node; attention trough (still backlog, still not designed here).
+
+---
+
+*Spec by CCS Align (seat leaf) for Alex Newman / CMEM house. On PASS: parent brief scenario 6 loses its OPEN marker; this file is the conflict rule of record.*

--- a/plans/2026-09-09-ccs-lock-not-in-group.md
+++ b/plans/2026-09-09-ccs-lock-not-in-group.md
@@ -1,0 +1,136 @@
+# CCS Lock — the "not in group" apply target (people not in a group)
+
+**Date:** 2026-09-09 (overnight lock-next work, written 2026-09-10)
+**Status:** RESEARCH / SPEC ONLY. No code, no `/do`, no compiler, no settings changes.
+**Parent brief:** [`plans/2026-09-09-ccs-scenario-research.md`](./2026-09-09-ccs-scenario-research.md) — this locks item 2 of its "Lock next" list (scenario 7).
+**Seat:** CCS Align (leaf). **Audience:** Prioritizer first, then Alex and the house.
+
+---
+
+## TLDR for Prioritizer (≤6 lines)
+
+1. "Apply to people **not** in a group" is the only target in the vocabulary that isn't a plain positive token match. Two ways to get it: bless negation (`not(group:building)`) or replace it with **managed positive buckets** whose membership is maintained by the same ops that change group membership.
+2. **Recommendation: lock managed positive buckets. Do not bless negation.** Every apply target stays a positive token match; visibility stays "share a token → see the chunk," with no whole-token-set evaluation and no fail-open edge cases.
+3. The management problem ("someone must remember to remove the token") is solved by **coupling**, not memory: the group-join op is *defined* to also drop `bucket:onboarding`. One op, two token changes, atomic.
+4. New-hire day one (Rivet, scenario 7) works cleanly: minted with `[seat:rivet, house:all, bucket:onboarding]`; sees house + onboarding pack, zero group internals. Joining Building swaps tokens in one op; onboarding band drops out of the cache wholesale — a clean single invalidation.
+5. Negation semantics are still written down below (section 4), so if the house ever hits a case positive buckets can't serve, the rejected option is specced rather than re-invented — but no current scenario needs it.
+6. Ask: PASS managed positive buckets as the lock; parent brief's scenario 7 row and apply-target table drop their OPEN flag.
+
+---
+
+## 1. The problem being locked
+
+The apply-target vocabulary from the parent brief:
+
+| Apply target | Mechanism |
+|---|---|
+| One person | positive token match |
+| Multiple people | positive token match |
+| Everyone in a group | positive token match |
+| **People not in a group** | **??? — the odd one out** |
+| House / everyone | positive token match |
+
+Four of five targets are the same trivial operation: the chunk carries a token, the agent carries a token, if they share one the agent sees the chunk. The fifth is different in kind — "not in Building" can't be answered by looking for a shared token; it requires proving a token is *absent* from the agent's whole set. That's where CSS-style systems get weird (negative selectors, specificity fights), and it's why the parent brief flagged it OPEN.
+
+The house case that wants it (scenario 7): an onboarding pack — "how the house works" — for seats that haven't landed in any sidebar group yet. The day Rivet joins Building, the pack should stop matching.
+
+Everything below stays inside the locks: three levels only (seat / sidebar-group / house), XML/DOM spine, bucket → apply ACL, packing with live work after the pending timeline squeezed toward the tip.
+
+---
+
+## 2. Option A (recommended): managed positive buckets
+
+### 2.1 The shape
+
+There is no negation anywhere. The "not in a group" audience is expressed as an ordinary bucket — `bucket:onboarding` — whose **membership is maintained by the same ops that change group membership**, instead of by anyone's memory.
+
+Two rules, and they're the entire mechanism:
+
+1. **Enrollment at mint.** When a seat is minted with no sidebar-group token, the mint op also grants `bucket:onboarding`. (A seat minted directly into a group — rare, but possible — never enrolls.)
+2. **Coupled removal at join.** The group-join op is *defined* as one atomic token swap: add `group:<x>`, remove `bucket:onboarding`. Not two ops someone sequences by hand; one op with two effects. There is no code path where a seat holds both a `group:*` token and `bucket:onboarding`.
+
+That coupling is the answer to the parent brief's stated workaround weakness ("a positive `bucket:onboarding` that someone must remember to remove"). Nobody remembers anything. The invariant — *onboarding membership = has no group token* — is enforced by the only two ops that can change either side of it.
+
+### 2.2 Why this matches house needs
+
+- **Visibility stays one mechanism.** Compile remains "select nodes sharing a token with the agent." No second evaluation mode, no ordering questions against deny-beats-allow (a positive bucket is just another allow; the restricting-flag lock in [`2026-09-09-ccs-lock-conflict-dedupe.md`](./2026-09-09-ccs-lock-conflict-dedupe.md) composes with it unchanged).
+- **Fail closed by construction.** An agent with a malformed or missing token set matches *less*, never more. (Contrast with negation, where a missing token grants visibility — section 4.3.)
+- **Auditable.** "Who gets the onboarding pack?" is answered by listing a bucket's members — the same audit as any other bucket — not by evaluating a predicate against every agent's token set and hoping the tokens are spelled right.
+- **The house's actual need is narrow.** Scanning all ten scenarios: the only "not in group" audience anyone has wanted is *new seats not yet in any group*. That is exactly an enrollment-lifecycle bucket. Nobody has asked for "everyone except Building" as a broadcast target; if that ever appears, see section 5, Q4.
+
+### 2.3 Scenario walkthroughs
+
+**New hire, day one (scenario 7).** Rivet is minted: `[seat:rivet, house:all, bucket:onboarding]`. Rivet's compiled cache contains: house-wide chunks (`house:all`, `house:rules`, the `house:status` roll-up) plus the onboarding pack. **No** Building internals, no sibling `seat:*` chunks, no `bucket:board-private`. The onboarding pack barely changes, so it packs in the **stable head** of Rivet's cache — day-one prompts stay byte-stable and cheap.
+
+**Joining a group.** Rivet joins Building. One op: `[seat:rivet, house:all, bucket:onboarding]` → `[seat:rivet, group:building, house:all]`. Effects on the next compile: the onboarding band drops out **wholesale** (a clean, single cache invalidation — a whole stable-head section removed, everything below repacks once) and the `group:building` slice packs into the middle band. Per the parent brief's scenario 7 note, Rivet sees Building chunks written *before* the join — membership-at-compile-time — and any pre-hire history wall remains its own bucket decision, unchanged by this lock.
+
+**Leaving a group.** Pepper-style moves (scenario 3) are unaffected: leaving Building for Planning is `group:building` → `group:planning`, and since a group token is present throughout, onboarding never re-enters the picture. The edge case is a seat leaving *all* groups (benched between assignments): **it does not re-enroll in onboarding.** Onboarding is a first-landing pack, not a "groupless" pack; re-reading the house tour doesn't help a veteran. If the house ever wants a benched-seat pack, that's a new bucket with its own PASS (section 5, Q3).
+
+**Multiple simultaneous new hires.** Nothing special — each carries `bucket:onboarding` independently; the pack is one node packing once per matching cache; each join removes one member. No cross-talk.
+
+**Migration of the pack itself.** Editing the onboarding pack invalidates only the caches of current members — usually zero or one seat. Cheapest possible blast radius, which is fitting for a document that changes about as often as house rules do.
+
+---
+
+## 3. What "managed" costs (honest ledger)
+
+- **Ops carry the invariant.** Mint and group-join must both honor the coupling. That's two ops to get right once, versus a predicate evaluated on every compile forever. Good trade, but it does mean the coupling belongs *in the op definition*, written into the ACL lock — not in a runbook.
+- **A stuck member is possible in theory** (a seat that never joins any group keeps the pack indefinitely). That's arguably correct — they're still un-landed — but a long-lived `bucket:onboarding` token is also a decent signal something's wrong with the hire. A staleness flag ("carried onboarding > N days") is a nice-to-have, parked in section 5, Q2.
+- **Each distinct "not in X" audience needs its own bucket.** True, and accepted: it forces every negative-sounding audience to be named, owned, and enumerable — which is exactly the discipline the house wants around who sees what.
+
+---
+
+## 4. Option B (rejected, but specced): raw negation `not(group:building)`
+
+Written down so the rejected road is on the record and never re-litigated from scratch. If the house ever keeps negation, these are the exact semantics — anything looser is a leak generator.
+
+### 4.1 Semantics
+
+- A negative selector may appear **only on a chunk**, never on an agent. Agents carry positive tokens only.
+- `not(group:building)` matches an agent iff `group:building` is absent from the agent's **complete token set at compile time**. Membership-at-compile-time, same as positive group matching.
+- `not(group:*)` (not in *any* group) must be spelled explicitly as the wildcard form; `not(group:building)` means "not in Building" and nothing more. The two are different audiences and confusing them is the first failure everyone would hit.
+- A chunk carrying only negative selectors is illegal — every chunk must carry at least one positive scope token (`house:all` at minimum) so the candidate audience is bounded before negation subtracts from it. `[house:all, not(group:building)]` = "everyone except Building." `[not(group:building)]` alone = refused at apply time.
+
+### 4.2 Evaluation order vs deny-beats-allow
+
+Negation slots into the existing compile as a third step — and the ordering matters:
+
+1. **Allow pass** — union of positive-label matches (unchanged).
+2. **Negation pass** — subtract agents matching any `not(...)` on the chunk. Negation *narrows an allow*; it can never grant.
+3. **Deny pass** — restricting buckets intersect last, exactly as in the conflict-dedupe lock. **A restricting bucket always beats a negation-widened audience**, so deny-beats-allow keeps its rank as the final word.
+
+Fail closed at every step: empty result = invisible node, flagged to owner.
+
+### 4.3 Failure modes vs plain token match (why it lost)
+
+- **Fail-open inversion.** Every positive-match failure mode errs toward *seeing less*. Negation inverts that: a missing or misspelled token means the agent "isn't in the group" and therefore **sees more**. A typo in Rivet's `group:building` token silently re-enrolls Rivet in every "not in Building" audience in the house. Absence-as-grant is the opposite of the fail-closed discipline every other lock leans on.
+- **Whole-set evaluation.** Positive match is "do these two sets intersect?" Negation is "prove this token appears nowhere in the agent's set" — compile now depends on the completeness and spelling of the entire token inventory, and a token added anywhere can flip audiences of chunks nobody touched.
+- **Unauditable audiences.** "Who sees this chunk?" stops being "list the bucket" and becomes "enumerate all agents and evaluate a predicate against each" — the audience has no name, no owner, and changes as a side effect of unrelated membership ops.
+- **Specificity creep.** Once `not()` exists, combinations follow (`not(group:building), not(group:admin)`, negation plus restriction…) and the house is reinventing CSS specificity wars inside its ACL. The parent brief's phrase for this was "negative selectors are where CSS gets weird." Correct then, correct now.
+- **New-agent default.** Every freshly minted agent matches every negation in the house on day one, before anyone has decided anything about them. Day-one Rivet would see all "not in Building," "not in Planning," "not in Admin" chunks simultaneously — audiences that were each designed with *someone else* in mind.
+
+---
+
+## 5. Recommendation and lock
+
+**Lock: managed positive buckets. Negation is not blessed as an apply target.**
+
+Concretely:
+
+1. The apply-target table in the parent brief changes its fifth row from "needs negation — OPEN" to: **"people not in a group → managed positive bucket (e.g. `bucket:onboarding`), membership coupled to mint and group-join ops."** All five targets are now plain positive token matches.
+2. The mint op grants `bucket:onboarding` to seats minted without a group token; the group-join op atomically removes it. This coupling text belongs in the ACL lock alongside the apply-target table.
+3. `not(...)` does not enter the token grammar. Section 4 stands as the reference spec should the house ever revisit — revisiting requires a new PASS with a scenario positive buckets demonstrably can't serve.
+4. Onboarding pack packing (stable head while held, wholesale drop on join) is confirmed as consistent with the packing lock; nothing new needed there.
+
+### Open questions
+
+1. **Who owns the coupling ops?** The mint and group-join ops need a named owner (Orifice as organizer is the natural fit, but that's an assignment for Alex/Prioritizer, not this seat's call).
+2. **Staleness flag for long-held onboarding tokens.** "Seat carried `bucket:onboarding` > N days" as a `house:status` line — useful, small, unowned. Nice-to-have, not part of this lock.
+3. **A "benched" bucket** for seats that leave all groups: not designed here; explicitly *not* the same bucket as onboarding. Needs its own PASS if the house ever benches seats.
+4. **"Everyone except group X" broadcasts.** No scenario needs it today. If one appears, the positive-bucket answer is to mint the complement bucket at apply time (enumerate current non-members) and accept that it's a snapshot — or bring the case back for a negation re-vote per point 3 above. Deliberately unresolved until a real case exists.
+
+**Phase-N, mention only:** attention trough — still backlog, still not designed here.
+
+---
+
+*Spec by CCS Align (seat leaf) for Alex Newman / CMEM house. On PASS: parent brief scenario 7 and the apply-target table lose their OPEN flags; this file is the "not in group" rule of record.*

--- a/plans/2026-09-09-ccs-scenario-research.md
+++ b/plans/2026-09-09-ccs-scenario-research.md
@@ -360,4 +360,15 @@ Cast: **Alex** (human, sole board), **Prioritizer** (shipmaster), **CCS Align** 
 
 ---
 
+## 7. Lock-next overnight (2026-09-10)
+
+Alex skipped the PASS widget, so this brief is being treated as the research SoT overnight. Lock-next items 1 and 2 from section 6 now have full specs:
+
+1. **Conflict rule (scenario 6)** → [`plans/2026-09-09-ccs-lock-conflict-dedupe.md`](./2026-09-09-ccs-lock-conflict-dedupe.md) — node identity + one-fact-once dedupe, the restricting-bucket flag (deny beats allow, fail closed), stripped views as explicitly authored derived nodes with `derived-from` edges (not compiler renderings), who sees full / stripped / nothing, packing once per matching cache, anti-patterns, open questions.
+2. **"Not in group" apply target (scenario 7)** → [`plans/2026-09-09-ccs-lock-not-in-group.md`](./2026-09-09-ccs-lock-not-in-group.md) — recommendation: **managed positive buckets** (`bucket:onboarding` with membership coupled atomically to mint and group-join ops); raw negation `not(group:building)` specced for the record but rejected (fail-open inversion, whole-set evaluation, unauditable audiences). Covers new-hire day one, onboarding packs, and join/leave migration.
+
+On PASS of those two files, scenario 6's OPEN, scenario 7's OPEN, and the apply-target table's negation row are resolved. Items 3–5 of section 6 (band-migration cadence, usage-left names/audiences, bucket-membership listing) remain unlocked. Attention trough: still Phase-N, still not designed.
+
+---
+
 *Research brief for Alex Newman / CMEM house. CCS Align (seat leaf) is the scenario source of truth; copy to Notion + box reports on PASS. Skillex owns subagent-deploy internals referenced in scenarios 9–10.*

--- a/plans/2026-09-09-ccs-scenario-research.md
+++ b/plans/2026-09-09-ccs-scenario-research.md
@@ -1,0 +1,363 @@
+# CCS Scenario Research — bucket → apply targets, 3 levels, packing
+
+**Date:** 2026-09-09
+**Status:** RESEARCH ONLY. No code, no `/do`, no compiler, no settings changes. Scenario exercise for the locked CCS model.
+**Seat:** CCS Align (leaf). Plan of record: [`plans/2026-09-09-ccs-align.md`](./2026-09-09-ccs-align.md).
+**Audience:** Prioritizer first (TLDR below), then Alex and the house.
+
+---
+
+## TLDR for Prioritizer (≤8 lines)
+
+1. Ten concrete scenarios exercise the locked model: 3 levels (seat / sidebar-group / house), XML/DOM spine, bucket-assign → apply-targets ACL, and packing (live status after pending timeline, squeezed toward the tip).
+2. Alex's lens holds everywhere tested: name a **bucket** of context, then **apply** it to one person, several people, a group, people *not* in a group, or the whole house. No scenario needed a 4th level.
+3. Two things want a lock next: (a) **deny-beats-allow + node-identity dedupe** for the two-bucket conflict case, (b) the **"not in group" apply target** — it's the only target that isn't a plain token match.
+4. Grok Memory silent inject ([#3953](https://github.com/thedotmack/claude-mem/pull/3953), merged) stays a **seat leaf** under this model — it already behaves like a one-person apply.
+5. New for Skillex: two **usage-left** scenarios (9–10). Usage-left is a high-churn bucket read by deployers before spawn; it packs in the live-work band near the tip, never with frozen house rules.
+6. Flat-concat fails differently in every scenario: leaks (1, 2, 8), staleness (3, 4, 9), duplication (6), and cache-bust economics (4, 10). The model earns its keep.
+7. Attention trough = Phase-N backlog. Mentioned, not designed.
+8. Ask: PASS this brief as scenario source of truth; CCS Align copies it to Notion + box reports.
+
+---
+
+## 1. The locked model (what these scenarios exercise)
+
+Four locks. Nothing here invents past them.
+
+1. **Three levels only.** Label namespaces: **seat** (one agent), **sidebar-group** (Building, Planning, Admin), **house** (everyone). No teams-of-teams, no 4th tier.
+2. **XML/DOM spine.** Context lives as nodes in a document tree. Operations connect / join / attach / traverse nodes. A chunk is a node; it exists once and can carry many labels.
+3. **Tailwind-style apply/class ACL — framed as Alex's model:**
+   - Step 1: assign a **bucket of data** (a named cache/context pack).
+   - Step 2: **apply** that bucket to targets — one person, multiple people, everyone in a group, people **not** in a group, or house-wide.
+   - Visibility = label match. A chunk carries bucket/class tokens; an agent carries class tokens; if they share a token, the agent sees the chunk. Example: Alex and seat X share a bucket → both carry the bucket label → both see it. This does **not** have to be exact CSS — it has to work for house needs (levels + packing + who-sees-what). Join-trees are how nodes relate, not how visibility is decided.
+4. **Packing.** The context cache includes "what everybody is working on" (live status). It goes **after** the pending timeline and is squeezed toward the **bottom of the middle band**, so high-churn content sits nearer the changing tip and stable content keeps the prefix cache warm.
+
+**Related, mention only:** Grok Memory silent inject ([#3953](https://github.com/thedotmack/claude-mem/pull/3953)) stays a **seat leaf** until group/house nodes exist (scenario 5). Attention trough = **Phase-N backlog** — named, not designed here.
+
+### Caching buckets (short note)
+
+A **bucket is a named pack in the middle/context cache** — a labeled slice of the CCC, not a separate file per reader. Applying a bucket attaches *visibility* (which agents' compiled caches include that slice); it does not copy text around. The opposite — flat concat — pastes everything into every prompt and hopes for the best. Every "failure mode" row below is what flat concat actually does. Provenance details for how buckets get filled (Oracle / Contextualizer internals) are not established in this brief — **OPEN**, moving on.
+
+---
+
+## 2. Token namespace sketch
+
+```
+house:all                    # everyone in the house (Alex + every seat)
+house:status                 # house-wide live status bucket
+house:rules                  # standing house rules (stable)
+
+group:building               # sidebar group membership tokens
+group:planning
+group:admin
+
+seat:ccs-align               # one token per seat (leaf identity)
+seat:prioritizer
+seat:barb
+seat:orifice
+seat:pepper
+seat:grok-memory
+alex                         # Alex is a person, not a seat; carries own token
+
+bucket:<name>                # custom buckets — named packs, applied to targets
+  bucket:board-private       #   e.g. Alex + Prioritizer only
+  bucket:support-inbox       #   e.g. Barb + group:admin
+  bucket:usage-left:house    #   Skillex deployer read (scenario 9)
+  bucket:usage-left:pepper   #   per-seat usage slice (scenario 10)
+```
+
+Apply targets in this vocabulary:
+
+| Apply target | How it's expressed |
+|---|---|
+| One person | chunk gets `seat:barb` (or `alex`); only that agent carries it |
+| Multiple people | chunk gets `bucket:x`; each named agent carries `bucket:x` |
+| Everyone in a group | chunk gets `group:building`; members carry it by membership |
+| People **not** in a group | needs negation (`not(group:building)`) — **OPEN**, see scenario 7 & recommendations |
+| House / everyone | chunk gets `house:all` |
+
+Seat > group > house on conflict; **deny beats allow**; fail closed if no rule matches (carried over from the CCS cascade discipline in the plan of record).
+
+---
+
+## 3. Packing band diagram
+
+```
+┌─────────────────────────────────────────────┐
+│ STABLE HEAD                                 │  house rules, profiles, standing
+│  house:rules, profiles, cascade             │  changes rarely → prefix cache warm
+├─────────────────────────────────────────────┤
+│ PENDING TIMELINE                            │  queued/pending items, recent
+│  ordered episodic feed (diary-derived)      │  decisions not yet closed out
+├─────────────────────────────────────────────┤
+│ LIVE-WORK BAND  ("what everybody is         │  ← placed AFTER pending timeline
+│  working on")                               │
+│   · house:status roll-up                    │  squeezed toward the BOTTOM of
+│   · bucket:usage-left:* (high-churn)        │  the middle band: highest churn
+│   · active spawn/assignment state           │  sits lowest, nearest the tip
+├─────────────────────────────────────────────┤
+│ TIP (changing edge)                         │  current turn / task at hand
+└─────────────────────────────────────────────┘
+```
+
+Rule of thumb used in every scenario below: **the more often a chunk changes, the lower it packs.** A chunk that moves bands (e.g. a pending item going live) invalidates cache from its position down — so churn at the bottom is cheap, churn at the top is expensive.
+
+---
+
+## 4. Scenarios
+
+Cast: **Alex** (human, sole board), **Prioritizer** (shipmaster), **CCS Align** (this seat, leaf), **Barb** (support), **Orifice** (organizer), **Pepper** (media), **Grok Memory** (silent inject). Groups: **Building**, **Planning**, **Admin**. **Skillex** owns the subagent-deploy skill (scenarios 9–10); its internals are not invented here.
+
+---
+
+### Scenario 1 (A) — Seat secret, group shared, house status: three chunks, three scopes
+
+**Setup.** In one afternoon three chunks are born: CCS Align drafts a private worry note ("my exclude-marks logic may double-fire — verify before saying anything"), Building writes a shared build note ("worker port resolution changed, use the snippet"), and the house status line updates ("Pepper cutting the launch video, Barb on inbox").
+
+**Bucket → apply targets:**
+- `seat:ccs-align` draft → **one person** (CCS Align only)
+- `group:building` build note → **everyone in a group** (Building members)
+- `house:status` line → **house / everyone**
+
+**Tokens on chunks:** draft note `[seat:ccs-align]`; build note `[group:building]`; status line `[house:all, house:status]`.
+
+**Tokens on agents:** CCS Align `[seat:ccs-align, group:building, house:all]`; Orifice `[seat:orifice, group:building, house:all]`; Barb `[seat:barb, group:admin, house:all]`; Alex `[alex, house:all]` (Alex can additionally be applied into anything — sole board).
+
+**Who sees what:** CCS Align sees all three. Orifice sees the build note + status, **not** the draft worry. Barb sees only the status line — **not** the build note (no `group:building`), **not** the draft.
+
+**Packing:** draft note → pending timeline of CCS Align's own cache only. Build note → stable-ish middle of Building members' caches (changes on port changes, not hourly). Status line → live-work band, bottom of middle, near tip, everyone.
+
+**Flat-concat failure:** all three chunks land in every prompt. Barb's support replies start referencing an unverified exclude-marks worry as if it were fact; the private draft is now house lore.
+
+**Open risk:** the status line *mentions* seats by name ("Pepper cutting the video"). House-wide status must be written as roll-up, not as a leak channel for group-private detail — who audits the roll-up wording is unowned.
+
+---
+
+### Scenario 2 (B) — Alex + one seat share a bucket; another seat does not
+
+**Setup.** Alex and Prioritizer share board-level context: hiring thoughts, which seats are underperforming, budget posture. Barb must never see this, even though Barb is house.
+
+**Bucket → apply targets:** `bucket:board-private` → **multiple people** (exactly Alex + Prioritizer).
+
+**Tokens on chunks:** board notes `[bucket:board-private]`. Nothing else — deliberately no `house:*` or `group:*` token on these chunks.
+
+**Tokens on agents:** Alex `[alex, house:all, bucket:board-private]`; Prioritizer `[seat:prioritizer, house:all, bucket:board-private]`; Barb `[seat:barb, group:admin, house:all]` — no board token.
+
+**Who sees what:** Alex and Prioritizer both carry the bucket label, so both see the chunks (this is the canonical "Alex + seat X share access → both carry the bucket label" example). Barb sees nothing of it; neither does CCS Align, Orifice, Pepper, or Grok Memory.
+
+**Packing:** board-private chunks sit in the pending timeline of the two matching caches (they're deliberations, not live churn). They never appear in anyone else's packing at all — absence, not redaction.
+
+**Flat-concat failure:** "which seats are underperforming" ends up in the underperforming seat's own prompt. Best case awkward, worst case the seat starts optimizing for the review text instead of the work.
+
+**Open risk:** bucket membership is invisible in the DOM unless you inspect agent tokens. Who can *list* the members of `bucket:board-private` (and where that listing itself packs) is undefined — the membership list is itself sensitive context.
+
+---
+
+### Scenario 3 (C) — Pepper moves from Building to Planning (class change)
+
+**Setup.** Pepper finishes the launch video and moves from Building to Planning to help scope next quarter's media. This is a **class change on the agent**, not on any chunk.
+
+**Bucket → apply targets:** no new bucket. Building chunks stay applied to **everyone in group Building**; Planning chunks stay applied to **everyone in group Planning**. Only Pepper's token set changes.
+
+**Tokens on chunks:** unchanged — `[group:building]` on build notes, `[group:planning]` on planning docs.
+
+**Tokens on agents:** Pepper before `[seat:pepper, group:building, house:all]` → after `[seat:pepper, group:planning, house:all]`.
+
+**Who sees what:** the moment the class flips, Pepper's compiled cache stops matching `group:building` chunks and starts matching `group:planning` ones. Building members keep seeing Building chunks; nobody else's view changes. Pepper keeps everything `seat:pepper` and `house:all`.
+
+**Packing:** Pepper's cache needs a **rebuild**: the Building slice drops out of the pending timeline and middle band, the Planning slice packs in. Live-work band updates naturally ("Pepper → Planning" is itself a house:status line near the tip).
+
+**Flat-concat failure:** there is no move. Pepper's prompt keeps carrying stale Building context forever, and Planning context just piles on top. Six months later Pepper is "in" four groups and the prompt is archaeology.
+
+**Open risk:** what happens to Building chunks Pepper *already acted on*? Access history isn't revoked by a class change (Pepper remembers the port snippet). The model governs *future compiles*, not past exposure — worth saying out loud so nobody expects a class change to be a memory wipe.
+
+---
+
+### Scenario 4 (D) — High-churn active work vs stable house rules (packing position)
+
+**Setup.** Two chunks with opposite lifecycles: the house rule "address the human as Alex, never Az" (changed once, months ago) and the live-work line "Orifice reorganizing inbox labels *right now*" (changes several times an hour).
+
+**Bucket → apply targets:** `house:rules` → **house / everyone**. `house:status` (live-work) → **house / everyone**. Same audience, different bands — this scenario is purely about *where* they pack.
+
+**Tokens on chunks:** rule `[house:all, house:rules]`; live line `[house:all, house:status]`.
+
+**Tokens on agents:** everyone carries `house:all` — all agents see both.
+
+**Who sees what:** everyone sees both chunks. Nobody is excluded. The interesting part is position.
+
+**Packing:** the rule goes in the **stable head** — top of the cache, byte-identical across compiles, keeps the prefix cache warm for every agent in the house. The live line goes in the **live-work band**: after the pending timeline, squeezed to the bottom of the middle band, nearest the tip. When Orifice's status changes, only the last few hundred tokens of every cache change; everything above stays cached.
+
+**Flat-concat failure:** status lines interleave with rules in insertion order. Every status flicker rewrites the middle of the prompt, busting the prefix cache house-wide, hourly. You pay full-price tokens on every compile to re-read a rule that hasn't changed since spring. (This is the same economics behind the plan-of-record's "no top-of-prompt clock" rule.)
+
+**Open risk:** chunks that *migrate* bands — a pending decision that becomes live work, or live work that hardens into a rule. Band migration invalidates cache from the migration point down; how often migration is allowed (per compile? per brainbeat?) is unowned and belongs with the packing lock.
+
+---
+
+### Scenario 5 (E) — Grok Memory silent inject #3953 as a seat leaf
+
+**Setup.** [#3953](https://github.com/thedotmack/claude-mem/pull/3953) (merged) silently injects Claude-Mem session context into the Grok Bot prompt path. Under this model: how does an already-shipped, pre-CCS feature sit inside the three levels?
+
+**Bucket → apply targets:** `seat:grok-memory` inject pack → **one person** (Grok Memory itself). That's the whole ACL.
+
+**Tokens on chunks:** injected session context `[seat:grok-memory]`. No group token, no house token — there **are no group/house nodes for it yet**, and this brief does not invent them.
+
+**Tokens on agents:** Grok Memory `[seat:grok-memory, house:all]`. Nobody else carries `seat:grok-memory`.
+
+**Who sees what:** Grok Memory sees its own injected pack. No other seat sees the inject content through CCS, and Grok Memory gains no *extra* reach from the model — it stays exactly the leaf it shipped as. It stays a seat leaf **until group/house nodes exist** for memory injection; promoting it to `group:*` or `house:*` would be a new decision with a new owner, not a side effect of adopting CCS.
+
+**Packing:** the inject lands in Grok Memory's own pending timeline (it's session context, moderately fresh), not in the live-work band and not in anyone else's cache at all.
+
+**Flat-concat failure:** silent inject + flat concat = the *silent* part breaks. Session context meant for one prompt path smears into every agent's prompt, and "silent" becomes "house-wide broadcast nobody approved."
+
+**Open risk:** #3953 predates the label model, so its inject is *implicitly* seat-scoped by code path, not by token. If group/house memory nodes ever exist, someone must retrofit explicit labels before widening — otherwise the widening happens by accident in whatever code touches the path next.
+
+---
+
+### Scenario 6 (F) — Conflict: the same email lands in two buckets
+
+**Setup.** A customer email arrives that is both a support ticket and board-sensitive (the customer is a potential acquirer complaining about a bug). Barb's intake labels it `bucket:support-inbox` (applied to Barb + group Admin). Alex separately marks it `bucket:board-private` (applied to Alex + Prioritizer).
+
+**Bucket → apply targets:** `bucket:support-inbox` → **one person + everyone in a group** (Barb, Admin). `bucket:board-private` → **multiple people** (Alex, Prioritizer). Same underlying content, two applies.
+
+**Tokens on chunks:** here the **DOM spine earns its keep**: the email is **one node** carrying both labels `[bucket:support-inbox, bucket:board-private]` — not two copied chunks. Ops attach labels to the node; they don't duplicate it.
+
+**Tokens on agents:** Barb `[…, bucket:support-inbox]`; Orifice (Admin) `[…, group:admin]` — wait, intake applied to Barb + group Admin, so Admin members match via `group:admin` if the node also carries `group:admin`, or via the bucket if they're enrolled; Alex and Prioritizer carry `bucket:board-private`.
+
+**Who sees what — and the conflict rule:** union-of-matches would show the full email to Barb, Admin, Alex, and Prioritizer. But the board apply carries an implicit *restriction intent* ("this is sensitive"). Two coherent resolutions exist: (a) **union** — both audiences see the one node; (b) **deny-beats-allow** — the board bucket adds a deny for non-members, so Barb sees a stripped/summary version and only Alex + Prioritizer see the full node. The plan-of-record cascade discipline says deny beats allow and fail closed — so (b) is the model-consistent answer, and Barb sees the ticket *facts* but not the board framing. **Who does NOT see it:** everyone outside both applies (Pepper, CCS Align, Grok Memory) sees nothing either way.
+
+**Packing:** the node packs once per matching cache: pending timeline for Barb (it's an open ticket), pending timeline for Alex/Prioritizer. If Barb's view is the stripped variant, that variant is what packs — the compile is per-viewer.
+
+**Flat-concat failure:** two *copies* of the email exist (one per bucket), they drift as each side annotates, and eventually Barb replies to the customer using stale text while the board discusses a version with different facts. Duplication plus drift, the classic.
+
+**Open risk:** "stripped/summary variant per viewer" implies per-viewer *renderings* of one node. That's compile-time work the house hasn't specced (it smells like the future compiler). For now the honest options are: one node + deny (Barb sees nothing and gets a separate hand-written ticket chunk), or accept union. Marked **OPEN** for the lock list.
+
+---
+
+### Scenario 7 (G) — New hire joins Building: what apply tokens they get
+
+**Setup.** A new seat, **Rivet**, is hired into Building to help with worker tooling.
+
+**Bucket → apply targets:** membership, not a new bucket: Rivet gets tokens; existing Building chunks (applied to **everyone in a group**) start matching automatically. One additional wrinkle: an onboarding pack `bucket:onboarding` is applied to **people not in a group** — specifically, seats *not yet* in any sidebar group get the "how the house works" pack; the moment Rivet lands in Building it stops matching.
+
+**Tokens on chunks:** Building notes `[group:building]`; onboarding pack `[bucket:onboarding, not(group:*)]` — the negation is the sketchy part, see below.
+
+**Tokens on agents:** Rivet on day one `[seat:rivet, house:all]` → after joining `[seat:rivet, group:building, house:all]`.
+
+**Who sees what:** day one — Rivet sees house-wide chunks + the onboarding pack; **no** Building internals yet. After joining — all current `group:building` chunks (the port snippet, the build notes), house status, own seat space. **Not:** any sibling's `seat:*` chunks (scenario 8), no `bucket:board-private`, no Planning/Admin group chunks. Notably Rivet **does** see group chunks written *before* the join — group visibility is membership-at-compile-time, not membership-at-write-time. If Building wants pre-hire history walled, that history needs its own bucket.
+
+**Packing:** onboarding pack sits in stable head of Rivet's cache day one (it barely changes), then drops out entirely after the join — a whole-band removal, which is a clean single cache invalidation. Building slice packs into the middle band on join.
+
+**Flat-concat failure:** onboarding text stays in the prompt forever (nothing ever leaves a concat), and Rivet gets *all* house history on day one including every group's internals — the exact opposite of a walled onboarding.
+
+**Open risk:** the `not(group:*)` apply target is the only target in the vocabulary that isn't a positive token match — it requires evaluating an agent's *whole* token set. That's a real mechanism decision (negative selectors are where CSS gets weird). Flagged for the lock list; workaround meanwhile is a positive `bucket:onboarding` that someone must remember to remove.
+
+---
+
+### Scenario 8 (H) — Sibling wall: two Building seats, seat-private notes stay private
+
+**Setup.** CCS Align and Orifice are both in Building. Each keeps seat-private working notes: CCS Align's exclude-mark drafts, Orifice's half-finished inbox re-org plan. They collaborate daily through `group:building` chunks.
+
+**Bucket → apply targets:** each seat's notes → **one person** (own seat). Shared work → **everyone in a group** (Building). No bucket ever spans exactly-the-two-of-them unless deliberately created.
+
+**Tokens on chunks:** `[seat:ccs-align]` on Align's drafts; `[seat:orifice]` on Orifice's plan; `[group:building]` on shared notes.
+
+**Tokens on agents:** CCS Align `[seat:ccs-align, group:building, house:all]`; Orifice `[seat:orifice, group:building, house:all]`. The group token they share matches only `group:building` chunks — sharing a group gives **zero** transitive access to a sibling's seat namespace. Siblings deny heavy buckets by default (plan-of-record cascade discipline: `obs`, `note`, `person` from a peer → deny).
+
+**Who sees what:** each seat sees own notes + Building shared + house. CCS Align does **not** see Orifice's re-org plan and vice versa. If they want to share one draft, the op is explicit: attach `group:building` to that node, or mint a two-person bucket.
+
+**Packing:** seat-private notes pack only in the owner's cache (pending timeline). Shared Building chunks pack in both. Neither seat's cache contains a byte of the sibling's private band — the wall is absence at compile, not a redaction marker that advertises something is hidden.
+
+**Flat-concat failure:** both seats' drafts sit in one shared context. Orifice "helpfully" completes CCS Align's half-thought exclude-marks idea in a different direction, both act, and the house gets two divergent implementations of one unverified draft. Sibling leak isn't just privacy — it's premature coordination on unbaked work.
+
+**Open risk:** group chat *about* private work erodes the wall socially ("as I said in my notes, …" quoted into a `group:building` chunk). The model can't stop a seat from voluntarily pasting private text into a shared bucket; that's a norms problem, worth one line in house rules rather than mechanism.
+
+---
+
+### Scenario 9 (Skillex) — Deployer checks house usage-left before spawning
+
+**Setup.** The **subagent-deploy skill (owner: Skillex — internals not designed here)** owns pick rules plus a **usage % check before spawn**: check everyone + house overall → warn if close → distribute work. Prioritizer asks for three research subagents. Before spawning, the deploy skill consults the usage-left cache.
+
+**Bucket → apply targets:** `bucket:usage-left:house` (house overall remaining %, per-seat burn summary) → applied to **deployers** — Prioritizer and any seat running the subagent-deploy skill. A dashboard variant could be applied to **house / everyone**, but the *actionable* bucket is deployer-scoped: most seats have no spawn decision to make with it.
+
+**Tokens on chunks:** usage roll-up `[bucket:usage-left:house]`, refreshed on a short cadence.
+
+**Tokens on agents:** Prioritizer `[seat:prioritizer, house:all, bucket:usage-left:house, bucket:board-private]`; a deploying seat gains `bucket:usage-left:house` while it holds the deploy skill; Barb, Pepper, Grok Memory do not carry it.
+
+**Who sees what:** Prioritizer and active deployers see house-remaining % and the per-seat burn summary. Barb does **not** — her prompts aren't taxed with fleet accounting. Gate behavior stays in the skill (Skillex's), not in CCS: the model only answers *who sees usage-left and when*, i.e. spawn is gated on a bucket the deployer can actually see at decision time.
+
+**Packing:** usage-left is **high-churn** — it changes with every spawn and every busy hour. It packs in the **live-work band, near the tip**, after the pending timeline — never in the stable head with house rules. A deployer's compile reads it as close to the decision point as possible, so the number is fresh relative to everything above it.
+
+**Flat-concat failure:** yesterday's usage snapshot sits mid-prompt looking authoritative. The deployer "checks" a stale number, spawns three subagents into a nearly-exhausted budget, and the warn-if-close rule fires *after* the money is spent. Stale gate = no gate.
+
+**Open risk:** freshness contract. A usage number is only as good as its timestamp; if the live-work band refresh cadence is slower than spawn frequency, two deployers can both read "room for 3 more" and jointly overshoot. Whether the check needs read-at-spawn-time semantics (vs read-at-compile-time) is Skillex's to spec — flagged, not solved.
+
+---
+
+### Scenario 10 (Skillex) — Seat-local usage slice vs house overall: warn-if-close, then redistribute
+
+**Setup.** Pepper is mid-render on the launch video and burning tokens fast. Pepper's seat-local usage slice says 85% of seat allowance gone; house overall is fine. The deploy skill's rule: warn when a seat is close, then **distribute work** to seats with headroom instead of spawning more under the hot seat.
+
+**Bucket → apply targets:**
+- `bucket:usage-left:pepper` (seat slice) → **multiple people**: Pepper (self-awareness) + Prioritizer (redistribution authority). Not house-wide — a seat's burn detail is nobody else's business.
+- `bucket:usage-left:house` → deployers, as in scenario 9.
+
+**Tokens on chunks:** Pepper slice `[bucket:usage-left:pepper]`; house roll-up `[bucket:usage-left:house]`.
+
+**Tokens on agents:** Pepper `[seat:pepper, group:planning, house:all, bucket:usage-left:pepper]`; Prioritizer carries both usage buckets. Orifice sees neither Pepper's slice nor (unless deploying) the house roll-up.
+
+**Who sees what:** Pepper sees own slice and can self-throttle. Prioritizer sees Pepper's slice **and** house overall, so the redistribute decision ("move the b-roll captioning to Orifice") is made with both numbers. Other seats see neither; they just receive redistributed work as normal group/seat chunks. The warn itself is a chunk in `bucket:usage-left:pepper` — visible exactly to the two agents who can act on it.
+
+**Packing:** both usage buckets pack in the **live-work band near the tip** of the caches that carry them. The *redistribution outcome* ("captioning → Orifice") is a normal live-work status line in `house:status` — also bottom-band. Stable head untouched; house rules don't flinch because a render ran hot.
+
+**Flat-concat failure:** every seat's burn detail concatenates into every prompt. Two failure flavors: seats start gaming visible meters ("Orifice looks cheap, dump everything there"), and the hourly meter flicker busts the prefix cache house-wide — you *spend* tokens broadcasting how few tokens are left.
+
+**Open risk:** warn-threshold placement. If "close" is defined in the bucket (data) vs in the skill (rule), you get different failure modes when they disagree. CCS Align's read: threshold is Skillex's rule; the bucket carries raw numbers only. **OPEN** for Skillex to confirm.
+
+---
+
+## 5. Coverage check
+
+| Required case | Scenario |
+|---|---|
+| A. Seat secret vs group shared vs house status | 1 |
+| B. Alex + one seat share a bucket; another does not | 2 |
+| C. Agent moves between sidebar groups | 3 |
+| D. High-churn work vs stable rules (packing) | 4 |
+| E. Silent inject #3953 as seat leaf | 5 |
+| F. Same content in two buckets (conflict) | 6 |
+| G. New hire joins a group (apply tokens) | 7 |
+| H. Sibling wall (optional 8th) | 8 |
+| Skillex: deployer reads usage-left before spawn | 9 |
+| Skillex: seat slice vs house overall, redistribute | 10 |
+| Apply target: one person | 1, 5, 8 |
+| Apply target: multiple people | 2, 6, 10 |
+| Apply target: everyone in a group | 1, 3, 7, 8 |
+| Apply target: people not in a group | 7 (flagged OPEN) |
+| Apply target: house / everyone | 1, 4, 9 (dashboard variant) |
+
+---
+
+## 6. Recommendations — lock next vs Phase-N
+
+**Lock next (small, model-level, no code):**
+
+1. **Conflict rule for multi-bucket nodes (scenario 6).** Adopt deny-beats-allow explicitly for bucket intersections, and decide between "deny = absence for non-members" vs "per-viewer stripped rendering." Recommendation: absence; per-viewer renderings are compiler territory.
+2. **The `not(group:X)` apply target (scenario 7).** Either bless negative selectors as a first-class target or replace with managed positive buckets (`bucket:onboarding` with an explicit remove step). Recommendation: managed positive buckets for now; negation is the one target that breaks plain token matching.
+3. **Band-migration cadence (scenario 4).** One sentence in the packing lock: chunks change bands only at compile/brainbeat boundaries, never mid-turn.
+4. **Usage-left bucket names + audiences (scenarios 9–10).** Lock `bucket:usage-left:house` → deployers + Prioritizer, `bucket:usage-left:<seat>` → seat + Prioritizer. Thresholds, pick rules, and gate mechanics stay with **Skillex** (subagent-deploy skill owner).
+5. **Bucket-membership visibility (scenario 2).** Decide who may list a bucket's members. Recommendation: Alex + Prioritizer only, and the listing itself is `bucket:board-private`.
+
+**Phase-N backlog (mention only, not designed here):**
+
+- **Attention trough** — stays backlog, per the locked model.
+- Per-viewer renderings / compiled variants of one node (the scenario-6 OPEN).
+- Group/house nodes for Grok Memory inject (#3953 widening) — needs its own owner and PASS.
+- Read-at-spawn-time freshness semantics for usage-left (scenario 9 OPEN) — Skillex.
+- Retroactive history walls for new group members (scenario 7 note).
+- Oracle / Contextualizer provenance for how buckets get filled — **OPEN**, no details invented in this brief.
+
+**Explicitly not proposed:** any implementation plan, middle-cache/compiler code, new levels beyond seat/group/house, changes to `src/`, plugin code, versions, or settings.
+
+---
+
+*Research brief for Alex Newman / CMEM house. CCS Align (seat leaf) is the scenario source of truth; copy to Notion + box reports on PASS. Skillex owns subagent-deploy internals referenced in scenarios 9–10.*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## TLDR (for Prioritizer)

1. Research/spec only — three markdown files under `plans/`, no `src/`, no versions, no `/do`, no code plan.
2. The scenario brief (unchanged in substance) stands as overnight research SoT since Alex skipped the PASS widget; its two **lock-next** items now have full specs.
3. **Conflict dedupe lock (scenario 6):** one underlying fact = one node identity in the DOM; applies attach labels, never mint copies. Buckets gain a **restricting** flag: normal labels are OR-allows, restricting labels are AND-gates — deny beats allow, empty result fails closed. "Stripped view" = an explicitly authored derived node with a `derived-from` edge (drift becomes flaggable), not compiler renderings (Phase-N). Scenario 6 resolves: Alex + Prioritizer see full, Barb/Admin see the authored ticket-facts node, everyone else nothing; each node packs once per matching cache.
4. **Not-in-group lock (scenario 7):** recommendation is **managed positive buckets** — `bucket:onboarding` granted at mint (no group token) and removed atomically by the group-join op. Raw negation `not(group:building)` is specced for the record but rejected: fail-open inversion (missing token grants visibility), whole-token-set evaluation, unauditable audiences. All five apply targets stay plain positive token matches.
5. Covers new-hire day one (Rivet), onboarding packs (stable head while held, wholesale drop on join), and join/leave migration. Attention trough stays Phase-N, mention only.
6. Ask: PASS the two lock specs; scenario 6/7 OPEN flags and the apply-target table's negation row resolve. Lock-next items 3–5 (band-migration cadence, usage-left names, bucket-membership listing) remain open.

## Files

- `plans/2026-09-09-ccs-scenario-research.md` — original ten-scenario brief; appended a short "Lock-next overnight" section pointing at the two new specs (rest untouched)
- `plans/2026-09-09-ccs-lock-conflict-dedupe.md` — NEW: deny-beats-allow + node-identity dedupe spec (node identity, one-fact-once, restricting flag + evaluation order, full/stripped/nothing table, packing, anti-patterns, open questions)
- `plans/2026-09-09-ccs-lock-not-in-group.md` — NEW: "not in group" apply-target spec (managed positive buckets recommended + coupling ops; negation semantics specced-and-rejected; scenario walkthroughs; open questions)

Related plan of record: `plans/2026-09-09-ccs-align.md`. Model constraints held throughout: 3 levels only (seat / sidebar-group / house), XML/DOM = document, bucket → apply = ACL, packing = live work after pending timeline squeezed toward the tip.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd3769ae-2a56-4ef7-93b2-6b352e9325db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd3769ae-2a56-4ef7-93b2-6b352e9325db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

