### PR TITLE
fix(supervisor): jail SDK subprocess cwd

### DIFF
--- a/src/supervisor/process-registry.ts
+++ b/src/supervisor/process-registry.ts
@@ -4,7 +4,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import path from 'path';
 import { logger } from '../utils/logger.js';
 import { sanitizeEnv } from './env-sanitizer.js';
-import { paths } from '../shared/paths.js';
+import { ensureDir, OBSERVER_SESSIONS_DIR, paths } from '../shared/paths.js';
 // Moved to shared/ so kill-process-tree.ts can use it without closing an
 // import cycle (process-registry already imports kill-process-tree). Re-exported
 // here so every existing caller keeps its import path.
@@ -659,6 +659,8 @@ export interface SpawnSdkOptions {
   command: string;
   args: string[];
   extraArgs?: string[];
+  // Part of the Claude SDK callback contract. Accepted at this trust boundary
+  // so callers remain compatible, but deliberately ignored for isolation.
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   signal?: AbortSignal;
@@ -688,6 +690,10 @@ export function normalizeSpawnSdkArgs(args: string[], extraArgs: string[] = []):
   return filteredArgs;
 }
 
+export function normalizeSpawnSdkCwd(sessionDbId: number): string {
+  return path.join(OBSERVER_SESSIONS_DIR, String(sessionDbId));
+}
+
 export function spawnSdkProcess(
   sessionDbId: number,
   options: SpawnSdkOptions
@@ -697,11 +703,22 @@ export function spawnSdkProcess(
   const useCmdWrapper = process.platform === 'win32' && options.command.endsWith('.cmd');
   const env = sanitizeEnv(options.env ?? process.env);
   const filteredArgs = normalizeSpawnSdkArgs(options.args, options.extraArgs);
+  const cwd = normalizeSpawnSdkCwd(sessionDbId);
+  try {
+    ensureDir(cwd);
+  } catch (error: unknown) {
+    const cause = error instanceof Error ? error : new Error(String(error));
+    logger.error('SDK_SPAWN', `[session-${sessionDbId}] failed to create observer session directory`, {
+      sessionDbId,
+      cwd,
+    }, cause);
+    return null;
+  }
 
   const isWin = process.platform === 'win32';
   const child = useCmdWrapper
     ? spawnHidden('cmd.exe', ['/d', '/c', options.command, ...filteredArgs], {
-        cwd: options.cwd,
+        cwd,
         env,
         detached: !isWin,
         stdio: ['pipe', 'pipe', 'pipe'],
@@ -709,7 +726,7 @@ export function spawnSdkProcess(
         windowsHide: true,
       })
     : spawnHidden(options.command, filteredArgs, {
-        cwd: options.cwd,
+        cwd,
         env,
         detached: !isWin,
         stdio: ['pipe', 'pipe', 'pipe'],

--- a/tests/supervisor/process-registry.test.ts
+++ b/tests/supervisor/process-registry.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, describe, expect, it } from 'bun:test';
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
+import { OBSERVER_SESSIONS_DIR } from '../../src/shared/paths.js';
 import {
   createProcessRegistry,
   isPidAlive,
   normalizeSpawnSdkArgs,
+  normalizeSpawnSdkCwd,
+  spawnSdkProcess,
   getProcessRegistry,
   waitForSlot,
   getParkedSlotWaiterCount,
@@ -13,6 +16,19 @@ import {
   type SlotReservation,
 } from '../../src/supervisor/process-registry.js';
 import { guardSharedProcessRegistrySingleton } from './process-registry-singleton-guard.js';
+
+const TEST_SESSION_ID = process.pid;
+const SDK_CWD_PROBE = 'console.log(process.cwd())';
+const EXPECTED_SDK_CWD = path.join(OBSERVER_SESSIONS_DIR, String(TEST_SESSION_ID));
+const PARENT_PATH = '..';
+const DIRECTORY_COLLISION = 'directory collision';
+
+function assertIsolatedObserverSessionsDir(): void {
+  const relativePath = path.relative(tmpdir(), OBSERVER_SESSIONS_DIR);
+  if (relativePath === PARENT_PATH || relativePath.startsWith(`${PARENT_PATH}${path.sep}`) || path.isAbsolute(relativePath)) {
+    throw new Error(`Refusing to mutate non-test observer directory: ${OBSERVER_SESSIONS_DIR}`);
+  }
+}
 
 // Registered at true file top level (outside every describe below), NOT
 // nested inside describe('waitForSlot / parked waiters (#2756)', ...): bun
@@ -402,6 +418,53 @@ describe('supervisor ProcessRegistry', () => {
         'session-123',
         '--no-session-persistence',
       ]);
+    });
+  });
+
+  describe('normalizeSpawnSdkCwd', () => {
+    it('jails SDK subprocess cwd to the observer sessions directory (#3357)', () => {
+      expect(normalizeSpawnSdkCwd(TEST_SESSION_ID)).toBe(EXPECTED_SDK_CWD);
+    });
+
+    it('applies the observer sessions cwd to direct SDK spawns', async () => {
+      assertIsolatedObserverSessionsDir();
+      tempDirs.push(EXPECTED_SDK_CWD);
+      const projectDir = makeTempDir();
+      tempDirs.push(projectDir);
+      mkdirSync(projectDir, { recursive: true });
+
+      const result = spawnSdkProcess(TEST_SESSION_ID, {
+        command: process.execPath,
+        args: ['--eval', SDK_CWD_PROBE],
+        cwd: projectDir,
+      });
+
+      expect(result).not.toBeNull();
+      try {
+        const output = await new Response(result!.process.stdout).text();
+        expect(output.trim()).toBe(realpathSync(EXPECTED_SDK_CWD));
+      } finally {
+        try { result!.process.kill('SIGKILL'); } catch { /* already exited */ }
+        await new Promise<void>((resolve) => {
+          if (result!.process.exitCode !== null) {
+            resolve();
+            return;
+          }
+          result!.process.once('exit', () => resolve());
+        });
+      }
+    });
+
+    it('returns null when the observer session directory cannot be created', () => {
+      assertIsolatedObserverSessionsDir();
+      mkdirSync(OBSERVER_SESSIONS_DIR, { recursive: true });
+      tempDirs.push(EXPECTED_SDK_CWD);
+      writeFileSync(EXPECTED_SDK_CWD, DIRECTORY_COLLISION);
+
+      expect(spawnSdkProcess(TEST_SESSION_ID, {
+        command: process.execPath,
+        args: ['--eval', SDK_CWD_PROBE],
+      })).toBeNull();
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**issue-patch-ship Gate: PASS** — rebase of #3432 onto current `main` (original was DIRTY/CONFLICTING; fork head is not writable from this agent).

## Gate

1. **RCA-later logged** — #3357: on Windows, `cross-spawn`/`cmd.exe /d /s /c` treats `>` in transcript text as redirection and writes 0-byte files; spawn cwd was the user's project, so those files land in the repo and get `git add -A`'d. This PR is the cwd-jail slice. Deeper "no shell / argv array" stays under plan-19 / #3607.
2. **No second-system** — existing `spawnSdkProcess` trust boundary + `OBSERVER_SESSIONS_DIR`; SDK callback `cwd` stays on the options type but is ignored at spawn.
3. **Not opinionated** — 2 files; each supervised child runs from `~/.claude-mem/observer-sessions/<sessionDbId>`, created before spawn, `null` on create failure.

## Change

- Jail each supervised SDK subprocess in its own observer-session directory, never the caller's project cwd.
- Keep the SDK callback `cwd` field for compatibility while deliberately ignoring it at the trust boundary.

Credit: @ousamabenyounes (#3432). `Co-authored-by` on squash.

Refs #3357 #3432 #3607

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf2b6d39-c930-4576-a81d-029e74141ef4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf2b6d39-c930-4576-a81d-029e74141ef4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

