### PR TITLE
fix(openrouter): classify OpenRouter by exact hostname, not URL substring

### DIFF
--- a/src/services/worker/OpenRouterProvider.ts
+++ b/src/services/worker/OpenRouterProvider.ts
@@ -261,6 +261,22 @@ export function normalizeOpenRouterModel(rawModel: unknown): { model: string; fa
 }
 
 /**
+ * True only when the URL hostname is exactly `openrouter.ai`.
+ *
+ * Path text and lookalike hosts must not inherit OpenRouter-only body fields
+ * (`models`, `usage`) — strict OpenAI-compatible gateways 400 on those.
+ * Malformed URLs fail closed (treat as non-OpenRouter). Shared by the request
+ * body and `session.endpointClass` so the two sites cannot drift.
+ */
+export function isOpenRouterApiUrl(apiUrl: string): boolean {
+  try {
+    return new URL(apiUrl).hostname.toLowerCase() === 'openrouter.ai';
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Build the chat-completions request body.
  *
  * Exported so the body shape is testable without a network round trip, which
@@ -280,7 +296,7 @@ export function buildOpenRouterRequestBody(input: {
   messages: OpenAIMessage[];
   apiUrl: string;
 }): Record<string, unknown> {
-  const isOpenRouter = input.apiUrl.includes('openrouter.ai');
+  const isOpenRouter = isOpenRouterApiUrl(input.apiUrl);
   const useFallbacks = isOpenRouter && input.fallbackModels.length > 0;
   return {
     ...(useFallbacks
@@ -386,7 +402,7 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
   protected prepareSessionExtras(session: ActiveSession, config: OpenRouterConfig): void {
     // openrouter.ai responses carry real usage/cost; custom OpenAI-compatible
     // gateways often fabricate or omit usage — let telemetry segment the two.
-    session.endpointClass = config.apiUrl.includes('openrouter.ai') ? 'openrouter' : 'custom';
+    session.endpointClass = isOpenRouterApiUrl(config.apiUrl) ? 'openrouter' : 'custom';
   }
 
   protected estimateTokens(text: string): number {

--- a/tests/worker/openrouter-model-fallbacks.test.ts
+++ b/tests/worker/openrouter-model-fallbacks.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import {
   buildOpenRouterRequestBody,
+  isOpenRouterApiUrl,
   resolveOpenRouterConfig,
 } from '../../src/services/worker/OpenRouterProvider.js';
 import { DEFAULT_OPENROUTER_API_URL } from '../../src/shared/openrouter-base-url.js';
@@ -145,6 +146,54 @@ describe('buildOpenRouterRequestBody', () => {
     expect(elsewhere).not.toHaveProperty('usage');
   });
 
+  it('sends OpenRouter fields for https://openrouter.ai/... when fallbacks exist', () => {
+    const body = buildOpenRouterRequestBody({
+      model: 'vendor/model-a',
+      fallbackModels: ['vendor/model-b'],
+      messages: MESSAGES,
+      apiUrl: 'https://openrouter.ai/api/v1/chat/completions',
+    });
+    expect(body.models).toEqual(['vendor/model-a', 'vendor/model-b']);
+    expect(body.usage).toEqual({ include: true });
+    expect(body).not.toHaveProperty('model');
+  });
+
+  it('treats a path containing openrouter.ai on a different host as a custom gateway', () => {
+    const body = buildOpenRouterRequestBody({
+      model: 'vendor/model-a',
+      fallbackModels: ['vendor/model-b'],
+      messages: MESSAGES,
+      apiUrl: 'https://gateway.example.com/proxy/openrouter.ai/v1/chat/completions',
+    });
+    expect(body.model).toBe('vendor/model-a');
+    expect(body).not.toHaveProperty('models');
+    expect(body).not.toHaveProperty('usage');
+  });
+
+  it('treats a lookalike hostname as a custom gateway', () => {
+    const body = buildOpenRouterRequestBody({
+      model: 'vendor/model-a',
+      fallbackModels: ['vendor/model-b'],
+      messages: MESSAGES,
+      apiUrl: 'https://openrouter.ai.evil.example/v1/chat/completions',
+    });
+    expect(body.model).toBe('vendor/model-a');
+    expect(body).not.toHaveProperty('models');
+    expect(body).not.toHaveProperty('usage');
+  });
+
+  it('treats a malformed URL as a custom gateway (model only)', () => {
+    const body = buildOpenRouterRequestBody({
+      model: 'vendor/model-a',
+      fallbackModels: ['vendor/model-b'],
+      messages: MESSAGES,
+      apiUrl: 'not a url',
+    });
+    expect(body.model).toBe('vendor/model-a');
+    expect(body).not.toHaveProperty('models');
+    expect(body).not.toHaveProperty('usage');
+  });
+
   it('carries the existing sampling parameters unchanged', () => {
     const body = buildOpenRouterRequestBody({
       model: 'vendor/model-a', fallbackModels: [], messages: MESSAGES, apiUrl: DEFAULT_OPENROUTER_API_URL,
@@ -152,5 +201,18 @@ describe('buildOpenRouterRequestBody', () => {
     expect(body.temperature).toBe(0.3);
     expect(body.max_tokens).toBe(4096);
     expect(body.messages).toEqual(MESSAGES);
+  });
+});
+
+describe('isOpenRouterApiUrl', () => {
+  it('matches the real openrouter.ai hostname, case-insensitively', () => {
+    expect(isOpenRouterApiUrl(DEFAULT_OPENROUTER_API_URL)).toBe(true);
+    expect(isOpenRouterApiUrl('https://OpenRouter.AI/api/v1/chat/completions')).toBe(true);
+  });
+
+  it('rejects path-text, lookalike hosts, and malformed URLs', () => {
+    expect(isOpenRouterApiUrl('https://gateway.example.com/proxy/openrouter.ai/v1/chat/completions')).toBe(false);
+    expect(isOpenRouterApiUrl('https://openrouter.ai.evil.example/v1/chat/completions')).toBe(false);
+    expect(isOpenRouterApiUrl('not a url')).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to merged #3971 (Greptile P1 left open) / #3829 item 3. Does **not** close #3829.

## Problem

`buildOpenRouterRequestBody` and `prepareSessionExtras` classified the endpoint with `apiUrl.includes('openrouter.ai')`. With fallback models configured, a custom `BASE_URL` whose **path** contains `openrouter.ai` or a **lookalike hostname** (`openrouter.ai.evil.example`) was treated as OpenRouter and received OpenRouter-only `models` / `usage` fields. Strict OpenAI-compatible gateways then 400 (`unknown request fields: models, usage; expected model`). Greptile T-Rex reproduced this on #3971.

## Fix

Shared `isOpenRouterApiUrl` helper used by both sites:

- OpenRouter only when `new URL(apiUrl).hostname` equals `openrouter.ai` (case-insensitive)
- Malformed URLs fail closed → single `model`, no `models`/`usage`

Normal `https://openrouter.ai/...` and ordinary custom gateways are unchanged.

## Tests

`tests/worker/openrouter-model-fallbacks.test.ts` now covers:

- real `https://openrouter.ai/...` → OpenRouter fields when fallbacks exist
- path containing `openrouter.ai` on a different host → `model` only
- lookalike hostname → non-OpenRouter
- malformed URL → non-OpenRouter

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1d9166d-e23c-43dd-9e25-251b1215c71b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1d9166d-e23c-43dd-9e25-251b1215c71b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

