### PR TITLE
fix(project-filter): expand ~ with a separator instead of concatenation

### DIFF
--- a/src/utils/project-filter.ts
+++ b/src/utils/project-filter.ts
@@ -1,13 +1,18 @@
 
-import { homedir } from 'os';
 import { basename } from 'path';
+import { expandHome } from '../shared/expand-home.js';
 import { logger } from './logger.js';
 
 function globToRegex(pattern: string): RegExp {
-  let expanded = pattern.startsWith('~')
-    ? homedir() + pattern.slice(1)
-    : pattern;
+  // Separators first, then home expansion. A pattern written on Windows as `~\projects\secret`
+  // is home-relative, but `expandHome` only recognises `~` and `~/` on POSIX — resolving
+  // another user's home is deliberately out of its scope. Expanding before normalising left
+  // that pattern as a literal `~/projects/secret`, which matches no absolute path, so a
+  // configured exclusion silently stopped excluding.
+  let expanded = expandHome(pattern.replace(/\\/g, '/'));
 
+  // Again on the way out: on Windows `homedir()` itself returns backslashes, so the
+  // expanded path needs normalising even when the pattern arrived POSIX-form.
   expanded = expanded.replace(/\\/g, '/');
 
   let regex = expanded.replace(/[.+^${}()|[\]\\]/g, '\\$&');

--- a/tests/utils/project-filter.test.ts
+++ b/tests/utils/project-filter.test.ts
@@ -50,6 +50,25 @@ describe('Project Filter', () => {
         expect(isProjectExcluded(`${home}/secret`, '~/secret')).toBe(true);
         expect(isProjectExcluded(`${home}/projects/secret`, '~/projects/*')).toBe(true);
       });
+
+      it('expands a Windows-form ~\\ pattern', () => {
+        const home = homedir();
+        // `expandHome` recognises `~` and `~/`, not `~\` on POSIX. Expanding before
+        // normalising separators left a Windows-written exclusion as a literal `~/...`,
+        // which matches no absolute path — so the entry silently stopped excluding.
+        expect(isProjectExcluded(`${home}/projects/secret`, '~\\projects\\secret')).toBe(true);
+        expect(isProjectExcluded(`${home}/projects/secret`, '~\\projects\\*')).toBe(true);
+        expect(isProjectExcluded(home, '~\\')).toBe(true);
+      });
+
+      it('does not glue the home directory onto a ~name pattern', () => {
+        const home = homedir();
+        // `~backup/*` used to expand by concatenation to `<home>backup/*`, a path with no
+        // separator between the home directory and the pattern. That excluded a sibling of
+        // the home directory nobody named, and left a real `~backup` directory unexcluded.
+        expect(isProjectExcluded(`${home}backup/thing`, '~backup/*')).toBe(false);
+        expect(isProjectExcluded('/opt/~backup/thing', '~backup/*')).toBe(false);
+      });
     });
 
     describe('with multiple patterns', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
NIGHT SHIP rebase of #3669 onto current `main`.

## Why

An `CLAUDE_MEM_EXCLUDED_PROJECTS` entry that starts with `~` but is not `~/` silently excludes the wrong thing. `~backup/*` expanded to `<home>backup/*` (no separator), so it excluded a sibling of the home directory and left a real `~backup` directory unexcluded. Windows `~\projects\*` failed open after `expandHome` started recognizing only `~` / `~/`.

## What

Normalize separators first, then use the shared `expandHome` helper. No new expander, no widening of `expandHome`'s `~user/` contract.

## Validation

- `bun test tests/utils/project-filter.test.ts` — 13 pass

No version bump, no npm publish.

Refs #3669

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ac47986-a153-4fd9-a3fd-173470163fe1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ac47986-a153-4fd9-a3fd-173470163fe1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

