### PR TITLE
fix(codex): stop an unparseable Bash command from blocking the tool call

### DIFF
--- a/src/cli/adapters/codex-file-context.ts
+++ b/src/cli/adapters/codex-file-context.ts
@@ -88,7 +88,19 @@ function extractFromBash(toolInput: unknown, cwd: string): string[] {
   const command = normalizeCommand((toolInput as { command?: unknown } | undefined)?.command);
   if (!command) return [];
 
-  const tokens = parse(command);
+  // `parse` throws on substitutions it cannot resolve — `${}` raises
+  // "Bad substitution" on every shell-quote 1.x, including 1.10.x. This is a
+  // best-effort enrichment that only adds `filePaths` for read commands, so an
+  // unparseable command must yield no paths rather than propagate: the throw
+  // escaped to the generic hook handler, which answers BLOCKING_ERROR and
+  // discards the tool call entirely (#3688). Failing to enrich is invisible;
+  // blocking the user's command is not.
+  let tokens: ParsedToken[];
+  try {
+    tokens = parse(command);
+  } catch {
+    return [];
+  }
   const paths: string[] = [];
 
   for (const segment of splitSegments(tokens)) {

--- a/tests/cli/adapters/codex-file-context.test.ts
+++ b/tests/cli/adapters/codex-file-context.test.ts
@@ -60,4 +60,26 @@ describe('extractFilePaths', () => {
     expect(extractFilePaths('mcp__fs__read_write', { path: 'README.md' }, tmpDir)).toEqual([]);
     expect(extractFilePaths('mcp__server__readonly', { path: 'README.md' }, tmpDir)).toEqual([]);
   });
+
+  // #3688: `parse` throws "Bad substitution" on `${}`. The throw escaped this
+  // best-effort enrichment and reached the generic hook handler, which answers
+  // BLOCKING_ERROR — so an ordinary shell command was blocked and the tool call
+  // discarded, to add a convenience field.
+  it('yields no paths instead of throwing on an unparseable substitution', () => {
+    expect(() => extractFilePaths('Bash', { command: 'cat ${}' }, tmpDir)).not.toThrow();
+    expect(extractFilePaths('Bash', { command: 'cat ${}' }, tmpDir)).toEqual([]);
+  });
+
+  it('yields no paths when the unparseable part rides alongside a real read', () => {
+    // The readable file is genuinely there, so this fails only because the
+    // command as a whole cannot be tokenised — not because the path is bad.
+    expect(
+      extractFilePaths('Bash', { command: 'cat README.md && cat ${}' }, tmpDir)
+    ).toEqual([]);
+  });
+
+  it('still extracts paths from a command that parses', () => {
+    // The guard must not swallow the feature it protects.
+    expect(extractFilePaths('Bash', { command: 'cat README.md' }, tmpDir)).toEqual(['README.md']);
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Night-ship rebase of #3756 onto latest main.

`extractFromBash` called `shell-quote` `parse()` on every Codex PreToolUse Bash command. `parse()` throws on empty substitutions (`${}`), and that throw reached the generic hook handler as `BLOCKING_ERROR`, discarding the tool call.

The parse is now guarded: an unparseable command yields no `filePaths` instead of blocking the user.

Supersedes #3756.
Closes #3688.

## Gate
1. RCA on #3756 / #3688
2. No second system — one try/catch on the existing enrichment path
3. Narrow — 2 files

## Test
`bun test tests/cli/adapters/codex-file-context.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b5cdf49-0a66-4ad6-9b99-162a00fe2df7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b5cdf49-0a66-4ad6-9b99-162a00fe2df7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

