### PR TITLE
feat(grok-bot): Phase 1 hack-on-Memory JIT — rich timeline INDEX

### DIFF
--- a/scripts/grok-bot-session-inject.mjs
+++ b/scripts/grok-bot-session-inject.mjs
@@ -14,10 +14,22 @@
  *   existing Memory mid-attach transport:
  *
  *     GET /api/context/inject  (Allowed params only: projects, platformSource)
- *       → <data>/ccs/<agentId>/timeline.md     (L1 seat bucket, editable)
+ *       → <agentDataRoot>/ccs/seats/<agentId>/TIMELINE.md   (L1 seat bucket)
  *       → agents/<id>/memory/log/zz-claude-mem-inject.md
  *       → host WatchedDirectory → getFrozenSectionUpdatesForTurn()
  *       → <instructions_update> "## Memory"
+ *
+ * CCS L1 tree (shape stamp). One clear default, under the agent-data tree
+ * so bots can edit it:
+ *
+ *     <agentDataRoot>/ccs/seats/<agentId>/TIMELINE.md   ← Phase 1 source
+ *     <agentDataRoot>/ccs/seats/<agentId>/PRIVATE.md    ← may exist; never written
+ *     <agentDataRoot>/ccs/house/                        ← reserved, inherit later
+ *     <agentDataRoot>/ccs/groups/                       ← reserved
+ *
+ * Override the `ccs/` root with CLAUDE_MEM_CCS_ROOT if needed. L1 pilot
+ * compiles one seat TIMELINE.md only. Allowlist (Orifice / Grok Memory),
+ * not house-wide * as the product.
  *
  * Host has no native `ccs_timeline` section (closed freeze list). That is an
  * implement hack, not a product rewrite. Native registry is a later upgrade.
@@ -48,8 +60,13 @@ const AGENT_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{1
 const HOST_MAX_FACT_CHARS = 500;
 const INJECT_TAG = '[claude-mem]';
 const INJECT_LOG_BASENAME = 'zz-claude-mem-inject.md';
-const TIMELINE_BUCKET_BASENAME = 'timeline.md';
+const TIMELINE_BUCKET_BASENAME = 'TIMELINE.md';
+const PRIVATE_BUCKET_BASENAME = 'PRIVATE.md';
 const PROFILE_BASENAME = 'profile.md';
+const CCS_DIRNAME = 'ccs';
+const CCS_SEATS_DIRNAME = 'seats';
+const CCS_HOUSE_DIRNAME = 'house';
+const CCS_GROUPS_DIRNAME = 'groups';
 
 /**
  * Slide-off window for the compiled INDEX. #3953 defaulted to 2 packed
@@ -82,7 +99,7 @@ const FILE_HEADER = [
   '',
   '<!-- Written by claude-mem grok-bot-session-inject (Phase 1 JIT).',
   '     Rich timeline INDEX compiled from the CCS L1 seat bucket',
-  '     (<data>/ccs/<agentId>/timeline.md). Landed here so the host Memory',
+  '     (<agentDataRoot>/ccs/seats/<agentId>/TIMELINE.md). Landed here so the host Memory',
   '     mid-attach (`<instructions_update>`) picks it up — same transport as #3953.',
   '     Dated facts, one observation per line as "- (YYYY-MM-DD) <fact>".',
   '     Each row keeps its observation ID for get_observations. Safe to read.',
@@ -93,9 +110,11 @@ const FILE_HEADER = [
 const BUCKET_HEADER = [
   '# Timeline bucket',
   '',
-  '<!-- CCS L1 seat bucket (editable). Claude-Mem is the JIT compiler:',
-  '     mtime change → recompile → zz-claude-mem-inject.md → host Memory.',
+  '<!-- CCS L1 seat bucket (editable). Path: ccs/seats/<seat-id>/TIMELINE.md.',
+  '     Claude-Mem is the JIT compiler: mtime change → recompile →',
+  '     zz-claude-mem-inject.md → host Memory mid-attach.',
   '     Row grammar: ID TIME TYPE TITLE. Keep the observation ID on every row.',
+  '     Sibling PRIVATE.md is reserved (this compiler never writes it).',
   '     Do not rename this file to profile.md. -->',
   '',
 ].join('\n');
@@ -210,6 +229,7 @@ export function loadConfig(env = process.env) {
     pick('CLAUDE_MEM_GROK_BOT_INJECT_WINDOW'),
     pick('CLAUDE_MEM_GROK_BOT_INJECT_MAX_LINES'),
   );
+  const agentDataRoot = discoverAgentDataRoot(env);
 
   return {
     enabled: String(pick('CLAUDE_MEM_GROK_BOT_INJECT_ENABLED') ?? '').toLowerCase() === 'true',
@@ -238,8 +258,13 @@ export function loadConfig(env = process.env) {
     // mtime poll used when inotify watches are unavailable (this box runs out
     // of watch descriptors regularly). Two statSync calls per agent per tick.
     pollMs: num('CLAUDE_MEM_GROK_BOT_INJECT_POLL_MS', 10_000),
-    agentDataRoot: discoverAgentDataRoot(env),
-    ccsRoot: String(pick('CLAUDE_MEM_CCS_ROOT') ?? '').trim() || path.join(dataDir(), 'ccs'),
+    agentDataRoot,
+    /**
+     * Default CCS root lives under the agent-data tree so bots can edit
+     * TIMELINE.md. CLAUDE_MEM_CCS_ROOT overrides (e.g. a data-dir-relative
+     * `ccs/` if a seat wants that instead).
+     */
+    ccsRoot: String(pick('CLAUDE_MEM_CCS_ROOT') ?? '').trim() || path.join(agentDataRoot, CCS_DIRNAME),
     stateFile: path.join(dataDir(), 'state', 'grok-bot-session-inject.json'),
     watchConfigFile: path.join(dataDir(), 'transcript-watch.json'),
   };
@@ -577,17 +602,33 @@ export function injectLogPath(agentDataRoot, agentId) {
   return path.join(agentDataRoot, 'agents', agentId, 'memory', 'log', INJECT_LOG_BASENAME);
 }
 
