### PR TITLE
fix(sync): register a memory_session_id, do not re-register it

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -2161,7 +2161,27 @@ export class SessionStore {
       throw new Error(`Session ${sessionDbId} not found in sdk_sessions`);
     }
 
-    if (session.memory_session_id !== memorySessionId) {
+    // REGISTER, DO NOT RE-REGISTER. `memory_session_id` is the FK parent key of
+    // `observations` and `session_summaries` (ON UPDATE CASCADE) and the join
+    // field `requeuePromptSync` pushes to replicas, so overwriting it is not a
+    // field update — it rewrites every memory the session owns and re-enqueues
+    // every prompt it has.
+    //
+    // The caller that made this matter is ClaudeProvider: a fresh SDK process
+    // mints a new session_id every turn, `resetCarriedMemorySessionId` clears the
+    // in-memory copy before each one, and nothing consumes a later turn's id
+    // (`shouldResume` is a hardcoded false, so `resume` never receives it). The
+    // condition below used to be `!==`, so every turn looked like a new identity.
+    //
+    // MEASURED on one store: sync_outbox held 1,100,783 rows for 6,930 distinct
+    // prompts — 158.8x, 393 MB of an 854 MB database — with its worst single
+    // prompt carrying 3,464 rows and 3,464 DISTINCT memory_session_ids. That is
+    // `requeuePromptSync`, whose own docstring describes a one-time repair
+    // ("Once the mapping lands"), running once per turn per prompt instead.
+    //
+    // A deliberate change of identity is still available through
+    // `updateMemorySessionId`. "Ensure registered" means make sure one exists.
+    if (session.memory_session_id === null) {
       this.db.prepare(`
         UPDATE sdk_sessions SET memory_session_id = ? WHERE id = ?
       `).run(memorySessionId, sessionDbId);
@@ -2169,8 +2189,13 @@ export class SessionStore {
 
       logger.info('DB', 'Registered memory_session_id before storage (FK fix)', {
         sessionDbId,
-        oldId: session.memory_session_id,
         newId: memorySessionId
+      });
+    } else if (session.memory_session_id !== memorySessionId) {
+      logger.debug('DB', 'Keeping the registered memory_session_id', {
+        sessionDbId,
+        registered: session.memory_session_id,
+        offered: memorySessionId
       });
     }
 

--- a/tests/worker/sync/session-identity-is-stable.test.ts
+++ b/tests/worker/sync/session-identity-is-stable.test.ts
@@ -1,0 +1,135 @@
+// A session's memory_session_id is its IDENTITY, not a per-turn value.
+//
+// It is the FK parent key of `observations` and `session_summaries`, declared
+// ON UPDATE CASCADE, and it is the join field `requeuePromptSync` pushes to
+// replicas. Changing it is therefore not a field update: it rewrites every
+// memory the session owns and re-enqueues every prompt it has.
+//
+// `ensureMemorySessionIdRegistered` used to write whenever the offered id
+// DIFFERED from the stored one, and its busiest caller offers a different one
+// every turn — ClaudeProvider starts a fresh SDK process per query(), and
+// `resetCarriedMemorySessionId` clears the in-memory copy before each one. So a
+// method whose name means "make sure one exists" re-identified the session on
+// every turn, and `requeuePromptSync` — whose own docstring describes a one-time
+// repair, "Once the mapping lands" — ran once per turn per prompt.
+//
+// MEASURED on one real store before this change:
+//
+//   1,100,783 sync_outbox rows for 6,930 distinct prompts  =  158.8x
+//   393 MB of an 854 MB database, in a table nothing drains
+//   worst single prompt: 3,464 rows carrying 3,464 DISTINCT memory_session_ids
+//
+// Nothing consumes a later turn's id. `shouldResume` in ClaudeProvider is a
+// hardcoded false and every read of it is a log line or a ternary that can only
+// take the false branch, so `resume` never receives it; the remaining readers
+// are log lines and `buildSummaryPrompt` metadata.
+//
+// Related and already fixed: #3628 stopped the same caller writing NULL over the
+// id at generator start, which cascaded NULL into a NOT NULL child and took the
+// whole generator run down with it. This is the other half — the write that
+// succeeds, and costs.
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SessionStore } from '../../../src/services/sqlite/SessionStore.js';
+
+const ISO = '2026-09-11T00:00:00.000Z';
+const EPOCH = 1757548800000;
+
+function outboxCount(db: Database): number {
+  return (db.prepare('SELECT COUNT(*) AS n FROM sync_outbox').get() as { n: number }).n;
+}
+
+function storedId(db: Database): string | null {
+  return (db.prepare('SELECT memory_session_id AS id FROM sdk_sessions WHERE id = 1').get() as { id: string | null }).id;
+}
+
+function addObservation(db: Database, memorySessionId: string): void {
+  db.prepare(`
+    INSERT INTO observations (memory_session_id, project, text, type, created_at, created_at_epoch)
+    VALUES (?, 'proj-x', 'a memory', 'discovery', ?, ?)
+  `).run(memorySessionId, ISO, EPOCH);
+}
+
+describe('a session keeps the identity it was given', () => {
+  let db: Database;
+  let store: SessionStore;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    store = new SessionStore(db);
+    db.prepare(`
+      INSERT INTO sdk_sessions (content_session_id, memory_session_id, project, platform_source, started_at, started_at_epoch, status)
+      VALUES ('sess-1', NULL, 'proj-x', 'claude', ?, ?, 'active')
+    `).run(ISO, EPOCH);
+    for (let n = 1; n <= 4; n++) {
+      db.prepare(`
+        INSERT INTO user_prompts (session_db_id, content_session_id, prompt_number, prompt_text, created_at, created_at_epoch, synced_at)
+        VALUES (1, 'sess-1', ?, ?, ?, ?, 111)
+      `).run(n, `prompt ${n}`, ISO, EPOCH);
+    }
+  });
+
+  afterEach(() => db.close());
+
+  it('registers an id that is missing, and repairs each prompt once', () => {
+    store.ensureMemorySessionIdRegistered(1, 'msid-A');
+
+    expect(storedId(db)).toBe('msid-A');
+    expect(outboxCount(db)).toBe(4); // the one-time repair: one op per prompt
+  });
+
+  it('re-registering the same id is free', () => {
+    store.ensureMemorySessionIdRegistered(1, 'msid-A');
+    const afterFirst = outboxCount(db);
+
+    for (let i = 0; i < 10; i++) store.ensureMemorySessionIdRegistered(1, 'msid-A');
+
+    expect(outboxCount(db)).toBe(afterFirst);
+  });
+
+  it('refuses to re-register a session that already has an identity', () => {
+    // The regression. Ten turns, ten SDK session ids, the shape ClaudeProvider
+    // produces. Before this change each one rewrote the session's identity and
+    // re-enqueued all four prompts: 40 ops instead of 4.
+    store.ensureMemorySessionIdRegistered(1, 'msid-A');
+    addObservation(db, 'msid-A');
+    const afterFirst = outboxCount(db);
+
+    for (let turn = 0; turn < 10; turn++) {
+      store.ensureMemorySessionIdRegistered(1, `msid-turn-${turn}`);
+    }
+
+    expect(outboxCount(db)).toBe(afterFirst);
+    expect(storedId(db)).toBe('msid-A');
+    // And the memory still hangs off the identity it was written under.
+    const observed = (db.prepare('SELECT memory_session_id AS id FROM observations').get() as { id: string }).id;
+    expect(observed).toBe('msid-A');
+  });
+
+  it('a deliberate change is still available, and shows what it costs', () => {
+    // `updateMemorySessionId` is the route for a genuine re-identification, and
+    // this pins the price so anything that starts calling it per turn has a
+    // number to be measured against instead of a 393 MB table nobody looks at.
+    store.ensureMemorySessionIdRegistered(1, 'msid-A');
+    addObservation(db, 'msid-A');
+    const afterFirst = outboxCount(db);
+
+    store.updateMemorySessionId(1, 'msid-B');
+
+    expect(storedId(db)).toBe('msid-B');
+    expect(outboxCount(db)).toBe(afterFirst + 4); // every prompt, again
+    // ON UPDATE CASCADE carried the change into the memory too.
+    const observed = (db.prepare('SELECT memory_session_id AS id FROM observations').get() as { id: string }).id;
+    expect(observed).toBe('msid-B');
+  });
+
+  it('a session with no prompts registers without emitting anything', () => {
+    db.prepare('DELETE FROM user_prompts').run();
+
+    store.ensureMemorySessionIdRegistered(1, 'msid-A');
+
+    expect(storedId(db)).toBe('msid-A');
+    expect(outboxCount(db)).toBe(0);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Same-repo rehost of #4024 so required CI can run (the fork PR is `MERGEABLE` / `UNSTABLE` with `action_required` first-time-contributor workflows).

## Gate

issue-patch-ship **PASS**: RCA is in the #4024 body (measured 1.1M `sync_outbox` rows / 158× prompt amplification). Narrow two-file patch. Not a second system — this is the other half of Batch H `#3629` / `#3628`: that PR stopped the NULL overwrite; this one stops the successful overwrite that re-identifies the session every ClaudeProvider turn.

## What

`ensureMemorySessionIdRegistered` wrote whenever the offered id **differed** from the stored one. ClaudeProvider mints a new SDK `session_id` every turn and clears the in-memory copy first, so every turn looked like a new identity. That rewrites the FK parent of `observations` / `session_summaries` (`ON UPDATE CASCADE`) and re-runs `requeuePromptSync` (documented as a one-time repair) once per turn per prompt.

Write only when the stored id is `NULL`. Deliberate re-identification stays on `updateMemorySessionId`.

## Credit

Cherry-picked from #4024 (`20b786c6`) by @vorrawut. No version bump / no npm.

## Test plan

- [x] Cherry-pick applied cleanly onto `033667ed` (13.24.16 / #4023)
- [x] `bun test tests/worker/sync/session-identity-is-stable.test.ts` — 5 pass / 0 fail
- [ ] CI green, then squash-merge
- [ ] Close #4024 pointing at this ship
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01f3ebb5-d3d6-4c0e-84b7-053e06390f4a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01f3ebb5-d3d6-4c0e-84b7-053e06390f4a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

