### PR TITLE
fix(sqlite): keep ON UPDATE CASCADE through session_summaries rebuilds

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -1087,6 +1087,48 @@ export class SessionStore {
     logger.warn('DB', `Created ${orphaned} stub sdk_sessions parent(s) for orphaned ${childTable} rows before rebuild (#3378)`);
   }
 
+  /**
+   * Live FK clause, not the schema_versions row: a later table rebuild can
+   * strip ON UPDATE CASCADE after v21 was already stamped (#3849).
+   */
+  private hasMemorySessionIdOnUpdateCascade(table: 'observations' | 'session_summaries'): boolean {
+    const fks = this.db.query(`PRAGMA foreign_key_list(${table})`).all() as Array<{
+      table: string;
+      from: string;
+      on_update: string;
+    }>;
+    return fks.some(fk =>
+      fk.table === 'sdk_sessions' &&
+      fk.from === 'memory_session_id' &&
+      fk.on_update === 'CASCADE'
+    );
+  }
+
+  /**
+   * After CREATE TABLE <newTable> from a fixed historical column list, add
+   * every live source column that list omitted (type and DEFAULT included)
+   * and return the full copy order. Same discipline as the v7 rebuild (#3890)
+   * so a repair of an already-migrated database cannot drop later columns.
+   */
+  private carryLiveColumnsOntoNewTable(
+    sourceTable: string,
+    newTable: string,
+    knownColumns: string[]
+  ): string[] {
+    const liveColumns = this.db.query(`PRAGMA table_info(${sourceTable})`).all() as TableColumnInfo[];
+    const extraColumns = liveColumns.filter(col => !knownColumns.includes(col.name));
+    for (const col of extraColumns) {
+      const type = col.type ? ` ${col.type}` : '';
+      const dflt = col.dflt_value === null || col.dflt_value === undefined ? '' : ` DEFAULT ${col.dflt_value}`;
+      this.db.run(`ALTER TABLE ${newTable} ADD COLUMN "${col.name}"${type}${dflt}`);
+      logger.debug('DB', `Carried ${col.name} over the ${sourceTable} rebuild (#3849)`);
+    }
+    // Copy only columns the source actually has. Known CREATE columns that
+    // the live table never grew (e.g. v8 hierarchical fields) stay at their
+    // new-table defaults instead of failing the SELECT.
+    return liveColumns.map(col => col.name);
+  }
+
   private removeSessionSummariesUniqueConstraint(): void {
     const summariesIndexes = this.db.query('PRAGMA index_list(session_summaries)').all() as IndexInfo[];
     // Only table-level UNIQUE constraints (PRAGMA origin 'u' — the v7 target,
@@ -1143,7 +1185,7 @@ export class SessionStore {
         prompt_number INTEGER,
         created_at TEXT NOT NULL,
         created_at_epoch INTEGER NOT NULL,
-        FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE
+        FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE CASCADE
       )
     `);
 
@@ -1248,7 +1290,7 @@ export class SessionStore {
         prompt_number INTEGER,
         created_at TEXT NOT NULL,
         created_at_epoch INTEGER NOT NULL,
-        FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE
+        FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE CASCADE
       )
     `);
 
