### PR TITLE
fix(install): find bun/uv where their installers actually place them (rehost #3532)

### DIFF
--- a/src/npx-cli/install/setup-runtime.ts
+++ b/src/npx-cli/install/setup-runtime.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs';
-import { exec, execSync, spawnSync, type SpawnSyncOptionsWithStringEncoding } from 'child_process';
+import { execFile, execSync, spawnSync, type SpawnSyncOptionsWithStringEncoding } from 'child_process';
 import { createRequire } from 'module';
 import { join } from 'path';
 import { homedir } from 'os';
@@ -9,6 +9,7 @@ import { USER_SETTINGS_PATH } from '../../shared/paths.js';
 import { buildSpawnSyncInvocation, lookupWindowsCommand } from '../../shared/spawn.js';
 import { IS_WINDOWS } from '../utils/paths.js';
 import { parseJsonWithBom } from '../../shared/atomic-json.js';
+import { getUvxBinDirs } from '../../shared/uvx-bin-dirs.js';
 
 const INSTALL_TIMEOUT_MS = (() => {
   const override = process.env.CLAUDE_MEM_INSTALL_TIMEOUT_MS;
@@ -53,13 +54,37 @@ function userHasOptedOutOfVectorSearch(): boolean {
   return value === true || value === 'true' || value === '1';
 }
 
-const BUN_COMMON_PATHS = IS_WINDOWS
-  ? [join(homedir(), '.bun', 'bin', 'bun.exe')]
-  : [join(homedir(), '.bun', 'bin', 'bun'), '/usr/local/bin/bun', '/opt/homebrew/bin/bun', '/home/linuxbrew/.linuxbrew/bin/bun'];
+/**
+ * Absolute paths bun's installer can write to, recomputed per call so an
+ * installer that set `$BUN_INSTALL` earlier in this process is still found.
+ * Honours `$BUN_INSTALL`, both `homedir()` and `%USERPROFILE%` (which differ on
+ * redirected Windows profiles), `%LOCALAPPDATA%\bun`, and the platform defaults.
+ * The previous `homedir()`-only list missed env-directed installs and aborted
+ * with "executable not found" even when the binary was present.
+ */
+export function bunCommonPaths(env: NodeJS.ProcessEnv = process.env): string[] {
+  const binName = IS_WINDOWS ? 'bun.exe' : 'bun';
+  const homeRoots = [homedir(), env.USERPROFILE].filter((v): v is string => Boolean(v));
+  const localAppData = IS_WINDOWS && env.LOCALAPPDATA
+    ? [join(env.LOCALAPPDATA, 'bun', binName), join(env.LOCALAPPDATA, 'bun', 'bin', binName)]
+    : [];
+  const systemPaths = IS_WINDOWS
+    ? []
+    : ['/usr/local/bin/bun', '/opt/homebrew/bin/bun', '/home/linuxbrew/.linuxbrew/bin/bun', '/usr/bin/bun', '/snap/bin/bun'];
+  const candidates = [
+    ...(env.BUN_INSTALL ? [join(env.BUN_INSTALL, 'bin', binName)] : []),
+    ...homeRoots.map(root => join(root, '.bun', 'bin', binName)),
+    ...localAppData,
+    ...systemPaths,
+  ];
+  return [...new Set(candidates)];
+}
 
-const UV_COMMON_PATHS = IS_WINDOWS
-  ? [join(homedir(), '.local', 'bin', 'uv.exe'), join(homedir(), '.cargo', 'bin', 'uv.exe')]
-  : [join(homedir(), '.local', 'bin', 'uv'), join(homedir(), '.cargo', 'bin', 'uv'), '/usr/local/bin/uv', '/opt/homebrew/bin/uv'];
+/** Absolute paths uv's installer can write to (getUvxBinDirs already dedupes). */
+export function uvCommonPaths(env: NodeJS.ProcessEnv = process.env): string[] {
+  const binName = IS_WINDOWS ? 'uv.exe' : 'uv';
+  return getUvxBinDirs({ env }).map(dir => join(dir, binName));
+}
 
 interface MarkerSchema {
   version: string;
@@ -99,7 +124,7 @@ function getToolPath(command: string, commonPaths: string[]): string | null {
 }
 
 export function getBunPath(): string | null {
-  return getToolPath('bun', BUN_COMMON_PATHS);
+  return getToolPath('bun', bunCommonPaths());
 }
 
 function isBunInstalled(): boolean {
@@ -121,7 +146,7 @@ export function getBunVersion(): string | null {
 }
 
 function getUvPath(): string | null {
-  return getToolPath('uv', UV_COMMON_PATHS);
+  return getToolPath('uv', uvCommonPaths());
 }
 
 function isUvInstalled(): boolean {
@@ -326,7 +351,7 @@ export async function ensureBun(summary?: InstallSummary): Promise<{ bunPath: st
 
   let bunPath = getBunPath();
   if (!bunPath) {
-    bunPath = BUN_COMMON_PATHS.find(existsSync) ?? null;
+    bunPath = bunCommonPaths().find(existsSync) ?? null;
   }
   if (!bunPath) {
     installerError(ErrorSeverity.ABORT, {
@@ -385,9 +410,10 @@ export async function ensureUv(
 
   let uvPath = getUvPath();
   if (!uvPath) {
-    // Re-probe UV_COMMON_PATHS directly — PATH may not yet include ~/.local/bin
-    // in the current shell even though the install just wrote the binary there.
-    uvPath = UV_COMMON_PATHS.find(existsSync) ?? null;
+    // Re-probe the known uv bin dirs directly — PATH may not yet include
+    // ~/.local/bin in the current shell even though the install just wrote the
+    // binary there.
+    uvPath = uvCommonPaths().find(existsSync) ?? null;
   }
   if (!uvPath) {
     if (options.allowVectorSearchOptOut && userHasOptedOutOfVectorSearch()) {
@@ -428,23 +454,23 @@ export async function installPluginDependencies(targetDir: string, bunPath: stri
     throw new Error(`installPluginDependencies: no package.json at ${targetDir}`);
   }
 
-  const bunCmd = IS_WINDOWS && bunPath.includes(' ') ? `"${bunPath}"` : bunPath;
-
   // Per CHANGELOG v12.6.1 -> v12.6.2: tree-sitter-swift's nested
   // tree-sitter-cli postinstall downloads a Rust binary and can hang the
   // install. Bun honors trustedDependencies; npm does not. We additionally
   // pass --ignore-scripts as belt-and-suspenders and bound it with a timeout.
-  // Async exec (not execSync): a blocked event loop freezes the installer's
-  // clack spinner for the duration of the install, which reads as a stall.
+  // Async execFile (not execFileSync): a blocked event loop freezes the
+  // installer's clack spinner for the duration of the install, which reads as a
+  // stall. execFile (not exec) passes bunPath as argv[0] with no shell, so a
+  // resolved path with spaces or shell metacharacters is never parsed.
   const runBunInstall = (): Promise<void> =>
     new Promise<void>((resolve, reject) => {
-      exec(`${bunCmd} install --frozen-lockfile --ignore-scripts`, {
+      execFile(bunPath, ['install', '--frozen-lockfile', '--ignore-scripts'], {
         cwd: targetDir,
         timeout: INSTALL_TIMEOUT_MS,
         maxBuffer: 16 * 1024 * 1024,
-        ...(IS_WINDOWS ? { shell: process.env.ComSpec ?? 'cmd.exe' } : {}),
+        ...(IS_WINDOWS ? { windowsHide: true } : {}),
       }, (error, stdout, stderr) =>
-        // exec errors don't carry stdio; attach so describeExecError can report it.
+        // execFile errors don't carry stdio; attach so describeExecError can report it.
         error ? reject(Object.assign(error, { stdout, stderr })) : resolve());
     });
 

--- a/src/shared/uvx-bin-dirs.ts
+++ b/src/shared/uvx-bin-dirs.ts
@@ -7,6 +7,7 @@ export interface UvxBinDirOptions {
   homedir?: () => string;
   platform?: NodeJS.Platform;
   isFile?: (filePath: string) => boolean;
+  env?: Record<string, string | undefined>;
 }
 
 function defaultIsFile(filePath: string): boolean {
@@ -17,18 +18,36 @@ function defaultIsFile(filePath: string): boolean {
   }
 }
 
+/**
+ * Directories the astral uv installer can place `uv`/`uvx` in, honouring the
+ * env vars the installer itself consults: the first of `UV_INSTALL_DIR`,
+ * `XDG_BIN_HOME`, `XDG_DATA_HOME/../bin`, then `$HOME/.local/bin`. Hard-coding
+ * only `~/.local/bin` and `~/.cargo/bin` missed every env-directed install.
+ */
 export function getUvxBinDirs(options: UvxBinDirOptions = {}): string[] {
-  const override = options.override ?? process.env.CLAUDE_MEM_CHROMA_UVX_PATH;
+  const env = options.env ?? process.env;
+  const override = options.override ?? env.CLAUDE_MEM_CHROMA_UVX_PATH;
   const homedir = options.homedir ?? os.homedir;
   const platform = options.platform ?? process.platform;
   const isFile = options.isFile ?? defaultIsFile;
   const home = homedir();
+
+  const xdgDataBin = env.XDG_DATA_HOME
+    ? path.join(env.XDG_DATA_HOME, '..', 'bin')
+    : undefined;
+
   const dirs = [
     override,
+    env.UV_INSTALL_DIR,
+    env.XDG_BIN_HOME,
+    xdgDataBin,
     path.join(home, '.local', 'bin'),
     path.join(home, '.cargo', 'bin'),
+    // Linux `/usr/local/bin` and `/usr/bin` are omitted on purpose — they are
+    // already on PATH, so the caller's PATH lookup covers system-package uv.
     ...(platform === 'darwin' ? ['/opt/homebrew/bin', '/usr/local/bin'] : []),
   ].filter((dir): dir is string => Boolean(dir));
 
-  return dirs.map(dir => isFile(dir) ? path.dirname(dir) : dir);
+  const resolved = dirs.map(dir => isFile(dir) ? path.dirname(dir) : dir);
+  return [...new Set(resolved)];
 }

--- a/tests/setup-runtime.test.ts
+++ b/tests/setup-runtime.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'fs';
+import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync, chmodSync } from 'fs';
 import { spawnSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -9,7 +9,11 @@ import {
   isInstallCurrent,
   platformBunRemediation,
   platformUvRemediation,
+  bunCommonPaths,
+  uvCommonPaths,
+  installPluginDependencies,
 } from '../src/npx-cli/install/setup-runtime';
+import { IS_WINDOWS } from '../src/npx-cli/utils/paths';
 
 const SETUP_RUNTIME_SOURCE_PATH = join(import.meta.dir, '..', 'src', 'npx-cli', 'install', 'setup-runtime.ts');
 const SHARED_SPAWN_SOURCE_PATH = join(import.meta.dir, '..', 'src', 'shared', 'spawn.ts');
@@ -153,6 +157,68 @@ describe('setup-runtime install marker', () => {
       expect(text.toLowerCase()).toContain('uv');
       expect(text).toContain('claude-mem install');
     });
+  });
+});
+
+describe('setup-runtime binary detection honours installer env vars', () => {
+  const bunName = IS_WINDOWS ? 'bun.exe' : 'bun';
+  const uvName = IS_WINDOWS ? 'uv.exe' : 'uv';
+
+  it('bunCommonPaths honours BUN_INSTALL', () => {
+    const paths = bunCommonPaths({ BUN_INSTALL: '/opt/bun' });
+    expect(paths).toContain(join('/opt/bun', 'bin', bunName));
+  });
+
+  it('uvCommonPaths honours UV_INSTALL_DIR', () => {
+    const paths = uvCommonPaths({ UV_INSTALL_DIR: '/opt/uv/bin' });
+    expect(paths).toContain(join('/opt/uv/bin', uvName));
+  });
+
+  it('uvCommonPaths honours XDG_BIN_HOME', () => {
+    const paths = uvCommonPaths({ XDG_BIN_HOME: '/xdg/bin' });
+    expect(paths).toContain(join('/xdg/bin', uvName));
+  });
+
+  it('bunCommonPaths returns absolute paths and no duplicates', () => {
+    const paths = bunCommonPaths({ BUN_INSTALL: '/opt/bun' });
+    expect(paths.length).toBe(new Set(paths).size);
+    expect(paths.every(p => p.length > 0)).toBe(true);
+  });
+});
+
+describe('installPluginDependencies passes the bun path as an argument, not through a shell', () => {
+  // The bun path now flows from installer env vars (e.g. $BUN_INSTALL) that can
+  // hold spaces or shell metacharacters. execFile must pass it as argv[0] so it
+  // never reaches a shell.
+  it('runs a bun path containing spaces and injection syntax without evaluating it', async () => {
+    if (IS_WINDOWS) return; // POSIX fake-bin shell script
+
+    const unique = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const marker = join(tmpdir(), `pwned-${unique}`);
+    // The bun executable lives in a dir whose name has a space and injection
+    // syntax; its output goes to a clean path so the fake script's own redirect
+    // is never the thing under test.
+    const base = join(tmpdir(), `bun space $(touch ${marker}) ${unique}`);
+    const targetDir = join(base, 'target');
+    const argsFile = join(tmpdir(), `args-${unique}.txt`);
+    mkdirSync(targetDir, { recursive: true });
+    writeFileSync(join(targetDir, 'package.json'), JSON.stringify({ dependencies: {} }));
+
+    const fakeBun = join(base, 'bun');
+    writeFileSync(fakeBun, `#!/bin/sh\nprintf '%s\\n' "$@" > "${argsFile}"\nexit 0\n`);
+    chmodSync(fakeBun, 0o755);
+
+    try {
+      await installPluginDependencies(targetDir, fakeBun);
+      const recorded = readFileSync(argsFile, 'utf-8').trim().split('\n');
+      expect(recorded).toEqual(['install', '--frozen-lockfile', '--ignore-scripts']);
+      // The $(touch ...) in the path must NOT have executed.
+      expect(existsSync(marker)).toBe(false);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+      rmSync(marker, { force: true });
+      rmSync(argsFile, { force: true });
+    }
   });
 });
 

--- a/tests/shared/uvx-bin-dirs.test.ts
+++ b/tests/shared/uvx-bin-dirs.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'bun:test';
+import { join } from 'path';
+import { getUvxBinDirs } from '../../src/shared/uvx-bin-dirs.js';
+
+const HOME = '/home/tester';
+const opts = (env: Record<string, string | undefined>) => ({
+  homedir: () => HOME,
+  platform: 'linux' as NodeJS.Platform,
+  isFile: () => false,
+  env,
+});
+
+describe('getUvxBinDirs installer env-var honouring', () => {
+  it('always includes the default ~/.local/bin and ~/.cargo/bin', () => {
+    const dirs = getUvxBinDirs(opts({}));
+    expect(dirs).toContain(join(HOME, '.local', 'bin'));
+    expect(dirs).toContain(join(HOME, '.cargo', 'bin'));
+  });
+
+  it('honours UV_INSTALL_DIR', () => {
+    const dirs = getUvxBinDirs(opts({ UV_INSTALL_DIR: '/opt/uv/bin' }));
+    expect(dirs).toContain('/opt/uv/bin');
+  });
+
+  it('honours XDG_BIN_HOME', () => {
+    const dirs = getUvxBinDirs(opts({ XDG_BIN_HOME: '/home/tester/.xdgbin' }));
+    expect(dirs).toContain('/home/tester/.xdgbin');
+  });
+
+  it('appends ../bin to XDG_DATA_HOME', () => {
+    const dirs = getUvxBinDirs(opts({ XDG_DATA_HOME: '/home/tester/.xdgdata' }));
+    expect(dirs).toContain(join('/home/tester/.xdgdata', '..', 'bin'));
+  });
+
+  it('honours the CLAUDE_MEM_CHROMA_UVX_PATH override', () => {
+    const dirs = getUvxBinDirs(opts({ CLAUDE_MEM_CHROMA_UVX_PATH: '/custom/bin' }));
+    expect(dirs).toContain('/custom/bin');
+  });
+
+  it('deduplicates repeated dirs', () => {
+    const dirs = getUvxBinDirs(opts({ UV_INSTALL_DIR: join(HOME, '.local', 'bin') }));
+    expect(dirs.filter(d => d === join(HOME, '.local', 'bin')).length).toBe(1);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rehost of PostHog PR #3532 onto current `main` (originally ~275 behind). Same-repo so CI can run without first-time-contributor approval.

## Root symptom
New users hit `install_failed` (`bun-missing-after-install` / `uv-missing-after-install`), and 2,659 distinct users later hit `uvx executable not found`. Detection only looked under `os.homedir()`. The installers write elsewhere when `BUN_INSTALL`, `UV_INSTALL_DIR`, `XDG_BIN_HOME`, `XDG_DATA_HOME`, or `%LOCALAPPDATA%` are set.

## What landed
- `getUvxBinDirs` honours the uv installer's own precedence (`UV_INSTALL_DIR` → `XDG_BIN_HOME` → `XDG_DATA_HOME/../bin` → `~/.local/bin`)
- `bunCommonPaths` honours `$BUN_INSTALL`, `%LOCALAPPDATA%\bun`, and `%USERPROFILE%` next to `homedir()`
- `installPluginDependencies` uses `execFile` so a bun path with spaces/metacharacters is never parsed by a shell

## Tests
`bun test tests/setup-runtime.test.ts tests/shared/uvx-bin-dirs.test.ts` — 27 pass / 0 fail

## Credit
Original work by @posthog in #3532.

Closes #3532

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30469fbe-1872-4e43-b006-f3ba0b321789?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30469fbe-1872-4e43-b006-f3ba0b321789&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

