### PR TITLE
fix(openrouter): accept empty reasoning responses

### DIFF
--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -208,7 +208,7 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     session: ActiveSession,
     model: string
   ): void {
-    if (!initResponse.content) {
+    if (!initResponse.content && !this.forwardEmptyMessageResponse) {
       logger.error('SDK', `Empty ${this.providerName} init response - session may lack context`, {
         sessionId: session.sessionDbId, model
       });
@@ -223,7 +223,7 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     // invented from <user_request> alone and would be stored as memory for work
     // that never happened. Keep the turn so role alternation holds, but never
     // hand it to the storage path.
-    session.conversationHistory.push({ role: 'assistant', content: initResponse.content });
+    session.conversationHistory.push({ role: 'assistant', content: initResponse.content || '' });
   }
 
   private async processObservationMessage(

--- a/src/services/worker/OpenRouterProvider.ts
+++ b/src/services/worker/OpenRouterProvider.ts
@@ -190,6 +190,7 @@ interface OpenRouterResponse {
     message?: {
       role?: string;
       content?: string;
+      reasoning_content?: string;
     };
     finish_reason?: string;
   }>;
@@ -566,12 +567,20 @@ export class OpenRouterProvider extends OpenAICompatibleProvider<OpenRouterConfi
     // dispatch returns to the gateway. No-op for every other endpoint.
     clearProFallbackOnGatewaySuccess(apiUrl);
 
-    if (!data.choices?.[0]?.message?.content) {
+    const choice = data.choices?.[0];
+    const message = choice?.message;
+    if (!message || typeof message.content !== 'string') {
       logger.error('SDK', 'Empty response from OpenRouter');
       return { content: '' };
     }
 
-    const content = data.choices[0].message.content;
+    const content = message.content;
+    if (content.length === 0) {
+      logger.debug('SDK', 'OpenRouter returned an empty message', {
+        finishReason: choice.finish_reason,
+        hasReasoningContent: Boolean(message.reasoning_content),
+      });
+    }
     const tokensUsed = data.usage?.total_tokens;
     const realInputTokens = data.usage?.prompt_tokens;
     const realOutputTokens = data.usage?.completion_tokens;

--- a/tests/worker/openrouter-empty-content.test.ts
+++ b/tests/worker/openrouter-empty-content.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import { OpenRouterProvider } from '../../src/services/worker/OpenRouterProvider.js';
+import { logger } from '../../src/utils/logger.js';
+
+describe('OpenRouterProvider empty content', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('accepts an empty message from a reasoning model and preserves usage', async () => {
+    global.fetch = mock(() => Promise.resolve(new Response(JSON.stringify({
+      model: 'reasoning-model',
+      choices: [{
+        message: {
+          role: 'assistant',
+          content: '',
+          reasoning_content: 'internal reasoning',
+        },
+        finish_reason: 'stop',
+      }],
+      usage: {
+        prompt_tokens: 12,
+        completion_tokens: 8,
+        total_tokens: 20,
+      },
+    }), { status: 200 })));
+    const errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
+
+    try {
+      const provider = new OpenRouterProvider({} as any, {} as any);
+      const result = await (provider as any).query(
+        [{ role: 'user', content: 'remember this' }],
+        {
+          apiKey: 'test-key',
+          model: 'reasoning-model',
+          fallbackModels: [],
+          apiUrl: 'https://openrouter.ai/api/v1/chat/completions',
+        },
+      );
+
+      expect(result).toEqual({
+        content: '',
+        tokensUsed: 20,
+        inputTokens: 12,
+        outputTokens: 8,
+        costUsd: undefined,
+        servedModel: 'reasoning-model',
+      });
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('preserves bookkeeping for an empty initialization response', () => {
+    const provider = new OpenRouterProvider({} as any, {} as any);
+    const session = {
+      sessionDbId: 42,
+      conversationHistory: [],
+      cumulativeInputTokens: 0,
+      cumulativeOutputTokens: 0,
+    } as any;
+    const errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
+
+    try {
+      (provider as any).handleInitResponse(
+        {
+          content: '',
+          tokensUsed: 20,
+          inputTokens: 12,
+          outputTokens: 8,
+          servedModel: 'reasoning-model',
+        },
+        session,
+        'configured-model',
+      );
+
+      expect(session.conversationHistory).toEqual([{ role: 'assistant', content: '' }]);
+      expect(session.cumulativeInputTokens).toBe(14);
+      expect(session.cumulativeOutputTokens).toBe(6);
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('still rejects a response without a message object', async () => {
+    global.fetch = mock(() => Promise.resolve(new Response(JSON.stringify({
+      choices: [{ finish_reason: 'stop' }],
+    }), { status: 200 })));
+    const errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
+
+    try {
+      const provider = new OpenRouterProvider({} as any, {} as any);
+      const result = await (provider as any).query(
+        [{ role: 'user', content: 'remember this' }],
+        {
+          apiKey: 'test-key',
+          model: 'reasoning-model',
+          fallbackModels: [],
+          apiUrl: 'https://openrouter.ai/api/v1/chat/completions',
+        },
+      );
+
+      expect(result).toEqual({ content: '' });
+      expect(errorSpy).toHaveBeenCalledWith('SDK', 'Empty response from OpenRouter');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
NIGHT SHIP rebase of #3576 onto current `main`.

## Why

Reasoning models (e.g. DeepSeek V4 Flash) can legally return `choices[0].message.content === ''` with `finish_reason: "stop"` and non-empty `reasoning_content`. The OpenRouter query path treated any falsy `content` as a malformed response, dropped usage metadata, and logged `Empty response from OpenRouter`. Init then logged `Empty OpenRouter init response` and skipped the turn.

## What

- Accept a present empty-string `content` as a valid no-op and keep usage / served-model metadata.
- Log missing message / non-string content as the malformed-response case.
- For providers with `forwardEmptyMessageResponse`, record the empty init turn in conversation history so role alternation holds. Init replies are still not sent to the storage path (current `handleInitResponse` contract).

Diff stays on the OpenRouter / OpenAICompatible empty-content path.

## Validation

- `npx -y bun@1.3.14 test tests/worker/openrouter-empty-content.test.ts` — 3 pass
- `npx -y bun@1.3.14 test tests/worker/openrouter-provider.test.ts tests/worker/openrouter-messages.test.ts` — 6 pass

No version bump, no npm publish.

Rebases #3576. Closes #3569.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-379ed12e-5369-49d5-980e-6d54668cca28?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-379ed12e-5369-49d5-980e-6d54668cca28&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

