### PR TITLE
fix(transcripts): stop reparenting ~user/ watch paths

### DIFF
--- a/src/services/transcripts/config.ts
+++ b/src/services/transcripts/config.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { homedir } from 'os';
 import { join, dirname } from 'path';
-import { paths } from '../../shared/paths.js';
+import { expandTilde, paths } from '../../shared/paths.js';
 import type { TranscriptSchema, TranscriptWatchConfig } from './types.js';
 
 export const DEFAULT_CONFIG_PATH = paths.transcriptsConfig();
@@ -55,10 +55,11 @@ export function filterNativeHookBackedCodexWatches(
 
 export function expandHomePath(inputPath: string): string {
   if (!inputPath) return inputPath;
-  if (inputPath.startsWith('~')) {
-    return join(homedir(), inputPath.slice(1));
-  }
-  return inputPath;
+  // Shared expandTilde/expandHome leave `~user/...` alone (resolving another
+  // user's home is out of scope). The old inline version sliced one character
+  // off any leading tilde, so `~alice/transcripts` was rewritten to
+  // `<home>/alice/transcripts` and the watcher ingested nothing silently.
+  return expandTilde(inputPath);
 }
 
 export function loadTranscriptWatchConfig(path = DEFAULT_CONFIG_PATH): TranscriptWatchConfig {

--- a/tests/transcripts/config.test.ts
+++ b/tests/transcripts/config.test.ts
@@ -3,6 +3,7 @@ import { homedir } from 'os';
 import { join } from 'path';
 import {
   SAMPLE_CONFIG,
+  expandHomePath,
   filterNativeHookBackedCodexWatches,
   isNativeHookBackedCodexWatch,
   shouldSuppressNativeCodexAgentsContext,
@@ -127,5 +128,38 @@ describe('transcript watcher config', () => {
     const allowed = filterNativeHookBackedCodexWatches(config, true);
     expect(allowed.removed).toBe(0);
     expect(allowed.config.watches).toHaveLength(2);
+  });
+});
+
+describe('expandHomePath', () => {
+  it('expands a bare ~ and a ~/ prefix to the current home directory', () => {
+    expect(expandHomePath('~')).toBe(homedir());
+    expect(expandHomePath('~/.codex/sessions')).toBe(join(homedir(), '.codex/sessions'));
+  });
+
+  it('expands the Windows ~\\ form only on win32', () => {
+    // expandHome treats `~\` as a home prefix on Windows only; on POSIX a
+    // backslash is a legal filename character and must stay literal.
+    if (process.platform === 'win32') {
+      expect(expandHomePath('~\\')).toBe(homedir());
+      expect(expandHomePath('~\\.codex\\sessions')).toBe(join(homedir(), '.codex\\sessions'));
+    } else {
+      expect(expandHomePath('~\\')).toBe('~\\');
+      expect(expandHomePath('~\\.codex\\sessions')).toBe('~\\.codex\\sessions');
+    }
+  });
+
+  it('leaves ~user/ paths alone instead of reparenting them under this user home', () => {
+    // `~alice/transcripts` names alice's home, not a directory inside ours.
+    // Rewriting it to <home>/alice/transcripts pointed the watcher at a path
+    // that does not exist, and it ingested nothing without reporting an error.
+    expect(expandHomePath('~alice/transcripts')).toBe('~alice/transcripts');
+    expect(expandHomePath('~backup/rollout.jsonl')).toBe('~backup/rollout.jsonl');
+  });
+
+  it('passes absolute, relative and empty paths through untouched', () => {
+    expect(expandHomePath('/var/log/codex.jsonl')).toBe('/var/log/codex.jsonl');
+    expect(expandHomePath('relative/path.jsonl')).toBe('relative/path.jsonl');
+    expect(expandHomePath('')).toBe('');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
NIGHT SHIP rebase of #3666 onto current `main`.

## Why

A transcript watch whose path names another user's home — `~alice/transcripts` — was silently rewritten to `<your home>/alice/transcripts`. The watcher then watched a directory that does not exist, ingested nothing, and reported no error. Same for a directory named `~backup`.

## What

Delete the divergent `startsWith('~')` expander and delegate to shared `expandTilde` / `expandHome`, which already leave `~user/` alone. Windows `~\` stays platform-aware (expanded on win32 only), matching the current helper contract.

## Validation

- `bun test tests/transcripts/config.test.ts` — 11 pass

No version bump, no npm publish.

Refs #3666

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ac47986-a153-4fd9-a3fd-173470163fe1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ac47986-a153-4fd9-a3fd-173470163fe1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

