### PR TITLE
fix(observer): don't confirm the queued batch on mid-stream empty SDK chunks (#3869)

### DIFF
--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -514,27 +514,35 @@ export class ClaudeProvider {
             });
           }
 
+          // The turn is over and the model never emitted text. Only a
+          // successful turn means "the model read the batch and chose to skip
+          // it" — forward the empty response once so the claim is acknowledged
+          // instead of being retried forever. An error result never reached
+          // that judgement, so its batch stays claimed and the next generator
+          // pass re-yields it (SessionManager.getMessageIterator).
           if (!turnDispatchedText) {
-            // The whole turn carried no text, so no frame handed the claimed
-            // batch to the parser. Do it once here with the empty response the
-            // turn actually produced: the batch is classified idle and
-            // confirmed, exactly as before #3492's frame-level skip. Skipping
-            // this would leave the batch claimed until session teardown
-            // disposes the in-RAM buffer, which drops it with no hand-off.
-            await processAgentResponse(
-              '',
-              session,
-              this.dbManager,
-              this.sessionManager,
-              worker,
-              (session.cumulativeInputTokens + session.cumulativeOutputTokens) - discoveryTokenBaseline,
-              session.earliestPendingTimestamp,
-              'SDK',
-              cwdTracker.lastCwd,
-              modelId,
-              activeResponseContext.current
-            );
-            discoveryTokenBaseline = session.cumulativeInputTokens + session.cumulativeOutputTokens;
+            const resultSubtype = (message as any).subtype as string | undefined;
+            if ((message as any).is_error === true || resultSubtype !== 'success') {
+              logger.warn('SDK', 'SDK turn failed before emitting text, leaving queue intact', {
+                sessionId: session.sessionDbId,
+                subtype: resultSubtype,
+              });
+            } else {
+              await processAgentResponse(
+                '',
+                session,
+                this.dbManager,
+                this.sessionManager,
+                worker,
+                (session.cumulativeInputTokens + session.cumulativeOutputTokens) - discoveryTokenBaseline,
+                session.earliestPendingTimestamp,
+                'SDK',
+                cwdTracker.lastCwd,
+                modelId,
+                activeResponseContext.current
+              );
+              discoveryTokenBaseline = session.cumulativeInputTokens + session.cumulativeOutputTokens;
+            }
           }
           turnDispatchedText = false;
         }

--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -303,6 +303,8 @@ export class ClaudeProvider {
       // without one still needs the idle hand-off, otherwise the claimed batch
       // is left dangling for session teardown to discard.
       let turnDispatchedText = false;
+      // One re-queue per generator pass for a batch a failed turn never read.
+      let retriedAfterErrorResult = false;
 
       for await (const message of queryResult) {
         // Quota-aware wall-clock guard (#2234): the SDK pushes
@@ -514,19 +516,25 @@ export class ClaudeProvider {
             });
           }
 
+          const resultSubtype = (message as any).subtype as string | undefined;
+          const resultIsError = (message as any).is_error === true || resultSubtype !== 'success';
+
           // The turn is over and the model never emitted text. Only a
           // successful turn means "the model read the batch and chose to skip
           // it" — forward the empty response once so the claim is acknowledged
-          // instead of being retried forever. An error result never reached
-          // that judgement, so its batch stays claimed and the next generator
-          // pass re-yields it (SessionManager.getMessageIterator).
+          // instead of being retried forever. A failed turn never reached that
+          // judgement, so its batch goes back to the buffer for the drain to
+          // re-yield. Exactly one such retry per generator pass: a message is
+          // always pending while a batch is re-queued, so the buffer never
+          // idles out, and an endlessly failing turn would spin on it.
           if (!turnDispatchedText) {
-            const resultSubtype = (message as any).subtype as string | undefined;
-            if ((message as any).is_error === true || resultSubtype !== 'success') {
-              logger.warn('SDK', 'SDK turn failed before emitting text, leaving queue intact', {
+            if (resultIsError && !retriedAfterErrorResult) {
+              retriedAfterErrorResult = true;
+              logger.warn('SDK', 'SDK turn failed before emitting text, re-queueing the claimed batch', {
                 sessionId: session.sessionDbId,
                 subtype: resultSubtype,
               });
+              await this.sessionManager.resetProcessingToPending(session.sessionDbId);
             } else {
               await processAgentResponse(
                 '',
@@ -543,6 +551,9 @@ export class ClaudeProvider {
               );
               discoveryTokenBaseline = session.cumulativeInputTokens + session.cumulativeOutputTokens;
             }
+          }
+          if (!resultIsError) {
+            retriedAfterErrorResult = false;
           }
           turnDispatchedText = false;
         }

--- a/tests/worker/claude-provider-assistant-frames.test.ts
+++ b/tests/worker/claude-provider-assistant-frames.test.ts
@@ -93,12 +93,15 @@ function assistantFrame(content: unknown) {
   };
 }
 
-function resultFrame() {
+function resultFrame(overrides: Record<string, unknown> = {}) {
   return {
     type: 'result',
     session_id: MEMORY_SESSION_ID,
+    subtype: 'success',
+    is_error: false,
     usage: { input_tokens: 120, output_tokens: 40 },
     total_cost_usd: 0.001,
+    ...overrides,
   };
 }
 
@@ -326,5 +329,22 @@ describe('ClaudeProvider assistant frame dispatch (#3492)', () => {
     // the flag must not stay latched from the first turn.
     expect(harness.storeObservations).toHaveBeenCalledTimes(1);
     expect(harness.confirmClaimedMessages).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-queues the claimed batch when a textless turn ends on an SDK error (#3869)', async () => {
+    const session = createSession();
+    const harness = createHarness(session);
+
+    scriptedMessages = [
+      assistantFrame([{ type: 'thinking', thinking: 'considering the batch', signature: 'sig' }]),
+      resultFrame({ subtype: 'error_during_execution', is_error: true }),
+    ];
+
+    await harness.provider.startSession(session);
+
+    expect(harness.storeObservations).not.toHaveBeenCalled();
+    expect(harness.confirmClaimedMessages).not.toHaveBeenCalled();
+    expect(harness.resetProcessingToPending).toHaveBeenCalledTimes(1);
+    expect(harness.remainingClaimed()).toHaveLength(1);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebase of #3869 onto current `main` after #3501 / #3877 / #3453 / #3894.

## Why a new PR

#3869 could not be updated on the fork (maintainer `update-branch` 403). Its first commit (`forward empty response once per turn`) is already landed by #3501. This PR keeps #3501's `hasTextBlock` / `turnDispatchedText` gating and applies only the remaining unique #3869 work: do not confirm a claimed batch when a textless turn ends on an SDK error; re-queue it once via `resetProcessingToPending`.

## Gate

1. RCA: YES — original #3869 body + #3454 / #3606. Mid-stream empty chunks were the volume; failed textless results were the leftover confirm-on-error path.
2. No second-system: YES — same ClaudeProvider result branch, not a parallel dispatcher.
3. Narrow: YES — error-result re-queue only.

## Verification

- Rebase onto `main` @ 7335467f is clean.
- `bun test tests/worker/claude-provider-assistant-frames.test.ts tests/worker/agents/response-processor.test.ts` → 38 pass.

## Credits

Original work by @EugeneChung in #3869.

Co-authored-by: Euigeun Chung <euigeun@dable.io>

Closes #3869

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d2a568f-4f7b-4486-bd8e-42634a6219d6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d2a568f-4f7b-4486-bd8e-42634a6219d6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

