### PR TITLE
fix(provider): pause the session on a reactive quota error instead of ending it

### DIFF
--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -400,6 +400,17 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
       const preserving = this.preservingAbortReason(error);
       if (preserving !== null) {
         session.abortReason = preserving;
+        // Abort as well as label. Without it the controller stays live while
+        // the error unwinds, and the session route books the failure twice —
+        // an observer failure and an error outcome on the way out, then the
+        // aborted outcome at finalization — leaving observer-health marked
+        // failed for a pause that is not a failure. This is what the two
+        // observer-text paths already do for the same conditions.
+        try {
+          session.abortController.abort();
+        } catch {
+          // best-effort; AbortController.abort() should not throw in normal use.
+        }
         logger.warn('SDK', `${this.providerName} paused on ${error.kind}; preserving buffered work`, {
           sessionId: session.sessionDbId,
           kind: error.kind,

--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -8,7 +8,7 @@ import type { ActiveSession, ConversationMessage } from '../worker-types.js';
 import { ModeManager } from '../domain/ModeManager.js';
 import type { ModeConfig } from '../domain/types.js';
 import { resolveSummaryTierModel } from './model-aliases.js';
-import { isClassified } from './provider-errors.js';
+import { isClassified, type ClassifiedProviderError } from './provider-errors.js';
 import {
   shouldRecycleConversation,
   conversationChars,
@@ -361,6 +361,32 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     }
   }
 
+  /**
+   * Map a classified provider failure onto the abortReason category that keeps
+   * buffered work alive.
+   *
+   * handleGeneratorExit finalizes the session — dropping whatever is buffered —
+   * for every category outside its preserve list. Quota was only ever set by
+   * the two PROACTIVE sites (the pre-request rate-limit guard and the
+   * observer-text heuristic), so a real 429 coming back from the provider left
+   * abortReason null and the session was torn down as if the failure were
+   * fatal (#3700). These conditions clear on their own; the work should still
+   * be there when they do.
+   */
+  private preservingAbortReason(error: ClassifiedProviderError): string | null {
+    switch (error.kind) {
+      case 'quota_exhausted':
+      case 'rate_limit':
+        return `quota:${error.kind}`;
+      // Same shape, same list: handleGeneratorExit already honours 'auth', and
+      // credentials that are fixed by /login are no more fatal than a 429.
+      case 'auth_invalid':
+        return `auth:${error.kind}`;
+      default:
+        return null;
+    }
+  }
+
   protected handleSessionError(error: unknown, session: ActiveSession, _worker?: WorkerRef): never {
     if (isAbortError(error)) {
       logger.warn('SDK', `${this.providerName} agent aborted`, { sessionId: session.sessionDbId });
@@ -368,6 +394,18 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     }
 
     if (isClassified(error)) {
+      // Set BEFORE the rethrow: the .finally() in SessionRoutes reads
+      // session.abortReason to decide whether to finalize the session, so a
+      // reason recorded after unwinding would arrive too late to matter.
+      const preserving = this.preservingAbortReason(error);
+      if (preserving !== null) {
+        session.abortReason = preserving;
+        logger.warn('SDK', `${this.providerName} paused on ${error.kind}; preserving buffered work`, {
+          sessionId: session.sessionDbId,
+          kind: error.kind,
+        });
+      }
+
       // Logged once at SessionRoutes' `Observer failed` line.
       logger.debug('SDK', `${this.providerName} agent error`, { sessionDbId: session.sessionDbId, kind: error.kind }, error);
     } else {

--- a/tests/worker/reactive-quota-abort-reason.test.ts
+++ b/tests/worker/reactive-quota-abort-reason.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it, mock, beforeEach, afterEach, spyOn } from 'bun:test';
+import { ModeManager } from '../../src/services/domain/ModeManager.js';
+import { OpenAICompatibleProvider, type ProviderQueryResult } from '../../src/services/worker/OpenAICompatibleProvider.js';
+import { ClassifiedProviderError } from '../../src/services/worker/provider-errors.js';
+import { handleGeneratorExit } from '../../src/services/worker/session/GeneratorExitHandler.js';
+import type { ActiveSession } from '../../src/services/worker-types.js';
+import type { DatabaseManager } from '../../src/services/worker/DatabaseManager.js';
+import type { SessionManager } from '../../src/services/worker/SessionManager.js';
+import type { SessionCompletionHandler } from '../../src/services/worker/session/SessionCompletionHandler.js';
+
+/**
+ * #3700 — a reactive 429 must pause the session, not finalize it.
+ *
+ * abortReason was only ever set to `quota:…` by the two PROACTIVE sites: the
+ * pre-request rate-limit guard, and the observer-text heuristic. An HTTP 429
+ * coming back from the provider was classified correctly and then rethrown
+ * with abortReason untouched, so SessionRoutes' .finally() saw `reason=null`
+ * and handleGeneratorExit tore the session down — dropping buffered work for
+ * a condition that clears by itself.
+ */
+
+const mockMode = {
+  name: 'code',
+  prompts: { init: 'init prompt', observation: 'obs prompt', summary: 'summary prompt' },
+  observation_types: [{ id: 'discovery' }],
+  observation_concepts: [],
+};
+
+function makeSession(overrides: Partial<ActiveSession> = {}): ActiveSession {
+  return {
+    sessionDbId: 382,
+    contentSessionId: 'test-session',
+    memorySessionId: 'mem-session-123',
+    project: 'home-infra',
+    platformSource: 'claude',
+    userPrompt: 'test prompt',
+    abortController: new AbortController(),
+    generatorPromise: null,
+    lastPromptNumber: 1,
+    startTime: Date.now(),
+    cumulativeInputTokens: 0,
+    cumulativeOutputTokens: 0,
+    earliestPendingTimestamp: null,
+    claimedMessageIds: [],
+    conversationHistory: [],
+    currentProvider: null,
+    consecutiveRestarts: 0,
+    consecutiveInvalidOutputs: 0,
+    lastGeneratorActivity: Date.now(),
+    ...overrides,
+  } as ActiveSession;
+}
+
+class ThrowingProvider extends OpenAICompatibleProvider<{ apiKey: string; model: string }> {
+  protected readonly providerName = 'Gemini';
+  protected readonly syntheticIdPrefix = 'gemini';
+  protected readonly forwardEmptyMessageResponse = false;
+
+  constructor(private readonly toThrow: unknown) {
+    super({} as DatabaseManager, {
+      getMessageIterator: async function* () { yield* []; },
+    } as unknown as SessionManager);
+  }
+
+  protected getConfig() {
+    return { apiKey: 'test-api-key', model: 'gemini-3.1-flash-lite' };
+  }
+
+  protected missingApiKeyError(): Error {
+    return new Error('missing key');
+  }
+
+  protected async query(): Promise<ProviderQueryResult> {
+    throw this.toThrow;
+  }
+
+  protected estimateTokens(): number {
+    return 0;
+  }
+
+  protected buildLastUsage(): ActiveSession['lastUsage'] {
+    return null;
+  }
+}
+
+async function runAndCatch(error: unknown, session: ActiveSession): Promise<void> {
+  const provider = new ThrowingProvider(error);
+  await provider.startSession(session).catch(() => {
+    // Rethrowing is the contract; this test is about what happened on the way out.
+  });
+}
+
+let modeSpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  modeSpy = spyOn(ModeManager, 'getInstance').mockReturnValue({
+    getActiveMode: () => mockMode,
+  } as unknown as ModeManager);
+});
+
+afterEach(() => {
+  modeSpy.mockRestore();
+});
+
+describe('reactive provider errors set a preserving abortReason (#3700)', () => {
+  it('marks a real 429 as a quota pause', async () => {
+    const session = makeSession();
+
+    await runAndCatch(
+      new ClassifiedProviderError('Gemini quota exhausted (status 429)', {
+        kind: 'quota_exhausted',
+        cause: null,
+      }),
+      session,
+    );
+
+    expect(session.abortReason).toBe('quota:quota_exhausted');
+  });
+
+  it('marks a rate_limit the same way', async () => {
+    const session = makeSession();
+
+    await runAndCatch(
+      new ClassifiedProviderError('rate limited', { kind: 'rate_limit', cause: null }),
+      session,
+    );
+
+    expect(session.abortReason).toBe('quota:rate_limit');
+  });
+
+  it('marks an invalid credential as an auth pause', async () => {
+    const session = makeSession();
+
+    await runAndCatch(
+      new ClassifiedProviderError('invalid api key', { kind: 'auth_invalid', cause: null }),
+      session,
+    );
+
+    expect(session.abortReason).toBe('auth:auth_invalid');
+  });
+
+  // The categories that genuinely are fatal must keep finalizing, or a broken
+  // session would linger forever instead of being cleaned up.
+  it('leaves genuinely unrecoverable errors without a preserving reason', async () => {
+    const session = makeSession();
+
+    await runAndCatch(
+      new ClassifiedProviderError('bad request', { kind: 'unrecoverable', cause: null }),
+      session,
+    );
+
+    expect(session.abortReason ?? null).toBeNull();
+  });
+
+  it('leaves unclassified errors alone', async () => {
+    const session = makeSession();
+
+    await runAndCatch(new Error('something else entirely'), session);
+
+    expect(session.abortReason ?? null).toBeNull();
+  });
+
+  it('still rethrows so the caller sees the failure', async () => {
+    const provider = new ThrowingProvider(
+      new ClassifiedProviderError('Gemini quota exhausted (status 429)', {
+        kind: 'quota_exhausted',
+        cause: null,
+      }),
+    );
+
+    await expect(provider.startSession(makeSession())).rejects.toThrow(/quota exhausted/);
+  });
+});
+
+/**
+ * The reason only matters because of what handleGeneratorExit does with it —
+ * assert the whole path rather than the string in isolation.
+ */
+describe('the reason actually reaches handleGeneratorExit (#3700)', () => {
+  function buildDeps() {
+    const finalizeSession = mock(() => Promise.resolve());
+    const removeSessionImmediate = mock(() => {});
+    return {
+      deps: {
+        sessionManager: {
+          getMessageBuffer: () => ({ getPendingCount: () => 4 }),
+          removeSessionImmediate,
+        } as unknown as SessionManager,
+        completionHandler: { finalizeSession } as unknown as SessionCompletionHandler,
+      },
+      finalizeSession,
+      removeSessionImmediate,
+    };
+  }
+
+  it('preserves buffered work for a reactive quota exit', async () => {
+    const session = makeSession();
+    await runAndCatch(
+      new ClassifiedProviderError('Gemini quota exhausted (status 429)', {
+        kind: 'quota_exhausted',
+        cause: null,
+      }),
+      session,
+    );
+
+    const { deps, finalizeSession, removeSessionImmediate } = buildDeps();
+    await handleGeneratorExit(session, session.abortReason, deps);
+
+    expect(finalizeSession).not.toHaveBeenCalled();
+    expect(removeSessionImmediate).not.toHaveBeenCalled();
+  });
+
+  // The exact failure the reporter logged: `Generator exited — finalizing
+  // session {reason=null}`, ten times over fifteen minutes.
+  it('finalizes when the reason is null, which is what the bug produced', async () => {
+    const { deps, finalizeSession } = buildDeps();
+    await handleGeneratorExit(makeSession(), null, deps);
+
+    expect(finalizeSession).toHaveBeenCalledWith(382);
+  });
+});

--- a/tests/worker/reactive-quota-abort-reason.test.ts
+++ b/tests/worker/reactive-quota-abort-reason.test.ts
@@ -160,6 +160,35 @@ describe('reactive provider errors set a preserving abortReason (#3700)', () => 
     expect(session.abortReason ?? null).toBeNull();
   });
 
