### PR TITLE
fix: trip worker-unavailable fail-loud latch once, then fail-open (rehost #3489)

### DIFF
--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -1,5 +1,6 @@
 import path from "path";
-import { readFileSync, existsSync, writeFileSync, renameSync, mkdirSync, readdirSync, statSync } from "fs";
+import { randomUUID } from "crypto";
+import { readFileSync, existsSync, writeFileSync, renameSync, mkdirSync, readdirSync, statSync, unlinkSync } from "fs";
 import { spawnHidden } from "./spawn.js";
 import { logger } from "../utils/logger.js";
 import { HOOK_TIMEOUTS, getTimeout } from "./hook-constants.js";
@@ -831,9 +832,14 @@ async function ensureWorkerReadyWithin(timeoutMs: number): Promise<boolean> {
 interface HookFailureState {
   consecutiveFailures: number;
   lastFailureAt: number;
+  thresholdTripped: boolean;
 }
 
 const FAIL_LOUD_DEFAULT_THRESHOLD = 3;
+const HOOK_FAILURE_LOCK_WAIT_MS = 1_000;
+const HOOK_FAILURE_LOCK_RETRY_MS = 10;
+const HOOK_FAILURE_LOCK_STALE_MS = 5_000;
+const HOOK_FAILURE_RESET_LOCK_WAIT_MS = HOOK_FAILURE_LOCK_STALE_MS + HOOK_FAILURE_LOCK_WAIT_MS;
 
 function getStateDir(): string {
   return path.join(DATA_DIR, 'state');
@@ -841,6 +847,81 @@ function getStateDir(): string {
 
 function getHookFailuresPath(): string {
   return path.join(getStateDir(), 'hook-failures.json');
+}
+
+function getHookFailuresLockPath(): string {
+  return path.join(getStateDir(), 'hook-failures.lock');
+}
+
+async function acquireHookFailureLock(waitMs = HOOK_FAILURE_LOCK_WAIT_MS): Promise<string | null> {
+  const stateDir = getStateDir();
+  const lockPath = getHookFailuresLockPath();
+  const token = randomUUID();
+  const payload = JSON.stringify({ pid: process.pid, token });
+  const deadline = Date.now() + waitMs;
+
+  while (Date.now() <= deadline) {
+    try {
+      mkdirSync(stateDir, { recursive: true });
+      writeFileSync(lockPath, payload, { flag: 'wx' });
+      return token;
+    } catch (error: unknown) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'EEXIST') {
+        logger.warn('SYSTEM', 'Hook-failure lock unavailable; skipping failure-state update', {
+          lockPath,
+          code,
+        }, err);
+        return null;
+      }
+
+      let mtimeMs: number;
+      try {
+        mtimeMs = statSync(lockPath).mtimeMs;
+      } catch {
+        continue;
+      }
+
+      if (Date.now() - mtimeMs > HOOK_FAILURE_LOCK_STALE_MS) {
+        let recheckedMtimeMs: number;
+        try {
+          recheckedMtimeMs = statSync(lockPath).mtimeMs;
+        } catch {
+          continue;
+        }
+        if (recheckedMtimeMs === mtimeMs) {
+          try {
+            unlinkSync(lockPath);
+            continue;
+          } catch {
+            // Another stale-lock breaker won, or the filesystem refused the
+            // removal. Retry within the bounded wait instead of failing loud.
+          }
+        }
+      }
+
+      await new Promise(resolve => setTimeout(resolve, HOOK_FAILURE_LOCK_RETRY_MS));
+    }
+  }
+
+  logger.warn('SYSTEM', 'Timed out waiting for hook-failure lock; skipping failure-state update', {
+    lockPath,
+    waitMs,
+  });
+  return null;
+}
+
+function releaseHookFailureLock(token: string): void {
+  const lockPath = getHookFailuresLockPath();
+  try {
+    const lock = JSON.parse(readFileSync(lockPath, 'utf-8')) as { token?: unknown };
+    if (lock.token !== token) return;
+    unlinkSync(lockPath);
+  } catch {
+    // Missing, unreadable, or foreign lock: never remove a lock this process
+    // cannot prove it owns. Stale locks self-heal during acquisition.
+  }
 }
 
 function parseHookFailureState(raw: string): HookFailureState {
@@ -852,6 +933,10 @@ function parseHookFailureState(raw: string): HookFailureState {
     lastFailureAt: typeof parsed.lastFailureAt === 'number' && Number.isFinite(parsed.lastFailureAt)
       ? parsed.lastFailureAt
       : 0,
+    // Backward-compatible migration: state files written before this field
+    // existed must still escalate once if their count already exceeds a
+    // subsequently lowered threshold.
+    thresholdTripped: parsed.thresholdTripped === true,
   };
 }
 
@@ -863,11 +948,11 @@ function readHookFailureState(): HookFailureState {
     // absent (ENOENT) on every hook run until the first worker failure, so
     // logging here would fire on effectively every healthy invocation; the
     // recovery is the zeroed default state below.
-    return { consecutiveFailures: 0, lastFailureAt: 0 };
+    return { consecutiveFailures: 0, lastFailureAt: 0, thresholdTripped: false };
   }
 }
 
-function writeHookFailureStateAtomic(state: HookFailureState): void {
+function writeHookFailureStateAtomic(state: HookFailureState): boolean {
   const stateDir = getStateDir();
   const dest = getHookFailuresPath();
   const tmp = `${dest}.tmp`;
@@ -877,10 +962,12 @@ function writeHookFailureStateAtomic(state: HookFailureState): void {
     }
     writeFileSync(tmp, JSON.stringify(state), 'utf-8');
     renameSync(tmp, dest);
+    return true;
   } catch (error: unknown) {
     logger.debug('SYSTEM', 'Failed to persist hook-failure counter', {
       error: error instanceof Error ? error.message : String(error),
     });
+    return false;
   }
 }
 
@@ -925,32 +1012,46 @@ export function getActiveHookType(): TelemetryHookType | null {
 }
 
 export async function recordWorkerUnreachable(): Promise<number> {
-  const state = readHookFailureState();
-  const next: HookFailureState = {
-    consecutiveFailures: state.consecutiveFailures + 1,
-    lastFailureAt: Date.now(),
-  };
-  writeHookFailureStateAtomic(next);
+  const lockToken = await acquireHookFailureLock();
+  if (lockToken === null) {
+    return readHookFailureState().consecutiveFailures;
+  }
 
-  const threshold = getFailLoudThreshold();
-  if (next.consecutiveFailures >= threshold) {
-    // hook_failed distress signal. Gated to the failure that JUST reached the
-    // threshold (`===`, not `>=`): the stderr warning below repeats on every
-    // failure past the threshold, but telemetry emits once per failure streak
-    // to bound volume. MUST be awaited BEFORE emitBlockingError — it calls
+  let next: HookFailureState;
+  let shouldEscalate = false;
+  try {
+    const state = readHookFailureState();
+    next = {
+      consecutiveFailures: state.consecutiveFailures + 1,
+      lastFailureAt: Date.now(),
+      thresholdTripped: state.thresholdTripped,
+    };
+    const threshold = getFailLoudThreshold();
+    shouldEscalate = next.consecutiveFailures >= threshold && !next.thresholdTripped;
+    if (shouldEscalate) next.thresholdTripped = true;
+    const statePersisted = writeHookFailureStateAtomic(next);
+    shouldEscalate = shouldEscalate && statePersisted;
+  } finally {
+    releaseHookFailureLock(lockToken);
+  }
+
+  if (shouldEscalate) {
+    // hook_failed distress signal. The inter-process lock above makes the
+    // read/check/latch/write transition exclusive, and the latched state is
+    // durable before telemetry or exit. The lock is deliberately released
+    // before either side effect.
+    // MUST be awaited BEFORE emitBlockingError — it calls
     // process.exit(2) immediately, which would kill a fire-and-forget POST
     // mid-flight. captureCliEvent never throws and is hard-capped at 2s, so
     // this cannot hang the fail-loud path. Closed-enum/count props only —
     // never error text. Transport is the direct CLI POST, never the worker
     // API (the defining failure here IS "worker unreachable").
-    if (next.consecutiveFailures === threshold) {
-      await captureCliEvent('hook_failed', {
-        ...(activeHookType !== null ? { hook_type: activeHookType } : {}),
-        error_mode: 'worker_unavailable',
-        consecutive_failures: next.consecutiveFailures,
-        threshold_tripped: true,
-      });
-    }
+    await captureCliEvent('hook_failed', {
+      ...(activeHookType !== null ? { hook_type: activeHookType } : {}),
+      error_mode: 'worker_unavailable',
+      consecutive_failures: next.consecutiveFailures,
+      threshold_tripped: true,
+    });
     // #2292 fix: BLOCKING_FEEDBACK. emitBlockingError flushes the Phase 2
     // stderr buffer (so preceding logger.warn lines also surface) and writes
     // via the bypass channel + exits 2. Previously this raw process.stderr.write
@@ -964,10 +1065,23 @@ export async function recordWorkerUnreachable(): Promise<number> {
   return next.consecutiveFailures;
 }
 
-function resetWorkerFailureCounter(): void {
-  const state = readHookFailureState();
-  if (state.consecutiveFailures === 0) return;
-  writeHookFailureStateAtomic({ consecutiveFailures: 0, lastFailureAt: 0 });
+async function resetWorkerFailureCounter(): Promise<void> {
+  // Recovery must outwait this lock's stale threshold. Returning after the
+  // shorter failure-path bound can leave thresholdTripped set and suppress
+  // the first escalation of the next outage.
+  const lockToken = await acquireHookFailureLock(HOOK_FAILURE_RESET_LOCK_WAIT_MS);
+  if (lockToken === null) return;
+  try {
+    const state = readHookFailureState();
+    if (state.consecutiveFailures === 0 && !state.thresholdTripped) return;
+    writeHookFailureStateAtomic({ consecutiveFailures: 0, lastFailureAt: 0, thresholdTripped: false });
+  } finally {
+    releaseHookFailureLock(lockToken);
+  }
+}
+
+export async function __resetWorkerFailureCounterForTesting(): Promise<void> {
+  await resetWorkerFailureCounter();
 }
 
 const WORKER_FALLBACK_BRAND: unique symbol = Symbol.for('claude-mem/worker-fallback');
@@ -1027,7 +1141,7 @@ export async function executeWithWorkerFallback<T = unknown>(
   }
   if (!response.ok) {
     const text = await response.text().catch(() => '');
-    resetWorkerFailureCounter();
+    await resetWorkerFailureCounter();
     if (response.status === 429 || response.status >= 500) {
       logger.warn('SYSTEM', `Worker API ${method} ${url} returned ${response.status}; skipping hook API call`, {
         body: text.substring(0, 200),
@@ -1044,7 +1158,7 @@ export async function executeWithWorkerFallback<T = unknown>(
     return parsed as T;
   }
 
-  resetWorkerFailureCounter();
+  await resetWorkerFailureCounter();
   const text = await response.text();
   if (text.length === 0) return undefined as unknown as T;
   try {

--- a/tests/cli/hook-stream-discipline.test.ts
+++ b/tests/cli/hook-stream-discipline.test.ts
@@ -64,6 +64,22 @@ describe('#2292 — fail-loud diagnostic is no longer swallowed', () => {
     expect(src).toContain('emitBlockingError(');
     expect(src).not.toMatch(/process\.stderr\.write\(\s*\n\s*`claude-mem worker unreachable/);
   });
+
+  it('claims the one-time latch under an inter-process lock before blocking', () => {
+    const src = readFileSync(join(REPO_ROOT, 'src', 'shared', 'worker-utils.ts'), 'utf-8');
+    const start = src.indexOf('export async function recordWorkerUnreachable');
+    const end = src.indexOf('function resetWorkerFailureCounter', start);
+    const implementation = src.slice(start, end);
+
+    expect(implementation).toContain('const lockToken = await acquireHookFailureLock()');
+    expect(implementation).toContain('next.consecutiveFailures >= threshold && !next.thresholdTripped');
+    expect(implementation).not.toContain('next.consecutiveFailures === threshold');
+    expect(implementation).toContain('shouldEscalate = shouldEscalate && statePersisted');
+    expect(implementation.indexOf('const statePersisted = writeHookFailureStateAtomic(next)'))
+      .toBeLessThan(implementation.indexOf("await captureCliEvent('hook_failed'"));
+    expect(implementation.indexOf('releaseHookFailureLock(lockToken)'))
+      .toBeLessThan(implementation.indexOf("await captureCliEvent('hook_failed'"));
+  });
 });
 
 describe('worker-unavailable transient path stays quiet (exit 0)', () => {

--- a/tests/cli/worker-failure-latch.test.ts
+++ b/tests/cli/worker-failure-latch.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import { pathToFileURL } from 'url';
+
+const REPO_ROOT = join(import.meta.dir, '..', '..');
+const WORKER_UTILS_URL = pathToFileURL(join(REPO_ROOT, 'src', 'shared', 'worker-utils.ts')).href;
+const testDirs: string[] = [];
+
+interface PersistedFailureState {
+  consecutiveFailures: number;
+  lastFailureAt: number;
+  thresholdTripped?: boolean;
+}
+
+function createStateDir(state: PersistedFailureState): string {
+  const dataDir = mkdtempSync(join(tmpdir(), 'claude-mem-hook-failure-'));
+  testDirs.push(dataDir);
+  const statePath = join(dataDir, 'state', 'hook-failures.json');
+  mkdirSync(dirname(statePath), { recursive: true });
+  writeFileSync(statePath, JSON.stringify(state), 'utf-8');
+  return dataDir;
+}
+
+function readState(dataDir: string): Required<PersistedFailureState> {
+  return JSON.parse(readFileSync(join(dataDir, 'state', 'hook-failures.json'), 'utf-8'));
+}
+
+function recordFailure(dataDir: string, threshold: number): ReturnType<typeof Bun.spawnSync> {
+  const source = `
+    const { recordWorkerUnreachable } = await import(${JSON.stringify(WORKER_UTILS_URL)});
+    await recordWorkerUnreachable();
+  `;
+  return Bun.spawnSync([process.execPath, '-e', source], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      CLAUDE_MEM_DATA_DIR: dataDir,
+      CLAUDE_CONFIG_DIR: dataDir,
+      CLAUDE_MEM_HOOK_FAIL_LOUD_THRESHOLD: String(threshold),
+      CLAUDE_MEM_TELEMETRY: '0',
+    },
+  });
+}
+
+function resetFailureState(dataDir: string): ReturnType<typeof Bun.spawnSync> {
+  const source = `
+    const { __resetWorkerFailureCounterForTesting } = await import(${JSON.stringify(WORKER_UTILS_URL)});
+    await __resetWorkerFailureCounterForTesting();
+  `;
+  return Bun.spawnSync([process.execPath, '-e', source], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      CLAUDE_MEM_DATA_DIR: dataDir,
+      CLAUDE_CONFIG_DIR: dataDir,
+      CLAUDE_MEM_TELEMETRY: '0',
+    },
+  });
+}
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('worker-unreachable fail-loud latch', () => {
+  it('migrates an already-exceeded counter and blocks only once', () => {
+    // Old state files do not have thresholdTripped. Simulate lowering the
+    // threshold from above 4 to 3 during the same worker outage.
+    const dataDir = createStateDir({ consecutiveFailures: 4, lastFailureAt: 1 });
+
+    const first = recordFailure(dataDir, 3);
+    expect(first.exitCode).toBe(2);
+    expect(new TextDecoder().decode(first.stderr)).toContain(
+      'claude-mem worker unreachable for 5 consecutive hooks.'
+    );
+    expect(readState(dataDir)).toMatchObject({
+      consecutiveFailures: 5,
+      thresholdTripped: true,
+    });
+
+    const second = recordFailure(dataDir, 3);
+    expect(second.exitCode).toBe(0);
+    expect(new TextDecoder().decode(second.stderr)).not.toContain('claude-mem worker unreachable');
+    expect(readState(dataDir)).toMatchObject({
+      consecutiveFailures: 6,
+      thresholdTripped: true,
+    });
+
+    const recovery = resetFailureState(dataDir);
+    expect(recovery.exitCode).toBe(0);
+    expect(readState(dataDir)).toEqual({
+      consecutiveFailures: 0,
+      lastFailureAt: 0,
+      thresholdTripped: false,
+    });
+  });
+
+  it('allows only one concurrent process to claim the latch', async () => {
+    const dataDir = createStateDir({ consecutiveFailures: 2, lastFailureAt: 1 });
+    const lockPath = join(dataDir, 'state', 'hook-failures.lock');
+    writeFileSync(lockPath, JSON.stringify({ pid: -1, token: 'test-barrier' }), 'utf-8');
+    const source = `
+      const { recordWorkerUnreachable } = await import(${JSON.stringify(WORKER_UTILS_URL)});
+      await recordWorkerUnreachable();
+    `;
+    const options = {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        CLAUDE_MEM_DATA_DIR: dataDir,
+        CLAUDE_CONFIG_DIR: dataDir,
+        CLAUDE_MEM_HOOK_FAIL_LOUD_THRESHOLD: '3',
+        CLAUDE_MEM_TELEMETRY: '0',
+      },
+      stdout: 'pipe' as const,
+      stderr: 'pipe' as const,
+    };
+
+    const workers = Array.from({ length: 6 }, () => Bun.spawn([process.execPath, '-e', source], options));
+    await new Promise(resolve => setTimeout(resolve, 200));
+    unlinkSync(lockPath);
+
+    const exits = await Promise.all(workers.map(worker => worker.exited));
+    const errors = await Promise.all(workers.map(worker => new Response(worker.stderr).text()));
+
+    expect(exits.filter(exit => exit === 2)).toHaveLength(1);
+    expect(exits.filter(exit => exit === 0)).toHaveLength(5);
+    expect(errors.join('').match(/claude-mem worker unreachable/g)?.length).toBe(1);
+    const state = readState(dataDir);
+    expect(state.thresholdTripped).toBe(true);
+    expect(state.consecutiveFailures).toBeGreaterThanOrEqual(3);
+    expect(state.consecutiveFailures).toBeLessThanOrEqual(8);
+  });
+
+  it('degrades without blocking when the latch cannot be persisted', () => {
+    const dataDir = createStateDir({ consecutiveFailures: 2, lastFailureAt: 1 });
+    const statePath = join(dataDir, 'state', 'hook-failures.json');
+    mkdirSync(`${statePath}.tmp`);
+
+    const first = recordFailure(dataDir, 3);
+    const second = recordFailure(dataDir, 3);
+
+    expect(first.exitCode).toBe(0);
+    expect(second.exitCode).toBe(0);
+    expect(new TextDecoder().decode(first.stderr)).not.toContain('claude-mem worker unreachable');
+    expect(new TextDecoder().decode(second.stderr)).not.toContain('claude-mem worker unreachable');
+    expect(readState(dataDir)).toEqual({ consecutiveFailures: 2, lastFailureAt: 1 });
+  });
+
+  it('waits through recovery lock contention so the next outage can escalate', async () => {
+    const dataDir = createStateDir({
+      consecutiveFailures: 2,
+      lastFailureAt: 1,
+      thresholdTripped: true,
+    });
+    const lockPath = join(dataDir, 'state', 'hook-failures.lock');
+    const readyPath = join(dataDir, 'reset-ready');
+    writeFileSync(lockPath, JSON.stringify({ pid: -1, token: 'test-barrier' }), 'utf-8');
+    const source = `
+      const { __resetWorkerFailureCounterForTesting } = await import(${JSON.stringify(WORKER_UTILS_URL)});
+      await Bun.write(${JSON.stringify(readyPath)}, 'ready');
+      await __resetWorkerFailureCounterForTesting();
+    `;
+    const recovery = Bun.spawn([process.execPath, '-e', source], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        CLAUDE_MEM_DATA_DIR: dataDir,
+        CLAUDE_CONFIG_DIR: dataDir,
+        CLAUDE_MEM_TELEMETRY: '0',
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+
+    const readyDeadline = Date.now() + 5_000;
+    while (!(await Bun.file(readyPath).exists()) && Date.now() <= readyDeadline) {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    expect(await Bun.file(readyPath).exists()).toBe(true);
+    await new Promise(resolve => setTimeout(resolve, 1_200));
+    unlinkSync(lockPath);
+
+    expect(await recovery.exited).toBe(0);
+    expect(readState(dataDir)).toEqual({
+      consecutiveFailures: 0,
+      lastFailureAt: 0,
+      thresholdTripped: false,
+    });
+
+    expect(recordFailure(dataDir, 2).exitCode).toBe(0);
+    const thresholdFailure = recordFailure(dataDir, 2);
+    expect(thresholdFailure.exitCode).toBe(2);
+    expect(new TextDecoder().decode(thresholdFailure.stderr)).toContain(
+      'claude-mem worker unreachable for 2 consecutive hooks.'
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rehost of community PR #3489 onto current `main` (originally ~283 behind; old CI red). Same-repo rebase so CI can run.

## What landed
`recordWorkerUnreachable()` used `consecutiveFailures >= threshold`. Once the worker had been unavailable long enough, every later hook invocation exited 2 and blocked the user's prompt.

- Block on the threshold transition only (`thresholdTripped` latch + inter-process lock)
- Later failures in the same outage use the existing graceful fallback
- Keep the orphaned-port diagnosis that landed on main after the original PR
- Do not invent a second outage system

## Credit
Original work by @tunabirgun in #3489.

Closes #3489

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1b4d1cd-aa44-45ee-8604-54335d8eace8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1b4d1cd-aa44-45ee-8604-54335d8eace8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

