### PR TITLE
fix(server-beta): bound session-summary input by payload size (rehost #3584)

### DIFF
--- a/src/server/generation/ProviderObservationGenerator.ts
+++ b/src/server/generation/ProviderObservationGenerator.ts
@@ -3,6 +3,8 @@
 import type { Job } from 'bullmq';
 import { logger } from '../../utils/logger.js';
 import { PostgresAgentEventsRepository } from '../../storage/postgres/agent-events.js';
+import type { PostgresAgentEvent } from '../../storage/postgres/agent-events.js';
+import { eventBlockBytes } from './providers/shared/prompt-builder.js';
 import { PostgresObservationGenerationJobRepository } from '../../storage/postgres/generation-jobs.js';
 import { PostgresProjectsRepository } from '../../storage/postgres/projects.js';
 import { PostgresAuthRepository } from '../../storage/postgres/auth.js';
@@ -56,6 +58,76 @@ export interface ProviderObservationGeneratorOptions {
   pool: PostgresPool;
   provider: ServerGenerationProvider;
   workerId?: string;
+}
+
+
+// The `limit` on listUnprocessedEvents caps the event COUNT, not the payload
+// volume, and event size varies by orders of magnitude. Long sessions therefore
+// still blow the provider context window: measured on a production deployment,
+// sessions that failed with "context overflow" carried up to 34 MB of event
+// payload (~9M tokens), and even truncated to the 500-event default they still
+// averaged ~634k tokens with a 1.55M worst case — against a ~200k window. No
+// model currently on offer absorbs that, so the input has to be bounded by size.
+//
+// Keep the head and the tail of the session: the opening carries the goal, the
+// close carries the outcome and what was left pending. Dropping the middle
+// yields a partial summary, which is strictly better than the current outcome
+// for these sessions — an unrecoverable failure and no summary at all.
+// Bounds the SESSION INPUT, not the finished prompt: buildServerGenerationPrompt
+// wraps the selected event blocks in request/project/job tags, the instructions and
+// the observation schema. That envelope is a fixed cost — 1,244 bytes with the mode
+// active here, independent of event count and payload size — so it is left out of
+// the budget rather than reserved from it. At the default that is 0.2%; only a
+// budget small enough to be unusable anyway (~1 KB buys one truncated tool call)
+// would be decided by it.
+const SUMMARY_INPUT_BUDGET_BYTES = Number.parseInt(
+  process.env.CLAUDE_MEM_SUMMARY_INPUT_BUDGET_BYTES ?? '',
+  10,
+) || 600_000;
+
+/**
+ * Bytes this event will actually contribute to the prompt.
+ *
+ * Delegates to the prompt builder instead of estimating: the builder
+ * pretty-prints, privacy-strips, truncates, XML-escapes and wraps every payload,
+ * and an estimate that skips any of those steps under-counts the request it is
+ * supposed to bound. Measuring the raw row would also count UTF-16 units rather
+ * than bytes, and would charge full price for a payload the builder truncates.
+ *
+ * Not defensive on purpose: an event that cannot be turned into a block here
+ * cannot be turned into one during prompt construction either, so swallowing the
+ * error would only trade a loud failure for the context overflow this budget
+ * exists to prevent.
+ */
+function promptFootprint(event: unknown): number {
+  return eventBlockBytes(event as PostgresAgentEvent);
+}
+
+export function capSummaryInput<T>(events: T[]): T[] {
+  const size = (e: T): number => promptFootprint(e);
+  let total = 0;
+  for (const e of events) total += size(e);
+  if (total <= SUMMARY_INPUT_BUDGET_BYTES) return events;
+
+  const half = SUMMARY_INPUT_BUDGET_BYTES / 2;
+  const head: T[] = [];
+  let headBytes = 0;
+  for (const e of events) {
+    const s = size(e);
+    if (headBytes + s > half) break;
+    head.push(e);
+    headBytes += s;
+  }
+  const tail: T[] = [];
+  let tailBytes = 0;
+  for (let i = events.length - 1; i >= head.length; i -= 1) {
+    const e = events[i] as T;
+    const s = size(e);
+    if (tailBytes + s > SUMMARY_INPUT_BUDGET_BYTES - headBytes) break;
+    tail.unshift(e);
+    tailBytes += s;
+  }
+  return [...head, ...tail];
 }
 
 export class ProviderObservationGenerator {
@@ -518,7 +590,7 @@ export class ProviderObservationGenerator {
         projectId: job.projectId,
         teamId: job.teamId,
       });
-      return events;
+      return capSummaryInput(events);
     }
 
     if (job.sourceType !== 'agent_event') {

--- a/src/server/generation/providers/shared/prompt-builder.ts
+++ b/src/server/generation/providers/shared/prompt-builder.ts
@@ -131,6 +131,24 @@ function buildEventBlock(event: PostgresAgentEvent): EventBlockResult {
   };
 }
 
