### PR TITLE
fix(observer): strip image payloads out of the observation prompt

### DIFF
--- a/src/sdk/prompts.ts
+++ b/src/sdk/prompts.ts
@@ -172,9 +172,16 @@ function stripImagePayloads(value: unknown, depth = 0): unknown {
   const record = value as Record<string, unknown>;
 
   // Anthropic content block: { type: 'image', source: { data: '<base64>' } }.
+  // A url-backed source is the same case as OpenAI's plain http URL — short,
+  // and it carries signal — so only an inlined payload is removed.
   const source = record.source;
   if (record.type === 'image' && source !== null && typeof source === 'object') {
-    return { type: 'image', source: elideImageSource(source as Record<string, unknown>) };
+    const record_source = source as Record<string, unknown>;
+    const url = record_source.url;
+    if (typeof url === 'string' && !url.startsWith('data:')) {
+      return value;
+    }
+    return { type: 'image', source: elideImageSource(record_source) };
   }
 
   // OpenAI content block: { type: 'image_url', image_url: { url: 'data:...' } }.

--- a/src/sdk/prompts.ts
+++ b/src/sdk/prompts.ts
@@ -154,6 +154,12 @@ const OBS_PROMPT_FIELD_TAIL_RATIO = 0.3;
 // keeping the part that has signal.
 const MAX_SANITIZE_DEPTH = 12;
 
+// URI schemes are case-insensitive. A `DATA:image/png;base64,…` source is the
+// same inlined payload as `data:` — Greptile reproduced the bypass on #3762.
+function isDataUrl(url: string): boolean {
+  return url.slice(0, 5).toLowerCase() === 'data:';
+}
+
 function elideImageSource(source: Record<string, unknown>): Record<string, unknown> {
   const data = source.data;
   const elided: Record<string, unknown> = { elided: 'image data withheld from the observer' };
@@ -178,7 +184,7 @@ function stripImagePayloads(value: unknown, depth = 0): unknown {
   if (record.type === 'image' && source !== null && typeof source === 'object') {
     const record_source = source as Record<string, unknown>;
     const url = record_source.url;
-    if (typeof url === 'string' && !url.startsWith('data:')) {
+    if (typeof url === 'string' && !isDataUrl(url)) {
       return value;
     }
     return { type: 'image', source: elideImageSource(record_source) };
@@ -190,7 +196,7 @@ function stripImagePayloads(value: unknown, depth = 0): unknown {
     const url = (imageUrl as Record<string, unknown>).url;
     // A plain http(s) URL is short and can carry signal; only a data: URL is
     // the inlined payload this exists to remove.
-    if (typeof url === 'string' && url.startsWith('data:')) {
+    if (typeof url === 'string' && isDataUrl(url)) {
       return {
         type: 'image_url',
         image_url: { elided: 'image data withheld from the observer', bytes: url.length },

--- a/src/sdk/prompts.ts
+++ b/src/sdk/prompts.ts
@@ -139,6 +139,66 @@ export const OBS_PROMPT_FIELD_MAX_CHARS = 16_000;
 const OBS_PROMPT_FIELD_HEAD_RATIO = 0.6;
 const OBS_PROMPT_FIELD_TAIL_RATIO = 0.3;
 
+// Image content blocks carry base64 payloads that are worthless to a text
+// observer and ruinously expensive to carry. Two things compound (#3730):
+// truncateObservationField keeps the head and tail of an oversized field, so
+// what survives a screenshot is thousands of characters of base64 rather than
+// the caption beside it; and the prompt is appended to
+// session.conversationHistory, which every later observation in the session
+// re-sends in full. A browser-automation session taking a few hundred
+// screenshots replays all of it, every time.
+//
+// Stripping generically, on the shape of the content block, rather than by
+// tool name: CLAUDE_MEM_SKIP_TOOLS needs every screenshot-producing tool
+// enumerated ahead of time, and it drops the observation entirely instead of
+// keeping the part that has signal.
+const MAX_SANITIZE_DEPTH = 12;
+
+function elideImageSource(source: Record<string, unknown>): Record<string, unknown> {
+  const data = source.data;
+  const elided: Record<string, unknown> = { elided: 'image data withheld from the observer' };
+  if (typeof source.media_type === 'string') elided.media_type = source.media_type;
+  if (typeof data === 'string') elided.bytes = data.length;
+  return elided;
+}
+
+function stripImagePayloads(value: unknown, depth = 0): unknown {
+  if (depth > MAX_SANITIZE_DEPTH || value === null || typeof value !== 'object') return value;
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => stripImagePayloads(entry, depth + 1));
+  }
+
+  const record = value as Record<string, unknown>;
+
+  // Anthropic content block: { type: 'image', source: { data: '<base64>' } }.
+  const source = record.source;
+  if (record.type === 'image' && source !== null && typeof source === 'object') {
+    return { type: 'image', source: elideImageSource(source as Record<string, unknown>) };
+  }
+
+  // OpenAI content block: { type: 'image_url', image_url: { url: 'data:...' } }.
+  const imageUrl = record.image_url;
+  if (record.type === 'image_url' && imageUrl !== null && typeof imageUrl === 'object') {
+    const url = (imageUrl as Record<string, unknown>).url;
+    // A plain http(s) URL is short and can carry signal; only a data: URL is
+    // the inlined payload this exists to remove.
+    if (typeof url === 'string' && url.startsWith('data:')) {
+      return {
+        type: 'image_url',
+        image_url: { elided: 'image data withheld from the observer', bytes: url.length },
+      };
+    }
+    return value;
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(record)) {
+    out[key] = stripImagePayloads(entry, depth + 1);
+  }
+  return out;
+}
+
 function truncateObservationField(value: unknown, maxChars: number = OBS_PROMPT_FIELD_MAX_CHARS): string {
   // JSON.stringify returns undefined for undefined / functions / symbols;
   // fall back to empty string so the call sites (template literal output)
@@ -178,8 +238,8 @@ export function buildObservationPrompt(obs: Observation): string {
   return `<observed_from_primary_session>
   <what_happened>${obs.tool_name}</what_happened>
   <occurred_at>${new Date(obs.created_at_epoch).toISOString()}</occurred_at>${obs.cwd ? `\n  <working_directory>${obs.cwd}</working_directory>` : ''}
-  <parameters>${truncateObservationField(toolInput)}</parameters>
-  <outcome>${truncateObservationField(toolOutput)}</outcome>
+  <parameters>${truncateObservationField(stripImagePayloads(toolInput))}</parameters>
+  <outcome>${truncateObservationField(stripImagePayloads(toolOutput))}</outcome>
 </observed_from_primary_session>
 
 If a <parameters> or <outcome> block above contains an "<elided chars=... />" marker, that field was truncated to fit the observer's context window. Describe only what you can see in the kept portion and do not infer details about the elided range.

--- a/tests/sdk/prompts.test.ts
+++ b/tests/sdk/prompts.test.ts
@@ -55,3 +55,138 @@ describe('buildObservationPrompt oversized field truncation (#2468)', () => {
     expect(prompt).not.toContain('reason="oversize"');
   });
 });
+
+describe('buildObservationPrompt image-payload stripping (#3730)', () => {
+  const BASE64 = 'iVBORw0KGgoAAAANSUhEUg' + 'A'.repeat(200_000);
+
+  function screenshotOutcome() {
+    return JSON.stringify({
+      content: [
+        { type: 'text', text: 'Took a screenshot of the viewport at 1280x720.' },
+        { type: 'image', source: { type: 'base64', media_type: 'image/png', data: BASE64 } },
+      ],
+    });
+  }
+
+  it('keeps no base64 run from an Anthropic image content block', () => {
+    const prompt = buildObservationPrompt({
+      id: 1,
+      tool_name: 'mcp__claude-in-chrome__computer',
+      tool_input: JSON.stringify({ action: 'screenshot' }),
+      tool_output: screenshotOutcome(),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    // Truncation alone did NOT solve this: it keeps the head and tail of an
+    // oversized field, so a screenshot used to survive as thousands of
+    // characters of base64 rather than as the caption beside it.
+    expect(/A{200,}/.test(prompt)).toBe(false);
+    expect(prompt).not.toContain('iVBORw0KGgo');
+  });
+
+  it('keeps the text that sits beside the image', () => {
+    const prompt = buildObservationPrompt({
+      id: 2,
+      tool_name: 'mcp__claude-in-chrome__computer',
+      tool_input: JSON.stringify({ action: 'screenshot' }),
+      tool_output: screenshotOutcome(),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    // Stripping must not degrade into skipping: the caption is the part the
+    // observer can actually narrate.
+    expect(prompt).toContain('Took a screenshot of the viewport');
+  });
+
+  it('says what was removed instead of removing it silently', () => {
+    const prompt = buildObservationPrompt({
+      id: 3,
+      tool_name: 'mcp__claude-in-chrome__computer',
+      tool_input: JSON.stringify({ action: 'screenshot' }),
+      tool_output: screenshotOutcome(),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(prompt).toContain('image data withheld from the observer');
+    expect(prompt).toContain('image/png');
+  });
+
+  it('collapses the prompt far below the per-field truncation cap', () => {
+    const prompt = buildObservationPrompt({
+      id: 4,
+      tool_name: 'mcp__claude-in-chrome__browser_batch',
+      tool_input: JSON.stringify({ action: 'screenshot' }),
+      tool_output: screenshotOutcome(),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    // The prompt is appended to session.conversationHistory and re-sent by
+    // every later observation in the session, so this saving compounds.
+    expect(prompt.length).toBeLessThan(2_000);
+  });
+
+  it('strips images nested inside arrays and objects', () => {
+    const prompt = buildObservationPrompt({
+      id: 5,
+      tool_name: 'mcp__browser__batch',
+      tool_input: JSON.stringify({ steps: [{ shot: { type: 'image', source: { data: BASE64 } } }] }),
+      tool_output: JSON.stringify({
+        results: { pages: [{ blocks: [{ type: 'image', source: { data: BASE64 } }] }] },
+      }),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(/A{200,}/.test(prompt)).toBe(false);
+  });
+
+  it('strips an OpenAI-style inlined data: URL', () => {
+    const prompt = buildObservationPrompt({
+      id: 6,
+      tool_name: 'some_openai_tool',
+      tool_input: JSON.stringify({}),
+      tool_output: JSON.stringify({
+        content: [{ type: 'image_url', image_url: { url: 'data:image/png;base64,' + BASE64 } }],
+      }),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(/A{200,}/.test(prompt)).toBe(false);
+    expect(prompt).toContain('image data withheld from the observer');
+  });
+
+  it('leaves a plain http image URL alone — it is short and it carries signal', () => {
+    const prompt = buildObservationPrompt({
+      id: 7,
+      tool_name: 'some_openai_tool',
+      tool_input: JSON.stringify({}),
+      tool_output: JSON.stringify({
+        content: [{ type: 'image_url', image_url: { url: 'https://example.com/shot.png' } }],
+      }),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(prompt).toContain('https://example.com/shot.png');
+  });
+
+  it('does not touch ordinary tool output', () => {
+    const prompt = buildObservationPrompt({
+      id: 8,
+      tool_name: 'exec_command',
+      tool_input: JSON.stringify({ cmd: 'pwd' }),
+      tool_output: JSON.stringify({ output: '/repo', type: 'image_of_the_day' }),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(prompt).toContain('/repo');
+    expect(prompt).toContain('image_of_the_day');
+    expect(prompt).not.toContain('withheld');
+  });
+});

--- a/tests/sdk/prompts.test.ts
+++ b/tests/sdk/prompts.test.ts
@@ -190,3 +190,41 @@ describe('buildObservationPrompt image-payload stripping (#3730)', () => {
     expect(prompt).not.toContain('withheld');
   });
 });
+
+describe('buildObservationPrompt keeps url-backed image sources (#3730 review)', () => {
+  it('leaves an Anthropic url source alone, the same as the OpenAI branch does', () => {
+    const prompt = buildObservationPrompt({
+      id: 9,
+      tool_name: 'mcp__browser__shot',
+      tool_input: JSON.stringify({}),
+      tool_output: JSON.stringify({
+        content: [
+          { type: 'image', source: { type: 'url', url: 'https://example.com/shot.png' } },
+        ],
+      }),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(prompt).toContain('https://example.com/shot.png');
+    expect(prompt).not.toContain('withheld');
+  });
+
+  it('still elides an Anthropic source whose url is an inlined data: URL', () => {
+    const prompt = buildObservationPrompt({
+      id: 10,
+      tool_name: 'mcp__browser__shot',
+      tool_input: JSON.stringify({}),
+      tool_output: JSON.stringify({
+        content: [
+          { type: 'image', source: { type: 'url', url: 'data:image/png;base64,' + 'A'.repeat(100_000) } },
+        ],
+      }),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(/A{200,}/.test(prompt)).toBe(false);
+    expect(prompt).toContain('image data withheld from the observer');
+  });
+});

--- a/tests/sdk/prompts.test.ts
+++ b/tests/sdk/prompts.test.ts
@@ -227,4 +227,22 @@ describe('buildObservationPrompt keeps url-backed image sources (#3730 review)',
     expect(/A{200,}/.test(prompt)).toBe(false);
     expect(prompt).toContain('image data withheld from the observer');
   });
+
+  it('elides an uppercase DATA: URI the same as lowercase data:', () => {
+    const prompt = buildObservationPrompt({
+      id: 11,
+      tool_name: 'mcp__browser__shot',
+      tool_input: JSON.stringify({}),
+      tool_output: JSON.stringify({
+        content: [
+          { type: 'image', source: { type: 'url', url: 'DATA:image/png;base64,' + 'A'.repeat(100_000) } },
+        ],
+      }),
+      created_at_epoch: Date.now(),
+      cwd: '/repo',
+    });
+
+    expect(/A{200,}/.test(prompt)).toBe(false);
+    expect(prompt).toContain('image data withheld from the observer');
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebases and ships #3762 onto latest `main`. Fixes #3730.

**Gate:** RCA in the original PR (screenshot base64 survives head/tail truncation and is re-billed on every later observation). No second system — strip in `buildObservationPrompt`. Narrow.

**Ship-time fix:** treat `DATA:` as `data:` (URI schemes are case-insensitive). Greptile reproduced the bypass.

**Local tests:** `bun test tests/sdk/prompts.test.ts` — 14 pass.

Original: https://github.com/thedotmack/claude-mem/pull/3762
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96a9a430-2ca5-4074-83b3-87db3e21f479?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96a9a430-2ca5-4074-83b3-87db3e21f479&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

