### PR TITLE
fix: add error listener to child.stdin in bun-runner.js to prevent EPIPE crash (#3895)

### DIFF
--- a/plugin/scripts/bun-runner.js
+++ b/plugin/scripts/bun-runner.js
@@ -175,6 +175,7 @@ if (needsCmdShell) {
 const child = spawn(spawnCmd, spawnArgs, spawnOptions);
 
 if (child.stdin) {
+  child.stdin.on('error', () => {});
   if (stdinData && stdinData.length > 0) {
     child.stdin.write(stdinData);
     child.stdin.end();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3895.

**Root cause:** `bun-runner.js` writes the hook payload to the spawned `bun` child's stdin with no `'error'` listener attached. If the child exits before the write completes (a race more likely with larger payloads), the resulting EPIPE has zero listeners and Node re-throws it as an unhandled exception, crashing the wrapper process.

**Fix:** One-line addition — attach a no-op `child.stdin.on('error', () => {})` before the write block. This is the standard Node pattern for suppressing EPIPE on best-effort writes. Consistent with the script's existing exit-0-on-error contract for hook failures.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86323535-1f70-476a-8644-43b4b56ca2b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86323535-1f70-476a-8644-43b4b56ca2b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

