### PR TITLE
fix: bound sync_outbox growth when cloud sync is unconfigured (rehost #3616)

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -96,6 +96,19 @@ interface SummaryDetailRow {
   created_at_epoch: number;
 }
 
+export interface SessionStoreOptions {
+  /**
+   * Whether this store may enqueue mutation ops into sync_outbox. The only
+   * consumer of that queue is CloudSync's drain, and DatabaseManager
+   * constructs CloudSync iff cloud sync is fully credentialed — so the
+   * worker bootstrap passes the same configuration state here, and an
+   * unconfigured install produces no ops it can never drain. Defaults to
+   * true (the pre-flag behavior) for direct constructions that never wire
+   * the flag.
+   */
+  syncOpsEnabled?: boolean;
+}
+
 interface SdkSessionDetailRow {
   id: number;
   content_session_id: string;
@@ -111,8 +124,10 @@ interface SdkSessionDetailRow {
 
 export class SessionStore {
   public db: Database;
+  private readonly syncOpsEnabled: boolean;
 
-  constructor(dbPathOrDb: string | Database = DB_PATH) {
+  constructor(dbPathOrDb: string | Database = DB_PATH, options: SessionStoreOptions = {}) {
+    this.syncOpsEnabled = options.syncOpsEnabled ?? true;
     if (dbPathOrDb instanceof Database) {
       this.db = dbPathOrDb;
     } else {
@@ -2066,8 +2081,25 @@ export class SessionStore {
    * RULES, SyncApply.ts). Pure SQL, no notify(): callers on the worker
    * connection nudge CloudSync themselves; the startup drain catches the
    * rest.
+   *
+   * Producer gate: acked ops are DELETEd by CloudSync's drain — the queue's
+   * ONLY retention path — and CloudSync exists iff cloud sync is fully
+   * credentialed. With syncOpsEnabled false (unconfigured install) this
+   * no-ops instead of growing sync_outbox forever.
+   *
+   * Supersede, don't append (set_prompt_session): every session
+   * re-registration re-emits the repair for EVERY prompt in the session
+   * (requeuePromptSync), and the mutation site bumps the prompt's sync_rev
+   * before each enqueue — so per target the newest op always carries the
+   * complete field set at the highest rev, and a still-queued older op is
+   * dead weight. Replicas apply by the op.rev >= row sync_rev guard, so
+   * dropping an unsent superseded op cannot regress them; one already pushed
+   * (ack lost mid-flight) is ordered before the newer op in the hub log and
+   * converges the same way. This bounds the outbox at one
+   * set_prompt_session row per prompt regardless of re-registration count.
    */
   private enqueueMutationOp(rev: string | number, body: CanonicalMutation): void {
+    if (!this.syncOpsEnabled) return;
     // set_prompt_session records NULL as the durable "this device" marker;
     // validate the exact mutation shape/UTF-8 bounds with a temporary valid
     // device id before appending. CloudSync substitutes the resolved device
@@ -2078,6 +2110,22 @@ export class SessionStore {
       if (target?.origin_device_id === null) target.origin_device_id = 'self';
     }
     validateCanonicalMutation(candidate);
+    if (body.op === 'set_prompt_session') {
+      // json_valid guards tampered rows from aborting the enqueue (the v49
+      // precedent); every writer stores JSON.stringify output. No rev guard:
+      // the sync_rev bump above each enqueue makes revs monotonic per
+      // target, so the incoming op always supersedes what is queued.
+      this.db.prepare(`
+        DELETE FROM sync_outbox
+        WHERE json_valid(body)
+          AND json_extract(body, '$.op') = 'set_prompt_session'
+          AND json_extract(body, '$.target.origin_device_id') IS ?
+          AND json_extract(body, '$.target.origin_local_id') = ?
+      `).run(
+        (body.target?.origin_device_id ?? null) as string | null,
+        String(body.target?.origin_local_id ?? ''),
+      );
+    }
     this.db.prepare(`
       INSERT INTO sync_outbox (op_uuid, rev, body, created_at_epoch)
       VALUES (?, ?, ?, ?)
@@ -2105,8 +2153,17 @@ export class SessionStore {
    * stampGuard unnecessary: the drain stamps synced_at only where the acked
    * rev still equals the row's sync_rev, so a registration landing while a
    * POST is in flight leaves the row unsynced and it re-pushes corrected.
+   *
+   * With sync ops disabled the whole repair is skipped: the bump + re-null
+   * exist only so already-pushed rows re-push corrected, nothing pushes
+   * without CloudSync, and a prompt that first syncs after a later
+   * enablement resolves its session join fields at snapshot time anyway
+   * (the drain SELECT joins sdk_sessions). Skipping also keeps v47
+   * launch-baseline rows excluded instead of promoting them into sync
+   * eligibility via the rev bump.
    */
   private requeuePromptSync(sessionDbId: number): void {
+    if (!this.syncOpsEnabled) return;
     const session = this.db.prepare(`
       SELECT memory_session_id, project, content_session_id, platform_source
       FROM sdk_sessions WHERE id = ?

--- a/src/services/worker/DatabaseManager.ts
+++ b/src/services/worker/DatabaseManager.ts
@@ -22,10 +22,20 @@ export class DatabaseManager {
 
     const settings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
 
+    // Cloud sync is active iff token, user id, and Hub URL are all non-empty
+    // (CloudSync.isConfigured's exact predicate). Evaluated once here and
+    // shared with SessionStore: sync_outbox rows are only ever deleted by
+    // CloudSync's ack path, so an install without a CloudSync must not
+    // produce mutation ops either — they would accumulate forever.
+    const cloudSyncConfigured =
+      settings.CLAUDE_MEM_CLOUD_SYNC_TOKEN !== '' &&
+      settings.CLAUDE_MEM_CLOUD_SYNC_USER_ID !== '' &&
+      settings.CLAUDE_MEM_CLOUD_SYNC_HUB_URL.trim() !== '';
+
     // The launch schema is SyncHub-native. SessionStore marks any pre-launch
     // local corpus as a nonqueued baseline once; only subsequent writes enter
     // the canonical v2 outbox.
-    this.sessionStore = new SessionStore(this.db);
+    this.sessionStore = new SessionStore(this.db, { syncOpsEnabled: cloudSyncConfigured });
     this.sessionSearch = new SessionSearch(this.db);
 
     const chromaEnabled = settings.CLAUDE_MEM_CHROMA_ENABLED !== 'false';
@@ -35,14 +45,9 @@ export class DatabaseManager {
       logger.info('DB', 'Chroma disabled via CLAUDE_MEM_CHROMA_ENABLED=false, using SQLite-only search');
     }
 
-    // Cloud sync is active iff token, user id, and Hub URL are all non-empty.
     // Inactive installs get null so the write-site `getCloudSync()?.notify()`
     // nudges are free no-ops.
-    if (
-      settings.CLAUDE_MEM_CLOUD_SYNC_TOKEN !== '' &&
-      settings.CLAUDE_MEM_CLOUD_SYNC_USER_ID !== '' &&
-      settings.CLAUDE_MEM_CLOUD_SYNC_HUB_URL.trim() !== ''
-    ) {
+    if (cloudSyncConfigured) {
       this.cloudSync = new CloudSync(this.db, settings);
     }
 

--- a/tests/worker/sync/outbox-growth.test.ts
+++ b/tests/worker/sync/outbox-growth.test.ts
@@ -1,0 +1,214 @@
+// sync_outbox growth bounds — the two halves of the unbounded-growth fix:
+//
+//   1. PRODUCER GATE: sync_outbox rows are only ever deleted by CloudSync's
+//      ack path, and DatabaseManager constructs CloudSync iff cloud sync is
+//      fully credentialed. SessionStore therefore takes the same
+//      configuration state (syncOpsEnabled) and enqueues NOTHING when it is
+//      false — an unconfigured install must not produce ops it can never
+//      drain. The default stays true (pre-flag behavior) so direct
+//      constructions keep enqueueing.
+//   2. SUPERSEDE, DON'T APPEND: each session (re)start can mint a fresh
+//      synthetic memory_session_id, and every re-registration re-emits one
+//      set_prompt_session op per prompt in the session (requeuePromptSync,
+//      full history each time). Observed in a live unconfigured 13.15.0
+//      deployment: 369 distinct prompts amplified into 10,457 queued ops
+//      (28x) across ~20 sessions x ~21 re-registrations. The newest op per
+//      (op, target) carries the complete field set at the highest rev
+//      (the mutation site bumps sync_rev before each enqueue), so enqueueing
+//      now deletes the superseded queued op first — bounding the outbox at
+//      one row per prompt regardless of re-registration count.
+//
+// After #4027, ensureMemorySessionIdRegistered is register-only (it keeps the
+// first memory_session_id). The remaining amplification path is
+// updateMemorySessionId, which OpenAI-compatible providers still call when
+// they mint a new synthetic id. The supersede tests therefore drive that
+// remaining writer.
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { SessionStore, type SessionStoreOptions } from '../../../src/services/sqlite/SessionStore.js';
+
+const ISO = '2026-07-09T00:00:00.000Z';
+
+interface OutboxRow {
+  op_uuid: string;
+  rev: string;
+  body: any;
+}
+
+function outboxRows(db: Database): OutboxRow[] {
+  return (db.prepare('SELECT op_uuid, CAST(rev AS TEXT) AS rev, body FROM sync_outbox ORDER BY id').all() as Array<{ op_uuid: string; rev: string; body: string }>)
+    .map(r => ({ op_uuid: r.op_uuid, rev: r.rev, body: JSON.parse(r.body) }));
+}
+
+function seedSessionWithPrompts(db: Database, promptCount: number): void {
+  db.prepare(`
+    INSERT INTO sdk_sessions (content_session_id, memory_session_id, project, platform_source, started_at, started_at_epoch, status)
+    VALUES ('sess-1', NULL, 'proj-x', 'claude', ?, 1751234567000, 'active')
+  `).run(ISO);
+  for (let i = 1; i <= promptCount; i++) {
+    db.prepare(`
+      INSERT INTO user_prompts (session_db_id, content_session_id, prompt_number, prompt_text, created_at, created_at_epoch, synced_at)
+      VALUES (1, 'sess-1', ?, ?, ?, ?, ?)
+    `).run(i, `prompt ${i}`, ISO, 1751234567890 + i, i === 1 ? 111 : null);
+  }
+}
+
+function promptRows(db: Database): Array<{ id: number; sync_rev: string; synced_at: number | null }> {
+  return db.prepare('SELECT id, CAST(sync_rev AS TEXT) AS sync_rev, synced_at FROM user_prompts ORDER BY id').all() as any;
+}
+
+describe('sync_outbox growth bounds', () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+  });
+
+  afterEach(() => db.close());
+
+  function makeStore(options?: SessionStoreOptions): SessionStore {
+    return new SessionStore(db, options);
+  }
+
+  // ---------------------------------------------------------------------------
+  // (1) producer gate — syncOpsEnabled: false enqueues nothing, anywhere
+  // ---------------------------------------------------------------------------
+  describe('producer gate (syncOpsEnabled: false)', () => {
+    it('updateMemorySessionId records the mapping but leaves sync_outbox empty and prompt sync state untouched', () => {
+      const store = makeStore({ syncOpsEnabled: false });
+      seedSessionWithPrompts(db, 2);
+
+      store.updateMemorySessionId(1, 'mem-late');
+
+      // The mapping itself still lands — only the sync lane is gated.
+      const session = db.prepare('SELECT memory_session_id FROM sdk_sessions WHERE id = 1').get() as any;
+      expect(session.memory_session_id).toBe('mem-late');
+
+      expect(outboxRows(db)).toEqual([]);
+      // The whole repair transaction is skipped: no sync_rev bump, no
+      // synced_at re-null — those serve only the sync lanes.
+      const prompts = promptRows(db);
+      expect(prompts.map(p => p.sync_rev)).toEqual(['1', '1']);
+      expect(prompts[0].synced_at).toBe(111);
+      expect(prompts[1].synced_at).toBeNull();
+    });
+
+    it('ensureMemorySessionIdRegistered leaves sync_outbox empty', () => {
+      const store = makeStore({ syncOpsEnabled: false });
+      seedSessionWithPrompts(db, 2);
+
+      store.ensureMemorySessionIdRegistered(1, 'mem-late');
+      store.ensureMemorySessionIdRegistered(1, 'mem-later'); // id change — the amplification trigger
+
+      const session = db.prepare('SELECT memory_session_id FROM sdk_sessions WHERE id = 1').get() as any;
+      expect(session.memory_session_id).toBe('mem-late');
+      expect(outboxRows(db)).toEqual([]);
+      expect(promptRows(db).map(p => p.sync_rev)).toEqual(['1', '1']);
+    });
+
+    it('createSDKSession still records a custom title locally but enqueues no set_title op', () => {
+      const store = makeStore({ syncOpsEnabled: false });
+
+      store.createSDKSession('sess-t', 'proj-x', 'first prompt', 'A Title', 'claude');
+
+      const session = db.prepare("SELECT custom_title FROM sdk_sessions WHERE content_session_id = 'sess-t'").get() as any;
+      expect(session.custom_title).toBe('A Title');
+      expect(outboxRows(db)).toEqual([]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // (2) supersede — re-registrations replace queued repair ops per target
+  // ---------------------------------------------------------------------------
+  describe('set_prompt_session supersede (sync enabled)', () => {
+    it('one registration enqueues exactly one op per prompt with the full repair body (pre-fix behavior preserved)', () => {
+      const store = makeStore({ syncOpsEnabled: true });
+      seedSessionWithPrompts(db, 2);
+
+      store.updateMemorySessionId(1, 'mem-late');
+
+      const ops = outboxRows(db);
+      expect(ops.length).toBe(2);
+      const byTarget = new Map(ops.map(o => [o.body.target.origin_local_id, o]));
+      for (const promptId of ['1', '2']) {
+        const op = byTarget.get(promptId)!;
+        expect(op.rev).toBe('2'); // rev = post-bump sync_rev — REV MINTING RULES
+        expect(op.body.op).toBe('set_prompt_session');
+        expect(op.body.target.origin_device_id).toBeNull();
+        expect(op.body.fields).toEqual({
+          memory_session_id: 'mem-late',
+          project: 'proj-x',
+          content_session_id: 'sess-1',
+          platform_source: 'claude',
+        });
+      }
+    });
+
+    it('N identity changes leave one op per prompt at the newest rev and fields, not N ops', () => {
+      // The remaining amplification path after #4027: updateMemorySessionId
+      // still rewrites identity and requeues every prompt. 3 prompts x 21
+      // synthetic memory ids produced 63 queued ops pre-fix; the bound is 3.
+      const store = makeStore(); // default construction — enqueue stays on
+      seedSessionWithPrompts(db, 3);
+
+      for (let k = 1; k <= 21; k++) {
+        store.updateMemorySessionId(1, `mem-${k}`);
+      }
+
+      const ops = outboxRows(db);
+      expect(ops.length).toBe(3); // one per prompt, NOT 63
+      const targets = ops.map(o => o.body.target.origin_local_id).sort();
+      expect(targets).toEqual(['1', '2', '3']);
+      for (const op of ops) {
+        expect(op.rev).toBe('22'); // 1 + one bump per identity change
+        expect(op.body.fields.memory_session_id).toBe('mem-21'); // newest repair wins
+      }
+      // The row lane agrees: prompts sit at the same post-bump rev, unsynced.
+      for (const row of promptRows(db)) {
+        expect(row.sync_rev).toBe('22');
+        expect(row.synced_at).toBeNull();
+      }
+    });
+
+    it('supersede is scoped to the (op, target) pair: other sessions and set_title ops survive', () => {
+      const store = makeStore();
+      seedSessionWithPrompts(db, 1);
+      // A second session with its own prompt, plus a queued set_title op.
+      store.createSDKSession('sess-2', 'proj-y', 'other prompt', 'Titled', 'claude');
+      db.prepare(`
+        INSERT INTO user_prompts (session_db_id, content_session_id, prompt_number, prompt_text, created_at, created_at_epoch)
+        VALUES (2, 'sess-2', 1, 'second session prompt', ?, 1751234567999)
+      `).run(ISO);
+      store.updateMemorySessionId(2, 'mem-other');
+
+      store.updateMemorySessionId(1, 'mem-a');
+      store.updateMemorySessionId(1, 'mem-b'); // supersedes only session 1's repair
+
+      const ops = outboxRows(db);
+      const titles = ops.filter(o => o.body.op === 'set_title');
+      const repairs = ops.filter(o => o.body.op === 'set_prompt_session');
+      expect(titles.length).toBe(1); // untouched by the repair supersede
+      expect(repairs.length).toBe(2); // one per prompt target across both sessions
+
+      const bySession = new Map(repairs.map(o => [o.body.fields.memory_session_id, o]));
+      expect(bySession.get('mem-other')!.body.target.origin_local_id).toBe('2');
+      expect(bySession.get('mem-b')!.body.target.origin_local_id).toBe('1');
+      expect(bySession.has('mem-a')).toBe(false); // superseded op is gone
+    });
+
+    it('mints a fresh op UUID for the superseding op (a UUID is never reused for a different logical mutation)', () => {
+      const store = makeStore();
+      seedSessionWithPrompts(db, 1);
+
+      store.updateMemorySessionId(1, 'mem-a');
+      const first = outboxRows(db)[0];
+      store.updateMemorySessionId(1, 'mem-b');
+      const second = outboxRows(db)[0];
+
+      expect(outboxRows(db).length).toBe(1);
+      expect(second.op_uuid).not.toBe(first.op_uuid);
+      expect(second.rev).toBe('3');
+    });
+  });
+});

--- a/tests/worker/sync/session-identity-is-stable.test.ts
+++ b/tests/worker/sync/session-identity-is-stable.test.ts
@@ -118,7 +118,10 @@ describe('a session keeps the identity it was given', () => {
     store.updateMemorySessionId(1, 'msid-B');
 
     expect(storedId(db)).toBe('msid-B');
-    expect(outboxCount(db)).toBe(afterFirst + 4); // every prompt, again
+    // Supersede, don't append: the repair still runs for every prompt, but
+    // replaces the queued set_prompt_session op per target. Cost stays one
+    // row per prompt, not afterFirst + 4.
+    expect(outboxCount(db)).toBe(afterFirst);
     // ON UPDATE CASCADE carried the change into the memory too.
     const observed = (db.prepare('SELECT memory_session_id AS id FROM observations').get() as { id: string }).id;
     expect(observed).toBe('msid-B');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rehost of community PR #3616 onto current `main` (originally ~269 behind). Complementary to #4027 (ClaudeProvider register-only). Same-repo so first-time-contributor CI approval is not required.

## What landed
On installs where cloud sync is **not configured** (the default), `sync_outbox` grows forever: the producer writes unconditionally while the only consumer (`CloudSync.drainMutations`) is never constructed. A second defect multiplies growth: every identity change re-enqueues the session's entire prompt history.

1. **Producer gate:** `SessionStore` takes `syncOpsEnabled`; `DatabaseManager` passes the same CloudSync-construction predicate. Unconfigured installs enqueue nothing.
2. **Supersede, don't append:** `set_prompt_session` deletes any queued op with the same `(op, target)` before insert. Bounds the outbox at one row per prompt.

## Adaptation after #4027
`ensureMemorySessionIdRegistered` is now register-only. The supersede tests drive `updateMemorySessionId`, which remains the writer for OpenAI-compatible synthetic IDs (#3597).

## Credit
Original work by @maksodf in #3616.

Closes #3616

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1b4d1cd-aa44-45ee-8604-54335d8eace8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1b4d1cd-aa44-45ee-8604-54335d8eace8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

