### PR TITLE
fix(context): fit the session block to the hook output limit by selection

### DIFF
--- a/src/services/context/ContextBudget.ts
+++ b/src/services/context/ContextBudget.ts
@@ -1,0 +1,89 @@
+import type { ContextConfig } from './types.js';
+
+/**
+ * Claude Code delivers a hook's stdout verbatim up to 10,000 characters. One
+ * character more and the whole block is written to disk and replaced by a ~2KB
+ * preview stub, so the model receives no context at all — and the hook still
+ * reports success, which is why this failed silently (#3802, #1899).
+ */
+export const CONTEXT_OUTPUT_LIMIT = 10_000;
+
+/**
+ * Item counts cannot keep the block under that limit, because items are not a
+ * fixed size: an observation title runs ~150-320 characters, a session-summary
+ * line ~250-600, and the last-session summary block 1-5K on its own. Any count
+ * that is safe on a quiet project wastes the budget, and any count that fills
+ * the budget there overflows on a busy one.
+ *
+ * So fit by measuring. Render, and while the result is over budget, drop the
+ * most expensive thing still in it and render again. Whole items are dropped,
+ * never cut in half, so the block always ends up well-formed — the header,
+ * footer and at least one observation always survive.
+ */
+export interface ContextBudgetResult {
+  text: string;
+  /** The config that produced `text`, after any reductions. */
+  config: ContextConfig;
+  /** Observations that survived; a prefix of the input, newest first. */
+  observationCount: number;
+  /** How many reduction steps were taken. 0 means the first render fit. */
+  reductions: number;
+  /** True when everything droppable is gone and the block is still over budget. */
+  overBudget: boolean;
+}
+
+/**
+ * The order things are given up in, cheapest loss first.
+ *
+ * Full observation narratives go first: they are the largest per-item cost and
+ * their titles remain in the timeline either way. The last-session summary
+ * block goes next, being a single 1-5K item. Only then do we start losing
+ * timeline entries, sessions before observations, because an observation is
+ * the smaller unit and the one the timeline is mostly made of.
+ */
+function reduceConfig(config: ContextConfig, observationCount: number): { config: ContextConfig; observationCount: number } | null {
+  if (config.fullObservationCount > 0) {
+    return { config: { ...config, fullObservationCount: 0 }, observationCount };
+  }
+  if (config.showLastSummary) {
+    return { config: { ...config, showLastSummary: false }, observationCount };
+  }
+  if (config.sessionCount > 0) {
+    return { config: { ...config, sessionCount: Math.floor(config.sessionCount / 2) }, observationCount };
+  }
+  if (observationCount > 1) {
+    return { config, observationCount: Math.floor(observationCount / 2) };
+  }
+  return null;
+}
+
+/**
+ * Render within `limit` characters, giving up content in `reduceConfig`'s order.
+ *
+ * `render` must be pure: it is called repeatedly with progressively smaller
+ * inputs, and the last result that fits is the one returned.
+ */
+export function fitContextToBudget<T>(
+  observations: T[],
+  config: ContextConfig,
+  render: (observations: T[], config: ContextConfig) => string,
+  limit: number = CONTEXT_OUTPUT_LIMIT
+): ContextBudgetResult {
+  let currentConfig = config;
+  let currentCount = observations.length;
+  let text = render(observations, currentConfig);
+  let reductions = 0;
+
+  while (text.length > limit) {
+    const next = reduceConfig(currentConfig, currentCount);
+    if (!next) {
+      return { text, config: currentConfig, observationCount: currentCount, reductions, overBudget: true };
+    }
+    currentConfig = next.config;
+    currentCount = next.observationCount;
+    text = render(observations.slice(0, currentCount), currentConfig);
+    reductions++;
+  }
+
+  return { text, config: currentConfig, observationCount: currentCount, reductions, overBudget: false };
+}

--- a/src/services/context/ContextBuilder.ts
+++ b/src/services/context/ContextBuilder.ts
@@ -12,6 +12,7 @@ import { SQLITE_BUSY_TIMEOUT_MS } from '../sqlite/connection.js';
 import type { ContextInput, ContextConfig, Observation, SessionSummary } from './types.js';
 import { colors } from './types.js';
 import { loadContextConfig } from './ContextConfigLoader.js';
