### PR TITLE
fix(sync): quarantine stale content-outbox origin_device_id after device remint

### DIFF
--- a/src/services/sync/CloudSync.ts
+++ b/src/services/sync/CloudSync.ts
@@ -91,6 +91,17 @@ interface MutationOutboxRow {
   operation_sha256: string | null;
 }
 
+interface ContentOutboxRow {
+  id: string;
+  entity_id: string;
+  kind: string;
+  origin_local_id: string;
+  entity_rev: string;
+  body: string;
+  operation_sha256: string;
+  deleted: number;
+}
+
 interface AckedOp {
   id: string;
   kind: string;
@@ -485,6 +496,7 @@ export class CloudSync {
       deviceName: this.deviceName,
       tokenLength: this.token.length, // never the token itself
     });
+    // flush() drops reminted-device stale outbox snapshots before drain.
     void this.flush();
   }
 
@@ -526,6 +538,7 @@ export class CloudSync {
     }
     this.flushing = true;
     try {
+      this.dropStaleOriginDeviceIdSnapshots();
       do {
         this.flushAgainRequested = false;
         await this.drainContentOutbox();
@@ -954,11 +967,13 @@ export class CloudSync {
   }
 
   /**
-   * After a device-id mint, hash-locked sync_outbox rows still carry the old
-   * origin_device_id. The hub 400s the whole batch and nothing else removes
-   * those poison heads, so healthy ops behind them never drain. Dead-letter
-   * the mismatched mutation ops and return the rest of the batch (or null
-   * when this is not that failure class / no matching rows were found).
+   * After a device-id mint, hash-locked sync_outbox / sync_content_outbox
+   * rows still carry the old origin_device_id. The hub 400s the whole batch
+   * and nothing else removes those poison heads, so healthy ops behind them
+   * never drain. Dead-letter the mismatched ops (content rows are dropped so
+   * drainKind can resnapshot under this.deviceId) and return the rest of the
+   * batch (or null when this is not that failure class / no matching rows
+   * were found).
    */
   private dropStaleOriginDeviceIdOps(ops: WireOp[], error: unknown): WireOp[] | null {
     const reason = error instanceof Error ? error.message : String(error);
@@ -966,13 +981,49 @@ export class CloudSync {
     const kept: WireOp[] = [];
     let quarantined = 0;
     for (const op of ops) {
-      if (this.quarantineStaleOriginDeviceIdMutation(op, reason)) {
+      if (
+        this.quarantineStaleOriginDeviceIdMutation(op, reason)
+        || this.quarantineStaleOriginDeviceIdContent(op, reason)
+      ) {
         quarantined++;
         continue;
       }
       kept.push(op);
     }
     return quarantined === 0 ? null : kept;
+  }
+
+  /**
+   * Client-side outbox hygiene after a device-id remint. Frozen content
+   * snapshots (and mutation canonical bodies) whose origin_device_id is not
+   * this.deviceId can never pass hub auth; drop them before the first POST
+   * so drainContentOutbox cannot wedge the flush.
+   */
+  private dropStaleOriginDeviceIdSnapshots(): void {
+    if (!this.deviceId) return;
+    const contentRows = this.db.prepare(`
+      SELECT CAST(id AS TEXT) AS id, entity_id, kind, origin_local_id, entity_rev,
+             body, operation_sha256, deleted
+      FROM sync_content_outbox
+      WHERE json_extract(body, '$.origin_device_id') IS NOT NULL
+        AND json_extract(body, '$.origin_device_id') != ?
+    `).all(this.deviceId) as ContentOutboxRow[];
+    const reason = 'stale origin_device_id does not match authenticated X-Device-Id';
+    for (const row of contentRows) {
+      this.quarantineStaleContentOutbox(row, reason);
+    }
+
+    const mutationRows = this.db.prepare(`
+      SELECT CAST(id AS TEXT) AS id, op_uuid, CAST(rev AS TEXT) AS rev,
+             body, canonical_body, operation_sha256
+      FROM sync_outbox
+      WHERE canonical_body IS NOT NULL
+        AND json_extract(canonical_body, '$.origin_device_id') IS NOT NULL
+        AND json_extract(canonical_body, '$.origin_device_id') != ?
+    `).all(this.deviceId) as MutationOutboxRow[];
+    for (const row of mutationRows) {
+      this.quarantineMutation(row, reason);
+    }
   }
 
   private quarantineStaleOriginDeviceIdMutation(op: WireOp, reason: string): boolean {
@@ -1001,6 +1052,74 @@ export class CloudSync {
     if (!row) return false;
     this.quarantineMutation(row, reason);
     return true;
+  }
+
+  private quarantineStaleOriginDeviceIdContent(op: WireOp, reason: string): boolean {
+    let originDeviceId: string | undefined;
+    let entityId: string | undefined;
+    let entityRev: string | undefined;
+    let kind: string | undefined;
+    try {
+      const body = JSON.parse(op.body) as {
+        origin_device_id?: unknown;
+        kind?: unknown;
+        id?: unknown;
+        entity_rev?: unknown;
+      };
+      if (typeof body.origin_device_id === 'string') originDeviceId = body.origin_device_id;
+      if (typeof body.id === 'string') entityId = body.id;
+      if (typeof body.entity_rev === 'string') entityRev = body.entity_rev;
+      if (typeof body.kind === 'string') kind = body.kind;
+    } catch {
+      return false;
+    }
+    if (!originDeviceId || originDeviceId === this.deviceId) return false;
+    if (!kind || !(kind in TABLE_BY_KIND) || !entityId || !entityRev) return false;
+    const row = this.db.prepare(`
+      SELECT CAST(id AS TEXT) AS id, entity_id, kind, origin_local_id, entity_rev,
+             body, operation_sha256, deleted
+      FROM sync_content_outbox
+      WHERE entity_id = ? AND entity_rev = ? AND operation_sha256 = ?
+    `).get(entityId, entityRev, op.operation_sha256) as ContentOutboxRow | undefined;
+    if (!row) return false;
+    this.quarantineStaleContentOutbox(row, reason);
+    return true;
+  }
+
+  /**
+   * Dead-letter a frozen content snapshot whose origin_device_id cannot pass
+   * hub auth, then delete it. Native local rows stay at synced_at NULL /
+   * origin_device_id NULL so drainKind resnapshots under this.deviceId.
+   * Tombstones have no local row left; dropping them is the only safe move
+   * (the old identity cannot be rewritten without forking attribution).
+   */
+  private quarantineStaleContentOutbox(row: ContentOutboxRow, reason: string): void {
+    const table = TABLE_BY_KIND[row.kind as RowKind];
+    const tx = this.db.transaction(() => {
+      this.db.prepare(`
+        INSERT INTO sync_dead_letter
+          (lane, queue_key, kind, origin_local_id, entity_rev, reason, raw_body, created_at_epoch)
+        VALUES ('content', ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(lane, queue_key, entity_rev, reason) DO NOTHING
+      `).run(row.entity_id, row.kind, row.origin_local_id, row.entity_rev, reason, row.body, Date.now());
+      this.db.prepare('DELETE FROM sync_content_outbox WHERE id = ?').run(row.id);
+      if (row.deleted === 0 && table) {
+        // Re-queue native rows that were never successfully stamped. Do not
+        // unstamp a current-device ack (synced_at > 0) — that would loop
+        // drainKind against an already-projected head.
+        this.db.prepare(`
+          UPDATE ${table} SET synced_at = NULL
+          WHERE id = ? AND origin_device_id IS NULL AND (synced_at IS NULL OR synced_at < 0)
+        `).run(row.origin_local_id);
+      }
+    });
+    tx();
+    logger.error('CLOUD_SYNC', 'Dropped stale content outbox snapshot; local row left unsynced for resnapshot', {
+      kind: row.kind,
+      originLocalId: row.origin_local_id,
+      entityRev: row.entity_rev,
+      reason,
+    });
   }
 
   private async pushOps(ops: WireOp[]): Promise<PushResponse> {

--- a/tests/worker/sync/cloud-sync.test.ts
+++ b/tests/worker/sync/cloud-sync.test.ts
@@ -1066,7 +1066,7 @@ describe('CloudSync', () => {
       expect(sync.status().lastError).toBeNull();
       expect(sync.status().quarantine.count).toBe(1);
       expect(sync.status().quarantine.latestReason).toMatch(
-        /invalid_ops: ops\[0\] origin_device_id does not match authenticated X-Device-Id/,
+        /origin_device_id does not match authenticated X-Device-Id/,
       );
       const dead = db.prepare(
         "SELECT queue_key, raw_body FROM sync_dead_letter WHERE lane = 'mutation'"
@@ -1117,6 +1117,112 @@ describe('CloudSync', () => {
       expect(calls.some(c =>
         c.parsed.ops.some((o: { kind: string; body: { fields?: { custom_title?: string } } }) =>
           o.kind === 'mutation' && o.body.fields?.custom_title === 'healthy title',
+        ),
+      )).toBe(true);
+      sync.stop();
+    });
+
+    function seedFrozenStaleContent(originLocalId: string, title: string, deleted = false): string {
+      const op = buildContentOperation({
+        kind: 'observation',
+        originDeviceId: STALE_DEVICE_ID,
+        originLocalId,
+        entityRev: '1',
+        payload: deleted ? null : observationPayload(title),
+        deleted,
+        deletedAt: deleted ? ISO : undefined,
+      });
+      const body = JSON.parse(op.body) as { id: string };
+      db.prepare(`
+        INSERT INTO sync_content_outbox
+          (entity_id, kind, origin_local_id, entity_rev, body,
+           operation_sha256, deleted, created_at_epoch)
+        VALUES (?, 'observation', ?, '1', ?, ?, ?, 1)
+      `).run(body.id, originLocalId, op.body, op.operation_sha256, deleted ? 1 : 0);
+      return body.id;
+    }
+
+    it('drops a reminted-device stale content outbox so flush resnapshots and drains', async () => {
+      seedObservation({ title: 'Title A' });
+      seedObservation({ title: 'healthy later' });
+      const staleEntityId = seedFrozenStaleContent('1', 'Title A');
+      expect(db.prepare('SELECT COUNT(*) AS n FROM sync_content_outbox').get()).toEqual({ n: 1 });
+
+      const { impl, calls } = makeFetchMock(call => {
+        const ops = calls[call - 1]?.wireParsed?.ops ?? [];
+        const hasStale = ops.some((op: { body: string }) => {
+          const body = JSON.parse(op.body) as { origin_device_id?: string };
+          return body.origin_device_id === STALE_DEVICE_ID;
+        });
+        if (!hasStale) return undefined;
+        return new Response(JSON.stringify({
+          error: 'invalid_ops: ops[0] origin_device_id does not match authenticated X-Device-Id',
+        }), { status: 400 });
+      });
+      const sync = makeCloudSync(impl);
+      await sync.flush();
+
+      expect(sync.status().lastError).toBeNull();
+      expect(sync.status().lastFlushAt).not.toBeNull();
+      expect(db.prepare('SELECT COUNT(*) AS n FROM sync_content_outbox').get()).toEqual({ n: 0 });
+      expect(pendingCount('observations')).toBe(0);
+      expect(sync.status().quarantine.count).toBe(1);
+      expect(sync.status().quarantine.latestReason).toMatch(
+        /origin_device_id does not match authenticated X-Device-Id/,
+      );
+
+      const dead = db.prepare(
+        "SELECT queue_key, kind, raw_body FROM sync_dead_letter WHERE lane = 'content'"
+      ).get() as { queue_key: string; kind: string; raw_body: string };
+      expect(dead.queue_key).toBe(staleEntityId);
+      expect(dead.kind).toBe('observation');
+      expect(JSON.parse(dead.raw_body).origin_device_id).toBe(STALE_DEVICE_ID);
+
+      const pushed = calls.flatMap(c => c.wireParsed.ops.map((op: { body: string }) => JSON.parse(op.body)));
+      expect(pushed.every((body: { origin_device_id: string }) => body.origin_device_id === 'device-fixture')).toBe(true);
+      expect(pushed.some((body: { origin_local_id: string; payload?: { title?: string } }) =>
+        body.origin_local_id === '1' && body.payload?.title === 'Title A',
+      )).toBe(true);
+      expect(pushed.some((body: { origin_local_id: string; payload?: { title?: string } }) =>
+        body.origin_local_id === '2' && body.payload?.title === 'healthy later',
+      )).toBe(true);
+      sync.stop();
+    });
+
+    it('drops a reminted-device stale content tombstone so later live snapshots drain', async () => {
+      seedObservation({ title: 'Title A' });
+      seedFrozenStaleContent('99', 'gone', true);
+
+      const { impl, calls } = makeFetchMock(call => {
+        const ops = calls[call - 1]?.wireParsed?.ops ?? [];
+        const hasStale = ops.some((op: { body: string }) => {
+          const body = JSON.parse(op.body) as { origin_device_id?: string };
+          return body.origin_device_id === STALE_DEVICE_ID;
+        });
+        if (!hasStale) return undefined;
+        return new Response(JSON.stringify({
+          error: 'invalid_ops: ops[0] origin_device_id does not match authenticated X-Device-Id',
+        }), { status: 400 });
+      });
+      const sync = makeCloudSync(impl);
+      await sync.flush();
+
+      expect(sync.status().lastError).toBeNull();
+      expect(sync.status().lastFlushAt).not.toBeNull();
+      expect(db.prepare('SELECT COUNT(*) AS n FROM sync_content_outbox').get()).toEqual({ n: 0 });
+      expect(pendingCount('observations')).toBe(0);
+      expect(sync.status().quarantine.count).toBe(1);
+      const dead = db.prepare(
+        "SELECT origin_local_id, raw_body FROM sync_dead_letter WHERE lane = 'content'"
+      ).get() as { origin_local_id: string; raw_body: string };
+      expect(dead.origin_local_id).toBe('99');
+      expect(JSON.parse(dead.raw_body)).toMatchObject({
+        origin_device_id: STALE_DEVICE_ID,
+        deleted: true,
+      });
+      expect(calls.some(c =>
+        c.parsed.ops.some((o: { kind: string; origin_id: string }) =>
+          o.kind === 'observation' && o.origin_id === '1',
         ),
       )).toBe(true);
       sync.stop();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On worker 13.24.8 (Alex Mac), `GET /api/sync/status` showed:

- `lastError`: `sync hub push 400: {"error":"invalid_ops: ops[0] origin_device_id does not match authenticated X-Device-Id"}`
- `lastFlushAt`: `null`

A reminted `deviceId` left a `sync_content_outbox` row frozen to the previous `origin_device_id` (`ee1b7637-…`) while settings `deviceId` was `a21c3dae-…`. `drainContentOutbox` runs before mutations/`drainKind`, so that one stale content op 400s the whole batch and leaves thousands of unsynced rows pending.

`quarantineStaleOriginDeviceIdMutation` already dead-letters mismatched **mutation** ops after that hub 400. Content outbox had no equivalent, so the poison head never cleared.

## Fix

Client outbox hygiene only — hub `X-Device-Id` auth is unchanged.

1. On `flush()` (also reached from `CloudSync.start()`), scan `sync_content_outbox` and frozen `sync_outbox.canonical_body` for `origin_device_id !== this.deviceId`.
2. Dead-letter those rows and delete them. Live content rows stay `synced_at NULL` / `origin_device_id NULL` so `drainKind` resnapshots under the current device id. Stale tombstones are dropped (the old identity cannot be rewritten without forking attribution).
3. The existing hub-400 `invalid_ops` path now quarantines stale **content** ops the same way, so a race that still POSTs a leftover snapshot cannot wedge the flush.

## Test

`tests/worker/sync/cloud-sync.test.ts` covers reminted `deviceId` + stale live content outbox (and a stale tombstone) → flush succeeds, stale row quarantined, later rows drain under the current device id.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abca1d44-0a23-492e-8de9-7b4736aeb9c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abca1d44-0a23-492e-8de9-7b4736aeb9c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

