### PR TITLE
fix(context): skip empty CLAUDE.md creation

### DIFF
--- a/src/utils/claude-md-utils.ts
+++ b/src/utils/claude-md-utils.ts
@@ -360,7 +360,7 @@ export async function updateFolderClaudeMdFiles(
       continue;
     }
 
-    if (hasNoActivity && !fileExists) {
+    if (isEmptyOrSkeleton && !fileExists) {
       logger.debug('FOLDER_INDEX', 'Skipping empty context file creation', { folderPath, targetFilename });
       continue;
     }

--- a/tests/utils/claude-md-utils.test.ts
+++ b/tests/utils/claude-md-utils.test.ts
@@ -1110,6 +1110,23 @@ describe('skeleton CLAUDE.md deny-list (#2400)', () => {
     content: [{ text: 'no observation rows here' }],
   };
 
+  it('does not create a new CLAUDE.md when the formatted timeline is empty', async () => {
+    delete process.env[ENV_KEY];
+
+    const folderPath = join(tempDir, 'empty-timeline');
+    mkdirSync(folderPath, { recursive: true });
+    const filePath = join(folderPath, 'file.ts');
+
+    global.fetch = mock(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(emptySkeletonResponse),
+    } as Response));
+
+    await updateFolderClaudeMdFiles([filePath], 'test-project', 37777, tempDir);
+
+    expect(existsSync(join(folderPath, 'CLAUDE.md'))).toBe(false);
+  });
+
   it('does NOT overwrite an existing CLAUDE.md with a skeleton when the folder matches the deny-list', async () => {
     process.env[ENV_KEY] = JSON.stringify(['**/transient']);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
NIGHT SHIP rebase of #3573 onto current `main`.

## Why

`updateFolderClaudeMdFiles` skipped create-if-absent only when the formatted timeline contained `*No recent activity*`. A fully empty formatted timeline (no parseable observation rows) still wrote a 43-byte stub `CLAUDE.md` with an empty `<claude-mem-context>` wrapper.

## What

Use the existing `isEmptyOrSkeleton` classification (`trim() === ''` or `*No recent activity*`) when deciding whether to create a missing context file. Existing-file rewrite behavior is unchanged.

## Validation

- `npx -y bun@1.3.14 test tests/utils/claude-md-utils.test.ts -t "skeleton CLAUDE.md"` — 4 pass

No version bump, no npm publish.

Rebases #3573. Closes #3544.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-379ed12e-5369-49d5-980e-6d54668cca28?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-379ed12e-5369-49d5-980e-6d54668cca28&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

