### PR TITLE
fix(sync): shrink content flush batches and raise hub push timeout

### DIFF
--- a/docs/public/cloud-sync.mdx
+++ b/docs/public/cloud-sync.mdx
@@ -124,6 +124,8 @@ installed client can reach SyncHub.
 | `CLAUDE_MEM_CLOUD_SYNC_WS` | `'true'` | Advisory WebSocket speed layer. `'false'` = HTTP polling only; sync stays fully correct at poll latency. |
 | `CLAUDE_MEM_CLOUD_SYNC_DEVICE_ID` | `''` | Stable identity of this machine. A fresh UUID is minted and persisted on first start. Don't edit it: every row is attributed to its origin device. |
 | `CLAUDE_MEM_CLOUD_SYNC_DEVICE_NAME` | machine hostname | Human-readable label for this device. |
+| `CLAUDE_MEM_CLOUD_SYNC_CONTENT_BATCH_SIZE` | `'40'` | Ops per content flush page. 200-op pages timed out at 30s under hub `projection_busy`. Max 500. |
+| `CLAUDE_MEM_CLOUD_SYNC_REQUEST_TIMEOUT_MS` | `'90000'` | Content-push `AbortSignal` timeout. Must exceed the hub's 45s projection fetch; default matches the 90s projection lease. |
 
 A Hub accepts at most 64 distinct device ids per account. Existing devices
 continue to sync normally at the limit; a new device receives

--- a/src/services/sync/CloudSync.ts
+++ b/src/services/sync/CloudSync.ts
@@ -60,12 +60,41 @@ import {
   type ContentKind,
 } from './CanonicalContent.js';
 
-// Page size for the drain SELECTs.
-const BATCH = 200;
+// Page size for drain SELECTs. 200-op content pushes timed out at 30s under
+// hub projection_busy (plan-24 #3618 / Alex Mac). 40 stays under one hub
+// projection page (PROJECTION_PAGE_MAX_OPS = 100).
+export const DEFAULT_CONTENT_BATCH_SIZE = 40;
+// Hub projection fetch aborts at 45s and holds a 90s lease
+// (workers/sync-hub PROJECTION_FETCH_TIMEOUT_MS / PROJECTION_LEASE_MS).
+// The previous 30s client timeout was shorter than both, so the client
+// aborted mid-lease and retried into projection_busy. Default matches the lease.
+export const DEFAULT_REQUEST_TIMEOUT_MS = 90_000;
+export const CONTENT_BATCH_SIZE_MIN = 1;
+export const CONTENT_BATCH_SIZE_MAX = 500;
+export const REQUEST_TIMEOUT_MS_MIN = 5_000;
+export const REQUEST_TIMEOUT_MS_MAX = 180_000;
 // Request-body packing budget — well under the hub's 8,000,000-byte cap.
 const MAX_BODY_BYTES = 4_000_000;
 // Hub cap: ≤500 ops per POST /v1/sync/ops request.
 const MAX_OPS_PER_PUSH = 500;
