### PR TITLE
fix(quota): ignore inactive overage utilization (fixes #3903)

### DIFF
--- a/src/services/worker/RateLimitStore.ts
+++ b/src/services/worker/RateLimitStore.ts
@@ -219,6 +219,10 @@ export function shouldAbortForQuota(
 
     const util = entry.utilization;
     const threshold = UTILIZATION_THRESHOLDS[window];
+    // An explicit false means the provider is not charging the overage bucket,
+    // so its utilization does not represent active quota consumption.
+    const appliesUtilizationThreshold =
+      window !== 'overage' || entry.isUsingOverage !== false;
 
     // Provider-side rejection trumps utilization heuristics. A snapshot with
     // status='rejected' (or overageStatus='rejected' on the overage window)
@@ -236,7 +240,7 @@ export function shouldAbortForQuota(
       };
     }
 
-    if (typeof util === 'number' && util >= threshold) {
+    if (appliesUtilizationThreshold && typeof util === 'number' && util >= threshold) {
       return {
         abort: true,
         window,

--- a/tests/worker/rate-limit-store.test.ts
+++ b/tests/worker/rate-limit-store.test.ts
@@ -123,6 +123,65 @@ describe('shouldAbortForQuota — cli/oauth auth', () => {
     store = freshStore();
   });
 
+  it('does not abort on inactive overage at 100% utilization', () => {
+    store.set({
+      rateLimitType: 'overage',
+      utilization: 1,
+      isUsingOverage: false,
+      status: 'allowed_warning',
+    });
+    const decision = shouldAbortForQuota(cliAuth, store, FIXED_NOW);
+    expect(decision.abort).toBe(false);
+  });
+
+  it('aborts on active overage above the utilization threshold', () => {
+    store.set({
+      rateLimitType: 'overage',
+      utilization: 0.96,
+      isUsingOverage: true,
+      status: 'allowed_warning',
+    });
+    const decision = shouldAbortForQuota(cliAuth, store, FIXED_NOW);
+    expect(decision.abort).toBe(true);
+    expect(decision.window).toBe('overage');
+  });
+
+  it('preserves overage utilization behavior when isUsingOverage is missing', () => {
+    store.set({
+      rateLimitType: 'overage',
+      utilization: 0.96,
+      status: 'allowed_warning',
+    });
+    const decision = shouldAbortForQuota(cliAuth, store, FIXED_NOW);
+    expect(decision.abort).toBe(true);
+    expect(decision.window).toBe('overage');
+  });
+
+  it('aborts when inactive overage is rejected by overageStatus', () => {
+    store.set({
+      rateLimitType: 'overage',
+      utilization: 0,
+      isUsingOverage: false,
+      status: 'allowed_warning',
+      overageStatus: 'rejected',
+    });
+    const decision = shouldAbortForQuota(cliAuth, store, FIXED_NOW);
+    expect(decision.abort).toBe(true);
+    expect(decision.window).toBe('overage');
+  });
+
+  it('aborts when inactive overage is rejected by status', () => {
+    store.set({
+      rateLimitType: 'overage',
+      utilization: 0,
+      isUsingOverage: false,
+      status: 'rejected',
+    });
+    const decision = shouldAbortForQuota(cliAuth, store, FIXED_NOW);
+    expect(decision.abort).toBe(true);
+    expect(decision.window).toBe('overage');
+  });
+
   it('aborts on five_hour at 0.96 with reason mentioning "five_hour"', () => {
     store.set({ rateLimitType: 'five_hour', utilization: 0.96 });
     const decision = shouldAbortForQuota(cliAuth, store, FIXED_NOW);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebased landing of #3904 onto `main` (original PR targeted `core-dev` and was from a fork that couldn't be updated).

## What changed

- Ignore the overage utilization threshold when the provider explicitly reports `isUsingOverage: false`
- Keep `status: "rejected"` and `overageStatus: "rejected"` authoritative
- Preserve the existing utilization behavior when `isUsingOverage` is absent

## Why

The provider can report `overage.utilization: 1` while explicitly declaring that overage is not in use. Treating that utilization as active aborts observer work and arms the persistent 30-minute quota cooldown even though the snapshot remains allowed.

## Gate confirmation

`isUsingOverage: false` from the provider IS authoritative for bypassing the utilization heuristic:
1. It's a direct signal from the billing provider (field in `RateLimitInfo` interface, sourced from `SDKRateLimitEvent`)
2. Provider rejection (`status: 'rejected'` / `overageStatus: 'rejected'`) is checked first and still takes hard precedence
3. Only the utilization threshold heuristic is bypassed, not the rejection check
4. When `isUsingOverage` is absent/undefined, existing behavior is preserved

Original author: @gfreschi
Original PR: #3904
Fixes #3903
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-93d93372-373a-4038-83e5-654608daf479?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93d93372-373a-4038-83e5-654608daf479&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