+/**
+ * Bytes this event contributes to the prompt.
+ *
+ * Measured on the block the prompt actually carries, not estimated from the raw
+ * row: the payload is pretty-printed, privacy-stripped, truncated, XML-escaped
+ * and wrapped in metadata tags above, and a caller that budgets the input has to
+ * agree with all of it. Deriving the number a second time is what let the two
+ * drift apart in the first place.
+ *
+ * Returns 0 for an event whose block is dropped, so it costs no budget either.
+ */
+export function eventBlockBytes(event: PostgresAgentEvent): number {
+  const { body } = buildEventBlock(event);
+  if (body.length === 0) return 0;
+  // + 1 for the '\n' that joins this block to the next one
+  return Buffer.byteLength(body, 'utf8') + 1;
+}
+
 function loadActiveModeOrFallback(): ModeConfig | { observation_types: ReadonlyArray<Pick<ObservationType, 'id'>> } {
   try {
     return ModeManager.getInstance().getActiveMode();

--- a/tests/server/generation/summary-input-budget.test.ts
+++ b/tests/server/generation/summary-input-budget.test.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'bun:test';
+import { capSummaryInput } from '../../../src/server/generation/ProviderObservationGenerator.js';
+import { eventBlockBytes } from '../../../src/server/generation/providers/shared/prompt-builder.js';
+import type { PostgresAgentEvent } from '../../../src/storage/postgres/agent-events.js';
+
+// listUnprocessedEvents caps the event COUNT, not the payload volume. Sessions
+// whose events are large still overflow the provider window, which surfaces as
+// an `unrecoverable` job and no summary at all. capSummaryInput bounds the
+// input by size, keeping the head (goal) and the tail (outcome).
+//
+// The budget is measured with eventBlockBytes — the same function the prompt
+// builder feeds — so these tests fail if the two ever disagree again.
+
+const budget = () =>
+  Number.parseInt(process.env.CLAUDE_MEM_SUMMARY_INPUT_BUDGET_BYTES ?? '', 10) || 600_000;
+
+const eventOf = (id: number, payload: string): PostgresAgentEvent => ({
+  id: `evt-${id}`,
+  projectId: 'p',
+  teamId: 't',
+  serverSessionId: 's',
+  sourceAdapter: 'hook',
+  sourceEventId: null,
+  idempotencyKey: `k-${id}`,
+  eventType: 'tool_use',
+  platformSource: 'claude',
+  payload,
+  metadata: {},
+  occurredAtEpoch: 1_700_000_000_000 + id,
+  receivedAtEpoch: 1_700_000_000_000 + id,
+  createdAtEpoch: 1_700_000_000_000 + id,
+});
+
+const filler = (id: number, bytes: number) => eventOf(id, 'x'.repeat(bytes));
+const sizeOf = (list: PostgresAgentEvent[]) =>
+  list.reduce<number>((acc, e) => acc + eventBlockBytes(e), 0);
+
+describe('capSummaryInput', () => {
+  it('returns every event when the batch fits the budget', () => {
+    const events = [filler(1, 10), filler(2, 10), filler(3, 10)];
+    expect(capSummaryInput(events)).toEqual(events);
+  });
+
+  it('bounds an oversized batch to the byte budget', () => {
+    const events = Array.from({ length: 400 }, (_, i) => filler(i, 5_000));
+    expect(sizeOf(events)).toBeGreaterThan(budget());
+
+    const capped = capSummaryInput(events);
+
+    expect(capped.length).toBeLessThan(events.length);
+    expect(sizeOf(capped)).toBeLessThanOrEqual(budget());
+  });
+
+  it('keeps both ends of the session, not just one', () => {
+    const events = Array.from({ length: 400 }, (_, i) => filler(i, 5_000));
+    const capped = capSummaryInput(events);
+
+    // the opening carries the goal, the close carries the outcome
+    expect(capped[0]?.id).toBe('evt-0');
+    expect(capped[capped.length - 1]?.id).toBe('evt-399');
+  });
+
+  it('keeps an oversized single event instead of returning nothing', () => {
+    // A 700 KB event exceeds both the head and the tail allowance. Measuring the
+    // raw row would drop it and hand the provider an empty session, even though
+    // the prompt truncates the payload to 16 KiB and it fits comfortably.
+    const capped = capSummaryInput([filler(1, 700_000)]);
+    expect(capped.length).toBe(1);
+    expect(sizeOf(capped)).toBeLessThanOrEqual(budget());
+  });
+
+  it('measures UTF-8 bytes, not UTF-16 code units', () => {
+    // 'é' is 1 UTF-16 unit but 2 UTF-8 bytes; a budget checked in .length would
+    // let the real request exceed the limit and fail as context overflow.
+    const capped = capSummaryInput([eventOf(1, 'é'.repeat(400_000))]);
+    expect(sizeOf(capped)).toBeLessThanOrEqual(budget());
+  });
+
+  it('counts XML escaping and block overhead, not just the raw payload', () => {
+    // Regression for the estimate this replaced: it measured the compact raw
+    // payload, while the builder pretty-prints, escapes and wraps it. 100 events
+    // of 3 KB of '<' weigh ~300 KB raw (under budget, so nothing was dropped)
+    // and render past 1 MB once every '<' becomes '&lt;'.
+    const events = Array.from({ length: 100 }, (_, i) => eventOf(i, '<'.repeat(3_000)));
+    const rawBytes = events.reduce((acc, e) => acc + Buffer.byteLength(e.payload as string), 0);
+
+    expect(rawBytes).toBeLessThan(budget());
+    expect(sizeOf(events)).toBeGreaterThan(budget());
+
+    expect(sizeOf(capSummaryInput(events))).toBeLessThanOrEqual(budget());
+  });
+
+  it('charges nothing for an event the builder drops', () => {
+    // A payload that strips to blank produces no block at all, so it must not
+    // consume budget the way the raw-row estimate made it.
+    expect(eventBlockBytes(eventOf(1, '   '))).toBe(0);
+  });
+
+  it('preserves chronological order', () => {
+    const events = Array.from({ length: 400 }, (_, i) => filler(i, 5_000));
+    const stamps = capSummaryInput(events).map((e) => e.occurredAtEpoch);
+    expect(stamps).toEqual([...stamps].sort((a, b) => a - b));
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rehost of community PR #3584 onto current `main` (originally ~269 behind). Same-repo so CI can run without first-time-contributor approval.

## What landed
`listUnprocessedEvents` caps event **count** (default 500), not payload volume. Long sessions still overflow the provider context window, get classified `unrecoverable`, and end with no summary. Measured: even the 500-event default averaged ~634k tokens (worst ~1.55M) against a ~200k window.

- Bound summary input by `CLAUDE_MEM_SUMMARY_INPUT_BUDGET_BYTES` (default 600_000)
- Measure the rendered prompt footprint (`eventBlockBytes`), not the raw row
- Keep the session head and tail; sessions already under budget are unchanged

## Credit
Original work by @alessandropcostabr in #3584.

Closes #3584

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1b4d1cd-aa44-45ee-8604-54335d8eace8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1b4d1cd-aa44-45ee-8604-54335d8eace8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

