### PR TITLE
fix(worker): make the LLM per-attempt deadline configurable and stop retrying it

### DIFF
--- a/src/services/worker/retry.ts
+++ b/src/services/worker/retry.ts
@@ -45,9 +45,45 @@ export interface RetryOptions {
   abortSignal?: AbortSignal;
 }
 
+/** Bounds shared with the other CLAUDE_MEM_*_TIMEOUT_MS settings. */
+const LLM_TIMEOUT_BOUNDS = { min: 500, max: 300_000 } as const;
+const FALLBACK_PER_ATTEMPT_TIMEOUT_MS = 30_000;
+
+/**
+ * Per-attempt deadline for a provider request.
+ *
+ * 30s suits a hosted provider and is far too short for a local model: a
+ * report on an Ollama backend measured successful requests with a median of
+ * 21s and a p99 of 29.8s, so the deadline was truncating work that had
+ * already been computed. The value was unreachable from configuration, and
+ * the workaround was editing the installed bundle after every update.
+ *
+ * Read here rather than through worker-utils' readTimeoutEnv: this module is
+ * a leaf that imports only the logger and the error classifier, and that one
+ * pulls in the supervisor and telemetry.
+ */
+export function resolveLlmTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.CLAUDE_MEM_LLM_TIMEOUT_MS;
+  if (!raw) return FALLBACK_PER_ATTEMPT_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (
+    Number.isFinite(parsed)
+    && parsed >= LLM_TIMEOUT_BOUNDS.min
+    && parsed <= LLM_TIMEOUT_BOUNDS.max
+  ) {
+    return parsed;
+  }
+  logger.warn('SDK', 'Invalid CLAUDE_MEM_LLM_TIMEOUT_MS, using default', {
+    value: raw,
+    min: LLM_TIMEOUT_BOUNDS.min,
+    max: LLM_TIMEOUT_BOUNDS.max,
+  });
+  return FALLBACK_PER_ATTEMPT_TIMEOUT_MS;
+}
+
 const DEFAULT_OPTIONS: Required<Omit<RetryOptions, 'label' | 'abortSignal'>> = {
   maxRetries: 2,
-  perAttemptTimeoutMs: 30_000,
+  perAttemptTimeoutMs: resolveLlmTimeoutMs(),
   baseDelayMs: 100,
   maxDelayMs: 30_000,
 };