+  // Review on #3760: labelling without aborting leaves the controller live
+  // while the error unwinds, so the session route books an observer failure
+  // and an error outcome before finalization books the aborted one — a pause
+  // recorded as a failure, twice.
+  it('aborts the controller so the pause is not also booked as a failure', async () => {
+    const session = makeSession();
+
+    await runAndCatch(
+      new ClassifiedProviderError('Gemini quota exhausted (status 429)', {
+        kind: 'quota_exhausted',
+        cause: null,
+      }),
+      session,
+    );
+
+    expect(session.abortController.signal.aborted).toBe(true);
+  });
+
+  it('leaves the controller alone for a genuinely fatal error', async () => {
+    const session = makeSession();
+
+    await runAndCatch(
+      new ClassifiedProviderError('bad request', { kind: 'unrecoverable', cause: null }),
+      session,
+    );
+
+    expect(session.abortController.signal.aborted).toBe(false);
+  });
+
   it('still rethrows so the caller sees the failure', async () => {
     const provider = new ThrowingProvider(
       new ClassifiedProviderError('Gemini quota exhausted (status 429)', {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebases and ships #3760 onto latest `main`. Fixes #3700.

**Gate:** RCA in the original PR (`abortReason` stayed null on a real 429, so the session was finalized and buffered work was dropped). No second system — set the existing preserve category. Narrow.

**Local tests:** `bun test tests/worker/reactive-quota-abort-reason.test.ts tests/worker/provider-errors.test.ts` — 16 pass.

Original: https://github.com/thedotmack/claude-mem/pull/3760
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96a9a430-2ca5-4074-83b3-87db3e21f479?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96a9a430-2ca5-4074-83b3-87db3e21f479&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

