### PR TITLE
fix(session): use latest user_prompts text on rehydration (#4047)

### DIFF
--- a/src/services/sqlite/SessionStore.ts
+++ b/src/services/sqlite/SessionStore.ts
@@ -2675,6 +2675,22 @@ export class SessionStore {
     return result.count;
   }
 
+  getLatestPromptTextFromUserPrompts(contentSessionId: string, sessionDbId?: number): string | null {
+    const resolvedSessionDbId = this.resolvePromptSessionDbId(contentSessionId, sessionDbId);
+    const whereClause = resolvedSessionDbId !== null ? 'session_db_id = ?' : 'content_session_id = ?';
+    const param = resolvedSessionDbId !== null ? resolvedSessionDbId : contentSessionId;
+    const result = this.db.prepare(`
+      SELECT prompt_text
+      FROM user_prompts
+      WHERE ${whereClause}
+        AND prompt_text IS NOT NULL
+        AND length(trim(prompt_text)) > 0
+      ORDER BY prompt_number DESC, created_at_epoch DESC
+      LIMIT 1
+    `).get(param) as { prompt_text: string } | undefined;
+    return result?.prompt_text ?? null;
+  }
+
   createSDKSession(
     contentSessionId: string,
     project: string,

--- a/src/services/worker/SessionManager.ts
+++ b/src/services/worker/SessionManager.ts
@@ -99,12 +99,21 @@ export class SessionManager {
       });
     }
 
-    const userPrompt = currentUserPrompt || dbSession.user_prompt;
+    const latestPromptText = currentUserPrompt
+      ? null
+      : this.dbManager.getSessionStore().getLatestPromptTextFromUserPrompts(
+          dbSession.content_session_id,
+          sessionDbId,
+        );
+    const userPrompt = currentUserPrompt || latestPromptText || dbSession.user_prompt;
 
     if (!currentUserPrompt) {
-      logger.debug('SESSION', 'No currentUserPrompt provided for new session, using database', {
+      logger.debug('SESSION', latestPromptText
+        ? 'No currentUserPrompt provided for new session, using latest user_prompts'
+        : 'No currentUserPrompt provided for new session, using database', {
         sessionDbId,
         promptNumber,
+        latestPrompt: latestPromptText?.substring(0, 80) ?? '',
         dbPrompt: dbSession.user_prompt?.substring(0, 80) ?? ''
       });
     } else {

--- a/tests/sqlite/session-store-prompts.test.ts
+++ b/tests/sqlite/session-store-prompts.test.ts
@@ -153,4 +153,45 @@ describe('SessionStore prompts', () => {
       expect(store.getPromptNumberFromUserPrompts(session)).toBe(100);
     });
   });
+
+  describe('getLatestPromptTextFromUserPrompts', () => {
+    it('returns null when none exist', () => {
+      expect(store.getLatestPromptTextFromUserPrompts('nonexistent-session')).toBeNull();
+    });
+
+    it('returns the latest non-empty prompt_text by prompt_number', () => {
+      const session = createSession('latest-prompt-session');
+      store.saveUserPrompt(session, 1, 'prompt1');
+      store.saveUserPrompt(session, 11, 'prompt11');
+
+      expect(store.getLatestPromptTextFromUserPrompts(session)).toBe('prompt11');
+    });
+
+    it('skips empty prompt_text and returns the previous non-empty row', () => {
+      const session = createSession('latest-empty-prompt-session');
+      const sessionDbId = (store.db.prepare(
+        'SELECT id FROM sdk_sessions WHERE content_session_id = ?'
+      ).get(session) as { id: number }).id;
+      store.saveUserPrompt(session, 1, 'prompt1', sessionDbId);
+      store.db.prepare(`
+        INSERT INTO user_prompts
+        (session_db_id, content_session_id, prompt_number, prompt_text, created_at, created_at_epoch)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `).run(sessionDbId, session, 12, '   ', new Date().toISOString(), Date.now());
+
+      expect(store.getLatestPromptTextFromUserPrompts(session, sessionDbId)).toBe('prompt1');
+    });
+
+    it('is session-isolated when the same content_session_id is shared', () => {
+      const contentSessionId = 'shared-latest-content-id';
+      const claudeId = store.createSDKSession(contentSessionId, 'claude-project', 'prompt1', undefined, 'claude');
+      const cursorId = store.createSDKSession(contentSessionId, 'cursor-project', 'cursor first', undefined, 'cursor');
+      store.saveUserPrompt(contentSessionId, 1, 'claude prompt1', claudeId);
+      store.saveUserPrompt(contentSessionId, 11, 'claude prompt11', claudeId);
+      store.saveUserPrompt(contentSessionId, 1, 'cursor prompt1', cursorId);
+
+      expect(store.getLatestPromptTextFromUserPrompts(contentSessionId, claudeId)).toBe('claude prompt11');
+      expect(store.getLatestPromptTextFromUserPrompts(contentSessionId, cursorId)).toBe('cursor prompt1');
+    });
+  });
 });

