### PR TITLE
fix(cleanup): tolerate negative statfs availability

### DIFF
--- a/src/services/infrastructure/CleanupV12_4_3.ts
+++ b/src/services/infrastructure/CleanupV12_4_3.ts
@@ -142,10 +142,10 @@ function executeCleanup(dbPath: string, effectiveDataDir: string, markerPath: st
     // and will ship in the next Bun release after 1.3.14. Until then, any
     // `bavail * bsize` math returns 0 and this gate would permanently skip
     // the cleanup with a misleading `free=0` error. Treat non-credible
-    // readings (bsize <= 0, NaN, or non-finite) as "skip the gate" rather
+    // readings (bsize <= 0, bavail < 0, NaN, or non-finite) as "skip the gate" rather
     // than "disk is full" -- a real out-of-space condition will still
     // surface from the subsequent VACUUM INTO / copyFileSync.
-    if (!Number.isFinite(bsize) || !Number.isFinite(bavail) || bsize <= 0) {
+    if (!Number.isFinite(bsize) || !Number.isFinite(bavail) || bsize <= 0 || bavail < 0) {
       logger.warn(
         'SYSTEM',
         'statfsSync returned non-credible values; proceeding without disk-space pre-flight',

--- a/tests/infrastructure/cleanup-v12_4_3.test.ts
+++ b/tests/infrastructure/cleanup-v12_4_3.test.ts
@@ -211,6 +211,41 @@ describe('runOneTimeV12_4_3Cleanup', () => {
     );
   });
 
+  it('proceeds with cleanup when statfsSync returns a negative available block count', () => {
+    const dbPath = path.join(tmpDataDir, 'claude-mem.db');
+    seedDatabase(dbPath, { observerSessions: 2, stuckCount: 10 });
+
+    const statfsSpy = spyOn(fs, 'statfsSync').mockImplementation(() => ({
+      type: 0,
+      bsize: 4096,
+      blocks: 4096,
+      bfree: 1048576,
+      bavail: -1,
+      files: 0,
+      ffree: 0,
+    }) as unknown as ReturnType<typeof fs.statfsSync>);
+
+    try {
+      runOneTimeV12_4_3Cleanup(tmpDataDir);
+    } finally {
+      statfsSpy.mockRestore();
+    }
+
+    const markerPath = path.join(tmpDataDir, '.cleanup-v12.4.3-applied');
+    expect(existsSync(markerPath)).toBe(true);
+    const payload = JSON.parse(readFileSync(markerPath, 'utf8'));
+    expect(payload.counts.observerSessions).toBe(2);
+    expect(payload.counts.stuckPendingMessages).toBe(10);
+    expect(payload.backupPath).toBeTruthy();
+    expect(existsSync(payload.backupPath)).toBe(true);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'SYSTEM',
+      expect.stringContaining('non-credible'),
+      expect.objectContaining({ bsize: 4096, bavail: -1 }),
+    );
+  });
+
   it('honors CLAUDE_MEM_SKIP_CLEANUP_V12_4_3=1 by exiting without writing the marker', () => {
     const dbPath = path.join(tmpDataDir, 'claude-mem.db');
     seedDatabase(dbPath, { observerSessions: 1, stuckCount: 10 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
NIGHT SHIP rebase of #3572 onto current `main`.

## Why

Bun on linux-x64 can truncate `statfsSync().bavail` to a signed int32. On filesystems with more than ~2^31 available blocks, `bavail` comes back negative. The existing credibility gate only rejected `bsize <= 0` / non-finite values, so cleanup computed `free < 0` and skipped forever with a misleading "Insufficient disk" error.

## What

Treat `bavail < 0` as non-credible disk telemetry and bypass only the pre-flight disk-space gate. A real out-of-space condition still surfaces from the subsequent `VACUUM INTO` / `copyFileSync`.

## Validation

- `npx -y bun@1.3.14 test tests/infrastructure/cleanup-v12_4_3.test.ts` — 7 pass

No version bump, no npm publish.

Rebases #3572. Closes #3551.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-379ed12e-5369-49d5-980e-6d54668cca28?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-379ed12e-5369-49d5-980e-6d54668cca28&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

