### PR TITLE
fix: upgrade shell-quote to 1.9.0 (CVE-2026-13311)

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "posthog-node": "^5.36.15",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "shell-quote": "^1.8.3",
+    "shell-quote": "1.9.0",
     "zod": "^4.4.3",
     "@derekstride/tree-sitter-sql": "^0.3.11",
     "@tree-sitter-grammars/tree-sitter-lua": "^0.4.1",

--- a/plugin/bun.lock
+++ b/plugin/bun.lock
@@ -11,7 +11,7 @@
         "@tree-sitter-grammars/tree-sitter-toml": "^0.7.0",
         "@tree-sitter-grammars/tree-sitter-yaml": "^0.7.1",
         "@tree-sitter-grammars/tree-sitter-zig": "^1.1.2",
-        "shell-quote": "^1.8.3",
+        "shell-quote": "1.9.0",
         "tree-sitter-bash": "^0.25.1",
         "tree-sitter-c": "^0.24.1",
         "tree-sitter-cli": "^0.26.5",
@@ -61,7 +61,7 @@
 
     "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
-    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
+    "shell-quote": ["shell-quote@1.9.0", "", {}, "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA=="],
 
     "tree-sitter": ["tree-sitter@0.25.0", "", { "dependencies": { "node-addon-api": "^8.3.0", "node-gyp-build": "^4.8.4" } }, "sha512-PGZZzFW63eElZJDe/b/R/LbsjDDYJa5UEjLZJB59RQsMX+fo0j54fqBPn1MGKav/QNa0JR0zBiVaikYDWCj5KQ=="],
 

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -30,7 +30,7 @@
     "@tree-sitter-grammars/tree-sitter-yaml": "^0.7.1",
     "@derekstride/tree-sitter-sql": "^0.3.11",
     "@tree-sitter-grammars/tree-sitter-markdown": "^0.3.2",
-    "shell-quote": "^1.8.3"
+    "shell-quote": "1.9.0"
   },
   "overrides": {
     "tree-sitter": "^0.25.0"

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -288,7 +288,7 @@ async function buildHooks() {
         '@tree-sitter-grammars/tree-sitter-yaml': '^0.7.1',
         '@derekstride/tree-sitter-sql': '^0.3.11',
         '@tree-sitter-grammars/tree-sitter-markdown': '^0.3.2',
-        'shell-quote': '^1.8.3',
+        'shell-quote': '1.9.0',
       },
       overrides: {
         'tree-sitter': '^0.25.0'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
NIGHT SHIP rebase of #3646 onto current `main`.

## Why

`plugin/bun.lock` still resolved `shell-quote@1.8.4`, which is CVE-2026-13311 (DoS via inefficient parse). The community PR only edited the generated plugin manifest/lockfile; `scripts/build-hooks.js` would regenerate `^1.8.3` on the next build and allow 1.8.4 again.

## What

Pin `shell-quote` to `1.9.0` in:

- `scripts/build-hooks.js` (generator source of truth)
- `plugin/package.json` / `plugin/bun.lock`
- root `package.json` (build-time inlined copy)

No key reorder, no other lockfile drift. Frozen-lockfile install resolves `shell-quote@1.9.0`.

## Validation

- `npx -y bun@1.3.14 install --frozen-lockfile --ignore-scripts` in `plugin/` — `shell-quote@1.9.0`
- `npx -y bun@1.3.14 test tests/cli/adapters/codex-file-context.test.ts` — 9 pass

No version bump, no npm publish.

Rebases #3646.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-379ed12e-5369-49d5-980e-6d54668cca28?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-379ed12e-5369-49d5-980e-6d54668cca28&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