@@ -1486,28 +1528,27 @@ export class SessionStore {
   }
 
   private addOnUpdateCascadeToForeignKeys(): void {
-    const applied = this.db.prepare('SELECT version FROM schema_versions WHERE version = ?').get(21) as SchemaVersion | undefined;
-    if (applied) return;
+    // Introspection, not the version row: v7 (and v9) can rebuild these
+    // tables after v21 is already stamped and silently drop ON UPDATE
+    // CASCADE. The live FK clause is the only reliable guard (#3849).
+    const observationsNeedsCascade = !this.hasMemorySessionIdOnUpdateCascade('observations');
+    const summariesNeedsCascade = !this.hasMemorySessionIdOnUpdateCascade('session_summaries');
+
+    if (!observationsNeedsCascade && !summariesNeedsCascade) {
+      this.db.prepare('INSERT OR IGNORE INTO schema_versions (version, applied_at) VALUES (?, ?)').run(21, new Date().toISOString());
+      return;
+    }
 
     logger.debug('DB', 'Adding ON UPDATE CASCADE to FK constraints on observations and session_summaries');
 
     this.db.run('PRAGMA foreign_keys = OFF');
     this.db.run('BEGIN TRANSACTION');
 
-    this.db.run('DROP TRIGGER IF EXISTS observations_ai');
-    this.db.run('DROP TRIGGER IF EXISTS observations_ad');
-    this.db.run('DROP TRIGGER IF EXISTS observations_au');
-
-    this.db.run('DROP TABLE IF EXISTS observations_new');
-
-    const observationsCols = this.db.query('PRAGMA table_info(observations)').all() as TableColumnInfo[];
-    const observationsHasMetadata = observationsCols.some(c => c.name === 'metadata');
-    const observationsHasContentHash = observationsCols.some(c => c.name === 'content_hash');
-    const metadataColumnSQL = observationsHasMetadata ? ',\n        metadata TEXT' : '';
-    const metadataSelectSQL = observationsHasMetadata ? ', metadata' : '';
-    const contentHashColumnSQL = observationsHasContentHash ? ',\n        content_hash TEXT' : '';
-    const contentHashSelectSQL = observationsHasContentHash ? ', content_hash' : '';
-
+    const observationsKnownColumns = [
+      'id', 'memory_session_id', 'project', 'text', 'type', 'title', 'subtitle',
+      'facts', 'narrative', 'concepts', 'files_read', 'files_modified',
+      'prompt_number', 'discovery_tokens', 'created_at', 'created_at_epoch',
+    ];
     const observationsNewSQL = `
       CREATE TABLE observations_new (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1525,16 +1566,9 @@ export class SessionStore {
         prompt_number INTEGER,
         discovery_tokens INTEGER DEFAULT 0,
         created_at TEXT NOT NULL,
-        created_at_epoch INTEGER NOT NULL${metadataColumnSQL}${contentHashColumnSQL},
+        created_at_epoch INTEGER NOT NULL,
         FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE CASCADE
       )
-    `;
-    const observationsCopySQL = `
-      INSERT INTO observations_new
-      SELECT id, memory_session_id, project, text, type, title, subtitle, facts,
-             narrative, concepts, files_read, files_modified, prompt_number,
-             discovery_tokens, created_at, created_at_epoch${metadataSelectSQL}${contentHashSelectSQL}
-      FROM observations
     `;
     const observationsIndexesSQL = `
       CREATE INDEX idx_observations_sdk_session ON observations(memory_session_id);
@@ -1561,12 +1595,11 @@ export class SessionStore {
       END;
     `;
 
-    this.db.run('DROP TRIGGER IF EXISTS session_summaries_ai');
-    this.db.run('DROP TRIGGER IF EXISTS session_summaries_ad');
-    this.db.run('DROP TRIGGER IF EXISTS session_summaries_au');
-
-    this.db.run('DROP TABLE IF EXISTS session_summaries_new');
-
+    const summariesKnownColumns = [
+      'id', 'memory_session_id', 'project', 'request', 'investigated', 'learned',
+      'completed', 'next_steps', 'files_read', 'files_edited', 'notes',
+      'prompt_number', 'discovery_tokens', 'created_at', 'created_at_epoch',
+    ];
     const summariesNewSQL = `
       CREATE TABLE session_summaries_new (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1586,13 +1619,6 @@ export class SessionStore {
         created_at_epoch INTEGER NOT NULL,
         FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE CASCADE
       )
-    `;
-    const summariesCopySQL = `
-      INSERT INTO session_summaries_new
-      SELECT id, memory_session_id, project, request, investigated, learned,
-             completed, next_steps, files_read, files_edited, notes,
-             prompt_number, discovery_tokens, created_at, created_at_epoch
-      FROM session_summaries
     `;
     const summariesIndexesSQL = `
       CREATE INDEX idx_session_summaries_sdk_session ON session_summaries(memory_session_id);
@@ -1619,8 +1645,30 @@ export class SessionStore {
     `;
 
     try {
-      this.recreateObservationsWithCascade(observationsNewSQL, observationsCopySQL, observationsIndexesSQL, observationsFTSTriggersSQL);
-      this.recreateSessionSummariesWithCascade(summariesNewSQL, summariesCopySQL, summariesIndexesSQL, summariesFTSTriggersSQL);
+      if (observationsNeedsCascade) {
+        this.db.run('DROP TRIGGER IF EXISTS observations_ai');
+        this.db.run('DROP TRIGGER IF EXISTS observations_ad');
+        this.db.run('DROP TRIGGER IF EXISTS observations_au');
+        this.db.run('DROP TABLE IF EXISTS observations_new');
+        this.recreateObservationsWithCascade(
+          observationsNewSQL,
+          observationsKnownColumns,
+          observationsIndexesSQL,
+          observationsFTSTriggersSQL
+        );
+      }
+      if (summariesNeedsCascade) {
+        this.db.run('DROP TRIGGER IF EXISTS session_summaries_ai');
+        this.db.run('DROP TRIGGER IF EXISTS session_summaries_ad');
+        this.db.run('DROP TRIGGER IF EXISTS session_summaries_au');
+        this.db.run('DROP TABLE IF EXISTS session_summaries_new');
+        this.recreateSessionSummariesWithCascade(
+          summariesNewSQL,
+          summariesKnownColumns,
+          summariesIndexesSQL,
+          summariesFTSTriggersSQL
+        );
+      }
 
       this.db.prepare('INSERT OR IGNORE INTO schema_versions (version, applied_at) VALUES (?, ?)').run(21, new Date().toISOString());
       this.db.run('COMMIT');
@@ -1636,9 +1684,16 @@ export class SessionStore {
     }
   }
 
-  private recreateObservationsWithCascade(createSQL: string, copySQL: string, indexesSQL: string, ftsTriggersSQL: string): void {
+  private recreateObservationsWithCascade(
+    createSQL: string,
+    knownColumns: string[],
+    indexesSQL: string,
+    ftsTriggersSQL: string
+  ): void {
     this.db.run(createSQL);
-    this.db.run(copySQL);
+    const copyColumns = this.carryLiveColumnsOntoNewTable('observations', 'observations_new', knownColumns);
+    const quoted = copyColumns.map(name => `"${name}"`).join(', ');
+    this.db.run(`INSERT INTO observations_new (${quoted}) SELECT ${quoted} FROM observations`);
     this.db.run('DROP TABLE observations');
     this.db.run('ALTER TABLE observations_new RENAME TO observations');
     this.db.run(indexesSQL);
@@ -1649,9 +1704,16 @@ export class SessionStore {
     }
   }
 
-  private recreateSessionSummariesWithCascade(createSQL: string, copySQL: string, indexesSQL: string, ftsTriggersSQL: string): void {
+  private recreateSessionSummariesWithCascade(
+    createSQL: string,
+    knownColumns: string[],
+    indexesSQL: string,
+    ftsTriggersSQL: string
+  ): void {
     this.db.run(createSQL);
-    this.db.run(copySQL);
+    const copyColumns = this.carryLiveColumnsOntoNewTable('session_summaries', 'session_summaries_new', knownColumns);
+    const quoted = copyColumns.map(name => `"${name}"`).join(', ');
+    this.db.run(`INSERT INTO session_summaries_new (${quoted}) SELECT ${quoted} FROM session_summaries`);
     this.db.run('DROP TABLE session_summaries');
     this.db.run('ALTER TABLE session_summaries_new RENAME TO session_summaries');
     this.db.run(indexesSQL);

--- a/tests/sqlite/session-store-migrations.test.ts
+++ b/tests/sqlite/session-store-migrations.test.ts
@@ -735,6 +735,14 @@ describe('SessionStore migrations', () => {
     expect(sessionFk?.on_delete).toBe('CASCADE');
   });
 
+  it('a fresh session_summaries FK uses ON UPDATE CASCADE and ON DELETE CASCADE', () => {
+    store = new SessionStore(':memory:');
+    const fks = store.db.query('PRAGMA foreign_key_list(session_summaries)').all() as Array<{ table: string; on_update: string; on_delete: string }>;
+    const sessionFk = fks.find(fk => fk.table === 'sdk_sessions');
+    expect(sessionFk?.on_update).toBe('CASCADE');
+    expect(sessionFk?.on_delete).toBe('CASCADE');
+  });
+
   it('fresh DB uses composite sdk session identity and session-scoped prompt/pending indexes', () => {
     store = new SessionStore(':memory:');
 

--- a/tests/sqlite/session-store-v7-rebuild-keeps-cascade.test.ts
+++ b/tests/sqlite/session-store-v7-rebuild-keeps-cascade.test.ts
@@ -1,0 +1,329 @@
+// Regression tests for #3849: two DDL paths disagreed on the
+// session_summaries.memory_session_id FK. addOnUpdateCascadeToForeignKeys
+// (v21) is version-row gated and runs once; removeSessionSummariesUniqueConstraint
+// (v7) is introspection-gated and can fire later, recreating the table with
+// ON DELETE CASCADE only. Parent-key rewrites in ensureMemorySessionIdRegistered
+// then throw FOREIGN KEY constraint failed for any session that already has a
+// summary. The same class of defect as #3890, on the FK clause rather than the
+// column list.
+import { describe, it, expect, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { mkdtempSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { SessionStore } from '../../src/services/sqlite/SessionStore.js';
+
+const ISO = '2025-07-01T00:00:00.000Z';
+const EPOCH = 1751328000000;
+
+function createBaseTables(db: Database, observationsOnUpdate: 'CASCADE' | 'NO ACTION' = 'CASCADE'): void {
+  db.run(`
+    CREATE TABLE schema_versions (
+      id INTEGER PRIMARY KEY,
+      version INTEGER UNIQUE NOT NULL,
+      applied_at TEXT NOT NULL
+    )
+  `);
+  db.run(`
+    CREATE TABLE sdk_sessions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      content_session_id TEXT NOT NULL,
+      memory_session_id TEXT UNIQUE,
+      project TEXT NOT NULL,
+      platform_source TEXT NOT NULL DEFAULT 'claude',
+      user_prompt TEXT,
+      started_at TEXT NOT NULL,
+      started_at_epoch INTEGER NOT NULL,
+      completed_at TEXT,
+      completed_at_epoch INTEGER,
+      status TEXT CHECK(status IN ('active', 'completed', 'failed')) NOT NULL DEFAULT 'active'
+    )
+  `);
+  const observationsUpdate = observationsOnUpdate === 'CASCADE' ? ' ON UPDATE CASCADE' : '';
+  db.run(`
+    CREATE TABLE observations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      memory_session_id TEXT NOT NULL,
+      project TEXT NOT NULL,
+      text TEXT,
+      type TEXT NOT NULL,
+      discovery_tokens INTEGER DEFAULT 0,
+      created_at TEXT NOT NULL,
+      created_at_epoch INTEGER NOT NULL,
+      FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE${observationsUpdate}
+    )
+  `);
+  db.prepare(`
+    INSERT INTO sdk_sessions (content_session_id, memory_session_id, project, started_at, started_at_epoch, status)
+    VALUES ('content-healthy', 'mem-healthy', 'proj-a', ?, ?, 'completed')
+  `).run(ISO, EPOCH);
+}
+
+/**
+ * The terminal v21 → v7 order: UNIQUE constraint still present (so v7 will
+ * rebuild) but version 21 is already stamped (so a version-row-gated v21
+ * would refuse to repair whatever the rebuild leaves behind).
+ */
+function seedDbWithUniqueConstraintAfterV21(dbPath: string): void {
+  const db = new Database(dbPath);
+  db.run('PRAGMA foreign_keys = OFF');
+  createBaseTables(db);
+  db.run(`
+    CREATE TABLE session_summaries (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      memory_session_id TEXT UNIQUE NOT NULL,
+      project TEXT NOT NULL,
+      request TEXT,
+      investigated TEXT,
+      learned TEXT,
+      completed TEXT,
+      next_steps TEXT,
+      files_read TEXT,
+      files_edited TEXT,
+      notes TEXT,
+      discovery_tokens INTEGER DEFAULT 0,
+      merged_into_project TEXT,
+      created_at TEXT NOT NULL,
+      created_at_epoch INTEGER NOT NULL,
+      FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE CASCADE
+    )
+  `);
+  for (const version of [4, 11, 21]) {
+    db.prepare('INSERT INTO schema_versions (version, applied_at) VALUES (?, ?)').run(version, ISO);
+  }
+  db.prepare(`
+    INSERT INTO session_summaries
+      (memory_session_id, project, request, discovery_tokens, merged_into_project, created_at, created_at_epoch)
+    VALUES ('mem-healthy', 'proj-a', 'first summary', 42, 'keep-merged', ?, ?)
+  `).run(ISO, EPOCH);
+  db.run('PRAGMA foreign_keys = ON');
+  db.close();
+}
+
+/**
+ * A database the old v7 rebuild already ran on after v21: no UNIQUE, version
+ * 21 stamped, session_summaries FK is ON DELETE CASCADE only. Later columns
+ * and values must survive the repair.
+ */
+function seedDbThatAlreadyLostCascade(dbPath: string): void {
+  const db = new Database(dbPath);
+  db.run('PRAGMA foreign_keys = OFF');
+  createBaseTables(db);
+  db.run(`
+    CREATE TABLE session_summaries (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      memory_session_id TEXT NOT NULL,
+      project TEXT NOT NULL,
+      request TEXT,
+      investigated TEXT,
+      learned TEXT,
+      completed TEXT,
+      next_steps TEXT,
+      files_read TEXT,
+      files_edited TEXT,
+      notes TEXT,
+      prompt_number INTEGER,
+      discovery_tokens INTEGER DEFAULT 0,
+      merged_into_project TEXT,
+      synced_at INTEGER,
+      origin_device_id TEXT,
+      origin_local_id TEXT,
+      sync_rev TEXT NOT NULL DEFAULT '1',
+      created_at TEXT NOT NULL,
+      created_at_epoch INTEGER NOT NULL,
+      FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE
+    )
+  `);
+  for (const version of [4, 7, 11, 21]) {
+    db.prepare('INSERT INTO schema_versions (version, applied_at) VALUES (?, ?)').run(version, ISO);
+  }
+  db.prepare(`
+    INSERT INTO session_summaries
+      (memory_session_id, project, request, discovery_tokens, merged_into_project, synced_at,
+       origin_device_id, origin_local_id, sync_rev, created_at, created_at_epoch)
+    VALUES ('mem-healthy', 'proj-a', 'already summarised', 7, 'keep-merged', 99,
+            'dev-1', 'local-9', '5', ?, ?)
+  `).run(ISO, EPOCH);
+  db.prepare(`
+    INSERT INTO observations (memory_session_id, project, text, type, created_at, created_at_epoch)
+    VALUES ('mem-healthy', 'proj-a', 'healthy text', 'discovery', ?, ?)
+  `).run(ISO, EPOCH);
+  db.run('PRAGMA foreign_keys = ON');
+  db.close();
+}
+
+function seedDbThatLostObservationsCascade(dbPath: string): void {
+  const db = new Database(dbPath);
+  db.run('PRAGMA foreign_keys = OFF');
+  createBaseTables(db, 'NO ACTION');
+  db.run(`
+    CREATE TABLE session_summaries (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      memory_session_id TEXT NOT NULL,
+      project TEXT NOT NULL,
+      request TEXT,
+      created_at TEXT NOT NULL,
+      created_at_epoch INTEGER NOT NULL,
+      FOREIGN KEY(memory_session_id) REFERENCES sdk_sessions(memory_session_id) ON DELETE CASCADE ON UPDATE CASCADE
+    )
+  `);
+  for (const version of [4, 7, 9, 11, 21]) {
+    db.prepare('INSERT INTO schema_versions (version, applied_at) VALUES (?, ?)').run(version, ISO);
+  }
+  db.prepare(`
+    INSERT INTO observations (memory_session_id, project, text, type, created_at, created_at_epoch)
+    VALUES ('mem-healthy', 'proj-a', 'obs that should cascade', 'discovery', ?, ?)
+  `).run(ISO, EPOCH);
+  db.run('PRAGMA foreign_keys = ON');
+  db.close();
+}
+
+function memorySessionFk(db: Database, table: 'observations' | 'session_summaries'): { on_update: string; on_delete: string } | undefined {
+  const fks = db.query(`PRAGMA foreign_key_list(${table})`).all() as Array<{
+    table: string;
+    from: string;
+    on_update: string;
+    on_delete: string;
+  }>;
+  return fks.find(fk => fk.table === 'sdk_sessions' && fk.from === 'memory_session_id');
+}
+
+function hasTableLevelUniqueConstraint(db: Database): boolean {
+  const indexes = db.query('PRAGMA index_list(session_summaries)').all() as Array<{ unique: number; origin: string }>;
+  return indexes.some(idx => idx.unique === 1 && idx.origin === 'u');
+}
+
+describe('session_summaries ON UPDATE CASCADE survives v7 rebuild (#3849)', () => {
+  let tempDir: string;
+
+  afterEach(() => {
+    if (tempDir && existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  function makeTempDbPath(): string {
+    tempDir = mkdtempSync(path.join(tmpdir(), 'claude-mem-v7-cascade-'));
+    return path.join(tempDir, 'claude-mem.db');
+  }
+
+  it('v7 rebuild after v21 is already stamped still leaves ON UPDATE CASCADE', () => {
+    const dbPath = makeTempDbPath();
+    seedDbWithUniqueConstraintAfterV21(dbPath);
+
+    const store = new SessionStore(dbPath);
+
+    expect(hasTableLevelUniqueConstraint(store.db)).toBe(false);
+    const summaryFk = memorySessionFk(store.db, 'session_summaries');
+    expect(summaryFk?.on_update).toBe('CASCADE');
+    expect(summaryFk?.on_delete).toBe('CASCADE');
+
+    const carried = store.db.prepare(
+      `SELECT discovery_tokens, merged_into_project FROM session_summaries WHERE request = 'first summary'`
+    ).get() as { discovery_tokens: number; merged_into_project: string };
+    expect(carried.discovery_tokens).toBe(42);
+    expect(carried.merged_into_project).toBe('keep-merged');
+
+    const session = store.db.prepare(
+      `SELECT id FROM sdk_sessions WHERE memory_session_id = 'mem-healthy'`
+    ).get() as { id: number };
+    store.ensureMemorySessionIdRegistered(session.id, 'mem-rotated');
+
+    expect(store.db.prepare(
+      `SELECT memory_session_id FROM sdk_sessions WHERE id = ?`
+    ).get(session.id)).toEqual({ memory_session_id: 'mem-rotated' });
+    expect(store.db.prepare(
+      `SELECT memory_session_id FROM session_summaries WHERE request = 'first summary'`
+    ).get()).toEqual({ memory_session_id: 'mem-rotated' });
+
+    store.db.close();
+  });
+
+  it('repairs a database that already lost CASCADE even though version 21 is stamped', () => {
+    const dbPath = makeTempDbPath();
+    seedDbThatAlreadyLostCascade(dbPath);
+
+    const store = new SessionStore(dbPath);
+
+    const summaryFk = memorySessionFk(store.db, 'session_summaries');
+    expect(summaryFk?.on_update).toBe('CASCADE');
+    expect(summaryFk?.on_delete).toBe('CASCADE');
+    const observationFk = memorySessionFk(store.db, 'observations');
+    expect(observationFk?.on_update).toBe('CASCADE');
+
+    const carried = store.db.prepare(`
+      SELECT discovery_tokens, merged_into_project, synced_at, origin_device_id, origin_local_id, sync_rev
+      FROM session_summaries WHERE request = 'already summarised'
+    `).get() as {
+      discovery_tokens: number;
+      merged_into_project: string;
+      synced_at: number;
+      origin_device_id: string;
+      origin_local_id: string;
+      sync_rev: string;
+    };
+    expect(carried.discovery_tokens).toBe(7);
+    expect(carried.merged_into_project).toBe('keep-merged');
+    expect(carried.synced_at).toBe(99);
+    expect(carried.origin_device_id).toBe('dev-1');
+    expect(carried.origin_local_id).toBe('local-9');
+    expect(carried.sync_rev).toBe('5');
+
+    const session = store.db.prepare(
+      `SELECT id FROM sdk_sessions WHERE memory_session_id = 'mem-healthy'`
+    ).get() as { id: number };
+    expect(() => store.ensureMemorySessionIdRegistered(session.id, 'mem-rotated')).not.toThrow();
+    expect(store.db.prepare(
+      `SELECT memory_session_id FROM session_summaries WHERE request = 'already summarised'`
+    ).get()).toEqual({ memory_session_id: 'mem-rotated' });
+    expect(store.db.prepare(
+      `SELECT memory_session_id FROM observations WHERE text = 'healthy text'`
+    ).get()).toEqual({ memory_session_id: 'mem-rotated' });
+
+    store.db.close();
+  });
+
+  it('repairs observations that lost ON UPDATE CASCADE after v21 was stamped', () => {
+    const dbPath = makeTempDbPath();
+    seedDbThatLostObservationsCascade(dbPath);
+
+    const store = new SessionStore(dbPath);
+
+    const observationFk = memorySessionFk(store.db, 'observations');
+    expect(observationFk?.on_update).toBe('CASCADE');
+    expect(observationFk?.on_delete).toBe('CASCADE');
+
+    const session = store.db.prepare(
+      `SELECT id FROM sdk_sessions WHERE memory_session_id = 'mem-healthy'`
+    ).get() as { id: number };
+    store.ensureMemorySessionIdRegistered(session.id, 'mem-rotated');
+    expect(store.db.prepare(
+      `SELECT memory_session_id FROM observations WHERE text = 'obs that should cascade'`
+    ).get()).toEqual({ memory_session_id: 'mem-rotated' });
+
+    store.db.close();
+  });
+
+  it('repair is a no-op on a second boot of an already-repaired database', () => {
+    const dbPath = makeTempDbPath();
+    seedDbThatAlreadyLostCascade(dbPath);
+
+    const first = new SessionStore(dbPath);
+    const session = first.db.prepare(
+      `SELECT id FROM sdk_sessions WHERE memory_session_id = 'mem-healthy'`
+    ).get() as { id: number };
+    first.ensureMemorySessionIdRegistered(session.id, 'mem-rotated');
+    first.db.close();
+
+    const second = new SessionStore(dbPath);
+    expect(memorySessionFk(second.db, 'session_summaries')?.on_update).toBe('CASCADE');
+    expect(second.db.prepare(
+      `SELECT COUNT(*) AS n FROM session_summaries WHERE memory_session_id = 'mem-rotated'`
+    ).get()).toEqual({ n: 1 });
+    expect(() => second.ensureMemorySessionIdRegistered(session.id, 'mem-rotated-again')).not.toThrow();
+    expect(second.db.prepare(
+      `SELECT memory_session_id FROM session_summaries WHERE request = 'already summarised'`
+    ).get()).toEqual({ memory_session_id: 'mem-rotated-again' });
+    second.db.close();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #3849.

After upgrade, `removeSessionSummariesUniqueConstraint()` (v7) could recreate `session_summaries` with `ON DELETE CASCADE` only — even when `addOnUpdateCascadeToForeignKeys()` (v21) had already run. v21 is version-row gated and will not re-apply, so `ensureMemorySessionIdRegistered()` parent-key rewrites then throw `FOREIGN KEY constraint failed` for any session that already has a summary. Same structural class as #3890 / #3955 (column loss on the v7 rebuild), this time on the FK clause.

## Change

`src/services/sqlite/SessionStore.ts` only:

- Every `session_summaries` / `observations` rebuild `CREATE TABLE` now declares `ON DELETE CASCADE ON UPDATE CASCADE` on `memory_session_id` (v7, v9, v21, plus the existing init/v21 templates).
- `addOnUpdateCascadeToForeignKeys()` is guarded by `PRAGMA foreign_key_list` (`on_update = CASCADE`), not by the presence of schema version 21. If a later rebuild stripped the clause, v21 repairs it even when the version row is already stamped.
- That repair copies live columns via `PRAGMA table_info` (same discipline as #3955) so post-v21 columns (`merged_into_project`, sync origin fields, etc.) are not dropped.

No version bump. Structural migration unification (one DDL source of truth / plan-21 / #3609) stays as follow-up; the RCA-later note on #3849 should remain visible.

## Tests

`tests/sqlite/session-store-v7-rebuild-keeps-cascade.test.ts`:

- v21 stamped + table-level UNIQUE still present (so v7 rebuilds): CASCADE survives, later-column values survive, `ensureMemorySessionIdRegistered` updates the parent and the summary row follows.
- Already-broken DB (v7 + v21 stamped, summaries FK is delete-only): repair restores CASCADE, later-column values survive, parent-key rewrite succeeds for a session that already has a summary (and its observations).
- Same repair for observations that lost CASCADE after v21.
- Second boot of a repaired DB is a no-op.

Also asserts a fresh `session_summaries` FK has both cascade clauses.

Local: `bun test tests/sqlite/` → 129 pass. `tsc --noEmit` clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6265abc1-89c4-48c3-85c3-886e1e528ac9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6265abc1-89c4-48c3-85c3-886e1e528ac9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

