### PR TITLE
test(windows): only skip the ghost gate for the one runtime signature

### DIFF
--- a/tests/integration/helpers/ghost-state.test.ts
+++ b/tests/integration/helpers/ghost-state.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Truth table for classifyPostKillState (the ghost gate's skip guard).
+ *
+ * The environmental states it classifies cannot be produced on demand — they
+ * are precisely the anomalies (a dead sidecar chain, a foreign port owner) the
+ * gate must fail on instead of skipping — so the classification itself is pure
+ * and its full table is asserted here.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { classifyPostKillState } from './ghost-state.js';
+
+// fixturePid=100, worker dead unless a case says otherwise.
+const base = { fixturePid: 100, fixtureAlive: false, portOwners: [] as number[], chainSurvived: true };
+
+describe('classifyPostKillState', () => {
+  it('returns ghost when the port is bound only under the dead fixture pid', () => {
+    // Scenario: the normal bun <= 1.3 shape. The chain's fate is irrelevant
+    // here — the full recovery path asserts it separately.
+    // Expected: ghost, with or without surviving sidecars.
+    expect(classifyPostKillState({ ...base, portOwners: [100], chainSurvived: true })).toEqual({ kind: 'ghost' });
+    expect(classifyPostKillState({ ...base, portOwners: [100], chainSurvived: false })).toEqual({ kind: 'ghost' });
+  });
+
+  it('skips only when the port is free AND the sidecar chain survived', () => {
+    // Scenario: the measured bun >= 1.4 signature — the socket is released
+    // with the worker while the chain lives on.
+    // Expected: the one and only skippable state.
+    expect(classifyPostKillState(base)).toEqual({ kind: 'runtime-capability-skip' });
+  });
+
+  it('fails on a free port when the sidecar chain died with the worker', () => {
+    // Scenario: the chain is gone too, so a free port proves nothing about
+    // socket inheritance — the scenario failed to form for unknown reasons.
+    // Expected: malformed (chain-died), never a skip.
+    expect(classifyPostKillState({ ...base, portOwners: [], chainSurvived: false })).toEqual({
+      kind: 'malformed',
+      reason: 'chain-died',
+    });
+  });
+
+  it('fails when the dead fixture pid shares the port with other owners', () => {
+    // Scenario: a ghost forms but something else also holds the port.
+    // Expected: malformed (ghost-shared-port).
+    expect(classifyPostKillState({ ...base, portOwners: [100, 200] })).toEqual({
+      kind: 'malformed',
+      reason: 'ghost-shared-port',
+    });
+  });
+
+  it('fails when the port is held only by processes that are not the fixture', () => {
+    // Scenario: an unrelated process (or another ghost) owns the port.
+    // Expected: malformed (foreign-owner), for one or several foreign pids.
+    expect(classifyPostKillState({ ...base, portOwners: [200] })).toEqual({
+      kind: 'malformed',
+      reason: 'foreign-owner',
+    });
+    expect(classifyPostKillState({ ...base, portOwners: [200, 300] })).toEqual({
+      kind: 'malformed',
+      reason: 'foreign-owner',
+    });
+  });
+
+  it('fails when the port is under the fixture pid but that pid is alive', () => {
+    // Scenario: the fixture pid was recycled by a new process after the kill.
+    // Expected: malformed (fixture-pid-recycled), not a ghost.
+    expect(classifyPostKillState({ ...base, fixtureAlive: true, portOwners: [100] })).toEqual({
+      kind: 'malformed',
+      reason: 'fixture-pid-recycled',
+    });
+  });
+});

--- a/tests/integration/helpers/ghost-state.ts
+++ b/tests/integration/helpers/ghost-state.ts
@@ -1,0 +1,63 @@
+/**
+ * Classifies the post-kill port/process state observed by the ghost-listener
+ * recovery gate into exactly one outcome.
+ *
+ * The gate may SKIP only for one state: the port is free AND the (pre-kill
+ * verified) sidecar chain is still alive — the measured bun >= 1.4 signature,
+ * where spawned children no longer inherit the listening socket. Every other
+ * non-ghost state is malformed — the chain died with the worker, the port is
+ * held by processes that are not the dead worker, a ghost shares the port, or
+ * the fixture pid was recycled — and must FAIL the gate: skipping any of those
+ * would pass without ever exercising the recovery the gate exists to test.
+ *
+ * Pure so the full state table is unit-testable; the environmental states are
+ * not constructible on demand (they are exactly the anomalies being named).
+ */
+
+export type PostKillState =
+  | { kind: 'ghost' }
+  | { kind: 'runtime-capability-skip' }
+  | {
+      kind: 'malformed';
+      reason: 'chain-died' | 'fixture-pid-recycled' | 'ghost-shared-port' | 'foreign-owner';
+    };
+
+export interface PostKillObservation {
+  /** PID the fixture reported at spawn; dead by the time this is called. */
+  fixturePid: number;
+  /** Result of a fresh liveness probe of fixturePid (guards PID recycling). */
+  fixtureAlive: boolean;
+  /** PIDs currently holding the fixture port LISTENING, from the final sample. */
+  portOwners: number[];
+  /** Whether any pre-kill-snapshotted sidecar descendant is still alive. */
+  chainSurvived: boolean;
+}
+
+export function classifyPostKillState(obs: PostKillObservation): PostKillState {
+  const { fixturePid, fixtureAlive, portOwners, chainSurvived } = obs;
+
+  // The ghost: the port is bound ONLY under the dead worker's pid.
+  if (!fixtureAlive && portOwners.length > 0 && portOwners.every(pid => pid === fixturePid)) {
+    return { kind: 'ghost' };
+  }
+
+  // The only skippable non-ghost state: no ghost can form because the runtime
+  // no longer hands the socket to children — but the chain must have SURVIVED
+  // the kill, which is what proves the release came from socket semantics and
+  // not from the chain dying for its own reasons.
+  if (portOwners.length === 0 && chainSurvived) {
+    return { kind: 'runtime-capability-skip' };
+  }
+
+  if (portOwners.length === 0) {
+    return { kind: 'malformed', reason: 'chain-died' };
+  }
+  if (portOwners.every(pid => pid === fixturePid)) {
+    // Only reachable when fixtureAlive: the ghost condition above already
+    // handled the dead-pid case, so this pid belongs to someone else now.
+    return { kind: 'malformed', reason: 'fixture-pid-recycled' };
+  }
+  return portOwners.some(pid => pid === fixturePid)
+    ? { kind: 'malformed', reason: 'ghost-shared-port' }
+    : { kind: 'malformed', reason: 'foreign-owner' };
+}

--- a/tests/integration/worker-ghost-port-recovery.test.ts
+++ b/tests/integration/worker-ghost-port-recovery.test.ts
@@ -38,10 +38,13 @@
  * socket handles, and bun >= 1.4 no longer passes the listening socket into
  * spawned children. Measured on one machine with identical code and logging:
  * under 1.3.6 the port stays LISTENING under the dead worker (ghost), under
- * 1.4.0 it is released with the worker. Where the scenario cannot be
- * constructed the gate says so and skips the recovery assertions, because
- * failing would report the runtime's behaviour, not the product's (the
- * fixture's sidecar chain is asserted first, so a broken fixture still fails).
+ * 1.4.0 it is released with the worker. The gate skips the recovery
+ * assertions for exactly that signature — port free AND the pre-kill-verified
+ * sidecar chain still alive (classifyPostKillState, helpers/ghost-state.ts) —
+ * because failing there would report the runtime's behaviour, not the
+ * product's. Every other non-ghost shape (chain died with the worker, port
+ * held by other processes, shared ghost, recycled pid) is malformed and
+ * FAILS: skipping those would pass the gate without exercising recovery.
  *
  * Requires the same isolation contract as the other chroma gates:
  * CLAUDE_MEM_DATA_DIR set in the environment before this process starts, and
@@ -60,6 +63,7 @@ import {
   describeProcesses,
   type ProcessIdentity,
 } from './helpers/process-tree.js';
+import { classifyPostKillState } from './helpers/ghost-state.js';
 
 const RUN_GATE = process.env.CLAUDE_MEM_TEST_CHROMA === '1';
 
@@ -437,22 +441,50 @@ describe.if(RUN_GATE && IS_WINDOWS)('worker recovers from a ghost listener left 
       await new Promise(resolve => setTimeout(resolve, 500));
     }
     const survivorsAfterKill = survivingProcesses(snapshot);
-    if (!ownerUnderDeadPid) {
-      // RUNTIME CAPABILITY SKIP, not a vacuous pass. The fixture above is
-      // verified (sidecar chain present AND matched by name), so the only
-      // thing missing is the socket inheritance the ghost is made of: bun >= 1.4
-      // no longer hands the listening socket to spawned children. Measured on
-      // one machine with identical code — 1.3.6 leaves the port bound under the
-      // dead worker, 1.4.0 releases it the moment the worker dies. Without
-      // inheritance there is no ghost for the reclaim to recover, and failing
-      // here would only report the runtime's behaviour, not the product's.
+    // Classify the settled state. Exactly ONE non-ghost state may skip — the
+    // port is free AND the pre-kill-verified sidecar chain is still alive —
+    // because that is the measured bun >= 1.4 signature (spawned children no
+    // longer inherit the listening socket). Every other non-ghost state is
+    // malformed: a chain that died with the worker proves nothing about socket
+    // inheritance, and a port held by an unrelated process, a shared ghost, or
+    // a recycled fixture pid means the scenario did not form. Skipping any of
+    // those would pass the gate without ever exercising recovery.
+    const finalOwners = listeningOwnerPids(fixture.port);
+    const state = classifyPostKillState({
+      fixturePid: fixture.pid,
+      fixtureAlive: processExists(fixture.pid),
+      portOwners: finalOwners,
+      chainSurvived: survivorsAfterKill.length > 0,
+    });
+    if (state.kind === 'runtime-capability-skip') {
+      // RUNTIME CAPABILITY SKIP, not a vacuous pass. The fixture's chain was
+      // verified before the kill and has survived it (asserted in the
+      // classification above), so the only thing missing is the socket
+      // inheritance the ghost is made of: bun >= 1.4 no longer hands the
+      // listening socket to spawned children. Measured on one machine with
+      // identical code — 1.3.6 leaves the port bound under the dead worker,
+      // 1.4.0 releases it the moment the worker dies. Without inheritance
+      // there is no ghost for the reclaim to recover, and failing here would
+      // only report the runtime's behaviour, not the product's.
       console.log(
-        `[ghost-gate] no ghost after the out-of-band kill: port ${fixture.port} is free, sidecar chain was present ` +
-          `(${describeProcesses(survivorsAfterKill)}). This runtime does not inherit the listening socket into ` +
+        `[ghost-gate] no ghost after the out-of-band kill: port ${fixture.port} is free and the verified sidecar chain ` +
+          `survived (${describeProcesses(survivorsAfterKill)}). This runtime does not inherit the listening socket into ` +
           'sidecar children (bun >= 1.4), so the ghost-listener scenario cannot be constructed here — skipping the ' +
           'recovery assertions. On bun <= 1.3 the scenario does form and the assertions below run.'
       );
       return;
+    }
+    if (state.kind === 'malformed') {
+      const describeOwner = (pid: number) => `${pid}${processExists(pid) ? ' (alive)' : ' (dead)'}`;
+      expect(
+        state.kind,
+        `post-kill state is malformed (${state.reason}): port ${fixture.port} owners=` +
+          `[${finalOwners.map(describeOwner).join(',')}] (fixture was ${fixture.pid}), sidecar chain ` +
+          `${survivorsAfterKill.length > 0 ? 'survived' : 'died'} ` +
+          `(${describeProcesses(survivorsAfterKill.length > 0 ? survivorsAfterKill : snapshot)}). ` +
+          'Not the bun >= 1.4 capability signature — failing instead of skipping, because these ' +
+          'states would pass the gate without exercising recovery.'
+      ).toBe('ghost');
     }
     expect(ownerUnderDeadPid, 'port must be LISTENING under the dead fixture PID (ghost)').toBe(true);
     expect(processExists(fixture.pid)).toBe(false);


### PR DESCRIPTION
## Summary

Follow-up to #3992 — which you landed as `32a3fd9b` and closed. Greptile flagged one P1 on that revision **two minutes after the close**, so the fix is not on `main`; this PR is only that delta, nothing else.

## What this PR does

**The capability skip on the landed gate is the negation of the happy path, so it skips far more than the signature it was written for.** `if (!ownerUnderDeadPid)` also returns for:

- a free port whose sidecar chain **died with the worker** — proves nothing about socket inheritance;
- a port held by an **unrelated process**;
- a **ghost sharing the port** with another owner;
- a **recycled fixture pid**.

All four returned before `ensureWorkerStarted()`, the orphan assertions and the health check — the gate could pass without ever exercising recovery.

**Fix:** `classifyPostKillState()` (`tests/integration/helpers/ghost-state.ts`) names the settled state from the final port-owner sample, the fixture's liveness, and the post-kill chain state:

| state | outcome |
|---|---|
| `ghost` — port bound only under the dead fixture pid | the recovery assertions run (unchanged) |
| `runtime-capability-skip` — port free AND the pre-kill-verified chain still alive | the ONLY skippable state |
| `malformed` — `chain-died` / `fixture-pid-recycled` / `ghost-shared-port` / `foreign-owner` | fails, naming the state and the observed owners |

The skip log line is now true by construction ("is free and the verified sidecar chain survived") instead of asserted in prose. The file header states the rule.

The classifier is pure, so the whole table is unit-tested (`helpers/ghost-state.test.ts`, 6 cases): these environmental states cannot be produced on demand, which is exactly why the classification is separated from the observation.

## How verified?

Local, Windows 11, isolated `CLAUDE_MEM_DATA_DIR`, real chroma chain, on this branch (based on `d87e749c`):

```
# bun 1.3.6 — full path (ghost forms; stage logs unchanged)
[ghost-gate] ghost confirmed: port LISTENING under dead pid=20424; survivors: conhost.exe, chroma-mcp.exe, python.exe, python.exe
[ghost-gate] ensureWorkerStarted returned 'ready' after 32908ms
 1 pass, 0 fail, 9 expect() calls [54.19s]

# bun 1.4.0 — the one skippable state
[ghost-gate] no ghost after the out-of-band kill: port 47777 is free and the verified sidecar chain survived (...)
 1 pass, 0 fail, 2 expect() calls [47.20s]
```

Fault injection (one line, `chainSurvived: false`, reverted): the malformed state now fails the gate —

```
post-kill state is malformed (chain-died): port 47777 owners=[] (fixture was 24112), sidecar chain survived (...)
```

— the same observation skipped silently before.

`bun test tests/integration/helpers/ghost-state.test.ts` → 6 pass. `bun run typecheck` clean.

## Relationship to #3992

#3992 is closed; its content is on `main` as `32a3fd9b`. This PR contains only the classifier, its unit test, and the gate re-wire (test-only, no production code).

## Checklist

- [x] Tests added/updated and passing
- [x] Typecheck passing
