### PR TITLE
fix(sync): realign outbox origin_device_id onto authenticated X-Device-Id

### DIFF
--- a/src/services/sync/CloudSync.ts
+++ b/src/services/sync/CloudSync.ts
@@ -528,6 +528,11 @@ export class CloudSync {
     try {
       do {
         this.flushAgainRequested = false;
+        // Remint / settings-loss leaves hash-locked outbox heads on the
+        // previous origin_device_id while this launch authenticates as
+        // X-Device-Id: this.deviceId. Realign before any POST so the hub
+        // never sees a mismatched batch (#3973 is the 400 safety net).
+        this.realignPendingOpsToAuthenticatedDevice();
         await this.drainContentOutbox();
         await this.drainMutations();
         for (const kind of KINDS) {
@@ -762,8 +767,10 @@ export class CloudSync {
    * Drain the sync_outbox (migration v42). Acked ops are DELETEd — the
    * outbox is a queue, not data — so the page SELECT naturally advances.
    * set_prompt_session bodies store target.origin_device_id = NULL ("this
-   * device"); the resolved id is substituted here, at push time, keeping
-   * device identity single-sourced (SyncApply DEVICE IDENTITY note).
+   * device"); the authenticated id is stamped here at snapshot time so the
+   * envelope, target, and X-Device-Id cannot diverge (SyncApply DEVICE
+   * IDENTITY note). Stale frozen snapshots are unfrozen by
+   * realignPendingOpsToAuthenticatedDevice() before this drain runs.
    */
   private async drainMutations(): Promise<void> {
     for (;;) {
@@ -807,7 +814,10 @@ export class CloudSync {
             const body = parsed as OpBody;
             if (body.op === 'set_prompt_session' && typeof body.target === 'object' && body.target !== null) {
               const target = body.target as Record<string, unknown>;
-              if (target.origin_device_id == null) target.origin_device_id = this.deviceId;
+              // Local-origin only: NULL / "self" / a reminted stale id all
+              // mean "this device". Stamp the authenticated id here so the
+              // envelope and target cannot diverge from X-Device-Id.
+              target.origin_device_id = this.deviceId;
             }
             op = buildMutationOperation({
               originDeviceId: this.deviceId,
@@ -932,7 +942,8 @@ export class CloudSync {
 
   /** POST one batch to the hub and stamp/delete on ack. */
   private async sendOps(ops: WireOp[]): Promise<void> {
-    let remaining = ops;
+    let remaining = this.rejectMismatchedOriginDeviceIdOps(ops);
+    if (remaining.length === 0) return;
     for (;;) {
       try {
         const response = await this.pushOps(remaining);
@@ -950,6 +961,38 @@ export class CloudSync {
         if (next.length === 0 || this.stopped) return;
         remaining = next;
       }
+    }
+  }
+
+  /**
+   * Never POST an op whose frozen origin_device_id ≠ X-Device-Id. Realign
+   * should have rewritten these; if any slip through, drop them locally
+   * (rewrite tombstones / re-snapshot live content; quarantine mutations)
+   * instead of eating a hub 400 on the whole batch.
+   */
+  private rejectMismatchedOriginDeviceIdOps(ops: WireOp[]): WireOp[] {
+    const kept: WireOp[] = [];
+    for (const op of ops) {
+      const originDeviceId = this.wireOpOriginDeviceId(op);
+      if (originDeviceId === this.deviceId) {
+        kept.push(op);
+        continue;
+      }
+      const reason = 'origin_device_id does not match authenticated X-Device-Id';
+      if (this.quarantineStaleOriginDeviceIdMutation(op, reason)) continue;
+      this.dropOrRewriteStaleContentOp(op);
+    }
+    return kept;
+  }
+
+  private wireOpOriginDeviceId(op: WireOp): string | null {
+    try {
+      const body = JSON.parse(op.body) as { origin_device_id?: unknown };
+      return typeof body.origin_device_id === 'string' && body.origin_device_id.length > 0
+        ? body.origin_device_id
+        : null;
+    } catch {
+      return null;
     }
   }
 
@@ -991,7 +1034,7 @@ export class CloudSync {
     } catch {
       return false;
     }
-    if (!originDeviceId || originDeviceId === this.deviceId || !mutationId) return false;
+    if (originDeviceId === this.deviceId || !mutationId) return false;
     const row = this.db.prepare(`
       SELECT CAST(id AS TEXT) AS id, op_uuid, CAST(rev AS TEXT) AS rev,
              body, canonical_body, operation_sha256
@@ -1484,11 +1527,219 @@ export class CloudSync {
   // -------------------------------------------------------------------------
 
   /**
+   * Unacked outbox snapshots are hash-locked to whatever device id was
+   * current when they were first canonicalised. After a remint they still
+   * carry the previous origin_device_id while this launch sends
+   * X-Device-Id: this.deviceId. Rewrite those pending rows onto the
+   * authenticated id before any POST. Already-acked work is not in the
+   * outbox. #3973 remains the hub-400 safety net.
+   */
+  private realignPendingOpsToAuthenticatedDevice(): void {
+    if (this.deviceId === '') return;
+    const mutations = this.realignPendingMutations();
+    const content = this.realignPendingContent();
+    if (mutations + content === 0) return;
+    logger.info('CLOUD_SYNC', 'Realigned pending outbox ops onto authenticated device id', {
+      deviceId: this.deviceId,
+      mutations,
+      content,
+    });
+  }
+
+  private realignPendingMutations(): number {
+    const rows = this.db.prepare(`
+      SELECT CAST(id AS TEXT) AS id, op_uuid, CAST(rev AS TEXT) AS rev,
+             body, canonical_body, operation_sha256
+      FROM sync_outbox
+    `).all() as MutationOutboxRow[];
+    let rewritten = 0;
+    const tx = this.db.transaction(() => {
+      for (const row of rows) {
+        if (!this.mutationNeedsDeviceRealign(row)) continue;
+        this.rewriteMutationOntoAuthenticatedDevice(row);
+        rewritten++;
+      }
+    });
+    tx();
+    return rewritten;
+  }
+
+  private mutationNeedsDeviceRealign(row: MutationOutboxRow): boolean {
+    if (row.canonical_body !== null) {
+      try {
+        const body = JSON.parse(row.canonical_body) as { origin_device_id?: unknown };
+        if (typeof body.origin_device_id === 'string' && body.origin_device_id === this.deviceId) {
+          return this.mutationBodyTargetNeedsRealign(row.body);
+        }
+      } catch {
+        return true;
+      }
+      return true;
+    }
+    return this.mutationBodyTargetNeedsRealign(row.body);
+  }
+
+  private mutationBodyTargetNeedsRealign(rawBody: string): boolean {
+    try {
+      const parsed = JSON.parse(rawBody) as {
+        op?: unknown;
+        target?: { origin_device_id?: unknown } | null;
+      };
+      if (parsed.op !== 'set_prompt_session' || !parsed.target || typeof parsed.target !== 'object') {
+        return false;
+      }
+      const targetId = parsed.target.origin_device_id;
+      if (targetId == null || targetId === 'self') return false;
+      return targetId !== this.deviceId;
+    } catch {
+      return false;
+    }
+  }
+
+  private rewriteMutationOntoAuthenticatedDevice(row: MutationOutboxRow): void {
+    let nextBody = row.body;
+    try {
+      const parsed = JSON.parse(row.body) as {
+        op?: unknown;
+        target?: Record<string, unknown> | null;
+      };
+      if (
+        parsed.op === 'set_prompt_session'
+        && parsed.target
+        && typeof parsed.target === 'object'
+        && !Array.isArray(parsed.target)
+      ) {
+        parsed.target.origin_device_id = this.deviceId;
+        nextBody = JSON.stringify(parsed);
+      }
+    } catch {
+      nextBody = row.body;
+    }
+    this.db.prepare(`
+      UPDATE sync_outbox
+      SET body = ?, canonical_body = NULL, operation_sha256 = NULL
+      WHERE id = ?
+    `).run(nextBody, row.id);
+  }
+
+  private realignPendingContent(): number {
+    const rows = this.db.prepare(`
+      SELECT CAST(id AS TEXT) AS id, entity_id, kind, origin_local_id,
+             CAST(entity_rev AS TEXT) AS entity_rev, body, deleted
+      FROM sync_content_outbox
+    `).all() as Array<{
+      id: string;
+      entity_id: string;
+      kind: RowKind;
+      origin_local_id: string;
+      entity_rev: string;
+      body: string;
+      deleted: number;
+    }>;
+    let rewritten = 0;
+    const tx = this.db.transaction(() => {
+      for (const row of rows) {
+        let originDeviceId: string | null = null;
+        try {
+          const body = JSON.parse(row.body) as { origin_device_id?: unknown };
+          if (typeof body.origin_device_id === 'string') originDeviceId = body.origin_device_id;
+        } catch {
+          continue;
+        }
+        if (originDeviceId === this.deviceId) continue;
+        if (row.deleted === 1) {
+          this.rewriteStaleContentTombstone(row);
+        } else {
+          // Live snapshot: drop it. The native row stays unsynced
+          // (origin_device_id IS NULL); drainKind re-snapshots under this.deviceId.
+          this.db.prepare('DELETE FROM sync_content_outbox WHERE id = ?').run(row.id);
+        }
+        rewritten++;
+      }
+    });
+    tx();
+    return rewritten;
+  }
+
+  private rewriteStaleContentTombstone(row: {
+    id: string;
+    kind: RowKind;
+    origin_local_id: string;
+    entity_rev: string;
+    body: string;
+  }): void {
+    let deletedAt = new Date().toISOString();
+    try {
+      const body = JSON.parse(row.body) as { deleted_at?: unknown };
+      if (typeof body.deleted_at === 'string' && body.deleted_at.length > 0) {
+        deletedAt = body.deleted_at;
+      }
+    } catch { /* keep now */ }
+    const op = buildContentOperation({
+      kind: row.kind,
+      originDeviceId: this.deviceId,
+      originLocalId: row.origin_local_id,
+      entityRev: row.entity_rev,
+      payload: null,
+      deleted: true,
+      deletedAt,
+    });
+    this.db.prepare('DELETE FROM sync_content_outbox WHERE id = ?').run(row.id);
+    this.db.prepare(`
+      INSERT INTO sync_content_outbox
+        (entity_id, kind, origin_local_id, entity_rev, body,
+         operation_sha256, deleted, created_at_epoch)
+      VALUES (?, ?, ?, ?, ?, ?, 1, ?)
+      ON CONFLICT(entity_id, entity_rev) DO NOTHING
+    `).run(
+      stableDocumentId(row.kind, this.deviceId, row.origin_local_id),
+      row.kind, row.origin_local_id, row.entity_rev,
+      op.body, op.operation_sha256, Date.now(),
+    );
+  }
+
+  private dropOrRewriteStaleContentOp(op: WireOp): void {
+    let entityId: string | undefined;
+    let deleted = false;
+    try {
+      const body = JSON.parse(op.body) as { id?: unknown; deleted?: unknown };
+      if (typeof body.id === 'string') entityId = body.id;
+      deleted = body.deleted === true;
+    } catch {
+      return;
+    }
+    if (!entityId) return;
+    if (deleted) {
+      const row = this.db.prepare(`
+        SELECT CAST(id AS TEXT) AS id, kind, origin_local_id,
+               CAST(entity_rev AS TEXT) AS entity_rev, body
+        FROM sync_content_outbox
+        WHERE entity_id = ? AND operation_sha256 = ?
+      `).get(entityId, op.operation_sha256) as {
+        id: string;
+        kind: RowKind;
+        origin_local_id: string;
+        entity_rev: string;
+        body: string;
+      } | undefined;
+      if (row) this.rewriteStaleContentTombstone(row);
+      return;
+    }
+    this.db.prepare(`
+      DELETE FROM sync_content_outbox
+      WHERE entity_id = ? AND operation_sha256 = ?
+    `).run(entityId, op.operation_sha256);
+  }
+
+  /**
    * Resolve this launch client's stable device id from settings, or mint and
    * immediately persist one. There is no standalone-client state to adopt.
+   * Whitespace-only values are treated as unset — the hub trims X-Device-Id,
+   * so a padded configured id would 400 against its own stamp.
    */
   private resolveDeviceId(configuredId: string): string {
-    if (configuredId) return configuredId;
+    const trimmed = configuredId.trim();
+    if (trimmed) return trimmed;
 
     // First run: mint and persist immediately, so a later
     // transient failure can't mint a different one and fork device identity.

--- a/tests/worker/sync/cloud-sync.test.ts
+++ b/tests/worker/sync/cloud-sync.test.ts
@@ -1014,11 +1014,12 @@ describe('CloudSync', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // After a device-id mint, frozen canonical_body rows stay hash-locked to
-  // the previous origin_device_id. The hub 400s invalid_ops on the batch
-  // head; those poison ops must dead-letter so later healthy ops can drain.
+  // After a device-id mint, frozen canonical_body / content-outbox rows stay
+  // hash-locked to the previous origin_device_id. Flush must rewrite those
+  // unacked snapshots onto the authenticated device id before POST — a hub
+  // 400 is the #3973 safety net, not the recovery path.
   // ---------------------------------------------------------------------------
-  describe('stale origin_device_id invalid_ops quarantine', () => {
+  describe('stale origin_device_id realign before push', () => {
     const STALE_DEVICE_ID = '1e1798f5-1111-4111-8111-111111111111';
     const STALE_OP_UUID = '11111111-1111-4111-8111-111111111111';
     const STALE_OP_UUID_2 = '22222222-2222-4222-8222-222222222222';
@@ -1042,85 +1043,208 @@ describe('CloudSync', () => {
       `).run(opUuid, JSON.stringify(mutation), op.body, op.operation_sha256);
     }
 
-    it('dead-letters a stale-head mutation so the healthy op behind it drains', async () => {
+    function seedUnfrozenStaleTargetMutation(opUuid: string): void {
+      db.prepare(`
+        INSERT INTO sync_outbox (op_uuid, rev, body, created_at_epoch)
+        VALUES (?, 1, ?, 1)
+      `).run(opUuid, JSON.stringify({
+        op: 'set_prompt_session',
+        target: { origin_device_id: STALE_DEVICE_ID, origin_local_id: '99' },
+        fields: { memory_session_id: 'mem-unfrozen' },
+      }));
+    }
+
+    function rejectIfStaleDevice(calls: RecordedRequest[]) {
+      return (call: number) => {
+        const ops = calls[call - 1]?.wireParsed?.ops ?? [];
+        const hasStale = ops.some((op: { body: string }) => {
+          const body = JSON.parse(op.body) as { origin_device_id?: string; mutation?: { target?: { origin_device_id?: string } } };
+          return body.origin_device_id === STALE_DEVICE_ID
+            || body.mutation?.target?.origin_device_id === STALE_DEVICE_ID;
+        });
+        if (!hasStale) return undefined;
+        return new Response(JSON.stringify({
+          error: 'invalid_ops: ops[0] origin_device_id does not match authenticated X-Device-Id',
+        }), { status: 400 });
+      };
+    }
+
+    function expectAuthenticatedStamps(calls: RecordedRequest[], deviceId: string): void {
+      expect(calls.length).toBeGreaterThan(0);
+      for (const call of calls) {
+        expect(call.headers['X-Device-Id']).toBe(deviceId);
+        for (const op of call.wireParsed.ops as Array<{ body: string }>) {
+          const body = JSON.parse(op.body) as {
+            origin_device_id: string;
+            mutation?: { op?: string; target?: { origin_device_id?: string } };
+          };
+          expect(body.origin_device_id).toBe(deviceId);
+          if (body.mutation?.op === 'set_prompt_session') {
+            expect(body.mutation.target?.origin_device_id).toBe(deviceId);
+          }
+        }
+      }
+    }
+
+    it('rewrites a frozen stale-head mutation onto the authenticated device id and drains the healthy op', async () => {
       seedFrozenStaleMutation(STALE_OP_UUID);
       store.createSDKSession('sess-healthy', 'proj-x', 'p', 'healthy title', 'claude');
       expect(outboxRows()[0].op_uuid).toBe(STALE_OP_UUID);
       expect(outboxRows().length).toBe(2);
 
-      const { impl, calls } = makeFetchMock(call => {
-        const ops = calls[call - 1]?.wireParsed?.ops ?? [];
-        const hasStale = ops.some((op: { body: string }) => {
-          const body = JSON.parse(op.body) as { origin_device_id?: string };
-          return body.origin_device_id === STALE_DEVICE_ID;
-        });
-        if (!hasStale) return undefined;
-        return new Response(JSON.stringify({
-          error: 'invalid_ops: ops[0] origin_device_id does not match authenticated X-Device-Id',
-        }), { status: 400 });
-      });
+      const { impl, calls } = makeFetchMock(call => rejectIfStaleDevice(calls)(call));
       const sync = makeCloudSync(impl);
       await sync.flush();
 
       expect(outboxRows().length).toBe(0);
       expect(sync.status().lastError).toBeNull();
-      expect(sync.status().quarantine.count).toBe(1);
-      expect(sync.status().quarantine.latestReason).toMatch(
-        /invalid_ops: ops\[0\] origin_device_id does not match authenticated X-Device-Id/,
-      );
-      const dead = db.prepare(
-        "SELECT queue_key, raw_body FROM sync_dead_letter WHERE lane = 'mutation'"
-      ).get() as { queue_key: string; raw_body: string };
-      expect(dead.queue_key).toBe(STALE_OP_UUID);
-      expect(JSON.parse(dead.raw_body).origin_device_id).toBe(STALE_DEVICE_ID);
-
-      const healthyPushes = calls.filter(c =>
-        c.parsed.ops.some((o: { kind: string; body: { fields?: { custom_title?: string } } }) =>
-          o.kind === 'mutation' && o.body.fields?.custom_title === 'healthy title',
-        ),
-      );
-      expect(healthyPushes.length).toBeGreaterThan(0);
-      expect(healthyPushes.some(c =>
-        c.parsed.ops.every((o: { body: { fields?: { custom_title?: string } } }) =>
-          o.body.fields?.custom_title === 'healthy title',
-        ),
-      )).toBe(true);
-      sync.stop();
-    });
-
-    it('quarantines every stale-head op in a rejected batch before draining later work', async () => {
-      seedFrozenStaleMutation(STALE_OP_UUID);
-      seedFrozenStaleMutation(STALE_OP_UUID_2);
-      store.createSDKSession('sess-healthy', 'proj-x', 'p', 'healthy title', 'claude');
-
-      const { impl, calls } = makeFetchMock(call => {
-        const ops = calls[call - 1]?.wireParsed?.ops ?? [];
-        const hasStale = ops.some((op: { body: string }) => {
-          const body = JSON.parse(op.body) as { origin_device_id?: string };
-          return body.origin_device_id === STALE_DEVICE_ID;
-        });
-        if (!hasStale) return undefined;
-        return new Response(JSON.stringify({
-          error: 'invalid_ops: ops[0] origin_device_id does not match authenticated X-Device-Id',
-        }), { status: 400 });
-      });
-      const sync = makeCloudSync(impl);
-      await sync.flush();
-
-      expect(outboxRows().length).toBe(0);
-      expect(sync.status().lastError).toBeNull();
-      expect(sync.status().quarantine.count).toBe(2);
-      const deadKeys = (db.prepare(
-        "SELECT queue_key FROM sync_dead_letter WHERE lane = 'mutation' ORDER BY queue_key"
-      ).all() as Array<{ queue_key: string }>).map(r => r.queue_key);
-      expect(deadKeys).toEqual([STALE_OP_UUID, STALE_OP_UUID_2]);
+      expect(sync.status().quarantine.count).toBe(0);
+      expectAuthenticatedStamps(calls, 'device-fixture');
       expect(calls.some(c =>
         c.parsed.ops.some((o: { kind: string; body: { fields?: { custom_title?: string } } }) =>
           o.kind === 'mutation' && o.body.fields?.custom_title === 'healthy title',
         ),
       )).toBe(true);
+      const repaired = calls.flatMap(c => c.parsed.ops).filter((o: { body?: { op?: string } }) =>
+        o.body?.op === 'set_prompt_session',
+      );
+      expect(repaired.length).toBe(1);
+      expect(repaired[0].body.target.origin_device_id).toBe('device-fixture');
       sync.stop();
     });
+
+    it('rewrites every stale-head op in the queue before draining later work', async () => {
+      seedFrozenStaleMutation(STALE_OP_UUID);
+      seedFrozenStaleMutation(STALE_OP_UUID_2);
+      store.createSDKSession('sess-healthy', 'proj-x', 'p', 'healthy title', 'claude');
+
+      const { impl, calls } = makeFetchMock(call => rejectIfStaleDevice(calls)(call));
+      const sync = makeCloudSync(impl);
+      await sync.flush();
+
+      expect(outboxRows().length).toBe(0);
+      expect(sync.status().lastError).toBeNull();
+      expect(sync.status().quarantine.count).toBe(0);
+      expectAuthenticatedStamps(calls, 'device-fixture');
+      const repaired = calls.flatMap(c => c.parsed.ops).filter((o: { body?: { op?: string } }) =>
+        o.body?.op === 'set_prompt_session',
+      );
+      expect(repaired.length).toBe(2);
+      expect(db.prepare('SELECT COUNT(*) AS n FROM sync_dead_letter').get()).toEqual({ n: 0 });
+      sync.stop();
+    });
+
+    it('stamps an unfrozen set_prompt_session whose raw target still has a stale device id', async () => {
+      seedUnfrozenStaleTargetMutation(STALE_OP_UUID);
+      const { impl, calls } = makeFetchMock(call => rejectIfStaleDevice(calls)(call));
+      const sync = makeCloudSync(impl);
+      await sync.flush();
+
+      expect(outboxRows().length).toBe(0);
+      expect(sync.status().quarantine.count).toBe(0);
+      expectAuthenticatedStamps(calls, 'device-fixture');
+      sync.stop();
+    });
+
+    it('drops a stale live content snapshot and re-snapshots under the authenticated device id', async () => {
+      seedObservation();
+      const stale = buildContentOperation({
+        kind: 'observation',
+        originDeviceId: STALE_DEVICE_ID,
+        originLocalId: '1',
+        entityRev: '1',
+        payload: observationPayload('Title A'),
+      });
+      const staleBody = JSON.parse(stale.body);
+      db.prepare(`
+        INSERT INTO sync_content_outbox
+          (entity_id, kind, origin_local_id, entity_rev, body,
+           operation_sha256, deleted, created_at_epoch)
+        VALUES (?, 'observation', '1', '1', ?, ?, 0, 1)
+      `).run(staleBody.id, stale.body, stale.operation_sha256);
+
+      const { impl, calls } = makeFetchMock(call => rejectIfStaleDevice(calls)(call));
+      const sync = makeCloudSync(impl);
+      await sync.flush();
+
+      expect(pendingCount('observations')).toBe(0);
+      expect(sync.status().lastError).toBeNull();
+      expect(sync.status().quarantine.count).toBe(0);
+      expectAuthenticatedStamps(calls, 'device-fixture');
+      const observationOps = calls.flatMap(c => c.wireParsed.ops as Array<{ body: string }>)
+        .map(op => JSON.parse(op.body) as { kind: string; id: string; origin_device_id: string })
+        .filter(body => body.kind === 'observation');
+      expect(observationOps.length).toBe(1);
+      expect(observationOps[0].origin_device_id).toBe('device-fixture');
+      expect(observationOps[0].id).toBe(stableDocumentId('observation', 'device-fixture', '1'));
+      expect(observationOps[0].id).not.toBe(staleBody.id);
+      sync.stop();
+    });
+
+    it('rewrites a stale content tombstone onto the authenticated device id', async () => {
+      const stale = buildContentOperation({
+        kind: 'observation',
+        originDeviceId: STALE_DEVICE_ID,
+        originLocalId: '7',
+        entityRev: '3',
+        payload: null,
+        deleted: true,
+        deletedAt: ISO,
+      });
+      const staleBody = JSON.parse(stale.body);
+      db.prepare(`
+        INSERT INTO sync_content_outbox
+          (entity_id, kind, origin_local_id, entity_rev, body,
+           operation_sha256, deleted, created_at_epoch)
+        VALUES (?, 'observation', '7', '3', ?, ?, 1, 1)
+      `).run(staleBody.id, stale.body, stale.operation_sha256);
+
+      const { impl, calls } = makeFetchMock(call => rejectIfStaleDevice(calls)(call));
+      const sync = makeCloudSync(impl);
+      await sync.flush();
+
+      expect(sync.status().lastError).toBeNull();
+      expect(sync.status().quarantine.count).toBe(0);
+      expect(sync.status().pending.tombstones).toBe(0);
+      expectAuthenticatedStamps(calls, 'device-fixture');
+      const tombstones = calls.flatMap(c => c.wireParsed.ops as Array<{ body: string }>)
+        .map(op => JSON.parse(op.body) as { deleted: boolean; origin_device_id: string; origin_local_id: string });
+      expect(tombstones.length).toBe(1);
+      expect(tombstones[0]).toMatchObject({
+        deleted: true,
+        origin_device_id: 'device-fixture',
+        origin_local_id: '7',
+      });
+      sync.stop();
+    });
+
+    it('realigns a frozen queue onto a freshly minted device id (upgrade / settings-loss)', async () => {
+      seedFrozenStaleMutation(STALE_OP_UUID);
+      seedObservation();
+
+      const { impl, calls } = makeFetchMock(call => rejectIfStaleDevice(calls)(call));
+      const sync = makeCloudSync(impl, { CLAUDE_MEM_CLOUD_SYNC_DEVICE_ID: '' });
+      const minted = sync.status().deviceId;
+      expect(minted).toMatch(/^[0-9a-f-]{36}$/);
+      await sync.flush();
+
+      expect(outboxRows().length).toBe(0);
+      expect(pendingCount('observations')).toBe(0);
+      expect(sync.status().lastError).toBeNull();
+      expect(sync.status().quarantine.count).toBe(0);
+      expectAuthenticatedStamps(calls, minted);
+      sync.stop();
+    });
+
+    it('treats a whitespace-only configured device id as unset (hub trims X-Device-Id)', () => {
+      const { impl } = makeFetchMock();
+      const sync = makeCloudSync(impl, { CLAUDE_MEM_CLOUD_SYNC_DEVICE_ID: '   ' });
+      const deviceId = sync.status().deviceId;
+      expect(deviceId).toMatch(/^[0-9a-f-]{36}$/);
+      expect(deviceId.trim()).toBe(deviceId);
+      sync.stop();
+    });
+
   });
 
   // ---------------------------------------------------------------------------
@@ -1514,6 +1638,22 @@ describe('CloudSync', () => {
       const sync = makeCloudSync(impl, { CLAUDE_MEM_CLOUD_SYNC_DEVICE_ID: 'settings-dev-9' });
       expect(sync.status().deviceId).toBe('settings-dev-9');
       expect(existsSync(settingsPath)).toBe(false);
+    });
+
+    it('trims a padded configured device id so the stamp matches X-Device-Id', async () => {
+      seedObservation();
+      const { impl, calls } = makeFetchMock();
+      const sync = makeCloudSync(impl, { CLAUDE_MEM_CLOUD_SYNC_DEVICE_ID: '  device-fixture  ' });
+      expect(sync.status().deviceId).toBe('device-fixture');
+      await sync.flush();
+      expect(calls.length).toBeGreaterThan(0);
+      for (const call of calls) {
+        expect(call.headers['X-Device-Id']).toBe('device-fixture');
+        for (const op of call.wireParsed.ops as Array<{ body: string }>) {
+          expect(JSON.parse(op.body).origin_device_id).toBe('device-fixture');
+        }
+      }
+      sync.stop();
     });
 
     it('mints a UUID and persists it when settings have no device id', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the P0 cloud-sync flush 400 `origin_device_id does not match authenticated X-Device-Id` (#3964 / plan-24 #3618).

## Problem

`CloudSync` freezes `sync_outbox.canonical_body` / `sync_content_outbox.body` with `origin_device_id = this.deviceId` at first snapshot, then authenticates every POST as `X-Device-Id: this.deviceId`. After a remint (settings key gone — six times in 24 days on the reporter’s install), hash-locked heads still carry the previous uuid. The hub correctly 400s the batch; nothing is pushed; `lastFlushAt` stays null.

#3973 (13.24.8) quarantines those mutation heads *after* the hub 400. That unsticks the queue but drops the stale ops and does not prevent the mismatch. Native rows stay `origin_device_id IS NULL` (“this device”); the wrong stamp lives only in the outbox freeze.

## Patch

Narrow, same path — no second sync system:

1. **Flush realigns unacked outbox ops** onto the authenticated device id before any POST (mutations: unfreeze + rewrite `set_prompt_session` target; live content snapshots: drop so `drainKind` re-snapshots; tombstones: rebuild under the current id).
2. **Drain always stamps** `set_prompt_session.target.origin_device_id` with `this.deviceId` (not only when NULL).
3. **Pre-send reject**: a mismatched op never leaves the client. #3973 hub-400 quarantine stays as the safety net.
4. **Trim** configured device ids so a padded settings value cannot 400 against the hub’s trimmed `X-Device-Id`.

Deeper identity/device-binding (why `CLAUDE_MEM_CLOUD_SYNC_DEVICE_ID` disappears — env empty-string override, settings-save races, multi-install mint) is RCA-later on #3618, not this stamp/flush fix.

## Tests

- Frozen stale mutation head + healthy op: rewritten, both drain, hub never sees the stale id, `quarantine.count = 0`.
- Two stale heads: both rewritten, not dead-lettered.
- Unfrozen raw body with a stale target id: stamped at snapshot.
- Stale live content snapshot: dropped and re-snapshotted under the current device / new `entity_id`.
- Stale content tombstone: rewritten and pushed.
- Settings-loss remint: frozen queue realigns onto the minted id; stamp matches `X-Device-Id`.
- Whitespace-only / padded configured ids.

No version bump.

RCA-later on #3618: https://github.com/thedotmack/claude-mem/issues/3618#issuecomment-5628976387

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-853b5a54-6bc3-45be-9b79-d3ac3e0ce1b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-853b5a54-6bc3-45be-9b79-d3ac3e0ce1b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

