### PR TITLE
fix(packaging): ship bug-report CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "translate:tier3": "npm run translate-readme -- vi tl id th hi bn ur ro sv",
     "translate:tier4": "npm run translate-readme -- it el hu fi da no",
     "translate:all": "npm run translate:tier1 & npm run translate:tier2 & npm run translate:tier3 & npm run translate:tier4 & wait",
-    "bug-report": "bun scripts/bug-report/cli.ts",
+    "bug-report": "node dist/bug-report/index.js",
     "cursor:install": "bun plugin/scripts/worker-service.cjs cursor install",
     "cursor:uninstall": "bun plugin/scripts/worker-service.cjs cursor uninstall",
     "cursor:status": "bun plugin/scripts/worker-service.cjs cursor status",

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -620,6 +620,32 @@ async function buildHooks() {
     const npxCliStats = fs.statSync(`${npxCliOutDir}/index.js`);
     console.log(`✓ npx-cli built (${(npxCliStats.size / 1024).toFixed(2)} KB)`);
 
+    console.log(`\n🔧 Building bug-report CLI...`);
+    const bugReportOutDir = 'dist/bug-report';
+    if (!fs.existsSync(bugReportOutDir)) {
+      fs.mkdirSync(bugReportOutDir, { recursive: true });
+    }
+    await build({
+      entryPoints: ['scripts/bug-report/cli.ts'],
+      bundle: true,
+      platform: 'node',
+      target: 'node20',
+      format: 'esm',
+      outfile: `${bugReportOutDir}/index.js`,
+      minify: true,
+      logLevel: 'error',
+      external: [
+        'fs', 'fs/promises', 'path', 'os', 'child_process', 'url',
+        'crypto', 'http', 'https', 'net', 'stream', 'util', 'events',
+        'buffer', 'querystring', 'readline', 'tty', 'assert',
+        'bun:sqlite',
+      ],
+    });
+
+    fs.chmodSync(`${bugReportOutDir}/index.js`, 0o755);
+    const bugReportStats = fs.statSync(`${bugReportOutDir}/index.js`);
+    console.log(`✓ bug-report built (${(bugReportStats.size / 1024).toFixed(2)} KB)`);
+
     if (fs.existsSync('openclaw/src/index.ts')) {
       console.log(`\n🔧 Building OpenClaw plugin...`);
       const openclawOutDir = 'openclaw/dist';
@@ -707,6 +733,7 @@ async function buildHooks() {
       'plugin/.mcp.json',
       '.codex-plugin/plugin.json',
       '.agents/plugins/marketplace.json',
+      'dist/bug-report/index.js',
     ];
     for (const filePath of requiredDistributionFiles) {
       if (!fs.existsSync(filePath)) {

--- a/tests/infrastructure/plugin-distribution.test.ts
+++ b/tests/infrastructure/plugin-distribution.test.ts
@@ -344,6 +344,13 @@ describe('Plugin Distribution - Startup Root Resolution', () => {
 });
 
 describe('Plugin Distribution - package.json Files Field', () => {
+  it('runs bug-report from the bundled distribution entry', () => {
+    const packageJson = readJson('package.json');
+
+    expect(packageJson.scripts['bug-report']).toBe('node dist/bug-report/index.js');
+    expect(packageJson.files).toContain('dist');
+  });
+
   it('should include bundled plugin entries in root package.json files field', () => {
     const packageJsonPath = path.join(projectRoot, 'package.json');
     const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
@@ -356,7 +363,7 @@ describe('Plugin Distribution - package.json Files Field', () => {
     expect(packageJson.files).toContain('plugin/sqlite');
   });
 
-  it('npm tarball includes sqlite runtime modules required by the worker', () => {
+  it('npm tarball includes generated runtime entries', () => {
     const result = spawnSync('npm', ['pack', '--dry-run', '--json'], {
       cwd: projectRoot,
       encoding: 'utf-8',
@@ -366,6 +373,7 @@ describe('Plugin Distribution - package.json Files Field', () => {
     const packed = JSON.parse(result.stdout);
     const filePaths = new Set(packed[0].files.map((file: { path: string }) => file.path));
 
+    expect(filePaths.has('dist/bug-report/index.js')).toBe(true);
     expect(filePaths.has('plugin/sqlite/SessionStore.js')).toBe(true);
     expect(filePaths.has('plugin/sqlite/observations/files.js')).toBe(true);
   });
@@ -381,6 +389,7 @@ describe('Plugin Distribution - Build Script Verification', () => {
     expect(content).toContain('plugin/sqlite/SessionStore.js');
     expect(content).toContain('plugin/sqlite/observations/files.js');
     expect(content).toContain('plugin/.claude-plugin/plugin.json');
+    expect(content).toContain('dist/bug-report/index.js');
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
NIGHT SHIP Batch F rebase of #3673 onto current `main`.

## Why

`npm run bug-report` in an installed marketplace checkout runs `bun scripts/bug-report/cli.ts`, but published installs do not ship that TypeScript source (#3637).

## What

- Bundle the existing `scripts/bug-report/cli.ts` into `dist/bug-report/index.js` during the standard build
- Point the npm script at that Node-compatible entry
- Assert the tarball includes the bundled file

No CLI rewrite, no version bump, no npm publish.

The original #3673 targets `core-dev` and is CONFLICTING against `main`; this is the cherry-pick ship vehicle.

Rebased onto `96b78224` after Batch F #4008 / #3726.

Refs #3637 #3673

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1cfe3aee-9ecf-473f-96f7-3bb413fb4d86?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1cfe3aee-9ecf-473f-96f7-3bb413fb4d86&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

