### PR TITLE
fix(chroma): reap unreadable writer lock past grace (fixes #3916)

### DIFF
--- a/src/services/sync/ChromaMcpManager.ts
+++ b/src/services/sync/ChromaMcpManager.ts
@@ -34,6 +34,9 @@ const CHROMA_PREWARM_REAP_TIMEOUT_MS = 1_000;
 const CHROMA_EXIT_OBSERVE_TIMEOUT_MS = 1_000;
 const RECONNECT_BACKOFF_MS = 10_000;
 const CHROMA_WRITER_LOCK_FILENAME = '.claude-mem-chroma-writer.lock';
+// An unparseable lock (typically a 0-byte file left by a crash mid-write) has no
+// owner to probe; once it is this old no concurrent writer is still filling it in.
+const CHROMA_WRITER_LOCK_UNREADABLE_GRACE_MS = 10_000;
 const CHROMA_SUPERVISOR_ID = 'chroma-mcp';
 const CHROMA_OUTPUT_TAIL_MAX_CHARS = 2048;
 const DEFAULT_MAX_PENDING_MUTATIONS = 5_000;
@@ -469,6 +472,20 @@ export class ChromaMcpManager {
 
         const existing = ChromaMcpManager.readChromaWriterLock(lockPath);
         if (!existing) {
+          // Without a readable owner the liveness reaper below can never run,
+          // so vector sync would stay dead until someone deletes the file (#3916).
+          // Treat an unreadable lock that is past the write grace period as stale.
+          if (ChromaMcpManager.isChromaWriterLockAbandoned(lockPath)) {
+            try {
+              fs.rmSync(lockPath, { force: true });
+              logger.info('CHROMA_MCP', 'Removed unreadable Chroma writer lock', { lockPath });
+              continue;
+            } catch (removeError) {
+              const message = `Unable to remove unreadable Chroma writer lock at ${lockPath}: ${removeError instanceof Error ? removeError.message : String(removeError)}`;
+              recordChromaVectorSearchUnavailable(message);
+              throw new ChromaUnavailableError(message, removeError instanceof Error ? removeError : undefined);
+            }
+          }
           const message = `Chroma writer lock at ${lockPath} is unreadable; refusing to start a second writer`;
           recordChromaVectorSearchUnavailable(message);
           throw new ChromaUnavailableError(message);
@@ -561,6 +578,15 @@ export class ChromaMcpManager {
       };
     } catch {
       return null;
+    }
+  }
+
+  private static isChromaWriterLockAbandoned(lockPath: string): boolean {
+    try {
+      return Date.now() - fs.statSync(lockPath).mtimeMs >= CHROMA_WRITER_LOCK_UNREADABLE_GRACE_MS;
+    } catch {
+      // Vanished between the failed create and the stat: nothing left to reap.
+      return true;
     }
   }
 

--- a/tests/services/sync/chroma-mcp-manager-singleton.test.ts
+++ b/tests/services/sync/chroma-mcp-manager-singleton.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterAll, mock } from 'bun:test';
 import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -895,6 +895,31 @@ describe('ChromaMcpManager singleton enforcement (#2313)', () => {
 
     expect(transportInstances.length).toBe(2);
     expect(existsSync(chromaWriterLockPath())).toBe(true);
+  });
+
+  it('replaces an unreadable Chroma writer lock once it is past the write grace period (#3916)', async () => {
+    mkdirSync(mockedChromaDir, { recursive: true });
+    writeFileSync(chromaWriterLockPath(), '');
+    const stale = new Date(Date.now() - 60_000);
+    utimesSync(chromaWriterLockPath(), stale, stale);
+    const mgr = ChromaMcpManager.getInstance();
+
+    await mgr.callTool('chroma_list_collections', { limit: 1 });
+
+    const lock = JSON.parse(readFileSync(chromaWriterLockPath(), 'utf-8'));
+    expect(lock.pid).toBe(process.pid);
+    expect(transportInstances.length).toBe(1);
+  });
+
+  it('still refuses a freshly written unreadable Chroma writer lock', async () => {
+    mkdirSync(mockedChromaDir, { recursive: true });
+    writeFileSync(chromaWriterLockPath(), '');
+    const mgr = ChromaMcpManager.getInstance();
+
+    await expect(mgr.callTool('chroma_list_collections', { limit: 1 })).rejects.toThrow('is unreadable');
+
+    expect(existsSync(chromaWriterLockPath())).toBe(true);
+    expect(transportInstances.length).toBe(0);
   });
 
   it('preserves remote mutation concurrency', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3916

Rebased from #3946 (by @L4XB) onto main after #3938 merged. Supersedes #3946.

**Problem:** `acquireChromaWriterLock()` throws `Chroma writer lock … is unreadable; refusing to start a second writer` as soon as `readChromaWriterLock()` returns `null`, i.e. before `isChromaWriterLockLive()` (the stale-lock reaper) can run. A 0-byte lock file left behind by a crash mid-write therefore disables vector sync permanently and silently: SQLite capture keeps working, `/api/health` is `ok`, and only deleting the file by hand brings the vector index back.

**Change:** an unparseable lock has no owner pid to probe, so its age is used instead. If the file's mtime is older than a short grace period (`CHROMA_WRITER_LOCK_UNREADABLE_GRACE_MS = 10s`, long enough for a concurrent writer to finish writing its payload) it is removed and the acquire is retried, mirroring the existing dead-PID path. A freshly written unreadable lock is still refused exactly as before, so the crash-mid-write race is not widened.

**Tests** (`tests/services/sync/chroma-mcp-manager-singleton.test.ts`):
- replaces an unreadable lock older than the grace period and connects;
- still refuses a freshly written unreadable lock, leaving the file in place.

```
bun test tests/services/sync/   # 26 pass, 0 fail, 100 assertions
```

Co-authored-by: Lukas Buck <L4XB@users.noreply.github.com>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1fed93c-5fd0-4862-b067-156f8c94eeb6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1fed93c-5fd0-4862-b067-156f8c94eeb6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

