### PR TITLE
fix: classify Bun 'socket connection was closed' as worker-unavailable (#3871)

### DIFF
--- a/src/cli/hook-command.ts
+++ b/src/cli/hook-command.ts
@@ -56,6 +56,8 @@ export function isWorkerUnavailableError(error: unknown): boolean {
     'fetch failed',
     'unable to connect',
     'socket hang up',
+    'socket connection was closed',
+    'connection closed',
   ];
   if (transportPatterns.some(p => lower.includes(p))) return true;
 

--- a/tests/hook-command.test.ts
+++ b/tests/hook-command.test.ts
@@ -88,6 +88,16 @@ describe('isWorkerUnavailableError', () => {
       expect(isWorkerUnavailableError(error)).toBe(true);
     });
 
+    it('should classify Bun "socket connection was closed unexpectedly" as worker unavailable (#3871)', () => {
+      const error = new Error('The socket connection was closed unexpectedly');
+      expect(isWorkerUnavailableError(error)).toBe(true);
+    });
+
+    it('should classify "connection closed" as worker unavailable (#3871)', () => {
+      const error = new Error('connection closed');
+      expect(isWorkerUnavailableError(error)).toBe(true);
+    });
+
     it('should classify ECONNABORTED as worker unavailable', () => {
       const error = new Error('ECONNABORTED');
       expect(isWorkerUnavailableError(error)).toBe(true);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3871.

**Root cause:** When the worker dies mid-request, Bun's fetch rejects with `"The socket connection was closed unexpectedly"`. This message matched none of the patterns in `isWorkerUnavailableError`, so the hook took the generic `BLOCKING_ERROR` branch — returning exit 2, causing Claude Code to block and erase the user's prompt.

**Fix:** Add `'socket connection was closed'` and `'connection closed'` to the transport-failure patterns in `isWorkerUnavailableError` so a mid-request worker death takes the existing skip-quietly path (exit 0) instead of blocking.

Includes two new test cases covering both patterns.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86323535-1f70-476a-8644-43b4b56ca2b2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86323535-1f70-476a-8644-43b4b56ca2b2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

