### PR TITLE
test(parser): pin observation type handling against the mode enum (rehost #3593)

### DIFF
--- a/src/sdk/parser.ts
+++ b/src/sdk/parser.ts
@@ -116,7 +116,7 @@ function parseObservationBlocks(text: string, correlationId?: string | number): 
         logger.error('PARSER', `Invalid observation type: ${type}, preserving emitted type`, { correlationId });
       }
     } else {
-      logger.error('PARSER', `Observation missing type field, using "${fallbackType}"`, { correlationId });
+      logger.error('PARSER', `Observation missing type field, defaulting to the first declared type: "${fallbackType}"`, { correlationId });
     }
 
     // #3379: concepts are matched exactly by the injection SQL, so a prefixed

--- a/tests/sdk/parser.test.ts
+++ b/tests/sdk/parser.test.ts
@@ -422,3 +422,52 @@ describe('parseAgentXml — concept normalization (#3379)', () => {
     expect(result[0].concepts).toEqual([]);
   });
 });
+
+// #3592: the active mode's `observation_types` enum is advisory — it is rendered
+// into the observer's prompt but never enforced at the parse site. These pin the
+// two branches as they behave today, so that whichever way the enum is eventually
+// enforced, the change is visible in the diff rather than silent.
+describe('parseAgentXml — observation type against the mode enum', () => {
+  it('preserves a type that is outside the enum', () => {
+    const xml = `<observation>
+      <type>sample-gate</type>
+      <title>Type the mode never declared</title>
+    </observation>`;
+
+    const result = expectObservation(xml);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('sample-gate');
+  });
+
+  it('falls back to the first declared type when <type> is absent', () => {
+    const xml = `<observation>
+      <title>No type element at all</title>
+    </observation>`;
+
+    const result = expectObservation(xml);
+
+    expect(result).toHaveLength(1);
+    // Positional, not neutral: the fallback is observation_types[0], which in the
+    // bundled `code` mode is `bugfix`. An untyped observation is therefore filed
+    // as a bug fix rather than as unclassified.
+    expect(result[0].type).toBe('bugfix');
+  });
+
+  it('follows the enum order rather than any fixed default', () => {
+    const modeManager = ModeManager.getInstance() as unknown as { activeMode: unknown };
+    modeManager.activeMode = {
+      observation_types: [{ id: 'refactor' }, { id: 'bugfix' }, { id: 'discovery' }],
+      observation_concepts: [],
+    };
+
+    const xml = `<observation>
+      <title>No type, reordered enum</title>
+    </observation>`;
+
+    const result = expectObservation(xml);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('refactor');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rehost of community PR #3593 onto current `main`. Tests + log wording only; no behavior change.

## What landed
Pins current observation-type handling at the parse site:
- out-of-enum types are preserved verbatim
- missing `<type>` falls back to `observation_types[0]`
- that fallback follows enum order, not a fixed default

Log line now says the fallback is the first declared type, not a neutral default.

## Credit
Original work by @ntdatt812 in #3593.

Closes #3593
Refs #3592

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1b4d1cd-aa44-45ee-8604-54335d8eace8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1b4d1cd-aa44-45ee-8604-54335d8eace8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

