### PR TITLE
fix(hooks): anchor project names to Claude project dir

### DIFF
--- a/src/cli/adapters/claude-code.ts
+++ b/src/cli/adapters/claude-code.ts
@@ -1,5 +1,6 @@
 import type { PlatformAdapter, NormalizedHookInput, HookResult } from '../types.js';
 import { AdapterRejectedInput, isValidCwd } from './errors.js';
+import { resolveHookProjectPath } from '../../utils/project-name.js';
 
 const MAX_AGENT_FIELD_LEN = 128;
 const pickAgentField = (v: unknown): string | undefined =>
@@ -8,7 +9,11 @@ const pickAgentField = (v: unknown): string | undefined =>
 export const claudeCodeAdapter: PlatformAdapter = {
   normalizeInput(raw) {
     const r = (raw ?? {}) as any;
-    const cwd = r.cwd || process.cwd();
+    const inputCwd = r.cwd ?? process.cwd();
+    if (!isValidCwd(inputCwd)) {
+      throw new AdapterRejectedInput('invalid_cwd');
+    }
+    const cwd = resolveHookProjectPath(inputCwd);
     if (!isValidCwd(cwd)) {
       throw new AdapterRejectedInput('invalid_cwd');
     }

--- a/src/utils/project-name.ts
+++ b/src/utils/project-name.ts
@@ -4,6 +4,28 @@ import { expandHome } from '../shared/expand-home.js';
 import { logger } from './logger.js';
 import { detectWorktree } from './worktree.js';
 
+const CLAUDE_PROJECT_DIR_ENV = 'CLAUDE_PROJECT_DIR';
+const UNKNOWN_PROJECT_NAME = 'unknown-project';
+
+/**
+ * Resolve the anchor directory for a Claude Code hook payload: prefer
+ * `CLAUDE_PROJECT_DIR` (the directory Claude Code declares for the session) over
+ * the raw hook cwd, so SDK/subagent temp cwds never become the project identity
+ * (#3437). Returns `null` when neither a declared project dir nor a usable cwd
+ * exists. Scoped to the hook adapter boundary — callers that already hold an
+ * authoritative cwd (worker, transcript, worktree) must not route through this.
+ */
+export function resolveHookProjectPath(cwd: string | null | undefined): string | null {
+  const claudeProjectDir = process.env[CLAUDE_PROJECT_DIR_ENV]?.trim();
+  if (claudeProjectDir) {
+    return claudeProjectDir;
+  }
+  if (!cwd || cwd.trim() === '') {
+    return null;
+  }
+  return cwd;
+}
+
 /**
  * Resolve the git repository ROOT for a directory, so a project's name is
  * stable across its subdirectories and worktrees (#2663). Returns the absolute
@@ -34,7 +56,7 @@ export function getProjectName(
 ): string {
   if (!cwd || cwd.trim() === '') {
     logger.warn('PROJECT_NAME', 'Empty cwd provided, using fallback', { cwd });
-    return 'unknown-project';
+    return UNKNOWN_PROJECT_NAME;
   }
 
   const expanded = expandHome(cwd, platform);
@@ -59,7 +81,7 @@ export function getProjectName(
       }
     }
     logger.warn('PROJECT_NAME', 'Root directory detected, using fallback', { cwd });
-    return 'unknown-project';
+    return UNKNOWN_PROJECT_NAME;
   }
 
   return basename;

--- a/tests/cli/adapters/claude-code-subagent.test.ts
+++ b/tests/cli/adapters/claude-code-subagent.test.ts
@@ -1,5 +1,25 @@
-import { describe, it, expect } from 'bun:test';
+import { afterAll, beforeEach, describe, it, expect } from 'bun:test';
 import { claudeCodeAdapter } from '../../../src/cli/adapters/claude-code.js';
+import { AdapterRejectedInput } from '../../../src/cli/adapters/errors.js';
+
+const CLAUDE_PROJECT_DIR_ENV = 'CLAUDE_PROJECT_DIR';
+const SDK_TEMP_CWD = '/tmp/sdk-subagent';
+const DECLARED_PROJECT_DIR = '/tmp/declared-project';
+const NON_STRING_CWD = 42;
+const WHITESPACE_CWD = '   ';
+const savedClaudeProjectDir = process.env[CLAUDE_PROJECT_DIR_ENV];
+
+beforeEach(() => {
+  delete process.env[CLAUDE_PROJECT_DIR_ENV];
+});
+
+afterAll(() => {
+  if (savedClaudeProjectDir !== undefined) {
+    process.env[CLAUDE_PROJECT_DIR_ENV] = savedClaudeProjectDir;
+  } else {
+    delete process.env[CLAUDE_PROJECT_DIR_ENV];
+  }
+});
 
 describe('claudeCodeAdapter.normalizeInput — subagent fields', () => {
   it('extracts agentId and agentType when both are present', () => {
@@ -14,6 +34,28 @@ describe('claudeCodeAdapter.normalizeInput — subagent fields', () => {
     expect(normalized.cwd).toBe('/tmp');
     expect(normalized.agentId).toBe('agent-abc');
     expect(normalized.agentType).toBe('Explore');
+  });
+
+  it('anchors an SDK subagent cwd to CLAUDE_PROJECT_DIR', () => {
+    process.env[CLAUDE_PROJECT_DIR_ENV] = DECLARED_PROJECT_DIR;
+
+    const normalized = claudeCodeAdapter.normalizeInput({
+      session_id: 'sdk-session',
+      cwd: SDK_TEMP_CWD,
+      agent_id: 'sdk-agent',
+    });
+
+    expect(normalized.cwd).toBe(DECLARED_PROJECT_DIR);
+  });
+
+  it('rejects a non-string cwd with the adapter error contract', () => {
+    expect(() => claudeCodeAdapter.normalizeInput({ cwd: NON_STRING_CWD })).toThrow(AdapterRejectedInput);
+  });
+
+  it('rejects a whitespace-only cwd once the anchor resolves to nothing', () => {
+    // No CLAUDE_PROJECT_DIR, so resolveHookProjectPath() returns null for a
+    // blank cwd and the post-resolution isValidCwd guard rejects it.
+    expect(() => claudeCodeAdapter.normalizeInput({ cwd: WHITESPACE_CWD })).toThrow(AdapterRejectedInput);
   });
 
   it('leaves agentId and agentType undefined when fields are absent (main-session payload)', () => {

--- a/tests/utils/project-name.test.ts
+++ b/tests/utils/project-name.test.ts
@@ -1,7 +1,28 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
 import { homedir } from 'os';
-import { getProjectName, getProjectContext } from '../../src/utils/project-name.js';
+import { getProjectName, getProjectContext, resolveHookProjectPath } from '../../src/utils/project-name.js';
+
+const CLAUDE_PROJECT_DIR_ENV = 'CLAUDE_PROJECT_DIR';
+const ANCHORED_PROJECT_DIR_NAME = 'anchored-project';
+const OTHER_PROJECT_DIR_NAME = 'other-project';
+const SDK_TEMP_DIR_NAME = 'T';
+const CLAUDE_PROJECT_TEMP_PREFIX = 'cm-claude-project-dir-';
+const REPO_NESTED_DIR = ['packages', 'sdk-session'];
+const GIT_INIT_ARGS = ['init', '-q'];
+const savedClaudeProjectDir = process.env[CLAUDE_PROJECT_DIR_ENV];
+
+beforeAll(() => {
+  delete process.env[CLAUDE_PROJECT_DIR_ENV];
+});
+
+afterAll(() => {
+  if (savedClaudeProjectDir !== undefined) {
+    process.env[CLAUDE_PROJECT_DIR_ENV] = savedClaudeProjectDir;
+  } else {
+    delete process.env[CLAUDE_PROJECT_DIR_ENV];
+  }
+});
 
 describe('getProjectName', () => {
   describe('tilde expansion', () => {
@@ -56,6 +77,18 @@ describe('getProjectName', () => {
     it('returns unknown-project for whitespace', () => {
       expect(getProjectName('   ')).toBe('unknown-project');
     });
+
+    it('returns unknown-project for the filesystem root', () => {
+      expect(getProjectName('/')).toBe('unknown-project');
+    });
+
+    it('keeps the hook cwd when CLAUDE_PROJECT_DIR is unavailable', () => {
+      expect(resolveHookProjectPath(SDK_TEMP_DIR_NAME)).toBe(SDK_TEMP_DIR_NAME);
+    });
+
+    it('returns null when hook cwd and CLAUDE_PROJECT_DIR are unavailable', () => {
+      expect(resolveHookProjectPath(null)).toBeNull();
+    });
   });
 
   describe('#2663 — name derived from git repo root', () => {
@@ -95,6 +128,66 @@ describe('getProjectName', () => {
       // A path that does not exist (and therefore cannot be in a repo) must
       // fall back to basename(cwd) rather than throwing or returning a root.
       expect(getProjectName('/no/such/dir/standalone-folder')).toBe('standalone-folder');
+    });
+  });
+
+  describe('#3437 — Claude project dir anchors SDK/subagent sessions', () => {
+    let tmp: string;
+    let repoRoot: string;
+    let nestedRepoDir: string;
+    let otherProjectDir: string;
+    let sdkTempDir: string;
+    beforeAll(async () => {
+      const { mkdtempSync, mkdirSync, realpathSync } = await import('fs');
+      const { execFileSync } = await import('child_process');
+      const { join } = await import('path');
+      const { tmpdir } = await import('os');
+
+      tmp = realpathSync(mkdtempSync(join(tmpdir(), CLAUDE_PROJECT_TEMP_PREFIX)));
+      repoRoot = join(tmp, ANCHORED_PROJECT_DIR_NAME);
+      nestedRepoDir = join(repoRoot, ...REPO_NESTED_DIR);
+      otherProjectDir = join(tmp, OTHER_PROJECT_DIR_NAME);
+      sdkTempDir = join(tmp, SDK_TEMP_DIR_NAME);
+      mkdirSync(nestedRepoDir, { recursive: true });
+      mkdirSync(otherProjectDir, { recursive: true });
+      mkdirSync(sdkTempDir, { recursive: true });
+      execFileSync('git', GIT_INIT_ARGS, { cwd: repoRoot });
+    });
+
+    afterAll(async () => {
+      const { rmSync } = await import('fs');
+
+      delete process.env[CLAUDE_PROJECT_DIR_ENV];
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    it('uses CLAUDE_PROJECT_DIR instead of an SDK temp cwd', () => {
+      process.env[CLAUDE_PROJECT_DIR_ENV] = repoRoot;
+
+      const hookProjectPath = resolveHookProjectPath(sdkTempDir);
+      expect(getProjectName(hookProjectPath)).toBe(ANCHORED_PROJECT_DIR_NAME);
+      expect(getProjectName(hookProjectPath)).not.toBe(SDK_TEMP_DIR_NAME);
+    });
+
+    it('resolves CLAUDE_PROJECT_DIR through its git root when it points at a subdirectory', () => {
+      process.env[CLAUDE_PROJECT_DIR_ENV] = nestedRepoDir;
+
+      expect(getProjectName(resolveHookProjectPath(sdkTempDir))).toBe(ANCHORED_PROJECT_DIR_NAME);
+    });
+
+    it('anchors getProjectContext to CLAUDE_PROJECT_DIR for write-path callers', () => {
+      process.env[CLAUDE_PROJECT_DIR_ENV] = repoRoot;
+
+      const ctx = getProjectContext(resolveHookProjectPath(sdkTempDir));
+      expect(ctx.primary).toBe(ANCHORED_PROJECT_DIR_NAME);
+      expect(ctx.allProjects).toEqual([ANCHORED_PROJECT_DIR_NAME]);
+    });
+
+    it('keeps an explicit project cwd authoritative outside hook normalization', () => {
+      process.env[CLAUDE_PROJECT_DIR_ENV] = repoRoot;
+
+      expect(getProjectName(otherProjectDir)).toBe(OTHER_PROJECT_DIR_NAME);
+      expect(getProjectContext(otherProjectDir).primary).toBe(OTHER_PROJECT_DIR_NAME);
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**issue-patch-ship Gate: PASS** — rebase of #3439 onto current `main` (original was DIRTY/CONFLICTING; fork head is not writable from this agent).

## Gate

1. **RCA-later logged** — #3437: `project` is `basename(cwd)`, so SDK/subagent temp dirs become store keys (`T`, tool workspaces, `$HOME`) and project-scoped search silently misses ~26% of rows. This PR is the hook-boundary `CLAUDE_PROJECT_DIR` slice. Full `resolveProjectIdentity()` stays under plan-20 / #3608.
2. **No second-system** — `resolveHookProjectPath` is used only by the Claude Code adapter. `getProjectName` / explicit worker, transcript, and worktree cwds stay authoritative (the RED that blocked putting the env read inside `getProjectName`).
3. **Not opinionated** — 4 files, mostly tests; no bogus-name denylist, no migration, no global identity rewrite.

## Change

- Prefer `CLAUDE_PROJECT_DIR` while normalizing Claude Code hook payloads.
- Keep existing git-root / worktree naming after that anchor is selected.

Credit: @ousamabenyounes (#3439). `Co-authored-by` on squash.

Refs #3437 #3439 #3608

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf2b6d39-c930-4576-a81d-029e74141ef4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf2b6d39-c930-4576-a81d-029e74141ef4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

