### PR TITLE
fix(worker): stop ENOENT crash when Bun runtime path is bad (rehost #3539)

### DIFF
--- a/src/services/infrastructure/ProcessManager.ts
+++ b/src/services/infrastructure/ProcessManager.ts
@@ -1,7 +1,7 @@
 
 import path from 'path';
 import { homedir } from 'os';
-import { existsSync, writeFileSync, readFileSync, unlinkSync, mkdirSync, statSync, utimesSync, copyFileSync } from 'fs';
+import { existsSync, writeFileSync, readFileSync, unlinkSync, mkdirSync, statSync, utimesSync, copyFileSync, realpathSync } from 'fs';
 import { execSync, spawnSync } from 'child_process';
 import { spawnHidden } from '../../shared/spawn.js';
 import { logger } from '../../utils/logger.js';
@@ -14,6 +14,9 @@ import { paths } from '../../shared/paths.js';
 const DATA_DIR = paths.dataDir();
 const PID_FILE = paths.workerPid();
 
+const BUN_NOT_FOUND_MESSAGE =
+  'Bun runtime not found — install from https://bun.sh and ensure it is on PATH or set BUN env var. The worker daemon requires Bun because it uses bun:sqlite.';
+
 interface RuntimeResolverOptions {
   platform?: NodeJS.Platform;
   execPath?: string;
@@ -21,6 +24,15 @@ interface RuntimeResolverOptions {
   homeDirectory?: string;
   pathExists?: (candidatePath: string) => boolean;
   lookupInPath?: (binaryName: string, platform: NodeJS.Platform) => string | null;
+  realpath?: (candidatePath: string) => string | null;
+}
+
+function resolveRealPath(candidatePath: string): string | null {
+  try {
+    return realpathSync(candidatePath);
+  } catch {
+    return null;
+  }
 }
 
 function isBunExecutablePath(executablePath: string | undefined | null): boolean {
@@ -84,6 +96,7 @@ function resolveWorkerRuntimePathUncached(options: RuntimeResolverOptions): stri
   const homeDirectory = options.homeDirectory ?? homedir();
   const pathExists = options.pathExists ?? existsSync;
   const lookupInPath = options.lookupInPath ?? lookupBinaryInPath;
+  const realpath = options.realpath ?? resolveRealPath;
 
   const candidatePaths: (string | undefined)[] = platform === 'win32'
     ? [
@@ -94,6 +107,7 @@ function resolveWorkerRuntimePathUncached(options: RuntimeResolverOptions): stri
         env.USERPROFILE ? path.join(env.USERPROFILE, '.bun', 'bin', 'bun.exe') : undefined,
         env.LOCALAPPDATA ? path.join(env.LOCALAPPDATA, 'bun', 'bun.exe') : undefined,
         env.LOCALAPPDATA ? path.join(env.LOCALAPPDATA, 'bun', 'bin', 'bun.exe') : undefined,
+        env.npm_config_prefix ? path.join(env.npm_config_prefix, 'bun.exe') : undefined, // npm -g install path
       ]
     : [
         env.BUN,
@@ -104,6 +118,7 @@ function resolveWorkerRuntimePathUncached(options: RuntimeResolverOptions): stri
         '/home/linuxbrew/.linuxbrew/bin/bun',
         '/usr/bin/bun', // Debian/Ubuntu apt install path
         '/snap/bin/bun', // Ubuntu Snap install path
+        env.npm_config_prefix ? path.join(env.npm_config_prefix, 'bin', 'bun') : undefined, // npm -g install path
       ];
 
   for (const candidate of candidatePaths) {
@@ -119,7 +134,17 @@ function resolveWorkerRuntimePathUncached(options: RuntimeResolverOptions): stri
     }
   }
 
-  return lookupInPath('bun', platform);
+  // PATH fallback. `which bun` returns a path that is on PATH but may be a
+  // dangling npm/nvm shim — the `bun` package's bin symlink whose real binary
+  // never downloaded. Guard it the same way the explicit candidates are
+  // guarded, resolving symlinks so a shim pointing at a missing target is
+  // rejected instead of returned (a bad path here later crashes the spawn).
+  const pathFallback = lookupInPath('bun', platform)?.trim();
+  if (!pathFallback || !isBunExecutablePath(pathFallback)) {
+    return null;
+  }
+  const realFallback = realpath(pathFallback) ?? pathFallback;
+  return pathExists(realFallback) ? realFallback : null;
 }
 
 import {
@@ -505,10 +530,7 @@ export function spawnDaemon(
 
   const runtimePath = resolveWorkerRuntimePath();
   if (!runtimePath) {
-    logger.error(
-      'SYSTEM',
-      'Bun runtime not found — install from https://bun.sh and ensure it is on PATH or set BUN env var. The worker daemon requires Bun because it uses bun:sqlite.'
-    );
+    logger.error('SYSTEM', BUN_NOT_FOUND_MESSAGE);
     return undefined;
   }
 
@@ -548,6 +570,15 @@ export function spawnDaemon(
     stdio: 'ignore',
     cwd: daemonWorkingDirectory(),
     env
+  });
+
+  // Node reports a bad runtime path (dangling shim, missing binary) as an
+  // asynchronous 'error' event, not a synchronous throw. Without this listener
+  // that ENOENT escapes as an uncaught exception in this long-lived process.
+  // Degrade to the Bun-not-found log; the caller sees the failure through the
+  // worker never binding its port.
+  child.on('error', (error: Error) => {
+    logger.error('SYSTEM', BUN_NOT_FOUND_MESSAGE, { runtimePath, execPath }, error);
   });
 
   if (child.pid === undefined) {

--- a/src/shared/worker-utils.ts
+++ b/src/shared/worker-utils.ts
@@ -699,6 +699,15 @@ export async function ensureWorkerRunning(): Promise<boolean> {
           // folder against rename or move long after the session ends (#3706).
           cwd: DATA_DIR,
         });
+        // A bad runtime path (dangling npm/nvm shim, missing binary) is
+        // reported by Node as an asynchronous 'error' event, which the
+        // synchronous try/catch below can never see. Without this listener the
+        // ENOENT escapes as an uncaught exception and takes down the worker
+        // mid session-end, silently stopping summarization. Log and let the
+        // readiness wait below report the failure.
+        proc.on('error', (error: Error) => {
+          logger.error('SYSTEM', 'Lazy-spawn of worker failed', { runtimePath, scriptPath }, error);
+        });
         proc.unref();
       } catch (error: unknown) {
         if (error instanceof Error) {
@@ -807,6 +816,9 @@ async function ensureWorkerReadyWithin(timeoutMs: number): Promise<boolean> {
       const proc = spawnHidden(runtimePath, [scriptPath, '--daemon'], {
         detached: true,
         stdio: ['ignore', 'ignore', 'ignore'],
+      });
+      proc.on('error', (error: Error) => {
+        logger.error('SYSTEM', 'Bounded worker startup spawn failed', { runtimePath, scriptPath }, error);
       });
       proc.unref();
     }

--- a/tests/infrastructure/process-manager.test.ts
+++ b/tests/infrastructure/process-manager.test.ts
@@ -346,11 +346,69 @@ describe('ProcessManager', () => {
         execPath: '/usr/bin/node',
         env: {} as NodeJS.ProcessEnv,
         homeDirectory: '/home/alice',
-        pathExists: () => false,
-        lookupInPath: () => '/custom/bin/bun'
+        pathExists: candidatePath => candidatePath === '/custom/bin/bun',
+        lookupInPath: () => '/custom/bin/bun',
+        realpath: candidatePath => candidatePath
       });
 
       expect(resolved).toBe('/custom/bin/bun');
+    });
+
+    it('should reject a dangling PATH fallback that resolves to a missing binary', () => {
+      // Reproduces the reported crash source: `which bun` returns an npm/nvm
+      // shim that is on PATH but whose real binary never landed. The unguarded
+      // fallback returned it verbatim; the guard now rejects it.
+      const resolved = resolveWorkerRuntimePath({
+        platform: 'linux',
+        execPath: '/usr/bin/node',
+        env: {} as NodeJS.ProcessEnv,
+        homeDirectory: '/home/alice',
+        pathExists: () => false,
+        lookupInPath: () => '/home/alice/.config/nvm/versions/node/v24.16.0/lib/node_modules/bun/bin/bun',
+        realpath: () => null
+      });
+
+      expect(resolved).toBeNull();
+    });
+
+    it('should reject a PATH fallback that is not a Bun executable', () => {
+      const resolved = resolveWorkerRuntimePath({
+        platform: 'linux',
+        execPath: '/usr/bin/node',
+        env: {} as NodeJS.ProcessEnv,
+        homeDirectory: '/home/alice',
+        pathExists: () => false,
+        lookupInPath: () => '/usr/bin/node'
+      });
+
+      expect(resolved).toBeNull();
+    });
+
+    it('should return the resolved real path when the PATH fallback is a symlink', () => {
+      const resolved = resolveWorkerRuntimePath({
+        platform: 'linux',
+        execPath: '/usr/bin/node',
+        env: {} as NodeJS.ProcessEnv,
+        homeDirectory: '/home/alice',
+        pathExists: candidatePath => candidatePath === '/home/alice/.bun/bin/bun',
+        lookupInPath: () => '/usr/local/bin/bun',
+        realpath: () => '/home/alice/.bun/bin/bun'
+      });
+
+      expect(resolved).toBe('/home/alice/.bun/bin/bun');
+    });
+
+    it('should resolve an npm-global Bun from npm_config_prefix', () => {
+      const resolved = resolveWorkerRuntimePath({
+        platform: 'linux',
+        execPath: '/usr/bin/node',
+        env: { npm_config_prefix: '/home/alice/.npm-global' } as NodeJS.ProcessEnv,
+        homeDirectory: '/home/alice',
+        pathExists: candidatePath => candidatePath === '/home/alice/.npm-global/bin/bun',
+        lookupInPath: () => null
+      });
+
+      expect(resolved).toBe('/home/alice/.npm-global/bin/bun');
     });
 
     it('should return null on non-Windows when Bun cannot be resolved', () => {
@@ -392,8 +450,9 @@ describe('ProcessManager', () => {
         platform: 'win32',
         execPath: 'C:\\Program Files\\nodejs\\node.exe',
         env: {} as NodeJS.ProcessEnv,
-        pathExists: () => false,
-        lookupInPath: () => 'C:\\Program Files\\Bun\\bun.exe'
+        pathExists: candidatePath => candidatePath === 'C:\\Program Files\\Bun\\bun.exe',
+        lookupInPath: () => 'C:\\Program Files\\Bun\\bun.exe',
+        realpath: candidatePath => candidatePath
       });
 
       expect(resolved).toBe('C:\\Program Files\\Bun\\bun.exe');

--- a/tests/shared/worker-utils-version-recycle.test.ts
+++ b/tests/shared/worker-utils-version-recycle.test.ts
@@ -57,7 +57,7 @@ mock.module('../../src/shared/spawn.js', () => ({
   spawnHidden: (command: string, args: string[]) => {
     spawnCalls.push({ command, args });
     successorUp = true;
-    return { pid: 5151, unref: () => {} };
+    return { pid: 5151, unref: () => {}, on: () => {} };
   },
 }));
 

--- a/tests/shared/worker-utils-zombie-port.test.ts
+++ b/tests/shared/worker-utils-zombie-port.test.ts
@@ -50,7 +50,7 @@ mock.module('../../src/supervisor/index.js', () => ({
 mock.module('../../src/shared/spawn.js', () => ({
   spawnHidden: (command: string, args: string[]) => {
     spawnCalls.push({ command, args });
-    return { pid: 5151, unref: () => {} };
+    return { pid: 5151, unref: () => {}, on: () => {} };
   },
 }));
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rehost of PostHog PR #3539 onto current `main` (originally ~275 behind). Same-repo so CI can run without first-time-contributor approval.

## Root symptom
A Bun install that resolves to a missing binary (npm/nvm shim whose real binary never downloaded) took down the long-lived worker during session end. Memories stopped being written. `resolveWorkerRuntimePath` returned the raw `which bun` path with no existence check, and detached spawns had no `error` listener — Node reports a bad executable as an async event the sync try/catch never sees.

## What landed
- Guard the PATH fallback the same way explicit candidates are guarded (reject missing / non-Bun paths; resolve symlinks)
- Add `npm_config_prefix` to the runtime candidate list
- Attach `error` listeners on detached spawns (`spawnDaemon`, lazy-spawn, bounded startup) so ENOENT logs and fails cleanly

## Tests
`bun test tests/infrastructure/process-manager.test.ts tests/shared/worker-utils-version-recycle.test.ts` — 79 pass / 0 fail

## Credit
Original work by @posthog in #3539.

Closes #3539

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30469fbe-1872-4e43-b006-f3ba0b321789?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30469fbe-1872-4e43-b006-f3ba0b321789&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

