### PR TITLE
fix(worker): diagnose an orphaned worker port after the cold-boot wait

### DIFF
--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -9,7 +9,7 @@ import { loadFromFileOnce } from "./hook-settings.js";
 import { validateWorkerPidFile, readOwnedWorkerPidInfo } from "../supervisor/index.js";
 import { emitBlockingError, emitDiagnostic } from "./hook-io.js";
 import { captureCliEvent } from "../services/telemetry/cli-telemetry.js";
-import { checkVersionMatch } from "../services/infrastructure/index.js";
+import { checkVersionMatch, isPortInUse } from "../services/infrastructure/index.js";
 // Imported from ProcessManager.js directly (not the infrastructure barrel):
 // tests mock the barrel module wholesale, and the resolver must stay real.
 // ProcessManager imports nothing from worker-utils, so no cycle.
@@ -718,6 +718,24 @@ export async function ensureWorkerRunning(): Promise<boolean> {
       logger.warn('SYSTEM', spawnLockHeld
         ? 'Worker port did not open after lazy-spawn within the cold-boot wait (~15s)'
         : 'Spawn-lock holder\'s worker port did not open within the cold-boot wait (~15s)');
+      // Zombie-socket diagnosis. Only reachable once the full cold-boot wait
+      // has expired, so a worker that merely bound late (server.listen runs
+      // BEFORE writePidFile — a warming worker legitimately has an occupied
+      // port and no PID file) has already had its chance to answer. If the
+      // port is STILL occupied with no reachable worker and no PID file
+      // naming a killable owner, the socket is orphaned at the OS level:
+      // Windows can leave a LISTEN socket behind for a process that no
+      // longer exists. Every future spawn is doomed — the new daemon's
+      // duplicate-gate sees the occupied port and exit(0)s without binding —
+      // so name the actual fix instead of letting the generic "unreachable"
+      // counter climb forever.
+      if (readOwnedWorkerPidInfo() === null && (await isPortInUse(getWorkerPort()))) {
+        orphanedPortDiagnosis = getWorkerPort();
+        logger.error('SYSTEM', 'Worker port is occupied by an unreachable process that no PID file claims (likely an orphaned OS socket); every lazy-spawn on this port will be silently refused', {
+          port: orphanedPortDiagnosis,
+          fix: ORPHANED_PORT_REMEDIATION,
+        });
+      }
       return false;
     }
   } finally {
@@ -735,6 +753,19 @@ export async function ensureWorkerRunning(): Promise<boolean> {
   }
   return true;
 }
+
+const ORPHANED_PORT_REMEDIATION =
+  'Set CLAUDE_MEM_WORKER_PORT to a different port in claude-mem settings, or reboot to release the stuck port';
+
+/**
+ * Port number diagnosed as holding an orphaned OS socket during this hook
+ * process, or null if that condition was never observed. Set by
+ * ensureWorkerRunning and read by recordWorkerUnreachable so the fail-loud
+ * message names the fix. Process-scoped deliberately: it is only ever set
+ * from a fresh probe earlier in the same invocation, so it cannot go stale
+ * across a reboot or a port change the way a persisted flag could.
+ */
+let orphanedPortDiagnosis: number | null = null;
 
 let aliveCache: boolean | null = null;
 
@@ -918,7 +949,9 @@ export async function recordWorkerUnreachable(): Promise<number> {
     // via the bypass channel + exits 2. Previously this raw process.stderr.write
     // was swallowed by hookCommand's blanket no-op, so the user/model never saw it.
     emitBlockingError(
-      `claude-mem worker unreachable for ${next.consecutiveFailures} consecutive hooks.`
+      orphanedPortDiagnosis !== null
+        ? `claude-mem worker unreachable for ${next.consecutiveFailures} consecutive hooks: port ${orphanedPortDiagnosis} is held by an unreachable process that no PID file claims, so the worker cannot bind it. ${ORPHANED_PORT_REMEDIATION}.`
+        : `claude-mem worker unreachable for ${next.consecutiveFailures} consecutive hooks.`
     );
   }
   return next.consecutiveFailures;

