### PR TITLE
fix(settings): normalize localhost worker host to 127.0.0.1 (rehost #3436)

### DIFF
--- a/scripts/bug-report/collector.ts
+++ b/scripts/bug-report/collector.ts
@@ -247,7 +247,9 @@ export async function collectDiagnostics(
 
   const pidInfo = await readPidFile(dataDir);
   const workerSettings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
-  const workerHost = process.env.CLAUDE_MEM_WORKER_HOST || workerSettings.CLAUDE_MEM_WORKER_HOST;
+  // loadFromFile already applies env overrides and normalizes 'localhost' to
+  // 127.0.0.1 (#2992); a raw process.env read here would bypass both.
+  const workerHost = workerSettings.CLAUDE_MEM_WORKER_HOST;
   const configuredWorkerPort = process.env.CLAUDE_MEM_WORKER_PORT || workerSettings.CLAUDE_MEM_WORKER_PORT;
   const workerPort = typeof pidInfo?.port === "number"
     ? pidInfo.port

--- a/scripts/check-pending-queue.ts
+++ b/scripts/check-pending-queue.ts
@@ -8,7 +8,9 @@ const DEFAULT_WORKER_HOST = workerSettings.CLAUDE_MEM_WORKER_HOST;
 const DEFAULT_WORKER_PORT = workerSettings.CLAUDE_MEM_WORKER_PORT;
 
 function resolveWorkerHost(): string {
-  return process.env.CLAUDE_MEM_WORKER_HOST || DEFAULT_WORKER_HOST;
+  // loadFromFile already applies env overrides and normalizes 'localhost'
+  // to 127.0.0.1 (#2992); a raw process.env read here would bypass both.
+  return DEFAULT_WORKER_HOST;
 }
 
 function resolveWorkerPort(): string {

--- a/scripts/export-memories.ts
+++ b/scripts/export-memories.ts
@@ -50,7 +50,7 @@ async function fetchWithTimeout(url: string, init?: RequestInit): Promise<Respon
 export async function exportMemories(query: string, outputFile: string, project?: string) {
   const settings = SettingsDefaultsManager.loadFromFile(join(resolveDataDir(), 'settings.json'));
   const port = parseWorkerPort(settings.CLAUDE_MEM_WORKER_PORT);
-  const baseUrl = `http://localhost:${port}`;
+  const baseUrl = `http://${settings.CLAUDE_MEM_WORKER_HOST}:${port}`;
 
   console.log(`🔍 Searching for: "${query}"${project ? ` (project: ${project})` : ' (all projects)'}`);
 

--- a/scripts/import-memories.ts
+++ b/scripts/import-memories.ts
@@ -5,7 +5,9 @@ import { SettingsDefaultsManager } from '../src/shared/SettingsDefaultsManager.j
 import { USER_SETTINGS_PATH } from '../src/shared/paths.js';
 
 const workerSettings = SettingsDefaultsManager.loadFromFile(USER_SETTINGS_PATH);
-const WORKER_HOST = process.env.CLAUDE_MEM_WORKER_HOST || workerSettings.CLAUDE_MEM_WORKER_HOST;
+// loadFromFile already applies env overrides and normalizes 'localhost' to
+// 127.0.0.1 (#2992); a raw process.env read here would bypass both.
+const WORKER_HOST = workerSettings.CLAUDE_MEM_WORKER_HOST;
 const WORKER_PORT = process.env.CLAUDE_MEM_WORKER_PORT || workerSettings.CLAUDE_MEM_WORKER_PORT;
 const WORKER_URL = `http://${WORKER_HOST}:${WORKER_PORT}`;
 

--- a/src/shared/SettingsDefaultsManager.ts
+++ b/src/shared/SettingsDefaultsManager.ts
@@ -286,7 +286,25 @@ export class SettingsDefaultsManager {
   }
 
   static get(key: keyof SettingsDefaults): string {
-    return process.env[key] ?? this.DEFAULTS[key];
+    const value = process.env[key] ?? this.DEFAULTS[key];
+    if (key === 'CLAUDE_MEM_WORKER_HOST') {
+      return this.normalizeWorkerHost(value);
+    }
+    return value;
+  }
+
+  // 'localhost' resolves IPv6-first on modern Windows resolvers while
+  // server.listen(port, 'localhost') binds ::1 only, so the hook client and
+  // the worker can land on different loopback families (#2992). Pin the
+  // documented IPv4 loopback so every consumer of the setting agrees.
+  private static normalizeWorkerHost(host: string): string {
+    return host === 'localhost' ? '127.0.0.1' : host;
+  }
+
+  private static finalizeSettings(settings: SettingsDefaults, applyEnvOverrides: boolean): SettingsDefaults {
+    const result = applyEnvOverrides ? this.applyEnvOverrides(settings) : settings;
+    result.CLAUDE_MEM_WORKER_HOST = this.normalizeWorkerHost(result.CLAUDE_MEM_WORKER_HOST);
+    return result;
   }
 
   static getInt(key: keyof SettingsDefaults): number {
@@ -317,7 +335,7 @@ export class SettingsDefaultsManager {
         } catch (error: unknown) {
           console.warn('[SETTINGS] Failed to create settings file, using in-memory defaults:', settingsPath, error instanceof Error ? error.message : String(error));
         }
-        return applyEnvOverrides ? this.applyEnvOverrides(defaults) : defaults;
+        return this.finalizeSettings(defaults, applyEnvOverrides);
       }
 
       const settingsData = readFileSync(settingsPath, 'utf-8');
@@ -370,11 +388,11 @@ export class SettingsDefaultsManager {
         }
       }
 
-      return applyEnvOverrides ? this.applyEnvOverrides(result) : result;
+      return this.finalizeSettings(result, applyEnvOverrides);
     } catch (error: unknown) {
       console.warn('[SETTINGS] Failed to load settings, using defaults:', settingsPath, error instanceof Error ? error.message : String(error));
       const defaults = this.getAllDefaults();
-      return applyEnvOverrides ? this.applyEnvOverrides(defaults) : defaults;
+      return this.finalizeSettings(defaults, applyEnvOverrides);
     }
   }
 }

