### PR TITLE
feat(telemetry): skill_invoked for bundled skills

### DIFF
--- a/docs/public/telemetry.mdx
+++ b/docs/public/telemetry.mdx
@@ -121,6 +121,9 @@ Every event property passes through a strict whitelist scrubber — any key not 
 | `error_mode` | `worker_unavailable` | Coarse hook failure mode: worker_unavailable / blocking_error — never an error message |
 | `consecutive_failures` | `3` | How many hook failures occurred in a row (the fail-loud counter) |
 | `threshold_tripped` | `true` | Whether the consecutive-failure count reached the fail-loud threshold |
+| `skill_id` | `mem-search` | Which bundled skill was invoked — a closed enum of `plugin/skills/` directory names, or `other`. Third-party skill names are never sent. |
+| `skill_source` | `first_party` | `first_party` (a shipped `plugin/skills/` skill) or `third_party` (collapsed to `skill_id: other`) |
+| `skill_trigger` | `tool` | How the skill was invoked: `tool` (host Skill tool) or `prompt` (typed `/skill` at session-init). Never the prompt body. |
 
 One value is derived server-side rather than sent by the client: PostHog resolves the request's sender IP to a **coarse location** (country / region / city) at ingestion, before the IP itself is discarded. The client never attaches an IP to any event, and the raw IP is never stored — see [What is NEVER collected](#what-is-never-collected).
 
@@ -140,6 +143,7 @@ One value is derived server-side rather than sent by the client: PostHog resolve
 | `observer_turn_rollup` | Emitted **once per session, at session end** — a per-session rollup that aggregates every compression in that session (stored observations, invalid-output drops, failures, aborts) instead of one event per turn | `rollup_reason` (session_end / worker_shutdown / safety_flush), `window_seq`, aggregated `outcomes_*` counts, `total_tokens_input`, `total_tokens_output`, `total_cost_usd`, `avg_duration_ms`, `avg_compression_ms`, `top_model`, `observed_model`, `observed_billing`, `observations_created` (sum of observations generated in the session — pairs with `total_cost_usd` to derive cost per observation), summed `obs_type_*` buckets, `window_start_ts`, plus the per-turn fields it summarizes (`provider`, `ide`) |
 | `context_injected_rollup` | A 5-minute time-window rollup of context injections (stored memory injected into new sessions) | aggregated `outcomes_ok` / `outcomes_error` counts, `count`, `total_tokens`, `avg_tokens`, `total_observations_injected` (sum of observations served from cache into prompts), `total_tokens_saved_vs_naive`, `window_start_ts` |
 | `search_performed` | A memory search runs (never the query text) | `endpoint`, `outcome`, `duration_ms`, `result_count`, `search_strategy`, `chroma_available`, `fallback_reason` |
