### PR TITLE
fix(health): cap each probe to the caller's remaining deadline (#3575)

### DIFF
--- a/src/services/infrastructure/HealthMonitor.ts
+++ b/src/services/infrastructure/HealthMonitor.ts
@@ -25,11 +25,12 @@ const HEALTH_PROBE_TIMEOUT_MS = 5_000;
 async function httpRequestToWorker(
   port: number,
   endpointPath: string,
-  method: string = 'GET'
+  method: string = 'GET',
+  timeoutMs: number = HEALTH_PROBE_TIMEOUT_MS,
 ): Promise<{ ok: boolean; statusCode: number; body: string }> {
   const response = await fetch(`http://${formatHostForUrl(getWorkerHost())}:${port}${endpointPath}`, {
     method,
-    signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
+    signal: AbortSignal.timeout(Math.max(1, timeoutMs)),
   });
   let body = '';
   try {
@@ -40,7 +41,7 @@ async function httpRequestToWorker(
   return { ok: response.ok, statusCode: response.status, body };
 }
 
-export async function isPortInUse(port: number): Promise<boolean> {
+export async function isPortInUse(port: number, timeoutMs: number = HEALTH_PROBE_TIMEOUT_MS): Promise<boolean> {
   if (process.platform === 'win32') {
     // Fast path: HTTP health check. A live claude-mem worker responds to
     // /api/health, so this is the cheapest non-disruptive probe for the
@@ -56,7 +57,7 @@ export async function isPortInUse(port: number): Promise<boolean> {
     // which still reports a bound port as in use.
     try {
       const response = await fetch(`http://${formatHostForUrl(getWorkerHost())}:${port}/api/health`, {
-        signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
+        signal: AbortSignal.timeout(Math.max(1, timeoutMs)),
       });
       if (response.ok) return true;
       // Non-ok response: port is reachable but the worker is unhealthy.
@@ -110,10 +111,16 @@ async function pollEndpointUntilOk(
   timeoutMs: number,
   retryLogMessage: string
 ): Promise<boolean> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
     try {
-      const result = await httpRequestToWorker(port, endpointPath);
+      const remainingMs = deadline - Date.now();
+      const result = await httpRequestToWorker(
+        port,
+        endpointPath,
+        'GET',
+        Math.min(HEALTH_PROBE_TIMEOUT_MS, remainingMs),
+      );
       if (result.ok) return true;
     } catch (error) {
       if (error instanceof Error) {
@@ -122,7 +129,10 @@ async function pollEndpointUntilOk(
         logger.debug('SYSTEM', retryLogMessage, { error: String(error) });
       }
     }
-    await new Promise(r => setTimeout(r, 500));
+    const retryDelayMs = Math.min(500, deadline - Date.now());
+    if (retryDelayMs > 0) {
+      await new Promise(r => setTimeout(r, retryDelayMs));
+    }
   }
   return false;
 }
@@ -136,10 +146,14 @@ export function waitForReadiness(port: number, timeoutMs: number = 30000): Promi
 }
 
 export async function waitForPortFree(port: number, timeoutMs: number = 10000): Promise<boolean> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    if (!(await isPortInUse(port))) return true;
-    await new Promise(r => setTimeout(r, 500));
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const remainingMs = deadline - Date.now();
+    if (!(await isPortInUse(port, Math.min(HEALTH_PROBE_TIMEOUT_MS, remainingMs)))) return true;
+    const retryDelayMs = Math.min(500, deadline - Date.now());
+    if (retryDelayMs > 0) {
+      await new Promise(r => setTimeout(r, retryDelayMs));
+    }
   }
   return false;
 }

--- a/tests/infrastructure/health-monitor.test.ts
+++ b/tests/infrastructure/health-monitor.test.ts
@@ -250,6 +250,29 @@ describe('HealthMonitor', () => {
       expect(elapsed).toBeLessThan(2500);
     });
 
+    // #3575 leftover after plan-15 already bounded each probe at 5s: a hung
+    // fetch must still honor the *caller* deadline, not sit out the full
+    // HEALTH_PROBE_TIMEOUT_MS. Without the remaining-ms cap, waitForHealth(100)
+    // would block ~5s inside AbortSignal.timeout.
+    it('should abort a fetch that never responds within the overall timeout', async () => {
+      global.fetch = mock((_input: RequestInfo | URL, init?: RequestInit) => new Promise((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) {
+          reject(new Error('expected an abort signal'));
+          return;
+        }
+        signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+      }));
+
+      const start = Date.now();
+      const result = await waitForHealth(39999, 100);
+      const elapsed = Date.now() - start;
+
+      expect(result).toBe(false);
+      expect(elapsed).toBeGreaterThanOrEqual(90);
+      expect(elapsed).toBeLessThan(500);
+    });
+
     it('should succeed after server becomes available', async () => {
       let callCount = 0;
       global.fetch = mock(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Narrow leftover of #3575 after rebase onto current `main`.

## Gate

issue-patch-ship **PASS** as *narrow timeout only*.

A literal rebase of #3575 is not mergeable: the 5s `AbortSignal` hang fix is already on `main` (plan-15 / #3603), and treating a timed-out Windows probe as occupied would regress the current fallthrough to `net.createServer`.

What was still missing: each probe still used the full 5s budget even when the caller deadline was shorter. `waitForHealth(100)` against a hung fetch sat ~5s inside `AbortSignal.timeout`. This PR caps `AbortSignal.timeout` and the 500ms retry sleep to the remaining caller deadline. Windows timeout still falls through to the socket probe.

## Credit

Remaining-deadline idea from #3575 by @dajiaohuang. No version bump / no npm.

## Test plan

- [x] `bun test tests/infrastructure/health-monitor.test.ts` — 23 pass / 0 fail (new hung-fetch case: 100ms)
- [ ] CI green, then squash-merge
- [ ] Close #3575 pointing at this ship
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01f3ebb5-d3d6-4c0e-84b7-053e06390f4a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01f3ebb5-d3d6-4c0e-84b7-053e06390f4a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