+import { fitContextToBudget, CONTEXT_OUTPUT_LIMIT } from './ContextBudget.js';
 import { calculateTokenEconomics } from './TokenCalculator.js';
 import {
   queryObservationsMulti,
@@ -256,18 +257,28 @@ export async function generateContextWithStats(
       return { text: withObserverHealthWarning(renderEmptyState(project, forHuman), forHuman), stats: null };
     }
 
-    const output = buildContextOutput(
-      project,
+    // `--full` is an explicit human request for everything; only the block that
+    // has to survive a hook's 10,000-character delivery limit is fitted (#3802).
+    const budget = fitContextToBudget(
       observations,
-      summaries,
       config,
-      cwd,
-      input?.session_id,
-      forHuman
+      (items, cfg) =>
+        buildContextOutput(project, items, summaries, cfg, cwd, input?.session_id, forHuman),
+      input?.full ? Number.POSITIVE_INFINITY : CONTEXT_OUTPUT_LIMIT
     );
 
+    if (budget.reductions > 0) {
+      logger.debug('HOOK', 'Trimmed context to fit the hook output limit', {
+        reductions: budget.reductions,
+        observations: budget.observationCount,
+        sessions: budget.config.sessionCount,
+        chars: budget.text.length,
+        overBudget: budget.overBudget,
+      });
+    }
+
     return {
-      text: withObserverHealthWarning(output, forHuman),
+      text: withObserverHealthWarning(budget.text, forHuman),
       stats: buildInjectStats(observations, summaries, Boolean(input?.full)),
     };
   } finally {

--- a/src/services/context/ContextBuilder.ts
+++ b/src/services/context/ContextBuilder.ts
@@ -202,6 +202,18 @@ function paintRed(text: string): string {
  * closest thing to its first reply.
  */
 export function withObserverHealthWarning(text: string, forHuman: boolean = false): string {
+  return appendObserverHealthWarning(observerHealthWarning(forHuman), text);
+}
+
+/**
+ * The warning on its own, or `''` when the observer is healthy.
+ *
+ * Split out so the fitted path can read the health ONCE and then measure the
+ * warning as part of the block it is fitting. `fitContextToBudget` calls its
+ * render repeatedly, and `readObserverHealth` touches state: re-reading it per
+ * reduction would let the measured length change under the loop.
+ */
+export function observerHealthWarning(forHuman: boolean = false): string {
   const health = readObserverHealth();
   // Failure banner wins when both are set: the quota-exhausted copy already
   // says capture is paused, and a cooldown is not a second outage. Cooldown
@@ -215,12 +227,72 @@ export function withObserverHealthWarning(text: string, forHuman: boolean = fals
     notice = renderObserverQuotaCooldownNotice(health);
   }
   if (!notice) {
-    return text;
+    return '';
   }
   // Colors only on the human render: the agent copy is fetched separately
   // (colors=false) and ANSI escapes there are noise in the model's context.
-  const rendered = forHuman ? paintRed(notice) : notice;
-  return text ? `${text}\n\n${rendered}` : rendered;
+  return forHuman ? paintRed(notice) : notice;
+}
+
+function appendObserverHealthWarning(warning: string, text: string): string {
+  if (!warning) return text;
+  return text ? `${text}\n\n${warning}` : warning;
+}
+
+/**
+ * Fit the block to `limit` and report on exactly what survived.
+ *
+ * Split out of `generateContextWithStats` so both halves can be tested without
+ * a database: the caller's only remaining job is to fetch rows. Two things have
+ * to happen together here, and neither is safe on its own.
+ *
+ * The health warning is rendered INSIDE the measured block. Appending it to the
+ * fitted result spends characters the fitter never counted, so an unhealthy
+ * observer could push a block just fitted to 9,998 back over the limit — and
+ * over the limit the whole block is replaced by the preview stub #3802 exists
+ * to avoid, which is exactly when an outage warning most needs to arrive.
+ *
+ * The stats describe what was DELIVERED, not what was queried.
+ * `ContextInjectStats` already promises this ("computed from the same
+ * observation set that was rendered"); before this, a run trimmed from seven
+ * observations to three still reported seven, so telemetry read as healthy
+ * precisely when context was being dropped. `sessionCount` is the same slice
+ * `buildContextOutput` takes for `displaySummaries`.
+ */
+export function fitContextForDelivery(
+  observations: Observation[],
+  summaries: SessionSummary[],
+  config: ContextConfig,
+  healthWarning: string,
+  renderBlock: (items: Observation[], cfg: ContextConfig) => string,
+  limit: number,
+  full: boolean
+): { text: string; stats: ContextInjectStats } {
+  const budget = fitContextToBudget(
+    observations,
+    config,
+    (items, cfg) => appendObserverHealthWarning(healthWarning, renderBlock(items, cfg)),
+    limit
+  );
+
+  if (budget.reductions > 0) {
+    logger.debug('HOOK', 'Trimmed context to fit the hook output limit', {
+      reductions: budget.reductions,
+      observations: budget.observationCount,
+      sessions: budget.config.sessionCount,
+      chars: budget.text.length,
+      overBudget: budget.overBudget,
+    });
+  }
+
+  return {
+    text: budget.text,
+    stats: buildInjectStats(
+      observations.slice(0, budget.observationCount),
+      summaries.slice(0, budget.config.sessionCount),
+      full
+    ),
+  };
 }
 
 export async function generateContextWithStats(
@@ -259,28 +331,16 @@ export async function generateContextWithStats(
 
     // `--full` is an explicit human request for everything; only the block that
     // has to survive a hook's 10,000-character delivery limit is fitted (#3802).
-    const budget = fitContextToBudget(
+    return fitContextForDelivery(
       observations,
+      summaries,
       config,
+      observerHealthWarning(forHuman),
       (items, cfg) =>
         buildContextOutput(project, items, summaries, cfg, cwd, input?.session_id, forHuman),
-      input?.full ? Number.POSITIVE_INFINITY : CONTEXT_OUTPUT_LIMIT
+      input?.full ? Number.POSITIVE_INFINITY : CONTEXT_OUTPUT_LIMIT,
+      Boolean(input?.full)
     );
-
-    if (budget.reductions > 0) {
-      logger.debug('HOOK', 'Trimmed context to fit the hook output limit', {
-        reductions: budget.reductions,
-        observations: budget.observationCount,
-        sessions: budget.config.sessionCount,
-        chars: budget.text.length,
-        overBudget: budget.overBudget,
-      });
-    }
-
-    return {
-      text: withObserverHealthWarning(budget.text, forHuman),
-      stats: buildInjectStats(observations, summaries, Boolean(input?.full)),
-    };
   } finally {
     rawDb.close();
   }

--- a/tests/context/context-budget-3802.test.ts
+++ b/tests/context/context-budget-3802.test.ts
@@ -3,6 +3,8 @@ import {
   fitContextToBudget,
   CONTEXT_OUTPUT_LIMIT,
 } from '../../src/services/context/ContextBudget.js';
+import { fitContextForDelivery } from '../../src/services/context/ContextBuilder.js';
+import type { Observation, SessionSummary } from '../../src/services/context/types.js';
 import type { ContextConfig } from '../../src/services/context/types.js';
 
 // #3802 — the SessionStart block was sized by item counts, so on an active
@@ -107,5 +109,149 @@ describe('context output budget (#3802)', () => {
     const result = fitContextToBudget(items(50), config, render);
 
     expect(result.text.length).toBeLessThanOrEqual(first.length);
+  });
+});
+
+// ── what happens around the fitter ────────────────────────────────
+//
+// Both of these are about the block that is actually DELIVERED. The fitter
+// itself was already correct; the delivered block was not, because a warning
+// was appended after fitting and the stats were computed before it.
+
+function obs(i: number): Observation {
+  return {
+    id: i,
+    memory_session_id: `session-${i}`,
+    type: 'discovery',
+    title: 'T'.repeat(200),
+    narrative: 'N'.repeat(1200),
+    created_at_epoch: 1_700_000_000 + i,
+  } as unknown as Observation;
+}
+
+function summary(i: number): SessionSummary {
+  return { id: i, memory_session_id: `session-${i}` } as unknown as SessionSummary;
+}
+
+/** Cost profile of the real renderer, ignoring the summaries it is handed. */
+function renderBlock(items: Observation[], config: ContextConfig): string {
+  const titles = items.length * 200;
+  const fulls = Math.min(config.fullObservationCount, items.length) * 1200;
+  const sessions = config.sessionCount * 400;
+  const lastSummary = config.showLastSummary ? 3000 : 0;
+  return 'x'.repeat(300 + titles + fulls + sessions + lastSummary + 200);
+}
+
+describe('what the fitted block delivers (#3811 review)', () => {
+  const WARNING = 'W'.repeat(600);
+
+  // 47 observations render to 9,900 characters under this config, so the block
+  // fits on its own and needs no reduction -- and 9,900 + a 600-character
+  // warning does not. That is the whole discriminator: with the warning inside
+  // the measured block the fitter gives something up, and without it the block
+  // is delivered 500 characters over the limit and replaced by the stub.
+  const NEAR_LIMIT = makeConfig({
+    fullObservationCount: 0,
+    sessionCount: 0,
+    showLastSummary: false,
+  });
+
+  it('counts the observer-health warning against the budget', () => {
+    // Without the warning this input fits at just under the limit, so a warning
+    // appended afterwards is the whole difference between delivered and stubbed.
+    const delivered = fitContextForDelivery(
+      Array.from({ length: 47 }, (_, i) => obs(i)),
+      [],
+      NEAR_LIMIT,
+      WARNING,
+      renderBlock,
+      CONTEXT_OUTPUT_LIMIT,
+      false,
+    );
+
+    expect(delivered.text).toContain(WARNING);
+    expect(delivered.text.length).toBeLessThanOrEqual(CONTEXT_OUTPUT_LIMIT);
+  });
+
+  it('leaves the block alone when the observer is healthy', () => {
+    const withWarning = fitContextForDelivery(
+      Array.from({ length: 47 }, (_, i) => obs(i)),
+      [],
+      NEAR_LIMIT,
+      WARNING,
+      renderBlock,
+      CONTEXT_OUTPUT_LIMIT,
+      false,
+    );
+    const healthy = fitContextForDelivery(
+      Array.from({ length: 47 }, (_, i) => obs(i)),
+      [],
+      NEAR_LIMIT,
+      '',
+      renderBlock,
+      CONTEXT_OUTPUT_LIMIT,
+      false,
+    );
+
+    expect(healthy.text).not.toContain('W');
+    // The warning costs budget, so the healthy block is allowed to carry more.
+    expect(healthy.stats.observation_count).toBeGreaterThanOrEqual(
+      withWarning.stats.observation_count,
+    );
+  });
+
+  it('reports the observations it delivered, not the ones it queried', () => {
+    const queried = Array.from({ length: 50 }, (_, i) => obs(i));
+    const delivered = fitContextForDelivery(
+      queried,
+      [],
+      makeConfig(),
+      '',
+      renderBlock,
+      CONTEXT_OUTPUT_LIMIT,
+      false,
+    );
+
+    expect(delivered.stats.observation_count).toBeLessThan(queried.length);
+    expect(delivered.stats.session_count).toBe(delivered.stats.observation_count);
+    expect(
+      delivered.stats.obs_type_bugfix +
+        delivered.stats.obs_type_discovery +
+        delivered.stats.obs_type_decision +
+        delivered.stats.obs_type_refactor +
+        delivered.stats.obs_type_other,
+    ).toBe(delivered.stats.observation_count);
+  });
+
+  it('reports a session summary only when one survived the reduction', () => {
+    // The fitter drops `sessionCount` to 0 long before it starts dropping
+    // observations, so a run trimmed this hard delivers no summary at all.
+    const delivered = fitContextForDelivery(
+      Array.from({ length: 50 }, (_, i) => obs(i)),
+      Array.from({ length: 10 }, (_, i) => summary(i)),
+      makeConfig(),
+      '',
+      renderBlock,
+      CONTEXT_OUTPUT_LIMIT,
+      false,
+    );
+
+    expect(delivered.stats.has_session_summary).toBe(false);
+  });
+
+  it('reports everything when nothing had to be given up', () => {
+    const queried = Array.from({ length: 3 }, (_, i) => obs(i));
+    const delivered = fitContextForDelivery(
+      queried,
+      [summary(0)],
+      makeConfig({ fullObservationCount: 0, sessionCount: 1, showLastSummary: false }),
+      '',
+      renderBlock,
+      CONTEXT_OUTPUT_LIMIT,
+      false,
+    );
+
+    expect(delivered.stats.observation_count).toBe(3);
+    expect(delivered.stats.has_session_summary).toBe(true);
   });
 });

--- a/tests/context/context-budget-3802.test.ts
+++ b/tests/context/context-budget-3802.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  fitContextToBudget,
+  CONTEXT_OUTPUT_LIMIT,
+} from '../../src/services/context/ContextBudget.js';
+import type { ContextConfig } from '../../src/services/context/types.js';
+
+// #3802 — the SessionStart block was sized by item counts, so on an active
+// project it went past Claude Code's 10,000-character per-hook-output limit and
+// the model silently received a ~2KB stub instead of any context at all.
+
+function makeConfig(overrides: Partial<ContextConfig> = {}): ContextConfig {
+  return {
+    totalObservationCount: 50,
+    fullObservationCount: 3,
+    sessionCount: 10,
+    showReadTokens: false,
+    showWorkTokens: false,
+    showSavingsAmount: false,
+    showSavingsPercent: false,
+    observationTypes: new Set<string>(),
+    observationConcepts: new Set<string>(),
+    fullObservationField: 'narrative',
+    showLastSummary: true,
+    showLastMessage: false,
+    ...overrides,
+  } as ContextConfig;
+}
+
+/**
+ * Stands in for buildContextOutput with the cost profile the issue measured:
+ * a fixed header and footer, ~200 characters per observation title, ~1,200 more
+ * for each full narrative, ~400 per session line, and a 3,000-character
+ * last-session summary block.
+ */
+function render(items: number[], config: ContextConfig): string {
+  const header = 'H'.repeat(300);
+  const titles = items.length * 200;
+  const fulls = Math.min(config.fullObservationCount, items.length) * 1200;
+  const sessions = config.sessionCount * 400;
+  const summary = config.showLastSummary ? 3000 : 0;
+  const footer = 'F'.repeat(200);
+  return header + 'x'.repeat(titles + fulls + sessions + summary) + footer;
+}
+
+const items = (n: number) => Array.from({ length: n }, (_, i) => i);
+
+describe('context output budget (#3802)', () => {
+  it('leaves a block that already fits completely alone', () => {
+    const config = makeConfig({ fullObservationCount: 1, sessionCount: 2, showLastSummary: false });
+    const result = fitContextToBudget(items(5), config, render);
+
+    expect(result.reductions).toBe(0);
+    expect(result.observationCount).toBe(5);
+    expect(result.config).toBe(config);
+    expect(result.text.length).toBeLessThanOrEqual(CONTEXT_OUTPUT_LIMIT);
+  });
+
+  it('fits a busy project that overflows on the plugin defaults', () => {
+    // 50 observations at the shipped defaults: ~10,000 of titles alone, plus
+    // full narratives, ten session lines and the summary block.
+    const before = render(items(50), makeConfig());
+    expect(before.length).toBeGreaterThan(CONTEXT_OUTPUT_LIMIT);
+
+    const result = fitContextToBudget(items(50), makeConfig(), render);
+    expect(result.text.length).toBeLessThanOrEqual(CONTEXT_OUTPUT_LIMIT);
+    expect(result.overBudget).toBe(false);
+  });
+
+  it('gives up full narratives before it gives up timeline entries', () => {
+    const result = fitContextToBudget(items(20), makeConfig(), render);
+
+    expect(result.config.fullObservationCount).toBe(0);
+    expect(result.observationCount).toBeGreaterThan(1);
+  });
+
+  it('gives up the last-session summary before it gives up observations', () => {
+    // 40 titles (8,000) + the 3,000-character summary block is over the limit;
+    // dropping the block alone brings it back to 8,500.
+    const config = makeConfig({ fullObservationCount: 0, sessionCount: 0 });
+    expect(render(items(40), config).length).toBeGreaterThan(CONTEXT_OUTPUT_LIMIT);
+
+    const result = fitContextToBudget(items(40), config, render);
+    expect(result.config.showLastSummary).toBe(false);
+    expect(result.observationCount).toBe(40);
+  });
+
+  it('keeps at least one observation and says so when nothing more can go', () => {
+    const huge = (items: number[]) => 'x'.repeat(20_000 + items.length);
+    const result = fitContextToBudget(items(10), makeConfig(), huge);
+
+    expect(result.observationCount).toBe(1);
+    expect(result.overBudget).toBe(true);
+    expect(result.text.length).toBeGreaterThan(CONTEXT_OUTPUT_LIMIT);
+  });
+
+  it('honours an explicit unlimited budget', () => {
+    const result = fitContextToBudget(items(50), makeConfig(), render, Number.POSITIVE_INFINITY);
+
+    expect(result.reductions).toBe(0);
+    expect(result.observationCount).toBe(50);
+  });
+
+  it('never returns a text longer than the one it started from', () => {
+    const config = makeConfig();
+    const first = render(items(50), config);
+    const result = fitContextToBudget(items(50), config, render);
+
+    expect(result.text.length).toBeLessThanOrEqual(first.length);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebases and ships #3811 onto latest `main`. Fixes #3802.

**Gate:** RCA in the original PR (item counts cannot keep a hook under 10,000 characters; overflow is silently replaced by a stub). No second system — measure and drop whole items. The reduction ladder is the one judgement call; it follows the issue's cost-per-value figures.

**Rebase notes:** keeps main's quota-cooldown notice inside the measured warning. Bundle rebuild left to the release step.

**Local tests:** `bun test tests/context/context-budget-3802.test.ts` — 12 pass.

Original: https://github.com/thedotmack/claude-mem/pull/3811
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96a9a430-2ca5-4074-83b3-87db3e21f479?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96a9a430-2ca5-4074-83b3-87db3e21f479&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

