### PR TITLE
fix(setup): guard plugin deps on completeness, not node_modules existence

### DIFF
--- a/plugin/scripts/version-check.js
+++ b/plugin/scripts/version-check.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { spawnSync } from 'child_process';
-import { existsSync, readFileSync, rmSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
+import { createRequire } from 'module';
 import { homedir } from 'os';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -10,6 +11,16 @@ const VERSION_CHECK_LOG_PREFIX = '[version-check]';
 const BUN_INSTALL_ARGS = Object.freeze(['install', '--production']);
 const BUN_INSTALL_TIMEOUT_MS = 120_000;
 const NODE_MODULES_DIRNAME = 'node_modules';
+// zod ships its public API behind subpath exports that worker-service.cjs
+// requires directly (19 external zod requires, 4 of them `zod/v3`). The
+// package directory existing does NOT imply these resolve - a stale or
+// integrity-failed install leaves the dir in place while the subpaths break,
+// surfacing as the `Cannot find module 'zod/v3'` crash in gh #3755 / #2730.
+// Mirrors ZOD_REQUIRED_SUBPATHS in src/npx-cli/install/setup-runtime.ts:243.
+const ZOD_REQUIRED_SUBPATHS = Object.freeze(['zod/v3', 'zod/v4', 'zod/v4-mini']);
+// A fresh extract can have all ~26 declared deps missing at once; cap the
+// diagnostic so the Setup transcript stays readable.
+const MISSING_DEPS_LOG_LIMIT = 5;
 
 function findBun() {
   const pathCheck = IS_WINDOWS
@@ -40,6 +51,95 @@ function findBun() {
   return null;
 }
 
+// Completeness probe for the plugin's declared dependency closure.
+//
+// `verifyCriticalModules` in src/npx-cli/install/setup-runtime.ts:245 is the
+// source of truth for this logic, but it is TypeScript ESM compiled into the
+// npx bundle while this script is standalone and dependency-free (run by
+// whatever Node the host provides), so the probe is inlined here rather than
+// imported. Keep the two in sync.
+//
+// Returns the list of specifiers that fail to resolve; an empty array means the
+// install tree is complete.
+function findMissingDependencies(pluginRoot) {
+  try {
+    let pkg;
+    try {
+      pkg = JSON.parse(readFileSync(join(pluginRoot, 'package.json'), 'utf-8'));
+    } catch {
+      // An unreadable or absent manifest is not this guard's problem to report:
+      // the install-marker check further down already emits its own
+      // `install marker unreadable` hint for exactly that state. Returning
+      // "complete" here avoids double-reporting the same condition.
+      return [];
+    }
+
+    const declared = Object.keys((pkg && pkg.dependencies) || {});
+    // LOAD-BEARING: a manifest declaring no dependencies is complete by
+    // definition. tests/plugin-version-check.test.ts builds precisely that
+    // fixture (version-only package.json, empty node_modules) and asserts
+    // stderr is exactly empty, so this early return must come before any
+    // install attempt or diagnostic.
+    if (declared.length === 0) return [];
+
+    const nodeModulesPath = join(pluginRoot, NODE_MODULES_DIRNAME);
+    // A require anchored inside the install tree, so require.resolve honors the
+    // installed package.json `exports` map when resolving subpaths rather than
+    // resolving from this script's own location (setup-runtime.ts:250-252).
+    const requireFromPlugin = createRequire(join(nodeModulesPath, 'noop.js'));
+    const resolvePaths = [nodeModulesPath];
+
+    const missing = [];
+
+    // Each declared dependency must be installed, not merely a directory on disk.
+    for (const dep of declared) {
+      try {
+        requireFromPlugin.resolve(dep, { paths: resolvePaths });
+      } catch {
+        // Bare-name resolution can fail for a perfectly-installed package that
+        // has no importable entry point - e.g. bin-only packages like
+        // `tree-sitter-cli`, whose package.json has `bin` but no
+        // `main`/`module`/`exports`/`index.js`. Falling back to its
+        // package.json distinguishes "installed but bin-only" from "genuinely
+        // missing": a truly absent package fails both probes (gh #2730).
+        try {
+          requireFromPlugin.resolve(dep + '/package.json', { paths: resolvePaths });
+        } catch {
+          missing.push(dep);
+        }
+      }
+    }
+
+    // Only probe the zod subpaths when zod is actually declared - the check
+    // must not hardcode a package the manifest may later drop
+    // (setup-runtime.ts:282).
+    if (declared.indexOf('zod') !== -1) {
+      for (const subpath of ZOD_REQUIRED_SUBPATHS) {
+        try {
+          requireFromPlugin.resolve(subpath, { paths: resolvePaths });
+        } catch {
+          missing.push(subpath);
+        }
+      }
+    }
+
+    return missing;
+  } catch {
+    // This probe runs inside the Setup hook. An unexpected throw (an exotic
+    // createRequire failure, an EACCES walking the tree) must never take Setup
+    // down - degrade to "assume complete" and let the worker surface the real
+    // error rather than blocking Claude Code startup here.
+    return [];
+  }
+}
+
+// Cap the named-module list so a fresh extract (every dep missing) does not
+// bury the Setup transcript.
+function formatMissing(missing) {
+  if (missing.length <= MISSING_DEPS_LOG_LIMIT) return missing.join(', ');
+  return missing.slice(0, MISSING_DEPS_LOG_LIMIT).join(', ') + ', +' + (missing.length - MISSING_DEPS_LOG_LIMIT) + ' more';
+}
+
 // Setup-phase auto-install of plugin runtime dependencies.
 //
 // The plugin marketplace extracts files into ~/.claude/plugins/cache/...
@@ -58,9 +158,18 @@ function findBun() {
 function ensurePluginDependencies(pluginRoot) {
   if (!existsSync(join(pluginRoot, 'package.json'))) return;
 
-  // Guard on node_modules (package-manager marker) rather than a specific
-  // package, so the check stays correct if dependencies are later renamed.
-  if (existsSync(join(pluginRoot, NODE_MODULES_DIRNAME))) return;
+  // Guard on COMPLETENESS of the declared dependency closure, not on the mere
+  // existence of node_modules. A tree that is simply present - because an
+  // install was interrupted mid-fetch, or because it was complete for an older
+  // version before a new dependency was added - satisfied the old existence
+  // check and permanently short-circuited repair on every subsequent Setup run.
+  // The worker then died at boot with `Cannot find module 'zod/v3'` while
+  // memory search kept working (mcp-server.cjs bundles zod), so the breakage
+  // was silent: users saw search succeed and never learned the worker was dead
+  // (gh #3755). Deriving the expected set from package.json `dependencies`
+  // keeps the check correct if dependencies are later renamed.
+  const missingBefore = findMissingDependencies(pluginRoot);
+  if (missingBefore.length === 0) return;
 
   const bunPath = findBun();
   if (!bunPath) {
@@ -68,8 +177,10 @@ function ensurePluginDependencies(pluginRoot) {
     return;
   }
 
-  // Progress diagnostic so users understand the (one-time) Setup hang.
-  console.error(`${VERSION_CHECK_LOG_PREFIX} installing plugin dependencies (first run, one-time)...`);
+  // Progress diagnostic so users understand the Setup hang - and, critically,
+  // so this failure mode stops being silent: name the modules that are actually
+  // unresolvable rather than implying a first run (gh #3755).
+  console.error(`${VERSION_CHECK_LOG_PREFIX} installing plugin dependencies (missing: ${formatMissing(missingBefore)})...`);
 
   let result;
   try {
@@ -104,24 +215,34 @@ function ensurePluginDependencies(pluginRoot) {
       reason = `exit ${result.status}`;
     }
     console.error(`${VERSION_CHECK_LOG_PREFIX} bun install failed (${reason}); worker may crash with missing module errors`);
-    // `bun install` often creates `node_modules/` BEFORE the failure point
-    // (network timeout mid-fetch, OOM kill, registry 5xx after partial
-    // resolution). The existence guard above would then permanently skip
-    // retry on every subsequent Setup run, leaving the plugin broken with
-    // no recovery path short of manual `rm -rf node_modules`. Remove the
-    // partial dir so the next Setup invocation can retry automatically
-    // (gh #2650 review).
-    try {
-      rmSync(join(pluginRoot, NODE_MODULES_DIRNAME), { recursive: true, force: true });
-    } catch (rmErr) {
-      const rmReason = rmErr && rmErr.message ? rmErr.message : String(rmErr);
-      console.error(`${VERSION_CHECK_LOG_PREFIX} failed to clean up partial node_modules (${rmReason}); next Setup run may skip retry`);
-    }
+    // The partial `node_modules/` a failed install leaves behind is deliberately
+    // PRESERVED. Retry no longer depends on deleting it: the completeness guard
+    // above re-detects the missing deps on the next Setup run, so the old
+    // recursive delete bought nothing - while actively destroying packages that
+    // still work. A half-installed tree still powers memory search (mcp-server.cjs
+    // bundles zod, zero external requires), so nuking it turns a degraded
+    // install into a dead one (gh #3755).
   } else {
-    // Close the diagnostic loop: a Setup hook that can block for up to
-    // 120s needs an explicit completion line so users can distinguish a
-    // hung install from one that finished silently (gh #2650 review).
-    console.error(`${VERSION_CHECK_LOG_PREFIX} plugin dependencies installed successfully`);
+    // A zero exit is NOT proof of a complete tree: `bun install` can exit 0
+    // while its integrity check silently failed, leaving the closure short
+    // (reported on gh #3755). Re-run the probe and report what actually
+    // resolves now rather than trusting the exit code.
+    //
+    // This second probe assumes a resolver that does NOT negatively cache the
+    // lookups the first probe just missed. Node is that resolver, and the Setup
+    // hook invokes this script under node explicitly (plugin/hooks/hooks.json:11
+    // ends in `node "$_P/scripts/version-check.js"`). Bun caches negative CJS
+    // lookups process-wide, so running this file under bun would make the
+    // re-check cry wolf on every successful fresh install. Keep the hook on node.
+    const missingAfter = findMissingDependencies(pluginRoot);
+    if (missingAfter.length === 0) {
+      // Close the diagnostic loop: a Setup hook that can block for up to
+      // 120s needs an explicit completion line so users can distinguish a
+      // hung install from one that finished silently (gh #2650 review).
+      console.error(`${VERSION_CHECK_LOG_PREFIX} plugin dependencies installed successfully`);
+    } else {
+      console.error(`${VERSION_CHECK_LOG_PREFIX} bun install exited 0 but dependencies are still missing: ${formatMissing(missingAfter)}; worker may crash with missing module errors`);
+    }
   }
 }
 

--- a/plugin/scripts/version-check.js
+++ b/plugin/scripts/version-check.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 import { spawnSync } from 'child_process';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, realpathSync } from 'fs';
 import { createRequire } from 'module';
 import { homedir } from 'os';
-import { join, dirname } from 'path';
+import { join, dirname, relative, isAbsolute } from 'path';
 import { fileURLToPath } from 'url';
 
 const IS_WINDOWS = process.platform === 'win32';
@@ -51,15 +51,44 @@ function findBun() {
   return null;
 }
 
+// realpathSync throws on a path that does not exist (ENOENT) or that cannot be
+// walked (EACCES). Falling back to the input keeps the containment check below
+// total: an unresolvable path simply compares as itself and fails containment,
+// which is the conservative answer.
+function realpathOrSelf(candidatePath) {
+  try {
+    return realpathSync(candidatePath);
+  } catch {
+    return candidatePath;
+  }
+}
+
+// True when `candidatePath` sits strictly inside `dirPath`. Uses path.relative
+// rather than string prefixing so that a sibling directory sharing a name
+// prefix (…/node_modules/zod-extra next to …/node_modules/zod) is not counted
+// as inside, and so Windows path separators and casing are handled by the
+// platform's own path logic.
+function isInsideDir(candidatePath, dirPath) {
+  const rel = relative(dirPath, candidatePath);
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
+}
+
 // Completeness probe for the plugin's declared dependency closure.
 //
-// `verifyCriticalModules` in src/npx-cli/install/setup-runtime.ts:245 is the
-// source of truth for this logic, but it is TypeScript ESM compiled into the
-// npx bundle while this script is standalone and dependency-free (run by
-// whatever Node the host provides), so the probe is inlined here rather than
-// imported. Keep the two in sync.
+// `verifyCriticalModules` in src/npx-cli/install/setup-runtime.ts:245 applies
+// the same contract on the npx install path, but it is TypeScript ESM compiled
+// into the npx bundle while this script is standalone and dependency-free (run
+// by whatever Node the host provides), so the probe is inlined here rather than
+// imported.
 //
-// Returns the list of specifiers that fail to resolve; an empty array means the
+// It deliberately does NOT copy that function's resolution strategy. Presence
+// is checked by statting inside this tree; see the comment on the loop below
+// for why require.resolve cannot be trusted to stay tree-local. The same
+// escape exists in verifyCriticalModules, where it is far less dangerous - it
+// runs as a post-install assertion that fails loud, not as the gate deciding
+// whether repair happens at all - but it is worth tightening there too.
+//
+// Returns the list of specifiers that are missing; an empty array means the
 // install tree is complete.
 function findMissingDependencies(pluginRoot) {
   try {
@@ -83,43 +112,57 @@ function findMissingDependencies(pluginRoot) {
     if (declared.length === 0) return [];
 
     const nodeModulesPath = join(pluginRoot, NODE_MODULES_DIRNAME);
-    // A require anchored inside the install tree, so require.resolve honors the
-    // installed package.json `exports` map when resolving subpaths rather than
-    // resolving from this script's own location (setup-runtime.ts:250-252).
-    const requireFromPlugin = createRequire(join(nodeModulesPath, 'noop.js'));
-    const resolvePaths = [nodeModulesPath];
-
     const missing = [];
 
-    // Each declared dependency must be installed, not merely a directory on disk.
+    // Presence is checked against THIS tree only, by direct stat rather than
+    // require.resolve. `require.resolve(dep, { paths: [nodeModulesPath] })`
+    // looks tree-scoped but is not: `paths` seeds Node's lookup, which then
+    // walks every ancestor directory and always consults the global folders
+    // ($HOME/.node_modules, $PREFIX/lib/node). Plugin roots live at
+    // ~/.claude/plugins/cache/thedotmack/claude-mem/<version>/, so a copy of a
+    // dependency anywhere above them - or installed globally - would satisfy
+    // the probe and let this guard report a gutted tree as complete, silently
+    // reintroducing the very bug it exists to catch (gh #3872 review).
+    //
+    // Statting `<node_modules>/<dep>/package.json` cannot escape the tree, and
+    // it is the same signal the repo already uses in
+    // scripts/check-postinstall-allowlist.js:75-78. It also handles the two
+    // awkward cases for free: scoped names split into their path segments, and
+    // bin-only packages like `tree-sitter-cli` - whose package.json has `bin`
+    // but no `main`/`module`/`exports`/`index.js`, so bare-name resolution
+    // fails even when they are perfectly installed (gh #2730).
     for (const dep of declared) {
-      try {
-        requireFromPlugin.resolve(dep, { paths: resolvePaths });
-      } catch {
-        // Bare-name resolution can fail for a perfectly-installed package that
-        // has no importable entry point - e.g. bin-only packages like
-        // `tree-sitter-cli`, whose package.json has `bin` but no
-        // `main`/`module`/`exports`/`index.js`. Falling back to its
-        // package.json distinguishes "installed but bin-only" from "genuinely
-        // missing": a truly absent package fails both probes (gh #2730).
-        try {
-          requireFromPlugin.resolve(dep + '/package.json', { paths: resolvePaths });
-        } catch {
-          missing.push(dep);
-        }
+      if (!existsSync(join(nodeModulesPath, ...dep.split('/'), 'package.json'))) {
+        missing.push(dep);
       }
     }
 
-    // Only probe the zod subpaths when zod is actually declared - the check
-    // must not hardcode a package the manifest may later drop
-    // (setup-runtime.ts:282).
-    if (declared.indexOf('zod') !== -1) {
+    // zod is the one package whose subpaths must be probed by real resolution:
+    // they are `exports`-map entries, so a present-and-correct directory does
+    // not imply `zod/v3` resolves (setup-runtime.ts:282, gh #2730). Skip it
+    // when zod is absent or undeclared - the manifest may drop it later, and a
+    // missing zod is already reported above.
+    if (declared.indexOf('zod') !== -1 && missing.indexOf('zod') === -1) {
+      // Anchored inside the install tree so the installed package's `exports`
+      // map is what gets consulted (setup-runtime.ts:250-252).
+      const requireFromPlugin = createRequire(join(nodeModulesPath, 'noop.js'));
+      // Both sides are realpath'd before comparison: bun can materialise
+      // node_modules entries as links into a shared store, and Node returns
+      // the real path of what it resolved. Comparing the two literally would
+      // then report a healthy linked install as missing and loop the install
+      // forever.
+      const zodDir = realpathOrSelf(join(nodeModulesPath, 'zod'));
       for (const subpath of ZOD_REQUIRED_SUBPATHS) {
+        let resolved;
         try {
-          requireFromPlugin.resolve(subpath, { paths: resolvePaths });
+          resolved = requireFromPlugin.resolve(subpath, { paths: [nodeModulesPath] });
         } catch {
           missing.push(subpath);
+          continue;
         }
+        // Same ancestor/global escape as above: a host-level zod could answer
+        // for the plugin's. Only a path inside this plugin's own zod counts.
+        if (!isInsideDir(realpathOrSelf(resolved), zodDir)) missing.push(subpath);
       }
     }
 

--- a/tests/plugin-version-check-ensure-deps.test.ts
+++ b/tests/plugin-version-check-ensure-deps.test.ts
@@ -1,8 +1,8 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { spawn } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
-import { join, resolve } from 'path';
+import { dirname, join, resolve } from 'path';
 
 const REPO_ROOT = resolve(import.meta.dir, '..');
 const VERSION_CHECK_PATH = join(REPO_ROOT, 'plugin', 'scripts', 'version-check.js');
@@ -10,14 +10,43 @@ const SPAWN_TIMEOUT_MS = 15_000;
 const INSTALL_DIAGNOSTIC = '[version-check] installing plugin dependencies';
 const INSTALL_SUCCESS_DIAGNOSTIC = '[version-check] plugin dependencies installed successfully';
 const INSTALL_FAILURE_DIAGNOSTIC = '[version-check] bun install failed';
-const FAKE_INSTALLED_MARKER_REL = join('node_modules', 'zod', 'v3', 'index.js');
+// Emitted when `bun install` returns 0 but the declared closure is still short —
+// the integrity-check-failed-but-exit-0 profile reported on gh #3755.
+const INSTALL_INCOMPLETE_DIAGNOSTIC =
+  '[version-check] bun install exited 0 but dependencies are still missing';
+// The fake bun touches this file on every `install` invocation, so "the install
+// path was not taken" is provable directly rather than inferred from a side
+// effect that a given behavior may or may not produce.
+const BUN_INVOKED_MARKER = '.bun-invoked';
+// A leftover fetch artifact the partial-then-fail bun drops inside node_modules.
+// Its survival is what proves the failed-install tree is preserved, not deleted.
+const PARTIAL_FETCH_ARTIFACT_REL = join('node_modules', 'zod', 'partial-fetch.tmp');
+// The exports map a genuinely resolvable zod must expose: worker-service.cjs
+// requires `zod/v3` directly, and version-check probes all three subpaths
+// (ZOD_REQUIRED_SUBPATHS, mirroring src/npx-cli/install/setup-runtime.ts:243).
+const ZOD_COMPLETE_EXPORTS: Record<string, string> = {
+  '.': './index.js',
+  './v3': './v3/index.js',
+  './v4': './v4/index.js',
+  './v4-mini': './v4-mini/index.js',
+};
 const SKIP_NON_UNIX = process.platform === 'win32';
 
 let tmpRoot: string;
 
+// Spawn `node` explicitly, NOT process.execPath. Under `bun test` execPath is
+// the bun binary, and bun's CJS resolver caches negative module lookups for the
+// life of the process: the pre-install probe would poison the post-install
+// re-check, making a perfectly good install report its dependencies as still
+// missing. Production runs this script under node (plugin/hooks/hooks.json
+// Setup command ends in `node "$_P/scripts/version-check.js"`), and
+// tests/plugin-version-check.test.ts already spawns 'node' for the same reason,
+// so node is both the honest and the matching runtime here.
+const NODE_BIN = 'node';
+
 function runVersionCheck(pluginRoot: string, fakeBinDir: string): Promise<{ stderr: string; stdout: string; code: number | null }> {
   return new Promise((resolveResult, reject) => {
-    const child = spawn(process.execPath, [VERSION_CHECK_PATH], {
+    const child = spawn(NODE_BIN, [VERSION_CHECK_PATH], {
       cwd: pluginRoot,
       env: {
         ...process.env,
@@ -60,43 +89,163 @@ function runVersionCheck(pluginRoot: string, fakeBinDir: string): Promise<{ stde
   });
 }
 
-type BunBehavior = 'success' | 'partial-then-fail';
+/**
+ * Write a genuinely resolvable fake package into <pluginRoot>/node_modules/<name>.
+ * Shape borrowed from tests/cli/verify-critical-modules.test.ts:11-31 — the
+ * package.json `exports` map is what makes subpaths like `zod/v3` resolve, and
+ * every file the map points at is materialized so resolution actually succeeds.
+ */
+function writeFakePackage(
+  pluginRoot: string,
+  name: string,
+  exportsMap: Record<string, string>,
+): void {
+  const pkgDir = join(pluginRoot, 'node_modules', ...name.split('/'));
+  mkdirSync(pkgDir, { recursive: true });
 
-function makeFreshPlugin(name: string, bunBehavior: BunBehavior = 'success'): { pluginRoot: string; fakeBinDir: string } {
+  writeFileSync(
+    join(pkgDir, 'package.json'),
+    JSON.stringify({ name, version: '0.0.0', type: 'module', exports: exportsMap }),
+  );
+
+  for (const target of Object.values(exportsMap)) {
+    const rel = target.replace(/^\.\//, '');
+    const stubPath = join(pkgDir, ...rel.split('/'));
+    mkdirSync(dirname(stubPath), { recursive: true });
+    writeFileSync(stubPath, 'export default {};\n');
+  }
+}
+
+/**
+ * Write a bin-only fake package, mirroring `tree-sitter-cli`: package.json has
+ * ONLY a `bin` field — no `main`/`module`/`exports` and no index.js — so its
+ * bare name is unresolvable by Node's rules even though it is fully installed.
+ * Copied from tests/cli/verify-critical-modules.test.ts:33-48 (gh #2730).
+ */
+function writeFakeBinOnlyPackage(pluginRoot: string, name: string, binName: string): void {
+  const pkgDir = join(pluginRoot, 'node_modules', ...name.split('/'));
+  mkdirSync(pkgDir, { recursive: true });
+  writeFileSync(
+    join(pkgDir, 'package.json'),
+    JSON.stringify({ name, version: '0.0.0', bin: { [binName]: './cli.js' } }),
+  );
+  writeFileSync(join(pkgDir, 'cli.js'), '#!/usr/bin/env node\n');
+}
+
+/**
+ * Resolve a specifier the same way version-check's findMissingDependencies does:
+ * a require anchored inside the install tree, with the tree as the sole resolve
+ * path, so the installed `exports` map governs subpath resolution. Lets a test
+ * assert real resolvability instead of mere file existence.
+ *
+ * Runs in a throwaway `node -e` subprocess on purpose. The bun process running
+ * this suite caches module-resolution misses, so probing a specifier before an
+ * install would make the same probe keep failing after it; a fresh process per
+ * probe is immune, and node is the runtime the Setup hook actually uses.
+ */
+function resolvesFromPluginTree(pluginRoot: string, specifier: string): boolean {
+  const nodeModulesPath = join(pluginRoot, 'node_modules');
+  const probe = [
+    "const { createRequire } = require('module');",
+    "const { join } = require('path');",
+    `const nm = ${JSON.stringify(nodeModulesPath)};`,
+    "const req = createRequire(join(nm, 'noop.js'));",
+    `req.resolve(${JSON.stringify(specifier)}, { paths: [nm] });`,
+  ].join('\n');
+  const probeResult = spawnSync(NODE_BIN, ['-e', probe], {
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return probeResult.status === 0;
+}
+
+/**
+ * Shell lines that make the fake bun materialize a resolvable package, i.e. the
+ * same tree writeFakePackage() produces but from inside the spawned installer.
+ * The old fake bun only touched `node_modules/zod/v3/index.js`, which is NOT a
+ * resolvable package (no package.json), so a "successful" install used to be
+ * indistinguishable from a broken one.
+ */
+function fakeInstallLinesFor(
+  pluginRoot: string,
+  name: string,
+  exportsMap: Record<string, string>,
+): string[] {
+  const pkgDir = join(pluginRoot, 'node_modules', ...name.split('/'));
+  const manifest = JSON.stringify({ name, version: '0.0.0', type: 'module', exports: exportsMap });
+  const lines = [
+    `  mkdir -p "${pkgDir}"`,
+    `  cat > "${pkgDir}/package.json" <<'PKGJSON'`,
+    manifest,
+    'PKGJSON',
+  ];
+  for (const target of Object.values(exportsMap)) {
+    const rel = target.replace(/^\.\//, '');
+    const stubPath = join(pkgDir, ...rel.split('/'));
+    lines.push(`  mkdir -p "${dirname(stubPath)}"`);
+    lines.push(`  printf 'export default {};\\n' > "${stubPath}"`);
+  }
+  return lines;
+}
+
+type BunBehavior =
+  // Installs a genuinely resolvable zod (package.json + full exports map + stubs).
+  | 'install-zod'
+  // Installs resolvable zod AND late-added-dep — the "repair after a manifest
+  // gained a dependency" path (gh #3755 second report).
+  | 'install-zod-and-late-dep'
+  // Exits 0 without writing anything: bun's integrity check silently failed.
+  | 'noop-zero'
+  // Creates a partial node_modules THEN exits non-zero (network timeout / OOM).
+  | 'partial-then-fail';
+
+function makeFreshPlugin(
+  name: string,
+  bunBehavior: BunBehavior = 'install-zod',
+  dependencies: Record<string, string> = { zod: '^3.0.0' },
+): { pluginRoot: string; fakeBinDir: string } {
   const pluginRoot = join(tmpRoot, name);
   mkdirSync(pluginRoot, { recursive: true });
   writeFileSync(join(pluginRoot, 'package.json'), JSON.stringify({
     name: 'fake-plugin',
     version: '0.0.0',
-    dependencies: { zod: '^3.0.0' },
+    dependencies,
   }));
+  // Matching marker so the version-drift hint never pollutes stderr — these
+  // tests assert on the absence of install diagnostics, not on empty stderr.
   writeFileSync(join(pluginRoot, '.install-version'), JSON.stringify({ version: '0.0.0' }));
 
   const fakeBinDir = join(pluginRoot, '.bin');
   mkdirSync(fakeBinDir, { recursive: true });
 
-  // Fake bun behaviors:
-  //   - success: creates the install marker file and exits 0 (happy path).
-  //   - partial-then-fail: creates the partial node_modules dir THEN exits
-  //     non-zero. Mirrors real bun's behavior under network timeout / OOM /
-  //     registry 5xx where node_modules already exists when the failure
-  //     surfaces. Required to cover the gh #2650 review-fix path that
-  //     cleans up the partial dir so the next Setup run can retry.
   const fakeBunPath = join(fakeBinDir, 'bun');
-  const installBody = bunBehavior === 'success'
-    ? [
-        `  mkdir -p "${pluginRoot}/node_modules/zod/v3"`,
-        `  : > "${pluginRoot}/node_modules/zod/v3/index.js"`,
-        '  exit 0',
-      ]
-    : [
-        `  mkdir -p "${pluginRoot}/node_modules"`,
-        '  echo "fake bun install failure mid-fetch" 1>&2',
-        '  exit 42',
-      ];
+  let installBody: string[];
+  if (bunBehavior === 'install-zod') {
+    installBody = [...fakeInstallLinesFor(pluginRoot, 'zod', ZOD_COMPLETE_EXPORTS), '  exit 0'];
+  } else if (bunBehavior === 'install-zod-and-late-dep') {
+    installBody = [
+      ...fakeInstallLinesFor(pluginRoot, 'zod', ZOD_COMPLETE_EXPORTS),
+      ...fakeInstallLinesFor(pluginRoot, 'late-added-dep', { '.': './index.js' }),
+      '  exit 0',
+    ];
+  } else if (bunBehavior === 'noop-zero') {
+    installBody = [
+      '  echo "fake bun integrity check silently failed" 1>&2',
+      '  exit 0',
+    ];
+  } else {
+    installBody = [
+      `  mkdir -p "${pluginRoot}/node_modules/zod"`,
+      `  : > "${pluginRoot}/${PARTIAL_FETCH_ARTIFACT_REL}"`,
+      '  echo "fake bun install failure mid-fetch" 1>&2',
+      '  exit 42',
+    ];
+  }
+
   const fakeBunScript = [
     '#!/usr/bin/env bash',
     'if [ "$1" = "install" ]; then',
+    `  : > "${join(pluginRoot, BUN_INVOKED_MARKER)}"`,
     ...installBody,
     'fi',
     'exit 0',
@@ -107,6 +256,10 @@ function makeFreshPlugin(name: string, bunBehavior: BunBehavior = 'success'): { 
   return { pluginRoot, fakeBinDir };
 }
 
+function bunWasInvoked(pluginRoot: string): boolean {
+  return existsSync(join(pluginRoot, BUN_INVOKED_MARKER));
+}
+
 beforeAll(() => {
   tmpRoot = mkdtempSync(join(tmpdir(), 'version-check-deps-'));
 });
@@ -115,7 +268,7 @@ afterAll(() => {
   try { rmSync(tmpRoot, { recursive: true, force: true }); } catch {}
 });
 
-describe.skipIf(SKIP_NON_UNIX)('version-check Setup-phase ensurePluginDependencies (gh #2649)', () => {
+describe.skipIf(SKIP_NON_UNIX)('version-check Setup-phase ensurePluginDependencies (gh #2649, #3755)', () => {
   test('installs plugin dependencies when node_modules is missing on fresh extract', async () => {
     // This is the gh #2640 / #2637 scenario: marketplace extracts files but
     // never runs `bun install`. Setup MUST detect the missing node_modules and
@@ -128,44 +281,191 @@ describe.skipIf(SKIP_NON_UNIX)('version-check Setup-phase ensurePluginDependenci
     expect(code).toBe(0);
     expect(stderr).toContain(INSTALL_DIAGNOSTIC);
     expect(stderr).toContain(INSTALL_SUCCESS_DIAGNOSTIC);
-    expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(true);
+    // Success is now asserted against real resolvability, not a stray file:
+    // the post-install re-check in version-check.js only reports success when
+    // every declared specifier — zod and its three subpaths — resolves.
+    expect(resolvesFromPluginTree(pluginRoot, 'zod')).toBe(true);
+    expect(resolvesFromPluginTree(pluginRoot, 'zod/v3')).toBe(true);
   });
 
-  test('cleans up partial node_modules after a failed install so next Setup can retry (gh #2650 review)', async () => {
-    // Reproduces the Greptile review concern: `bun install` often creates
-    // the node_modules directory BEFORE it fails (mid-fetch network
-    // timeout, registry 5xx, OOM kill). Without explicit cleanup, the
-    // `existsSync(node_modules)` guard would permanently short-circuit
-    // every subsequent Setup run and the user has no recovery path short
-    // of a manual `rm -rf node_modules`. Verify that after a failed
-    // install the partial dir is removed.
-    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-partial-fail', 'partial-then-fail');
-
-    // Sanity-check the failure path: node_modules MUST exist before our
-    // cleanup runs (otherwise we are not exercising the gh #2650 scenario).
-    // Run version-check once and confirm both the failure diagnostic and
-    // the post-cleanup absence of node_modules.
-    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
-
-    expect(code).toBe(0);
-    expect(stderr).toContain(INSTALL_FAILURE_DIAGNOSTIC);
-    expect(stderr).toContain('exit 42');
-    expect(existsSync(join(pluginRoot, 'node_modules'))).toBe(false);
-  });
-
-  test('skips install when node_modules is already present', async () => {
-    // Setup runs on every Claude Code launch. If node_modules already exists,
-    // the install MUST be skipped — otherwise we re-run a 100 MB+ install on
-    // every cold start and burn the user's bandwidth.
-    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-already-installed');
+  test('installs when node_modules exists but is empty (gh #3755)', async () => {
+    // REGRESSION PIN, inverted. The old guard was `existsSync(node_modules)`,
+    // so a directory that merely EXISTED — created by an interrupted install,
+    // or left behind after a partial fetch — permanently short-circuited repair
+    // on every subsequent Setup run. The worker then died at boot with
+    // `Cannot find module 'zod/v3'` while memory search kept working (zod is
+    // bundled into mcp-server.cjs), which is why the breakage stayed silent for
+    // months. An empty node_modules alongside a declared dependency MUST now
+    // trigger the install, and the diagnostic MUST name what is missing so the
+    // failure stops being invisible.
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-empty-node-modules');
     mkdirSync(join(pluginRoot, 'node_modules'), { recursive: true });
 
     const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
 
     expect(code).toBe(0);
+    expect(stderr).toContain(INSTALL_DIAGNOSTIC);
+    expect(stderr).toContain('missing: zod');
+    expect(bunWasInvoked(pluginRoot)).toBe(true);
+    expect(stderr).toContain(INSTALL_SUCCESS_DIAGNOSTIC);
+    expect(resolvesFromPluginTree(pluginRoot, 'zod/v3')).toBe(true);
+  });
+
+  test('preserves a partial node_modules after a failed install and retries on the next run', async () => {
+    // The gh #2650 review added an `rmSync(node_modules)` after a failed
+    // install, because the existence guard would otherwise block retry forever.
+    // With the completeness guard that delete is not merely unnecessary, it is
+    // harmful: the gh #3755 reporter had 12 of 26 packages on disk, still
+    // powering memory search, and nuking them would have turned a degraded
+    // install into a dead one. So assert the inverse of the old test — the
+    // partial tree SURVIVES, and retry happens anyway because the guard
+    // re-detects the missing closure rather than depending on deletion.
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-partial-fail', 'partial-then-fail');
+
+    const first = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(first.code).toBe(0);
+    expect(first.stderr).toContain(INSTALL_FAILURE_DIAGNOSTIC);
+    expect(first.stderr).toContain('exit 42');
+    // The partially-fetched tree is still on disk, artifact and all.
+    expect(existsSync(join(pluginRoot, 'node_modules'))).toBe(true);
+    expect(existsSync(join(pluginRoot, PARTIAL_FETCH_ARTIFACT_REL))).toBe(true);
+
+    // Second Setup run: node_modules exists (and would have satisfied the old
+    // existence guard), but zod still does not resolve, so the install is
+    // attempted again. This is the proof that retry no longer depends on rm.
+    rmSync(join(pluginRoot, BUN_INVOKED_MARKER), { force: true });
+    const second = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(second.code).toBe(0);
+    expect(bunWasInvoked(pluginRoot)).toBe(true);
+    expect(second.stderr).toContain(INSTALL_DIAGNOSTIC);
+    expect(second.stderr).toContain(INSTALL_FAILURE_DIAGNOSTIC);
+    expect(second.stderr).toContain('exit 42');
+    expect(existsSync(join(pluginRoot, PARTIAL_FETCH_ARTIFACT_REL))).toBe(true);
+  });
+
+  test('skips install when the declared closure fully resolves', async () => {
+    // Setup runs on every Claude Code launch. A complete tree MUST short-circuit
+    // — otherwise we re-run a 100 MB+ install on every cold start and burn the
+    // user's bandwidth. "Complete" now means genuinely resolvable (package.json
+    // + exports map + stub files), not just a directory named node_modules.
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-complete-tree');
+    writeFakePackage(pluginRoot, 'zod', ZOD_COMPLETE_EXPORTS);
+
+    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
     expect(stderr).not.toContain(INSTALL_DIAGNOSTIC);
-    // The fake bun would have created zod/v3/index.js if invoked — its
-    // absence proves the install path was not taken.
-    expect(existsSync(join(pluginRoot, FAKE_INSTALLED_MARKER_REL))).toBe(false);
+    expect(bunWasInvoked(pluginRoot)).toBe(false);
+  });
+
+  test('detects and names a missing scoped dependency', async () => {
+    // 6 of the plugin's 26 real dependencies are scoped (`@scope/pkg`), so the
+    // scoped-path split in the probe is load-bearing: a naive single-segment
+    // join would look for `node_modules/@scope%2Fpkg` and mis-report every
+    // scoped package as missing (or, worse, as present).
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin(
+      'plugin-missing-scoped',
+      'noop-zero',
+      { zod: '^3.0.0', '@fake-scope/missing-pkg': '^1.0.0' },
+    );
+    // zod resolves, so the scoped package is the ONLY thing that can be named.
+    writeFakePackage(pluginRoot, 'zod', ZOD_COMPLETE_EXPORTS);
+
+    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
+    expect(stderr).toContain(`${INSTALL_DIAGNOSTIC} (missing: @fake-scope/missing-pkg)`);
+    expect(bunWasInvoked(pluginRoot)).toBe(true);
+  });
+
+  test('treats a bin-only dependency as present, not missing (gh #2730)', async () => {
+    // `tree-sitter-cli` is bin-only: its package.json has a `bin` field and no
+    // `main`/`module`/`exports`/`index.js`, so bare-name resolution fails for a
+    // perfectly installed package. Without the `${dep}/package.json` fallback
+    // the guard would report it missing forever and re-run `bun install` on
+    // every single Setup — the false-positive that gh #2730 pinned.
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin(
+      'plugin-bin-only-dep',
+      'install-zod',
+      { zod: '^3.0.0', 'faux-cli': '^1.0.0' },
+    );
+    writeFakePackage(pluginRoot, 'zod', ZOD_COMPLETE_EXPORTS);
+    writeFakeBinOnlyPackage(pluginRoot, 'faux-cli', 'faux');
+
+    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
+    expect(stderr).not.toContain('faux-cli');
+    // Bin-only-ness alone must not drag the whole tree back into install.
+    expect(stderr).not.toContain(INSTALL_DIAGNOSTIC);
+    expect(bunWasInvoked(pluginRoot)).toBe(false);
+  });
+
+  test('detects an unresolvable zod subpath even when zod itself resolves (gh #3755)', async () => {
+    // The literal crash string in the bug report is `Cannot find module
+    // 'zod/v3'` — with `node_modules/zod` sitting right there on disk. A stale
+    // or integrity-failed install leaves the package directory intact while the
+    // subpath exports break, so probing the package root is not enough: the
+    // three subpaths worker-service.cjs requires must be probed individually.
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-zod-missing-subpath', 'noop-zero');
+    writeFakePackage(pluginRoot, 'zod', {
+      '.': './index.js',
+      './v4': './v4/index.js',
+      './v4-mini': './v4-mini/index.js',
+    });
+
+    // Precondition: zod itself resolves, so only the subpath can be reported.
+    expect(resolvesFromPluginTree(pluginRoot, 'zod')).toBe(true);
+    expect(resolvesFromPluginTree(pluginRoot, 'zod/v3')).toBe(false);
+
+    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
+    expect(stderr).toContain(`${INSTALL_DIAGNOSTIC} (missing: zod/v3)`);
+    expect(bunWasInvoked(pluginRoot)).toBe(true);
+  });
+
+  test('reports failure when bun install exits 0 but installs nothing (gh #3755)', async () => {
+    // `bun install` can exit 0 while its integrity check silently failed,
+    // leaving the closure short. Trusting the exit code would print "installed
+    // successfully" over a tree that still cannot boot the worker — exactly the
+    // reassuring-but-wrong transcript users saw. The post-install re-check must
+    // downgrade this to a named failure.
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('plugin-exit-zero-noop', 'noop-zero');
+
+    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
+    expect(stderr).toContain(INSTALL_DIAGNOSTIC);
+    expect(stderr).toContain(INSTALL_INCOMPLETE_DIAGNOSTIC);
+    expect(stderr).toContain('zod');
+    expect(stderr).not.toContain(INSTALL_SUCCESS_DIAGNOSTIC);
+  });
+
+  test('detects and repairs a dependency added to the manifest after a complete install (gh #3755)', async () => {
+    // The second gh #3755 report, end to end: the tree was complete for the
+    // PREVIOUS manifest, then an upgrade added a dependency. Under the old
+    // existence guard node_modules was present, so Setup skipped forever and
+    // the new dependency was never installed. Deriving the expected set from
+    // package.json `dependencies` makes the delta detectable, and the install
+    // then repairs it in the same run.
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin(
+      'plugin-newly-added-dep',
+      'install-zod-and-late-dep',
+      { zod: '^3.0.0', 'late-added-dep': '^1.0.0' },
+    );
+    // Tree as it was left by the previous version's install: zod only.
+    writeFakePackage(pluginRoot, 'zod', ZOD_COMPLETE_EXPORTS);
+    expect(resolvesFromPluginTree(pluginRoot, 'late-added-dep')).toBe(false);
+
+    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
+    // Only the delta is named — the already-satisfied zod must not be reported.
+    expect(stderr).toContain(`${INSTALL_DIAGNOSTIC} (missing: late-added-dep)`);
+    expect(stderr).toContain(INSTALL_SUCCESS_DIAGNOSTIC);
+    expect(resolvesFromPluginTree(pluginRoot, 'late-added-dep')).toBe(true);
   });
 });

--- a/tests/plugin-version-check-ensure-deps.test.ts
+++ b/tests/plugin-version-check-ensure-deps.test.ts
@@ -468,4 +468,34 @@ describe.skipIf(SKIP_NON_UNIX)('version-check Setup-phase ensurePluginDependenci
     expect(stderr).toContain(INSTALL_SUCCESS_DIAGNOSTIC);
     expect(resolvesFromPluginTree(pluginRoot, 'late-added-dep')).toBe(true);
   });
+
+  test('does not accept a dependency resolved from OUTSIDE the plugin tree (gh #3872 review)', async () => {
+    // The completeness probe must answer "is it installed HERE", not "can this
+    // machine resolve it from somewhere".
+    //
+    // `require.resolve(dep, { paths: [nodeModules] })` reads as tree-scoped but
+    // is not: `paths` only seeds Node's lookup, which then walks every ancestor
+    // directory and always consults the global folders. Real plugin roots sit
+    // at ~/.claude/plugins/cache/thedotmack/claude-mem/<version>/, so a zod
+    // anywhere above them — or installed globally — answered for the plugin's
+    // own. The guard reported a gutted tree as complete and skipped repair,
+    // silently reinstating the gh #3755 bug it exists to catch.
+    //
+    // Fixture: an EMPTY plugin node_modules with a complete zod one directory
+    // up, which is exactly the shape that fooled the probe.
+    const { pluginRoot, fakeBinDir } = makeFreshPlugin('leak-host/plugin');
+    mkdirSync(join(pluginRoot, 'node_modules'), { recursive: true });
+    // `leak-host` is the plugin root's parent, so its node_modules is the first
+    // ancestor Node's lookup reaches after the plugin's own.
+    writeFakePackage(join(tmpRoot, 'leak-host'), 'zod', ZOD_COMPLETE_EXPORTS);
+
+    const { stderr, code } = await runVersionCheck(pluginRoot, fakeBinDir);
+
+    expect(code).toBe(0);
+    // The ancestor copy must not satisfy the closure: repair has to run.
+    expect(stderr).toContain(`${INSTALL_DIAGNOSTIC} (missing: zod)`);
+    expect(stderr).toContain(INSTALL_SUCCESS_DIAGNOSTIC);
+    // And the repair must have populated the plugin's OWN tree.
+    expect(existsSync(join(pluginRoot, 'node_modules', 'zod', 'package.json'))).toBe(true);
+  });
 });


### PR DESCRIPTION
Rebased replacement of #3872 — conflicts resolved, version bump commit dropped per ship instructions.

Original PR: #3872. Fixes #3755. Refs #3604 (plan-16), #2730.

---

Guard on completeness instead of mere `node_modules/` existence. Every key of `package.json` `dependencies` must resolve, with a `<dep>/package.json` fallback for bin-only packages like `tree-sitter-cli` (#2730), plus the zod subpaths the worker actually requires.

Two consequences:
- Post-failure `rmSync` of `node_modules` removed (completeness guard re-detects gaps)
- Zero exit from `bun install` no longer trusted (re-probes closure afterward)

Full details in #3872.