### PR TITLE
fix(windows): bound the port-occupancy probe so a ghost listener cannot hang the launcher

### DIFF
--- a/src/services/infrastructure/HealthMonitor.ts
+++ b/src/services/infrastructure/HealthMonitor.ts
@@ -45,8 +45,19 @@ export async function isPortInUse(port: number): Promise<boolean> {
     // Fast path: HTTP health check. A live claude-mem worker responds to
     // /api/health, so this is the cheapest non-disruptive probe for the
     // common case (worker is running and healthy).
+    //
+    // Bounded like every other probe (HEALTH_PROBE_TIMEOUT_MS): a ghost
+    // listener — the dead worker's inherited socket, held open by its chroma
+    // sidecar chain (plan-15 #3603) — completes the TCP handshake and then
+    // never answers. Unbounded, this fetch would hang forever, and with it
+    // ensureWorkerStarted(), which calls this BEFORE it can reach the reclaim:
+    // the very bug the reclaim exists to fix would instead wedge every
+    // launcher. On timeout the flow falls through to the socket probe below,
+    // which still reports a bound port as in use.
     try {
-      const response = await fetch(`http://${formatHostForUrl(getWorkerHost())}:${port}/api/health`);
+      const response = await fetch(`http://${formatHostForUrl(getWorkerHost())}:${port}/api/health`, {
+        signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
+      });
       if (response.ok) return true;
       // Non-ok response: port is reachable but the worker is unhealthy.
       // Fall through to the net.createServer check below so we still report

--- a/tests/infrastructure/health-monitor.test.ts
+++ b/tests/infrastructure/health-monitor.test.ts
@@ -141,6 +141,50 @@ describe('HealthMonitor', () => {
       }
     });
 
+    it('should probe Windows health through an abortable signal so a ghost listener cannot hang it (#3603)', async () => {
+      const origPlatform = process.platform;
+      try {
+        Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+
+        // A ghost listener completes the TCP handshake and never answers, so a
+        // probe without its own abort budget never settles — and
+        // ensureWorkerStarted(), which runs this check BEFORE it can reach the
+        // ghost reclaim, hangs with it. The abort signal is the fix: capture
+        // it off the call, and model the abort as the rejection it produces.
+        const inits: Array<RequestInit | undefined> = [];
+        const fetchMock = mock((_url: string, init?: RequestInit) => {
+          inits.push(init);
+          const abortError = new Error('The operation was aborted due to timeout');
+          abortError.name = 'TimeoutError';
+          return Promise.reject(abortError);
+        });
+        global.fetch = fetchMock as any;
+
+        const createServerMock = mock(() => ({
+          once: mock((event: string, cb: Function) => {
+            if (event === 'error') setTimeout(() => cb({ code: 'EADDRINUSE' }), 0);
+          }),
+          listen: mock(() => {}),
+        }));
+
+        const netSpy = spyOn(net, 'createServer').mockImplementation(createServerMock as any);
+
+        const result = await isPortInUse(37777);
+
+        expect(inits.length).toBeGreaterThan(0);
+        expect(inits[0]?.signal).toBeInstanceOf(AbortSignal);
+        // An aborted probe is inconclusive, never "free": the flow falls
+        // through to the socket probe, which reports the bound port as in use
+        // so the launcher can go on to reclaim the ghost.
+        expect(result).toBe(true);
+        expect(net.createServer).toHaveBeenCalled();
+
+        netSpy.mockRestore();
+      } finally {
+        Object.defineProperty(process, 'platform', { value: origPlatform, configurable: true });
+      }
+    });
+
     it('should fall through to socket probe on Windows when health check fails and port is actually free', async () => {
       const origPlatform = process.platform;
       try {

--- a/tests/integration/worker-ghost-port-recovery.test.ts
+++ b/tests/integration/worker-ghost-port-recovery.test.ts
@@ -64,6 +64,14 @@ const RECOVERY_TIMEOUT_MS = 600_000;
 const GHOST_SETTLE_TIMEOUT_MS = 30_000;
 const ORPHAN_SETTLE_TIMEOUT_MS = 30_000;
 
+// Every stage inside ensureWorkerStarted() is supposed to carry its own
+// deadline (health probes, the reclaim, the readiness wait). The first CI run
+// of this gate proved how expensive a MISSING one is: the launcher awaited a
+// ghost's silent socket forever, and the gate died on bun's 600s cap with no
+// output pointing at the stage. Racing the call itself turns any future
+// unbounded await into a named failure — and a stage line in the log.
+const ENSURE_STARTED_DEADLINE_MS = 300_000;
+
 const here = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURE = path.join(here, 'fixtures', 'ghost-worker-host.ts');
 
@@ -114,6 +122,21 @@ function listeningOwnerPids(port: number): number[] {
     }
   }
   return [...owners];
+}
+
+/** Bound an external await whose internals this test cannot inspect. */
+async function withDeadline<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`timed out waiting for: ${label}`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 async function waitFor(predicate: () => boolean, timeoutMs: number, label: string): Promise<void> {
@@ -236,6 +259,7 @@ describe.if(RUN_GATE && IS_WINDOWS)('worker recovers from a ghost listener left 
   it('reclaims the dead worker\'s sidecar chain and starts a new worker', async () => {
     assertIsolatedDataDir();
     const fixture = await startFixture();
+    console.log(`[ghost-gate] fixture ready: pid=${fixture.pid} port=${fixture.port} chromaRootPid=${fixture.chromaRootPid}`);
 
     // Snapshot BEFORE the kill: once the root exits, identity is the only
     // way to tell the survivors apart from anything that recycled its PID.
@@ -275,6 +299,7 @@ describe.if(RUN_GATE && IS_WINDOWS)('worker recovers from a ghost listener left 
       survivorsAfterKill.length > 0,
       `sidecar chain must survive the out-of-band kill: ${describeProcesses(snapshot)}`
     ).toBe(true);
+    console.log(`[ghost-gate] ghost confirmed: port LISTENING under dead pid=${fixture.pid}; survivors: ${describeProcesses(survivorsAfterKill)}`);
 
     // Drive the PRODUCTION launcher. On main this returns 'dead' — no
     // reclaim exists, so the ghost blocks every spawn forever.
@@ -282,7 +307,14 @@ describe.if(RUN_GATE && IS_WINDOWS)('worker recovers from a ghost listener left 
     const { resolveWorkerScriptPath } = await import('../../src/shared/worker-utils.js');
     const scriptPath = resolveWorkerScriptPath();
     expect(scriptPath).not.toBeNull();
-    const result = await ensureWorkerStarted(fixture.port, scriptPath!);
+    console.log(`[ghost-gate] driving production ensureWorkerStarted() on port ${fixture.port}`);
+    const startedAt = Date.now();
+    const result = await withDeadline(
+      ensureWorkerStarted(fixture.port, scriptPath!),
+      ENSURE_STARTED_DEADLINE_MS,
+      'ensureWorkerStarted'
+    );
+    console.log(`[ghost-gate] ensureWorkerStarted returned '${result}' after ${Date.now() - startedAt}ms`);
     expect(result, `ensureWorkerStarted must not give up on a reclaimable ghost (was: ${result})`).not.toBe('dead');
 
     // The reclaim must have taken the sidecar chain down with the ghost.


### PR DESCRIPTION
## Summary

Follow-up to #3900 (merged), which left main's Windows job red: the gate it added (`Ghost-listener recovery gate (#3603)`) failed in 12 of 12 runs. There were **two** defects behind that, and this PR fixes both.

**1. `isPortInUse()`'s Windows fast path was an unbounded HTTP probe** — the one probe #3900 left without a timeout. A ghost listener completes the TCP handshake and never answers, so the fetch never settled; `ensureWorkerStarted()` calls it *before* the reclaim, so the reclaim could never fire.

**2. The gate never got past its own fixture handshake on CI.** The fixture reported `ready` on its redirected stdout, and that line stayed invisible to the test until the process was killed at the 600s cap — every failing run shows the same shape: no stage output, exactly `2 expect() calls`, and the fixture's chroma chain already alive 3s in.

Section 2 was found by section 1's diagnostics. The first revision of this PR fixed the probe (verified below) and assumed it explained the CI hang; the stage log added in that revision disproved that on the next run — the test never reached `ensureWorkerStarted()`. A redirected stdout can hold a single small line unflushed in a process that then idles, so the gate's readiness handshake must not depend on it.

## What does this PR do?

1. **`src/services/infrastructure/HealthMonitor.ts`** — the Windows fast-path fetch carries the same `HEALTH_PROBE_TIMEOUT_MS` (5s) abort budget as every other probe in the module. On timeout the existing fall-through runs the socket probe (`net.createServer` → `EADDRINUSE`), which still reports the bound port as in use, so the launcher proceeds to the reclaim. No behavior change for a healthy worker or a foreign process holding the port.

2. **`tests/integration/fixtures/ghost-worker-host.ts`** — every event is appended to an events file (`fs.appendFileSync`, a syscall per call) as well as stdout. The stdout copy stays for human debugging; the file is the contract. It also emits `progress` stages (`port-bound`, `create-collection-start/done`, `add-documents-done`) with elapsed times.

3. **`tests/integration/worker-ghost-port-recovery.test.ts`**
   - reads readiness from the events file;
   - logs a `[ghost-gate] waiting for fixture ready: elapsed=… lastStage=…` line every 15s, so the timeline is in the CI log even if bun's timeout kills the run;
   - fails at 240s (below bun's 600s cap) with the full events/stdout/stderr dump;
   - races `ensureWorkerStarted()` against a 300s deadline and reaps the in-flight call during teardown instead of leaving it running past cleanup (Greptile P2).

4. **`tests/infrastructure/health-monitor.test.ts`** — regression test: the Windows probe must carry an `AbortSignal`, and an abort must fall through to the socket probe. Restores the net mock on the failure path (Greptile P2).

## How verified?

**Isolated probe (Windows 11, bun 1.3.6)** — a listener that accepts connections and never responds (the ghost shape), driving `isPortInUse()` directly:

| | result |
|---|---|
| before | never settles — watchdog: `HANG CONFIRMED after 20000ms` |
| after | returns `true` after **5047ms** (5s abort → socket probe → `EADDRINUSE`) |

**The gate, A/B on the same machine** (`CLAUDE_MEM_TEST_CHROMA=1`, isolated `CLAUDE_MEM_DATA_DIR`, real chroma chain, port isolated from the developer's live worker):

- probe fix reverted: `ensureWorkerStarted` never returns; the deadline reports `timed out waiting for: ensureWorkerStarted` at 318s. (318s exceeds the sum of every bounded stage on that path — ≤6s + ≤6s health waits, ~10s reclaim, 60s readiness.)
- current revision: passes in 43.7s, with the new stage timeline —

```
[ghost-gate] fixture ready after 8208ms: {"pid":55612,"port":47777,"chromaRootPid":67688}
[ghost-gate] ghost confirmed: port LISTENING under dead pid=55612; survivors: conhost.exe, chroma-mcp.exe, python.exe, python.exe
[ghost-gate] driving production ensureWorkerStarted() on port 47777
[ghost-gate] ensureWorkerStarted returned 'ready' after 27506ms
 1 pass, 0 fail | Ran 1 test [43.69s]
```

**Unit + types**: new test passes; `bun run typecheck` clean. (Three unrelated tests in `health-monitor.test.ts` fail on this dev machine only — they do real network probes and a live worker holds 37777 here; they pass where the port is free.)

**CI**: the `chroma lifecycle · worker-recycle orphan gate` job is the arbiter — it is the only environment where the handshake failure reproduces, and it reproduces every time. If it still fails, the stage line it prints names the stage.

## Out of scope

In the newest main run (`2714e869`) a different step failed once: `Worker-recycle orphan gate (#3482)` reported `csrss.exe / winlogon.exe / fontdrvhost.exe / dwm.exe` as orphaned descendants of its fixture. That step passed in the other 12 post-merge runs with this same code, and neither its test nor its enumeration helper is touched by #3900 — it reads like a rare bad process-table read (`Get-CimInstance` under churn). Flagging rather than fixing it here.

## Checklist

- [x] Tests added/updated and passing
- [x] Typecheck passing
