### PR TITLE
fix(hooks): fail open on malformed hook stdin

### DIFF
--- a/src/cli/hook-command.ts
+++ b/src/cli/hook-command.ts
@@ -80,6 +80,10 @@ export function isNonBlockingHookInputError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   const lower = message.toLowerCase();
 
+  if (lower.startsWith('malformed json at stdin eof:') || lower.startsWith('incomplete json after ')) {
+    return true;
+  }
+
   return lower.includes('transcript path') &&
     (lower.includes('missing') || lower.includes('does not exist'));
 }

--- a/src/cli/hook-command.ts
+++ b/src/cli/hook-command.ts
@@ -21,6 +21,7 @@ import { logger } from '../utils/logger.js';
 
 export interface HookCommandOptions {
   skipExit?: boolean;
+  stdinSafetyTimeoutMs?: number;
 }
 
 /**
@@ -94,7 +95,7 @@ async function executeHookPipeline(
   platform: string,
   options: HookCommandOptions
 ): Promise<number> {
-  const rawInput = await readJsonFromStdin();
+  const rawInput = await readJsonFromStdin({ safetyTimeoutMs: options.stdinSafetyTimeoutMs });
   const input = adapter.normalizeInput(rawInput);
   input.platform = platform;
   const result = await handler.execute(input);

--- a/src/cli/stdin-reader.ts
+++ b/src/cli/stdin-reader.ts
@@ -35,10 +35,16 @@ function tryParseJson(input: string): { success: true; value: unknown } | { succ
 
 export const SAFETY_TIMEOUT_MS = 30000;
 
-export async function readJsonFromStdin(): Promise<unknown> {
+export interface ReadJsonFromStdinOptions {
+  safetyTimeoutMs?: number;
+}
+
+export async function readJsonFromStdin(options: ReadJsonFromStdinOptions = {}): Promise<unknown> {
   if (!isStdinAvailable()) {
     return undefined;
   }
+
+  const safetyTimeoutMs = options.safetyTimeoutMs ?? SAFETY_TIMEOUT_MS;
 
   return new Promise((resolve, reject) => {
     let input = '';
@@ -83,13 +89,13 @@ export async function readJsonFromStdin(): Promise<unknown> {
       if (!resolved) {
         if (!tryResolveWithJson()) {
           if (input.trim()) {
-            rejectWith(new Error(`Incomplete JSON after ${SAFETY_TIMEOUT_MS}ms: ${input.slice(0, 100)}...`));
+            rejectWith(new Error(`Incomplete JSON after ${safetyTimeoutMs}ms: ${input.slice(0, 100)}...`));
           } else {
             resolveWith(undefined);
           }
         }
       }
-    }, SAFETY_TIMEOUT_MS);
+    }, safetyTimeoutMs);
 
     const onData = (chunk: Buffer | string) => {
       input += chunk;

--- a/src/cli/stdin-reader.ts
+++ b/src/cli/stdin-reader.ts
@@ -33,7 +33,7 @@ function tryParseJson(input: string): { success: true; value: unknown } | { succ
   }
 }
 
-const SAFETY_TIMEOUT_MS = 30000;
+export const SAFETY_TIMEOUT_MS = 30000;
 
 export async function readJsonFromStdin(): Promise<unknown> {
   if (!isStdinAvailable()) {

--- a/tests/cli/stdin-reader.test.ts
+++ b/tests/cli/stdin-reader.test.ts
@@ -1,29 +1,11 @@
 
 import { describe, it, expect, afterEach } from 'bun:test';
-import { Readable } from 'stream';
 
 import { readJsonFromStdin } from '../../src/cli/stdin-reader.js';
-
-const realStdin = process.stdin;
-const realStdinDescriptor = Object.getOwnPropertyDescriptor(process, 'stdin');
-
-function installFakeStdin(payload: string): void {
-  const fake = Readable.from([payload], { objectMode: false }) as unknown as NodeJS.ReadStream;
-  Object.defineProperty(fake, 'isTTY', { value: false, configurable: true });
-  Object.defineProperty(process, 'stdin', {
-    configurable: true,
-    enumerable: realStdinDescriptor?.enumerable ?? true,
-    writable: true,
-    value: fake,
-  });
-}
+import { installFakeStdin, restoreStdin } from '../fake-stdin.js';
 
 afterEach(() => {
-  if (realStdinDescriptor) {
-    Object.defineProperty(process, 'stdin', realStdinDescriptor);
-  } else {
-    Object.defineProperty(process, 'stdin', { value: realStdin, configurable: true, writable: true });
-  }
+  restoreStdin();
 });
 
 describe('readJsonFromStdin — onEnd contract (#2089)', () => {

--- a/tests/fake-stdin.ts
+++ b/tests/fake-stdin.ts
@@ -1,10 +1,12 @@
-import { Readable } from 'stream';
+import { PassThrough, Readable } from 'stream';
 
 const realStdin = process.stdin;
 const realStdinDescriptor = Object.getOwnPropertyDescriptor(process, 'stdin');
+let activeFake: NodeJS.ReadStream | null = null;
 
 export function installFakeStdin(payload: string): void {
   const fake = Readable.from([payload], { objectMode: false }) as unknown as NodeJS.ReadStream;
+  activeFake = fake;
   Object.defineProperty(fake, 'isTTY', { value: false, configurable: true });
   Object.defineProperty(process, 'stdin', {
     configurable: true,
@@ -14,7 +16,22 @@ export function installFakeStdin(payload: string): void {
   });
 }
 
+export function installOpenFakeStdin(payload: string): void {
+  const fake = new PassThrough() as unknown as NodeJS.ReadStream & { write(chunk: string): boolean };
+  Object.defineProperty(fake, 'isTTY', { value: false, configurable: true });
+  Object.defineProperty(process, 'stdin', {
+    configurable: true,
+    enumerable: realStdinDescriptor?.enumerable ?? true,
+    writable: true,
+    value: fake,
+  });
+  activeFake = fake;
+  fake.write(payload);
+}
+
 export function restoreStdin(): void {
+  activeFake?.destroy?.();
+  activeFake = null;
   if (realStdinDescriptor) {
     Object.defineProperty(process, 'stdin', realStdinDescriptor);
   } else {

--- a/tests/fake-stdin.ts
+++ b/tests/fake-stdin.ts
@@ -1,0 +1,23 @@
+import { Readable } from 'stream';
+
+const realStdin = process.stdin;
+const realStdinDescriptor = Object.getOwnPropertyDescriptor(process, 'stdin');
+
+export function installFakeStdin(payload: string): void {
+  const fake = Readable.from([payload], { objectMode: false }) as unknown as NodeJS.ReadStream;
+  Object.defineProperty(fake, 'isTTY', { value: false, configurable: true });
+  Object.defineProperty(process, 'stdin', {
+    configurable: true,
+    enumerable: realStdinDescriptor?.enumerable ?? true,
+    writable: true,
+    value: fake,
+  });
+}
+
+export function restoreStdin(): void {
+  if (realStdinDescriptor) {
+    Object.defineProperty(process, 'stdin', realStdinDescriptor);
+  } else {
+    Object.defineProperty(process, 'stdin', { value: realStdin, configurable: true, writable: true });
+  }
+}

--- a/tests/hook-command.test.ts
+++ b/tests/hook-command.test.ts
@@ -74,12 +74,12 @@ describe('isNonBlockingHookInputError', () => {
     ]);
   });
 
-  it('fails open through hookCommand for UserPromptSubmit stdin and emits one empty envelope', async () => {
+  it('fails open through hookCommand for the UserPromptSubmit session-init hook and emits one empty envelope', async () => {
     installFakeStdin('{"session_id":');
     const output: string[] = [];
     console.log = (...args: unknown[]) => output.push(args.join(' '));
 
-    const exitCode = await hookCommand('claude-code', 'user-message', { skipExit: true });
+    const exitCode = await hookCommand('claude-code', 'session-init', { skipExit: true });
 
     expect(exitCode).toBe(0);
     expect(output).toEqual(['{}']);
@@ -90,7 +90,7 @@ describe('isNonBlockingHookInputError', () => {
     const output: string[] = [];
     console.log = (...args: unknown[]) => output.push(args.join(' '));
 
-    const exitCode = await hookCommand('claude-code', 'user-message', {
+    const exitCode = await hookCommand('claude-code', 'session-init', {
       skipExit: true,
       stdinSafetyTimeoutMs: 1,
     });

--- a/tests/hook-command.test.ts
+++ b/tests/hook-command.test.ts
@@ -1,33 +1,17 @@
 import { describe, it, expect, afterEach } from 'bun:test';
-import { Readable } from 'stream';
 import {
   buildNoOpResult,
   hookCommand,
   isNonBlockingHookInputError,
   isWorkerUnavailableError,
 } from '../src/cli/hook-command.js';
+import { SAFETY_TIMEOUT_MS } from '../src/cli/stdin-reader.js';
+import { installFakeStdin, restoreStdin } from './fake-stdin.js';
 
-const realStdin = process.stdin;
-const realStdinDescriptor = Object.getOwnPropertyDescriptor(process, 'stdin');
 const realConsoleLog = console.log;
 
-function installFakeStdin(payload: string): void {
-  const fake = Readable.from([payload], { objectMode: false }) as unknown as NodeJS.ReadStream;
-  Object.defineProperty(fake, 'isTTY', { value: false, configurable: true });
-  Object.defineProperty(process, 'stdin', {
-    configurable: true,
-    enumerable: realStdinDescriptor?.enumerable ?? true,
-    writable: true,
-    value: fake,
-  });
-}
-
 afterEach(() => {
-  if (realStdinDescriptor) {
-    Object.defineProperty(process, 'stdin', realStdinDescriptor);
-  } else {
-    Object.defineProperty(process, 'stdin', { value: realStdin, configurable: true, writable: true });
-  }
+  restoreStdin();
   console.log = realConsoleLog;
 });
 
@@ -90,8 +74,19 @@ describe('isNonBlockingHookInputError', () => {
     ]);
   });
 
+  it('fails open through hookCommand for UserPromptSubmit stdin and emits one empty envelope', async () => {
+    installFakeStdin('{"session_id":');
+    const output: string[] = [];
+    console.log = (...args: unknown[]) => output.push(args.join(' '));
+
+    const exitCode = await hookCommand('claude-code', 'user-message', { skipExit: true });
+
+    expect(exitCode).toBe(0);
+    expect(output).toEqual(['{}']);
+  });
+
   it('classifies incomplete stdin timeout diagnostics as non-blocking', () => {
-    expect(isNonBlockingHookInputError(new Error('Incomplete JSON after 5000ms: {"session_id":...'))).toBe(true);
+    expect(isNonBlockingHookInputError(new Error(`Incomplete JSON after ${SAFETY_TIMEOUT_MS}ms: {"session_id":...`))).toBe(true);
   });
 
   it('keeps unrelated errors with a reader phrase blocking', () => {

--- a/tests/hook-command.test.ts
+++ b/tests/hook-command.test.ts
@@ -1,5 +1,35 @@
-import { describe, it, expect } from 'bun:test';
-import { buildNoOpResult, isNonBlockingHookInputError, isWorkerUnavailableError } from '../src/cli/hook-command.js';
+import { describe, it, expect, afterEach } from 'bun:test';
+import { Readable } from 'stream';
+import {
+  buildNoOpResult,
+  hookCommand,
+  isNonBlockingHookInputError,
+  isWorkerUnavailableError,
+} from '../src/cli/hook-command.js';
+
+const realStdin = process.stdin;
+const realStdinDescriptor = Object.getOwnPropertyDescriptor(process, 'stdin');
+const realConsoleLog = console.log;
+
+function installFakeStdin(payload: string): void {
+  const fake = Readable.from([payload], { objectMode: false }) as unknown as NodeJS.ReadStream;
+  Object.defineProperty(fake, 'isTTY', { value: false, configurable: true });
+  Object.defineProperty(process, 'stdin', {
+    configurable: true,
+    enumerable: realStdinDescriptor?.enumerable ?? true,
+    writable: true,
+    value: fake,
+  });
+}
+
+afterEach(() => {
+  if (realStdinDescriptor) {
+    Object.defineProperty(process, 'stdin', realStdinDescriptor);
+  } else {
+    Object.defineProperty(process, 'stdin', { value: realStdin, configurable: true, writable: true });
+  }
+  console.log = realConsoleLog;
+});
 
 describe('buildNoOpResult', () => {
   it('attaches a valid SessionStart hookSpecificOutput for the context event (#2972)', () => {
@@ -43,6 +73,29 @@ describe('isNonBlockingHookInputError', () => {
   it('does not classify unrelated hook errors as non-blocking input errors', () => {
     expect(isNonBlockingHookInputError(new Error('Cannot read properties of undefined'))).toBe(false);
     expect(isNonBlockingHookInputError(new Error('Request failed: 400'))).toBe(false);
+  });
+
+  it('fails open through hookCommand for truncated stdin and emits one no-op envelope', async () => {
+    installFakeStdin('{"session_id":');
+    const output: string[] = [];
+    console.log = (...args: unknown[]) => output.push(args.join(' '));
+
+    const exitCode = await hookCommand('claude-code', 'context', { skipExit: true });
+
+    expect(exitCode).toBe(0);
+    expect(output).toEqual([
+      JSON.stringify({
+        hookSpecificOutput: { hookEventName: 'SessionStart', additionalContext: '' },
+      }),
+    ]);
+  });
+
+  it('classifies incomplete stdin timeout diagnostics as non-blocking', () => {
+    expect(isNonBlockingHookInputError(new Error('Incomplete JSON after 5000ms: {"session_id":...'))).toBe(true);
+  });
+
+  it('keeps unrelated errors with a reader phrase blocking', () => {
+    expect(isNonBlockingHookInputError(new Error('Handler failed: Malformed JSON at stdin EOF: {"session_id":...'))).toBe(false);
   });
 });
 

--- a/tests/hook-command.test.ts
+++ b/tests/hook-command.test.ts
@@ -6,7 +6,7 @@ import {
   isWorkerUnavailableError,
 } from '../src/cli/hook-command.js';
 import { SAFETY_TIMEOUT_MS } from '../src/cli/stdin-reader.js';
-import { installFakeStdin, restoreStdin } from './fake-stdin.js';
+import { installFakeStdin, installOpenFakeStdin, restoreStdin } from './fake-stdin.js';
 
 const realConsoleLog = console.log;
 
@@ -80,6 +80,20 @@ describe('isNonBlockingHookInputError', () => {
     console.log = (...args: unknown[]) => output.push(args.join(' '));
 
     const exitCode = await hookCommand('claude-code', 'user-message', { skipExit: true });
+
+    expect(exitCode).toBe(0);
+    expect(output).toEqual(['{}']);
+  });
+
+  it('fails open through hookCommand when stdin reaches the incomplete timeout path', async () => {
+    installOpenFakeStdin('{"session_id":');
+    const output: string[] = [];
+    console.log = (...args: unknown[]) => output.push(args.join(' '));
+
+    const exitCode = await hookCommand('claude-code', 'user-message', {
+      skipExit: true,
+      stdinSafetyTimeoutMs: 1,
+    });
 
     expect(exitCode).toBe(0);
     expect(output).toEqual(['{}']);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Night-ship rebase of #3717 onto latest main.

Malformed or incomplete hook stdin currently reaches the generic blocking-error path and can discard `UserPromptSubmit`. `isNonBlockingHookInputError` now treats the stdin reader's `Malformed JSON at stdin EOF:` and `Incomplete JSON after ` diagnostics as unavailable input, so those paths fail open through the existing no-op route.

The reader, adapters, worker-unavailable threshold, and generic blocking branch stay unchanged. `Handler failed: Malformed JSON...` remains blocking.

Supersedes #3717.
Refs #3699 (closed via plan-17 #3605 consolidation, not shipped).
Refs #3605.

Original work by @rodboev (Rod Boev).

## Gate
1. RCA on #3717 / #3699 — main still only recognizes missing transcript path
2. No second system — extends the existing predicate; hook-io remains sole exit owner
3. Narrow — hook-command + stdin-reader + tests

## Test
`bun test tests/hook-command.test.ts tests/cli/stdin-reader.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b606ec7e-fb36-49f5-91b6-6d6750f59c7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b606ec7e-fb36-49f5-91b6-6d6750f59c7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

