### PR TITLE
fix(windows): resolve Volta Bun shims to bun.exe

### DIFF
--- a/src/services/integrations/install-paths.ts
+++ b/src/services/integrations/install-paths.ts
@@ -17,6 +17,7 @@ import path from 'path';
 import { homedir } from 'os';
 import { existsSync } from 'fs';
 import { MARKETPLACE_ROOT } from '../../shared/paths.js';
+import { lookupWindowsCommand } from '../../shared/spawn.js';
 
 function firstExisting(candidates: string[]): string | null {
   for (const candidate of candidates) {
@@ -78,7 +79,11 @@ export function getWorkerServiceAbsolutePath(): string | null {
  * via PATH at exec time) when no known install location exists.
  */
 export function getBunAbsolutePath(): string {
+  const pathResolvedBun = process.platform === 'win32'
+    ? lookupWindowsCommand('bun')
+    : null;
   const candidates = [
+    ...(pathResolvedBun?.toLowerCase().endsWith('.exe') ? [pathResolvedBun] : []),
     path.join(homedir(), '.bun', 'bin', 'bun'),
     '/usr/local/bin/bun',
     '/usr/bin/bun',

--- a/src/shared/spawn.ts
+++ b/src/shared/spawn.ts
@@ -6,7 +6,7 @@ import {
   type ChildProcess,
   type SpawnSyncOptionsWithStringEncoding,
 } from 'node:child_process';
-import { extname } from 'node:path';
+import { dirname, extname, join } from 'node:path';
 
 export type SpawnHiddenOptions = SpawnOptions;
 
@@ -55,12 +55,65 @@ export function lookupWindowsCommandCandidates(command: string): string[] {
   }
 }
 
-export function lookupWindowsCommand(command: string): string | null {
-  const candidates = lookupWindowsCommandCandidates(command);
-  return candidates.find(candidate => WINDOWS_NATIVE_EXTENSIONS.has(extname(candidate).toLowerCase()))
+type VoltaWhichRunner = (
+  command: string,
+  args: readonly string[],
+  options: SpawnSyncOptionsWithStringEncoding,
+) => { status: number | null; stdout: string };
+
+const VOLTA_SHIM_RESOLUTION_TIMEOUT_MS = 5_000;
+
+const runVoltaWhich: VoltaWhichRunner = (command, args, options) =>
+  spawnSync(command, args, options);
+
+export function selectWindowsCommandCandidate(
+  candidates: string[],
+  resolveShim?: (shimPath: string) => string | null,
+): string | null {
+  const native = candidates.find(candidate =>
+    WINDOWS_NATIVE_EXTENSIONS.has(extname(candidate).toLowerCase()));
+  if (native) return native;
+
+  const shim = candidates.find(candidate =>
+    WINDOWS_CMD_EXTENSIONS.has(extname(candidate).toLowerCase()));
+  if (shim && resolveShim) {
+    const resolved = resolveShim(shim);
+    if (resolved && WINDOWS_NATIVE_EXTENSIONS.has(extname(resolved).toLowerCase())) {
+      return resolved;
+    }
+  }
+
+  return shim
     ?? candidates.find(candidate => WINDOWS_COMMAND_EXTENSIONS.has(extname(candidate).toLowerCase()))
     ?? candidates[0]
     ?? null;
+}
+
+export function resolveVoltaShim(
+  command: string,
+  shimPath: string,
+  run: VoltaWhichRunner = runVoltaWhich,
+): string | null {
+  if (!/[\\/]volta[\\/]bin[\\/]/i.test(shimPath)) return null;
+  try {
+    const result = run(join(dirname(shimPath), 'volta.exe'), ['which', command], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: VOLTA_SHIM_RESOLUTION_TIMEOUT_MS,
+      windowsHide: true,
+    });
+    if (result.status !== 0 || !result.stdout.trim()) return null;
+    return result.stdout.split(/\r?\n/).map(line => line.trim()).find(Boolean) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function lookupWindowsCommand(command: string): string | null {
+  return selectWindowsCommandCandidate(
+    lookupWindowsCommandCandidates(command),
+    shimPath => resolveVoltaShim(command, shimPath),
+  );
 }
 
 export function buildSpawnSyncInvocation(

--- a/tests/shared/spawn-candidate.test.ts
+++ b/tests/shared/spawn-candidate.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  resolveVoltaShim,
+  selectWindowsCommandCandidate,
+} from '../../src/shared/spawn.js';
+
+describe('Windows #3677 - Volta Bun shims resolve to the native executable', () => {
+  it('prefers the native executable returned for a Volta shim', () => {
+    const shim = 'C:\\Users\\tester\\AppData\\Local\\Volta\\bin\\bun.cmd';
+    const executable = 'C:\\Users\\tester\\AppData\\Local\\Volta\\tools\\image\\bun\\1.3.11\\bun.exe';
+
+    expect(selectWindowsCommandCandidate([shim], candidate => {
+      expect(candidate).toBe(shim);
+      return executable;
+    })).toBe(executable);
+  });
+
+  it('keeps a non-Volta command shim when no native target is resolved', () => {
+    const shim = 'C:\\Users\\tester\\AppData\\Roaming\\npm\\bun.cmd';
+    expect(selectWindowsCommandCandidate([shim], () => null)).toBe(shim);
+  });
+
+  it('bounds a stalled Volta probe and falls back to the shim', () => {
+    const shim = 'C:\\Users\\tester\\AppData\\Local\\Volta\\bin\\bun.cmd';
+    let timeout: number | undefined;
+
+    const selected = selectWindowsCommandCandidate([shim], candidate =>
+      resolveVoltaShim('bun', candidate, (_command, _args, options) => {
+        timeout = options.timeout;
+        return { status: null, stdout: '' };
+      }),
+    );
+
+    expect(timeout).toBe(5_000);
+    expect(selected).toBe(shim);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
NIGHT SHIP Batch F rebase of #3689 onto current `main`.

## Why

On Windows, Volta exposes `bun` as `%LOCALAPPDATA%\Volta\bin\bun.cmd`. `npx claude-mem status` resolves that shim and `spawnHidden`s it, which Node rejects with `spawnSync EINVAL` (#3677).

## What

- If `where bun` hits a Volta `.cmd` shim, ask sibling `volta.exe which bun` (5s bound) and prefer the native `.exe`
- Use that `.exe` when installer-managed host configs bake a Bun path
- Leave non-Volta / non-Windows resolution unchanged; fall back to the shim if the probe fails

This is the original #3689 fix, re-applied on top of the `lookupWindowsCommandCandidates` split. The contributor fork could not be force-updated (GitHub App `workflows` permission), so this same-repo rebase is the ship vehicle.

No version bump / no npm publish.

Refs #3677 #3689

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1cfe3aee-9ecf-473f-96f7-3bb413fb4d86?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1cfe3aee-9ecf-473f-96f7-3bb413fb4d86&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

