### PR TITLE
fix: treat empty-string cwd as absent and fall through to fallbacks (#3887)

### DIFF
--- a/src/cli/adapters/antigravity-cli.ts
+++ b/src/cli/adapters/antigravity-cli.ts
@@ -7,10 +7,10 @@ export const antigravityCliAdapter: PlatformAdapter = {
 
     // unverified: confirm Antigravity sets GEMINI_* env vars on first real hook firing
     const cwd = r.cwd
-      ?? process.env.GEMINI_CWD
-      ?? process.env.GEMINI_PROJECT_DIR
-      ?? process.env.CLAUDE_PROJECT_DIR
-      ?? process.cwd();
+      || process.env.GEMINI_CWD
+      || process.env.GEMINI_PROJECT_DIR
+      || process.env.CLAUDE_PROJECT_DIR
+      || process.cwd();
     if (!isValidCwd(cwd)) {
       throw new AdapterRejectedInput('invalid_cwd');
     }

--- a/src/cli/adapters/claude-code.ts
+++ b/src/cli/adapters/claude-code.ts
@@ -8,7 +8,7 @@ const pickAgentField = (v: unknown): string | undefined =>
 export const claudeCodeAdapter: PlatformAdapter = {
   normalizeInput(raw) {
     const r = (raw ?? {}) as any;
-    const cwd = r.cwd ?? process.cwd();
+    const cwd = r.cwd || process.cwd();
     if (!isValidCwd(cwd)) {
       throw new AdapterRejectedInput('invalid_cwd');
     }

--- a/src/cli/adapters/codex.ts
+++ b/src/cli/adapters/codex.ts
@@ -59,7 +59,7 @@ function inferOutputEvent(result: HookResult): CodexEventName | undefined {
 export const codexAdapter: PlatformAdapter = {
   normalizeInput(raw): NormalizedHookInput {
     const r = (raw ?? {}) as Record<string, unknown>;
-    const cwd = typeof r.cwd === 'string' ? r.cwd : process.cwd();
+    const cwd = (typeof r.cwd === 'string' && r.cwd) || process.cwd();
     if (!isValidCwd(cwd)) {
       throw new AdapterRejectedInput('invalid_cwd');
     }

--- a/src/cli/adapters/cursor.ts
+++ b/src/cli/adapters/cursor.ts
@@ -31,7 +31,7 @@ export const cursorAdapter: PlatformAdapter = {
   normalizeInput(raw) {
     const r = (raw ?? {}) as any;
     const isShellCommand = !!r.command && !r.tool_name;
-    const cwd = r.workspace_roots?.[0] ?? r.cwd ?? process.cwd();
+    const cwd = r.workspace_roots?.[0] || r.cwd || process.cwd();
     if (!isValidCwd(cwd)) {
       throw new AdapterRejectedInput('invalid_cwd');
     }

--- a/src/cli/adapters/raw.ts
+++ b/src/cli/adapters/raw.ts
@@ -4,7 +4,7 @@ import { AdapterRejectedInput, isValidCwd } from './errors.js';
 export const rawAdapter: PlatformAdapter = {
   normalizeInput(raw) {
     const r = (raw ?? {}) as any;
-    const cwd = r.cwd ?? process.cwd();
+    const cwd = r.cwd || process.cwd();
     if (!isValidCwd(cwd)) {
       throw new AdapterRejectedInput('invalid_cwd');
     }

--- a/src/cli/adapters/windsurf.ts
+++ b/src/cli/adapters/windsurf.ts
@@ -7,7 +7,7 @@ export const windsurfAdapter: PlatformAdapter = {
     const toolInfo = r.tool_info ?? {};
     const actionName: string = r.agent_action_name ?? '';
 
-    const cwd = toolInfo.cwd ?? process.cwd();
+    const cwd = toolInfo.cwd || process.cwd();
     if (!isValidCwd(cwd)) {
       throw new AdapterRejectedInput('invalid_cwd');
     }

--- a/tests/antigravity-cli-compat.test.ts
+++ b/tests/antigravity-cli-compat.test.ts
@@ -78,8 +78,9 @@ describe('antigravityCliAdapter - normalizeInput', () => {
     expect(result.cwd).toBe('/tmp/explicit-cwd');
   });
 
-  it('rejects an invalid (empty) cwd', () => {
-    expect(() => antigravityCliAdapter.normalizeInput({ cwd: '' })).toThrow('adapter rejected input: invalid_cwd');
+  it('falls back to process.cwd() when cwd is an empty string (#3887)', () => {
+    const result = antigravityCliAdapter.normalizeInput({ cwd: '' });
+    expect(result.cwd).toBe(process.cwd());
   });
 
   it('maps AfterAgent prompt_response into toolName/toolInput/toolResponse', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3887.

**Root cause:** All platform adapters used nullish coalescing (`??`) for cwd resolution. `??` only catches `null`/`undefined`, so an empty string `""` passed through as-is, failed `isValidCwd()`, and threw `AdapterRejectedInput("invalid_cwd")` — silently dropping the observation (exit 0, no row stored). Reported as 272 silently dropped observations in a single day.

**Fix:** Switch to logical OR (`||`) so empty strings fall through to `process.env` fallbacks and `process.cwd()`, matching the existing intent of "use this unless it is unusable."

Adapters changed: `claude-code`, `raw`, `antigravity-cli`, `windsurf`, `cursor`, `codex`. Updated the existing test that asserted the old throw-on-empty behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86323535-1f70-476a-8644-43b4b56ca2b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86323535-1f70-476a-8644-43b4b56ca2b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

