### PR TITLE
fix(cli-resolve): stop cold-start false "too old" and name spawn failures (rehost #3528, #3533)

### DIFF
--- a/src/shared/find-claude-executable.ts
+++ b/src/shared/find-claude-executable.ts
@@ -113,8 +113,13 @@ type ProbeResult =
   | { kind: 'capable'; version: string }
   /** Runs (`--version` works) but rejects the capability flags — too old. */
   | { kind: 'incompatible'; version: string; detail: string }
-  /** Does not run at all (desktop app, missing interpreter, corrupt install). */
-  | { kind: 'broken'; detail: string };
+  /**
+   * Does not resolve to a usable CLI. `launchFailed` is true only when the OS
+   * could not start the process at all (desktop app, missing interpreter,
+   * corrupt install); false when the process ran but failed its version probe
+   * (non-zero exit, timeout, or no version output).
+   */
+  | { kind: 'broken'; detail: string; launchFailed: boolean };
 
 /**
  * Run `<candidate> <args>` and return trimmed stdout, or null on any failure.
@@ -124,7 +129,7 @@ type ProbeResult =
  * injection if the path contains characters like `"`, `;`, `&` — reachable
  * on Windows via a crafted CLAUDE_CODE_PATH in settings.json.
  */
-function runProbe(candidate: string, args: readonly string[]): { stdout: string } | { error: string } {
+function runProbe(candidate: string, args: readonly string[]): { stdout: string } | { error: string; flagRejection: boolean; launchFailed: boolean } {
   try {
     const stdout = _internals.execFileSync(candidate, [...args], {
       encoding: 'utf8',
@@ -134,15 +139,31 @@ function runProbe(candidate: string, args: readonly string[]): { stdout: string 
     }).trim();
     return { stdout };
   } catch (error) {
-    const stderr = (error as { stderr?: unknown }).stderr;
-    const firstLine = String(stderr ?? (error instanceof Error ? error.message : error))
+    const err = error as { stderr?: unknown; status?: unknown; signal?: unknown; killed?: unknown };
+    const stderrText = String(err.stderr ?? '').trim();
+    const firstLine = (stderrText || (error instanceof Error ? error.message : String(error)))
       .split('\n')[0]
       .trim();
+    // A genuine flag rejection is the ONLY proof a CLI is too old: it ran to
+    // argument parsing, wrote a diagnostic to stderr, and exited non-zero.
+    // A timeout or signal kill (killed/signal set, empty stderr — a Windows
+    // cold start losing the 10 s race) leaves no such proof, so it must stay
+    // retryable and never classify as incompatible.
+    const status = err.status;
+    const killed = err.killed === true;
+    const signalled = err.signal != null;
+    const flagRejection = stderrText.length > 0 && !killed && !signalled && typeof status === 'number' && status !== 0;
+    // Did the OS fail to launch the process at all (ENOENT/EACCES/ENOEXEC), or
+    // did the process run and then fail? A launch failure yields neither an
+    // exit status nor a termination signal — the child never started. A
+    // non-zero exit sets `status`; a timeout sets `signal`/`killed`. Only a
+    // true launch failure is the "found but could not be executed" case.
+    const launchFailed = err.status == null && err.signal == null && !err.killed;
     // Probe failures are expected classification signals (stale CLI, desktop
     // app, broken install); callers warn on or surface the detail, so this
     // stays at debug with the full error for deep troubleshooting.
-    logger.debug('SDK', `Probe of "${candidate}" failed: ${firstLine || 'probe failed'}`, { args: [...args] }, error);
-    return { error: firstLine || 'probe failed' };
+    logger.debug('SDK', `Probe of "${candidate}" failed: ${firstLine || 'probe failed'}`, { args: [...args], flagRejection, launchFailed }, error);
+    return { error: firstLine || 'probe failed', flagRejection, launchFailed };
   }
 }
 
@@ -152,6 +173,13 @@ function runProbe(candidate: string, args: readonly string[]): { stdout: string 
  * plain `--version` spawn run, to split "runs but too old" from "doesn't run
  * at all" without pattern-matching stderr wording — so the two-spawn cost is
  * paid only for stale/broken installs, and the result is cached.
+ *
+ * A capability probe that failed WITHOUT flag-rejection evidence (empty
+ * stderr from a timeout or signal kill) is not proof of an old CLI: on a
+ * Windows cold start the first spawn can lose the 10 s race, then the now-warm
+ * plain `--version` returns instantly — which must NOT read as "runs but too
+ * old". So after `--version` warms the binary, the capability probe runs once
+ * more; only real flag rejection classifies the CLI as incompatible.
  */
 function probeCandidate(candidate: string): ProbeResult {
   const capability = runProbe(candidate, CAPABILITY_PROBE_ARGS);
@@ -165,12 +193,33 @@ function probeCandidate(candidate: string): ProbeResult {
   // variants) classifies the same way, so no stderr pattern-matching.
   const plain = runProbe(candidate, ['--version']);
   if ('stdout' in plain && plain.stdout) {
-    const detail = 'error' in capability ? capability.error : 'rejects capability flags';
-    return { kind: 'incompatible', version: plain.stdout, detail };
+    if ('flagRejection' in capability && capability.flagRejection) {
+      return { kind: 'incompatible', version: plain.stdout, detail: capability.error };
+    }
+    // No flag-rejection evidence: the capability probe most likely lost a
+    // cold-start race that the --version spawn just warmed away. Re-probe the
+    // warm binary once before giving up.
+    const warm = runProbe(candidate, CAPABILITY_PROBE_ARGS);
+    if ('stdout' in warm && warm.stdout) {
+      return { kind: 'capable', version: warm.stdout };
+    }
+    if ('flagRejection' in warm && warm.flagRejection) {
+      return { kind: 'incompatible', version: plain.stdout, detail: warm.error };
+    }
+    // Still no flag-rejection proof, only ambiguous failures. Use the binary
+    // rather than throw the misleading "too old" error and strand a CLI that
+    // answers --version; a genuinely old CLI rejects the flag with a non-empty
+    // stderr, which the checks above already catch.
+    return { kind: 'capable', version: plain.stdout };
   }
 
   const detail = 'error' in capability ? capability.error : 'failed --version check';
-  return { kind: 'broken', detail };
+  // The plain --version is the last word on whether this binary can launch:
+  // if it errored on a spawn failure, so did the capability probe (same
+  // binary); if it exited cleanly with no output, `launchFailed` is absent
+  // (it ran, it just gave no version), so default to false.
+  const launchFailed = 'launchFailed' in plain ? plain.launchFailed : false;
+  return { kind: 'broken', detail, launchFailed };
 }
 
 /** Parse "2.1.176 (Claude Code)" → [2, 1, 176]; unparseable sorts lowest. */
@@ -255,6 +304,25 @@ function discoverCandidates(): string[] {
   return deduped;
 }
 
+/**
+ * Describe a configured CLAUDE_CODE_PATH for an error message without ambiguity.
+ *
+ * Telemetry scrubbing rewrites the home directory to `~` before an error
+ * reaches error tracking (see redactHomeDir in
+ * src/services/telemetry/error-scrub.ts), so a real absolute path such as
+ * /home/user/.local/bin/claude arrives tildified and looks exactly like a
+ * literal `~` the user typed into settings — the tilde bug already fixed in
+ * find-claude-executable (expandTilde below). Stating whether the value is the
+ * raw setting or the tilde-expanded one stops a redacted `~` from being read as
+ * a settings `~`, so the next person does not re-fix a fixed bug.
+ */
+function describeConfiguredPath(rawSetting: string, expandedPath: string): string {
+  if (rawSetting === expandedPath) {
+    return `"${rawSetting}" (used verbatim, no tilde expansion)`;
+  }
+  return `"${rawSetting}" (tilde-expanded to "${expandedPath}")`;
+}
+
 function updateInstructions(): string {
   return (
     'Update it (`claude update`, or `npm install -g @anthropic-ai/claude-code@latest` for npm installs), ' +
@@ -291,9 +359,10 @@ export function findClaudeExecutable(logComponent: Component = 'SDK'): string {
     // probe spawn see a real absolute path (SettingsRoutes also normalizes on
     // write; this covers files edited by hand).
     const configuredPath = expandTilde(settings.CLAUDE_CODE_PATH, _internals.homedir());
+    const describedPath = describeConfiguredPath(settings.CLAUDE_CODE_PATH, configuredPath);
     if (!_internals.existsSync(configuredPath)) {
       throw new Error(
-        `CLAUDE_CODE_PATH is set to "${settings.CLAUDE_CODE_PATH}" but the file does not exist.`
+        `CLAUDE_CODE_PATH is set to ${describedPath} but the file does not exist.`
       );
     }
 
@@ -309,19 +378,34 @@ export function findClaudeExecutable(logComponent: Component = 'SDK'): string {
     }
     if (probe.kind === 'incompatible') {
       throw new Error(
-        `CLAUDE_CODE_PATH is set to "${settings.CLAUDE_CODE_PATH}" (${probe.version}) but that CLI is too old for claude-mem — ` +
+        `CLAUDE_CODE_PATH is set to ${describedPath} (${probe.version}) but that CLI is too old for claude-mem — ` +
         `it rejects flags every memory agent spawn requires (${probe.detail}). ${updateInstructions()}`
       );
     }
     if (looksLikeDesktopAppPath(configuredPath)) {
       throw new Error(
-        `Found desktop app at "${settings.CLAUDE_CODE_PATH}" but it doesn't support headless mode. ` +
+        `Found desktop app at ${describedPath} but it doesn't support headless mode. ` +
         `Install Claude Code CLI: npm install -g @anthropic-ai/claude-code`
       );
     }
+    // existsSync passed above, so the file is really there — the probe failed.
+    // Split the two ways that happens. A launch failure (ENOENT from a launcher
+    // whose shebang interpreter is missing, or a native-installer stub pointing
+    // at a deleted version directory) means the OS never ran the file; a
+    // re-check of the path cannot fix it, so name the likely cause. A process
+    // that ran but exited non-zero, timed out, or printed no version is a
+    // different problem — do not claim it "could not be executed".
+    if (probe.launchFailed) {
+      throw new Error(
+        `CLAUDE_CODE_PATH is set to ${describedPath} — the file exists but could not be executed (${probe.detail}). ` +
+        `A launcher script whose interpreter (shebang) is missing, or a native-installer stub pointing at a deleted version directory, fails this way. ` +
+        `Reinstall the Claude Code CLI or point CLAUDE_CODE_PATH at a working binary.`
+      );
+    }
     throw new Error(
-      `CLAUDE_CODE_PATH is set to "${settings.CLAUDE_CODE_PATH}" but it failed the --version check (${probe.detail}). ` +
-      `Ensure this is a working Claude Code CLI binary.`
+      `CLAUDE_CODE_PATH is set to ${describedPath} — the file ran but failed its version probe (${probe.detail}). ` +
+      `It may be the wrong program, or a wrapper that errors before printing a version. ` +
+      `Ensure CLAUDE_CODE_PATH points at a working Claude Code CLI binary.`
     );
   }
 

--- a/tests/shared/find-claude-executable.test.ts
+++ b/tests/shared/find-claude-executable.test.ts
@@ -16,8 +16,16 @@ import { logger } from '../../src/utils/logger.js';
 interface FakeCli {
   version: string;
   supportsDontAsk: boolean;
-  /** Fails every probe (corrupt install / desktop app) — the `broken` branch. */
+  /** Fails to launch on every probe (corrupt install / desktop app) — the `broken` branch. */
   broken?: boolean;
+  /** Launches but exits non-zero on every probe — a `broken` result whose process still ran. */
+  ranButFailed?: boolean;
+  /**
+   * Number of leading capability probes that time out before the binary
+   * responds — models a Windows cold start losing the 10 s race. Plain
+   * `--version` probes always answer (they warm the binary).
+   */
+  capabilityTimeouts?: number;
 }
 
 const ORIGINALS = { ..._internals };
@@ -26,6 +34,8 @@ const ORIGINALS = { ..._internals };
 let fakeClis: Map<string, FakeCli>;
 /** Every execFileSync invocation, for probe-count assertions. */
 let probeCalls: Array<{ path: string; args: string[] }>;
+/** Capability-probe count per path, so `capabilityTimeouts` fires only the first N. */
+let capabilityProbeCounts: Map<string, number>;
 /** Symlink map for realpathSync; identity when absent. */
 let realPaths: Map<string, string>;
 /** stdout of `which -a claude`; null = which fails. */
@@ -52,19 +62,47 @@ function installFakes(options: { settingsPath?: string; platform?: NodeJS.Platfo
     probeCalls.push({ path, args });
     const real = realPaths.get(path) ?? path;
     const cli = fakeClis.get(path) ?? fakeClis.get(real);
+    const isCapabilityProbe = args.includes('--permission-mode');
     if (!cli) {
-      const error = new Error(`spawn ${path} ENOENT`) as Error & { stderr: string };
+      const error = new Error(`spawn ${path} ENOENT`) as Error & { stderr: string; code: string };
       error.stderr = '';
+      error.code = 'ENOENT';
       throw error;
     }
     if (cli.broken) {
+      // Spawn/launch failure: the OS never started the process, so no exit
+      // status or signal is set (mirrors ENOENT/EACCES from execFileSync).
       const error = new Error('Command failed') as Error & { stderr: string };
       error.stderr = 'cannot execute binary file';
       throw error;
     }
-    if (args.includes('--permission-mode') && !cli.supportsDontAsk) {
-      const error = new Error('Command failed') as Error & { stderr: string };
+    if (cli.ranButFailed) {
+      // The process ran and exited non-zero: `status` is set, so this is NOT a
+      // launch failure.
+      const error = new Error('Command failed') as Error & { stderr: string; status: number };
+      error.stderr = 'boom: exiting 17';
+      error.status = 17;
+      throw error;
+    }
+    if (isCapabilityProbe && cli.capabilityTimeouts) {
+      const seen = capabilityProbeCounts.get(path) ?? 0;
+      if (seen < cli.capabilityTimeouts) {
+        capabilityProbeCounts.set(path, seen + 1);
+        // A 10 s timeout kills the spawn with a signal and leaves stderr empty
+        // — no flag-rejection evidence, so it must stay retryable.
+        const error = new Error(`spawnSync ${path} ETIMEDOUT`) as Error & { stderr: string; killed: boolean; signal: string };
+        error.stderr = '';
+        error.killed = true;
+        error.signal = 'SIGTERM';
+        throw error;
+      }
+    }
+    if (isCapabilityProbe && !cli.supportsDontAsk) {
+      // A real flag rejection: the CLI parsed the flag, wrote a diagnostic to
+      // stderr, and exited non-zero.
+      const error = new Error('Command failed') as Error & { stderr: string; status: number };
       error.stderr = "error: option '--permission-mode <mode>' argument 'dontAsk' is invalid. Allowed choices are acceptEdits, bypassPermissions, default, plan.";
+      error.status = 1;
       throw error;
     }
     return `${cli.version} (Claude Code)`;
@@ -75,6 +113,7 @@ beforeEach(() => {
   resetClaudeExecutableCache();
   fakeClis = new Map();
   probeCalls = [];
+  capabilityProbeCounts = new Map();
   realPaths = new Map();
   whichOutput = null;
 });
@@ -156,6 +195,45 @@ describe('findClaudeExecutable candidate selection', () => {
   });
 });
 
+describe('findClaudeExecutable cold-start race', () => {
+  // The reported Windows failure: a current CLI whose first capability probe
+  // times out gets mislabeled "too old". The capability probe must be re-run
+  // on the warm binary, and only real flag rejection may classify it as old.
+  it('selects a current CLI whose first capability probe times out on a cold start', () => {
+    installFakes();
+    whichOutput = '/home/tester/.local/bin/claude\n';
+    fakeClis.set('/home/tester/.local/bin/claude', {
+      version: '2.1.176',
+      supportsDontAsk: true,
+      capabilityTimeouts: 1,
+    });
+
+    expect(findClaudeExecutable('SDK')).toBe('/home/tester/.local/bin/claude');
+  });
+
+  it('does not throw "too old" when a timing-out capability probe leaves no flag-rejection proof', () => {
+    installFakes();
+    whichOutput = '/home/tester/.local/bin/claude\n';
+    // Every capability probe times out, but --version answers — no proof the
+    // CLI rejects the flag, so use it rather than throw the misleading error.
+    fakeClis.set('/home/tester/.local/bin/claude', {
+      version: '2.1.176',
+      supportsDontAsk: true,
+      capabilityTimeouts: 5,
+    });
+
+    expect(findClaudeExecutable('SDK')).toBe('/home/tester/.local/bin/claude');
+  });
+
+  it('still rejects a genuinely old CLI that writes a flag-rejection error to stderr', () => {
+    installFakes();
+    whichOutput = '/opt/homebrew/bin/claude\n';
+    fakeClis.set('/opt/homebrew/bin/claude', { version: '2.0.42', supportsDontAsk: false });
+
+    expect(() => findClaudeExecutable('SDK')).toThrow(/too old/);
+  });
+});
+
 describe('findClaudeExecutable broken candidates', () => {
   // A "broken" install fails BOTH the capability probe and plain --version
   // (corrupt binary, dangling symlink, desktop app). Distinct from
@@ -206,11 +284,25 @@ describe('findClaudeExecutable broken candidates', () => {
     expect(() => findClaudeExecutable('SDK')).toThrow(/Claude executable not found/);
   });
 
-  it('reports a broken configured CLAUDE_CODE_PATH with the probe failure', () => {
+  it('reports a configured CLAUDE_CODE_PATH that exists but cannot be launched', () => {
     installFakes({ settingsPath: '/custom/claude' });
     fakeClis.set('/custom/claude', { version: '0.0.0', supportsDontAsk: false, broken: true });
 
-    expect(() => findClaudeExecutable('SDK')).toThrow(/failed the --version check/);
+    // The file exists (existsSync passes) and the OS could not launch it (no
+    // exit status), so it is reported as "exists but could not be executed" —
+    // not "file does not exist" and not the old dead-end "--version check".
+    expect(() => findClaudeExecutable('SDK')).toThrow(/exists but could not be executed/);
+    expect(() => findClaudeExecutable('SDK')).toThrow(/shebang|native-installer/);
+  });
+
+  it('reports a configured CLAUDE_CODE_PATH that ran but failed its version probe without claiming it could not launch', () => {
+    installFakes({ settingsPath: '/custom/claude' });
+    fakeClis.set('/custom/claude', { version: '0.0.0', supportsDontAsk: false, ranButFailed: true });
+
+    // The process started and exited non-zero, so the launch-failure guidance
+    // (shebang / native-installer stub) must NOT appear.
+    expect(() => findClaudeExecutable('SDK')).toThrow(/ran but failed its version probe/);
+    expect(() => findClaudeExecutable('SDK')).not.toThrow(/could not be executed|shebang|native-installer/);
   });
 
   it('reports a desktop-app CLAUDE_CODE_PATH with CLI install guidance', () => {
@@ -254,6 +346,23 @@ describe('findClaudeExecutable explicit CLAUDE_CODE_PATH', () => {
     expect(findClaudeExecutable('SDK')).toBe('/home/tester/.local/bin/claude');
     // Every spawn must see the expanded path, never the literal tilde.
     expect(probeCalls.every((call) => call.path === '/home/tester/.local/bin/claude')).toBe(true);
+  });
+
+  it('labels a verbatim absolute path as un-expanded so a redacted ~ is not mistaken for a tilde setting', () => {
+    // Telemetry rewrites /home/tester -> ~ before an error is sent, so this
+    // absolute path arrives tildified. The "used verbatim" note tells the
+    // reader no tilde was expanded, so a ~ in the report is redaction.
+    installFakes({ settingsPath: '/home/tester/.local/bin/claude' });
+    fakeClis.set('/home/tester/.local/bin/claude', { version: '0.0.0', supportsDontAsk: false, broken: true });
+
+    expect(() => findClaudeExecutable('SDK')).toThrow(/used verbatim, no tilde expansion/);
+  });
+
+  it('labels a tilde path as expanded in the error so the two forms are visible', () => {
+    installFakes({ settingsPath: '~/.local/bin/claude' });
+    fakeClis.set('/home/tester/.local/bin/claude', { version: '0.0.0', supportsDontAsk: false, broken: true });
+
+    expect(() => findClaudeExecutable('SDK')).toThrow(/tilde-expanded to "\/home\/tester\/\.local\/bin\/claude"/);
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rehost of PostHog PRs #3528 and #3533 onto current `main` (originally ~275 behind). Combined because both change `src/shared/find-claude-executable.ts`. Same-repo so CI can run without first-time-contributor approval.

## Root symptom
Windows users on a **current** Claude Code CLI get hard-blocked with a "too old for claude-mem" error, so capture stops. The capability probe times out on a ~225 MB cold start, then the now-warm `--version` returns instantly — read as "runs, but too old". A related path exists but will not spawn (missing shebang interpreter / stale native-installer stub) and was reported as the already-fixed tilde bug because telemetry redacts `$HOME` to `~`.

## What landed
- Classify a CLI `incompatible` only with real flag-rejection evidence (non-empty stderr, non-zero exit, no signal kill)
- After `--version` warms the binary, re-run the capability probe once
- Ambiguous failures (`--version` works, no flag-rejection proof) use the binary instead of throwing "too old"
- Report "exists but won't spawn" separately from "ran but failed its version probe"
- Label configured paths as verbatim vs tilde-expanded so telemetry-redacted `~` cannot be mistaken for a settings `~`

## Tests
`bun test tests/shared/find-claude-executable.test.ts` — 27 pass / 0 fail

## Credit
Original work by @posthog in #3528 and #3533.

Closes #3528
Closes #3533

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30469fbe-1872-4e43-b006-f3ba0b321789?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30469fbe-1872-4e43-b006-f3ba0b321789&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

