### PR TITLE
fix(windsurf): read hooks.json with the BOM-tolerant parser

### DIFF
--- a/src/services/integrations/WindsurfHooksInstaller.ts
+++ b/src/services/integrations/WindsurfHooksInstaller.ts
@@ -4,6 +4,7 @@ import { homedir } from 'os';
 import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync, renameSync } from 'fs';
 import { logger } from '../../utils/logger.js';
 import { getWorkerHost, getWorkerPort } from '../../shared/worker-utils.js';
+import { parseJsonWithBom } from '../../shared/atomic-json.js';
 import { DATA_DIR } from '../../shared/paths.js';
 import { getBunAbsolutePath as findBunPath, getWorkerServiceAbsolutePath as findWorkerServicePath } from './install-paths.js';
 
@@ -129,7 +130,7 @@ function mergeAndWriteHooksJson(
   let existingConfig: WindsurfHooksJson = { hooks: {} };
   if (existsSync(WINDSURF_HOOKS_JSON_PATH)) {
     try {
-      existingConfig = JSON.parse(readFileSync(WINDSURF_HOOKS_JSON_PATH, 'utf-8'));
+      existingConfig = parseJsonWithBom<WindsurfHooksJson>(readFileSync(WINDSURF_HOOKS_JSON_PATH, 'utf-8'));
       if (!existingConfig.hooks) {
         existingConfig.hooks = {};
       }
@@ -316,7 +317,7 @@ export function uninstallWindsurfHooks(): number {
 }
 
 function removeClaudeMemHookEntries(): void {
-  const parsed = JSON.parse(readFileSync(WINDSURF_HOOKS_JSON_PATH, 'utf-8')) as Partial<WindsurfHooksJson>;
+  const parsed = parseJsonWithBom<Partial<WindsurfHooksJson>>(readFileSync(WINDSURF_HOOKS_JSON_PATH, 'utf-8'));
   const config: WindsurfHooksJson = { hooks: parsed.hooks ?? {} };
 
   for (const eventName of WINDSURF_HOOK_EVENTS) {
@@ -363,7 +364,7 @@ export function checkWindsurfHooksStatus(): number {
 
     let parsedConfig: Partial<WindsurfHooksJson> | null = null;
     try {
-      parsedConfig = JSON.parse(readFileSync(WINDSURF_HOOKS_JSON_PATH, 'utf-8'));
+      parsedConfig = parseJsonWithBom(readFileSync(WINDSURF_HOOKS_JSON_PATH, 'utf-8'));
     } catch (error) {
       const normalizedError = error instanceof Error ? error : new Error(String(error));
       logger.error('WORKER', 'Unable to parse hooks.json', { path: WINDSURF_HOOKS_JSON_PATH }, normalizedError);

--- a/tests/windsurf-hooks-bom.test.ts
+++ b/tests/windsurf-hooks-bom.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { parseJsonWithBom } from '../src/shared/atomic-json.js';
+
+// The installer writes to a fixed path under the real home directory, so a filesystem test would
+// touch the developer's own Windsurf config. This asserts against the source instead, the same way
+// npm-install-windows-hide.test.ts does for its spawn options.
+const SOURCE = readFileSync(
+  join(import.meta.dir, '../src/services/integrations/WindsurfHooksInstaller.ts'),
+  'utf8',
+);
+
+describe("WindsurfHooksInstaller reads Windsurf's hooks.json", () => {
+  it('never parses that file with a BOM-blind JSON.parse', () => {
+    // A hooks.json rewritten by PowerShell 5.1 or a Windows editor carries a UTF-8 BOM. Parsing it
+    // with JSON.parse throws, and the catch turns a perfectly valid file into "Corrupt hooks.json,
+    // refusing to overwrite" — so install and uninstall both stop on a file that is not corrupt.
+    expect(SOURCE).not.toMatch(/JSON\.parse\(\s*readFileSync\(\s*WINDSURF_HOOKS_JSON_PATH/);
+  });
+
+  it('uses the shared BOM-tolerant reader for each of the three reads', () => {
+    // `[^(]*` rather than `<[^>]*>` so a nested type argument such as
+    // `<Partial<WindsurfHooksJson>>` still counts.
+    const uses = SOURCE.match(
+      /parseJsonWithBom[^(]*\(\s*readFileSync\(\s*WINDSURF_HOOKS_JSON_PATH/g,
+    );
+    expect(uses?.length).toBe(3);
+  });
+
+  it('that reader accepts what JSON.parse rejects', () => {
+    const bommed = '\uFEFF' + JSON.stringify({ hooks: { afterFileEdit: [] } });
+    expect(() => JSON.parse(bommed)).toThrow();
+    expect(parseJsonWithBom<{ hooks: Record<string, unknown> }>(bommed).hooks).toBeDefined();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
NIGHT SHIP rebase of #3670 onto current `main`.

## Why

On Windows, a valid `~/.codeium/windsurf/hooks.json` with a UTF-8 BOM is reported as corrupt, so install and uninstall stop. The file is not corrupt — PowerShell 5.1 and several Windows editors add the BOM. Windsurf itself reads it fine.

## What

Route the three reads of Windsurf's own `hooks.json` through the existing `parseJsonWithBom` helper (same fix as `readJsonSafe` in #3307). No new parser, no retry, no env-var gate.

`WINDSURF_REGISTRY_FILE` is left as-is — claude-mem writes that file itself.

## Validation

- `bun test tests/windsurf-hooks-bom.test.ts` — 3 pass

No version bump, no npm publish.

Refs #3670

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ac47986-a153-4fd9-a3fd-173470163fe1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ac47986-a153-4fd9-a3fd-173470163fe1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

