### PR TITLE
fix(sync-hub): bound scheduled projection repair work (rehost #3555)

### DIFF
--- a/workers/sync-hub/src/index.ts
+++ b/workers/sync-hub/src/index.ts
@@ -81,6 +81,10 @@ const DEFAULT_CACHE_TTL_SECONDS = 60;
 const MAX_OPS_PER_PUSH = 500; // mirrors the getChanges page cap
 const MAX_PUSH_BODY_BYTES = 8_000_000;
 const CANONICAL_DECIMAL = /^(?:0|[1-9][0-9]*)$/;
+// Scheduled repair is deliberately incremental. One page is at most 100 ops or
+// 4 MB, so a deeply lagging user cannot monopolize a cron request or keep the
+// per-user projection lease busy while every other user waits.
+const REPAIR_DRAIN_MAX_PAGES = 1;
 
 /**
  * Pro declares a 60-second maximum duration. Abort the complete response-body
@@ -591,6 +595,8 @@ export interface ProjectionDrainDependencies {
 	fetchImpl?: ProjectionFetch;
 	/** Test seam for deterministic Durable Object lease timestamps. */
 	now?: () => number;
+	/** Optional page budget. Omitted client-triggered drains still reach target. */
+	maxPages?: number;
 }
 
 function projectionNow(dependencies: ProjectionDrainDependencies): number | undefined {
@@ -607,6 +613,12 @@ export async function drainProjection(
 	targetSeq: string,
 	dependencies: ProjectionDrainDependencies = {},
 ): Promise<DrainResult> {
+	if (
+		dependencies.maxPages !== undefined
+		&& (!Number.isSafeInteger(dependencies.maxPages) || dependencies.maxPages < 1)
+	) {
+		throw new Error("projection maxPages must be a positive safe integer");
+	}
 	const stub = env.SYNC_HUB.getByName(userId);
 	let state = await stub.getProjectionState();
 	if (decimalAtLeast(state.projected_seq, targetSeq)) {
@@ -641,6 +653,7 @@ export async function drainProjection(
 
 	const token = lease.lease_token;
 	let releaseLeaseEarly = false;
+	let projectedPages = 0;
 	try {
 		for (;;) {
 			state = await stub.getProjectionState();
@@ -791,6 +804,14 @@ export async function drainProjection(
 					checkpointAt,
 				);
 			releaseLeaseEarly = true;
+			projectedPages++;
+			if (
+				dependencies.maxPages !== undefined
+				&& projectedPages >= dependencies.maxPages
+				&& !decimalAtLeast(state.projected_seq, targetSeq)
+			) {
+				return { ok: true, projectedSeq: state.projected_seq };
+			}
 		}
 	} catch (error) {
 		return {
@@ -831,7 +852,9 @@ async function handleRepairDrain(request: Request, env: Env): Promise<Response> 
 	if (decimalAtLeast(target, state.head_seq) && target !== state.head_seq) {
 		return errorResponse(400, "through_seq exceeds Hub head_seq");
 	}
-	const drained = await drainProjection(env, record.user_id, target);
+	const drained = await drainProjection(env, record.user_id, target, {
+		maxPages: REPAIR_DRAIN_MAX_PAGES,
+	});
 	const finalState = await stub.getProjectionState();
 	if (!drained.ok) {
 		return json(drained.httpStatus, {
@@ -843,7 +866,13 @@ async function handleRepairDrain(request: Request, env: Env): Promise<Response> 
 			projected_through_seq: finalState.projected_seq,
 		});
 	}
-	return json(200, {
+	// A bounded repair that checkpointed one page is successful progress, but it
+	// is not a completed request until the original target has been reached.
+	// HTTP 202 preserves the existing JSON schema while giving the Pro caller an
+	// explicit continuation signal. Explicit through_seq callers are complete
+	// once their requested target is reached even if newer ops arrived meanwhile.
+	const complete = decimalAtLeast(finalState.projected_seq, target);
+	return json(complete ? 200 : 202, {
 		protocol_version: 1,
 		user_id: record.user_id,
 		epoch: finalState.epoch,

--- a/workers/sync-hub/test/sync-hub.test.ts
+++ b/workers/sync-hub/test/sync-hub.test.ts
@@ -709,6 +709,37 @@ describe("projection checkpoint, lease fencing, and launch log retention", () =>
 		)).acquired).toBe(true);
 		expect(releaseCalls).toBe(0);
 	});
+
+	it("bounds scheduled repair work and releases the lease after safe progress", async () => {
+		const userId = "projection-bounded-repair";
+		const stub = hub(userId);
+		const ops = await Promise.all(
+			Array.from({ length: 101 }, (_, index) => observationOp(String(index + 1))),
+		);
+		const pushed = ok(await stub.pushOps("dev-a", ops));
+
+		const partial = await drainProjection(projectionEnv("success"), userId, pushed.head_seq, {
+			maxPages: 1,
+			fetchTimeoutMs: 100,
+		});
+		expect(partial).toEqual({ ok: true, projectedSeq: "100" });
+		expect((await stub.getProjectionState()).projected_seq).toBe("100");
+
+		// The bounded success is deterministic and checkpointed, so the lease is
+		// released immediately and the next cron can finish the same user.
+		const finished = await drainProjection(projectionEnv("success"), userId, pushed.head_seq, {
+			maxPages: 1,
+			fetchTimeoutMs: 100,
+		});
+		expect(finished).toEqual({ ok: true, projectedSeq: "101" });
+		expect((await stub.getProjectionState()).projected_seq).toBe("101");
+	});
+
+	it("rejects invalid projection page budgets before acquiring a lease", async () => {
+		await expect(drainProjection(projectionEnv("success"), "projection-bad-budget", "1", {
+			maxPages: 0,
+		})).rejects.toThrow(/positive safe integer/);
+	});
 });
 
 describe("large cursor pagination", () => {
@@ -792,6 +823,34 @@ describe("front Worker durability and repair", () => {
 		expect(response.status).toBe(200);
 		const body = await response.json() as { head_seq: string; projected_through_seq: string };
 		expect(body.projected_through_seq).toBe(body.head_seq);
+	});
+
+	it("returns 202 until a bounded scheduled repair reaches its target", async () => {
+		const repairUser = "66666666-6666-4666-8666-666666666667";
+		const stub = hub(repairUser);
+		const ops = await Promise.all(
+			Array.from({ length: 101 }, (_, index) => observationOp(String(index + 1))),
+		);
+		ok(await stub.pushOps("dev-a", ops));
+		const request = () => SELF.fetch(`${base}/internal/v1/projection/drain`, {
+			method: "POST",
+			headers: { Authorization: "Bearer test-projector-secret", "Content-Type": "application/json" },
+			body: JSON.stringify({ protocol_version: 1, user_id: repairUser }),
+		});
+
+		const partial = await request();
+		expect(partial.status).toBe(202);
+		expect(await partial.json()).toMatchObject({
+			head_seq: "101",
+			projected_through_seq: "100",
+		});
+
+		const complete = await request();
+		expect(complete.status).toBe(200);
+		expect(await complete.json()).toMatchObject({
+			head_seq: "101",
+			projected_through_seq: "101",
+		});
 	});
 
 	it("surfaces deterministic Pro document rejection as nonretryable 409", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rehost of #3555 onto current `main`. Same-repo so CI can run. Applied the bound carefully against current `drainProjection` (the source fork tip's indent was messy).

## Root symptom
The secret-gated scheduled projection repair endpoint tried to drain an arbitrarily large backlog in one HTTP request. In production this produced timeouts and prolonged lease contention even though individual projection pages were succeeding.

## What landed
- Bound scheduled repair to one projection page per user and invocation (`REPAIR_DRAIN_MAX_PAGES = 1`)
- Release the fencing lease after that page is durably checkpointed
- Return HTTP 202 with the existing result schema while the captured repair target remains ahead of the durable checkpoint; HTTP 200 once reached
- Client-triggered projection (no `maxPages`) still drains through the requested target
- Reject invalid page budgets before acquiring a lease

Merging this repository does not deploy the Cloudflare Worker.

## Tests
Added coverage for the 202-to-200 continuation contract, partial checkpoint progress, immediate lease release, and invalid budgets.

## Credit
Original work by @ChenglinWei97 in #3555.

Closes #3555
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30469fbe-1872-4e43-b006-f3ba0b321789?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30469fbe-1872-4e43-b006-f3ba0b321789&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

