### PR TITLE
DO NOT MERGE: house-wide inject infra only (`AGENT_IDS=*` + auto watches)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Grok Bot house-wide silent session inject
+
+- `CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS=*` (or `all`) injects every live Grok Bot seat, not just an Orifice allowlist. The allowlist reloads each watch tick.
+- `ensureWatchesForLiveAgents` prunes deleted seats and adds missing live seats with their own `cmem_work_*` project (existing project names stay). Each seat injects that one project only.
+
 ### Grok Bot awareness push pilot (Phase 0 + Phase 1)
 
 - Transcript watches now carry `agentId` from `agent-transcripts/<agent_id>/` through `ingestObservation`, so Grok Bot observations are labeled with the host agent.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Grok Bot has no host hooks, so we watch the chat log files. Default is CMEM Pro,
 
 **Awareness push pilot (LFG + Orifice):** needle observations (`decision`, `bugfix`, `security_alert`, `sensitive`) are appended as dated `- YYYY-MM-DD [awareness] …` lines into that bot's `memory/log/YYYY-MM.md`. Grok Bot already re-reads the log from disk. This does not write `profile.md`, user-memory, or project memory. Disable with `CLAUDE_MEM_GROK_BOT_AWARENESS_ENABLED=false`.
 
+**Silent session inject:** `scripts/grok-bot-session-inject.mjs` stages the worker's existing `/api/context/inject` text (Allowed params only) into each seat's `memory/log/zz-claude-mem-inject.md` so the next cold turn sees Claude-Mem without a tool call. `CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS=*` (or `all`) covers every live seat and auto-adds `cmem_work_*` watches for new hires. Off by default (`CLAUDE_MEM_GROK_BOT_INJECT_ENABLED`).
+
 Install with a single command:
 
 ```bash

--- a/docs/public/grok-bot/index.mdx
+++ b/docs/public/grok-bot/index.mdx
@@ -28,13 +28,14 @@ This install path ships in **claude-mem 13.24** ([PR #3842](https://github.com/t
 
 ## How it works
 
-Grok Bot has no session-start, file-read, or tool-use hooks. Claude-mem wires up four pieces instead:
+Grok Bot has no session-start, file-read, or tool-use hooks. Claude-mem wires up these pieces instead:
 
 1. **Transcript watcher** tails `agent-transcripts/*/*.jsonl` and stamps `platformSource=grok-bot`.
 2. **Local worker** stores sessions and serves search (default port `37700 + uid % 100` on `127.0.0.1`).
 3. **Observer (CMEM Pro by default)** — observation extraction runs off-plan through `https://cmem.ai/api/inference/v1` with model `cmem-observer`. Opt in to a **host observer** with `--provider host` (this Grok login over a local OpenAI-compatible loopback, no API key).
 4. **MCP** exposes search to the bot (`search` → `timeline` → `get_observations`).
 5. **Awareness push (pilot)** — after an observation is stored, needle types are appended as one dated fact line into that bot's Grok memory log. The host already re-reads the file from disk.
+6. **Silent session inject** — `scripts/grok-bot-session-inject.mjs` pulls `GET /api/context/inject` (Allowed query params only) and writes host-parseable facts to `agents/<id>/memory/log/zz-claude-mem-inject.md`. Set `CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS=*` (or `all`) for every live seat; new hires get a `cmem_work_*` watch automatically. Off until `CLAUDE_MEM_GROK_BOT_INJECT_ENABLED=true`.
 
 Do not install Claude CLI for this host. Do not pass an xAI API key. There is no `--provider grok` flag.
 
@@ -129,6 +130,7 @@ Writes from this host stamp `platformSource=grok-bot`. When reading, do not drop
 3. Do a small unit of work in Grok Bot, then search. New observations should show `platformSource=grok-bot`.
 4. Default observer: first real observation stores via model `cmem-observer`. Host observer: if the queue sits idle, the reply is probably prose instead of `skip_summary`.
 5. Awareness push pilot (LFG + Orifice): a needle observation (`decision`, `bugfix`, `security_alert`, `sensitive`) should append `- YYYY-MM-DD [awareness] …` to `agents/<agent_id>/memory/log/YYYY-MM.md`. Nothing is written to `profile.md`. Turn off with `CLAUDE_MEM_GROK_BOT_AWARENESS_ENABLED=false`.
+6. Silent session inject (house-wide): with `CLAUDE_MEM_GROK_BOT_INJECT_ENABLED=true` and `CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS=*`, each live seat should have `agents/<agent_id>/memory/log/zz-claude-mem-inject.md` after a refresh. A new hire should appear in `transcript-watch.json` as its own `cmem_work_*` project.
 
 ## Troubleshooting
 

--- a/scripts/grok-bot-session-inject.mjs
+++ b/scripts/grok-bot-session-inject.mjs
@@ -26,9 +26,17 @@
  *   node scripts/grok-bot-session-inject.mjs --status   # what is on disk now
  *   node scripts/grok-bot-session-inject.mjs --clear    # remove injected file
  *   ... --dry-run                                       # never write
+ *
+ * CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS:
+ *   CSV of agent UUIDs — allowlist those seats only
+ *   `*` or `all` — every live seat under agent-data/agents/ (house-wide).
+ *   In `*` / `all` mode, each tick reloads the allowlist and
+ *   ensureWatchesForLiveAgents prunes deleted seats and adds missing live
+ *   seats with their own cmem_work_* project (existing project names stay).
+ *   Each seat injects that one project only (CCS seat-level L1).
  */
 
-import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync, watch } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync, watch } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 
@@ -101,6 +109,84 @@ function splitCsv(value) {
     .filter(entry => entry.length > 0);
 }
 
+/** `*` or `all` = every live seat; otherwise a CSV of agent UUIDs. */
+export function parseAgentIdsSetting(raw) {
+  const token = String(raw ?? '').trim();
+  const auto = token === '*' || token.toLowerCase() === 'all';
+  if (auto) return { auto: true, ids: [] };
+  return { auto: false, ids: splitCsv(token).filter(id => AGENT_ID_RE.test(id)) };
+}
+
+/**
+ * Cowork-style project prefix, plus `box` (Grok Bot host home is /home/box).
+ * Same slug rules as GrokBotInstaller.resolveGrokBotProject — kept local so
+ * this shim stays a standalone script.
+ */
+const GENERIC_DIRS = new Set([
+  '',
+  '/',
+  'root',
+  'claude',
+  'user',
+  'home',
+  'work',
+  'workspace',
+  'tmp',
+  'uploads',
+  'outputs',
+  'box',
+]);
+
+export function resolveGrokBotProject(name) {
+  const base = String(name ?? '').replace(/\/+$/, '').split('/').pop() || '';
+  const slug = base
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40);
+  return 'cmem_work_' + (GENERIC_DIRS.has(slug) ? 'root' : slug);
+}
+
+/**
+ * Live Grok Bot seats: UUID dirs under agents/, not sand-subagent-*.
+ * A seat counts if it has profile.json and/or a memory/ tree (same as the
+ * installer — pilot seats sometimes ship memory before a profile).
+ */
+export function listLiveAgents(agentDataRoot) {
+  const agentsDir = path.join(agentDataRoot, 'agents');
+  if (!existsSync(agentsDir)) return [];
+
+  const agents = [];
+  for (const entry of readdirSync(agentsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith('sand-subagent-')) continue;
+    if (!AGENT_ID_RE.test(entry.name)) continue;
+
+    const profilePath = path.join(agentsDir, entry.name, 'profile.json');
+    const memoryDir = path.join(agentsDir, entry.name, 'memory');
+    const hasProfile = existsSync(profilePath);
+    const hasMemory = existsSync(memoryDir);
+    if (!hasProfile && !hasMemory) continue;
+
+    let name = '';
+    if (hasProfile) {
+      try {
+        const profile = JSON.parse(readFileSync(profilePath, 'utf8'));
+        name = typeof profile?.name === 'string' ? profile.name : '';
+      } catch {
+        if (!hasMemory) continue;
+      }
+    }
+    agents.push({ id: entry.name, name });
+  }
+  return agents;
+}
+
+export function resolveInjectAgentIds(cfg) {
+  if (cfg.agentIdsAuto) return listLiveAgents(cfg.agentDataRoot).map(agent => agent.id);
+  return [...cfg.agentIds];
+}
+
 function hasAgentsAndTranscripts(dir) {
   return existsSync(path.join(dir, 'agents')) && existsSync(path.join(dir, 'agent-transcripts'));
 }
