### PR TITLE
fix(transcripts): scan configured dot-directories

### DIFF
--- a/src/services/transcripts/watcher.ts
+++ b/src/services/transcripts/watcher.ts
@@ -223,7 +223,7 @@ export class TranscriptWatcher {
   }
 
   private scanGlob(pattern: string): string[] {
-    return Array.from(new Bun.Glob(pattern).scanSync({ absolute: true, onlyFiles: true }));
+    return Array.from(new Bun.Glob(pattern).scanSync({ absolute: true, onlyFiles: true, dot: true }));
   }
 
   private normalizeGlobPattern(inputPath: string): string {

--- a/tests/transcripts/watcher-start-at-end.test.ts
+++ b/tests/transcripts/watcher-start-at-end.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import { appendFileSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import type { NormalizedHookInput } from '../../src/cli/types.js';
 import type { TranscriptSchema, WatchTarget } from '../../src/services/transcripts/types.js';
 
@@ -51,6 +51,29 @@ describe('TranscriptWatcher startAtEnd', () => {
   afterEach(() => {
     loggerSpies.forEach(spy => spy.mockRestore());
     rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('discovers transcripts inside dot-directories', () => {
+    const transcriptPath = join(
+      tmpRoot,
+      'brain',
+      'conversation-id',
+      '.system_generated',
+      'logs',
+      'transcript_full.jsonl',
+    );
+    mkdirSync(join(transcriptPath, '..'), { recursive: true });
+    writeFileSync(transcriptPath, '', 'utf8');
+
+    const watcher = new TranscriptWatcher(
+      { version: 1, watches: [] },
+      join(tmpRoot, 'state.json'),
+    );
+    const pattern = join(tmpRoot, 'brain', '**', '.system_generated', 'logs', 'transcript_full.jsonl');
+
+    const matches = (watcher as any).resolveWatchFiles(pattern) as string[];
+
+    expect(matches.map(match => resolve(match))).toEqual([resolve(transcriptPath)]);
   });
 
   it('does not replay history from transcript files discovered after startup', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
NIGHT SHIP rebase of #3574 onto current `main`.

## Why

`TranscriptWatcher.scanGlob()` called `Bun.Glob(...).scanSync()` without `dot: true`. Bun skips dot-directories even when the pattern names them explicitly, so transcripts under paths like `.system_generated/logs` (Antigravity) were never discovered.

## What

Pass `{dot: true}` to `scanSync`. Matching stays constrained to the configured watch pattern.

## Validation

- `npx -y bun@1.3.14 test tests/transcripts/watcher-start-at-end.test.ts` — 2 pass

No version bump, no npm publish.

Rebases #3574. Closes #3512.

Note: #3633 also touches `watcher.ts` (FileTailer serialization). That rebase lands after this one.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-379ed12e-5369-49d5-980e-6d54668cca28?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-379ed12e-5369-49d5-980e-6d54668cca28&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