--- a/tests/infrastructure/health-monitor.test.ts
+++ b/tests/infrastructure/health-monitor.test.ts
@@ -309,6 +309,23 @@ describe('HealthMonitor', () => {
     });
 
     it('should honor configured worker host when polling health', async () => {
+      process.env.CLAUDE_MEM_WORKER_HOST = '127.0.0.2';
+      const fetchMock = mock(() => Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve('')
+      } as unknown as Response));
+      global.fetch = fetchMock;
+
+      await waitForHealth(37777, 1000);
+
+      expect(fetchMock.mock.calls[0][0]).toBe('http://127.0.0.2:37777/api/health');
+    });
+
+    it('should normalize a localhost worker host to 127.0.0.1 when polling health', async () => {
+      // 'localhost' resolves IPv6-first on modern Windows while the worker
+      // binds a single family, so SettingsDefaultsManager pins it to the
+      // IPv4 loopback (#2992) — the poll URL must reflect that.
       process.env.CLAUDE_MEM_WORKER_HOST = 'localhost';
       const fetchMock = mock(() => Promise.resolve({
         ok: true,
@@ -319,7 +336,7 @@ describe('HealthMonitor', () => {
 
       await waitForHealth(37777, 1000);
 
-      expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:37777/api/health');
+      expect(fetchMock.mock.calls[0][0]).toBe('http://127.0.0.1:37777/api/health');
     });
 
     it('should use default timeout when not specified', async () => {

--- a/tests/scripts/export-memories.test.ts
+++ b/tests/scripts/export-memories.test.ts
@@ -55,7 +55,7 @@ describe('export-memories script', () => {
     let batchSignal: unknown;
     const fetchMock = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
-      if (url.startsWith('http://localhost:45678/api/search?')) {
+      if (url.startsWith('http://127.0.0.1:45678/api/search?')) {
         searchSignal = init?.signal;
         return new Response(JSON.stringify({
           observations: [
@@ -69,7 +69,7 @@ describe('export-memories script', () => {
         }), { status: 200 });
       }
 
-      if (url === 'http://localhost:45678/api/sdk-sessions/batch') {
+      if (url === 'http://127.0.0.1:45678/api/sdk-sessions/batch') {
         batchSignal = init?.signal;
         batchBody = JSON.parse(String(init?.body));
         return new Response(JSON.stringify([
@@ -172,7 +172,7 @@ describe('export-memories script', () => {
 
     const fetchMock = mock(async (input: RequestInfo | URL) => {
       const url = String(input);
-      if (url.startsWith('http://localhost:45678/api/search?')) {
+      if (url.startsWith('http://127.0.0.1:45678/api/search?')) {
         return new Response(JSON.stringify({
           observations: [{ memory_session_id: 'memory-a' }],
           sessions: [],
@@ -180,7 +180,7 @@ describe('export-memories script', () => {
         }), { status: 200 });
       }
 
-      if (url === 'http://localhost:45678/api/sdk-sessions/batch') {
+      if (url === 'http://127.0.0.1:45678/api/sdk-sessions/batch') {
         return new Response('worker unavailable', {
           status: 503,
           statusText: 'Service Unavailable',

--- a/tests/shared/settings-defaults-manager.test.ts
+++ b/tests/shared/settings-defaults-manager.test.ts
@@ -659,4 +659,72 @@ describe('SettingsDefaultsManager', () => {
       expect(result.CLAUDE_MEM_WORKER_PORT).toBe('33333'); 
     });
   });
+
+  describe('CLAUDE_MEM_WORKER_HOST localhost normalization (#2992)', () => {
+    // On modern Windows resolvers 'localhost' resolves IPv6-first while
+    // server.listen(port, 'localhost') binds ::1 only, so a 'localhost'
+    // host value can put the hook client and the worker on different
+    // loopback families. The manager pins it to the IPv4 loopback.
+    let originalHostEnv: string | undefined;
+
+    beforeEach(() => {
+      originalHostEnv = process.env.CLAUDE_MEM_WORKER_HOST;
+      delete process.env.CLAUDE_MEM_WORKER_HOST;
+    });
+
+    afterEach(() => {
+      if (originalHostEnv === undefined) {
+        delete process.env.CLAUDE_MEM_WORKER_HOST;
+      } else {
+        process.env.CLAUDE_MEM_WORKER_HOST = originalHostEnv;
+      }
+    });
+
+    it('should normalize a file value of localhost to 127.0.0.1', () => {
+      writeFileSync(settingsPath, JSON.stringify({ CLAUDE_MEM_WORKER_HOST: 'localhost' }));
+
+      const result = SettingsDefaultsManager.loadFromFile(settingsPath);
+
+      expect(result.CLAUDE_MEM_WORKER_HOST).toBe('127.0.0.1');
+    });
+
+    it('should normalize an env override of localhost to 127.0.0.1', () => {
+      process.env.CLAUDE_MEM_WORKER_HOST = 'localhost';
+
+      const result = SettingsDefaultsManager.loadFromFile(settingsPath);
+
+      expect(result.CLAUDE_MEM_WORKER_HOST).toBe('127.0.0.1');
+    });
+
+    it('should normalize localhost through get() when set via env', () => {
+      process.env.CLAUDE_MEM_WORKER_HOST = 'localhost';
+
+      expect(SettingsDefaultsManager.get('CLAUDE_MEM_WORKER_HOST')).toBe('127.0.0.1');
+    });
+
+    it('should normalize when env overrides are skipped', () => {
+      writeFileSync(settingsPath, JSON.stringify({ CLAUDE_MEM_WORKER_HOST: 'localhost' }));
+
+      const result = SettingsDefaultsManager.loadFromFile(settingsPath, false);
+
+      expect(result.CLAUDE_MEM_WORKER_HOST).toBe('127.0.0.1');
+    });
+
+    it('should pass through non-localhost hosts unchanged', () => {
+      writeFileSync(settingsPath, JSON.stringify({ CLAUDE_MEM_WORKER_HOST: '0.0.0.0' }));
+
+      const result = SettingsDefaultsManager.loadFromFile(settingsPath);
+
+      expect(result.CLAUDE_MEM_WORKER_HOST).toBe('0.0.0.0');
+    });
+
+    it('should not rewrite the settings file when normalizing', () => {
+      const content = JSON.stringify({ CLAUDE_MEM_WORKER_HOST: 'localhost' }, null, 2);
+      writeFileSync(settingsPath, content);
+
+      SettingsDefaultsManager.loadFromFile(settingsPath);
+
+      expect(readFileSync(settingsPath, 'utf-8')).toBe(content);
+    });
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rehost of community PR #3436 onto current `main` (originally ~296 behind / no fresh CI). Same-repo so CI can run.

## Root symptom
#2992: hooks time out after ~29s on Windows when `CLAUDE_MEM_WORKER_HOST=localhost`. The validator accepts `localhost`, but `server.listen(port, 'localhost')` binds `::1` only on Windows, so IPv4 clients (and the install-time shutdown helper at `127.0.0.1`) cannot see the worker. On machines where `::1` SYNs are dropped, every hook fetch hangs until the 30s abort.

## What landed
- Normalize `'localhost'` → `'127.0.0.1'` in `SettingsDefaultsManager.get()` and every `loadFromFile` exit (read-side only; settings.json is not rewritten)
- Stop raw `process.env.CLAUDE_MEM_WORKER_HOST` bypasses in scripts so they cannot skip normalization

## Tests
`bun test tests/shared/settings-defaults-manager.test.ts tests/infrastructure/health-monitor.test.ts` — 78 pass / 0 fail

## Credit
Original work by @Ravencloned in #3436.

Closes #3436
Closes #2992

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30469fbe-1872-4e43-b006-f3ba0b321789?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30469fbe-1872-4e43-b006-f3ba0b321789&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

