### PR TITLE
fix(worker): reuse OpenAI-compatible synthetic session IDs (rehost #3597)

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -2042,6 +2042,14 @@ export class SessionStore {
   }
 
   updateMemorySessionId(sessionDbId: number, memorySessionId: string | null): void {
+    const current = this.db.prepare(`
+      SELECT memory_session_id
+      FROM sdk_sessions
+      WHERE id = ?
+    `).get(sessionDbId) as { memory_session_id: string | null } | undefined;
+
+    if (!current || current.memory_session_id === memorySessionId) return;
+
     this.db.prepare(`
       UPDATE sdk_sessions
       SET memory_session_id = ?

--- a/src/services/worker/OpenAICompatibleProvider.ts
+++ b/src/services/worker/OpenAICompatibleProvider.ts
@@ -122,10 +122,18 @@ export abstract class OpenAICompatibleProvider<TConfig extends { apiKey: string;
     }
 
     if (!session.memorySessionId) {
-      const syntheticMemorySessionId = `${this.syntheticIdPrefix}-${session.contentSessionId}-${Date.now()}`;
-      session.memorySessionId = syntheticMemorySessionId;
-      this.dbManager.getSessionStore().updateMemorySessionId(session.sessionDbId, syntheticMemorySessionId);
-      logger.info('SESSION', `MEMORY_ID_GENERATED | sessionDbId=${session.sessionDbId} | provider=${this.providerName}`);
+      const persistedMemorySessionId = this.dbManager.getSessionById(session.sessionDbId).memory_session_id;
+      const syntheticIdPrefix = `${this.syntheticIdPrefix}-${session.contentSessionId}-`;
+
+      if (persistedMemorySessionId?.startsWith(syntheticIdPrefix)) {
+        session.memorySessionId = persistedMemorySessionId;
+        logger.info('SESSION', `MEMORY_ID_REUSED | sessionDbId=${session.sessionDbId} | provider=${this.providerName}`);
+      } else {
+        const syntheticMemorySessionId = `${syntheticIdPrefix}${Date.now()}`;
+        session.memorySessionId = syntheticMemorySessionId;
+        this.dbManager.getSessionStore().updateMemorySessionId(session.sessionDbId, syntheticMemorySessionId);
+        logger.info('SESSION', `MEMORY_ID_GENERATED | sessionDbId=${session.sessionDbId} | provider=${this.providerName}`);
+      }
     }
 
     const mode = ModeManager.getInstance().getActiveMode();

--- a/tests/worker/openai-compatible-summary-tier.test.ts
+++ b/tests/worker/openai-compatible-summary-tier.test.ts
@@ -121,4 +121,37 @@ describe('OpenAICompatibleProvider summary tier routing', () => {
 
     expect(provider.queriedModels).toEqual(['session-model', 'session-model']);
   });
+
+  it('reuses the persisted synthetic id when an in-memory session restarts', async () => {
+    const updateMemorySessionId = mock(() => {});
+    const provider = new TestProvider({
+      getSessionById: () => ({ memory_session_id: 'test-test-session-1234' }),
+      getSessionStore: () => ({ updateMemorySessionId }),
+    } as any, {
+      getMessageIterator: async function* () {},
+    } as any);
+    const session = makeSession({ memorySessionId: null });
+
+    await provider.startSession(session);
+
+    expect(session.memorySessionId).toBe('test-test-session-1234');
+    expect(updateMemorySessionId).not.toHaveBeenCalled();
+  });
+
+  it('replaces a persisted synthetic id from a different provider', async () => {
+    const updateMemorySessionId = mock(() => {});
+    const provider = new TestProvider({
+      getSessionById: () => ({ memory_session_id: 'other-test-session-1234' }),
+      getSessionStore: () => ({ updateMemorySessionId }),
+    } as any, {
+      getMessageIterator: async function* () {},
+    } as any);
+    const session = makeSession({ memorySessionId: null });
+
+    await provider.startSession(session);
+
+    expect(session.memorySessionId).toStartWith('test-test-session-');
+    expect(updateMemorySessionId).toHaveBeenCalledTimes(1);
+    expect(updateMemorySessionId).toHaveBeenCalledWith(1, session.memorySessionId);
+  });
 });

--- a/tests/worker/sync/mutation-sites.test.ts
+++ b/tests/worker/sync/mutation-sites.test.ts
@@ -177,6 +177,16 @@ describe('mutation sites', () => {
       }
     });
 
+    it('updateMemorySessionId emits nothing when the id is unchanged', () => {
+      store.updateMemorySessionId(1, 'mem-late');
+      expect(outboxRows(db).length).toBe(2);
+
+      store.updateMemorySessionId(1, 'mem-late');
+
+      expect(outboxRows(db).length).toBe(2);
+      for (const row of promptRows()) expect(row.sync_rev).toBe('2');
+    });
+
     it('ensureMemorySessionIdRegistered goes through the same repair (only when the id actually changes)', () => {
       store.ensureMemorySessionIdRegistered(1, 'mem-late');
       expect(outboxRows(db).length).toBe(2);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rehost of community PR #3597 onto current `main` (originally ~276 behind). OpenRouter/Gemini counterpart to #4027.

## What landed
`SessionManager` initializes reloaded in-memory sessions without a memory-session ID so Claude SDK sessions are not resumed with stale remote IDs. OpenAI-compatible providers treated every reload as a new identity. Each new timestamped ID called `updateMemorySessionId`, which requeued every native prompt as `set_prompt_session`.

- Reuse a persisted synthetic ID when the provider/content prefix matches
- Mint a new ID only when the stored ID belongs to a different provider/session
- Make `updateMemorySessionId` a no-op when the value is unchanged

## Credit
Original work by @SYMBaiEX in #3597.

Closes #3597
Related to #2793

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1b4d1cd-aa44-45ee-8604-54335d8eace8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1b4d1cd-aa44-45ee-8604-54335d8eace8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

