### PR TITLE
fix(server-beta): stop discarding session-summary responses (rehost #3587)

### DIFF
--- a/src/server/generation/processGeneratedResponse.ts
+++ b/src/server/generation/processGeneratedResponse.ts
@@ -197,7 +197,17 @@ export async function processSessionSummaryResponse(
 
   const summary = parsed.summary ?? null;
   const skipped = summary?.skipped === true;
-  const summaryContent = summary ? renderSummaryContent(summary) : '';
+
+  // Defence in depth: a provider that answers with <observation> blocks instead of
+  // a <summary> block used to be dropped here silently — parsed.summary was null,
+  // the content was judged empty, the job completed and parsed.observations was
+  // never looked at. Fold those blocks into the summary body rather than
+  // discarding a response the model was billed for.
+  const fallbackObservations = !summary && !skipped ? parsed.observations : [];
+  const summaryContent = summary
+    ? renderSummaryContent(summary)
+    : fallbackObservations.map(o => renderObservationContent(o)).join('\n\n');
+
   const privateContentDetected = skipped || summaryContent.trim().length === 0;
 
   const rendered: RenderedObservation[] = privateContentDetected
@@ -500,6 +510,15 @@ function renderObservationContent(observation: ParsedObservation): string {
   if (observation.narrative) parts.push(observation.narrative);
   if (observation.facts && observation.facts.length > 0) {
     parts.push(observation.facts.map(f => `- ${f}`).join('\n'));
+  }
+  // The parser treats concepts as content: an observation whose only populated
+  // field is <concepts> survives its empty-observation guard. This renderer did
+  // not, so that observation rendered to '' and was dropped by the empty-content
+  // skip in persistGeneratedObservations - accepted, discarded, job completed.
+  // Rendered last-resort only, so responses that carry prose keep the body they
+  // already have and no existing content changes shape.
+  if (parts.length === 0 && observation.concepts && observation.concepts.length > 0) {
+    parts.push(`Concepts: ${observation.concepts.join(', ')}`);
   }
   return parts.join('\n\n').trim();
 }

--- a/src/server/generation/providers/shared/prompt-builder.ts
+++ b/src/server/generation/providers/shared/prompt-builder.ts
@@ -72,6 +72,42 @@ export function buildServerGenerationPrompt(
 
   const observationOutputSchema = buildObservationOutputSchema(mode);
 
+  // Summary jobs are a different task from event jobs, and the persistence path
+  // for them (processGeneratedResponse -> parsed.summary) only understands a
+  // <summary> block. Asking for <observation> here yields a response the summary
+  // path silently discards, so branch the instruction on the job's source type.
+  const isSessionSummary = context.job.sourceType === 'session_summary';
+
+  const summaryInstruction = [
+    'You are reviewing a complete agent session. Return a single',
+    '<summary>...</summary> XML block describing the arc of the session. If the',
+    'session contains nothing worth recording (e.g., everything was scrubbed by',
+    'privacy filters or the activity was trivial), return a single self-closing',
+    '<skip_summary /> tag and nothing else. Do not include any prose outside the XML.',
+    '',
+    'Schema for the <summary> block (at least one of the first five is required):',
+    '<summary>',
+    '  <request>what the user asked for</request>',
+    '  <investigated>what was explored, and how</investigated>',
+    '  <learned>durable findings worth remembering later</learned>',
+    '  <completed>what was actually done</completed>',
+    '  <next_steps>what is left open</next_steps>',
+    '  <notes>anything else worth keeping</notes>',
+    '</summary>',
+  ];
+
+  const observationInstruction = [
+    'You are observing an agent at work. Return one or more',
+    '<observation>...</observation> XML blocks summarizing durable, useful',
+    'discoveries from the events above. If the events contain nothing worth',
+    'recording (e.g., everything was scrubbed by privacy filters or the',
+    'activity was trivial), return a single self-closing <skip_summary />',
+    'tag and nothing else. Do not include any prose outside the XML.',
+    '',
+    'Schema for each <observation> block:',
+    observationOutputSchema,
+  ];
+
   const prompt = [
     '<server_beta_observation_request>',
     `  <project_id>${escapeXml(context.project.projectId)}</project_id>`,
@@ -82,15 +118,7 @@ export function buildServerGenerationPrompt(
     '  </agent_events>',
     '</server_beta_observation_request>',
     '',
-    'You are observing an agent at work. Return one or more',
-    '<observation>...</observation> XML blocks summarizing durable, useful',
-    'discoveries from the events above. If the events contain nothing worth',
-    'recording (e.g., everything was scrubbed by privacy filters or the',
-    'activity was trivial), return a single self-closing <skip_summary />',
-    'tag and nothing else. Do not include any prose outside the XML.',
-    '',
-    'Schema for each <observation> block:',
-    observationOutputSchema,
+    ...(isSessionSummary ? summaryInstruction : observationInstruction),
   ].join('\n');
 
   return { prompt, hadPrivateContent, skippedAll };

--- a/tests/server/generation/process-generated-response.test.ts
+++ b/tests/server/generation/process-generated-response.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../src/storage/postgres/index.js';
 import {
   processGeneratedResponse,
+  processSessionSummaryResponse,
   markGenerationFailed,
 } from '../../../src/server/generation/processGeneratedResponse.js';
 import { ModeManager } from '../../../src/services/domain/ModeManager.js';
@@ -96,6 +97,161 @@ describe('processGeneratedResponse + markGenerationFailed', () => {
       teamId,
     });
   }
+
+  // Regression: the summary path used to read only parsed.summary. A provider that
+  // answered with <observation> blocks (which is what the shared prompt asked for)
+  // produced summary=null, was judged empty, and the job completed having discarded
+  // a paid-for response. Measured on a production deployment: 4,898 summary jobs,
+  // zero observations persisted.
+  it('persists a summary job answered with <observation> blocks instead of dropping it', async () => {
+    const session = await storage.sessions.create({
+      projectId,
+      teamId,
+      contentSessionId: `content-${crypto.randomUUID()}`,
+      agentId: 'agent-1',
+      platformSource: 'claude-code',
+      metadata: {},
+    });
+
+    const summaryJob = await storage.observationGenerationJobs.create({
+      projectId,
+      teamId,
+      sourceType: 'session_summary',
+      sourceId: session.id,
+      serverSessionId: session.id,
+      jobType: 'observation_generate_session_summary',
+    });
+
+    await storage.observationGenerationJobs.transitionStatus({
+      id: summaryJob.id,
+      projectId,
+      teamId,
+      status: 'processing',
+    });
+
+    const fresh = (await storage.observationGenerationJobs.getByIdForScope({
+      id: summaryJob.id,
+      projectId,
+      teamId,
+    }))!;
+
+    const outcome = await processSessionSummaryResponse({
+      pool: pool as unknown as Parameters<typeof processSessionSummaryResponse>[0]['pool'],
+      job: fresh,
+      rawText: `
+        <observation>
+          <type>discovery</type>
+          <title>Session arc</title>
+          <facts><fact>the run ended with the queue drained</fact></facts>
+        </observation>
+      `,
+      providerLabel: 'fake',
+      modelId: 'fake-1',
+    });
+
+    expect(outcome.kind).toBe('completed');
+    if (outcome.kind === 'completed') {
+      // the point of the fix: the response is kept, not silently discarded
+      expect(outcome.observations.length).toBeGreaterThan(0);
+      expect(outcome.observations[0]!.content).toContain('queue drained');
+    }
+
+    const reloaded = await storage.observationGenerationJobs.getByIdForScope({
+      id: summaryJob.id,
+      projectId,
+      teamId,
+    });
+    expect(reloaded?.status).toBe('completed');
+  });
+
+  // The parser's empty-observation guard accepts a block whose only populated
+  // field is <concepts>, but renderObservationContent ignored concepts, so the
+  // block rendered to '' and was skipped as empty content - the same
+  // accepted-then-discarded shape this PR is about, one layer down.
+  it('persists a concepts-only response instead of completing the job empty', async () => {
+    const session = await storage.sessions.create({
+      projectId,
+      teamId,
+      contentSessionId: `content-${crypto.randomUUID()}`,
+      agentId: 'agent-1',
+      platformSource: 'claude-code',
+      metadata: {},
+    });
+
+    const summaryJob = await storage.observationGenerationJobs.create({
+      projectId,
+      teamId,
+      sourceType: 'session_summary',
+      sourceId: session.id,
+      serverSessionId: session.id,
+      jobType: 'observation_generate_session_summary',
+    });
+
+    await storage.observationGenerationJobs.transitionStatus({
+      id: summaryJob.id,
+      projectId,
+      teamId,
+      status: 'processing',
+    });
+
+    const fresh = (await storage.observationGenerationJobs.getByIdForScope({
+      id: summaryJob.id,
+      projectId,
+      teamId,
+    }))!;
+
+    const outcome = await processSessionSummaryResponse({
+      pool: pool as unknown as Parameters<typeof processSessionSummaryResponse>[0]['pool'],
+      job: fresh,
+      rawText: `
+        <observation>
+          <type>discovery</type>
+          <concepts><concept>outbox drain</concept><concept>valkey backpressure</concept></concepts>
+        </observation>
+      `,
+      providerLabel: 'fake',
+      modelId: 'fake-1',
+    });
+
+    expect(outcome.kind).toBe('completed');
+    if (outcome.kind === 'completed') {
+      expect(outcome.observations).toHaveLength(1);
+      expect(outcome.observations[0]!.content).toContain('outbox drain');
+      expect(outcome.observations[0]!.content).toContain('valkey backpressure');
+      expect(outcome.privateContentDetected).toBe(false);
+    }
+  });
+
+  // Same defect on the per-event path: concepts-only blocks were skipped by the
+  // empty-content guard and the job still completed.
+  it('persists a concepts-only observation on the per-event path', async () => {
+    await storage.observationGenerationJobs.transitionStatus({
+      id: jobId,
+      projectId,
+      teamId,
+      status: 'processing',
+    });
+    const fresh = (await reloadJob())!;
+
+    const outcome = await processGeneratedResponse({
+      pool: pool as unknown as Parameters<typeof processGeneratedResponse>[0]['pool'],
+      job: fresh,
+      rawText: `
+        <observation>
+          <type>discovery</type>
+          <concepts><concept>lease renewal</concept></concepts>
+        </observation>
+      `,
+      providerLabel: 'fake',
+      modelId: 'fake-1',
+    });
+
+    expect(outcome.kind).toBe('completed');
+    if (outcome.kind === 'completed') {
+      expect(outcome.observations).toHaveLength(1);
+      expect(outcome.observations[0]!.content).toContain('lease renewal');
+    }
+  });
 
   it('persists observation, links source, and marks job completed for valid XML', async () => {
     const xml = `

--- a/tests/server/generation/providers.test.ts
+++ b/tests/server/generation/providers.test.ts
@@ -21,14 +21,14 @@ import { OpenRouterObservationProvider } from '../../../src/server/generation/pr
 import { buildServerGenerationPrompt } from '../../../src/server/generation/providers/shared/prompt-builder.js';
 import type { ServerGenerationContext } from '../../../src/server/generation/providers/shared/types.js';
 
-function makeContext(overrides: Partial<{ payload: unknown; serverSessionId: string | null }> = {}): ServerGenerationContext {
+function makeContext(overrides: Partial<{ payload: unknown; serverSessionId: string | null; sourceType: 'agent_event' | 'session_summary' }> = {}): ServerGenerationContext {
   return {
     job: {
       id: 'job-1',
       projectId: 'proj-1',
       teamId: 'team-1',
       agentEventId: 'evt-1',
-      sourceType: 'agent_event',
+      sourceType: overrides.sourceType ?? 'agent_event',
       sourceId: 'evt-1',
       serverSessionId: overrides.serverSessionId ?? null,
       jobType: 'observation_generate_for_event',
@@ -160,6 +160,35 @@ describe('shared error classification', () => {
 });
 
 describe('buildServerGenerationPrompt', () => {
+  // A session_summary job is a different task, and its persistence path only
+  // understands a <summary> block. Asking it for <observation> produced responses
+  // that the summary path discarded without a trace.
+  it('asks for a <summary> block on session_summary jobs', () => {
+    const result = buildServerGenerationPrompt(makeContext({ sourceType: 'session_summary' }));
+    expect(result.prompt).toContain('<summary>...</summary>');
+    expect(result.prompt).toContain('<request>');
+    expect(result.prompt).toContain('<learned>');
+    expect(result.prompt).toContain('<next_steps>');
+  });
+
+  it('does not ask a session_summary job for <observation> blocks', () => {
+    const result = buildServerGenerationPrompt(makeContext({ sourceType: 'session_summary' }));
+    expect(result.prompt).not.toContain('<observation>...</observation>');
+  });
+
+  it('still asks for <observation> blocks on agent_event jobs', () => {
+    const result = buildServerGenerationPrompt(makeContext());
+    expect(result.prompt).toContain('<observation>...</observation>');
+    expect(result.prompt).not.toContain('<summary>...</summary>');
+  });
+
+  it('keeps offering the skip escape hatch on both job types', () => {
+    for (const sourceType of ['agent_event', 'session_summary'] as const) {
+      expect(buildServerGenerationPrompt(makeContext({ sourceType })).prompt)
+        .toContain('<skip_summary />');
+    }
+  });
+
   it('strips <private> tags from event payload before sending', () => {
     const context = makeContext({
       payload: '<private>secret</private>visible',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rehost of community PR #3587 onto current `main` (originally ~266 behind). Same-repo so CI can run without first-time-contributor approval.

## What landed
Session-summary jobs asked for `<observation>` blocks while `processSessionSummaryResponse` only read `parsed.summary`. The model complied, `parseAgentXml` returned `{ observations, summary: null }`, and the summary path completed the job after discarding a billed response. Recurrence of #1345 in server-beta.

1. Branch `buildServerGenerationPrompt` on `job.sourceType` so summary jobs request a `<summary>` block.
2. If a provider still answers with `<observation>` blocks, fold them into the summary body instead of dropping them.
3. Render concepts-only observations as a last-resort body so they are not accepted then discarded.

## Credit
Original work by @alessandropcostabr in #3587.

Closes #3587

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1b4d1cd-aa44-45ee-8604-54335d8eace8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1b4d1cd-aa44-45ee-8604-54335d8eace8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

