### PR TITLE
fix(hooks): skip plugin cache sessions (rehost #3429)

### DIFF
--- a/src/shared/should-track-project.ts
+++ b/src/shared/should-track-project.ts
@@ -1,8 +1,27 @@
 
-import { relative, isAbsolute, normalize } from 'path';
+import { relative, isAbsolute, join, normalize } from 'path';
 import { isProjectExcluded } from '../utils/project-filter.js';
 import { loadFromFileOnce } from './hook-settings.js';
-import { OBSERVER_SESSIONS_DIR, OBSERVER_SESSIONS_PROJECT } from './paths.js';
+import {
+  CLAUDE_CONFIG_DIR,
+  MARKETPLACE_ROOT,
+  OBSERVER_SESSIONS_DIR,
+  OBSERVER_SESSIONS_PROJECT,
+} from './paths.js';
+
+const PLUGINS_DIR_NAME = 'plugins';
+const PLUGIN_CACHE_DIR_NAME = 'cache';
+const CLAUDE_MEM_PLUGIN_OWNER = 'thedotmack';
+const CLAUDE_MEM_PLUGIN_NAME = 'claude-mem';
+const PLUGIN_RUNTIME_DIR_NAME = 'plugin';
+const PLUGIN_CACHE_ROOT = join(
+  CLAUDE_CONFIG_DIR,
+  PLUGINS_DIR_NAME,
+  PLUGIN_CACHE_DIR_NAME,
+  CLAUDE_MEM_PLUGIN_OWNER,
+  CLAUDE_MEM_PLUGIN_NAME,
+);
+const PLUGIN_MARKETPLACE_PLUGIN_ROOT = join(MARKETPLACE_ROOT, PLUGIN_RUNTIME_DIR_NAME);
 
 function isWithin(child: string, parent: string): boolean {
   const normChild = normalize(child);
@@ -16,6 +35,9 @@ export function shouldTrackProject(cwd: string): boolean {
   if (process.env.CLAUDE_MEM_INTERNAL === '1') return false;
   if (!cwd) return true;
   if (isWithin(cwd, OBSERVER_SESSIONS_DIR)) {
+    return false;
+  }
+  if (isWithin(cwd, PLUGIN_CACHE_ROOT) || isWithin(cwd, PLUGIN_MARKETPLACE_PLUGIN_ROOT)) {
     return false;
   }
   const settings = loadFromFileOnce();

--- a/tests/cli/handlers/session-init-plugin-cache-skip.test.ts
+++ b/tests/cli/handlers/session-init-plugin-cache-skip.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { join } from 'path';
+import { CLAUDE_CONFIG_DIR } from '../../../src/shared/paths.js';
+import {
+  sessionInitHandler,
+  setSessionInitDependenciesForTesting,
+} from '../../../src/cli/handlers/session-init.js';
+
+const PLUGINS_DIR_NAME = 'plugins';
+const PLUGIN_CACHE_DIR_NAME = 'cache';
+const CLAUDE_MEM_PLUGIN_OWNER = 'thedotmack';
+const CLAUDE_MEM_PLUGIN_NAME = 'claude-mem';
+const PLUGIN_VERSION_DIR_NAME = '13.12.4';
+
+describe('sessionInitHandler plugin cache self-capture guard', () => {
+  afterEach(() => {
+    setSessionInitDependenciesForTesting();
+  });
+
+  it('skips session init when the SDK hook cwd is inside the installed plugin cache', async () => {
+    const workerCalls: Array<{ apiPath: string; method: string; body: unknown }> = [];
+    setSessionInitDependenciesForTesting({
+      executeWithWorkerFallback: async (apiPath, method, body) => {
+        workerCalls.push({ apiPath, method, body });
+        return { sessionDbId: 42, promptNumber: 1 };
+      },
+    });
+
+    const cwd = join(
+      CLAUDE_CONFIG_DIR,
+      PLUGINS_DIR_NAME,
+      PLUGIN_CACHE_DIR_NAME,
+      CLAUDE_MEM_PLUGIN_OWNER,
+      CLAUDE_MEM_PLUGIN_NAME,
+      PLUGIN_VERSION_DIR_NAME,
+    );
+    const savedInternal = process.env.CLAUDE_MEM_INTERNAL;
+    delete process.env.CLAUDE_MEM_INTERNAL;
+    try {
+      const result = await sessionInitHandler.execute({
+        sessionId: 'observer-sdk-session',
+        cwd,
+        platform: 'claude-code',
+        prompt: 'observer prompt',
+      });
+
+      expect(result.continue).toBe(true);
+      expect(result.suppressOutput).toBe(true);
+      expect(workerCalls).toEqual([]);
+    } finally {
+      if (savedInternal === undefined) {
+        delete process.env.CLAUDE_MEM_INTERNAL;
+      } else {
+        process.env.CLAUDE_MEM_INTERNAL = savedInternal;
+      }
+    }
+  });
+});

--- a/tests/shared/should-track-project.test.ts
+++ b/tests/shared/should-track-project.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
-import { OBSERVER_SESSIONS_DIR } from '../../src/shared/paths.js';
-import { normalize } from 'path';
+import { CLAUDE_CONFIG_DIR, MARKETPLACE_ROOT, OBSERVER_SESSIONS_DIR } from '../../src/shared/paths.js';
+import { join, normalize } from 'path';
 
 // Snapshot the real module BEFORE mock.module mutates the live namespace, then
 // re-register it in afterAll. bun's mock.module is process-global and
@@ -20,6 +20,14 @@ afterAll(() => {
 
 // Import after mock so the module picks up the mocked dependency
 const { shouldTrackProject } = await import('../../src/shared/should-track-project.js');
+
+const PLUGINS_DIR_NAME = 'plugins';
+const PLUGIN_CACHE_DIR_NAME = 'cache';
+const CLAUDE_MEM_PLUGIN_OWNER = 'thedotmack';
+const CLAUDE_MEM_PLUGIN_NAME = 'claude-mem';
+const PLUGIN_VERSION_DIR_NAME = '13.12.4';
+const PLUGIN_RUNTIME_DIR_NAME = 'plugin';
+const PLUGIN_SCRIPTS_DIR_NAME = 'scripts';
 
 describe('shouldTrackProject — path normalization', () => {
   let savedInternal: string | undefined;
@@ -50,6 +58,27 @@ describe('shouldTrackProject — path normalization', () => {
 
   it('returns false when cwd matches OBSERVER_SESSIONS_DIR exactly (native separators)', () => {
     expect(shouldTrackProject(OBSERVER_SESSIONS_DIR)).toBe(false);
+  });
+
+  it('returns false when cwd is inside the installed plugin cache', () => {
+    const pluginVersionDir = join(
+      CLAUDE_CONFIG_DIR,
+      PLUGINS_DIR_NAME,
+      PLUGIN_CACHE_DIR_NAME,
+      CLAUDE_MEM_PLUGIN_OWNER,
+      CLAUDE_MEM_PLUGIN_NAME,
+      PLUGIN_VERSION_DIR_NAME,
+    );
+
+    expect(shouldTrackProject(pluginVersionDir)).toBe(false);
+    expect(shouldTrackProject(join(pluginVersionDir, PLUGIN_RUNTIME_DIR_NAME, PLUGIN_SCRIPTS_DIR_NAME))).toBe(false);
+  });
+
+  it('returns false when cwd is inside the marketplace plugin runtime', () => {
+    const marketplacePluginDir = join(MARKETPLACE_ROOT, PLUGIN_RUNTIME_DIR_NAME);
+
+    expect(shouldTrackProject(marketplacePluginDir)).toBe(false);
+    expect(shouldTrackProject(join(marketplacePluginDir, PLUGIN_SCRIPTS_DIR_NAME))).toBe(false);
   });
 
   it('returns true for an unrelated project path', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rehost of community PR #3429 onto current `main`. Same-repo so CI can run. The original PR's typecheck failed; this rehost uses the typed `setSessionInitDependenciesForTesting` seam instead of an untyped `--eval` harness.

## Root symptom
SessionStart hooks running from a plugin version directory created a user project named after the plugin version (#3425).

## What landed
- Treat installed claude-mem plugin cache and marketplace runtime directories as internal paths that hooks must not track
- Session-init returns early (no `/api/sessions/init`) when cwd is inside those roots

## Tests
`bun test tests/shared/should-track-project.test.ts tests/cli/handlers/session-init-plugin-cache-skip.test.ts` — 8 pass / 0 fail

## Credit
Original work by @ousamabenyounes in #3429.

Closes #3429
Closes #3425

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30469fbe-1872-4e43-b006-f3ba0b321789?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30469fbe-1872-4e43-b006-f3ba0b321789&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