-/** L1 seat-level CCS bucket. House-wide tree cascade is a later upgrade. */
-export function timelineBucketPath(ccsRoot, agentId) {
+/** `ccs/seats/<seat-id>/` — L1 seat folder. house/ and groups/ are siblings, later. */
+export function seatBucketDir(ccsRoot, agentId) {
   if (!AGENT_ID_RE.test(agentId)) {
     throw new Error(`Refusing bucket path for non-UUID agent id: ${agentId}`);
   }
-  return path.join(ccsRoot, agentId, TIMELINE_BUCKET_BASENAME);
+  return path.join(ccsRoot, CCS_SEATS_DIRNAME, agentId);
+}
+
+/** Primary L1 timeline bucket. Concrete default: `<agentDataRoot>/ccs/seats/<id>/TIMELINE.md`. */
+export function timelineBucketPath(ccsRoot, agentId) {
+  return path.join(seatBucketDir(ccsRoot, agentId), TIMELINE_BUCKET_BASENAME);
+}
+
+/** Reserved sibling. This compiler never writes or compiles it. */
+export function privateBucketPath(ccsRoot, agentId) {
+  return path.join(seatBucketDir(ccsRoot, agentId), PRIVATE_BUCKET_BASENAME);
 }
 
 function refuseProfile(basename) {
   if (String(basename).toLowerCase() === PROFILE_BASENAME) {
     throw new Error('Refusing write to profile.md');
+  }
+}
+
+function refusePrivate(basename) {
+  if (String(basename).toUpperCase() === PRIVATE_BUCKET_BASENAME) {
+    throw new Error('Refusing write to PRIVATE.md');
   }
 }
 
@@ -605,14 +646,21 @@ export function assertSafeInjectPath(agentDataRoot, agentId, filePath) {
 }
 
 export function assertSafeBucketPath(ccsRoot, agentId, filePath) {
-  const expectedDir = path.resolve(path.join(ccsRoot, agentId));
+  const expectedDir = path.resolve(seatBucketDir(ccsRoot, agentId));
   const resolved = path.resolve(filePath);
-  refuseProfile(path.basename(resolved));
+  const base = path.basename(resolved);
+  refuseProfile(base);
+  refusePrivate(base);
   if (path.dirname(resolved) !== expectedDir) {
     throw new Error('Refusing bucket write outside CCS L1 seat folder');
   }
-  if (path.basename(resolved) !== TIMELINE_BUCKET_BASENAME) {
-    throw new Error(`Refusing bucket write to a file this compiler does not own: ${path.basename(resolved)}`);
+  // house/ and groups/ are reserved; the dirname check already excludes them.
+  if (resolved.includes(`${path.sep}${CCS_HOUSE_DIRNAME}${path.sep}`)
+    || resolved.includes(`${path.sep}${CCS_GROUPS_DIRNAME}${path.sep}`)) {
+    throw new Error('Refusing bucket write under ccs/house or ccs/groups');
+  }
+  if (base !== TIMELINE_BUCKET_BASENAME) {
+    throw new Error(`Refusing bucket write to a file this compiler does not own: ${base}`);
   }
 }
 
@@ -825,7 +873,7 @@ function runWatch(initialCfg) {
       for (const dir of [
         path.join(cfg.agentDataRoot, 'agents', agentId),
         path.join(cfg.agentDataRoot, 'agent-transcripts', agentId),
-        path.join(cfg.ccsRoot, agentId),
+        seatBucketDir(cfg.ccsRoot, agentId),
       ]) {
         if (!existsSync(dir) || watchedDirs.has(dir)) continue;
         watchedDirs.add(dir);
@@ -876,7 +924,7 @@ function runWatch(initialCfg) {
   const pollActivity = () => {
     const dirs = new Set(watchedDirs);
     for (const agentId of resolveAgentIds(cfg)) {
-      dirs.add(path.join(cfg.ccsRoot, agentId));
+      dirs.add(seatBucketDir(cfg.ccsRoot, agentId));
       const bucket = timelineBucketPath(cfg.ccsRoot, agentId);
       dirs.add(bucket);
     }

--- a/scripts/grok-bot-session-inject.mjs
+++ b/scripts/grok-bot-session-inject.mjs
@@ -1,34 +1,44 @@
 #!/usr/bin/env node
 /**
- * Claude-Mem -> Grok Bot silent session inject.
+ * Claude-Mem → Grok Bot Memory mid-attach JIT (Phase 1 hack-on-Memory).
  *
- * Pulls the worker's existing session-inject text (GET /api/context/inject,
- * Allowed query params only) and lands it in a Grok Bot agent's own memory
- * log as parseable fact lines. The sand host already watches that folder, so
- * the next cold / non-resume turn picks the change up through its mid-epoch
- * frozen-section path (`getFrozenSectionUpdatesForTurn` ->
- * `promptWithInstructionsUpdate`) and the agent sees the context without
- * anybody calling a memory tool.
+ * Product shape (Alex’s only — do not contradict):
+ *   1. markdown files = buckets (editable)
+ *   2. mtime = cache bust
+ *   3. folder tree = CCS (L1 seat-level first)
+ *   4. Claude-Mem = JIT compiler
  *
- * This process binds no port. It only makes outbound HTTP to the local
- * claude-mem worker, and only ever writes one file it owns:
+ * Authorized Phase 1 path (Alex YES 2026-09-10 ~1:18pm PT):
+ *   Listen to markdown timeline bucket(s) after edit (mtime), compile a rich
+ *   timeline INDEX (not the #3953 thin MAX_LINES=2 pointer), land via the
+ *   existing Memory mid-attach transport:
  *
- *     <agent-data>/agents/<agentId>/memory/log/zz-claude-mem-inject.md
+ *     GET /api/context/inject  (Allowed params only: projects, platformSource)
+ *       → <data>/ccs/<agentId>/timeline.md     (L1 seat bucket, editable)
+ *       → agents/<id>/memory/log/zz-claude-mem-inject.md
+ *       → host WatchedDirectory → getFrozenSectionUpdatesForTurn()
+ *       → <instructions_update> "## Memory"
  *
- * Sibling of GrokBotAwarenessPusher: awareness lines are `- <date> [awareness]`
- * and deliberately do NOT match the host's fact grammar. Inject lines here use
- * the host's `- (YYYY-MM-DD) <fact>` grammar precisely because they are meant
- * to reach the prompt.
+ * Host has no native `ccs_timeline` section (closed freeze list). That is an
+ * implement hack, not a product rewrite. Native registry is a later upgrade.
+ *
+ * Slide-off window is ~50–100 newest rows. Every index row keeps the
+ * observation ID so deep fetch (`get_observations`) still works. Host chat
+ * is left alone. No new inject query params, no parallel memory API, no
+ * tool plane, no listening socket.
+ *
+ * Default seat list is the explicit Orifice/pilot allowlist.
+ * `CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS=*` (or `all`) is optional infra.
  *
  * Usage:
  *   node scripts/grok-bot-session-inject.mjs --once     # one refresh pass
  *   node scripts/grok-bot-session-inject.mjs --watch    # daemon
  *   node scripts/grok-bot-session-inject.mjs --status   # what is on disk now
- *   node scripts/grok-bot-session-inject.mjs --clear    # remove injected file
+ *   node scripts/grok-bot-session-inject.mjs --clear    # remove inject + bucket
  *   ... --dry-run                                       # never write
  */
 
-import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync, watch } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync, watch } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 
@@ -38,6 +48,22 @@ const AGENT_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{1
 const HOST_MAX_FACT_CHARS = 500;
 const INJECT_TAG = '[claude-mem]';
 const INJECT_LOG_BASENAME = 'zz-claude-mem-inject.md';
+const TIMELINE_BUCKET_BASENAME = 'timeline.md';
+const PROFILE_BASENAME = 'profile.md';
+
+/**
+ * Slide-off window for the compiled INDEX. #3953 defaulted to 2 packed
+ * pointer lines; Phase 1 is a rich index of ~50–100 rows, each with an ID.
+ */
+const DEFAULT_INDEX_WINDOW = 80;
+const MAX_INDEX_WINDOW = 100;
+
+/**
+ * Compact index rows so more of the window can survive the host's ~4000-char
+ * Memory recall budget. The host freeze list is the implement hack; native
+ * `ccs_timeline` is the later upgrade. Stay well under HOST_MAX_FACT_CHARS.
+ */
+const DEFAULT_INDEX_LINE_CHARS = 160;
 
 /**
  * The host ranks recalled log facts by
@@ -47,19 +73,30 @@ const INJECT_LOG_BASENAME = 'zz-claude-mem-inject.md';
  * recency, so on a seat whose log is already full of episode summaries a
  * plain-tier line loses every slot in the 4000-char recall budget and never
  * reaches the prompt at all. Orifice is exactly that seat. Episode tier is
- * therefore the default: a session-context digest is a session-level summary,
- * which is what that tier ranks. Drop to `plain` on a quiet seat where the
- * feed does not need to outrank the agent's own episodes.
+ * therefore the default.
  */
 const TIER_PREFIXES = { episode: '[episode] ', plain: '', note: '[note] ' };
 
 const FILE_HEADER = [
   '# Memory log',
   '',
-  '<!-- Written by claude-mem grok-bot-session-inject. Rewritten in place on every refresh.',
-  '     Content is the worker\'s GET /api/context/inject text for this agent\'s project(s),',
-  '     reshaped into the host fact grammar so the next cold turn picks it up.',
-  '     Dated facts, one per line as "- (YYYY-MM-DD) <fact>". Safe to read, grep, and edit. -->',
+  '<!-- Written by claude-mem grok-bot-session-inject (Phase 1 JIT).',
+  '     Rich timeline INDEX compiled from the CCS L1 seat bucket',
+  '     (<data>/ccs/<agentId>/timeline.md). Landed here so the host Memory',
+  '     mid-attach (`<instructions_update>`) picks it up — same transport as #3953.',
+  '     Dated facts, one observation per line as "- (YYYY-MM-DD) <fact>".',
+  '     Each row keeps its observation ID for get_observations. Safe to read.',
+  '     This file is a compiled cache; edit the bucket, not this file. -->',
+  '',
+].join('\n');
+
+const BUCKET_HEADER = [
+  '# Timeline bucket',
+  '',
+  '<!-- CCS L1 seat bucket (editable). Claude-Mem is the JIT compiler:',
+  '     mtime change → recompile → zz-claude-mem-inject.md → host Memory.',
+  '     Row grammar: ID TIME TYPE TITLE. Keep the observation ID on every row.',
+  '     Do not rename this file to profile.md. -->',
   '',
 ].join('\n');
 
@@ -69,6 +106,11 @@ const FILE_HEADER = [
  * newest row and crowd out a real observation.
  */
 const DROP_PREFIXES = ['Legend:', 'Format:', 'Fetch details:', 'Access '];
+
+/** Observation index row from /api/context/inject: `17399 1:18p ○ title`. */
+export const OBSERVATION_ROW_RE = /^(\d+)\s+\S+/;
+/** Session-summary row: `S10489 …`. */
+export const SUMMARY_ROW_RE = /^(S\d+)\s+\S+/;
 
 // ---------------------------------------------------------------- config ----
 
@@ -99,6 +141,23 @@ function splitCsv(value) {
     .split(',')
     .map(entry => entry.trim())
     .filter(entry => entry.length > 0);
+}
+
+/**
+ * Phase 1 window. Legacy MAX_LINES=2 is the #3953 pointer and is not the
+ * end state — treat it as unset so a leftover pilot json cannot pin us
+ * back to two packed lines. Explicit WINDOW still wins, including small
+ * values for tests.
+ */
+export function resolveIndexWindow(windowRaw, maxLinesRaw, fallback = DEFAULT_INDEX_WINDOW) {
+  const pick = windowRaw != null && String(windowRaw).trim() !== ''
+    ? windowRaw
+    : (maxLinesRaw != null && String(maxLinesRaw).trim() !== '' && Number(maxLinesRaw) > 2
+      ? maxLinesRaw
+      : fallback);
+  const parsed = Number(pick);
+  if (!Number.isFinite(parsed) || parsed < 1) return fallback;
+  return Math.min(Math.trunc(parsed), MAX_INDEX_WINDOW);
 }
 
 function hasAgentsAndTranscripts(dir) {
@@ -132,7 +191,7 @@ function discoverAgentDataRoot(env) {
  * The dedicated file keeps pilot wiring out of the live settings.json the
  * worker owns and rewrites.
  */
-function loadConfig(env = process.env) {
+export function loadConfig(env = process.env) {
   const settings = readJson(path.join(dataDir(), 'settings.json'), {});
   const local = readJson(path.join(dataDir(), 'grok-bot-session-inject.json'), {});
   const pick = key => env[key] ?? local[key] ?? settings[key];
@@ -141,10 +200,21 @@ function loadConfig(env = process.env) {
     return Number.isFinite(raw) && raw > 0 ? raw : fallback;
   };
 
-  const agentIds = splitCsv(pick('CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS')).filter(id => AGENT_ID_RE.test(id));
+  const agentIdsRaw = String(pick('CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS') ?? '').trim();
+  const agentIdsAuto = agentIdsRaw === '*' || agentIdsRaw.toLowerCase() === 'all';
+  const agentIds = agentIdsAuto
+    ? []
+    : splitCsv(agentIdsRaw).filter(id => AGENT_ID_RE.test(id));
+
+  const window = resolveIndexWindow(
+    pick('CLAUDE_MEM_GROK_BOT_INJECT_WINDOW'),
+    pick('CLAUDE_MEM_GROK_BOT_INJECT_MAX_LINES'),
+  );
 
   return {
     enabled: String(pick('CLAUDE_MEM_GROK_BOT_INJECT_ENABLED') ?? '').toLowerCase() === 'true',
+    /** When true, every live seat in transcript-watch.json is included (and new seats are ensured). */
+    agentIdsAuto,
     agentIds,
     /** `agentId=projA,projB;agentId2=projC` — overrides transcript-watch.json. */
     projectsByAgent: parseProjectMap(pick('CLAUDE_MEM_GROK_BOT_INJECT_PROJECTS_BY_AGENT')),
@@ -159,16 +229,17 @@ function loadConfig(env = process.env) {
     intervalMs: num('CLAUDE_MEM_GROK_BOT_INJECT_INTERVAL_MS', 120_000),
     minGapMs: num('CLAUDE_MEM_GROK_BOT_INJECT_MIN_GAP_MS', 20_000),
     tier: resolveTier(pick('CLAUDE_MEM_GROK_BOT_INJECT_TIER')),
-    // Each emitted line spends its own length out of the host's 4000-char
-    // recall budget, evicting that much of the agent's own memory. Keep it
-    // small: the point is a pointer into claude-mem, not a second memory.
-    maxLines: num('CLAUDE_MEM_GROK_BOT_INJECT_MAX_LINES', 2),
-    maxLineChars: Math.min(num('CLAUDE_MEM_GROK_BOT_INJECT_MAX_LINE_CHARS', 460), HOST_MAX_FACT_CHARS - 20),
+    /** Slide-off window: newest N observation rows in the compiled INDEX. */
+    window,
+    /** Back-compat alias used by older call sites / tests. */
+    maxLines: window,
+    maxLineChars: Math.min(num('CLAUDE_MEM_GROK_BOT_INJECT_MAX_LINE_CHARS', DEFAULT_INDEX_LINE_CHARS), HOST_MAX_FACT_CHARS - 20),
     timeoutMs: num('CLAUDE_MEM_GROK_BOT_INJECT_TIMEOUT_MS', 8_000),
     // mtime poll used when inotify watches are unavailable (this box runs out
     // of watch descriptors regularly). Two statSync calls per agent per tick.
     pollMs: num('CLAUDE_MEM_GROK_BOT_INJECT_POLL_MS', 10_000),
     agentDataRoot: discoverAgentDataRoot(env),
+    ccsRoot: String(pick('CLAUDE_MEM_CCS_ROOT') ?? '').trim() || path.join(dataDir(), 'ccs'),
     stateFile: path.join(dataDir(), 'state', 'grok-bot-session-inject.json'),
     watchConfigFile: path.join(dataDir(), 'transcript-watch.json'),
   };
@@ -191,7 +262,7 @@ function parseProjectMap(raw) {
  * Agent -> project comes from the transcript-watch config the Grok Bot
  * installer already writes, so there is exactly one mapping on the box.
  */
-function projectsForAgent(cfg, agentId) {
+export function projectsForAgent(cfg, agentId) {
   const override = cfg.projectsByAgent.get(agentId.toLowerCase());
   if (override) return override;
   const watches = readJson(cfg.watchConfigFile, {})?.watches ?? [];
@@ -202,6 +273,118 @@ function projectsForAgent(cfg, agentId) {
     if (project && !projects.includes(project)) projects.push(project);
   }
   return projects;
+}
+
+export function slugGrokBotProject(name) {
+  const base = String(name ?? '').replace(/\/+$/, '').split('/').pop() || '';
+  const cleaned = base.replace(/[^\w\s-]/gu, '');
+  const slug = cleaned
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40);
+  const generic = new Set(['', 'root', 'box', 'home', 'user', 'work', 'workspace', 'tmp', 'uploads', 'outputs', 'claude']);
+  return 'cmem_work_' + (generic.has(slug) ? 'root' : slug);
+}
+
+export function listLiveAgents(agentDataRoot) {
+  const agentsDir = path.join(agentDataRoot, 'agents');
+  if (!existsSync(agentsDir)) return [];
+  const out = [];
+  for (const entry of readdirSync(agentsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !AGENT_ID_RE.test(entry.name)) continue;
+    const profilePath = path.join(agentsDir, entry.name, 'profile.json');
+    if (!existsSync(profilePath)) continue;
+    let name = entry.name;
+    try {
+      const profile = JSON.parse(readFileSync(profilePath, 'utf8'));
+      if (typeof profile?.name === 'string' && profile.name.trim()) name = profile.name.trim();
+    } catch { /* keep id */ }
+    out.push({ id: entry.name, name });
+  }
+  return out;
+}
+
+/**
+ * Keep transcript-watch in sync with live seats: prune deleted, add missing.
+ * Preserves existing project names so diaries do not jump buckets on rename.
+ * Only runs in AGENT_IDS=* / all mode.
+ */
+export function ensureWatchesForLiveAgents(cfg, { log = () => {} } = {}) {
+  const watchCfg = readJson(cfg.watchConfigFile, null);
+  if (!watchCfg || !Array.isArray(watchCfg.watches)) return { added: 0, pruned: 0 };
+
+  const live = listLiveAgents(cfg.agentDataRoot);
+  const liveIds = new Set(live.map(a => a.id));
+  const before = watchCfg.watches.length;
+
+  const kept = [];
+  const seen = new Set();
+  let pruned = 0;
+  for (const watch of watchCfg.watches) {
+    if (watch?.name !== 'grok-bot') {
+      kept.push(watch);
+      continue;
+    }
+    const agentId = String(watch?.agentId ?? '').trim();
+    if (!agentId || agentId === '*') {
+      pruned += 1;
+      continue;
+    }
+    if (!liveIds.has(agentId)) {
+      pruned += 1;
+      continue;
+    }
+    kept.push(watch);
+    seen.add(agentId);
+  }
+
+  let added = 0;
+  for (const agent of live) {
+    if (seen.has(agent.id)) continue;
+    const project = slugGrokBotProject(agent.name);
+    const workspace = path.join(cfg.agentDataRoot, '.cmem-projects', project);
+    const transcriptDir = path.join(cfg.agentDataRoot, 'agent-transcripts', agent.id);
+    mkdirSync(workspace, { recursive: true });
+    mkdirSync(transcriptDir, { recursive: true });
+    kept.push({
+      name: 'grok-bot',
+      schema: 'grok-bot',
+      path: path.join(transcriptDir, '*.jsonl'),
+      workspace,
+      project,
+      startAtEnd: true,
+      agentId: agent.id,
+    });
+    seen.add(agent.id);
+    added += 1;
+    log(`watch+ ${agent.name} (${agent.id}) -> ${project}`);
+  }
+
+  if (added || pruned || kept.length !== before) {
+    watchCfg.watches = kept;
+    watchCfg.version = watchCfg.version || 1;
+    writeFileAtomic(cfg.watchConfigFile, `${JSON.stringify(watchCfg, null, 2)}\n`);
+  }
+  return { added, pruned };
+}
+
+/** Resolve the seat list for this pass. Auto mode = every live watched seat. */
+export function resolveAgentIds(cfg, { log = () => {} } = {}) {
+  if (cfg.agentIdsAuto) {
+    ensureWatchesForLiveAgents(cfg, { log });
+    const watches = readJson(cfg.watchConfigFile, {})?.watches ?? [];
+    const ids = [];
+    for (const watch of watches) {
+      if (watch?.name !== 'grok-bot') continue;
+      const agentId = String(watch?.agentId ?? '').trim();
+      if (!AGENT_ID_RE.test(agentId)) continue;
+      if (!existsSync(path.join(cfg.agentDataRoot, 'agents', agentId))) continue;
+      if (!ids.includes(agentId)) ids.push(agentId);
+    }
+    return ids;
+  }
+  return cfg.agentIds;
 }
 
 // ------------------------------------------------------------- inject io ----
@@ -254,87 +437,165 @@ function factLine(date, body, maxChars, tier) {
   return line.length <= maxChars ? line : `${line.slice(0, maxChars - 1)}…`;
 }
 
+function isBoilerplate(line) {
+  if (!line) return true;
+  if (DROP_PREFIXES.some(prefix => line.startsWith(prefix))) return true;
+  if (line.startsWith('<!--') || line === '-->') return true;
+  if (line.startsWith('# Timeline bucket')) return true;
+  if (line.startsWith('# Memory log')) return true;
+  return false;
+}
+
 /**
- * Reshape inject text into host-parseable fact lines.
- *
- * Newest-first throughout, and deliberately few: every line spends its own
- * length out of the agent's 4000-char recall budget, so this is a pointer
- * into claude-mem (project, stats, the freshest observation IDs, how to fetch
- * the rest), not a second copy of the memory.
+ * Parse editable-bucket / inject markdown into index rows.
+ * Observation and summary rows keep their source ID (Phase 0 packet intent).
  */
-export function injectTextToFactLines(text, { projects, maxLines, maxLineChars, tier = 'episode', now = new Date() }) {
+export function parseTimelineRows(text) {
+  const rows = [];
+  for (const raw of String(text).split('\n')) {
+    const line = raw.trim();
+    if (isBoilerplate(line)) continue;
+    if (line.startsWith('###')) continue;
+    if (line.startsWith('#') && !OBSERVATION_ROW_RE.test(line) && !SUMMARY_ROW_RE.test(line)) continue;
+    if (line.startsWith('Mode:') || line.startsWith('Stats:')) continue;
+
+    if (OBSERVATION_ROW_RE.test(line) || SUMMARY_ROW_RE.test(line)) {
+      const id = (OBSERVATION_ROW_RE.exec(line) || SUMMARY_ROW_RE.exec(line))[1];
+      rows.push({ id, raw: collapse(line) });
+      continue;
+    }
+    if (/^No previous sessions found/i.test(line)) {
+      rows.push({ id: null, raw: collapse(line) });
+    }
+  }
+  return rows;
+}
+
+/**
+ * Newest-first slide-off. Inject/bucket markdown is oldest-first under day
+ * headers, so the last parsed row is the freshest.
+ */
+export function slideWindow(rows, window) {
+  const size = resolveIndexWindow(window, undefined, DEFAULT_INDEX_WINDOW);
+  const newestFirst = rows.slice().reverse();
+  const kept = newestFirst.slice(0, size);
+  return { kept, omitted: Math.max(0, newestFirst.length - kept.length) };
+}
+
+/**
+ * Compile markdown-bucket / inject text into host-parseable INDEX facts.
+ *
+ * One observation per line (rich index, not a packed 2-line pointer).
+ * Newest first. Slide-off drops the oldest rows past `window`.
+ * Every kept observation/summary row still carries its ID.
+ */
+export function injectTextToFactLines(text, {
+  projects,
+  window,
+  maxLines,
+  maxLineChars,
+  tier = 'episode',
+  now = new Date(),
+} = {}) {
   const date = todayStamp(now);
+  // Index rows stay compact so more of the window can attach. The lead fact
+  // is allowed the host's full 500-char cap so stats + the ID fetch hint
+  // are not sliced off.
+  const headerMax = Math.min(HOST_MAX_FACT_CHARS - 20, Math.max(maxLineChars ?? DEFAULT_INDEX_LINE_CHARS, 460));
+  const emitHeader = body => factLine(date, body, headerMax, tier);
   const emit = body => factLine(date, body, maxLineChars, tier);
+  const windowSize = resolveIndexWindow(window, maxLines);
   const lines = String(text)
     .split('\n')
     .map(line => line.trim())
     .filter(line => line.length > 0)
-    .filter(line => !DROP_PREFIXES.some(prefix => line.startsWith(prefix)));
+    .filter(line => !isBoilerplate(line));
 
   const meta = [];
-  const rows = [];
   for (const line of lines) {
-    // `# [project] ...` is the inject header; `### Sep 8, 2026` are date
-    // sections that belong with the rows they head.
-    const isHeader = line.startsWith('#') && !line.startsWith('##');
-    if (isHeader || line.startsWith('Mode:') || line.startsWith('Stats:')) meta.push(line);
-    else rows.push(collapse(line));
+    const isInjectHeader = line.startsWith('# [') && !line.startsWith('##');
+    if (isInjectHeader || line.startsWith('Mode:') || line.startsWith('Stats:')) {
+      meta.push(line);
+    }
   }
 
+  const parsed = parseTimelineRows(text);
+  const { kept, omitted } = slideWindow(parsed, windowSize);
+
   const primary = projects[projects.length - 1] ?? 'unknown';
+  const stats = meta
+    .map(line => line.replace(/^#\s*/, ''))
+    // The inject header carries a fetch clock. Keeping it would make the
+    // fact block differ on every poll, so the host would see a "memory
+    // changed" delta — and re-announce it on the next turn — for a timestamp
+    // and nothing else. Facts already carry a date. mtime = cache bust.
+    .map(line => line.replace(/\s*recent context,.*$/, '').trim())
+    .filter(Boolean)
+    .join(' · ');
+
   const head = [
-    `Claude-Mem session context for ${primary}`,
-    meta
-      .map(line => line.replace(/^#\s*/, ''))
-      // The inject header carries a fetch clock. Keeping it would make the
-      // fact block differ on every poll, so the host would see a "memory
-      // changed" delta — and re-announce it on the next turn — for a timestamp
-      // and nothing else. Facts already carry a date.
-      .map(line => line.replace(/\s*recent context,.*$/, '').trim())
-      .filter(Boolean)
-      .join(' · '),
-    'fetch detail with the claude-mem tools (get_observations by ID)',
+    `Claude-Mem timeline index for ${primary}`,
+    stats,
+    `${kept.length} rows; fetch get_observations by ID`,
+    omitted > 0 ? `+${omitted} older in bucket` : '',
   ]
     .filter(Boolean)
     .join(' — ');
 
-  const out = [emit(head)];
-  const budget = Math.max(0, maxLines - 1);
-  if (rows.length === 0) return out;
-  if (budget === 0) return out;
-
-  // Newest first, so a truncated feed loses the oldest rows.
-  const newestFirst = rows.slice().reverse();
-  let used = 0;
-  for (let line = 0; line < budget && used < newestFirst.length; line += 1) {
-    const chunk = [];
-    let length = 0;
-    while (used < newestFirst.length) {
-      const row = newestFirst[used];
-      const next = chunk.length === 0 ? row.length : length + 3 + row.length;
-      if (chunk.length > 0 && next > maxLineChars - 60) break;
-      chunk.push(row);
-      length = next;
-      used += 1;
-    }
-    if (chunk.length === 0) break;
-    const omitted = line === budget - 1 ? newestFirst.length - used : 0;
-    const tail = omitted > 0 ? ` (+${omitted} older rows in claude-mem)` : '';
-    out.push(emit(`${chunk.join(' | ')}${tail}`));
+  const out = [emitHeader(head)];
+  for (const row of kept) {
+    out.push(emit(row.raw));
   }
   return out;
+}
+
+export function factBlock(contents) {
+  return String(contents ?? '')
+    .split('\n')
+    .filter(line => line.startsWith('- ('))
+    .join('\n');
+}
+
+/** True when the compiled INDEX (not the file header) actually changed. */
+export function shouldRewriteInject(existingContents, nextContents) {
+  return factBlock(existingContents) !== factBlock(nextContents);
+}
+
+/** Stable identity of the editable bucket: observation rows only, no clocks. */
+export function bucketRowPayload(text) {
+  return parseTimelineRows(text)
+    .map(row => row.raw)
+    .join('\n');
 }
 
 // ------------------------------------------------------------- disk write ----
 
 export function injectLogPath(agentDataRoot, agentId) {
+  if (!AGENT_ID_RE.test(agentId)) {
+    throw new Error(`Refusing inject path for non-UUID agent id: ${agentId}`);
+  }
   return path.join(agentDataRoot, 'agents', agentId, 'memory', 'log', INJECT_LOG_BASENAME);
 }
 
+/** L1 seat-level CCS bucket. House-wide tree cascade is a later upgrade. */
+export function timelineBucketPath(ccsRoot, agentId) {
+  if (!AGENT_ID_RE.test(agentId)) {
+    throw new Error(`Refusing bucket path for non-UUID agent id: ${agentId}`);
+  }
+  return path.join(ccsRoot, agentId, TIMELINE_BUCKET_BASENAME);
+}
+
+function refuseProfile(basename) {
+  if (String(basename).toLowerCase() === PROFILE_BASENAME) {
+    throw new Error('Refusing write to profile.md');
+  }
+}
+
 /** Mirrors the awareness pusher guard: never escape memory/log, never profile.md. */
-function assertSafeInjectPath(agentDataRoot, agentId, filePath) {
+export function assertSafeInjectPath(agentDataRoot, agentId, filePath) {
   const expectedDir = path.resolve(path.join(agentDataRoot, 'agents', agentId, 'memory', 'log'));
   const resolved = path.resolve(filePath);
+  refuseProfile(path.basename(resolved));
   if (path.dirname(resolved) !== expectedDir) {
     throw new Error('Refusing inject write outside agent memory/log');
   }
@@ -343,10 +604,36 @@ function assertSafeInjectPath(agentDataRoot, agentId, filePath) {
   }
 }
 
+export function assertSafeBucketPath(ccsRoot, agentId, filePath) {
+  const expectedDir = path.resolve(path.join(ccsRoot, agentId));
+  const resolved = path.resolve(filePath);
+  refuseProfile(path.basename(resolved));
+  if (path.dirname(resolved) !== expectedDir) {
+    throw new Error('Refusing bucket write outside CCS L1 seat folder');
+  }
+  if (path.basename(resolved) !== TIMELINE_BUCKET_BASENAME) {
+    throw new Error(`Refusing bucket write to a file this compiler does not own: ${path.basename(resolved)}`);
+  }
+}
+
 function writeFileAtomic(filePath, contents) {
+  mkdirSync(path.dirname(filePath), { recursive: true });
   const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`;
   writeFileSync(tmp, contents, 'utf8');
   renameSync(tmp, filePath);
+}
+
+/**
+ * mtime-stable rewrite: identical bytes → do not touch the file.
+ * mtime is the cache-bust signal; churning it on a no-op recompile
+ * would make the host re-announce Memory for nothing.
+ */
+export function writeFileIfChanged(filePath, contents) {
+  if (existsSync(filePath) && readFileSync(filePath, 'utf8') === contents) {
+    return { changed: false, filePath };
+  }
+  writeFileAtomic(filePath, contents);
+  return { changed: true, filePath };
 }
 
 function loadState(cfg) {
@@ -358,9 +645,17 @@ function saveState(cfg, state) {
   writeFileAtomic(cfg.stateFile, `${JSON.stringify(state, null, 2)}\n`);
 }
 
+function bucketMtimeMs(filePath) {
+  try {
+    return statSync(filePath).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
 // ---------------------------------------------------------------- passes ----
 
-async function refreshAgent(cfg, agentId, { dryRun = false, log = () => {} } = {}) {
+export async function refreshAgent(cfg, agentId, { dryRun = false, log = () => {}, fetchInjectFn = fetchInject } = {}) {
   const projects = projectsForAgent(cfg, agentId);
   if (projects.length === 0) {
     return { agentId, status: 'skipped', reason: 'no project mapped for agent' };
@@ -371,56 +666,138 @@ async function refreshAgent(cfg, agentId, { dryRun = false, log = () => {} } = {
     return { agentId, status: 'skipped', reason: `agent dir missing: ${agentDir}` };
   }
 
-  const { url, body } = await fetchInject(cfg, projects);
-  const factLines = injectTextToFactLines(body, {
+  const bucketPath = timelineBucketPath(cfg.ccsRoot, agentId);
+  assertSafeBucketPath(cfg.ccsRoot, agentId, bucketPath);
+  const filePath = injectLogPath(cfg.agentDataRoot, agentId);
+  assertSafeInjectPath(cfg.agentDataRoot, agentId, filePath);
+
+  const state = loadState(cfg);
+  const prior = state[agentId] ?? {};
+  const existingBucket = existsSync(bucketPath) ? readFileSync(bucketPath, 'utf8') : '';
+  const existingPayload = bucketRowPayload(existingBucket);
+  // Ownership: if the on-disk rows are not what this compiler last seeded,
+  // the human (or another editor) owns the bucket. mtime alone is too coarse
+  // on some filesystems; the row payload is the cache-bust identity.
+  const userEdited = Boolean(
+    existingBucket
+    && prior.bucketWrittenPayload
+    && existingPayload !== prior.bucketWrittenPayload,
+  );
+
+  let url = prior.url ?? null;
+  let fetchedBody = null;
+  if (!userEdited) {
+    try {
+      const fetched = await fetchInjectFn(cfg, projects);
+      url = fetched.url;
+      fetchedBody = fetched.body;
+    } catch (error) {
+      if (!existingBucket) throw error;
+      log(`WARN fetch failed for ${agentId}, compiling existing bucket: ${error?.message ?? error}`);
+    }
+  }
+
+  let bucketContents = existingBucket;
+  let bucketStatus = existingBucket ? 'existing' : 'missing';
+  if (!userEdited && fetchedBody != null) {
+    const nextBucket = `${BUCKET_HEADER}${String(fetchedBody).trim()}\n`;
+    if (bucketRowPayload(existingBucket) !== bucketRowPayload(nextBucket)) {
+      if (dryRun) {
+        bucketStatus = 'would-write';
+        bucketContents = nextBucket;
+      } else {
+        writeFileIfChanged(bucketPath, nextBucket);
+        bucketContents = nextBucket;
+        bucketStatus = 'written';
+      }
+    } else {
+      bucketStatus = 'unchanged';
+      bucketContents = existingBucket || nextBucket;
+    }
+  } else if (userEdited) {
+    bucketStatus = 'user-edited';
+  }
+
+  const compileSource = bucketContents || fetchedBody || '';
+  const factLines = injectTextToFactLines(compileSource, {
     projects,
-    maxLines: cfg.maxLines,
+    window: cfg.window ?? cfg.maxLines,
     maxLineChars: cfg.maxLineChars,
     tier: cfg.tier,
   });
   const contents = `${FILE_HEADER}${factLines.join('\n')}\n`;
 
-  const filePath = injectLogPath(cfg.agentDataRoot, agentId);
-  assertSafeInjectPath(cfg.agentDataRoot, agentId, filePath);
-
   const existing = existsSync(filePath) ? readFileSync(filePath, 'utf8') : '';
-  // Header stamps a fetch time, so compare the fact block, not the whole file.
-  const changed = factBlock(existing) !== factBlock(contents);
+  const changed = shouldRewriteInject(existing, contents);
+
+  const stampBucketMtime = () => {
+    if (dryRun) return;
+    const next = loadState(cfg);
+    const stamp = bucketMtimeMs(bucketPath);
+    next[agentId] = {
+      ...(next[agentId] ?? {}),
+      projects,
+      filePath,
+      bucketPath,
+      bucketMtimeMs: stamp,
+      bucketWrittenPayload: bucketRowPayload(existsSync(bucketPath) ? readFileSync(bucketPath, 'utf8') : bucketContents),
+      factLines: factLines.length,
+      window: cfg.window ?? cfg.maxLines,
+      bytes: existsSync(filePath) ? Buffer.byteLength(readFileSync(filePath, 'utf8')) : 0,
+      writtenAt: new Date().toISOString(),
+      url,
+    };
+    saveState(cfg, next);
+  };
 
   if (!changed) {
-    return { agentId, projects, url, status: 'unchanged', filePath, factLines: factLines.length };
+    stampBucketMtime();
+    return {
+      agentId,
+      projects,
+      url,
+      status: 'unchanged',
+      filePath,
+      bucketPath,
+      bucketStatus,
+      factLines: factLines.length,
+    };
   }
   if (dryRun) {
-    return { agentId, projects, url, status: 'would-write', filePath, factLines: factLines.length, preview: factLines };
+    return {
+      agentId,
+      projects,
+      url,
+      status: 'would-write',
+      filePath,
+      bucketPath,
+      bucketStatus,
+      factLines: factLines.length,
+      preview: factLines,
+    };
   }
 
-  mkdirSync(path.dirname(filePath), { recursive: true });
-  writeFileAtomic(filePath, contents);
-  log(`wrote ${factLines.length} inject facts for ${agentId} (${projects.join(',')}) -> ${filePath}`);
+  writeFileIfChanged(filePath, contents);
+  stampBucketMtime();
+  log(`wrote ${factLines.length} index rows for ${agentId} (${projects.join(',')}) -> ${filePath}`);
 
-  const state = loadState(cfg);
-  state[agentId] = {
+  return {
+    agentId,
     projects,
+    url,
+    status: 'written',
     filePath,
+    bucketPath,
+    bucketStatus,
     factLines: factLines.length,
-    bytes: Buffer.byteLength(contents),
-    writtenAt: new Date().toISOString(),
+    preview: factLines,
   };
-  saveState(cfg, state);
-
-  return { agentId, projects, url, status: 'written', filePath, factLines: factLines.length, preview: factLines };
-}
-
-function factBlock(contents) {
-  return contents
-    .split('\n')
-    .filter(line => line.startsWith('- ('))
-    .join('\n');
 }
 
 async function runOnce(cfg, opts) {
   const results = [];
-  for (const agentId of cfg.agentIds) {
+  const agentIds = resolveAgentIds(cfg, opts);
+  for (const agentId of agentIds) {
     try {
       results.push(await refreshAgent(cfg, agentId, opts));
     } catch (error) {
@@ -432,16 +809,40 @@ async function runOnce(cfg, opts) {
 
 // ----------------------------------------------------------------- watch ----
 
-function runWatch(cfg) {
+function runWatch(initialCfg) {
   const log = message => console.log(`[grok-inject ${new Date().toISOString()}] ${message}`);
-  log(`watching ${cfg.agentIds.length} agent(s); worker :${cfg.workerPort}; interval ${cfg.intervalMs}ms; root ${cfg.agentDataRoot}`);
+  let cfg = initialCfg;
+  const agentIds = resolveAgentIds(cfg, { log });
+  log(`watching ${cfg.agentIdsAuto ? 'AUTO' : agentIds.length} seat(s); worker :${cfg.workerPort}; window ${cfg.window}; root ${cfg.agentDataRoot}; ccs ${cfg.ccsRoot}`);
 
   let lastRunAt = 0;
   let pending = null;
   let running = false;
+  const watchedDirs = new Set();
+
+  const ensureActivityWatches = (ids) => {
+    for (const agentId of ids) {
+      for (const dir of [
+        path.join(cfg.agentDataRoot, 'agents', agentId),
+        path.join(cfg.agentDataRoot, 'agent-transcripts', agentId),
+        path.join(cfg.ccsRoot, agentId),
+      ]) {
+        if (!existsSync(dir) || watchedDirs.has(dir)) continue;
+        watchedDirs.add(dir);
+        try {
+          watch(dir, { persistent: true }, () => void kick('activity'));
+        } catch (error) {
+          // Boxes run out of inotify descriptors; the mtime poll below covers it.
+          log(`WARN cannot watch ${dir} (${error?.code ?? error?.message}) — falling back to mtime poll`);
+        }
+      }
+    }
+  };
 
   const kick = async reason => {
     if (running) return;
+    // Reload config each pass so * picks up new hires without a process restart.
+    cfg = loadConfig();
     const since = Date.now() - lastRunAt;
     if (since < cfg.minGapMs) {
       if (pending === null) {
@@ -455,49 +856,37 @@ function runWatch(cfg) {
     running = true;
     lastRunAt = Date.now();
     try {
+      const ids = resolveAgentIds(cfg, { log });
+      ensureActivityWatches(ids);
       for (const result of await runOnce(cfg, { log })) {
         if (result.status === 'error') log(`ERROR ${result.agentId}: ${result.reason}`);
         else if (result.status === 'skipped') log(`skip ${result.agentId}: ${result.reason}`);
+        else if (result.status === 'written') log(`wrote ${result.agentId} (${result.factLines} index rows)`);
       }
     } finally {
       running = false;
     }
   };
 
-  // Turn activity: the host touches the agent's store while a turn runs, and
-  // appends to the transcript when it lands. Either is a cue to refresh, so the
-  // delta is already staged for the agent's next cold turn.
-  const activityPaths = [];
-  for (const agentId of cfg.agentIds) {
-    for (const dir of [
-      path.join(cfg.agentDataRoot, 'agents', agentId),
-      path.join(cfg.agentDataRoot, 'agent-transcripts', agentId),
-    ]) {
-      if (!existsSync(dir)) continue;
-      activityPaths.push(dir);
-      try {
-        watch(dir, { persistent: true }, () => void kick('activity'));
-      } catch (error) {
-        // Boxes run out of inotify descriptors; the mtime poll below covers it.
-        log(`WARN cannot watch ${dir} (${error?.code ?? error?.message}) — falling back to mtime poll`);
-      }
-    }
-  }
+  ensureActivityWatches(agentIds);
 
+  // mtime poll fallback when inotify watches are unavailable. Also the
+  // product cache-bust: markdown bucket mtime → recompile.
   const mtimes = new Map();
   const pollActivity = () => {
-    for (const dir of activityPaths) {
-      let stamp;
+    const dirs = new Set(watchedDirs);
+    for (const agentId of resolveAgentIds(cfg)) {
+      dirs.add(path.join(cfg.ccsRoot, agentId));
+      const bucket = timelineBucketPath(cfg.ccsRoot, agentId);
+      dirs.add(bucket);
+    }
+    for (const dir of dirs) {
       try {
-        stamp = statSync(dir).mtimeMs;
-      } catch {
-        continue;
-      }
-      if (mtimes.get(dir) !== stamp) {
-        const first = !mtimes.has(dir);
+        const stamp = statSync(dir).mtimeMs;
+        const prev = mtimes.get(dir);
         mtimes.set(dir, stamp);
-        if (!first) void kick('mtime');
-      }
+        if (prev !== undefined && stamp !== prev) void kick('mtime');
+      } catch { /* path gone */ }
     }
   };
   pollActivity();
@@ -513,16 +902,24 @@ function runWatch(cfg) {
 function printStatus(cfg) {
   console.log(JSON.stringify({
     enabled: cfg.enabled,
+    agentIdsAuto: cfg.agentIdsAuto,
     agentDataRoot: cfg.agentDataRoot,
+    ccsRoot: cfg.ccsRoot,
     workerPort: cfg.workerPort,
-    agents: cfg.agentIds.map(agentId => {
+    window: cfg.window,
+    agents: resolveAgentIds(cfg).map(agentId => {
       const filePath = injectLogPath(cfg.agentDataRoot, agentId);
+      const bucketPath = timelineBucketPath(cfg.ccsRoot, agentId);
       const exists = existsSync(filePath);
+      const bucketExists = existsSync(bucketPath);
       return {
         agentId,
         projects: projectsForAgent(cfg, agentId),
         filePath,
+        bucketPath,
         exists,
+        bucketExists,
+        bucketMtimeMs: bucketExists ? bucketMtimeMs(bucketPath) : null,
         facts: exists ? factBlock(readFileSync(filePath, 'utf8')).split('\n').filter(Boolean).length : 0,
       };
     }),
@@ -531,14 +928,18 @@ function printStatus(cfg) {
 }
 
 function clearAgents(cfg) {
-  for (const agentId of cfg.agentIds) {
+  for (const agentId of resolveAgentIds(cfg)) {
     const filePath = injectLogPath(cfg.agentDataRoot, agentId);
     assertSafeInjectPath(cfg.agentDataRoot, agentId, filePath);
     rmSync(filePath, { force: true });
     console.log(`removed ${filePath}`);
+    const bucketPath = timelineBucketPath(cfg.ccsRoot, agentId);
+    assertSafeBucketPath(cfg.ccsRoot, agentId, bucketPath);
+    rmSync(bucketPath, { force: true });
+    console.log(`removed ${bucketPath}`);
   }
   const state = loadState(cfg);
-  for (const agentId of cfg.agentIds) delete state[agentId];
+  for (const agentId of resolveAgentIds(cfg)) delete state[agentId];
   saveState(cfg, state);
 }
 
@@ -554,8 +955,8 @@ async function main() {
     process.exitCode = 78; // EX_CONFIG
     return;
   }
-  if (cfg.agentIds.length === 0) {
-    console.error('No allowlisted agents. Set CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS.');
+  if (!cfg.agentIdsAuto && cfg.agentIds.length === 0) {
+    console.error('No allowlisted agents. Set CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS to a list (Orifice/pilot default) or *.');
     process.exitCode = 78;
     return;
   }

--- a/tests/grok-bot-session-inject.test.ts
+++ b/tests/grok-bot-session-inject.test.ts
@@ -6,6 +6,8 @@ import {
   injectTextToFactLines,
   injectLogPath,
   timelineBucketPath,
+  privateBucketPath,
+  seatBucketDir,
   loadConfig,
   slugGrokBotProject,
   listLiveAgents,
@@ -345,11 +347,48 @@ describe('mtime-stable rewrite', () => {
     const b = a.replace('3:41am UTC', '9:00pm UTC');
     expect(bucketRowPayload(a)).toBe(bucketRowPayload(b));
   });
+
+  it('writes TIMELINE.md under ccs/seats/<id> and never touches PRIVATE.md', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'grok-inject-layout-'));
+    try {
+      writeSeat(root, ORIFICE, 'Orifice');
+      writeFileSync(path.join(root, 'transcript-watch.json'), JSON.stringify({
+        watches: [{ name: 'grok-bot', agentId: ORIFICE, project: 'cmem_work_orifice' }],
+      }));
+      const ccsRoot = path.join(root, 'ccs');
+      const privatePath = privateBucketPath(ccsRoot, ORIFICE);
+      mkdirSync(path.dirname(privatePath), { recursive: true });
+      writeFileSync(privatePath, '# keep me\n');
+
+      const result = await refreshAgent({
+        agentIdsAuto: false,
+        agentIds: [ORIFICE],
+        agentDataRoot: root,
+        ccsRoot,
+        watchConfigFile: path.join(root, 'transcript-watch.json'),
+        projectsByAgent: new Map(),
+        window: 80,
+        maxLineChars: 160,
+        tier: 'episode',
+        stateFile: path.join(root, 'state.json'),
+      }, ORIFICE, {
+        fetchInjectFn: async () => ({ url: 'http://inject', body: sampleInject(3) }),
+      });
+
+      expect(result.bucketPath).toBe(`${ccsRoot}/seats/${ORIFICE}/TIMELINE.md`);
+      expect(existsSync(result.bucketPath as string)).toBe(true);
+      expect(readFileSync(privatePath, 'utf8')).toBe('# keep me\n');
+      expect(existsSync(path.join(ccsRoot, 'house'))).toBe(false);
+      expect(existsSync(path.join(ccsRoot, 'groups'))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('path guards', () => {
   const root = '/home/box/agent-data';
-  const ccs = '/home/box/.claude-mem/ccs';
+  const ccs = path.join(root, 'ccs');
 
   it('targets the agent log folder and never profile.md', () => {
     const filePath = injectLogPath(root, ORIFICE);
@@ -373,18 +412,35 @@ describe('path guards', () => {
       .toThrow(/does not own/);
   });
 
-  it('places the editable bucket at CCS L1 seat-level, never profile.md', () => {
+  it('places the editable bucket at ccs/seats/<seat-id>/TIMELINE.md', () => {
     const bucket = timelineBucketPath(ccs, ORIFICE);
-    expect(bucket).toBe(`${ccs}/${ORIFICE}/timeline.md`);
+    expect(bucket).toBe(`${ccs}/seats/${ORIFICE}/TIMELINE.md`);
+    expect(seatBucketDir(ccs, ORIFICE)).toBe(`${ccs}/seats/${ORIFICE}`);
+    expect(privateBucketPath(ccs, ORIFICE)).toBe(`${ccs}/seats/${ORIFICE}/PRIVATE.md`);
     expect(bucket.endsWith('profile.md')).toBe(false);
+    expect(bucket.endsWith('PRIVATE.md')).toBe(false);
   });
 
-  it('refuses bucket writes to profile.md or outside the seat folder', () => {
-    expect(() => assertSafeBucketPath(ccs, ORIFICE, path.join(ccs, ORIFICE, 'profile.md')))
+  it('defaults CCS under the agent-data tree (bots can edit TIMELINE.md)', () => {
+    const cfg = loadConfig({ GROK_BOT_AGENT_DATA: root });
+    expect(cfg.ccsRoot).toBe(path.join(root, 'ccs'));
+    expect(timelineBucketPath(cfg.ccsRoot, ORIFICE)).toBe(
+      `${root}/ccs/seats/${ORIFICE}/TIMELINE.md`,
+    );
+  });
+
+  it('refuses bucket writes to profile.md, PRIVATE.md, house/, groups/, or another seat', () => {
+    expect(() => assertSafeBucketPath(ccs, ORIFICE, path.join(ccs, 'seats', ORIFICE, 'profile.md')))
       .toThrow(/profile\.md/);
-    expect(() => assertSafeBucketPath(ccs, ORIFICE, path.join(ccs, 'other', 'timeline.md')))
+    expect(() => assertSafeBucketPath(ccs, ORIFICE, path.join(ccs, 'seats', ORIFICE, 'PRIVATE.md')))
+      .toThrow(/PRIVATE\.md/);
+    expect(() => assertSafeBucketPath(ccs, ORIFICE, path.join(ccs, 'house', 'TIMELINE.md')))
+      .toThrow(/outside CCS L1 seat folder|house/);
+    expect(() => assertSafeBucketPath(ccs, ORIFICE, path.join(ccs, 'groups', 'TIMELINE.md')))
+      .toThrow(/outside CCS L1 seat folder|groups/);
+    expect(() => assertSafeBucketPath(ccs, ORIFICE, path.join(ccs, 'seats', BIFF, 'TIMELINE.md')))
       .toThrow(/outside CCS L1 seat folder/);
-    expect(() => assertSafeBucketPath(ccs, ORIFICE, path.join(ccs, ORIFICE, '..', BIFF, 'timeline.md')))
+    expect(() => assertSafeBucketPath(ccs, ORIFICE, path.join(ccs, 'seats', ORIFICE, '..', BIFF, 'TIMELINE.md')))
       .toThrow(/outside CCS L1 seat folder/);
     expect(() => assertSafeInjectPath(root, ORIFICE, path.join(root, 'agents', ORIFICE, 'memory', 'log', '..', 'profile.md')))
       .toThrow(/profile\.md|outside/);
@@ -397,7 +453,7 @@ describe('path guards', () => {
 });
 
 describe('loadConfig defaults', () => {
-  it('prefers the Orifice/pilot allowlist; * / all are opt-in', () => {
+  it('prefers the Orifice / Grok Memory allowlist; * / all are infra, not the product', () => {
     const listed = loadConfig({ CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS: `${ORIFICE}` });
     expect(listed.agentIdsAuto).toBe(false);
     expect(listed.agentIds).toEqual([ORIFICE]);

--- a/tests/grok-bot-session-inject.test.ts
+++ b/tests/grok-bot-session-inject.test.ts
@@ -1,5 +1,28 @@
 import { describe, it, expect } from 'bun:test';
-import { injectTextToFactLines, injectLogPath } from '../scripts/grok-bot-session-inject.mjs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  injectTextToFactLines,
+  injectLogPath,
+  timelineBucketPath,
+  loadConfig,
+  slugGrokBotProject,
+  listLiveAgents,
+  ensureWatchesForLiveAgents,
+  resolveAgentIds,
+  projectsForAgent,
+  parseTimelineRows,
+  slideWindow,
+  shouldRewriteInject,
+  writeFileIfChanged,
+  factBlock,
+  bucketRowPayload,
+  assertSafeInjectPath,
+  assertSafeBucketPath,
+  resolveIndexWindow,
+  refreshAgent,
+} from '../scripts/grok-bot-session-inject.mjs';
 
 /**
  * The whole point of this shim is that the sand host parses what it writes.
@@ -16,6 +39,9 @@ const HOST_MEMORY_FACT_LINE = /^-\s+\((\d{4}-\d{2}-\d{2})\)\s+(.+?)\s*$/;
 const HOST_MAX_CONTENT_LENGTH = 500;
 
 const NOW = new Date('2026-09-10T03:41:00.000Z');
+const ORIFICE = '95601360-61f7-4fd9-bb3a-2c976b2b85c0';
+const BIFF = '1e5a61c5-5e1e-4ba6-862f-cd831dac62e9';
+const GONE = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
 
 function sampleInject(rowCount: number): string {
   const rows = Array.from({ length: rowCount }, (_, i) => `${17000 + i} 6:0${i % 10}p ○ observation number ${i}`);
@@ -34,8 +60,46 @@ function sampleInject(rowCount: number): string {
   ].join('\n');
 }
 
+function writeSeat(root: string, agentId: string, name: string): void {
+  mkdirSync(path.join(root, 'agents', agentId), { recursive: true });
+  mkdirSync(path.join(root, 'agent-transcripts', agentId), { recursive: true });
+  writeFileSync(path.join(root, 'agents', agentId, 'profile.json'), JSON.stringify({ name }));
+}
+
+function watchCfg(root: string, extra: Record<string, unknown> = {}) {
+  return {
+    agentIdsAuto: true,
+    agentIds: [],
+    agentDataRoot: root,
+    watchConfigFile: path.join(root, 'transcript-watch.json'),
+    projectsByAgent: new Map(),
+    ...extra,
+  };
+}
+
+describe('resolveIndexWindow', () => {
+  it('defaults to the Phase 1 rich-index window, not the #3953 pointer', () => {
+    expect(resolveIndexWindow(undefined, undefined)).toBe(80);
+    expect(resolveIndexWindow('', 2)).toBe(80);
+    expect(resolveIndexWindow(undefined, 2)).toBe(80);
+  });
+
+  it('honors an explicit WINDOW and clamps to 100', () => {
+    expect(resolveIndexWindow(50, 2)).toBe(50);
+    expect(resolveIndexWindow(100, 2)).toBe(100);
+    expect(resolveIndexWindow(400, 2)).toBe(100);
+    expect(resolveIndexWindow(undefined, 60)).toBe(60);
+  });
+});
+
 describe('injectTextToFactLines', () => {
-  const options = { projects: ['cmem_work_orifice'], maxLines: 2, maxLineChars: 460, tier: 'episode', now: NOW };
+  const options = {
+    projects: ['cmem_work_orifice'],
+    window: 80,
+    maxLineChars: 160,
+    tier: 'episode',
+    now: NOW,
+  };
 
   it('emits lines the host parses as memory facts', () => {
     const lines = injectTextToFactLines(sampleInject(20), options);
@@ -48,10 +112,19 @@ describe('injectTextToFactLines', () => {
     }
   });
 
-  it('never exceeds the configured line budget', () => {
+  it('is a rich index: one observation per line, not a packed 2-line pointer', () => {
+    const lines = injectTextToFactLines(sampleInject(20), options);
+    expect(lines.length).toBe(21); // header + 20 rows
+    const indexRows = lines.slice(1);
+    expect(indexRows.some(line => line.includes(' | '))).toBe(false);
+    expect(indexRows.filter(line => /170\d{2}/.test(line)).length).toBe(20);
+  });
+
+  it('never exceeds the configured slide-off window', () => {
     const lines = injectTextToFactLines(sampleInject(400), options);
-    expect(lines.length).toBeLessThanOrEqual(options.maxLines);
-    for (const line of lines) {
+    expect(lines.length).toBeLessThanOrEqual(options.window + 1);
+    expect(lines[0].length).toBeLessThanOrEqual(HOST_MAX_CONTENT_LENGTH);
+    for (const line of lines.slice(1)) {
       expect(line.length).toBeLessThanOrEqual(options.maxLineChars);
     }
   });
@@ -67,11 +140,12 @@ describe('injectTextToFactLines', () => {
     }
   });
 
-  it('keeps the newest rows when it has to truncate', () => {
+  it('keeps the newest rows when it has to slide off', () => {
     const lines = injectTextToFactLines(sampleInject(400), options).join('\n');
     expect(lines).toContain('observation number 399');
+    expect(lines).toContain('17399');
     expect(lines).not.toContain('observation number 0 ');
-    expect(lines).toContain('older rows in claude-mem');
+    expect(lines).toContain('older in bucket');
   });
 
   it('drops glyph-legend boilerplate but keeps the project header and stats', () => {
@@ -90,19 +164,371 @@ describe('injectTextToFactLines', () => {
     expect(lines[0]).toContain('cmem_work_orifice');
     expect(lines[1]).toContain('No previous sessions found.');
   });
+
+  it('does not churn the fact block when only the inject fetch clock changes', () => {
+    const a = injectTextToFactLines(sampleInject(5).replace('3:41am UTC', '3:42am UTC'), options);
+    const b = injectTextToFactLines(sampleInject(5).replace('3:41am UTC', '4:01am UTC'), options);
+    expect(factBlock(a.join('\n'))).toBe(factBlock(b.join('\n')));
+  });
 });
 
-describe('injectLogPath', () => {
+describe('row grammar and slide-off window', () => {
+  it('parses observation IDs from inject / bucket markdown', () => {
+    const rows = parseTimelineRows(sampleInject(3));
+    expect(rows.map(row => row.id)).toEqual(['17000', '17001', '17002']);
+    expect(rows[0].raw).toContain('17000');
+    expect(rows[0].raw).toContain('observation number 0');
+  });
+
+  it('keeps summary IDs too', () => {
+    const rows = parseTimelineRows('S10489 Session started (Sep 10, 2026)\n17001 1:18p ○ hello');
+    expect(rows.map(row => row.id)).toEqual(['S10489', '17001']);
+  });
+
+  it('ignores legend, day headers, and the CCS bucket title', () => {
+    const rows = parseTimelineRows([
+      '# Timeline bucket',
+      '<!-- comment -->',
+      'Legend: 🎯session',
+      '### Sep 10, 2026',
+      '17099 1:18p ○ keep me',
+    ].join('\n'));
+    expect(rows).toEqual([{ id: '17099', raw: '17099 1:18p ○ keep me' }]);
+  });
+
+  it('slides off oldest rows and reports how many dropped', () => {
+    const rows = parseTimelineRows(sampleInject(120));
+    const { kept, omitted } = slideWindow(rows, 80);
+    expect(kept).toHaveLength(80);
+    expect(omitted).toBe(40);
+    expect(kept[0].id).toBe('17119');
+    expect(kept[kept.length - 1].id).toBe('17040');
+    expect(kept.some(row => row.id === '17000')).toBe(false);
+  });
+
+  it('puts the observation ID on every compiled index row so deep fetch works', () => {
+    const lines = injectTextToFactLines(sampleInject(12), {
+      projects: ['cmem_work_orifice'],
+      window: 80,
+      maxLineChars: 160,
+      now: NOW,
+    });
+    const indexRows = lines.slice(1);
+    expect(indexRows).toHaveLength(12);
+    for (const line of indexRows) {
+      const id = /\[claude-mem\] (\d+) /.exec(line)?.[1];
+      expect(id).toBeTruthy();
+      expect(HOST_MEMORY_FACT_LINE.test(line)).toBe(true);
+    }
+    expect(lines[0]).toContain('get_observations by ID');
+  });
+});
+
+describe('mtime-stable rewrite', () => {
+  it('shouldRewriteInject ignores header comments and compares the fact block', () => {
+    const facts = injectTextToFactLines(sampleInject(4), {
+      projects: ['cmem_work_orifice'],
+      window: 80,
+      maxLineChars: 160,
+      now: NOW,
+    }).join('\n');
+    const a = `# Memory log\n\n<!-- first fetch -->\n\n${facts}\n`;
+    const b = `# Memory log\n\n<!-- later fetch, different comment -->\n\n${facts}\n`;
+    expect(shouldRewriteInject(a, b)).toBe(false);
+    expect(shouldRewriteInject(a, `${a}\n- (2026-09-10) [episode] [claude-mem] 99999 1:00p ○ new\n`)).toBe(true);
+  });
+
+  it('writeFileIfChanged does not bump mtime when bytes are unchanged', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'grok-inject-mtime-'));
+    try {
+      const file = path.join(dir, 'timeline.md');
+      writeFileSync(file, 'same-bytes\n');
+      const before = statSync(file).mtimeMs;
+      const first = writeFileIfChanged(file, 'same-bytes\n');
+      expect(first.changed).toBe(false);
+      expect(statSync(file).mtimeMs).toBe(before);
+
+      const second = writeFileIfChanged(file, 'different-bytes\n');
+      expect(second.changed).toBe(true);
+      expect(readFileSync(file, 'utf8')).toBe('different-bytes\n');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('refreshAgent is mtime-stable across identical inject payloads', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'grok-inject-refresh-'));
+    try {
+      writeSeat(root, ORIFICE, 'Orifice');
+      writeFileSync(path.join(root, 'transcript-watch.json'), JSON.stringify({
+        watches: [{ name: 'grok-bot', agentId: ORIFICE, project: 'cmem_work_orifice' }],
+      }));
+      const body = sampleInject(8);
+      const cfg = {
+        agentIdsAuto: false,
+        agentIds: [ORIFICE],
+        agentDataRoot: root,
+        ccsRoot: path.join(root, 'ccs'),
+        watchConfigFile: path.join(root, 'transcript-watch.json'),
+        projectsByAgent: new Map(),
+        window: 80,
+        maxLineChars: 160,
+        tier: 'episode',
+        stateFile: path.join(root, 'state.json'),
+      };
+
+      const fetchInjectFn = async () => ({ url: 'http://127.0.0.1:37700/api/context/inject?projects=cmem_work_orifice', body });
+      const first = await refreshAgent(cfg, ORIFICE, { fetchInjectFn });
+      expect(first.status).toBe('written');
+      expect(first.factLines).toBe(9);
+
+      const injectPath = first.filePath as string;
+      const bucketPath = first.bucketPath as string;
+      const injectMtime = statSync(injectPath).mtimeMs;
+      const bucketMtime = statSync(bucketPath).mtimeMs;
+
+      const second = await refreshAgent(cfg, ORIFICE, { fetchInjectFn });
+      expect(second.status).toBe('unchanged');
+      expect(statSync(injectPath).mtimeMs).toBe(injectMtime);
+      expect(statSync(bucketPath).mtimeMs).toBe(bucketMtime);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('compiles a user-edited bucket without overwriting it', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'grok-inject-user-'));
+    try {
+      writeSeat(root, ORIFICE, 'Orifice');
+      writeFileSync(path.join(root, 'transcript-watch.json'), JSON.stringify({
+        watches: [{ name: 'grok-bot', agentId: ORIFICE, project: 'cmem_work_orifice' }],
+      }));
+      const cfg = {
+        agentIdsAuto: false,
+        agentIds: [ORIFICE],
+        agentDataRoot: root,
+        ccsRoot: path.join(root, 'ccs'),
+        watchConfigFile: path.join(root, 'transcript-watch.json'),
+        projectsByAgent: new Map(),
+        window: 80,
+        maxLineChars: 160,
+        tier: 'episode',
+        stateFile: path.join(root, 'state.json'),
+      };
+
+      await refreshAgent(cfg, ORIFICE, {
+        fetchInjectFn: async () => ({ url: 'http://inject', body: sampleInject(3) }),
+      });
+
+      const bucketPath = timelineBucketPath(cfg.ccsRoot, ORIFICE);
+      const edited = `${readFileSync(bucketPath, 'utf8').trim()}\n18888 2:00p ○ user edited row\n`;
+      writeFileSync(bucketPath, edited);
+
+      let fetched = 0;
+      const result = await refreshAgent(cfg, ORIFICE, {
+        fetchInjectFn: async () => {
+          fetched += 1;
+          return { url: 'http://inject', body: sampleInject(3) };
+        },
+      });
+      expect(fetched).toBe(0);
+      expect(result.bucketStatus).toBe('user-edited');
+      expect(readFileSync(bucketPath, 'utf8')).toBe(edited);
+      expect(readFileSync(result.filePath as string, 'utf8')).toContain('18888');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('treats identical observation rows as an unchanged bucket payload even if the fetch clock moved', () => {
+    const a = sampleInject(4);
+    const b = a.replace('3:41am UTC', '9:00pm UTC');
+    expect(bucketRowPayload(a)).toBe(bucketRowPayload(b));
+  });
+});
+
+describe('path guards', () => {
+  const root = '/home/box/agent-data';
+  const ccs = '/home/box/.claude-mem/ccs';
+
   it('targets the agent log folder and never profile.md', () => {
-    const filePath = injectLogPath('/home/box/agent-data', '95601360-61f7-4fd9-bb3a-2c976b2b85c0');
+    const filePath = injectLogPath(root, ORIFICE);
     expect(filePath).toBe(
-      '/home/box/agent-data/agents/95601360-61f7-4fd9-bb3a-2c976b2b85c0/memory/log/zz-claude-mem-inject.md',
+      `/home/box/agent-data/agents/${ORIFICE}/memory/log/zz-claude-mem-inject.md`,
     );
     expect(filePath.endsWith('profile.md')).toBe(false);
   });
 
   it('uses a filename the host never writes itself (host owns YYYY-MM.md)', () => {
-    const filePath = injectLogPath('/root', '95601360-61f7-4fd9-bb3a-2c976b2b85c0');
+    const filePath = injectLogPath('/root', ORIFICE);
     expect(/\d{4}-\d{2}\.md$/.test(filePath)).toBe(false);
+  });
+
+  it('refuses inject writes to profile.md and anything outside memory/log', () => {
+    expect(() => assertSafeInjectPath(root, ORIFICE, path.join(root, 'agents', ORIFICE, 'memory', 'log', 'profile.md')))
+      .toThrow(/profile\.md/);
+    expect(() => assertSafeInjectPath(root, ORIFICE, path.join(root, 'agents', ORIFICE, 'profile.md')))
+      .toThrow(/outside agent memory\/log|profile\.md/);
+    expect(() => assertSafeInjectPath(root, ORIFICE, path.join(root, 'agents', ORIFICE, 'memory', 'log', '2026-09.md')))
+      .toThrow(/does not own/);
+  });
+
+  it('places the editable bucket at CCS L1 seat-level, never profile.md', () => {
+    const bucket = timelineBucketPath(ccs, ORIFICE);
+    expect(bucket).toBe(`${ccs}/${ORIFICE}/timeline.md`);
+    expect(bucket.endsWith('profile.md')).toBe(false);
+  });
+
+  it('refuses bucket writes to profile.md or outside the seat folder', () => {
+    expect(() => assertSafeBucketPath(ccs, ORIFICE, path.join(ccs, ORIFICE, 'profile.md')))
+      .toThrow(/profile\.md/);
+    expect(() => assertSafeBucketPath(ccs, ORIFICE, path.join(ccs, 'other', 'timeline.md')))
+      .toThrow(/outside CCS L1 seat folder/);
+    expect(() => assertSafeBucketPath(ccs, ORIFICE, path.join(ccs, ORIFICE, '..', BIFF, 'timeline.md')))
+      .toThrow(/outside CCS L1 seat folder/);
+    expect(() => assertSafeInjectPath(root, ORIFICE, path.join(root, 'agents', ORIFICE, 'memory', 'log', '..', 'profile.md')))
+      .toThrow(/profile\.md|outside/);
+  });
+
+  it('refuses non-UUID agent ids so a path cannot escape the seat folder', () => {
+    expect(() => injectLogPath(root, '../etc')).toThrow(/non-UUID/);
+    expect(() => timelineBucketPath(ccs, '*')).toThrow(/non-UUID/);
+  });
+});
+
+describe('loadConfig defaults', () => {
+  it('prefers the Orifice/pilot allowlist; * / all are opt-in', () => {
+    const listed = loadConfig({ CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS: `${ORIFICE}` });
+    expect(listed.agentIdsAuto).toBe(false);
+    expect(listed.agentIds).toEqual([ORIFICE]);
+    expect(listed.window).toBe(80);
+
+    expect(loadConfig({ CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS: '*' }).agentIdsAuto).toBe(true);
+    expect(loadConfig({ CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS: '*' }).agentIds).toEqual([]);
+    expect(loadConfig({ CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS: 'all' }).agentIdsAuto).toBe(true);
+    expect(loadConfig({ CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS: 'ALL' }).agentIdsAuto).toBe(true);
+  });
+
+  it('does not let a leftover MAX_LINES=2 pin the compiler to the thin pointer', () => {
+    expect(loadConfig({ CLAUDE_MEM_GROK_BOT_INJECT_MAX_LINES: '2' }).window).toBe(80);
+    expect(loadConfig({ CLAUDE_MEM_GROK_BOT_INJECT_WINDOW: '50' }).window).toBe(50);
+  });
+});
+
+describe('AGENT_IDS=* / all', () => {
+  it('lists live UUID seats that have profile.json', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'grok-inject-live-'));
+    try {
+      writeSeat(root, ORIFICE, 'Orifice');
+      writeSeat(root, BIFF, 'Biff');
+      mkdirSync(path.join(root, 'agents', 'not-a-uuid'), { recursive: true });
+      writeFileSync(path.join(root, 'agents', 'not-a-uuid', 'profile.json'), JSON.stringify({ name: 'Nope' }));
+      mkdirSync(path.join(root, 'agents', GONE, 'memory', 'log'), { recursive: true });
+
+      const live = listLiveAgents(root);
+      expect(live.map(agent => agent.id).sort()).toEqual([BIFF, ORIFICE].sort());
+      expect(live.find(agent => agent.id === ORIFICE)?.name).toBe('Orifice');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('resolveAgentIds in auto mode ensures watches and returns every live watched seat', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'grok-inject-resolve-'));
+    try {
+      writeSeat(root, ORIFICE, 'Orifice');
+      writeFileSync(path.join(root, 'transcript-watch.json'), JSON.stringify({ version: 1, watches: [] }));
+
+      const cfg = watchCfg(root);
+      expect(resolveAgentIds(cfg)).toEqual([ORIFICE]);
+
+      writeSeat(root, BIFF, 'Biff');
+      expect(resolveAgentIds(cfg).sort()).toEqual([BIFF, ORIFICE].sort());
+      expect(projectsForAgent(cfg, ORIFICE)).toEqual(['cmem_work_orifice']);
+      expect(projectsForAgent(cfg, BIFF)).toEqual(['cmem_work_biff']);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('ensureWatchesForLiveAgents', () => {
+  it('adds missing live seats with cmem_work_* and preserves existing project names', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'grok-inject-ensure-'));
+    try {
+      writeSeat(root, ORIFICE, 'Orifice');
+      writeSeat(root, BIFF, 'Biff');
+      writeFileSync(path.join(root, 'transcript-watch.json'), JSON.stringify({
+        version: 1,
+        schemas: { cursor: { name: 'cursor' } },
+        watches: [
+          { name: 'cursor', path: '/tmp/cursor.jsonl', schema: 'cursor' },
+          { name: 'grok-bot', agentId: ORIFICE, project: 'cmem_work_orifice_pilot', schema: 'grok-bot' },
+        ],
+      }));
+
+      const result = ensureWatchesForLiveAgents(watchCfg(root));
+      expect(result).toEqual({ added: 1, pruned: 0 });
+
+      const parsed = JSON.parse(readFileSync(path.join(root, 'transcript-watch.json'), 'utf8'));
+      expect(parsed.schemas.cursor.name).toBe('cursor');
+      const cursor = parsed.watches.filter((watch: { name: string }) => watch.name === 'cursor');
+      expect(cursor).toHaveLength(1);
+
+      const byId = Object.fromEntries(
+        parsed.watches
+          .filter((watch: { name: string; agentId?: string }) => watch.name === 'grok-bot')
+          .map((watch: { agentId: string }) => [watch.agentId, watch]),
+      );
+      expect(byId[ORIFICE].project).toBe('cmem_work_orifice_pilot');
+      expect(byId[BIFF].project).toBe('cmem_work_biff');
+      expect(byId[BIFF].path).toBe(path.join(root, 'agent-transcripts', BIFF, '*.jsonl'));
+      expect(byId[BIFF].workspace).toBe(path.join(root, '.cmem-projects', 'cmem_work_biff'));
+      expect(existsSync(path.join(root, '.cmem-projects', 'cmem_work_biff'))).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('prunes deleted seats and catch-all * watches, and leaves other watches alone', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'grok-inject-prune-'));
+    try {
+      writeSeat(root, ORIFICE, 'Orifice');
+      writeFileSync(path.join(root, 'transcript-watch.json'), JSON.stringify({
+        watches: [
+          { name: 'cursor', path: '/tmp/cursor.jsonl', schema: 'cursor' },
+          { name: 'grok-bot', agentId: '*', project: 'cmem_work_root' },
+          { name: 'grok-bot', agentId: ORIFICE, project: 'cmem_work_orifice' },
+          { name: 'grok-bot', agentId: GONE, project: 'cmem_work_gone' },
+        ],
+      }));
+
+      const result = ensureWatchesForLiveAgents(watchCfg(root));
+      expect(result).toEqual({ added: 0, pruned: 2 });
+
+      const parsed = JSON.parse(readFileSync(path.join(root, 'transcript-watch.json'), 'utf8'));
+      expect(parsed.watches.map((watch: { agentId?: string; name: string }) => watch.agentId || watch.name))
+        .toEqual(['cursor', ORIFICE]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('is a no-op when transcript-watch.json is missing', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'grok-inject-missing-'));
+    try {
+      writeSeat(root, ORIFICE, 'Orifice');
+      expect(ensureWatchesForLiveAgents(watchCfg(root))).toEqual({ added: 0, pruned: 0 });
+      expect(existsSync(path.join(root, 'transcript-watch.json'))).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('slugs new-hire names with the box slugGrokBotProject rules', () => {
+    expect(slugGrokBotProject('Biff')).toBe('cmem_work_biff');
+    expect(slugGrokBotProject('New Bot')).toBe('cmem_work_new-bot');
+    expect(slugGrokBotProject('box')).toBe('cmem_work_root');
+    expect(slugGrokBotProject('Orifice!')).toBe('cmem_work_orifice');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Product shape stands

Alex YES (2026-09-10 ~1:18pm PT). This PR does **not** rewrite the product.

1. markdown files = buckets (editable)
2. mtime = cache bust
3. folder tree = CCS (L1 seat-level first)
4. Claude-Mem = JIT compiler

The host’s closed freeze list (no native `ccs_timeline` section) is an **implement hack**, not a product reject. Native `ccs_timeline` / host registry is a **later upgrade**, not this PR. The product is not blocked.

## CCS L1 tree (shape stamp)

One clear default, under the agent-data tree so bots can edit it:

```
<agentDataRoot>/ccs/seats/<agentId>/TIMELINE.md   ← Phase 1 source (~50–100 rows + IDs)
<agentDataRoot>/ccs/seats/<agentId>/PRIVATE.md    ← may exist; this compiler never writes it
<agentDataRoot>/ccs/house/                        ← reserved; optional house inherit later
<agentDataRoot>/ccs/groups/                       ← reserved
```

Override the `ccs/` root with `CLAUDE_MEM_CCS_ROOT` if a seat wants it under `CLAUDE_MEM_DATA_DIR` instead. L1 pilot compiles **one seat `TIMELINE.md` only**.

## Authorized Phase 1 path

Hack on top of the existing [#3953](https://github.com/thedotmack/claude-mem/pull/3953) Memory mid-attach transport:

```
GET /api/context/inject   (Allowed params only: projects + optional platformSource)
  → <agentDataRoot>/ccs/seats/<agentId>/TIMELINE.md     CCS L1 seat bucket (editable)
  → agents/<id>/memory/log/zz-claude-mem-inject.md
  → host WatchedDirectory → getFrozenSectionUpdatesForTurn()
  → <instructions_update> "## Memory"
```

1. Watch `TIMELINE.md` mtime (and/or rewrite it from worker inject when the compiler still owns the rows)
2. Compile a **rich timeline INDEX** — one observation per line, not the thin `MAX_LINES=2` pointer
3. Host Memory `instructions_update` carries it (hack path)

Slide-off window default **80** (clamped 1–100). Every kept row still carries its observation ID for `get_observations`. mtime-stable rewrite: identical fact block / identical bucket rows → file is not touched. Host chat is left alone. No new inject query params. No parallel memory API. No tool plane.

## Config

- **Default / product:** explicit Orifice or Grok Memory allowlist (`CLAUDE_MEM_GROK_BOT_INJECT_AGENT_IDS=<uuid>`). Not house-wide `*` as the product.
- **Optional infra only:** `*` / `all` (same plumbing as draft #3958)
- `CLAUDE_MEM_GROK_BOT_INJECT_WINDOW` (default 80). A leftover `MAX_LINES=2` does **not** pin the compiler back to the thin pointer
- Off until `CLAUDE_MEM_GROK_BOT_INJECT_ENABLED=true`

## Tests

`tests/grok-bot-session-inject.test.ts` — 36 bun tests:

- Host fact grammar + 500-char cap
- Row grammar with observation IDs (and summary IDs)
- Slide-off window (newest kept, oldest dropped)
- mtime-stable rewrite / no churn on fetch-clock-only change
- User-edited `TIMELINE.md` is compiled, not overwritten
- Concrete path `ccs/seats/<id>/TIMELINE.md`; `PRIVATE.md` left untouched
- Path guards: never `profile.md`, never `PRIVATE.md`, never `ccs/house` or `ccs/groups`, never host `YYYY-MM.md`
- Allowlist default; `*` / `all` optional infra

## Later (not this PR)

Clean `ccs_timeline` host registry. House inherit from `ccs/house/`. Groups cascade. #3958 stays infra-only until this payload is the one being fanned out.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-996ab31a-236b-4342-a75f-4f291095b2d5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-996ab31a-236b-4342-a75f-4f291095b2d5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

