### PR TITLE
fix(sync): register a memory_session_id, do not re-register it

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -2152,7 +2152,7 @@ export class SessionStore {
     sessionDbId: number,
     memorySessionId: string,
     workerPort?: number
-  ): void {
+  ): string {
     const session = this.db.prepare(`
       SELECT id, memory_session_id, worker_port FROM sdk_sessions WHERE id = ?
     `).get(sessionDbId) as { id: number; memory_session_id: string | null; worker_port: number | null } | undefined;
@@ -2208,6 +2208,8 @@ export class SessionStore {
         UPDATE sdk_sessions SET worker_port = ? WHERE id = ?
       `).run(workerPort, sessionDbId);
     }
+
+    return session.memory_session_id ?? memorySessionId;
   }
 
   getAllProjects(platformSource?: string): string[] {

--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -2161,7 +2161,27 @@ export class SessionStore {
       throw new Error(`Session ${sessionDbId} not found in sdk_sessions`);
     }
 
-    if (session.memory_session_id !== memorySessionId) {
+    // REGISTER, DO NOT RE-REGISTER. `memory_session_id` is the FK parent key of
+    // `observations` and `session_summaries` (ON UPDATE CASCADE) and the join
+    // field `requeuePromptSync` pushes to replicas, so overwriting it is not a
+    // field update — it rewrites every memory the session owns and re-enqueues
+    // every prompt it has.
+    //
+    // The caller that made this matter is ClaudeProvider: a fresh SDK process
+    // mints a new session_id every turn, `resetCarriedMemorySessionId` clears the
+    // in-memory copy before each one, and nothing consumes a later turn's id
+    // (`shouldResume` is a hardcoded false, so `resume` never receives it). The
+    // condition below used to be `!==`, so every turn looked like a new identity.
+    //
+    // MEASURED on one store: sync_outbox held 1,100,783 rows for 6,930 distinct
+    // prompts — 158.8x, 393 MB of an 854 MB database — with its worst single
+    // prompt carrying 3,464 rows and 3,464 DISTINCT memory_session_ids. That is
+    // `requeuePromptSync`, whose own docstring describes a one-time repair
+    // ("Once the mapping lands"), running once per turn per prompt instead.
+    //
+    // A deliberate change of identity is still available through
+    // `updateMemorySessionId`. "Ensure registered" means make sure one exists.
+    if (session.memory_session_id === null) {
       this.db.prepare(`
         UPDATE sdk_sessions SET memory_session_id = ? WHERE id = ?
       `).run(memorySessionId, sessionDbId);
@@ -2169,8 +2189,13 @@ export class SessionStore {
 
       logger.info('DB', 'Registered memory_session_id before storage (FK fix)', {
         sessionDbId,
-        oldId: session.memory_session_id,
         newId: memorySessionId
+      });
+    } else if (session.memory_session_id !== memorySessionId) {
+      logger.debug('DB', 'Keeping the registered memory_session_id', {
+        sessionDbId,
+        registered: session.memory_session_id,
+        offered: memorySessionId
       });
     }
 

--- a/src/services/worker/ClaudeProvider.ts
+++ b/src/services/worker/ClaudeProvider.ts
@@ -200,7 +200,8 @@ export class ClaudeProvider {
    * links observations and session_summaries carries ON UPDATE CASCADE plus a
    * NOT NULL column. A NULL write cascades into the child rows and violates
    * NOT NULL, which rolls back the whole storage transaction (#3628).
-   * Legitimate re-keying flows through ensureMemorySessionIdRegistered.
+   * Legitimate re-keying flows through updateMemorySessionId.
+   * ensureMemorySessionIdRegistered only fills a NULL id.
    */
   private resetCarriedMemorySessionId(session: ActiveSession): void {
     if (session.memorySessionId) {
@@ -367,12 +368,11 @@ export class ClaudeProvider {
         if (message.session_id && message.session_id !== session.memorySessionId) {
           const previousId = session.memorySessionId;
           session.memorySessionId = message.session_id;
-          this.dbManager.getSessionStore().ensureMemorySessionIdRegistered(
+          const registeredId = this.dbManager.getSessionStore().ensureMemorySessionIdRegistered(
             session.sessionDbId,
             message.session_id
           );
-          const verification = this.dbManager.getSessionStore().getSessionById(session.sessionDbId);
-          const dbVerified = verification?.memory_session_id === message.session_id;
+          const dbVerified = registeredId === message.session_id;
           const logMessage = previousId
             ? `MEMORY_ID_CHANGED | sessionDbId=${session.sessionDbId} | from=${previousId} | to=${message.session_id} | dbVerified=${dbVerified}`
             : `MEMORY_ID_CAPTURED | sessionDbId=${session.sessionDbId} | memorySessionId=${message.session_id} | dbVerified=${dbVerified}`;
@@ -382,7 +382,8 @@ export class ClaudeProvider {
             previousId
           });
           if (!dbVerified) {
-            logger.error('SESSION', `MEMORY_ID_MISMATCH | sessionDbId=${session.sessionDbId} | expected=${message.session_id} | got=${verification?.memory_session_id}`, {
+            // Expected on later turns: ensure keeps the first registered id.
+            logger.debug('SESSION', `Keeping the registered memory_session_id | sessionDbId=${session.sessionDbId} | registered=${registeredId} | offered=${message.session_id}`, {
               sessionId: session.sessionDbId
             });
           }

--- a/src/services/worker/agents/ResponseProcessor.ts
+++ b/src/services/worker/agents/ResponseProcessor.ts
@@ -465,11 +465,16 @@ export async function processAgentResponse(
   );
 
   const sessionStore = dbManager.getSessionStore();
-  sessionStore.ensureMemorySessionIdRegistered(session.sessionDbId, session.memorySessionId, getWorkerPort());
+  // ensure registers only when the stored id is NULL. Persist against the
+  // registered identity so a later turn's fresh SDK session_id cannot FK-miss
+  // observations/summaries that already hang off the first id.
+  const registeredMemorySessionId =
+    sessionStore.ensureMemorySessionIdRegistered(session.sessionDbId, session.memorySessionId, getWorkerPort())
+    || session.memorySessionId;
 
-  logger.info('DB', `STORING | sessionDbId=${session.sessionDbId} | memorySessionId=${session.memorySessionId} | obsCount=${sanitizedObservations.length} | hasSummary=${!!summaryForStore}`, {
+  logger.info('DB', `STORING | sessionDbId=${session.sessionDbId} | memorySessionId=${registeredMemorySessionId} | obsCount=${sanitizedObservations.length} | hasSummary=${!!summaryForStore}`, {
     sessionId: session.sessionDbId,
-    memorySessionId: session.memorySessionId
+    memorySessionId: registeredMemorySessionId
   });
 
   const labeledObservations = sanitizedObservations.map(obs => ({
@@ -481,7 +486,7 @@ export async function processAgentResponse(
   let result: ReturnType<typeof sessionStore.storeObservations>;
   try {
     result = sessionStore.storeObservations(
-      session.memorySessionId,
+      registeredMemorySessionId,
       context.project,
       labeledObservations,
       summaryForStore,
@@ -495,9 +500,9 @@ export async function processAgentResponse(
     session.pendingAgentType = null;
   }
 
-  logger.info('DB', `STORED | sessionDbId=${session.sessionDbId} | memorySessionId=${session.memorySessionId} | obsCount=${result.observationIds.length} | obsIds=[${result.observationIds.join(',')}] | summaryId=${result.summaryId || 'none'}`, {
+  logger.info('DB', `STORED | sessionDbId=${session.sessionDbId} | memorySessionId=${registeredMemorySessionId} | obsCount=${result.observationIds.length} | obsIds=[${result.observationIds.join(',')}] | summaryId=${result.summaryId || 'none'}`, {
     sessionId: session.sessionDbId,
-    memorySessionId: session.memorySessionId
+    memorySessionId: registeredMemorySessionId
   });
 
   session.lastSummaryStored = result.summaryId !== null;

--- a/tests/fk-constraint-fix.test.ts
+++ b/tests/fk-constraint-fix.test.ts
@@ -119,14 +119,16 @@ describe('FK Constraint Fix (Issue #846)', () => {
     // The session ID and its child rows stay intact after the failed write.
     expect(store.getSessionById(sessionDbId)?.memory_session_id).toBe(firstMemorySessionId);
 
-    // The second pass captures a fresh SDK id and re-keys through the
-    // supported path. Storing new child rows succeeds.
+    // A later generator pass offers a fresh SDK id. ensure registers only
+    // when the stored id is NULL — it must not re-identify the session.
+    // Deliberate re-keying is updateMemorySessionId. Storage stays on the
+    // registered identity so ON UPDATE CASCADE / NOT NULL children stay valid.
     const secondMemorySessionId = 'second-pass-memory-id';
     store.ensureMemorySessionIdRegistered(sessionDbId, secondMemorySessionId);
-    expect(store.getSessionById(sessionDbId)?.memory_session_id).toBe(secondMemorySessionId);
+    expect(store.getSessionById(sessionDbId)?.memory_session_id).toBe(firstMemorySessionId);
 
     const result = store.storeObservation(
-      secondMemorySessionId,
+      firstMemorySessionId,
       'test-project',
       {
         type: 'discovery',
@@ -156,10 +158,10 @@ describe('FK Constraint Fix (Issue #846)', () => {
     store.ensureMemorySessionIdRegistered(sessionDbId, newMemorySessionId);
 
     const after = store.getSessionById(sessionDbId);
-    expect(after?.memory_session_id).toBe(newMemorySessionId);
+    expect(after?.memory_session_id).toBe(oldMemorySessionId);
 
     const result = store.storeObservation(
-      newMemorySessionId,
+      oldMemorySessionId,
       'test-project',
       {
         type: 'bugfix',

--- a/tests/session_id_usage_validation.test.ts
+++ b/tests/session_id_usage_validation.test.ts
@@ -109,7 +109,7 @@ describe('Session ID Critical Invariants', () => {
 
       store.ensureMemorySessionIdRegistered(sessionDbId, 'second-generator-memory-id');
       session = store.getSessionById(sessionDbId);
-      expect(session?.memory_session_id).toBe('second-generator-memory-id');
+      expect(session?.memory_session_id).toBe(firstMemoryId);
     });
 
     it('should NOT reset memorySessionId when it is still NULL (first prompt scenario)', () => {

--- a/tests/sqlite/session-store-synced-at.test.ts
+++ b/tests/sqlite/session-store-synced-at.test.ts
@@ -449,14 +449,20 @@ describe('SessionStore prompt re-push hooks (memory id lands after first sync)',
     expect(stampedCount(db, 'user_prompts')).toBe(3);
   });
 
-  it('ensureMemorySessionIdRegistered requeues on change and no-ops when already registered', () => {
+  it('ensureMemorySessionIdRegistered requeues on first register and no-ops when already registered', () => {
     store.ensureMemorySessionIdRegistered(1, 'mem-a');
     expect(stampedCount(db, 'user_prompts')).toBe(3);
 
+    // Offered id differs, but the session already has an identity — no rewrite, no requeue.
     store.ensureMemorySessionIdRegistered(1, 'mem-a3');
+    expect(stampedCount(db, 'user_prompts')).toBe(3);
+
+    // First register (stored id is NULL) is the one-time repair.
+    db.prepare(`UPDATE sdk_sessions SET memory_session_id = NULL WHERE id = 2`).run();
+    store.ensureMemorySessionIdRegistered(2, 'mem-b2');
     const prompts = syncedAtById(db, 'user_prompts');
-    expect(prompts.get(1)).toBeNull();
-    expect(prompts.get(2)).toBeNull();
-    expect(prompts.get(3)).toBe(1751234567890);
+    expect(prompts.get(1)).toBe(1751234567890);
+    expect(prompts.get(2)).toBe(1751234567890);
+    expect(prompts.get(3)).toBeNull();
   });
 });

--- a/tests/sqlite/session-store-v7-rebuild-keeps-cascade.test.ts
+++ b/tests/sqlite/session-store-v7-rebuild-keeps-cascade.test.ts
@@ -2,9 +2,10 @@
 // session_summaries.memory_session_id FK. addOnUpdateCascadeToForeignKeys
 // (v21) is version-row gated and runs once; removeSessionSummariesUniqueConstraint
 // (v7) is introspection-gated and can fire later, recreating the table with
-// ON DELETE CASCADE only. Parent-key rewrites in ensureMemorySessionIdRegistered
-// then throw FOREIGN KEY constraint failed for any session that already has a
-// summary. The same class of defect as #3890, on the FK clause rather than the
+// ON DELETE CASCADE only. Parent-key rewrites then throw FOREIGN KEY
+// constraint failed for any session that already has a summary. Those
+// rewrites go through updateMemorySessionId (ensure only fills a NULL id).
+// The same class of defect as #3890, on the FK clause rather than the
 // column list.
 import { describe, it, expect, afterEach } from 'bun:test';
 import { Database } from 'bun:sqlite';
@@ -227,7 +228,7 @@ describe('session_summaries ON UPDATE CASCADE survives v7 rebuild (#3849)', () =
     const session = store.db.prepare(
       `SELECT id FROM sdk_sessions WHERE memory_session_id = 'mem-healthy'`
     ).get() as { id: number };
-    store.ensureMemorySessionIdRegistered(session.id, 'mem-rotated');
+    store.updateMemorySessionId(session.id, 'mem-rotated');
 
     expect(store.db.prepare(
       `SELECT memory_session_id FROM sdk_sessions WHERE id = ?`
@@ -272,7 +273,7 @@ describe('session_summaries ON UPDATE CASCADE survives v7 rebuild (#3849)', () =
     const session = store.db.prepare(
       `SELECT id FROM sdk_sessions WHERE memory_session_id = 'mem-healthy'`
     ).get() as { id: number };
-    expect(() => store.ensureMemorySessionIdRegistered(session.id, 'mem-rotated')).not.toThrow();
+    expect(() => store.updateMemorySessionId(session.id, 'mem-rotated')).not.toThrow();
     expect(store.db.prepare(
       `SELECT memory_session_id FROM session_summaries WHERE request = 'already summarised'`
     ).get()).toEqual({ memory_session_id: 'mem-rotated' });
@@ -296,7 +297,7 @@ describe('session_summaries ON UPDATE CASCADE survives v7 rebuild (#3849)', () =
     const session = store.db.prepare(
       `SELECT id FROM sdk_sessions WHERE memory_session_id = 'mem-healthy'`
     ).get() as { id: number };
-    store.ensureMemorySessionIdRegistered(session.id, 'mem-rotated');
+    store.updateMemorySessionId(session.id, 'mem-rotated');
     expect(store.db.prepare(
       `SELECT memory_session_id FROM observations WHERE text = 'obs that should cascade'`
     ).get()).toEqual({ memory_session_id: 'mem-rotated' });
@@ -312,7 +313,7 @@ describe('session_summaries ON UPDATE CASCADE survives v7 rebuild (#3849)', () =
     const session = first.db.prepare(
       `SELECT id FROM sdk_sessions WHERE memory_session_id = 'mem-healthy'`
     ).get() as { id: number };
-    first.ensureMemorySessionIdRegistered(session.id, 'mem-rotated');
+    first.updateMemorySessionId(session.id, 'mem-rotated');
     first.db.close();
 
     const second = new SessionStore(dbPath);
@@ -320,7 +321,7 @@ describe('session_summaries ON UPDATE CASCADE survives v7 rebuild (#3849)', () =
     expect(second.db.prepare(
       `SELECT COUNT(*) AS n FROM session_summaries WHERE memory_session_id = 'mem-rotated'`
     ).get()).toEqual({ n: 1 });
-    expect(() => second.ensureMemorySessionIdRegistered(session.id, 'mem-rotated-again')).not.toThrow();
+    expect(() => second.updateMemorySessionId(session.id, 'mem-rotated-again')).not.toThrow();
     expect(second.db.prepare(
       `SELECT memory_session_id FROM session_summaries WHERE request = 'already summarised'`
     ).get()).toEqual({ memory_session_id: 'mem-rotated-again' });

--- a/tests/worker/sync/session-identity-is-stable.test.ts
+++ b/tests/worker/sync/session-identity-is-stable.test.ts
@@ -1,0 +1,135 @@
+// A session's memory_session_id is its IDENTITY, not a per-turn value.
+//
+// It is the FK parent key of `observations` and `session_summaries`, declared
+// ON UPDATE CASCADE, and it is the join field `requeuePromptSync` pushes to
+// replicas. Changing it is therefore not a field update: it rewrites every
+// memory the session owns and re-enqueues every prompt it has.
+//
+// `ensureMemorySessionIdRegistered` used to write whenever the offered id
+// DIFFERED from the stored one, and its busiest caller offers a different one
+// every turn — ClaudeProvider starts a fresh SDK process per query(), and
+// `resetCarriedMemorySessionId` clears the in-memory copy before each one. So a
+// method whose name means "make sure one exists" re-identified the session on
+// every turn, and `requeuePromptSync` — whose own docstring describes a one-time
+// repair, "Once the mapping lands" — ran once per turn per prompt.
+//
+// MEASURED on one real store before this change:
+//
+//   1,100,783 sync_outbox rows for 6,930 distinct prompts  =  158.8x
+//   393 MB of an 854 MB database, in a table nothing drains
+//   worst single prompt: 3,464 rows carrying 3,464 DISTINCT memory_session_ids
+//
+// Nothing consumes a later turn's id. `shouldResume` in ClaudeProvider is a
+// hardcoded false and every read of it is a log line or a ternary that can only
+// take the false branch, so `resume` never receives it; the remaining readers
+// are log lines and `buildSummaryPrompt` metadata.
+//
+// Related and already fixed: #3628 stopped the same caller writing NULL over the
+// id at generator start, which cascaded NULL into a NOT NULL child and took the
+// whole generator run down with it. This is the other half — the write that
+// succeeds, and costs.
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SessionStore } from '../../../src/services/sqlite/SessionStore.js';
+
+const ISO = '2026-09-11T00:00:00.000Z';
+const EPOCH = 1757548800000;
+
+function outboxCount(db: Database): number {
+  return (db.prepare('SELECT COUNT(*) AS n FROM sync_outbox').get() as { n: number }).n;
+}
+
+function storedId(db: Database): string | null {
+  return (db.prepare('SELECT memory_session_id AS id FROM sdk_sessions WHERE id = 1').get() as { id: string | null }).id;
+}
+
+function addObservation(db: Database, memorySessionId: string): void {
+  db.prepare(`
+    INSERT INTO observations (memory_session_id, project, text, type, created_at, created_at_epoch)
+    VALUES (?, 'proj-x', 'a memory', 'discovery', ?, ?)
+  `).run(memorySessionId, ISO, EPOCH);
+}
+
+describe('a session keeps the identity it was given', () => {
+  let db: Database;
+  let store: SessionStore;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    store = new SessionStore(db);
+    db.prepare(`
+      INSERT INTO sdk_sessions (content_session_id, memory_session_id, project, platform_source, started_at, started_at_epoch, status)
+      VALUES ('sess-1', NULL, 'proj-x', 'claude', ?, ?, 'active')
+    `).run(ISO, EPOCH);
+    for (let n = 1; n <= 4; n++) {
+      db.prepare(`
+        INSERT INTO user_prompts (session_db_id, content_session_id, prompt_number, prompt_text, created_at, created_at_epoch, synced_at)
+        VALUES (1, 'sess-1', ?, ?, ?, ?, 111)
+      `).run(n, `prompt ${n}`, ISO, EPOCH);
+    }
+  });
+
+  afterEach(() => db.close());
+
+  it('registers an id that is missing, and repairs each prompt once', () => {
+    store.ensureMemorySessionIdRegistered(1, 'msid-A');
+
+    expect(storedId(db)).toBe('msid-A');
+    expect(outboxCount(db)).toBe(4); // the one-time repair: one op per prompt
+  });
+
+  it('re-registering the same id is free', () => {
+    store.ensureMemorySessionIdRegistered(1, 'msid-A');
+    const afterFirst = outboxCount(db);
+
+    for (let i = 0; i < 10; i++) store.ensureMemorySessionIdRegistered(1, 'msid-A');
+
+    expect(outboxCount(db)).toBe(afterFirst);
+  });
+
+  it('refuses to re-register a session that already has an identity', () => {
+    // The regression. Ten turns, ten SDK session ids, the shape ClaudeProvider
+    // produces. Before this change each one rewrote the session's identity and
+    // re-enqueued all four prompts: 40 ops instead of 4.
+    store.ensureMemorySessionIdRegistered(1, 'msid-A');
+    addObservation(db, 'msid-A');
+    const afterFirst = outboxCount(db);
+
+    for (let turn = 0; turn < 10; turn++) {
+      store.ensureMemorySessionIdRegistered(1, `msid-turn-${turn}`);
+    }
+
+    expect(outboxCount(db)).toBe(afterFirst);
+    expect(storedId(db)).toBe('msid-A');
+    // And the memory still hangs off the identity it was written under.
+    const observed = (db.prepare('SELECT memory_session_id AS id FROM observations').get() as { id: string }).id;
+    expect(observed).toBe('msid-A');
+  });
+
+  it('a deliberate change is still available, and shows what it costs', () => {
+    // `updateMemorySessionId` is the route for a genuine re-identification, and
+    // this pins the price so anything that starts calling it per turn has a
+    // number to be measured against instead of a 393 MB table nobody looks at.
+    store.ensureMemorySessionIdRegistered(1, 'msid-A');
+    addObservation(db, 'msid-A');
+    const afterFirst = outboxCount(db);
+
+    store.updateMemorySessionId(1, 'msid-B');
+
+    expect(storedId(db)).toBe('msid-B');
+    expect(outboxCount(db)).toBe(afterFirst + 4); // every prompt, again
+    // ON UPDATE CASCADE carried the change into the memory too.
+    const observed = (db.prepare('SELECT memory_session_id AS id FROM observations').get() as { id: string }).id;
+    expect(observed).toBe('msid-B');
+  });
+
+  it('a session with no prompts registers without emitting anything', () => {
+    db.prepare('DELETE FROM user_prompts').run();
+
+    store.ensureMemorySessionIdRegistered(1, 'msid-A');
+
+    expect(storedId(db)).toBe('msid-A');
+    expect(outboxCount(db)).toBe(0);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #4024 (and same-repo rehost #4025) so Linux CI can go green. Cherry-picked @vorrawut's production fix, then retargeted the eight suites that still treated `ensureMemorySessionIdRegistered` as the re-key path.

## Gate

issue-patch-ship **PASS**: RCA is in #4024 (measured 1.1M `sync_outbox` rows / 158.8× prompt amplification from per-turn re-registration). Narrow SessionStore write condition (NULL-only register). Not a second system — other half of shipped #3629/#3628 (that PR stopped the NULL overwrite; this one stops the successful overwrite).

Cannot merge #4024 as-is: Linux CI RED because existing tests expected overwrite.

## What

`ensureMemorySessionIdRegistered` wrote whenever the offered id **differed** from the stored one. `memory_session_id` is the FK parent of `observations` / `session_summaries` (`ON UPDATE CASCADE`) and the join field `requeuePromptSync` pushes to replicas. ClaudeProvider mints a new SDK `session_id` every turn and `#3628` only clears the in-memory copy, so every turn looked like a new identity.

Write only when the stored id is `NULL`. Deliberate re-identification stays on `updateMemorySessionId`.

## Test rewrites (the 8 CI failures)

Deliberate identity changes now go through `updateMemorySessionId`. What they still assert:

| Suite | Was | Now |
|---|---|---|
| FK Constraint Fix — second generator pass (#3628) | ensure overwrites, store under new id | NULL write still throws; ensure keeps first id; store under registered id |
| FK Constraint Fix — worker restart | ensure overwrites stale id | ensure keeps registered id; store under that id |
| Resume Safety — preserve across createSDKSession | ensure overwrites on second generator | createSDKSession still preserves; ensure keeps first id |
| SessionStore prompt re-push hooks | ensure requeues on offered-id change | first register requeues; already-registered (even different offered id) no-ops |
| session_summaries ON UPDATE CASCADE (#3849) × 4 | mutate id via ensure to prove CASCADE | same CASCADE assertions via `updateMemorySessionId` |

## Production callers

`ensure` now returns the registered id. ResponseProcessor persists against that id so a later turn's fresh SDK `session_id` cannot FK-miss child rows (Greptile P1 on #4024). ClaudeProvider logs a refused re-register at debug instead of `MEMORY_ID_MISMATCH` error.

No version bump / no npm publish.

## Test plan

- [x] Cherry-pick #4024 (`20b786c6`) onto `033667ed` (13.24.16)
- [x] `bun test` on the touched suites — 80 pass / 0 fail
- [x] `tsc --noEmit` — clean
- [ ] CI green, then squash-merge
- [ ] Close #4024 and #4025 as superseded, pointing at the merge SHA
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27ec6440-2aee-41c5-890c-5815c8ec3ab4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27ec6440-2aee-41c5-890c-5815c8ec3ab4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

