### PR TITLE
fix(oauth): sanitize macOS keychain account to match Claude Code (closes #4037)

### DIFF
--- a/src/shared/oauth-token.ts
+++ b/src/shared/oauth-token.ts
@@ -25,6 +25,24 @@ const KEYCHAIN_SERVICE_NAME = 'Claude Code-credentials';
 const READ_TIMEOUT_MS = 5000;
 
 /**
+ * #4037 — Claude Code (measured in 2.1.268 `pk()`) only accepts keychain
+ * account names matching `/^[a-zA-Z0-9._-]+$/`. A Unix username that fails
+ * that test (MDM Macs named after an email, e.g. `first.last@example.com`)
+ * is stored and read as the literal `claude-code-user`. We must query the
+ * same account Claude Code wrote, or the lookup permanently misses.
+ */
+const MACOS_KEYCHAIN_ACCOUNT_SAFE = /^[a-zA-Z0-9._-]+$/;
+const MACOS_KEYCHAIN_ACCOUNT_FALLBACK = 'claude-code-user';
+
+/**
+ * Map a Unix username to the macOS keychain `-a` account Claude Code uses.
+ * Exported so tests can pin the charset rule independently of `security`.
+ */
+export function sanitizeMacOsKeychainAccount(username: string): string {
+  return MACOS_KEYCHAIN_ACCOUNT_SAFE.test(username) ? username : MACOS_KEYCHAIN_ACCOUNT_FALLBACK;
+}
+
+/**
  * #2753 — resolve the effective CLAUDE_CONFIG_DIR for the keychain lookup +
  * SDK subprocess env, honoring the precedence: the
  * CLAUDE_MEM_CLAUDE_CONFIG_DIR setting > process.env.CLAUDE_CONFIG_DIR >
@@ -154,12 +172,18 @@ function isExpired(expiresAtMs: number | undefined): boolean {
  * touching the real `security` binary. Exported (not just internal to
  * readClaudeOAuthToken) specifically so tests can drive it directly with a
  * fake execImpl.
+ *
+ * `username` is the same kind of test seam for #4037: `userInfo()` is also
+ * captured at call time from the host OS, so tests pass a raw Unix username
+ * here and assert the `-a` account that actually gets queried. Production
+ * call sites omit it and we read `userInfo().username`.
  */
 export async function readMacOsKeychain(
   serviceName: string,
   execImpl: typeof execFileAsync = execFileAsync,
+  username: string = userInfo().username,
 ): Promise<OAuthTokenResult> {
-  const account = userInfo().username;
+  const account = sanitizeMacOsKeychainAccount(username);
   let stdout: string;
   try {
     ({ stdout } = await execImpl(

--- a/tests/shared/oauth-token.test.ts
+++ b/tests/shared/oauth-token.test.ts
@@ -12,6 +12,7 @@ import {
   resolveEffectiveClaudeConfigDir,
   deriveMacKeychainServiceName,
   readMacOsKeychain,
+  sanitizeMacOsKeychainAccount,
 } from '../../src/shared/oauth-token.js';
 import { paths, CLAUDE_CONFIG_DIR, DEFAULT_CLAUDE_CONFIG_DIR } from '../../src/shared/paths.js';
 import { buildIsolatedEnvWithFreshOAuth } from '../../src/shared/EnvManager.js';
@@ -550,6 +551,83 @@ describe('readClaudeOAuthToken (#2753) — darwin dispatch wires the derived ser
     expect(result.kind).toBe('present');
     if (result.kind === 'present') {
       expect(result.token).toBe('sk-ant-oat01-default-token');
+    }
+  });
+});
+
+/**
+ * #4037 — Claude Code stores the OAuth blob under `-a claude-code-user`
+ * when the Unix username fails `/^[a-zA-Z0-9._-]+$/` (MDM Macs named
+ * after an email). readMacOsKeychain must query that same account, not
+ * the raw `userInfo().username`. username is injected (same reason as
+ * execImpl) so this never depends on the host OS account.
+ */
+describe('sanitizeMacOsKeychainAccount (#4037)', () => {
+  it('returns the raw username when it matches Claude Code\'s safe charset', () => {
+    expect(sanitizeMacOsKeychainAccount('alex')).toBe('alex');
+    expect(sanitizeMacOsKeychainAccount('alex.newman')).toBe('alex.newman');
+    expect(sanitizeMacOsKeychainAccount('alex_newman-1')).toBe('alex_newman-1');
+    expect(sanitizeMacOsKeychainAccount('Runner.01')).toBe('Runner.01');
+  });
+
+  it('falls back to claude-code-user when the username contains @ or other illegal chars', () => {
+    expect(sanitizeMacOsKeychainAccount('first.last@example.com')).toBe('claude-code-user');
+    expect(sanitizeMacOsKeychainAccount('alex newman')).toBe('claude-code-user');
+    expect(sanitizeMacOsKeychainAccount('alex+mem')).toBe('claude-code-user');
+    expect(sanitizeMacOsKeychainAccount('')).toBe('claude-code-user');
+  });
+});
+
+describe('readMacOsKeychain (#4037) — keychain -a account follows Claude Code sanitize', () => {
+  const futureExpiresAt = Date.now() + 60 * 60 * 1000;
+  const payload = JSON.stringify({
+    claudeAiOauth: { accessToken: 'sk-ant-oat01-account-token', expiresAt: futureExpiresAt },
+  });
+
+  function fakeExecForAccount(expectedAccount: string) {
+    return mock((_cmd: string, args: readonly string[]) => {
+      const accountArgIndex = args.indexOf('-a');
+      const account = accountArgIndex >= 0 ? args[accountArgIndex + 1] : undefined;
+      if (account === expectedAccount) {
+        return Promise.resolve({ stdout: payload, stderr: '' });
+      }
+      return Promise.reject(new Error(`unexpected keychain account: ${account}`));
+    });
+  }
+
+  it('queries account claude-code-user when the Unix username contains @', async () => {
+    const fakeExecImpl = fakeExecForAccount('claude-code-user');
+    const result = await readMacOsKeychain(
+      'Claude Code-credentials',
+      fakeExecImpl,
+      'first.last@example.com',
+    );
+
+    expect(fakeExecImpl).toHaveBeenCalledTimes(1);
+    const callArgs = fakeExecImpl.mock.calls[0][1] as string[];
+    expect(callArgs[callArgs.indexOf('-a') + 1]).toBe('claude-code-user');
+    expect(callArgs).not.toContain('first.last@example.com');
+    expect(result.kind).toBe('present');
+    if (result.kind === 'present') {
+      expect(result.token).toBe('sk-ant-oat01-account-token');
+    }
+  });
+
+  it('queries the raw username when it is legal for Claude Code\'s keychain account', async () => {
+    const fakeExecImpl = fakeExecForAccount('alex.newman');
+    const result = await readMacOsKeychain(
+      'Claude Code-credentials',
+      fakeExecImpl,
+      'alex.newman',
+    );
+
+    expect(fakeExecImpl).toHaveBeenCalledTimes(1);
+    const callArgs = fakeExecImpl.mock.calls[0][1] as string[];
+    expect(callArgs[callArgs.indexOf('-a') + 1]).toBe('alex.newman');
+    expect(callArgs).not.toContain('claude-code-user');
+    expect(result.kind).toBe('present');
+    if (result.kind === 'present') {
+      expect(result.token).toBe('sk-ant-oat01-account-token');
     }
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #4037.

Reported and measured by @Bsile: on macOS, when the Unix username contains characters outside `[a-zA-Z0-9._-]` (common on MDM Macs named after an email, e.g. `first.last@example.com`), Claude Code stores and reads the OAuth blob under keychain account `claude-code-user`. claude-mem queried `-a` with the raw `userInfo().username`, so the lookup permanently missed. Interactive Claude Code still worked; observer batches got `Not logged in · Please run /login` and observations stopped.

## Fix

Mirror Claude Code’s `pk()` sanitize in `readMacOsKeychain` only:

- username matches `/^[a-zA-Z0-9._-]+$/` → query that account (unchanged for typical usernames)
- otherwise → query `claude-code-user`

Kept `-a` rather than dropping it, so a machine with more than one account on the same service still hits the one Claude Code wrote.

No version bump in this PR; that is a separate ship step after merge.

## Tests

`tests/shared/oauth-token.test.ts` (injected `execImpl` + injected username, no real keychain):

- illegal username (`first.last@example.com`) → `-a claude-code-user` is queried
- legal username (`alex.newman`) → raw username is still queried
- charset helper covers `@`, space, `+`, empty, and the safe `._-` set

`bun test tests/shared/oauth-token.test.ts`: 39 pass / 0 fail.

## RCA follow-ups (keep open — this PR is stop-bleed only)

These are **not** closed by merging this patch:

1. **Multi-account same-service.** Confirm whether a machine that holds several accounts under `Claude Code-credentials` ever needs a different strategy than “sanitize then `-a`” (e.g. dropping `-a` and taking the first match).
2. **Failed keychain should stay loud.** A miss should remain an actionable error in claude-mem logs/UI, not only surface as the SDK child’s interactive `Not logged in · Please run /login` (which sends users to `/login` in a session that is already authenticated).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e06d0e4-4cac-467e-9ccc-9a606f0ca94e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e06d0e4-4cac-467e-9ccc-9a606f0ca94e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