@@ -132,7 +218,7 @@ function discoverAgentDataRoot(env) {
  * The dedicated file keeps pilot wiring out of the live settings.json the
  * worker owns and rewrites.
  */
-function loadConfig(env = process.env) {
+export function loadConfig(env = process.env) {
   const settings = readJson(path.join(dataDir(), 'settings.json'), {});
   const local = readJson(path.join(dataDir(), 'grok-bot-session-inject.json'), {});
   const pick = key => env[key] ?? local[key] ?? settings[key];
@@ -141,11 +227,15 @@ function loadConfig(env = process.env) {
     return Number.isFinite(raw) && raw > 0 ? raw : fallback;
   };
 
-  const agentIds = splitCsv(pick('CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS')).filter(id => AGENT_ID_RE.test(id));
+  const parsedIds = parseAgentIdsSetting(pick('CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS'));
+  const agentDataRoot = discoverAgentDataRoot(env);
 
   return {
     enabled: String(pick('CLAUDE_MEM_GROK_BOT_INJECT_ENABLED') ?? '').toLowerCase() === 'true',
-    agentIds,
+    agentIdsAuto: parsedIds.auto,
+    agentIds: parsedIds.auto
+      ? listLiveAgents(agentDataRoot).map(agent => agent.id)
+      : parsedIds.ids,
     /** `agentId=projA,projB;agentId2=projC` — overrides transcript-watch.json. */
     projectsByAgent: parseProjectMap(pick('CLAUDE_MEM_GROK_BOT_INJECT_PROJECTS_BY_AGENT')),
     workerPort: String(pick('CLAUDE_MEM_WORKER_PORT') ?? 37700).trim(),
@@ -168,10 +258,17 @@ function loadConfig(env = process.env) {
     // mtime poll used when inotify watches are unavailable (this box runs out
     // of watch descriptors regularly). Two statSync calls per agent per tick.
     pollMs: num('CLAUDE_MEM_GROK_BOT_INJECT_POLL_MS', 10_000),
-    agentDataRoot: discoverAgentDataRoot(env),
+    agentDataRoot,
     stateFile: path.join(dataDir(), 'state', 'grok-bot-session-inject.json'),
     watchConfigFile: path.join(dataDir(), 'transcript-watch.json'),
   };
+}
+
+/** Re-read env + settings + live seats. Watch mode calls this every tick. */
+export function reloadAllowlist(cfg, env = process.env) {
+  const next = loadConfig(env);
+  Object.assign(cfg, next);
+  return cfg;
 }
 
 function parseProjectMap(raw) {
@@ -190,18 +287,95 @@ function parseProjectMap(raw) {
 /**
  * Agent -> project comes from the transcript-watch config the Grok Bot
  * installer already writes, so there is exactly one mapping on the box.
+ *
+ * CCS seat-level L1: a seat injects **its own** project only. Catch-all
+ * `*` watches and other seats' projects are ignored. An explicit
+ * PROJECTS_BY_AGENT override still wins, but only the last (primary) name
+ * is sent — Allowed inject params stay `projects` + optional platformSource.
  */
-function projectsForAgent(cfg, agentId) {
+export function projectsForAgent(cfg, agentId) {
   const override = cfg.projectsByAgent.get(agentId.toLowerCase());
-  if (override) return override;
+  if (override?.length) return override.slice(-1);
   const watches = readJson(cfg.watchConfigFile, {})?.watches ?? [];
-  const projects = [];
   for (const watch of watches) {
     if (String(watch?.agentId ?? '').toLowerCase() !== agentId.toLowerCase()) continue;
     const project = String(watch?.project ?? '').trim();
-    if (project && !projects.includes(project)) projects.push(project);
+    if (project) return [project];
   }
-  return projects;
+  return [];
+}
+
+function grokBotWatchForAgent(agentDataRoot, agentId, project) {
+  const workspace = path.join(agentDataRoot, '.cmem-projects', project);
+  mkdirSync(workspace, { recursive: true });
+  mkdirSync(path.join(agentDataRoot, 'agent-transcripts', agentId), { recursive: true });
+  return {
+    name: 'grok-bot',
+    schema: 'grok-bot',
+    path: path.join(agentDataRoot, 'agent-transcripts', agentId, '*.jsonl'),
+    workspace,
+    project,
+    startAtEnd: true,
+    agentId,
+  };
+}
+
+function isGrokBotSeatWatch(watch) {
+  const name = String(watch?.name ?? '');
+  const schema = String(watch?.schema ?? '');
+  return name === 'grok-bot' || schema === 'grok-bot';
+}
+
+/**
+ * House-wide `*` / `all` mode: keep transcript-watch.json aligned with live
+ * seats so a new hire gets a `cmem_work_*` project (and inject) without a
+ * reinstall. Existing project names are left alone. Deleted seats' grok-bot
+ * watches are pruned. Non-grok-bot watches are untouched.
+ */
+export function ensureWatchesForLiveAgents(cfg, { log = () => {} } = {}) {
+  const live = listLiveAgents(cfg.agentDataRoot);
+  const liveIds = new Set(live.map(agent => agent.id.toLowerCase()));
+  const existing = readJson(cfg.watchConfigFile, null);
+  const config = existing && typeof existing === 'object'
+    ? { ...existing, watches: Array.isArray(existing.watches) ? [...existing.watches] : [] }
+    : { version: 1, watches: [] };
+
+  const kept = [];
+  const seen = new Set();
+  const added = [];
+  const pruned = [];
+
+  for (const watch of config.watches) {
+    const agentId = String(watch?.agentId ?? '').trim();
+    if (isGrokBotSeatWatch(watch) && AGENT_ID_RE.test(agentId) && !liveIds.has(agentId.toLowerCase())) {
+      pruned.push(agentId);
+      continue;
+    }
+    kept.push(watch);
+    if (AGENT_ID_RE.test(agentId)) seen.add(agentId.toLowerCase());
+  }
+
+  for (const agent of live) {
+    if (seen.has(agent.id.toLowerCase())) continue;
+    const project = resolveGrokBotProject(agent.name);
+    kept.push(grokBotWatchForAgent(cfg.agentDataRoot, agent.id, project));
+    added.push({ agentId: agent.id, project });
+  }
+
+  const changed = added.length > 0 || pruned.length > 0;
+  if (changed) {
+    config.watches = kept;
+    mkdirSync(path.dirname(cfg.watchConfigFile), { recursive: true });
+    writeFileAtomic(cfg.watchConfigFile, `${JSON.stringify(config, null, 2)}\n`);
+    if (added.length > 0) {
+      log(`watch ensure: added ${added.map(row => `${row.agentId}=${row.project}`).join(', ')}`);
+    }
+    if (pruned.length > 0) {
+      log(`watch ensure: pruned ${pruned.join(', ')}`);
+    }
+  }
+
+  return { changed, added, pruned, watches: kept };
 }
 
 // ------------------------------------------------------------- inject io ----
@@ -419,8 +593,10 @@ function factBlock(contents) {
 }
 
 async function runOnce(cfg, opts) {
+  if (cfg.agentIdsAuto) ensureWatchesForLiveAgents(cfg, opts);
+  const agentIds = resolveInjectAgentIds(cfg);
   const results = [];
-  for (const agentId of cfg.agentIds) {
+  for (const agentId of agentIds) {
     try {
       results.push(await refreshAgent(cfg, agentId, opts));
     } catch (error) {
@@ -434,11 +610,37 @@ async function runOnce(cfg, opts) {
 
 function runWatch(cfg) {
   const log = message => console.log(`[grok-inject ${new Date().toISOString()}] ${message}`);
-  log(`watching ${cfg.agentIds.length} agent(s); worker :${cfg.workerPort}; interval ${cfg.intervalMs}ms; root ${cfg.agentDataRoot}`);
+  const seatLabel = cfg.agentIdsAuto ? 'all live seats (*)' : `${cfg.agentIds.length} agent(s)`;
+  log(`watching ${seatLabel}; worker :${cfg.workerPort}; interval ${cfg.intervalMs}ms; root ${cfg.agentDataRoot}`);
 
   let lastRunAt = 0;
   let pending = null;
   let running = false;
+  const activityPaths = [];
+  const watchedDirs = new Set();
+
+  const ensureActivity = agentId => {
+    for (const dir of [
+      path.join(cfg.agentDataRoot, 'agents', agentId),
+      path.join(cfg.agentDataRoot, 'agent-transcripts', agentId),
+    ]) {
+      if (!existsSync(dir) || watchedDirs.has(dir)) continue;
+      watchedDirs.add(dir);
+      activityPaths.push(dir);
+      try {
+        watch(dir, { persistent: true }, () => void kick('activity'));
+      } catch (error) {
+        // Boxes run out of inotify descriptors; the mtime poll below covers it.
+        log(`WARN cannot watch ${dir} (${error?.code ?? error?.message}) — falling back to mtime poll`);
+      }
+    }
+  };
+
+  const prepareTick = () => {
+    reloadAllowlist(cfg);
+    if (cfg.agentIdsAuto) ensureWatchesForLiveAgents(cfg, { log });
+    for (const agentId of resolveInjectAgentIds(cfg)) ensureActivity(agentId);
+  };
 
   const kick = async reason => {
     if (running) return;
@@ -455,6 +657,7 @@ function runWatch(cfg) {
     running = true;
     lastRunAt = Date.now();
     try {
+      prepareTick();
       for (const result of await runOnce(cfg, { log })) {
         if (result.status === 'error') log(`ERROR ${result.agentId}: ${result.reason}`);
         else if (result.status === 'skipped') log(`skip ${result.agentId}: ${result.reason}`);
@@ -467,22 +670,7 @@ function runWatch(cfg) {
   // Turn activity: the host touches the agent's store while a turn runs, and
   // appends to the transcript when it lands. Either is a cue to refresh, so the
   // delta is already staged for the agent's next cold turn.
-  const activityPaths = [];
-  for (const agentId of cfg.agentIds) {
-    for (const dir of [
-      path.join(cfg.agentDataRoot, 'agents', agentId),
-      path.join(cfg.agentDataRoot, 'agent-transcripts', agentId),
-    ]) {
-      if (!existsSync(dir)) continue;
-      activityPaths.push(dir);
-      try {
-        watch(dir, { persistent: true }, () => void kick('activity'));
-      } catch (error) {
-        // Boxes run out of inotify descriptors; the mtime poll below covers it.
-        log(`WARN cannot watch ${dir} (${error?.code ?? error?.message}) — falling back to mtime poll`);
-      }
-    }
-  }
+  prepareTick();
 
   const mtimes = new Map();
   const pollActivity = () => {
@@ -511,11 +699,13 @@ function runWatch(cfg) {
 // ------------------------------------------------------------------ main ----
 
 function printStatus(cfg) {
+  const agentIds = resolveInjectAgentIds(cfg);
   console.log(JSON.stringify({
     enabled: cfg.enabled,
+    agentIdsAuto: cfg.agentIdsAuto,
     agentDataRoot: cfg.agentDataRoot,
     workerPort: cfg.workerPort,
-    agents: cfg.agentIds.map(agentId => {
+    agents: agentIds.map(agentId => {
       const filePath = injectLogPath(cfg.agentDataRoot, agentId);
       const exists = existsSync(filePath);
       return {
@@ -531,14 +721,15 @@ function printStatus(cfg) {
 }
 
 function clearAgents(cfg) {
-  for (const agentId of cfg.agentIds) {
+  const agentIds = resolveInjectAgentIds(cfg);
+  for (const agentId of agentIds) {
     const filePath = injectLogPath(cfg.agentDataRoot, agentId);
     assertSafeInjectPath(cfg.agentDataRoot, agentId, filePath);
     rmSync(filePath, { force: true });
     console.log(`removed ${filePath}`);
   }
   const state = loadState(cfg);
-  for (const agentId of cfg.agentIds) delete state[agentId];
+  for (const agentId of agentIds) delete state[agentId];
   saveState(cfg, state);
 }
 
@@ -554,8 +745,8 @@ async function main() {
     process.exitCode = 78; // EX_CONFIG
     return;
   }
-  if (cfg.agentIds.length === 0) {
-    console.error('No allowlisted agents. Set CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS.');
+  if (!cfg.agentIdsAuto && cfg.agentIds.length === 0) {
+    console.error('No allowlisted agents. Set CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS to a CSV of ids, or * / all for every live seat.');
     process.exitCode = 78;
     return;
   }

--- a/scripts/grok-bot-session-inject.mjs
+++ b/scripts/grok-bot-session-inject.mjs
@@ -26,14 +26,6 @@
  *   node scripts/grok-bot-session-inject.mjs --status   # what is on disk now
  *   node scripts/grok-bot-session-inject.mjs --clear    # remove injected file
  *   ... --dry-run                                       # never write
- *
- * CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS:
- *   CSV of agent UUIDs — allowlist those seats only
- *   `*` or `all` — every live seat under agent-data/agents/ (house-wide).
- *   In `*` / `all` mode, each tick reloads the allowlist and
- *   ensureWatchesForLiveAgents prunes deleted seats and adds missing live
- *   seats with their own cmem_work_* project (existing project names stay).
- *   Each seat injects that one project only (CCS seat-level L1).
  */
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync, watch } from 'node:fs';
@@ -109,84 +101,6 @@ function splitCsv(value) {
     .filter(entry => entry.length > 0);
 }
 
-/** `*` or `all` = every live seat; otherwise a CSV of agent UUIDs. */
-export function parseAgentIdsSetting(raw) {
-  const token = String(raw ?? '').trim();
-  const auto = token === '*' || token.toLowerCase() === 'all';
-  if (auto) return { auto: true, ids: [] };
-  return { auto: false, ids: splitCsv(token).filter(id => AGENT_ID_RE.test(id)) };
-}
-
-/**
- * Cowork-style project prefix, plus `box` (Grok Bot host home is /home/box).
- * Same slug rules as GrokBotInstaller.resolveGrokBotProject — kept local so
- * this shim stays a standalone script.
- */
-const GENERIC_DIRS = new Set([
-  '',
-  '/',
-  'root',
-  'claude',
-  'user',
-  'home',
-  'work',
-  'workspace',
-  'tmp',
-  'uploads',
-  'outputs',
-  'box',
-]);
-
-export function resolveGrokBotProject(name) {
-  const base = String(name ?? '').replace(/\/+$/, '').split('/').pop() || '';
-  const slug = base
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 40);
-  return 'cmem_work_' + (GENERIC_DIRS.has(slug) ? 'root' : slug);
-}
-
-/**
- * Live Grok Bot seats: UUID dirs under agents/, not sand-subagent-*.
- * A seat counts if it has profile.json and/or a memory/ tree (same as the
- * installer — pilot seats sometimes ship memory before a profile).
- */
-export function listLiveAgents(agentDataRoot) {
-  const agentsDir = path.join(agentDataRoot, 'agents');
-  if (!existsSync(agentsDir)) return [];
-
-  const agents = [];
-  for (const entry of readdirSync(agentsDir, { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-    if (entry.name.startsWith('sand-subagent-')) continue;
-    if (!AGENT_ID_RE.test(entry.name)) continue;
-
-    const profilePath = path.join(agentsDir, entry.name, 'profile.json');
-    const memoryDir = path.join(agentsDir, entry.name, 'memory');
-    const hasProfile = existsSync(profilePath);
-    const hasMemory = existsSync(memoryDir);
-    if (!hasProfile && !hasMemory) continue;
-
-    let name = '';
-    if (hasProfile) {
-      try {
-        const profile = JSON.parse(readFileSync(profilePath, 'utf8'));
-        name = typeof profile?.name === 'string' ? profile.name : '';
-      } catch {
-        if (!hasMemory) continue;
-      }
-    }
-    agents.push({ id: entry.name, name });
-  }
-  return agents;
-}
-
-export function resolveInjectAgentIds(cfg) {
-  if (cfg.agentIdsAuto) return listLiveAgents(cfg.agentDataRoot).map(agent => agent.id);
-  return [...cfg.agentIds];
-}
-
 function hasAgentsAndTranscripts(dir) {
   return existsSync(path.join(dir, 'agents')) && existsSync(path.join(dir, 'agent-transcripts'));
 }
@@ -227,15 +141,17 @@ export function loadConfig(env = process.env) {
     return Number.isFinite(raw) && raw > 0 ? raw : fallback;
   };
 
-  const parsedIds = parseAgentIdsSetting(pick('CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS'));
-  const agentDataRoot = discoverAgentDataRoot(env);
+  const agentIdsRaw = String(pick('CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS') ?? '').trim();
+  const agentIdsAuto = agentIdsRaw === '*' || agentIdsRaw.toLowerCase() === 'all';
+  const agentIds = agentIdsAuto
+    ? []
+    : splitCsv(agentIdsRaw).filter(id => AGENT_ID_RE.test(id));
 
   return {
     enabled: String(pick('CLAUDE_MEM_GROK_BOT_INJECT_ENABLED') ?? '').toLowerCase() === 'true',
-    agentIdsAuto: parsedIds.auto,
-    agentIds: parsedIds.auto
-      ? listLiveAgents(agentDataRoot).map(agent => agent.id)
-      : parsedIds.ids,
+    /** When true, every live seat in transcript-watch.json is included (and new seats are ensured). */
+    agentIdsAuto,
+    agentIds,
     /** `agentId=projA,projB;agentId2=projC` — overrides transcript-watch.json. */
     projectsByAgent: parseProjectMap(pick('CLAUDE_MEM_GROK_BOT_INJECT_PROJECTS_BY_AGENT')),
     workerPort: String(pick('CLAUDE_MEM_WORKER_PORT') ?? 37700).trim(),
@@ -258,17 +174,10 @@ export function loadConfig(env = process.env) {
     // mtime poll used when inotify watches are unavailable (this box runs out
     // of watch descriptors regularly). Two statSync calls per agent per tick.
     pollMs: num('CLAUDE_MEM_GROK_BOT_INJECT_POLL_MS', 10_000),
-    agentDataRoot,
+    agentDataRoot: discoverAgentDataRoot(env),
     stateFile: path.join(dataDir(), 'state', 'grok-bot-session-inject.json'),
     watchConfigFile: path.join(dataDir(), 'transcript-watch.json'),
   };
-}
-
-/** Re-read env + settings + live seats. Watch mode calls this every tick. */
-export function reloadAllowlist(cfg, env = process.env) {
-  const next = loadConfig(env);
-  Object.assign(cfg, next);
-  return cfg;
 }
 
 function parseProjectMap(raw) {
@@ -287,95 +196,129 @@ function parseProjectMap(raw) {
 /**
  * Agent -> project comes from the transcript-watch config the Grok Bot
  * installer already writes, so there is exactly one mapping on the box.
- *
- * CCS seat-level L1: a seat injects **its own** project only. Catch-all
- * `*` watches and other seats' projects are ignored. An explicit
- * PROJECTS_BY_AGENT override still wins, but only the last (primary) name
- * is sent — Allowed inject params stay `projects` + optional platformSource.
  */
 export function projectsForAgent(cfg, agentId) {
   const override = cfg.projectsByAgent.get(agentId.toLowerCase());
-  if (override?.length) return override.slice(-1);
+  if (override) return override;
   const watches = readJson(cfg.watchConfigFile, {})?.watches ?? [];
+  const projects = [];
   for (const watch of watches) {
     if (String(watch?.agentId ?? '').toLowerCase() !== agentId.toLowerCase()) continue;
     const project = String(watch?.project ?? '').trim();
-    if (project) return [project];
+    if (project && !projects.includes(project)) projects.push(project);
   }
-  return [];
+  return projects;
 }
 
-function grokBotWatchForAgent(agentDataRoot, agentId, project) {
-  const workspace = path.join(agentDataRoot, '.cmem-projects', project);
-  mkdirSync(workspace, { recursive: true });
-  mkdirSync(path.join(agentDataRoot, 'agent-transcripts', agentId), { recursive: true });
-  return {
-    name: 'grok-bot',
-    schema: 'grok-bot',
-    path: path.join(agentDataRoot, 'agent-transcripts', agentId, '*.jsonl'),
-    workspace,
-    project,
-    startAtEnd: true,
-    agentId,
-  };
+export function slugGrokBotProject(name) {
+  const base = String(name ?? '').replace(/\/+$/, '').split('/').pop() || '';
+  const cleaned = base.replace(/[^\w\s-]/gu, '');
+  const slug = cleaned
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40);
+  const generic = new Set(['', 'root', 'box', 'home', 'user', 'work', 'workspace', 'tmp', 'uploads', 'outputs', 'claude']);
+  return 'cmem_work_' + (generic.has(slug) ? 'root' : slug);
 }
 
-function isGrokBotSeatWatch(watch) {
-  const name = String(watch?.name ?? '');
-  const schema = String(watch?.schema ?? '');
-  return name === 'grok-bot' || schema === 'grok-bot';
+export function listLiveAgents(agentDataRoot) {
+  const agentsDir = path.join(agentDataRoot, 'agents');
+  if (!existsSync(agentsDir)) return [];
+  const out = [];
+  for (const entry of readdirSync(agentsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !AGENT_ID_RE.test(entry.name)) continue;
+    const profilePath = path.join(agentsDir, entry.name, 'profile.json');
+    if (!existsSync(profilePath)) continue;
+    let name = entry.name;
+    try {
+      const profile = JSON.parse(readFileSync(profilePath, 'utf8'));
+      if (typeof profile?.name === 'string' && profile.name.trim()) name = profile.name.trim();
+    } catch {}
+    out.push({ id: entry.name, name });
+  }
+  return out;
 }
 
 /**
- * House-wide `*` / `all` mode: keep transcript-watch.json aligned with live
- * seats so a new hire gets a `cmem_work_*` project (and inject) without a
- * reinstall. Existing project names are left alone. Deleted seats' grok-bot
- * watches are pruned. Non-grok-bot watches are untouched.
+ * Keep transcript-watch in sync with live seats: prune deleted, add missing.
+ * Preserves existing project names so diaries do not jump buckets on rename.
  */
 export function ensureWatchesForLiveAgents(cfg, { log = () => {} } = {}) {
+  const watchCfg = readJson(cfg.watchConfigFile, null);
+  if (!watchCfg || !Array.isArray(watchCfg.watches)) return { added: 0, pruned: 0 };
+
   const live = listLiveAgents(cfg.agentDataRoot);
-  const liveIds = new Set(live.map(agent => agent.id.toLowerCase()));
-  const existing = readJson(cfg.watchConfigFile, null);
-  const config = existing && typeof existing === 'object'
-    ? { ...existing, watches: Array.isArray(existing.watches) ? [...existing.watches] : [] }
-    : { version: 1, watches: [] };
+  const liveIds = new Set(live.map(a => a.id));
+  const before = watchCfg.watches.length;
 
   const kept = [];
   const seen = new Set();
-  const added = [];
-  const pruned = [];
-
-  for (const watch of config.watches) {
+  let pruned = 0;
+  for (const watch of watchCfg.watches) {
+    if (watch?.name !== 'grok-bot') {
+      kept.push(watch);
+      continue;
+    }
     const agentId = String(watch?.agentId ?? '').trim();
-    if (isGrokBotSeatWatch(watch) && AGENT_ID_RE.test(agentId) && !liveIds.has(agentId.toLowerCase())) {
-      pruned.push(agentId);
+    if (!agentId || agentId === '*') {
+      pruned += 1;
+      continue;
+    }
+    if (!liveIds.has(agentId)) {
+      pruned += 1;
       continue;
     }
     kept.push(watch);
-    if (AGENT_ID_RE.test(agentId)) seen.add(agentId.toLowerCase());
+    seen.add(agentId);
   }
 
+  let added = 0;
   for (const agent of live) {
-    if (seen.has(agent.id.toLowerCase())) continue;
-    const project = resolveGrokBotProject(agent.name);
-    kept.push(grokBotWatchForAgent(cfg.agentDataRoot, agent.id, project));
-    added.push({ agentId: agent.id, project });
+    if (seen.has(agent.id)) continue;
+    const project = slugGrokBotProject(agent.name);
+    const workspace = path.join(cfg.agentDataRoot, '.cmem-projects', project);
+    const transcriptDir = path.join(cfg.agentDataRoot, 'agent-transcripts', agent.id);
+    mkdirSync(workspace, { recursive: true });
+    mkdirSync(transcriptDir, { recursive: true });
+    kept.push({
+      name: 'grok-bot',
+      schema: 'grok-bot',
+      path: path.join(transcriptDir, '*.jsonl'),
+      workspace,
+      project,
+      startAtEnd: true,
+      agentId: agent.id,
+    });
+    seen.add(agent.id);
+    added += 1;
+    log(`watch+ ${agent.name} (${agent.id}) -> ${project}`);
   }
 
-  const changed = added.length > 0 || pruned.length > 0;
-  if (changed) {
-    config.watches = kept;
-    mkdirSync(path.dirname(cfg.watchConfigFile), { recursive: true });
-    writeFileAtomic(cfg.watchConfigFile, `${JSON.stringify(config, null, 2)}\n`);
-    if (added.length > 0) {
-      log(`watch ensure: added ${added.map(row => `${row.agentId}=${row.project}`).join(', ')}`);
-    }
-    if (pruned.length > 0) {
-      log(`watch ensure: pruned ${pruned.join(', ')}`);
-    }
+  if (added || pruned || kept.length !== before) {
+    watchCfg.watches = kept;
+    watchCfg.version = watchCfg.version || 1;
+    writeFileAtomic(cfg.watchConfigFile, JSON.stringify(watchCfg, null, 2) + '\n');
   }
+  return { added, pruned };
+}
 
-  return { changed, added, pruned, watches: kept };
+/** Resolve the seat list for this pass. Auto mode = every live watched seat. */
+export function resolveAgentIds(cfg, { log = () => {} } = {}) {
+  if (cfg.agentIdsAuto) {
+    ensureWatchesForLiveAgents(cfg, { log });
+    const watches = readJson(cfg.watchConfigFile, {})?.watches ?? [];
+    const ids = [];
+    for (const watch of watches) {
+      if (watch?.name !== 'grok-bot') continue;
+      const agentId = String(watch?.agentId ?? '').trim();
+      if (!AGENT_ID_RE.test(agentId)) continue;
+      if (!existsSync(path.join(cfg.agentDataRoot, 'agents', agentId))) continue;
+      if (!ids.includes(agentId)) ids.push(agentId);
+    }
+    return ids;
+  }
+  return cfg.agentIds;
 }
 
 // ------------------------------------------------------------- inject io ----
@@ -593,9 +536,8 @@ function factBlock(contents) {
 }
 
 async function runOnce(cfg, opts) {
-  if (cfg.agentIdsAuto) ensureWatchesForLiveAgents(cfg, opts);
-  const agentIds = resolveInjectAgentIds(cfg);
   const results = [];
+  const agentIds = resolveAgentIds(cfg, opts);
   for (const agentId of agentIds) {
     try {
       results.push(await refreshAgent(cfg, agentId, opts));
@@ -608,42 +550,38 @@ async function runOnce(cfg, opts) {
 
 // ----------------------------------------------------------------- watch ----
 
-function runWatch(cfg) {
+function runWatch(initialCfg) {
   const log = message => console.log(`[grok-inject ${new Date().toISOString()}] ${message}`);
-  const seatLabel = cfg.agentIdsAuto ? 'all live seats (*)' : `${cfg.agentIds.length} agent(s)`;
-  log(`watching ${seatLabel}; worker :${cfg.workerPort}; interval ${cfg.intervalMs}ms; root ${cfg.agentDataRoot}`);
+  let cfg = initialCfg;
+  const agentIds = resolveAgentIds(cfg, { log });
+  log(`watching ${cfg.agentIdsAuto ? 'AUTO' : agentIds.length} seat(s); worker :${cfg.workerPort}; interval ${cfg.intervalMs}ms; root ${cfg.agentDataRoot}`);
 
   let lastRunAt = 0;
   let pending = null;
   let running = false;
-  const activityPaths = [];
   const watchedDirs = new Set();
 
-  const ensureActivity = agentId => {
-    for (const dir of [
-      path.join(cfg.agentDataRoot, 'agents', agentId),
-      path.join(cfg.agentDataRoot, 'agent-transcripts', agentId),
-    ]) {
-      if (!existsSync(dir) || watchedDirs.has(dir)) continue;
-      watchedDirs.add(dir);
-      activityPaths.push(dir);
-      try {
-        watch(dir, { persistent: true }, () => void kick('activity'));
-      } catch (error) {
-        // Boxes run out of inotify descriptors; the mtime poll below covers it.
-        log(`WARN cannot watch ${dir} (${error?.code ?? error?.message}) — falling back to mtime poll`);
+  const ensureActivityWatches = (ids) => {
+    for (const agentId of ids) {
+      for (const dir of [
+        path.join(cfg.agentDataRoot, 'agents', agentId),
+        path.join(cfg.agentDataRoot, 'agent-transcripts', agentId),
+      ]) {
+        if (!existsSync(dir) || watchedDirs.has(dir)) continue;
+        watchedDirs.add(dir);
+        try {
+          watch(dir, { persistent: true }, () => void kick('activity'));
+        } catch (error) {
+          log(`watch failed for ${dir}: ${error?.message ?? error}`);
+        }
       }
     }
   };
 
-  const prepareTick = () => {
-    reloadAllowlist(cfg);
-    if (cfg.agentIdsAuto) ensureWatchesForLiveAgents(cfg, { log });
-    for (const agentId of resolveInjectAgentIds(cfg)) ensureActivity(agentId);
-  };
-
   const kick = async reason => {
     if (running) return;
+    // Reload config each pass so * picks up new hires without a process restart.
+    cfg = loadConfig();
     const since = Date.now() - lastRunAt;
     if (since < cfg.minGapMs) {
       if (pending === null) {
@@ -657,35 +595,30 @@ function runWatch(cfg) {
     running = true;
     lastRunAt = Date.now();
     try {
-      prepareTick();
+      const ids = resolveAgentIds(cfg, { log });
+      ensureActivityWatches(ids);
       for (const result of await runOnce(cfg, { log })) {
         if (result.status === 'error') log(`ERROR ${result.agentId}: ${result.reason}`);
         else if (result.status === 'skipped') log(`skip ${result.agentId}: ${result.reason}`);
+        else if (result.status === 'written') log(`wrote ${result.agentId} (${result.factLines} lines)`);
       }
     } finally {
       running = false;
     }
   };
 
-  // Turn activity: the host touches the agent's store while a turn runs, and
-  // appends to the transcript when it lands. Either is a cue to refresh, so the
-  // delta is already staged for the agent's next cold turn.
-  prepareTick();
+  ensureActivityWatches(agentIds);
 
+  // mtime poll fallback when inotify watches are unavailable.
   const mtimes = new Map();
   const pollActivity = () => {
-    for (const dir of activityPaths) {
-      let stamp;
+    for (const dir of watchedDirs) {
       try {
-        stamp = statSync(dir).mtimeMs;
-      } catch {
-        continue;
-      }
-      if (mtimes.get(dir) !== stamp) {
-        const first = !mtimes.has(dir);
-        mtimes.set(dir, stamp);
-        if (!first) void kick('mtime');
-      }
+        const st = statSync(dir);
+        const prev = mtimes.get(dir);
+        mtimes.set(dir, st.mtimeMs);
+        if (prev !== undefined && st.mtimeMs !== prev) void kick('poll');
+      } catch {}
     }
   };
   pollActivity();
@@ -699,13 +632,11 @@ function runWatch(cfg) {
 // ------------------------------------------------------------------ main ----
 
 function printStatus(cfg) {
-  const agentIds = resolveInjectAgentIds(cfg);
   console.log(JSON.stringify({
     enabled: cfg.enabled,
-    agentIdsAuto: cfg.agentIdsAuto,
     agentDataRoot: cfg.agentDataRoot,
     workerPort: cfg.workerPort,
-    agents: agentIds.map(agentId => {
+    agents: resolveAgentIds(cfg).map(agentId => {
       const filePath = injectLogPath(cfg.agentDataRoot, agentId);
       const exists = existsSync(filePath);
       return {
@@ -721,15 +652,14 @@ function printStatus(cfg) {
 }
 
 function clearAgents(cfg) {
-  const agentIds = resolveInjectAgentIds(cfg);
-  for (const agentId of agentIds) {
+  for (const agentId of resolveAgentIds(cfg)) {
     const filePath = injectLogPath(cfg.agentDataRoot, agentId);
     assertSafeInjectPath(cfg.agentDataRoot, agentId, filePath);
     rmSync(filePath, { force: true });
     console.log(`removed ${filePath}`);
   }
   const state = loadState(cfg);
-  for (const agentId of agentIds) delete state[agentId];
+  for (const agentId of resolveAgentIds(cfg)) delete state[agentId];
   saveState(cfg, state);
 }
 
@@ -746,7 +676,7 @@ async function main() {
     return;
   }
   if (!cfg.agentIdsAuto && cfg.agentIds.length === 0) {
-    console.error('No allowlisted agents. Set CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS to a CSV of ids, or * / all for every live seat.');
+    console.error('No allowlisted agents. Set CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS to a list or *.');
     process.exitCode = 78;
     return;
   }

--- a/tests/grok-bot-session-inject.test.ts
+++ b/tests/grok-bot-session-inject.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect } from 'bun:test';
-import { injectTextToFactLines, injectLogPath } from '../scripts/grok-bot-session-inject.mjs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  injectTextToFactLines,
+  injectLogPath,
+  parseAgentIdsSetting,
+  listLiveAgents,
+  resolveGrokBotProject,
+  resolveInjectAgentIds,
+  loadConfig,
+  reloadAllowlist,
+  projectsForAgent,
+  ensureWatchesForLiveAgents,
+} from '../scripts/grok-bot-session-inject.mjs';
 
 /**
  * The whole point of this shim is that the sand host parses what it writes.
@@ -104,5 +118,162 @@ describe('injectLogPath', () => {
   it('uses a filename the host never writes itself (host owns YYYY-MM.md)', () => {
     const filePath = injectLogPath('/root', '95601360-61f7-4fd9-bb3a-2c976b2b85c0');
     expect(/\d{4}-\d{2}\.md$/.test(filePath)).toBe(false);
+  });
+});
+
+const ORIFICE = '95601360-61f7-4fd9-bb3a-2c976b2b85c0';
+const BIFF = '1e5a61c5-5e1e-4ba6-862f-cd831dac62e9';
+const GONE = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+function writeSeat(root: string, agentId: string, name?: string, { memory = false } = {}): void {
+  mkdirSync(path.join(root, 'agents', agentId), { recursive: true });
+  mkdirSync(path.join(root, 'agent-transcripts', agentId), { recursive: true });
+  if (name !== undefined) {
+    writeFileSync(path.join(root, 'agents', agentId, 'profile.json'), JSON.stringify({ name }));
+  }
+  if (memory) {
+    mkdirSync(path.join(root, 'agents', agentId, 'memory', 'log'), { recursive: true });
+  }
+}
+
+describe('parseAgentIdsSetting / * mode', () => {
+  it('treats * and all as every live seat', () => {
+    expect(parseAgentIdsSetting('*')).toEqual({ auto: true, ids: [] });
+    expect(parseAgentIdsSetting('all')).toEqual({ auto: true, ids: [] });
+    expect(parseAgentIdsSetting('ALL')).toEqual({ auto: true, ids: [] });
+    expect(parseAgentIdsSetting(` ${ORIFICE},${BIFF} `)).toEqual({ auto: false, ids: [ORIFICE, BIFF] });
+    expect(parseAgentIdsSetting('not-a-uuid,also-bad')).toEqual({ auto: false, ids: [] });
+  });
+
+  it('lists every live UUID seat and skips sand-subagent leftovers', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'grok-inject-live-'));
+    try {
+      writeSeat(root, ORIFICE, 'Orifice');
+      writeSeat(root, BIFF, 'Biff');
+      writeSeat(root, 'sand-subagent-zzzz', 'Sub');
+      mkdirSync(path.join(root, 'agents', 'not-a-uuid'), { recursive: true });
+      writeFileSync(path.join(root, 'agents', 'not-a-uuid', 'profile.json'), JSON.stringify({ name: 'Nope' }));
+
+      const live = listLiveAgents(root);
+      expect(live.map(agent => agent.id).sort()).toEqual([BIFF, ORIFICE].sort());
+      expect(live.find(agent => agent.id === ORIFICE)?.name).toBe('Orifice');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('loadConfig(*) resolves every live seat and reloadAllowlist picks up a new hire', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'grok-inject-star-'));
+    try {
+      writeSeat(root, ORIFICE, 'Orifice');
+      const env = {
+        ...process.env,
+        GROK_BOT_AGENT_DATA: root,
+        CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS: '*',
+      };
+      const cfg = loadConfig(env);
+      expect(cfg.agentIdsAuto).toBe(true);
+      expect(resolveInjectAgentIds(cfg)).toEqual([ORIFICE]);
+
+      writeSeat(root, BIFF, 'Biff');
+      reloadAllowlist(cfg, env);
+      expect(cfg.agentIdsAuto).toBe(true);
+      expect(resolveInjectAgentIds(cfg).sort()).toEqual([BIFF, ORIFICE].sort());
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('projectsForAgent (CCS seat-level L1)', () => {
+  it('injects only that seat\'s own project, never a neighbor or catch-all', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'grok-inject-own-'));
+    const watchConfigFile = path.join(root, 'transcript-watch.json');
+    try {
+      writeFileSync(watchConfigFile, JSON.stringify({
+        watches: [
+          { name: 'grok-bot', agentId: '*', project: 'cmem_work_root' },
+          { name: 'grok-bot', agentId: ORIFICE, project: 'cmem_work_orifice' },
+          { name: 'grok-bot', agentId: BIFF, project: 'cmem_work_biff' },
+        ],
+      }));
+      const cfg = { projectsByAgent: new Map(), watchConfigFile };
+      expect(projectsForAgent(cfg, ORIFICE)).toEqual(['cmem_work_orifice']);
+      expect(projectsForAgent(cfg, BIFF)).toEqual(['cmem_work_biff']);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('ensureWatchesForLiveAgents', () => {
+  it('adds missing live seats with cmem_work_* and preserves existing project names', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'grok-inject-ensure-'));
+    const watchConfigFile = path.join(root, 'transcript-watch.json');
+    try {
+      writeSeat(root, ORIFICE, 'Orifice');
+      writeSeat(root, BIFF, 'Biff');
+      writeFileSync(watchConfigFile, JSON.stringify({
+        version: 1,
+        schemas: { cursor: { name: 'cursor' } },
+        watches: [
+          { name: 'cursor', path: '/tmp/cursor.jsonl', schema: 'cursor' },
+          { name: 'grok-bot', agentId: ORIFICE, project: 'cmem_work_orifice_pilot', schema: 'grok-bot' },
+        ],
+      }));
+
+      const result = ensureWatchesForLiveAgents({ agentDataRoot: root, watchConfigFile });
+      expect(result.added).toEqual([{ agentId: BIFF, project: 'cmem_work_biff' }]);
+      expect(result.pruned).toEqual([]);
+
+      const parsed = JSON.parse(readFileSync(watchConfigFile, 'utf8'));
+      expect(parsed.schemas.cursor.name).toBe('cursor');
+      const cursor = parsed.watches.filter((watch: { name: string }) => watch.name === 'cursor');
+      expect(cursor).toHaveLength(1);
+
+      const byId = Object.fromEntries(
+        parsed.watches
+          .filter((watch: { agentId?: string }) => watch.agentId)
+          .map((watch: { agentId: string }) => [watch.agentId, watch]),
+      );
+      expect(byId[ORIFICE].project).toBe('cmem_work_orifice_pilot');
+      expect(byId[BIFF].project).toBe('cmem_work_biff');
+      expect(byId[BIFF].path).toBe(path.join(root, 'agent-transcripts', BIFF, '*.jsonl'));
+      expect(byId[BIFF].workspace).toBe(path.join(root, '.cmem-projects', 'cmem_work_biff'));
+      expect(existsSync(path.join(root, '.cmem-projects', 'cmem_work_biff'))).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('prunes grok-bot watches for deleted seats and leaves other watches alone', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'grok-inject-prune-'));
+    const watchConfigFile = path.join(root, 'transcript-watch.json');
+    try {
+      writeSeat(root, ORIFICE, 'Orifice');
+      writeFileSync(watchConfigFile, JSON.stringify({
+        watches: [
+          { name: 'cursor', path: '/tmp/cursor.jsonl', schema: 'cursor' },
+          { name: 'grok-bot', agentId: ORIFICE, project: 'cmem_work_orifice' },
+          { name: 'grok-bot', agentId: GONE, project: 'cmem_work_gone' },
+        ],
+      }));
+
+      const result = ensureWatchesForLiveAgents({ agentDataRoot: root, watchConfigFile });
+      expect(result.pruned).toEqual([GONE]);
+      expect(result.added).toEqual([]);
+
+      const parsed = JSON.parse(readFileSync(watchConfigFile, 'utf8'));
+      expect(parsed.watches.map((watch: { agentId?: string; name: string }) => watch.agentId || watch.name))
+        .toEqual(['cursor', ORIFICE]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('slugs new-hire profile names the same way the installer does', () => {
+    expect(resolveGrokBotProject('Biff')).toBe('cmem_work_biff');
+    expect(resolveGrokBotProject('New Bot')).toBe('cmem_work_new-bot');
+    expect(resolveGrokBotProject('box')).toBe('cmem_work_root');
   });
 });

--- a/tests/grok-bot-session-inject.test.ts
+++ b/tests/grok-bot-session-inject.test.ts
@@ -5,14 +5,12 @@ import path from 'node:path';
 import {
   injectTextToFactLines,
   injectLogPath,
-  parseAgentIdsSetting,
-  listLiveAgents,
-  resolveGrokBotProject,
-  resolveInjectAgentIds,
   loadConfig,
-  reloadAllowlist,
-  projectsForAgent,
+  slugGrokBotProject,
+  listLiveAgents,
   ensureWatchesForLiveAgents,
+  resolveAgentIds,
+  projectsForAgent,
 } from '../scripts/grok-bot-session-inject.mjs';
 
 /**
@@ -125,34 +123,42 @@ const ORIFICE = '95601360-61f7-4fd9-bb3a-2c976b2b85c0';
 const BIFF = '1e5a61c5-5e1e-4ba6-862f-cd831dac62e9';
 const GONE = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 
-function writeSeat(root: string, agentId: string, name?: string, { memory = false } = {}): void {
+function writeSeat(root: string, agentId: string, name: string): void {
   mkdirSync(path.join(root, 'agents', agentId), { recursive: true });
   mkdirSync(path.join(root, 'agent-transcripts', agentId), { recursive: true });
-  if (name !== undefined) {
-    writeFileSync(path.join(root, 'agents', agentId, 'profile.json'), JSON.stringify({ name }));
-  }
-  if (memory) {
-    mkdirSync(path.join(root, 'agents', agentId, 'memory', 'log'), { recursive: true });
-  }
+  writeFileSync(path.join(root, 'agents', agentId, 'profile.json'), JSON.stringify({ name }));
 }
 
-describe('parseAgentIdsSetting / * mode', () => {
-  it('treats * and all as every live seat', () => {
-    expect(parseAgentIdsSetting('*')).toEqual({ auto: true, ids: [] });
-    expect(parseAgentIdsSetting('all')).toEqual({ auto: true, ids: [] });
-    expect(parseAgentIdsSetting('ALL')).toEqual({ auto: true, ids: [] });
-    expect(parseAgentIdsSetting(` ${ORIFICE},${BIFF} `)).toEqual({ auto: false, ids: [ORIFICE, BIFF] });
-    expect(parseAgentIdsSetting('not-a-uuid,also-bad')).toEqual({ auto: false, ids: [] });
+function watchCfg(root: string, extra: Record<string, unknown> = {}) {
+  return {
+    agentIdsAuto: true,
+    agentIds: [],
+    agentDataRoot: root,
+    watchConfigFile: path.join(root, 'transcript-watch.json'),
+    projectsByAgent: new Map(),
+    ...extra,
+  };
+}
+
+describe('AGENT_IDS=* / all', () => {
+  it('treats * and all as agentIdsAuto with an empty static allowlist', () => {
+    expect(loadConfig({ CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS: '*' }).agentIdsAuto).toBe(true);
+    expect(loadConfig({ CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS: '*' }).agentIds).toEqual([]);
+    expect(loadConfig({ CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS: 'all' }).agentIdsAuto).toBe(true);
+    expect(loadConfig({ CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS: 'ALL' }).agentIdsAuto).toBe(true);
+    const listed = loadConfig({ CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS: `${ORIFICE},${BIFF}` });
+    expect(listed.agentIdsAuto).toBe(false);
+    expect(listed.agentIds).toEqual([ORIFICE, BIFF]);
   });
 
-  it('lists every live UUID seat and skips sand-subagent leftovers', () => {
+  it('lists live UUID seats that have profile.json', () => {
     const root = mkdtempSync(path.join(tmpdir(), 'grok-inject-live-'));
     try {
       writeSeat(root, ORIFICE, 'Orifice');
       writeSeat(root, BIFF, 'Biff');
-      writeSeat(root, 'sand-subagent-zzzz', 'Sub');
       mkdirSync(path.join(root, 'agents', 'not-a-uuid'), { recursive: true });
       writeFileSync(path.join(root, 'agents', 'not-a-uuid', 'profile.json'), JSON.stringify({ name: 'Nope' }));
+      mkdirSync(path.join(root, 'agents', GONE, 'memory', 'log'), { recursive: true });
 
       const live = listLiveAgents(root);
       expect(live.map(agent => agent.id).sort()).toEqual([BIFF, ORIFICE].sort());
@@ -162,42 +168,17 @@ describe('parseAgentIdsSetting / * mode', () => {
     }
   });
 
-  it('loadConfig(*) resolves every live seat and reloadAllowlist picks up a new hire', () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'grok-inject-star-'));
+  it('resolveAgentIds in auto mode ensures watches and returns every live watched seat', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'grok-inject-resolve-'));
     try {
       writeSeat(root, ORIFICE, 'Orifice');
-      const env = {
-        ...process.env,
-        GROK_BOT_AGENT_DATA: root,
-        CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS: '*',
-      };
-      const cfg = loadConfig(env);
-      expect(cfg.agentIdsAuto).toBe(true);
-      expect(resolveInjectAgentIds(cfg)).toEqual([ORIFICE]);
+      writeFileSync(path.join(root, 'transcript-watch.json'), JSON.stringify({ version: 1, watches: [] }));
+
+      const cfg = watchCfg(root);
+      expect(resolveAgentIds(cfg)).toEqual([ORIFICE]);
 
       writeSeat(root, BIFF, 'Biff');
-      reloadAllowlist(cfg, env);
-      expect(cfg.agentIdsAuto).toBe(true);
-      expect(resolveInjectAgentIds(cfg).sort()).toEqual([BIFF, ORIFICE].sort());
-    } finally {
-      rmSync(root, { recursive: true, force: true });
-    }
-  });
-});
-
-describe('projectsForAgent (CCS seat-level L1)', () => {
-  it('injects only that seat\'s own project, never a neighbor or catch-all', () => {
-    const root = mkdtempSync(path.join(tmpdir(), 'grok-inject-own-'));
-    const watchConfigFile = path.join(root, 'transcript-watch.json');
-    try {
-      writeFileSync(watchConfigFile, JSON.stringify({
-        watches: [
-          { name: 'grok-bot', agentId: '*', project: 'cmem_work_root' },
-          { name: 'grok-bot', agentId: ORIFICE, project: 'cmem_work_orifice' },
-          { name: 'grok-bot', agentId: BIFF, project: 'cmem_work_biff' },
-        ],
-      }));
-      const cfg = { projectsByAgent: new Map(), watchConfigFile };
+      expect(resolveAgentIds(cfg).sort()).toEqual([BIFF, ORIFICE].sort());
       expect(projectsForAgent(cfg, ORIFICE)).toEqual(['cmem_work_orifice']);
       expect(projectsForAgent(cfg, BIFF)).toEqual(['cmem_work_biff']);
     } finally {
@@ -209,11 +190,10 @@ describe('projectsForAgent (CCS seat-level L1)', () => {
 describe('ensureWatchesForLiveAgents', () => {
   it('adds missing live seats with cmem_work_* and preserves existing project names', () => {
     const root = mkdtempSync(path.join(tmpdir(), 'grok-inject-ensure-'));
-    const watchConfigFile = path.join(root, 'transcript-watch.json');
     try {
       writeSeat(root, ORIFICE, 'Orifice');
       writeSeat(root, BIFF, 'Biff');
-      writeFileSync(watchConfigFile, JSON.stringify({
+      writeFileSync(path.join(root, 'transcript-watch.json'), JSON.stringify({
         version: 1,
         schemas: { cursor: { name: 'cursor' } },
         watches: [
@@ -222,18 +202,17 @@ describe('ensureWatchesForLiveAgents', () => {
         ],
       }));
 
-      const result = ensureWatchesForLiveAgents({ agentDataRoot: root, watchConfigFile });
-      expect(result.added).toEqual([{ agentId: BIFF, project: 'cmem_work_biff' }]);
-      expect(result.pruned).toEqual([]);
+      const result = ensureWatchesForLiveAgents(watchCfg(root));
+      expect(result).toEqual({ added: 1, pruned: 0 });
 
-      const parsed = JSON.parse(readFileSync(watchConfigFile, 'utf8'));
+      const parsed = JSON.parse(readFileSync(path.join(root, 'transcript-watch.json'), 'utf8'));
       expect(parsed.schemas.cursor.name).toBe('cursor');
       const cursor = parsed.watches.filter((watch: { name: string }) => watch.name === 'cursor');
       expect(cursor).toHaveLength(1);
 
       const byId = Object.fromEntries(
         parsed.watches
-          .filter((watch: { agentId?: string }) => watch.agentId)
+          .filter((watch: { name: string; agentId?: string }) => watch.name === 'grok-bot')
           .map((watch: { agentId: string }) => [watch.agentId, watch]),
       );
       expect(byId[ORIFICE].project).toBe('cmem_work_orifice_pilot');
@@ -246,24 +225,23 @@ describe('ensureWatchesForLiveAgents', () => {
     }
   });
 
-  it('prunes grok-bot watches for deleted seats and leaves other watches alone', () => {
+  it('prunes deleted seats and catch-all * watches, and leaves other watches alone', () => {
     const root = mkdtempSync(path.join(tmpdir(), 'grok-inject-prune-'));
-    const watchConfigFile = path.join(root, 'transcript-watch.json');
     try {
       writeSeat(root, ORIFICE, 'Orifice');
-      writeFileSync(watchConfigFile, JSON.stringify({
+      writeFileSync(path.join(root, 'transcript-watch.json'), JSON.stringify({
         watches: [
           { name: 'cursor', path: '/tmp/cursor.jsonl', schema: 'cursor' },
+          { name: 'grok-bot', agentId: '*', project: 'cmem_work_root' },
           { name: 'grok-bot', agentId: ORIFICE, project: 'cmem_work_orifice' },
           { name: 'grok-bot', agentId: GONE, project: 'cmem_work_gone' },
         ],
       }));
 
-      const result = ensureWatchesForLiveAgents({ agentDataRoot: root, watchConfigFile });
-      expect(result.pruned).toEqual([GONE]);
-      expect(result.added).toEqual([]);
+      const result = ensureWatchesForLiveAgents(watchCfg(root));
+      expect(result).toEqual({ added: 0, pruned: 2 });
 
-      const parsed = JSON.parse(readFileSync(watchConfigFile, 'utf8'));
+      const parsed = JSON.parse(readFileSync(path.join(root, 'transcript-watch.json'), 'utf8'));
       expect(parsed.watches.map((watch: { agentId?: string; name: string }) => watch.agentId || watch.name))
         .toEqual(['cursor', ORIFICE]);
     } finally {
@@ -271,9 +249,21 @@ describe('ensureWatchesForLiveAgents', () => {
     }
   });
 
-  it('slugs new-hire profile names the same way the installer does', () => {
-    expect(resolveGrokBotProject('Biff')).toBe('cmem_work_biff');
-    expect(resolveGrokBotProject('New Bot')).toBe('cmem_work_new-bot');
-    expect(resolveGrokBotProject('box')).toBe('cmem_work_root');
+  it('is a no-op when transcript-watch.json is missing', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'grok-inject-missing-'));
+    try {
+      writeSeat(root, ORIFICE, 'Orifice');
+      expect(ensureWatchesForLiveAgents(watchCfg(root))).toEqual({ added: 0, pruned: 0 });
+      expect(existsSync(path.join(root, 'transcript-watch.json'))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('slugs new-hire names with the box slugGrokBotProject rules', () => {
+    expect(slugGrokBotProject('Biff')).toBe('cmem_work_biff');
+    expect(slugGrokBotProject('New Bot')).toBe('cmem_work_new-bot');
+    expect(slugGrokBotProject('box')).toBe('cmem_work_root');
+    expect(slugGrokBotProject('Orifice!')).toBe('cmem_work_orifice');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## HARD HOLD — do not merge as a product ship

**This PR is infra / plumbing only. It does not satisfy Alex’s HARD LOCK.**

**HARD LOCK:** middle-band timeline append is the **only** Claude-Mem → Grok inject path. Thin 2-line pointers are **not** the end state.

**#3958 as written fans out the same thin `MAX_LINES=2` / #3953 digest payload house-wide.** That is not a product ship.

**Merge only after Grok Memory Phase 1** (middle-band timeline payload), **or keep this PR as draft plumbing** for later. Do not merge on the current payload.

---

## What this PR is

L1 house-wide **infra**:

- `CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS=*` (or `all`) → `agentIdsAuto` (every live seat)
- `ensureWatchesForLiveAgents` + `resolveAgentIds` — auto new-hire watches, prune deleted seats, preserve existing project names
- Each `--watch` kick reloads config

Canonical source: live-box Oracle unified diff on `scripts/grok-bot-session-inject.mjs` (~695 lines). Test-only `export`s for bun.

## What this PR is not

- **Not** the hard-lock inject path
- **Not** a new inject payload (still #3953 thin-digest → `zz-claude-mem-inject.md`)
- **Not** Grok Memory Phase 1 middle-band timeline writer
- No new `/api/context/inject` query params (`projects` + optional `platformSource` only)
- Awareness pusher unchanged

Payload work stays out of this PR. Follow-up: middle-band timeline writer.

## Tests

15 bun tests pin `*` / `all`, live-seat listing, watch ensure/preserve/prune. Off by default until `CLAUDE_MEM_GROK_BOT_INJECT_ENABLED=true`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbf18eac-a6fa-4212-a50c-05ee8b37d9f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbf18eac-a6fa-4212-a50c-05ee8b37d9f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