@@ -87,7 +123,11 @@ export async function withRetry<T>(
 
     // Per-attempt timeout via AbortController. Forward external aborts too.
     const attemptController = new AbortController();
-    const timeoutHandle = setTimeout(() => attemptController.abort(), opts.perAttemptTimeoutMs);
+    let deadlineExpired = false;
+    const timeoutHandle = setTimeout(() => {
+      deadlineExpired = true;
+      attemptController.abort();
+    }, opts.perAttemptTimeoutMs);
     const onExternalAbort = () => attemptController.abort();
     options.abortSignal?.addEventListener('abort', onExternalAbort, { once: true });
 
@@ -96,9 +136,21 @@ export async function withRetry<T>(
     } catch (err: unknown) {
       lastError = err;
 
+      // Our own deadline, not a network blip. The abort surfaces with no HTTP  // status, so it classifies as transient and was retried twice — against a
+      // backend that is already saturated, those attempts are what turn a
+      // latency problem into a congestion collapse. Raise the deadline instead.
+      if (deadlineExpired) {
+        throw new Error(
+          `${opts.label ?? 'Request'} exceeded the ${opts.perAttemptTimeoutMs}ms per-attempt deadline. `
+          + 'Raise CLAUDE_MEM_LLM_TIMEOUT_MS if the backend is simply slow.',
+          { cause: err },
+        );
+      }
+
       if (!isRetryableKind(err)) {
         throw err;
       }
+    
 
       if (attempt === opts.maxRetries) {
         throw err;

--- a/src/services/worker/retry.ts
+++ b/src/services/worker/retry.ts
@@ -65,7 +65,10 @@ const FALLBACK_PER_ATTEMPT_TIMEOUT_MS = 30_000;
 export function resolveLlmTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
   const raw = env.CLAUDE_MEM_LLM_TIMEOUT_MS;
   if (!raw) return FALLBACK_PER_ATTEMPT_TIMEOUT_MS;
-  const parsed = Number.parseInt(raw, 10);
+  // Complete integer only. parseInt('90000ms') would silently accept a typo
+  // as 90000 — Greptile reproduced that on #3808.
+  const trimmed = raw.trim();
+  const parsed = /^\d+$/.test(trimmed) ? Number(trimmed) : Number.NaN;
   if (
     Number.isFinite(parsed)
     && parsed >= LLM_TIMEOUT_BOUNDS.min

--- a/tests/worker/llm-timeout.test.ts
+++ b/tests/worker/llm-timeout.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'bun:test';
+import { resolveLlmTimeoutMs, withRetry } from '../../src/services/worker/retry.js';
+
+// #3794: the per-attempt deadline was hardcoded at 30s and unreachable from
+// configuration. On a local model that truncates work already computed — a
+// reported Ollama backend had a p99 of 29.8s against a 30s deadline — and the
+// only workaround was editing the installed bundle after every update.
+describe('resolveLlmTimeoutMs', () => {
+  it('defaults to 30s when nothing is configured', () => {
+    expect(resolveLlmTimeoutMs({})).toBe(30_000);
+  });
+
+  it('takes a value inside the shared 500..300000 bounds', () => {
+    expect(resolveLlmTimeoutMs({ CLAUDE_MEM_LLM_TIMEOUT_MS: '90000' })).toBe(90_000);
+    expect(resolveLlmTimeoutMs({ CLAUDE_MEM_LLM_TIMEOUT_MS: '500' })).toBe(500);
+    expect(resolveLlmTimeoutMs({ CLAUDE_MEM_LLM_TIMEOUT_MS: '300000' })).toBe(300_000);
+  });
+
+  it('falls back to the default rather than trusting a value out of range', () => {
+    // A zero or a negative would disable the deadline; a huge one would park a
+    // worker for hours. Both keep the default, matching the other
+    // CLAUDE_MEM_*_TIMEOUT_MS settings.
+    for (const value of ['0', '-1', '499', '300001', 'abc', '']) {
+      expect(resolveLlmTimeoutMs({ CLAUDE_MEM_LLM_TIMEOUT_MS: value })).toBe(30_000);
+    }
+  });
+});
+
+describe('per-attempt deadline', () => {
+  it('does not retry a request that blew the deadline', async () => {
+    // The abort surfaces with no HTTP status, so it classified as transient and
+    // was retried twice against a backend that is already saturated.
+    let attempts = 0;
+    const started = Date.now();
+    await expect(
+      withRetry(
+        async signal => {
+          attempts += 1;
+          await new Promise((_resolve, reject) => {
+            signal.addEventListener('abort', () => reject(new Error('The operation was aborted.')), { once: true });
+          });
+          return 'unreachable';
+        },
+        { label: 'probe', perAttemptTimeoutMs: 20, maxRetries: 2 },
+      ),
+    ).rejects.toThrow(/per-attempt deadline/);
+    expect(attempts).toBe(1);
+    // Three attempts plus backoff would take far longer than one deadline.
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+
+  it('still retries a genuine transient failure', async () => {
+    let attempts = 0;
+    const out = await withRetry(
+      async () => {
+        attempts += 1;
+        if (attempts < 2) throw new Error('socket hang up');
+        return 'ok';
+      },
+      { label: 'probe', perAttemptTimeoutMs: 5_000, maxRetries: 2, baseDelayMs: 1 },
+    );
+    expect(out).toBe('ok');
+    expect(attempts).toBe(2);
+  });
+});

--- a/tests/worker/llm-timeout.test.ts
+++ b/tests/worker/llm-timeout.test.ts
@@ -20,7 +20,7 @@ describe('resolveLlmTimeoutMs', () => {
     // A zero or a negative would disable the deadline; a huge one would park a
     // worker for hours. Both keep the default, matching the other
     // CLAUDE_MEM_*_TIMEOUT_MS settings.
-    for (const value of ['0', '-1', '499', '300001', 'abc', '']) {
+    for (const value of ['0', '-1', '499', '300001', 'abc', '', '90000ms']) {
       expect(resolveLlmTimeoutMs({ CLAUDE_MEM_LLM_TIMEOUT_MS: value })).toBe(30_000);
     }
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rebases and ships #3808 onto latest `main`. Fixes #3794.

**Gate:** RCA in the original PR (30s deadline was unreachable from config and classified as transient, so a slow local model was retried into congestion). No second system. Narrow.

**Ship-time fix:** reject suffixed values like `90000ms` instead of `parseInt`-accepting them.

**Local tests:** `bun test tests/worker/llm-timeout.test.ts tests/worker/retry-policy.test.ts` — 12 pass.

Original: https://github.com/thedotmack/claude-mem/pull/3808
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96a9a430-2ca5-4074-83b3-87db3e21f479?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96a9a430-2ca5-4074-83b3-87db3e21f479&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