--- a/tests/worker/session-manager-null-prompt.test.ts
+++ b/tests/worker/session-manager-null-prompt.test.ts
@@ -3,7 +3,10 @@ import { logger } from '../../src/utils/logger.js';
 import { SessionManager } from '../../src/services/worker/SessionManager.js';
 import type { DatabaseManager } from '../../src/services/worker/DatabaseManager.js';
 
-function makeDbManager(userPrompt: string | null): DatabaseManager {
+function makeDbManager(
+  userPrompt: string | null,
+  latestPromptText: string | null = null,
+): DatabaseManager {
   return {
     getSessionById: () => ({
       content_session_id: 'content-123',
@@ -14,6 +17,7 @@ function makeDbManager(userPrompt: string | null): DatabaseManager {
     }),
     getSessionStore: () => ({
       getPromptNumberFromUserPrompts: () => 1,
+      getLatestPromptTextFromUserPrompts: () => latestPromptText,
     }),
   } as unknown as DatabaseManager;
 }
@@ -41,6 +45,32 @@ describe('SessionManager with NULL user_prompt (worker-restart stale-session win
 
     expect(session.contentSessionId).toBe('content-123');
     expect(session.userPrompt ?? null).toBeNull();
+  });
+
+  it('cold init uses latest user_prompts text when currentUserPrompt is absent', () => {
+    const sm = new SessionManager(makeDbManager('prompt1', 'prompt11'));
+
+    const session = sm.initializeSession(1);
+
+    expect(session.userPrompt).toBe('prompt11');
+    expect(session.lastPromptNumber).toBe(1);
+  });
+
+  it('cold init falls back to sdk_sessions.user_prompt when user_prompts has no latest text', () => {
+    const sm = new SessionManager(makeDbManager('prompt1', null));
+
+    const session = sm.initializeSession(1);
+
+    expect(session.userPrompt).toBe('prompt1');
+  });
+
+  it('cold init prefers an explicit currentUserPrompt over latest user_prompts text', () => {
+    const sm = new SessionManager(makeDbManager('prompt1', 'prompt11'));
+
+    const session = sm.initializeSession(1, 'fresh prompt', 2);
+
+    expect(session.userPrompt).toBe('fresh prompt');
+    expect(session.lastPromptNumber).toBe(2);
   });
 
   it('cached-session paths tolerate a NULL cached prompt and accept a fresh one', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #4047.

On session rehydration, `lastPromptNumber` already comes from `user_prompts`, but `<user_request>` / `session.userPrompt` fell back to `sdk_sessions.user_prompt` (first prompt only, never updated). That mismatch fed the observer stale request text with a current prompt number.

This follows suggested fix (1) from the issue and the RCA-later comment: when `currentUserPrompt` is absent at cold init, load the latest non-empty `user_prompts.prompt_text` for that session. Fall back to `sdk_sessions.user_prompt` only if no `user_prompts` row exists.

No SQLite trigger, no column rename/migration, no second session-state subsystem.

## Gate (issue-patch-ship)

- [x] RCA-later logged on #4047
- [x] No second-system — same `initializeSession` cold path, correct row read
- [x] Not opinionated/wide — `SessionManager` + `SessionStore` helper + tests only

## Before / after

**Before:** cold init with absent `currentUserPrompt` set `userPrompt` from `dbSession.user_prompt` (prompt #1) while `lastPromptNumber` came from `user_prompts`.

**After:** same init path reads latest non-empty `user_prompts.prompt_text` (same session resolution as `getPromptNumberFromUserPrompts`). Debug log says "using latest user_prompts" when that source is used, not "using database".

Cached-session updates when `currentUserPrompt` is provided are unchanged.

## Test plan

- `tests/worker/session-manager-null-prompt.test.ts`: cold init with db first-prompt `"prompt1"` + latest user_prompts `"prompt11"` → `session.userPrompt === "prompt11"`; existing NULL `user_prompt` tolerance stays green
- `tests/sqlite/session-store-prompts.test.ts`: `getLatestPromptTextFromUserPrompts` latest-by-number, empty-text skip, session isolation
- `npm run typecheck` + targeted bun tests

No version bump / tag / npm publish in this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-72f87f29-e8e7-42c6-bdc8-0f664d43953f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-72f87f29-e8e7-42c6-bdc8-0f664d43953f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