--- a/tests/shared/worker-utils-version-recycle.test.ts
+++ b/tests/shared/worker-utils-version-recycle.test.ts
@@ -45,6 +45,7 @@ const spawnCalls: Array<{ command: string; args: string[] }> = [];
 
 mock.module('../../src/services/infrastructure/index.js', () => ({
   checkVersionMatch: () => Promise.resolve(versionMatchResult),
+  isPortInUse: () => Promise.resolve(false),
 }));
 
 mock.module('../../src/supervisor/index.js', () => ({

--- a/tests/shared/worker-utils-zombie-port.test.ts
+++ b/tests/shared/worker-utils-zombie-port.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import * as realInfrastructure from '../../src/services/infrastructure/index.js';
+import * as realSupervisor from '../../src/supervisor/index.js';
+import * as realSpawn from '../../src/shared/spawn.js';
+import * as realHookIo from '../../src/shared/hook-io.js';
+import * as realCliTelemetry from '../../src/services/telemetry/cli-telemetry.js';
+
+const realInfrastructureSnapshot = { ...realInfrastructure };
+const realSupervisorSnapshot = { ...realSupervisor };
+const realSpawnSnapshot = { ...realSpawn };
+// emitBlockingError is mocked to a no-op collector below; restoring it in
+// afterAll keeps a silenced fail-loud path from leaking into other suites
+// sharing this process.
+const realHookIoSnapshot = { ...realHookIo };
+const realCliTelemetrySnapshot = { ...realCliTelemetry };
+
+// Two states share one signature — port occupied, no owned PID file — and
+// must NOT be conflated:
+//
+//   1. A warming worker. server.listen() runs BEFORE writePidFile(), so a
+//      worker that is mid-boot legitimately holds the port with no PID file.
+//      It becomes healthy shortly and must be waited for, not written off.
+//   2. An orphaned OS socket. Nothing behind the port will ever answer
+//      (Windows can leave a LISTEN socket owned by a dead PID). Every spawn
+//      is silently refused by the new daemon's duplicate-gate, so hooks loop
+//      forever on "worker unreachable".
+//
+// The only thing separating them is time, so the zombie diagnosis must live
+// AFTER the cold-boot wait, never before it.
+
+const spawnCalls: Array<{ command: string; args: string[] }> = [];
+let portOccupied = true;
+// Health responses to serve in order; the last entry repeats once exhausted.
+// `false` = connection refused, `true` = healthy worker.
+let healthSequence: boolean[] = [];
+
+mock.module('../../src/services/infrastructure/index.js', () => ({
+  checkVersionMatch: () => Promise.resolve({ matches: true, pluginVersion: '13.16.0', workerVersion: '13.16.0' }),
+  isPortInUse: () => Promise.resolve(portOccupied),
+}));
+
+mock.module('../../src/supervisor/index.js', () => ({
+  validateWorkerPidFile: () => 'missing',
+  readOwnedWorkerPidInfo: () => null,
+}));
+
+mock.module('../../src/shared/spawn.js', () => ({
+  spawnHidden: (command: string, args: string[]) => {
+    spawnCalls.push({ command, args });
+    return { pid: 5151, unref: () => {} };
+  },
+}));
+
+// emitBlockingError is the only channel the user actually sees when hooks
+// start failing; the real one writes to stderr and process.exit(2)s.
+const blockingErrors: string[] = [];
+mock.module('../../src/shared/hook-io.js', () => ({
+  emitBlockingError: (message: string) => {
+    blockingErrors.push(message);
+  },
+}));
+
+mock.module('../../src/services/telemetry/cli-telemetry.js', () => ({
+  captureCliEvent: () => Promise.resolve(),
+}));
+
+async function importWorkerUtilsFresh() {
+  return import(`../../src/shared/worker-utils.js?worker-utils-zombie-port=${Date.now()}-${Math.random()}`);
+}
+
+function nextHealthy(): boolean {
+  if (healthSequence.length === 0) return false;
+  return healthSequence.length === 1 ? healthSequence[0] : healthSequence.shift()!;
+}
+
+function installFetchMock(): void {
+  global.fetch = mock(() => {
+    if (!nextHealthy()) {
+      return Promise.reject(new Error('connect ECONNREFUSED 127.0.0.1'));
+    }
+    const body = { version: '13.16.0', ready: true, status: 'ok' };
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify(body)),
+      json: () => Promise.resolve(body),
+    } as unknown as Response);
+  }) as unknown as typeof fetch;
+}
+
+describe('ensureWorkerRunning — occupied port with no owned PID file', () => {
+  const originalFetch = global.fetch;
+  const originalDataDir = process.env.CLAUDE_MEM_DATA_DIR;
+  let tempDataDir: string;
+
+  beforeEach(() => {
+    tempDataDir = mkdtempSync(join(tmpdir(), 'claude-mem-zombie-port-'));
+    process.env.CLAUDE_MEM_DATA_DIR = tempDataDir;
+    spawnCalls.length = 0;
+    blockingErrors.length = 0;
+    portOccupied = true;
+    healthSequence = [false];
+    installFetchMock();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    if (originalDataDir === undefined) {
+      delete process.env.CLAUDE_MEM_DATA_DIR;
+    } else {
+      process.env.CLAUDE_MEM_DATA_DIR = originalDataDir;
+    }
+    rmSync(tempDataDir, { recursive: true, force: true });
+    mock.restore();
+  });
+
+  afterAll(() => {
+    mock.module('../../src/services/infrastructure/index.js', () => realInfrastructureSnapshot);
+    mock.module('../../src/supervisor/index.js', () => realSupervisorSnapshot);
+    mock.module('../../src/shared/spawn.js', () => realSpawnSnapshot);
+    mock.module('../../src/shared/hook-io.js', () => realHookIoSnapshot);
+    mock.module('../../src/services/telemetry/cli-telemetry.js', () => realCliTelemetrySnapshot);
+  });
+
+  // Regression guard for the warming-worker race: a worker that has bound the
+  // port but not yet written its PID file must be waited for and reported
+  // available, NOT short-circuited as an unrecoverable occupied port.
+  it('waits for a warming worker that has bound the port but not yet written its PID file', async () => {
+    // Refused on the first probes (still booting), healthy afterwards.
+    healthSequence = [false, false, true];
+
+    const workerUtils = await importWorkerUtilsFresh();
+    const result = await workerUtils.ensureWorkerRunning();
+
+    expect(result).toBe(true);
+  }, 30000);
+
+  it('gives up without spawning again when the port stays occupied and unreachable', async () => {
+    healthSequence = [false];
+
+    const workerUtils = await importWorkerUtilsFresh();
+    const result = await workerUtils.ensureWorkerRunning();
+
+    expect(result).toBe(false);
+  }, 30000);
+
+  // The log file is not where a user looks when their prompts start getting
+  // blocked. Once the orphaned-port condition is diagnosed, the fail-loud
+  // message must name the port and the fix, not just a failure count.
+  it('surfaces the port and its remediation on the fail-loud channel, not only in the log', async () => {
+    healthSequence = [false];
+
+    const workerUtils = await importWorkerUtilsFresh();
+    expect(await workerUtils.ensureWorkerRunning()).toBe(false);
+
+    // Threshold is 3 consecutive failures before emitBlockingError fires.
+    await workerUtils.recordWorkerUnreachable();
+    await workerUtils.recordWorkerUnreachable();
+    await workerUtils.recordWorkerUnreachable();
+
+    expect(blockingErrors.length).toBeGreaterThan(0);
+    const message = blockingErrors[blockingErrors.length - 1];
+    expect(message).toContain(String(workerUtils.getWorkerPort()));
+    expect(message).toContain('CLAUDE_MEM_WORKER_PORT');
+  }, 30000);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Night-ship rebase of #3747 onto latest main.

On Windows, a LISTEN socket can outlive its process. The worker looks dead, a replacement lazy-spawns, then immediately `exit(0)`s because the zombie port is still occupied. Hooks loop on a generic "worker unreachable" count.

After the existing cold-boot wait expires, if the port is still occupied with no PID file, the fail-loud message now names the port and tells the user to set `CLAUDE_MEM_WORKER_PORT` or reboot.

Diagnosis stays after the wait so a warming worker that bound before writing its PID file is not false-positived.

Supersedes #3747.
Fixes #3746.

## Gate
1. RCA on #3747 / #3746
2. Fail-loud on the existing failure path — no persisted circuit breaker
3. Narrow — diagnosis + tests

## Test
`bun test tests/shared/worker-utils-zombie-port.test.ts tests/shared/worker-utils-timeout.test.ts tests/shared/worker-utils-version-recycle.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b5cdf49-0a66-4ad6-9b99-162a00fe2df7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b5cdf49-0a66-4ad6-9b99-162a00fe2df7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