+| `skill_invoked` | A bundled skill is invoked — the host Skill tool loads its instructions, or the user types a first-party `/skill` at session-init. **Not** work completion; no `duration_ms` / outcome. Worker path only. Unknown `/foo` emits nothing. | `skill_id` (closed enum + `other`), `skill_source` (`first_party` / `third_party`), `skill_trigger` (`tool` / `prompt`), `ide` |
 | `worker_stopped` | The background worker shuts down gracefully | `uptime_seconds`, `shutdown_reason` (stop / restart / signal) |
 | `usage_limit_hit` | The Claude subscription behind the observer reports a window as `rejected` — since the observer shares the observed session's account, this is when the user's own Claude Code session ran out of usage. Emitted once per exhausted window (deduped on the window's reset time; a worker restart while still capped re-emits once). Only fires when the observer runs on Claude with a subscription login — API-key, Gemini, and OpenRouter observers never see it | `limit_window` (five_hour / seven_day / seven_day_opus / seven_day_sonnet / overage / unknown), `overage_status` (allowed / allowed_warning / rejected / unknown), `is_using_overage`, `resets_in_minutes`, `ide`, `provider`, `observed_model`, `observed_billing` |
 | `hook_failed` | A claude-mem hook fails hard — the worker is unreachable past the fail-loud threshold, or a blocking error occurs | `hook_type`, `error_mode`, `consecutive_failures`, `threshold_tripped` |
@@ -207,6 +211,8 @@ A few things worth knowing:
 | Hardware or machine identifiers | Not even hashed MAC addresses or hostnames |
 | Environment variable values | Ever |
 | Emails, usernames, or any PII | Ever — emails, tokens, keys, and credentials are redacted out of error text too |
+| Skill arguments, skill markdown, or prompt bodies | `skill_invoked` sends only a closed `skill_id` / `skill_source` / `skill_trigger`. `tool_input.args` and the rest of a slash prompt never leave the machine |
+| Third-party skill names | Collapsed to `skill_id: other` + `skill_source: third_party`. Unknown `/foo` slash tokens emit no event at all |
 
 **One honest exception: error messages.** Since the addition of [error tracking](#error-tracking), redacted error **messages and stack traces** ARE collected (as `$exception` events) — that is a deliberate change from the previous coarse-category-only posture, and it is consent-gated with its own [kill-switch](#how-to-opt-out-four-ways). Raw paths, prompts, project names, source code, and model output are still **never** collected — they are stripped from the error text before it leaves your machine.
 

--- a/src/npx-cli/commands/telemetry.ts
+++ b/src/npx-cli/commands/telemetry.ts
@@ -79,6 +79,9 @@ const COLLECTED_FIELDS = [
   'error_mode       worker_unavailable / blocking_error (never a message)',
   'consecutive_failures   hook failures in a row (the fail-loud counter)',
   'threshold_tripped      whether the fail-loud threshold was reached',
+  'skill_id         first-party plugin/skills name or other (never a third-party name)',
+  'skill_source     first_party / third_party',
+  'skill_trigger    tool (Skill tool) / prompt (typed /skill)',
 ];
 
 const EVENT_NAMES = [
@@ -90,6 +93,7 @@ const EVENT_NAMES = [
   'session_compressed',
   'context_injected',
   'search_performed',
+  'skill_invoked',
   'hook_failed',
   'error_occurred',
 ];

--- a/src/services/telemetry/scrub.ts
+++ b/src/services/telemetry/scrub.ts
@@ -185,6 +185,13 @@ export const ALLOWED_PROPERTY_KEYS: Set<string> = new Set([
   // context_injected_rollup aggregation fields:
   'total_tokens',
   'avg_tokens',
+  // skill_invoked — closed skill identity only. skill_id is a first-party
+  // plugin/skills/ name or `other`; skill_source is first_party | third_party;
+  // skill_trigger is tool | prompt. Never a third-party skill name, never
+  // tool_input.args, never the prompt body.
+  'skill_id',
+  'skill_source',
+  'skill_trigger',
   // Per-session/window observation volume folded into the rollups so the
   // context-cache-value and observation-type metrics survive the retirement of
   // the legacy per-occurrence streams. observations_created (generation side,

--- a/src/services/telemetry/skill-id.ts
+++ b/src/services/telemetry/skill-id.ts
@@ -1,0 +1,107 @@
+/**
+ * Closed-set skill identity for `skill_invoked` telemetry.
+ *
+ * First-party ids are pinned to `plugin/skills/*/`. Sibling copies of the
+ * same skill (cursor / cowork / grok-bot `mem-search`) collapse to that one
+ * id. Third-party names never leave the machine — they become `skill_id: other`
+ * with `skill_source: third_party`.
+ *
+ * Pure module: no I/O, never throws, never returns caller-supplied free text.
+ */
+
+export const FIRST_PARTY_SKILL_IDS = [
+  'babysit',
+  'ccs-align',
+  'cloud-sync',
+  'design-is',
+  'do',
+  'how-it-works',
+  'knowledge-agent',
+  'learn-codebase',
+  'make-plan',
+  'mem-search',
+  'mode-creator',
+  'oh-my-issues',
+  'pathfinder',
+  'smart-explore',
+  'standup',
+  'timeline-report',
+  'version-bump',
+  'weekly-digests',
+  'what-the',
+  'wowerpoint',
+] as const;
+
+export type FirstPartySkillId = (typeof FIRST_PARTY_SKILL_IDS)[number];
+export type SkillId = FirstPartySkillId | 'other';
+export type SkillSource = 'first_party' | 'third_party';
+export type SkillTrigger = 'tool' | 'prompt';
+
+export type SkillClassification = {
+  skill_id: SkillId;
+  skill_source: SkillSource;
+};
+
+const FIRST_PARTY_SKILL_ID_SET: ReadonlySet<string> = new Set(FIRST_PARTY_SKILL_IDS);
+
+const OTHER_SKILL: SkillClassification = {
+  skill_id: 'other',
+  skill_source: 'third_party',
+};
+
+/**
+ * Normalize a host-supplied skill token to a closed allowlist id.
+ *
+ * - Non-strings / empty → other + third_party
+ * - Trim + lowercase
+ * - Strip a leading `/` so slash tokens and Skill names share a path
+ * - If the token contains `:`, keep the last segment (`claude-mem:mem-search`
+ *   and `cowork:mem-search` both become `mem-search`)
+ * - Never return the original string
+ */
+export function classifySkillId(raw: unknown): SkillClassification {
+  const token = normalizeSkillToken(raw);
+  if (!token) return OTHER_SKILL;
+  if (FIRST_PARTY_SKILL_ID_SET.has(token)) {
+    return { skill_id: token as FirstPartySkillId, skill_source: 'first_party' };
+  }
+  return OTHER_SKILL;
+}
+
+/**
+ * Skill tool hosts put the skill name on `tool_input.skill`. Anything else
+ * (including SlashCommand) is out of scope here — slash mapping is
+ * `firstPartySkillFromSlashPrompt`.
+ */
+export function skillNameFromToolInput(toolName: string, toolInput: unknown): unknown {
+  if (toolName !== 'Skill') return undefined;
+  if (!toolInput || typeof toolInput !== 'object') return undefined;
+  return (toolInput as { skill?: unknown }).skill;
+}
+
+/**
+ * Leading `/token` of a user prompt, only when it is a first-party skill.
+ * Unknown `/foo` returns null so the session-init path emits nothing (and
+ * never a third-party name). The rest of the prompt is ignored.
+ */
+export function firstPartySkillFromSlashPrompt(prompt: unknown): FirstPartySkillId | null {
+  if (typeof prompt !== 'string') return null;
+  const trimmed = prompt.trimStart();
+  if (!trimmed.startsWith('/')) return null;
+  const token = trimmed.split(/\s/, 1)[0] ?? '';
+  const classified = classifySkillId(token);
+  if (classified.skill_source !== 'first_party') return null;
+  return classified.skill_id as FirstPartySkillId;
+}
+
+function normalizeSkillToken(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null;
+  let token = raw.trim().toLowerCase();
+  if (!token) return null;
+  token = token.replace(/^\/+/, '');
+  const colon = token.lastIndexOf(':');
+  if (colon !== -1) {
+    token = token.slice(colon + 1).replace(/^\/+/, '');
+  }
+  return token || null;
+}

--- a/src/services/telemetry/skill-id.ts
+++ b/src/services/telemetry/skill-id.ts
@@ -1,10 +1,10 @@
 /**
- * Closed-set skill identity for `skill_invoked` telemetry.
+ * Closed-set skill identity for skill_invoked telemetry.
  *
- * First-party ids are pinned to `plugin/skills/*/`. Sibling copies of the
- * same skill (cursor / cowork / grok-bot `mem-search`) collapse to that one
- * id. Third-party names never leave the machine — they become `skill_id: other`
- * with `skill_source: third_party`.
+ * First-party ids are pinned to plugin/skills/<name>/. Sibling copies of the
+ * same skill (cursor / cowork / grok-bot mem-search) collapse to that one
+ * id. Third-party names never leave the machine — they become skill_id other
+ * with skill_source third_party.
  *
  * Pure module: no I/O, never throws, never returns caller-supplied free text.
  */

--- a/src/services/worker/http/routes/SessionRoutes.ts
+++ b/src/services/worker/http/routes/SessionRoutes.ts
@@ -20,6 +20,8 @@ import { USER_SETTINGS_PATH } from '../../../../shared/paths.js';
 import { getProjectContext } from '../../../../utils/project-name.js';
 import { handleGeneratorExit } from '../../session/GeneratorExitHandler.js';
 import { telemetryBuffer } from '../../../telemetry/buffer.js';
+import { captureEvent } from '../../../telemetry/telemetry.js';
+import { firstPartySkillFromSlashPrompt } from '../../../telemetry/skill-id.js';
 import { SessionCompletionHandler } from '../../session/SessionCompletionHandler.js';
 import { USER_PROMPT_DEDUPE_WINDOW_MS } from '../../../../shared/user-prompts.js';
 import {
@@ -578,6 +580,16 @@ export class SessionRoutes extends BaseRouteHandler {
       logger.debug('HTTP', 'session-init: skipping internal protocol payload before session creation', { contentSessionId });
       res.json({ skipped: true, reason: 'internal_protocol' });
       return;
+    }
+
+    const slashSkillId = firstPartySkillFromSlashPrompt(rawPrompt);
+    if (slashSkillId) {
+      captureEvent('skill_invoked', {
+        skill_id: slashSkillId,
+        skill_source: 'first_party',
+        skill_trigger: 'prompt',
+        ide: platformSource,
+      });
     }
 
     let prompt = rawPrompt || '[media prompt]';

--- a/src/services/worker/http/shared.ts
+++ b/src/services/worker/http/shared.ts
@@ -10,6 +10,8 @@ import { USER_SETTINGS_PATH } from '../../../shared/paths.js';
 import { getProjectContext } from '../../../utils/project-name.js';
 import { normalizePlatformSource } from '../../../shared/platform-source.js';
 import { PrivacyCheckValidator } from '../validation/PrivacyCheckValidator.js';
+import { captureEvent } from '../../telemetry/telemetry.js';
+import { classifySkillId, skillNameFromToolInput } from '../../telemetry/skill-id.js';
 
 interface IngestContext {
   sessionManager: SessionManager;
@@ -79,6 +81,17 @@ export async function ingestObservation(payload: ObservationPayload): Promise<In
     settings.CLAUDE_MEM_SKIP_TOOLS.split(',').map(t => t.trim()).filter(Boolean)
   );
   if (skipTools.has(payload.toolName)) {
+    if (payload.toolName === 'Skill') {
+      const { skill_id, skill_source } = classifySkillId(
+        skillNameFromToolInput(payload.toolName, payload.toolInput),
+      );
+      captureEvent('skill_invoked', {
+        skill_id,
+        skill_source,
+        skill_trigger: 'tool',
+        ide: platformSource,
+      });
+    }
     return { ok: true, status: 'skipped', reason: 'tool_excluded' };
   }
 

--- a/tests/telemetry/scrub.test.ts
+++ b/tests/telemetry/scrub.test.ts
@@ -240,6 +240,20 @@ describe('scrubProperties', () => {
     expect(result).toEqual({ version: '1.0.0' });
   });
 
+  it('keeps the skill_invoked identity keys with primitive values', () => {
+    const result = scrubProperties({
+      skill_id: 'mem-search',
+      skill_source: 'first_party',
+      skill_trigger: 'tool',
+    });
+
+    expect(result).toEqual({
+      skill_id: 'mem-search',
+      skill_source: 'first_party',
+      skill_trigger: 'tool',
+    });
+  });
+
   it('drops sensitive-looking keys even if present', () => {
     const result = scrubProperties({
       path: '/Users/alice/secret-project/index.ts',
@@ -262,8 +276,30 @@ describe('scrubProperties', () => {
     expect(Object.keys(result)).not.toContain('ip');
   });
 
+  it('drops skill args / raw skill / prompt keys even when skill identity is present', () => {
+    const result = scrubProperties({
+      skill_id: 'other',
+      skill_source: 'third_party',
+      skill_trigger: 'tool',
+      skill: 'someone-else:evil',
+      args: '/Users/alice/secret --pr 42',
+      command: '/foo do the thing',
+      prompt: '/foo leak this body',
+    });
+
+    expect(result).toEqual({
+      skill_id: 'other',
+      skill_source: 'third_party',
+      skill_trigger: 'tool',
+    });
+    expect(Object.keys(result)).not.toContain('skill');
+    expect(Object.keys(result)).not.toContain('args');
+    expect(Object.keys(result)).not.toContain('command');
+    expect(Object.keys(result)).not.toContain('prompt');
+  });
+
   it('whitelist never contains sensitive keys', () => {
-    for (const key of ['path', 'cwd', 'prompt', 'query', 'project_name', 'email', 'ip']) {
+    for (const key of ['path', 'cwd', 'prompt', 'query', 'project_name', 'email', 'ip', 'args', 'skill', 'command']) {
       expect(ALLOWED_PROPERTY_KEYS.has(key)).toBe(false);
     }
   });

--- a/tests/telemetry/skill-id.test.ts
+++ b/tests/telemetry/skill-id.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'bun:test';
+import { existsSync, readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import {
+  FIRST_PARTY_SKILL_IDS,
+  classifySkillId,
+  skillNameFromToolInput,
+  firstPartySkillFromSlashPrompt,
+} from '../../src/services/telemetry/skill-id';
+
+const PROJECT_ROOT = join(import.meta.dir, '../..');
+const PLUGIN_SKILLS_DIR = join(PROJECT_ROOT, 'plugin/skills');
+
+const MEM_SEARCH_COPIES = [
+  'plugin/skills/mem-search/SKILL.md',
+  'claude-mem-cursor/skills/mem-search/SKILL.md',
+  'cowork/skills/mem-search/SKILL.md',
+  'claude-mem-grok-bot/skills/mem-search/SKILL.md',
+];
+
+function pluginSkillIdsOnDisk(): string[] {
+  return readdirSync(PLUGIN_SKILLS_DIR, { withFileTypes: true })
+    .filter((entry) => (
+      entry.isDirectory()
+      && existsSync(join(PLUGIN_SKILLS_DIR, entry.name, 'SKILL.md'))
+    ))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+describe('FIRST_PARTY_SKILL_IDS pinned to plugin/skills/', () => {
+  it('matches every plugin/skills/*/SKILL.md directory and no others', () => {
+    expect([...FIRST_PARTY_SKILL_IDS].sort()).toEqual(pluginSkillIdsOnDisk());
+  });
+
+  it('collapses sibling mem-search copies to one first-party id', () => {
+    for (const rel of MEM_SEARCH_COPIES) {
+      expect(existsSync(join(PROJECT_ROOT, rel))).toBe(true);
+    }
+    expect(classifySkillId('mem-search')).toEqual({
+      skill_id: 'mem-search',
+      skill_source: 'first_party',
+    });
+    expect(classifySkillId('claude-mem:mem-search')).toEqual({
+      skill_id: 'mem-search',
+      skill_source: 'first_party',
+    });
+    expect(classifySkillId('cowork:mem-search')).toEqual({
+      skill_id: 'mem-search',
+      skill_source: 'first_party',
+    });
+    expect(classifySkillId('cursor:mem-search')).toEqual({
+      skill_id: 'mem-search',
+      skill_source: 'first_party',
+    });
+  });
+
+  it('is a pure helper — no captureEvent, completion, or duration fields', () => {
+    const src = readFileSync(join(PROJECT_ROOT, 'src/services/telemetry/skill-id.ts'), 'utf8');
+    expect(src).not.toContain('captureEvent');
+    expect(src).not.toContain('skill_completed');
+    expect(src).not.toContain('duration_ms');
+  });
+});
+
+describe('classifySkillId', () => {
+  it('classifies a bare first-party name as first_party', () => {
+    expect(classifySkillId('mem-search')).toEqual({
+      skill_id: 'mem-search',
+      skill_source: 'first_party',
+    });
+  });
+
+  it('strips a claude-mem: prefix', () => {
+    expect(classifySkillId('claude-mem:make-plan')).toEqual({
+      skill_id: 'make-plan',
+      skill_source: 'first_party',
+    });
+  });
+
+  it('lowercases and accepts CLAUDE-MEM:DO', () => {
+    expect(classifySkillId('CLAUDE-MEM:DO')).toEqual({
+      skill_id: 'do',
+      skill_source: 'first_party',
+    });
+  });
+
+  it('never returns a third-party name', () => {
+    expect(classifySkillId('someone-else:evil')).toEqual({
+      skill_id: 'other',
+      skill_source: 'third_party',
+    });
+    expect(classifySkillId('../../etc/passwd')).toEqual({
+      skill_id: 'other',
+      skill_source: 'third_party',
+    });
+    expect(classifySkillId('superpowers')).toEqual({
+      skill_id: 'other',
+      skill_source: 'third_party',
+    });
+  });
+
+  it('collapses empty and non-string input to other / third_party', () => {
+    expect(classifySkillId('')).toEqual({ skill_id: 'other', skill_source: 'third_party' });
+    expect(classifySkillId('   ')).toEqual({ skill_id: 'other', skill_source: 'third_party' });
+    expect(classifySkillId(null)).toEqual({ skill_id: 'other', skill_source: 'third_party' });
+    expect(classifySkillId({ skill: 'x' })).toEqual({ skill_id: 'other', skill_source: 'third_party' });
+  });
+
+  it('never echoes the original string', () => {
+    const classified = classifySkillId('Someone-Else:SecretSkill');
+    expect(JSON.stringify(classified)).not.toContain('Someone-Else');
+    expect(JSON.stringify(classified)).not.toContain('SecretSkill');
+    expect(classified.skill_id).toBe('other');
+  });
+});
+
+describe('skillNameFromToolInput', () => {
+  it('reads toolInput.skill only for the Skill tool', () => {
+    expect(skillNameFromToolInput('Skill', { skill: 'mem-search', args: '/secret' })).toBe('mem-search');
+    expect(skillNameFromToolInput('SlashCommand', { command: '/mem-search' })).toBeUndefined();
+    expect(skillNameFromToolInput('Skill', 'not-an-object')).toBeUndefined();
+    expect(skillNameFromToolInput('Read', { skill: 'mem-search' })).toBeUndefined();
+  });
+});
+
+describe('firstPartySkillFromSlashPrompt', () => {
+  it('returns the first-party id for a leading /skill token', () => {
+    expect(firstPartySkillFromSlashPrompt('/mem-search how did we do auth?')).toBe('mem-search');
+    expect(firstPartySkillFromSlashPrompt('/make-plan')).toBe('make-plan');
+    expect(firstPartySkillFromSlashPrompt('  /claude-mem:do\nnext line')).toBe('do');
+  });
+
+  it('emits nothing (null) for unknown /foo and non-slash prompts', () => {
+    expect(firstPartySkillFromSlashPrompt('/foo')).toBeNull();
+    expect(firstPartySkillFromSlashPrompt('/someone-else:evil')).toBeNull();
+    expect(firstPartySkillFromSlashPrompt('please /mem-search later')).toBeNull();
+    expect(firstPartySkillFromSlashPrompt('mem-search')).toBeNull();
+    expect(firstPartySkillFromSlashPrompt('')).toBeNull();
+    expect(firstPartySkillFromSlashPrompt(null)).toBeNull();
+  });
+
+  it('does not treat the rest of the prompt as an id', () => {
+    const id = firstPartySkillFromSlashPrompt('/standup secret project /Users/alice/repo');
+    expect(id).toBe('standup');
+  });
+});

--- a/tests/worker/skill-invoked-telemetry.test.ts
+++ b/tests/worker/skill-invoked-telemetry.test.ts
@@ -1,0 +1,292 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import type { Server } from 'node:http';
+import express from 'express';
+import { SessionStore } from '../../src/services/sqlite/SessionStore.js';
+import { setIngestContext, ingestObservation } from '../../src/services/worker/http/shared.js';
+import { SessionRoutes } from '../../src/services/worker/http/routes/SessionRoutes.js';
+import { logger } from '../../src/utils/logger.js';
+import { postHogCaptureCalls } from '../preload';
+import { __resetTelemetryForTests } from '../../src/services/telemetry/telemetry';
+
+const savedEnv: Record<string, string | undefined> = {};
+const ENV_KEYS = [
+  'CLAUDE_MEM_TELEMETRY',
+  'CLAUDE_MEM_TELEMETRY_DEBUG',
+  'DO_NOT_TRACK',
+];
+
+function skillInvokedCalls(): Array<{ event: string; properties: Record<string, unknown> }> {
+  return postHogCaptureCalls.filter((call) => call.event === 'skill_invoked') as Array<{
+    event: string;
+    properties: Record<string, unknown>;
+  }>;
+}
+
+describe('skill_invoked telemetry', () => {
+  let store: SessionStore | undefined;
+  let queued: Array<{ sessionDbId: number; data: any }>;
+  let loggerSpies: ReturnType<typeof spyOn>[] = [];
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) savedEnv[key] = process.env[key];
+    process.env.CLAUDE_MEM_TELEMETRY = '1';
+    delete process.env.CLAUDE_MEM_TELEMETRY_DEBUG;
+    delete process.env.DO_NOT_TRACK;
+
+    __resetTelemetryForTests();
+    postHogCaptureCalls.length = 0;
+
+    loggerSpies = [
+      spyOn(logger, 'info').mockImplementation(() => {}),
+      spyOn(logger, 'debug').mockImplementation(() => {}),
+      spyOn(logger, 'warn').mockImplementation(() => {}),
+      spyOn(logger, 'error').mockImplementation(() => {}),
+      spyOn(logger, 'dataIn').mockImplementation(() => {}),
+    ];
+
+    queued = [];
+    store = new SessionStore(new Database(':memory:'));
+
+    setIngestContext({
+      sessionManager: {
+        queueObservation: async (sessionDbId: number, data: any) => {
+          queued.push({ sessionDbId, data });
+        },
+      } as any,
+      dbManager: { getSessionStore: () => store } as any,
+      eventBroadcaster: { broadcastObservationQueued: mock(() => {}) } as any,
+      ensureGeneratorRunning: mock(async () => {}),
+    });
+  });
+
+  afterEach(() => {
+    loggerSpies.forEach((spy) => spy.mockRestore());
+    store?.close();
+    store = undefined;
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+    __resetTelemetryForTests();
+    postHogCaptureCalls.length = 0;
+  });
+
+  const skillPayload = (overrides: Record<string, unknown> = {}) => ({
+    contentSessionId: 'content-session-skill',
+    toolName: 'Skill',
+    toolInput: { skill: 'mem-search', args: '/Users/alice/secret-project --pr 99' },
+    toolResponse: { ok: true, text: '# Memory Search\nnever send this' },
+    cwd: '/workspace/claude-mem',
+    platformSource: 'claude-code',
+    toolUseId: 'toolu_skill_01',
+    ...overrides,
+  });
+
+  it('emits skill_invoked on the tool_excluded Skill skip and still skips observation', async () => {
+    const result = await ingestObservation(skillPayload());
+
+    expect(result).toEqual({ ok: true, status: 'skipped', reason: 'tool_excluded' });
+    expect(queued).toHaveLength(0);
+    expect(store!.queryToolUses({})).toHaveLength(0);
+
+    expect(skillInvokedCalls()).toHaveLength(1);
+    const props = skillInvokedCalls()[0].properties;
+    expect(props.skill_id).toBe('mem-search');
+    expect(props.skill_source).toBe('first_party');
+    expect(props.skill_trigger).toBe('tool');
+    expect(props.ide).toBe('claude');
+    expect(JSON.stringify(props)).not.toContain('args');
+    expect(JSON.stringify(props)).not.toContain('/Users/alice');
+    expect(JSON.stringify(props)).not.toContain('secret-project');
+    expect(JSON.stringify(props)).not.toContain('Memory Search');
+  });
+
+  it('collapses a third-party Skill name to other / third_party', async () => {
+    const result = await ingestObservation(skillPayload({
+      toolInput: { skill: 'someone-else:evil', args: 'do not leak' },
+    }));
+
+    expect(result).toEqual({ ok: true, status: 'skipped', reason: 'tool_excluded' });
+    expect(skillInvokedCalls()).toHaveLength(1);
+    const props = skillInvokedCalls()[0].properties;
+    expect(props.skill_id).toBe('other');
+    expect(props.skill_source).toBe('third_party');
+    expect(JSON.stringify(props)).not.toContain('someone-else');
+    expect(JSON.stringify(props)).not.toContain('evil');
+    expect(JSON.stringify(props)).not.toContain('do not leak');
+  });
+
+  it('does not emit skill_invoked for other skipped tools', async () => {
+    const result = await ingestObservation(skillPayload({
+      toolName: 'SlashCommand',
+      toolInput: { command: '/mem-search' },
+    }));
+
+    expect(result).toEqual({ ok: true, status: 'skipped', reason: 'tool_excluded' });
+    expect(skillInvokedCalls()).toHaveLength(0);
+  });
+
+  it('does not emit skill_invoked for non-Skill ingested tools', async () => {
+    const result = await ingestObservation({
+      contentSessionId: 'content-session-read',
+      toolName: 'Read',
+      toolInput: { file_path: '/tmp/a.ts' },
+      toolResponse: { ok: true },
+      cwd: '/workspace/claude-mem',
+      toolUseId: 'toolu_read_01',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(skillInvokedCalls()).toHaveLength(0);
+  });
+
+  it('emits nothing when DO_NOT_TRACK is set', async () => {
+    process.env.DO_NOT_TRACK = '1';
+    __resetTelemetryForTests();
+    postHogCaptureCalls.length = 0;
+
+    const result = await ingestObservation(skillPayload());
+    expect(result).toEqual({ ok: true, status: 'skipped', reason: 'tool_excluded' });
+    expect(skillInvokedCalls()).toHaveLength(0);
+  });
+
+  it('emits nothing when CLAUDE_MEM_TELEMETRY=0', async () => {
+    process.env.CLAUDE_MEM_TELEMETRY = '0';
+    __resetTelemetryForTests();
+    postHogCaptureCalls.length = 0;
+
+    const result = await ingestObservation(skillPayload());
+    expect(result).toEqual({ ok: true, status: 'skipped', reason: 'tool_excluded' });
+    expect(skillInvokedCalls()).toHaveLength(0);
+  });
+});
+
+describe('skill_invoked from session-init slash prompts', () => {
+  let store: SessionStore | undefined;
+  let server: Server | undefined;
+  let port = 0;
+  let loggerSpies: ReturnType<typeof spyOn>[] = [];
+
+  beforeEach(async () => {
+    for (const key of ENV_KEYS) savedEnv[key] = process.env[key];
+    process.env.CLAUDE_MEM_TELEMETRY = '1';
+    delete process.env.CLAUDE_MEM_TELEMETRY_DEBUG;
+    delete process.env.DO_NOT_TRACK;
+
+    __resetTelemetryForTests();
+    postHogCaptureCalls.length = 0;
+
+    loggerSpies = [
+      spyOn(logger, 'info').mockImplementation(() => {}),
+      spyOn(logger, 'debug').mockImplementation(() => {}),
+      spyOn(logger, 'warn').mockImplementation(() => {}),
+      spyOn(logger, 'error').mockImplementation(() => {}),
+    ];
+
+    store = new SessionStore(new Database(':memory:'));
+    const routes = new SessionRoutes(
+      { getSession: () => undefined } as any,
+      { getSessionStore: () => store, getCloudSync: () => null } as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+    );
+
+    const app = express();
+    app.use(express.json());
+    routes.setupRoutes(app);
+
+    await new Promise<void>((resolve, reject) => {
+      server = app.listen(0, '127.0.0.1', () => {
+        const addr = server!.address();
+        if (!addr || typeof addr === 'string') {
+          reject(new Error('session-init test server did not bind a port'));
+          return;
+        }
+        port = addr.port;
+        resolve();
+      });
+    });
+  });
+
+  afterEach(async () => {
+    loggerSpies.forEach((spy) => spy.mockRestore());
+    await new Promise<void>((resolve, reject) => {
+      if (!server) {
+        resolve();
+        return;
+      }
+      server.close((err) => (err ? reject(err) : resolve()));
+      server = undefined;
+    });
+    store?.close();
+    store = undefined;
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+    __resetTelemetryForTests();
+    postHogCaptureCalls.length = 0;
+  });
+
+  afterAll(() => {
+    __resetTelemetryForTests();
+  });
+
+  async function postInit(body: Record<string, unknown>): Promise<Response> {
+    return fetch(`http://127.0.0.1:${port}/api/sessions/init`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it('emits skill_invoked with skill_trigger prompt for a first-party slash', async () => {
+    const response = await postInit({
+      contentSessionId: 'slash-session-1',
+      project: 'claude-mem',
+      prompt: '/mem-search how did we do auth last time?',
+      platformSource: 'cursor',
+    });
+
+    expect(response.ok).toBe(true);
+    expect(skillInvokedCalls()).toHaveLength(1);
+    const props = skillInvokedCalls()[0].properties;
+    expect(props.skill_id).toBe('mem-search');
+    expect(props.skill_source).toBe('first_party');
+    expect(props.skill_trigger).toBe('prompt');
+    expect(props.ide).toBe('cursor');
+    expect(JSON.stringify(props)).not.toContain('how did we do auth');
+    expect(JSON.stringify(props)).not.toContain('last time');
+  });
+
+  it('emits nothing for an unknown /foo slash and never sends the body', async () => {
+    const response = await postInit({
+      contentSessionId: 'slash-session-2',
+      project: 'claude-mem',
+      prompt: '/foo please leak this secret path /Users/alice',
+      platformSource: 'cursor',
+    });
+
+    expect(response.ok).toBe(true);
+    expect(skillInvokedCalls()).toHaveLength(0);
+    expect(JSON.stringify(postHogCaptureCalls)).not.toContain('/Users/alice');
+    expect(JSON.stringify(postHogCaptureCalls)).not.toContain('please leak');
+  });
+
+  it('emits nothing when the prompt is not a leading slash skill', async () => {
+    const response = await postInit({
+      contentSessionId: 'slash-session-3',
+      project: 'claude-mem',
+      prompt: 'can you /mem-search later?',
+      platformSource: 'cursor',
+    });
+
+    expect(response.ok).toBe(true);
+    expect(skillInvokedCalls()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PostHog can now answer which bundled skills people actually invoke, on which host/version.

Alex HARD YES (2026-09-10): implement now. Event name is **`skill_invoked`** (not `skill_loaded`). PR #3925 is A/B plan reference only.

## What shipped

1. **`src/services/telemetry/skill-id.ts`** — first-party allowlist pinned to `plugin/skills/` (20 dirs including `ccs-align`). Sibling `mem-search` copies collapse to one id. Third-party names become `skill_id: other` + `skill_source: third_party` and never leave the machine.
2. **Skill tool path** — `captureEvent('skill_invoked', { skill_id, skill_source, skill_trigger: 'tool', ide })` inside the `tool_excluded` skip gate in `shared.ts` when `toolName === 'Skill'`, **before** the return. Skill stays on `CLAUDE_MEM_SKIP_TOOLS`. Never collects `tool_input.args`.
3. **Slash path** — session-init emits the same event with `skill_trigger: 'prompt'` when the leading token is first-party. Unknown `/foo` emits nothing. Never sends the prompt body.
4. **Docs / CLI** — added `skill_invoked` plus `skill_id` / `skill_source` / `skill_trigger` rows only. Did not refresh the stale `EVENT_NAMES` list.
5. **Tests** — `tests/telemetry/skill-id.test.ts`, scrub whitelist coverage, `tests/worker/skill-invoked-telemetry.test.ts`.

Reuses existing `captureEvent` / consent / scrub. No new PostHog client, no new consent switch, no `duration_ms` / outcome, no `skill_completed`, no plugin/scripts changes.

## Privacy

- Closed `skill_id` enum + `other`
- Third-party names never sent
- No skill markdown, args, or prompt text
- Same opt-out as every other analytics event (`DO_NOT_TRACK`, `CLAUDE_MEM_TELEMETRY=0`, `telemetry.json`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f631da8-15bb-4324-ba42-02bce4c05de8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f631da8-15bb-4324-ba42-02bce4c05de8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

