### PR TITLE
fix(sync): quarantine stale-device-id outbox heads so sync can drain

### DIFF
--- a/src/services/sync/CloudSync.ts
+++ b/src/services/sync/CloudSync.ts
@@ -121,6 +121,13 @@ function operationTupleKey(tuple: {
   ]);
 }
 
+/** Hub 400 that names a frozen origin_device_id ≠ authenticated X-Device-Id. */
+function isStaleOriginDeviceIdReject(message: string): boolean {
+  return message.includes('sync hub push 400:')
+    && message.includes('invalid_ops')
+    && message.includes('origin_device_id does not match authenticated X-Device-Id');
+}
+
 const TABLE_BY_KIND: Record<RowKind, string> = {
   observation: 'observations',
   summary: 'session_summaries',
@@ -925,14 +932,75 @@ export class CloudSync {
 
   /** POST one batch to the hub and stamp/delete on ack. */
   private async sendOps(ops: WireOp[]): Promise<void> {
-    const response = await this.pushOps(ops);
-    // stop() while the POST was in flight: the DB may already be closing, so
-    // skip the stamp. The hub dedupes on (origin_device, kind, origin_id,
-    // rev), so re-pushing these ops on next start is harmless.
-    if (this.stopped) return;
-    this.validatePushResponse(response, ops);
-    this.stampAcked(response.acked, ops);
-    this.emitHeadSeq(response.head_seq);
+    let remaining = ops;
+    for (;;) {
+      try {
+        const response = await this.pushOps(remaining);
+        // stop() while the POST was in flight: the DB may already be closing, so
+        // skip the stamp. The hub dedupes on (origin_device, kind, origin_id,
+        // rev), so re-pushing these ops on next start is harmless.
+        if (this.stopped) return;
+        this.validatePushResponse(response, remaining);
+        this.stampAcked(response.acked, remaining);
+        this.emitHeadSeq(response.head_seq);
+        return;
+      } catch (error) {
+        const next = this.dropStaleOriginDeviceIdOps(remaining, error);
+        if (next === null) throw error;
+        if (next.length === 0 || this.stopped) return;
+        remaining = next;
+      }
+    }
+  }
+
+  /**
+   * After a device-id mint, hash-locked sync_outbox rows still carry the old
+   * origin_device_id. The hub 400s the whole batch and nothing else removes
+   * those poison heads, so healthy ops behind them never drain. Dead-letter
+   * the mismatched mutation ops and return the rest of the batch (or null
+   * when this is not that failure class / no matching rows were found).
+   */
+  private dropStaleOriginDeviceIdOps(ops: WireOp[], error: unknown): WireOp[] | null {
+    const reason = error instanceof Error ? error.message : String(error);
+    if (!isStaleOriginDeviceIdReject(reason)) return null;
+    const kept: WireOp[] = [];
+    let quarantined = 0;
+    for (const op of ops) {
+      if (this.quarantineStaleOriginDeviceIdMutation(op, reason)) {
+        quarantined++;
+        continue;
+      }
+      kept.push(op);
+    }
+    return quarantined === 0 ? null : kept;
+  }
+
+  private quarantineStaleOriginDeviceIdMutation(op: WireOp, reason: string): boolean {
+    let originDeviceId: string | undefined;
+    let mutationId: string | undefined;
+    try {
+      const body = JSON.parse(op.body) as {
+        origin_device_id?: unknown;
+        kind?: unknown;
+        id?: unknown;
+      };
+      if (typeof body.origin_device_id === 'string') originDeviceId = body.origin_device_id;
+      if (body.kind === 'mutation' && typeof body.id === 'string' && body.id.startsWith('mutation:')) {
+        mutationId = body.id.slice('mutation:'.length);
+      }
+    } catch {
+      return false;
+    }
+    if (!originDeviceId || originDeviceId === this.deviceId || !mutationId) return false;
+    const row = this.db.prepare(`
+      SELECT CAST(id AS TEXT) AS id, op_uuid, CAST(rev AS TEXT) AS rev,
+             body, canonical_body, operation_sha256
+      FROM sync_outbox
+      WHERE op_uuid = ? AND (operation_sha256 IS NULL OR operation_sha256 = ?)
+    `).get(mutationId, op.operation_sha256) as MutationOutboxRow | undefined;
+    if (!row) return false;
+    this.quarantineMutation(row, reason);
+    return true;
   }
 
   private async pushOps(ops: WireOp[]): Promise<PushResponse> {

--- a/tests/worker/sync/cloud-sync.test.ts
+++ b/tests/worker/sync/cloud-sync.test.ts
@@ -13,7 +13,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { SessionStore } from '../../../src/services/sqlite/SessionStore.js';
 import { CloudSync, type CloudSyncSettingKeys, type CloudSyncOptions } from '../../../src/services/sync/CloudSync.js';
-import { buildContentOperation, stableDocumentId } from '../../../src/services/sync/CanonicalContent.js';
+import { buildContentOperation, buildMutationOperation, stableDocumentId } from '../../../src/services/sync/CanonicalContent.js';
 
 const ISO = '2026-07-09T00:00:00.000Z';
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
@@ -1010,6 +1010,116 @@ describe('CloudSync', () => {
         "SELECT raw_body FROM sync_dead_letter WHERE lane = 'mutation'"
       ).get() as { raw_body: string };
       expect(JSON.parse(dead.raw_body).fields.custom_title).toBe('X'.repeat(2_100_000));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // After a device-id mint, frozen canonical_body rows stay hash-locked to
+  // the previous origin_device_id. The hub 400s invalid_ops on the batch
+  // head; those poison ops must dead-letter so later healthy ops can drain.
+  // ---------------------------------------------------------------------------
+  describe('stale origin_device_id invalid_ops quarantine', () => {
+    const STALE_DEVICE_ID = '1e1798f5-1111-4111-8111-111111111111';
+    const STALE_OP_UUID = '11111111-1111-4111-8111-111111111111';
+    const STALE_OP_UUID_2 = '22222222-2222-4222-8222-222222222222';
+
+    function seedFrozenStaleMutation(opUuid: string): void {
+      const mutation = {
+        op: 'set_prompt_session' as const,
+        target: { origin_device_id: STALE_DEVICE_ID, origin_local_id: '1632' },
+        fields: { memory_session_id: 'mem-stale' },
+      };
+      const op = buildMutationOperation({
+        originDeviceId: STALE_DEVICE_ID,
+        mutationId: opUuid,
+        entityRev: '1',
+        mutation,
+      });
+      db.prepare(`
+        INSERT INTO sync_outbox
+          (op_uuid, rev, body, canonical_body, operation_sha256, created_at_epoch)
+        VALUES (?, 1, ?, ?, ?, 1)
+      `).run(opUuid, JSON.stringify(mutation), op.body, op.operation_sha256);
+    }
+
+    it('dead-letters a stale-head mutation so the healthy op behind it drains', async () => {
+      seedFrozenStaleMutation(STALE_OP_UUID);
+      store.createSDKSession('sess-healthy', 'proj-x', 'p', 'healthy title', 'claude');
+      expect(outboxRows()[0].op_uuid).toBe(STALE_OP_UUID);
+      expect(outboxRows().length).toBe(2);
+
+      const { impl, calls } = makeFetchMock(call => {
+        const ops = calls[call - 1]?.wireParsed?.ops ?? [];
+        const hasStale = ops.some((op: { body: string }) => {
+          const body = JSON.parse(op.body) as { origin_device_id?: string };
+          return body.origin_device_id === STALE_DEVICE_ID;
+        });
+        if (!hasStale) return undefined;
+        return new Response(JSON.stringify({
+          error: 'invalid_ops: ops[0] origin_device_id does not match authenticated X-Device-Id',
+        }), { status: 400 });
+      });
+      const sync = makeCloudSync(impl);
+      await sync.flush();
+
+      expect(outboxRows().length).toBe(0);
+      expect(sync.status().lastError).toBeNull();
+      expect(sync.status().quarantine.count).toBe(1);
+      expect(sync.status().quarantine.latestReason).toMatch(
+        /invalid_ops: ops\[0\] origin_device_id does not match authenticated X-Device-Id/,
+      );
+      const dead = db.prepare(
+        "SELECT queue_key, raw_body FROM sync_dead_letter WHERE lane = 'mutation'"
+      ).get() as { queue_key: string; raw_body: string };
+      expect(dead.queue_key).toBe(STALE_OP_UUID);
+      expect(JSON.parse(dead.raw_body).origin_device_id).toBe(STALE_DEVICE_ID);
+
+      const healthyPushes = calls.filter(c =>
+        c.parsed.ops.some((o: { kind: string; body: { fields?: { custom_title?: string } } }) =>
+          o.kind === 'mutation' && o.body.fields?.custom_title === 'healthy title',
+        ),
+      );
+      expect(healthyPushes.length).toBeGreaterThan(0);
+      expect(healthyPushes.some(c =>
+        c.parsed.ops.every((o: { body: { fields?: { custom_title?: string } } }) =>
+          o.body.fields?.custom_title === 'healthy title',
+        ),
+      )).toBe(true);
+      sync.stop();
+    });
+
+    it('quarantines every stale-head op in a rejected batch before draining later work', async () => {
+      seedFrozenStaleMutation(STALE_OP_UUID);
+      seedFrozenStaleMutation(STALE_OP_UUID_2);
+      store.createSDKSession('sess-healthy', 'proj-x', 'p', 'healthy title', 'claude');
+
+      const { impl, calls } = makeFetchMock(call => {
+        const ops = calls[call - 1]?.wireParsed?.ops ?? [];
+        const hasStale = ops.some((op: { body: string }) => {
+          const body = JSON.parse(op.body) as { origin_device_id?: string };
+          return body.origin_device_id === STALE_DEVICE_ID;
+        });
+        if (!hasStale) return undefined;
+        return new Response(JSON.stringify({
+          error: 'invalid_ops: ops[0] origin_device_id does not match authenticated X-Device-Id',
+        }), { status: 400 });
+      });
+      const sync = makeCloudSync(impl);
+      await sync.flush();
+
+      expect(outboxRows().length).toBe(0);
+      expect(sync.status().lastError).toBeNull();
+      expect(sync.status().quarantine.count).toBe(2);
+      const deadKeys = (db.prepare(
+        "SELECT queue_key FROM sync_dead_letter WHERE lane = 'mutation' ORDER BY queue_key"
+      ).all() as Array<{ queue_key: string }>).map(r => r.queue_key);
+      expect(deadKeys).toEqual([STALE_OP_UUID, STALE_OP_UUID_2]);
+      expect(calls.some(c =>
+        c.parsed.ops.some((o: { kind: string; body: { fields?: { custom_title?: string } } }) =>
+          o.kind === 'mutation' && o.body.fields?.custom_title === 'healthy title',
+        ),
+      )).toBe(true);
+      sync.stop();
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3964

## Problem

After a cloud-sync device-id mint, ops already sitting in `sync_outbox` stay hash-locked to the previous `origin_device_id`. The hub rejects the whole batch with `400 invalid_ops` (`ops[0] origin_device_id does not match authenticated X-Device-Id`). Nothing quarantined those poison heads, so healthy ops behind them never drained and the queue grew forever.

`quarantineMutation` already existed, but it only ran when *local* canonicalisation threw. A server-side 400 never reached it.

## Patch

On that specific hub 400, identify mutation ops in the rejected batch whose envelope `origin_device_id` ≠ the authenticated device id, move them to `sync_dead_letter` via the existing `quarantineMutation` path, and continue the remaining batch in the same flush.

This is quarantine-on-reject only. It does **not** rewrite/rehash outbox rows on mint (deferred RCA: mint-without-rewriting-outbox). Other 4xx/5xx still fail the flush and back off as before.

## Tests

- Stale head + healthy op behind it: head dead-lettered, healthy op pushed, `lastError` cleared.
- Two stale heads in one rejected batch: both quarantined, later healthy work drains.

Local evidence: `bun test tests/worker/sync/cloud-sync.test.ts` — 54 pass (including the two new cases). Also green: `sync-apply.test.ts`, `session-store-synced-at.test.ts`, `cloud-sync-routes.test.ts`.

No version bump.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21b4ecbd-3829-4ee6-9cc3-709e1e5fb033?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21b4ecbd-3829-4ee6-9cc3-709e1e5fb033&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