+
+function parseBoundedInt(raw: string | undefined, fallback: number, min: number, max: number): number {
+  if (raw == null || raw === '') return fallback;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < min || n > max) return fallback;
+  return n;
+}
+
+/** Settings / env knob for content flush page size. Out-of-range → default 40. */
+export function parseContentBatchSize(raw: string | undefined): number {
+  return parseBoundedInt(raw, DEFAULT_CONTENT_BATCH_SIZE, CONTENT_BATCH_SIZE_MIN, CONTENT_BATCH_SIZE_MAX);
+}
+
+/** Settings / env knob for content-push AbortSignal timeout. Out-of-range → 90s. */
+export function parseRequestTimeoutMs(raw: string | undefined): number {
+  return parseBoundedInt(raw, DEFAULT_REQUEST_TIMEOUT_MS, REQUEST_TIMEOUT_MS_MIN, REQUEST_TIMEOUT_MS_MAX);
+}
+
 const EMPTY_PUSH_REQUEST_BYTES = Buffer.byteLength(
   JSON.stringify({ protocol_version: 2, ops: [] }),
   'utf8',
@@ -202,7 +231,7 @@ const KINDS: KindSpec[] = [
         metadata, merged_into_project, created_at, created_at_epoch
       FROM observations
       WHERE synced_at IS NULL AND origin_device_id IS NULL
-      ORDER BY id LIMIT ${BATCH}`,
+      ORDER BY id LIMIT ?`,
     selectOneSql: `
       SELECT CAST(id AS TEXT) AS id, CAST(sync_rev AS TEXT) AS sync_rev,
         memory_session_id, project, text, type, title, subtitle,
@@ -245,7 +274,7 @@ const KINDS: KindSpec[] = [
         discovery_tokens, merged_into_project, created_at, created_at_epoch
       FROM session_summaries
       WHERE synced_at IS NULL AND origin_device_id IS NULL
-      ORDER BY id LIMIT ${BATCH}`,
+      ORDER BY id LIMIT ?`,
     selectOneSql: `
       SELECT CAST(id AS TEXT) AS id, CAST(sync_rev AS TEXT) AS sync_rev,
         memory_session_id, project, request, investigated, learned,
@@ -297,7 +326,7 @@ const KINDS: KindSpec[] = [
         s.platform_source AS platform_source
       FROM user_prompts up LEFT JOIN sdk_sessions s ON up.session_db_id = s.id
       WHERE up.synced_at IS NULL AND up.origin_device_id IS NULL
-      ORDER BY up.id LIMIT ${BATCH}`,
+      ORDER BY up.id LIMIT ?`,
     selectOneSql: `
       SELECT CAST(up.id AS TEXT) AS id, CAST(up.sync_rev AS TEXT) AS sync_rev,
         up.content_session_id AS content_session_id,
@@ -327,13 +356,18 @@ export type CloudSyncSettingKeys = Pick<SettingsDefaults,
   | 'CLAUDE_MEM_CLOUD_SYNC_HUB_URL'
   | 'CLAUDE_MEM_CLOUD_SYNC_DEVICE_ID'
   | 'CLAUDE_MEM_CLOUD_SYNC_DEVICE_NAME'
->;
+> & Partial<Pick<SettingsDefaults,
+  | 'CLAUDE_MEM_CLOUD_SYNC_CONTENT_BATCH_SIZE'
+  | 'CLAUDE_MEM_CLOUD_SYNC_REQUEST_TIMEOUT_MS'
+>>;
 
 export interface CloudSyncOptions {
   /** Injectable for tests; defaults to globalThis.fetch. */
   fetchImpl?: typeof fetch;
   /** settings.json path where a newly resolved device id is persisted. */
   settingsPath?: string;
+  /** Override content/mutation drain page size (default 40). */
+  contentBatchSize?: number;
   /** Trailing debounce for notify() bursts. */
   debounceMs?: number;
   /**
@@ -346,7 +380,7 @@ export interface CloudSyncOptions {
   /** First retry delay after a failed flush; doubles up to backoffMaxMs. */
   backoffInitialMs?: number;
   backoffMaxMs?: number;
-  /** Per-request timeout — a hub POST can never hang the drain. */
+  /** Per-request timeout — a hub POST can never hang the drain. Default 90s. */
   requestTimeoutMs?: number;
 }
 
@@ -379,6 +413,7 @@ export class CloudSync {
   private readonly fastDebounceMs: number;
   private readonly backoffInitialMs: number;
   private readonly backoffMaxMs: number;
+  private readonly contentBatchSize: number;
   private readonly requestTimeoutMs: number;
 
   /** '' when unconfigured or when device-id resolution failed closed. */
@@ -432,7 +467,12 @@ export class CloudSync {
     this.fastDebounceMs = options.fastDebounceMs ?? 250;
     this.backoffInitialMs = options.backoffInitialMs ?? 30_000;
     this.backoffMaxMs = options.backoffMaxMs ?? 600_000;
-    this.requestTimeoutMs = options.requestTimeoutMs ?? 30_000;
+    this.contentBatchSize = options.contentBatchSize ?? parseContentBatchSize(
+      settings.CLAUDE_MEM_CLOUD_SYNC_CONTENT_BATCH_SIZE,
+    );
+    this.requestTimeoutMs = options.requestTimeoutMs ?? parseRequestTimeoutMs(
+      settings.CLAUDE_MEM_CLOUD_SYNC_REQUEST_TIMEOUT_MS,
+    );
     this.nextBackoffMs = this.backoffInitialMs;
 
     if (this.isConfigured()) {
@@ -748,8 +788,8 @@ export class CloudSync {
       if (this.stopped) return;
       const rows = this.db.prepare(`
         SELECT body, operation_sha256 FROM sync_content_outbox
-        ORDER BY deleted DESC, id LIMIT ${BATCH}
-      `).all() as Array<CanonicalWireOp>;
+        ORDER BY deleted DESC, id LIMIT ?
+      `).all(this.contentBatchSize) as Array<CanonicalWireOp>;
       if (rows.length === 0) return;
       let batch: WireOp[] = [];
       let bytes = 0;
@@ -784,8 +824,8 @@ export class CloudSync {
       const rows = this.db.prepare(
         `SELECT CAST(id AS TEXT) AS id, op_uuid, CAST(rev AS TEXT) AS rev,
                 body, canonical_body, operation_sha256
-         FROM sync_outbox ORDER BY id LIMIT ${BATCH}`
-      ).all() as MutationOutboxRow[];
+         FROM sync_outbox ORDER BY id LIMIT ?`
+      ).all(this.contentBatchSize) as MutationOutboxRow[];
       if (rows.length === 0) break;
 
       // Same size-bounded packing as drainKind: mutation bodies are usually
@@ -863,7 +903,7 @@ export class CloudSync {
     // change a retry's body/hash; ack reconciliation queues a higher revision.
     for (;;) {
       if (this.stopped) return;
-      const rows = this.db.prepare(kind.selectSql).all() as LocalRow[];
+      const rows = this.db.prepare(kind.selectSql).all(this.contentBatchSize) as LocalRow[];
       if (rows.length === 0) break;
       for (const r of rows) {
         this.snapshotContentRow(kind, r);

--- a/src/services/worker/http/routes/SettingsRoutes.ts
+++ b/src/services/worker/http/routes/SettingsRoutes.ts
@@ -310,6 +310,20 @@ export class SettingsRoutes extends BaseRouteHandler {
       }
     }
 
+    if (settings.CLAUDE_MEM_CLOUD_SYNC_CONTENT_BATCH_SIZE) {
+      const batch = parseInt(settings.CLAUDE_MEM_CLOUD_SYNC_CONTENT_BATCH_SIZE, 10);
+      if (isNaN(batch) || batch < 1 || batch > 500) {
+        return { valid: false, error: 'CLAUDE_MEM_CLOUD_SYNC_CONTENT_BATCH_SIZE must be between 1 and 500' };
+      }
+    }
+
+    if (settings.CLAUDE_MEM_CLOUD_SYNC_REQUEST_TIMEOUT_MS) {
+      const timeoutMs = parseInt(settings.CLAUDE_MEM_CLOUD_SYNC_REQUEST_TIMEOUT_MS, 10);
+      if (isNaN(timeoutMs) || timeoutMs < 5000 || timeoutMs > 180000) {
+        return { valid: false, error: 'CLAUDE_MEM_CLOUD_SYNC_REQUEST_TIMEOUT_MS must be between 5000 and 180000' };
+      }
+    }
+
     return { valid: true };
   }
 

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -92,6 +92,10 @@ export interface SettingsDefaults {
   CLAUDE_MEM_CLOUD_SYNC_DEVICE_ID: string;
   CLAUDE_MEM_CLOUD_SYNC_DEVICE_NAME: string;
   CLAUDE_MEM_CLOUD_SYNC_WS: string;    // advisory WebSocket speed layer (Phase 4) — 'false' = HTTP polling only
+  // Content flush knobs. 200-op pages + 30s timeout hit hub projection_busy
+  // (#3618). Defaults: 40 ops / 90s (hub projection lease).
+  CLAUDE_MEM_CLOUD_SYNC_CONTENT_BATCH_SIZE: string;
+  CLAUDE_MEM_CLOUD_SYNC_REQUEST_TIMEOUT_MS: string;
   // Observation TV remote broadcast. EMPTY = OFF: the read-only guard is not
   // mounted and the worker behaves exactly as before. Set (with a non-loopback
   // CLAUDE_MEM_WORKER_HOST) to expose ONLY /tv, /tv.html, /stream and
@@ -223,6 +227,8 @@ export class SettingsDefaultsManager {
     CLAUDE_MEM_CLOUD_SYNC_DEVICE_ID: '',      // Minted at first CloudSync start, then persisted back here
     CLAUDE_MEM_CLOUD_SYNC_DEVICE_NAME: hostname(),  // Human-readable label for the cmem.ai Devices panel
     CLAUDE_MEM_CLOUD_SYNC_WS: 'true',  // Advisory WebSocket speed layer (plan Phase 4). 'false' = HTTP polling only — sync stays fully correct, just poll-latency (prime directive #2)
+    CLAUDE_MEM_CLOUD_SYNC_CONTENT_BATCH_SIZE: '40',  // Drain page size; 200-op content pushes timed out under hub projection_busy
+    CLAUDE_MEM_CLOUD_SYNC_REQUEST_TIMEOUT_MS: '90000',  // Content-push AbortSignal; matches hub PROJECTION_LEASE_MS (90s)
     // Observation TV remote broadcast. EMPTY = OFF: the read-only guard is not
     // mounted and the worker behaves exactly as before. Set (with a non-loopback
     // CLAUDE_MEM_WORKER_HOST) to expose ONLY /tv, /tv.html, /stream and

--- a/tests/shared/settings-defaults-manager.test.ts
+++ b/tests/shared/settings-defaults-manager.test.ts
@@ -510,6 +510,12 @@ describe('SettingsDefaultsManager', () => {
     it('CLAUDE_MEM_CLAUDE_CONFIG_DIR defaults to empty string', () => {
       expect(SettingsDefaultsManager.getAllDefaults().CLAUDE_MEM_CLAUDE_CONFIG_DIR).toBe('');
     });
+
+    it('cloud sync content flush knobs default to 40 ops / 90s', () => {
+      const defaults = SettingsDefaultsManager.getAllDefaults();
+      expect(defaults.CLAUDE_MEM_CLOUD_SYNC_CONTENT_BATCH_SIZE).toBe('40');
+      expect(defaults.CLAUDE_MEM_CLOUD_SYNC_REQUEST_TIMEOUT_MS).toBe('90000');
+    });
   });
 
   describe('get', () => {

--- a/tests/worker/sync/cloud-sync.test.ts
+++ b/tests/worker/sync/cloud-sync.test.ts
@@ -12,7 +12,15 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { SessionStore } from '../../../src/services/sqlite/SessionStore.js';
-import { CloudSync, type CloudSyncSettingKeys, type CloudSyncOptions } from '../../../src/services/sync/CloudSync.js';
+import {
+  CloudSync,
+  parseContentBatchSize,
+  parseRequestTimeoutMs,
+  DEFAULT_CONTENT_BATCH_SIZE,
+  DEFAULT_REQUEST_TIMEOUT_MS,
+  type CloudSyncSettingKeys,
+  type CloudSyncOptions,
+} from '../../../src/services/sync/CloudSync.js';
 import { buildContentOperation, buildMutationOperation, stableDocumentId } from '../../../src/services/sync/CanonicalContent.js';
 
 const ISO = '2026-07-09T00:00:00.000Z';
@@ -121,6 +129,29 @@ function makeFetchMock(handler?: (call: number) => Response | Error | undefined)
   }) as typeof fetch;
   return { impl, calls };
 }
+
+describe('cloud sync flush knobs', () => {
+  it('defaults content batch to 40 and request timeout to 90s', () => {
+    expect(DEFAULT_CONTENT_BATCH_SIZE).toBe(40);
+    expect(DEFAULT_REQUEST_TIMEOUT_MS).toBe(90_000);
+    expect(parseContentBatchSize(undefined)).toBe(40);
+    expect(parseRequestTimeoutMs(undefined)).toBe(90_000);
+  });
+
+  it('accepts in-range settings and rejects out-of-range / garbage', () => {
+    expect(parseContentBatchSize('10')).toBe(10);
+    expect(parseContentBatchSize('500')).toBe(500);
+    expect(parseContentBatchSize('0')).toBe(40);
+    expect(parseContentBatchSize('501')).toBe(40);
+    expect(parseContentBatchSize('nope')).toBe(40);
+    expect(parseRequestTimeoutMs('60000')).toBe(60_000);
+    expect(parseRequestTimeoutMs('5000')).toBe(5_000);
+    expect(parseRequestTimeoutMs('180000')).toBe(180_000);
+    expect(parseRequestTimeoutMs('4999')).toBe(90_000);
+    expect(parseRequestTimeoutMs('180001')).toBe(90_000);
+    expect(parseRequestTimeoutMs('')).toBe(90_000);
+  });
+});
 
 describe('CloudSync', () => {
   let tempDir: string;
@@ -510,21 +541,75 @@ describe('CloudSync', () => {
     sync.stop();
   });
 
-  it('loops 200-row pages until fully drained and stamps every batch', async () => {
-    for (let i = 0; i < 450; i++) seedObservation({ title: `obs ${i}` });
+  it('loops default 40-row pages until fully drained and stamps every batch', async () => {
+    for (let i = 0; i < 90; i++) seedObservation({ title: `obs ${i}` });
 
     const { impl, calls } = makeFetchMock();
     const sync = makeCloudSync(impl);
     await sync.flush();
 
     expect(calls.length).toBe(3);
-    expect(calls.map(c => c.parsed.ops.length)).toEqual([200, 200, 50]);
+    expect(calls.map(c => c.parsed.ops.length)).toEqual([40, 40, 10]);
     expect(pendingCount('observations')).toBe(0);
 
     const status = sync.status();
     expect(status.pending).toEqual({ observations: 0, summaries: 0, prompts: 0, mutations: 0, tombstones: 0 });
     expect(status.lastFlushAt).not.toBeNull();
     expect(status.lastError).toBeNull();
+  });
+
+  it('pages content flushes at CLAUDE_MEM_CLOUD_SYNC_CONTENT_BATCH_SIZE', async () => {
+    for (let i = 0; i < 25; i++) seedObservation({ title: `obs ${i}` });
+
+    const { impl, calls } = makeFetchMock();
+    const sync = makeCloudSync(impl, { CLAUDE_MEM_CLOUD_SYNC_CONTENT_BATCH_SIZE: '10' });
+    await sync.flush();
+
+    expect(calls.map(c => c.parsed.ops.length)).toEqual([10, 10, 5]);
+    expect(pendingCount('observations')).toBe(0);
+  });
+
+  it('lets options.contentBatchSize override the settings page size', async () => {
+    for (let i = 0; i < 15; i++) seedObservation({ title: `obs ${i}` });
+
+    const { impl, calls } = makeFetchMock();
+    const sync = makeCloudSync(
+      impl,
+      { CLAUDE_MEM_CLOUD_SYNC_CONTENT_BATCH_SIZE: '10' },
+      { contentBatchSize: 6 },
+    );
+    await sync.flush();
+
+    expect(calls.map(c => c.parsed.ops.length)).toEqual([6, 6, 3]);
+  });
+
+  it('falls back to the default content batch when the setting is out of range', async () => {
+    for (let i = 0; i < 90; i++) seedObservation({ title: `obs ${i}` });
+
+    const { impl, calls } = makeFetchMock();
+    const sync = makeCloudSync(impl, { CLAUDE_MEM_CLOUD_SYNC_CONTENT_BATCH_SIZE: '9999' });
+    await sync.flush();
+
+    expect(calls.map(c => c.parsed.ops.length)).toEqual([40, 40, 10]);
+  });
+
+  it('aborts a hung content push at the configured requestTimeoutMs', async () => {
+    seedObservation({ title: 'hung-push' });
+    const impl = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal;
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(resolve, 80);
+        signal?.addEventListener('abort', () => {
+          clearTimeout(timer);
+          reject(signal.reason ?? new DOMException('The operation was aborted due to timeout', 'TimeoutError'));
+        });
+      });
+      return canonicalSuccess([], 0);
+    }) as typeof fetch;
+    const sync = makeCloudSync(impl, {}, { requestTimeoutMs: 20 });
+    await sync.flush();
+    expect(sync.status().lastError).toMatch(/aborted|timed out|timeout|TimeoutError/i);
+    expect(pendingCount('observations')).toBe(1);
   });
 
   it('authenticates a read-only Hub status probe even when the local queue is empty', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

MacGyver local proof on worker **13.24.8** (Alex Mac):

- `jy=200` content batch (~**524KB**) hits the hardcoded constructor `requestTimeoutMs = 3e4` → client `"The operation timed out."` + hub **503 `projection_busy`**
- `jy=40` (~**100KB**) drains steadily (**3867→3189** pending)
- Settings did not expose timeout; the installed-worker `jy` 200→40 patch is wiped on plugin-cache update

Hub side (`workers/sync-hub`): `PROJECTION_PAGE_MAX_OPS = 100`, `PROJECTION_FETCH_TIMEOUT_MS = 45s`, `PROJECTION_LEASE_MS = 90s`. A 200-op page is two projection pages; 30s is shorter than both hub bounds, so abort-and-retry lands on `projection_busy`.

## Fix

CloudSync flush knobs only — no second sync system, no version bump (13.24.9 is #3990).

1. Default content drain page size **200 → 40** (the proven-working size; ~100KB; under one hub projection page). Same former `BATCH` / `jy` constant for `drainKind`, `drainContentOutbox`, and mutation page `LIMIT`.
2. Default content-push `requestTimeoutMs` **30s → 90s** (matches the hub lease so the client waits for projection instead of aborting into `projection_busy`).
3. Settings (existing `CLAUDE_MEM_CLOUD_SYNC_*` pattern) so plugin updates cannot wipe the knobs:
   - `CLAUDE_MEM_CLOUD_SYNC_CONTENT_BATCH_SIZE` (default `40`, range 1–500)
   - `CLAUDE_MEM_CLOUD_SYNC_REQUEST_TIMEOUT_MS` (default `90000`, range 5000–180000)

Out-of-range values fall back to the safe defaults.

## Test

- `tests/worker/sync/cloud-sync.test.ts` — default 40-row paging, settings override, invalid fallback, options override, hung-push abort (`"The operation timed out."`)
- Parser unit tests for batch/timeout bounds
- Settings defaults lock the new keys at `40` / `90000`

Refs #3618. Follow-up to #3987.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00c3b18b-f284-4727-871a-8b59c6c18f7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00c3b18b-f284-4727-871a-8b59c6c18f7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

