### PR TITLE
fix(transcripts): serialize FileTailer reads and clear partial on truncation

### DIFF
--- a/src/services/transcripts/watcher.ts
+++ b/src/services/transcripts/watcher.ts
@@ -14,6 +14,8 @@ interface TailState {
 class FileTailer {
   private watcher: ReturnType<typeof fsWatch> | null = null;
   private tailState: TailState;
+  private readTask: Promise<void> | null = null;
+  private readPending = false;
 
   constructor(
     private filePath: string,
@@ -25,9 +27,9 @@ class FileTailer {
   }
 
   start(): void {
-    this.readNewData().catch(() => undefined);
+    this.requestRead();
     this.watcher = fsWatch(this.filePath, { persistent: true }, () => {
-      this.readNewData().catch(() => undefined);
+      this.requestRead();
     });
   }
 
@@ -37,7 +39,25 @@ class FileTailer {
   }
 
   poke(): void {
-    this.readNewData().catch(() => undefined);
+    this.requestRead();
+  }
+
+  private requestRead(): void {
+    if (this.readTask) {
+      this.readPending = true;
+      return;
+    }
+
+    this.readTask = this.drainReads().finally(() => {
+      this.readTask = null;
+    });
+  }
+
+  private async drainReads(): Promise<void> {
+    do {
+      this.readPending = false;
+      await this.readNewData().catch(() => undefined);
+    } while (this.readPending);
   }
 
   private async readNewData(): Promise<void> {
@@ -53,6 +73,7 @@ class FileTailer {
 
     if (size < this.tailState.offset) {
       this.tailState.offset = 0;
+      this.tailState.partial = '';
     }
 
     if (size === this.tailState.offset) return;

--- a/tests/transcripts/watcher-start-at-end.test.ts
+++ b/tests/transcripts/watcher-start-at-end.test.ts
@@ -32,6 +32,30 @@ import { TranscriptWatcher } from '../../src/services/transcripts/watcher.js';
 
 const waitForAsyncTail = () => new Promise(resolve => setTimeout(resolve, 50));
 
+const createUserMessage = (sessionId: string, prompt: string) => JSON.stringify({
+  type: 'event',
+  payload: {
+    type: 'user_message',
+    session_id: sessionId,
+    message: prompt,
+  },
+});
+
+const createSchema = (): TranscriptSchema => ({
+  name: 'codex-test',
+  events: [
+    {
+      name: 'user-message',
+      match: { path: 'payload.type', equals: 'user_message' },
+      action: 'session_init',
+      fields: {
+        sessionId: 'payload.session_id',
+        prompt: 'payload.message',
+      },
+    },
+  ],
+});
+
 describe('TranscriptWatcher startAtEnd', () => {
   let tmpRoot: string;
   let loggerSpies: ReturnType<typeof spyOn>[] = [];
@@ -141,5 +165,64 @@ describe('TranscriptWatcher startAtEnd', () => {
     const prompts = sessionInitCalls.map(call => call.prompt);
     expect(prompts).toContain('live prompt');
     expect(prompts).not.toContain('historical prompt that must not be replayed');
+  });
+
+  it('serializes overlapping poke calls for the same appended data', async () => {
+    const sessionId = '019e050e-7ae0-71b2-b19f-6cc428e5763b';
+    const filePath = join(tmpRoot, `${sessionId}.jsonl`);
+    const statePath = join(tmpRoot, 'state.json');
+    const schema = createSchema();
+    const watch: WatchTarget = {
+      name: 'codex',
+      path: filePath,
+      schema,
+      startAtEnd: true,
+    };
+
+    writeFileSync(filePath, `${createUserMessage(sessionId, 'historical prompt')}\n`, 'utf8');
+
+    const watcher = new TranscriptWatcher({ version: 1, watches: [watch] }, statePath);
+    await (watcher as any).addTailer(filePath, watch, schema);
+    await waitForAsyncTail();
+
+    const tailer = (watcher as any).tailers.get(filePath);
+    tailer.close();
+    appendFileSync(filePath, `${createUserMessage(sessionId, 'live prompt')}\n`, 'utf8');
+
+    tailer.poke();
+    tailer.poke();
+    await waitForAsyncTail();
+    watcher.stop();
+
+    const livePrompts = sessionInitCalls.filter(call => call.prompt === 'live prompt');
+    expect(livePrompts).toHaveLength(1);
+  });
+
+  it('discards a buffered partial line when the file is truncated', async () => {
+    const sessionId = '019e050e-7ae0-71b2-b19f-6cc428e5763c';
+    const filePath = join(tmpRoot, `${sessionId}.jsonl`);
+    const statePath = join(tmpRoot, 'state.json');
+    const schema = createSchema();
+    const watch: WatchTarget = {
+      name: 'codex',
+      path: filePath,
+      schema,
+    };
+
+    writeFileSync(filePath, `{"incomplete":"${'x'.repeat(1024)}`, 'utf8');
+
+    const watcher = new TranscriptWatcher({ version: 1, watches: [watch] }, statePath);
+    await (watcher as any).addTailer(filePath, watch, schema);
+    await waitForAsyncTail();
+
+    const tailer = (watcher as any).tailers.get(filePath);
+    tailer.close();
+    writeFileSync(filePath, `${createUserMessage(sessionId, 'after truncation')}\n`, 'utf8');
+
+    tailer.poke();
+    await waitForAsyncTail();
+    watcher.stop();
+
+    expect(sessionInitCalls.map(call => call.prompt)).toEqual(['after truncation']);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
NIGHT SHIP rebase of #3633 onto current `main` (after #4016).

## Why

`FileTailer.start()`, `fs.watch`, and `poke()` could all call `readNewData()` at once. Overlapping reads can consume the same byte range twice (duplicate transcript entries) or move the shared offset backwards. On truncation, `offset` was reset but `partial` was kept, so a stale fragment could be prepended to the first new line.

## What

- Single-flight coalescing scheduler for all read triggers.
- Clear `partial` when `size < offset`.

Does not add inode-based rotation detection or claim exactly-once delivery across crashes.

## Validation

- `npx -y bun@1.3.14 test tests/transcripts/watcher-start-at-end.test.ts` — 4 pass (on the pre-rebase stack; rebased after #4016)

No version bump, no npm publish.

Rebases #3633. Related: #2192, #2209, #2219, #1661.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-379ed12e-5369-49d5-980e-6d54668cca28?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-379ed12e-5369-49d5-980e-6d54668cca28&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

