### PR TITLE
test(smart-file-read): raise grammar-lib-reuse timeouts for CI

### DIFF
--- a/tests/services/smart-file-read/grammar-lib-reuse.test.ts
+++ b/tests/services/smart-file-read/grammar-lib-reuse.test.ts
@@ -36,7 +36,7 @@ function typescriptLib(): string {
 }
 
 describe.if(treeSitterAvailable())('compiled grammar reuse', () => {
-  it('parses through a compiled artifact and does not rebuild it on the next call', () => {
+  it('parses through a compiled artifact and does not rebuild it on the next call', { timeout: 30000 }, () => {
     expect(parseFile(SOURCE, 'greeter.ts').symbols.map((s) => s.name)).toContain('greet');
 
     const libPath = typescriptLib();
@@ -46,7 +46,7 @@ describe.if(treeSitterAvailable())('compiled grammar reuse', () => {
     expect(statSync(libPath).mtimeMs).toBe(builtAt);
   });
 
-  it('rebuilds an artifact older than the grammar sources', () => {
+  it('rebuilds an artifact older than the grammar sources', { timeout: 30000 }, () => {
     expect(parseFile(SOURCE, 'greeter.ts').symbols.map((s) => s.name)).toContain('greet');
 
     // A plugin update ships new grammar packages; an artifact left over from the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Post-merge CI for [#3966](https://github.com/thedotmack/claude-mem/pull/3966) (fixes [#3926](https://github.com/thedotmack/claude-mem/issues/3926)) failed on `typecheck · build · test · bundle-size` ([run 34548192839](https://github.com/thedotmack/claude-mem/actions/runs/34548192839)). Both cases in `describe('compiled grammar reuse')` blew the default bun:test 5000ms timeout:

1. `parses through a compiled artifact and does not rebuild it on the next call` — timed out after 5000ms
2. `rebuilds an artifact older than the grammar sources` — failed at ~4739ms in the same suite

The first `parseFile()` compiles a tree-sitter TypeScript grammar from C (~0.7s locally, often slower on CI). Two sequential compiles/rebuilds can exceed 5s.

This unblocks post-merge CI for #3966 / #3926.

## Change

Raise the per-test timeout on **both** `it(...)` cases in `tests/services/smart-file-read/grammar-lib-reuse.test.ts` to 30000ms via bun:test's `{ timeout: 30000 }` options argument.

No production parser changes. No refactors. No version bump.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c594faa1-7e30-40c2-9c0f-50636a971f0d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c594faa1-7e30-40c2-9c0f-50636a971f0d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

