### PR TITLE
fix(antigravity): align hooks/adapter/transcript with agy 1.2.1 contract (#4057)

### DIFF
--- a/docs/public/antigravity-cli/setup.mdx
+++ b/docs/public/antigravity-cli/setup.mdx
@@ -10,7 +10,7 @@ description: "Add persistent memory to Antigravity CLI with claude-mem"
 Antigravity CLI (`agy`) is Google's standalone successor to Gemini CLI — it reuses Gemini CLI's `~/.gemini/` config tree and, per Google, "keeps the most critical features of Gemini CLI: Agent Skills, Hooks, Subagents, and Extensions." Claude-mem changes what happens across sessions by capturing observations, decisions, and patterns — then injecting relevant context into each new session.
 
 <Info>
-**How it works:** Claude-mem installs lifecycle hooks into Antigravity CLI's shared `~/.gemini/settings.json` that capture tool usage, agent responses, and session events. A local worker service extracts semantic observations and injects relevant history at session start — via `GEMINI.md`, an MCP server, and a rules file.
+**How it works:** Claude-mem installs lifecycle hooks into Antigravity CLI's `~/.gemini/config/hooks.json` that capture tool usage, agent responses, and session events. A local worker service extracts semantic observations and injects relevant history at session start — via `GEMINI.md`, an MCP server, and a rules file.
 </Info>
 
 <Note>
@@ -33,7 +33,7 @@ npx claude-mem install --ide antigravity
 
 The installer will:
 1. Auto-detect Antigravity CLI (checks for `agy` in `PATH`, or an existing `~/.gemini/antigravity` directory)
-2. Install 8 lifecycle hooks into `~/.gemini/settings.json`
+2. Install the Antigravity CLI lifecycle hooks into `~/.gemini/config/hooks.json`
 3. Inject context configuration into `~/.gemini/GEMINI.md`
 4. Register claude-mem's MCP server in `~/.gemini/antigravity/mcp_config.json` **and** `~/.gemini/config/mcp_config.json`
 5. Write a rules/context placeholder to `~/.agents/rules/claude-mem-context.md`
@@ -103,7 +103,7 @@ Claude-mem needs an AI provider to extract observations from your sessions. Choo
 npx claude-mem status
 
 # Check hooks are installed — look for claude-mem entries
-cat ~/.gemini/settings.json | grep claude-mem
+cat ~/.gemini/config/hooks.json | grep claude-mem
 
 # Check MCP registration in either candidate config path
 cat ~/.gemini/antigravity/mcp_config.json | grep claude-mem
@@ -124,20 +124,19 @@ On session start, you'll see claude-mem context injected with your recent observ
 
 ## What gets captured
 
-Claude-mem registers all 8 confirmed Antigravity CLI lifecycle hooks (verified against a live install):
+Claude-mem registers the five lifecycle hooks Antigravity CLI (`agy` 1.2.1) actually fires:
 
 | Hook | Internal event | Purpose |
 |------|-----------------|---------|
-| **SessionStart** | `context` | Injects memory context into the session |
-| **BeforeAgent** | `session-init` | Captures user prompts |
-| **AfterAgent** | `observation` | Records full agent responses |
-| **BeforeTool** | `observation` | Logs tool invocations before execution |
-| **AfterTool** | `observation` | Captures tool results after execution |
-| **Notification** | `observation` | Records system events (permissions, etc.) |
-| **PreCompress** | `summarize` | Captures session summary before compression |
-| **SessionEnd** | `session-complete` | Marks session complete |
+| **PreInvocation** | `context` | Injects memory context (via `injectSteps`) before the agent runs |
+| **PreToolUse** | `observation` | Records tool intent, returns `{"decision":"allow"}` so the call proceeds |
+| **PostToolUse** | `observation` | Captures tool results after execution |
+| **PostInvocation** | `observation` | Records the agent's response (from the transcript's `PLANNER_RESPONSE` node) |
+| **Stop** | `summarize` | Captures the session summary at turn/session end |
 
-All 8 events above are **confirmed** — verified directly against a live, already-installed Antigravity CLI's `~/.gemini/settings.json` (not assumed from Gemini CLI's schema alone).
+<Note>
+These are the real `agy` 1.2.1 event names. Earlier releases mistakenly registered Gemini CLI names (`SessionStart`, `BeforeAgent`, `AfterAgent`, `BeforeTool`, `AfterTool`) into `~/.gemini/settings.json` — none of which exist in the `agy` binary, so hooks never fired and no observations were recorded (issue [#4057](https://github.com/thedotmack/claude-mem/issues/4057)).
+</Note>
 
 ## MCP registration
 
@@ -150,17 +149,17 @@ This gives claude-mem's search tools (`search`, `smart_search`, `timeline`, etc.
 
 ## Future enhancement (not implemented in this release)
 
-Antigravity CLI ships a first-class plugin-marketplace subcommand system: `agy plugin {list,import,install,uninstall,enable,disable,validate,link}`. Notably, `agy plugin import gemini|claude` suggests native cross-tool plugin migration — structurally similar to Codex CLI's `.codex-plugin/plugin.json` marketplace mechanism. This could eventually be a cleaner, more idiomatic way to bundle claude-mem's hooks + MCP + skills registration than hand-editing `settings.json`. It isn't implemented here because its manifest schema isn't discoverable without running `agy plugin import`/`install` against a real manifest, which would mutate a user's live local plugin state. Tracked as a candidate follow-up.
+Antigravity CLI ships a first-class plugin-marketplace subcommand system: `agy plugin {list,import,install,uninstall,enable,disable,validate,link}`. Notably, `agy plugin import gemini|claude` suggests native cross-tool plugin migration — structurally similar to Codex CLI's `.codex-plugin/plugin.json` marketplace mechanism. This could eventually be a cleaner, more idiomatic way to bundle claude-mem's hooks + MCP + skills registration than hand-editing `hooks.json`. It isn't implemented here because its manifest schema isn't discoverable without running `agy plugin import`/`install` against a real manifest, which would mutate a user's live local plugin state. Tracked as a candidate follow-up.
 
 ## Troubleshooting
 
 ### Hooks not firing
 
-1. Verify hooks exist in settings:
+1. Verify hooks exist in the hooks config:
    ```bash
-   cat ~/.gemini/settings.json
+   cat ~/.gemini/config/hooks.json
    ```
-   You should see entries like `"SessionStart"`, `"AfterTool"`, etc. with claude-mem commands.
+   You should see entries like `"PreInvocation"`, `"PostToolUse"`, `"Stop"`, etc. with claude-mem commands.
 
 2. Restart Antigravity CLI after installation.
 
@@ -202,7 +201,7 @@ npx claude-mem install --ide antigravity
 npx claude-mem uninstall
 ```
 
-This removes claude-mem's hooks from `~/.gemini/settings.json`, cleans up the context section in `~/.gemini/GEMINI.md`, removes claude-mem's entry from both MCP config files, and removes the rules context section — while preserving everything else in those files.
+This removes claude-mem's hooks from `~/.gemini/config/hooks.json` (and any legacy entries from `~/.gemini/settings.json`), cleans up the context section in `~/.gemini/GEMINI.md`, removes claude-mem's entry from both MCP config files, and removes the rules context section — while preserving everything else in those files.
 
 ## Next Steps
 

--- a/src/cli/adapters/antigravity-cli.ts
+++ b/src/cli/adapters/antigravity-cli.ts
@@ -1,80 +1,137 @@
 import type { PlatformAdapter } from '../types.js';
 import { AdapterRejectedInput, isValidCwd } from './errors.js';
+import { extractLastMessage } from '../../shared/transcript-parser.js';
+
+// `agy` wraps the real user message in <USER_REQUEST>...</USER_REQUEST> and
+// appends injected <ADDITIONAL_METADATA> (local time) and <USER_SETTINGS_CHANGE>
+// (model switches) blocks. Keep only the genuine request text.
+function unwrapAgyUserInput(text: string): string {
+  const match = text.match(/<USER_REQUEST>\s*([\s\S]*?)\s*<\/USER_REQUEST>/);
+  if (match) return match[1].trim();
+  return text
+    .replace(/<ADDITIONAL_METADATA>[\s\S]*?<\/ADDITIONAL_METADATA>/g, '')
+    .replace(/<USER_SETTINGS_CHANGE>[\s\S]*?<\/USER_SETTINGS_CHANGE>/g, '')
+    .trim();
+}
+
+// Antigravity's hook stdin is camelCase protojson with NO explicit event-name
+// field (issue #4057). The event is encoded by which hook fired (the CLI arg in
+// hooks.json → internal handler), and the payload key shape is the reliable
+// discriminator for output formatting:
+//   - PreToolUse     : { conversationId, workspacePaths, transcriptPath,
+//                        toolCall, stepIdx }                 (toolCall, no error)
+//   - PostToolUse    : { ..., toolCall, error? }            (toolCall + error key)
+//   - Pre/PostInvocation : { ..., invocationNum, initialNumSteps } (no toolCall)
+//   - Stop           : { ..., terminationReason }
+//
+// formatOutput() must key its protojson response off the same raw payload, so we
+// stash the last normalized raw input here (one normalizeInput→formatOutput
+// cycle per hook process, so module state is safe).
+let lastRawInput: Record<string, any> = {};
 
 export const antigravityCliAdapter: PlatformAdapter = {
   normalizeInput(raw) {
     const r = (raw ?? {}) as any;
+    lastRawInput = r;
 
-    // unverified: confirm Antigravity sets GEMINI_* env vars on first real hook firing
-    const cwd = r.cwd
-      || process.env.GEMINI_CWD
-      || process.env.GEMINI_PROJECT_DIR
-      || process.env.CLAUDE_PROJECT_DIR
-      || process.cwd();
+    const cwd = r.workspacePaths?.[0]
+      ?? r.cwd
+      ?? process.env.GEMINI_CWD
+      ?? process.env.GEMINI_PROJECT_DIR
+      ?? process.env.CLAUDE_PROJECT_DIR
+      ?? process.cwd();
     if (!isValidCwd(cwd)) {
       throw new AdapterRejectedInput('invalid_cwd');
     }
 
-    const sessionId = r.session_id
+    const sessionId = r.conversationId
+      ?? r.session_id
       ?? process.env.GEMINI_SESSION_ID
       ?? undefined;
 
-    const hookEventName: string | undefined = r.hook_event_name;
+    const transcriptPath = r.transcriptPath ?? r.transcript_path;
 
-    let toolName: string | undefined = r.tool_name;
-    let toolInput: unknown = r.tool_input;
+    const hasToolCall = Boolean(r.toolCall);
+    const hasErrorKey = 'error' in r;
+    // Pre/PostInvocation payloads are identical; both carry invocationNum and no
+    // toolCall.
+    const isInvocationEvent = 'invocationNum' in r && !hasToolCall;
+
+    let toolName: string | undefined = r.toolCall?.name ?? r.tool_name;
+    let toolInput: unknown = r.toolCall?.args ?? r.tool_input;
     let toolResponse: unknown = r.tool_response;
 
-    if (hookEventName === 'AfterAgent' && r.prompt_response) {
-      toolName = toolName ?? 'AntigravityProvider';
-      toolInput = toolInput ?? { prompt: r.prompt };
-      toolResponse = toolResponse ?? { response: r.prompt_response };
+    // Antigravity does not put the user's prompt on stdin — it lives in the
+    // transcript's USER_INPUT node. Pull it (unwrapped) for both invocation
+    // observations and context injection.
+    const transcriptPrompt = transcriptPath
+      ? unwrapAgyUserInput(extractLastMessage(transcriptPath, 'user'))
+      : '';
+    const prompt: string | undefined = r.prompt ?? (transcriptPrompt || undefined);
+
+    if (isInvocationEvent) {
+      // PreInvocation routes to the context handler (ignores tool fields);
+      // PostInvocation routes to observation and records the assistant's turn,
+      // which lives in the transcript's PLANNER_RESPONSE node.
+      const response = transcriptPath
+        ? extractLastMessage(transcriptPath, 'assistant')
+        : '';
+      toolName = 'AntigravityProvider';
+      toolInput = { prompt: prompt ?? 'User Query' };
+      toolResponse = { response: response || 'Completed' };
     }
 
-    if (hookEventName === 'BeforeTool' && toolName && !toolResponse) {
+    if (hasToolCall && !hasErrorKey && toolName && !toolResponse) {
+      // PreToolUse — the tool has not executed yet.
       toolResponse = { _preExecution: true };
     }
 
-    if (hookEventName === 'Notification') {
-      toolName = toolName ?? 'AntigravityNotification';
-      toolInput = toolInput ?? {
-        notification_type: r.notification_type,
-        message: r.message,
-      };
-      toolResponse = toolResponse ?? { details: r.details };
+    if (hasToolCall && hasErrorKey && toolName && !toolResponse) {
+      // PostToolUse — record the outcome.
+      toolResponse = typeof r.error === 'string' && r.error
+        ? { error: r.error }
+        : { status: 'completed' };
     }
 
     return {
       sessionId,
       cwd,
-      prompt: r.prompt,
+      prompt,
       toolName,
       toolInput,
       toolResponse,
-      transcriptPath: r.transcript_path,
+      transcriptPath,
     };
   },
 
+  // Antigravity deserializes hook stdout with strict protojson: unknown fields
+  // (continue / suppressOutput / systemMessage / hookSpecificOutput) make it
+  // discard the whole payload (issue #4057). Emit ONLY fields agy understands:
+  //   - PreToolUse     → { "decision": "allow" }   (or "deny" to block)
+  //   - PreInvocation  → { "injectSteps": [ ... ] } (context injection)
+  //   - PostToolUse / PostInvocation / Stop → {}
   formatOutput(result) {
-    const output: Record<string, unknown> = {};
+    const r = result ?? {};
+    const raw = lastRawInput ?? {};
+    const isPreTool = Boolean(raw.toolCall) && !('error' in raw);
 
-    output.continue = result.continue ?? true;
-
-    if (result.suppressOutput !== undefined) {
-      output.suppressOutput = result.suppressOutput;
+    if (r.continue === false || r.decision === 'block') {
+      return { decision: 'deny', reason: r.reason ?? 'Denied by hook' };
     }
 
-    if (result.systemMessage) {
+    // Context injection (PreInvocation) surfaces as additionalContext /
+    // systemMessage on the result. Antigravity injects it via injectSteps.
+    const additionalContext = r.hookSpecificOutput?.additionalContext ?? r.systemMessage;
+    if (additionalContext) {
       const ansiRegex = /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
-      output.systemMessage = result.systemMessage.replace(ansiRegex, '');
+      const cleanMessage = (additionalContext as string).replace(ansiRegex, '');
+      return { injectSteps: [{ ephemeralMessage: cleanMessage }] };
     }
 
-    if (result.hookSpecificOutput) {
-      output.hookSpecificOutput = {
-        additionalContext: result.hookSpecificOutput.additionalContext,
-      };
+    if (isPreTool) {
+      return { decision: 'allow' };
     }
 
-    return output;
+    return {};
   }
 };

--- a/src/services/integrations/AntigravityCliHooksInstaller.ts
+++ b/src/services/integrations/AntigravityCliHooksInstaller.ts
@@ -2,6 +2,7 @@
 import path from 'path';
 import { homedir } from 'os';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { execSync } from 'child_process';
 import { logger } from '../../utils/logger.js';
 import {
   getWorkerServiceAbsolutePath as findWorkerServicePath,
@@ -33,12 +34,22 @@ interface AntigravitySettingsJson {
   [key: string]: unknown;
 }
 
-// Antigravity CLI (`agy`) shares Gemini CLI's exact `~/.gemini/` config tree —
-// confirmed 2026-07-03 against a live install (see Phase B0 findings in
-// plans/2026-07-03-antigravity-cli-migration.md). Same settings.json, same
-// hook JSON schema, same GEMINI.md context file. Not a typo/leftover.
+// Antigravity CLI (`agy`) shares Gemini CLI's `~/.gemini/` config tree for
+// context (GEMINI.md) and MCP, but — contrary to an earlier assumption — it
+// does NOT read lifecycle hooks from `settings.json`. Confirmed against
+// `agy` 1.2.1 (issue #4057): the CLI loads hook definitions from a dedicated
+// `hooks.json` and fires the `PreToolUse` / `PostToolUse` / `PreInvocation` /
+// `PostInvocation` / `Stop` events (the Gemini-CLI `BeforeTool` / `AfterTool`
+// / `BeforeAgent` / `SessionStart` names do not exist in the binary, so hooks
+// written under those keys never execute).
 const GEMINI_CONFIG_DIR = path.join(homedir(), '.gemini');
+// Legacy path — retained ONLY so uninstall can strip hooks written by prior
+// (pre-#4057) versions that mistakenly registered them here. New installs
+// never write hooks to settings.json.
 const GEMINI_SETTINGS_PATH = path.join(GEMINI_CONFIG_DIR, 'settings.json');
+// The hooks file `agy` actually loads (issue #4057). Lives alongside the
+// already-used `~/.gemini/config/mcp_config.json`.
+const GEMINI_HOOKS_CONFIG_PATH = path.join(GEMINI_CONFIG_DIR, 'config', 'hooks.json');
 const GEMINI_MD_PATH = path.join(GEMINI_CONFIG_DIR, 'GEMINI.md');
 
 // B0 found two real, genuinely ambiguous MCP config paths on a live machine —
@@ -60,18 +71,62 @@ const RULES_CONTEXT_PATH = path.join(homedir(), '.agents', 'rules', 'claude-mem-
 const HOOK_NAME = 'claude-mem';
 const HOOK_TIMEOUT_MS = 10000;
 
-// 7 confirmed-live hook events (B0). SessionEnd is deliberately excluded:
-// 'session-complete' has no handler in src/cli/handlers/index.ts — it was
-// removed on purpose (see CHANGELOG.md:777) since the worker self-completes.
+// The 5 hook events `agy` 1.2.1 actually fires (issue #4057), mapped to
+// claude-mem's internal handlers:
+//   - PreInvocation  → context     (inject memory before the agent runs; the
+//                                    adapter emits `injectSteps` on this path)
+//   - PreToolUse     → observation (records tool intent; adapter emits
+//                                    `{"decision":"allow"}` so the call proceeds)
+//   - PostToolUse    → observation (records the tool result)
+//   - PostInvocation → observation (records the assistant response, pulled from
+//                                    the transcript's PLANNER_RESPONSE node)
+//   - Stop           → summarize   (session/turn end → summary)
+// The old Gemini-CLI names (SessionStart/BeforeAgent/AfterAgent/BeforeTool/
+// AfterTool/Notification/PreCompress) are NOT present in the agy binary and
+// were never executed.
 const ANTIGRAVITY_EVENT_TO_INTERNAL_EVENT: Record<string, string> = {
-  'SessionStart': 'context',
-  'BeforeAgent': 'session-init',
-  'AfterAgent': 'observation',
-  'BeforeTool': 'observation',
-  'AfterTool': 'observation',
-  'Notification': 'observation',
-  'PreCompress': 'summarize',
+  'PreInvocation': 'context',
+  'PreToolUse': 'observation',
+  'PostToolUse': 'observation',
+  'PostInvocation': 'observation',
+  'Stop': 'summarize',
 };
+
+// `agy` splits a hook command string on spaces and does NOT strip quotes, so a
+// quoted path makes bun receive a literal `"C:/path/bun"` argument and fail
+// with "File not found" (verified on a live install — quoted paths broke every
+// hook with exit status 1). On Windows, a space inside the path can't be
+// quoted away either, so resolve the 8.3 short path to remove the space; if 8.3
+// generation is disabled we fall back to the raw path with a warning rather
+// than blocking the install.
+function toSpaceFreePath(filePath: string): string {
+  if (!filePath.includes(' ')) return filePath;
+  if (process.platform !== 'win32') {
+    console.warn(
+      `  WARNING: Antigravity CLI hook path contains spaces: ${filePath}\n` +
+      `  agy splits commands on spaces, so hooks may fail to launch.\n` +
+      `  Move bun or the plugin to a path without spaces.`,
+    );
+    return filePath;
+  }
+  try {
+    const shortPath = execSync(
+      `for %~I in ("${filePath}") do @echo %~sI`,
+      { shell: 'cmd.exe', encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] },
+    ).trim();
+    if (shortPath && !shortPath.includes(' ')) return shortPath;
+  } catch (error) {
+    if (error instanceof Error) {
+      logger.error('WORKER', 'Failed to resolve Windows 8.3 short path', { path: filePath }, error);
+    }
+  }
+  console.warn(
+    `  WARNING: Antigravity CLI hook path contains spaces and 8.3 short-path\n` +
+    `  resolution failed: ${filePath}\n` +
+    `  agy splits commands on spaces, so hooks may fail to launch.`,
+  );
+  return filePath;
+}
 
 function buildHookCommand(
   bunPath: string,
@@ -83,10 +138,13 @@ function buildHookCommand(
     throw new Error(`Unknown Antigravity CLI event: ${antigravityEventName}`);
   }
 
-  const escapedBunPath = bunPath.replace(/\\/g, '\\\\');
-  const escapedWorkerPath = workerServicePath.replace(/\\/g, '\\\\');
+  // Emit bare, forward-slashed paths (see toSpaceFreePath): agy does not run the
+  // command through a shell, so quotes are taken literally and backslashes are
+  // fragile.
+  const formattedBunPath = toSpaceFreePath(bunPath).replace(/\\/g, '/');
+  const formattedWorkerPath = toSpaceFreePath(workerServicePath).replace(/\\/g, '/');
 
-  return `"${escapedBunPath}" "${escapedWorkerPath}" hook antigravity-cli ${internalEvent}`;
+  return `${formattedBunPath} ${formattedWorkerPath} hook antigravity-cli ${internalEvent}`;
 }
 
 function createHookGroup(hookCommand: string): AntigravityHookGroup {
@@ -124,19 +182,46 @@ function writeAntigravitySettings(settings: AntigravitySettingsJson): void {
   writeFileSync(GEMINI_SETTINGS_PATH, JSON.stringify(settings, null, 2) + '\n');
 }
 
-// Generic JSON-group merge — doesn't depend on event names, copied verbatim
-// from the removed GeminiCliHooksInstaller.ts.
-function mergeHooksIntoSettings(
-  existingSettings: AntigravitySettingsJson,
-  newHooks: AntigravityHooksConfig,
-): AntigravitySettingsJson {
-  const settings = { ...existingSettings };
-  if (!settings.hooks) {
-    settings.hooks = {};
+// Read the standalone `hooks.json` agy loads. Returns the event→groups map
+// (the whole file). Empty/missing file → {}. Genuinely corrupt (non-empty,
+// unparseable) content throws so we never clobber a user's hand-edited hooks.
+function readAntigravityHooksConfig(): AntigravityHooksConfig {
+  if (!existsSync(GEMINI_HOOKS_CONFIG_PATH)) {
+    return {};
   }
+  const content = readFileSync(GEMINI_HOOKS_CONFIG_PATH, 'utf-8');
+  if (!content.trim()) {
+    return {};
+  }
+  try {
+    return JSON.parse(content) as AntigravityHooksConfig;
+  } catch (error) {
+    logger.error(
+      'WORKER',
+      'Corrupt JSON in Antigravity CLI hooks config',
+      { path: GEMINI_HOOKS_CONFIG_PATH },
+      error instanceof Error ? error : new Error(String(error)),
+    );
+    throw new Error(`Corrupt JSON in ${GEMINI_HOOKS_CONFIG_PATH}, refusing to overwrite user hooks`);
+  }
+}
+
+function writeAntigravityHooksConfig(hooksConfig: AntigravityHooksConfig): void {
+  mkdirSync(path.dirname(GEMINI_HOOKS_CONFIG_PATH), { recursive: true });
+  writeFileSync(GEMINI_HOOKS_CONFIG_PATH, JSON.stringify(hooksConfig, null, 2) + '\n');
+}
+
+// Generic JSON-group merge — merges claude-mem's hook groups into an existing
+// event→groups map (keyed on the `claude-mem` hook name), preserving any hooks
+// the user or other tools registered. Event-name agnostic.
+function mergeHooksIntoConfig(
+  existingConfig: AntigravityHooksConfig,
+  newHooks: AntigravityHooksConfig,
+): AntigravityHooksConfig {
+  const config: AntigravityHooksConfig = { ...existingConfig };
 
   for (const [eventName, newGroups] of Object.entries(newHooks)) {
-    const existingGroups: AntigravityHookGroup[] = settings.hooks[eventName] ?? [];
+    const existingGroups: AntigravityHookGroup[] = config[eventName] ?? [];
 
     for (const newGroup of newGroups) {
       const existingGroupIndex = existingGroups.findIndex((group: AntigravityHookGroup) =>
@@ -156,10 +241,10 @@ function mergeHooksIntoSettings(
       }
     }
 
-    settings.hooks[eventName] = existingGroups;
+    config[eventName] = existingGroups;
   }
 
-  return settings;
+  return config;
 }
 
 function setupGeminiMdContextSection(): void {
@@ -241,17 +326,17 @@ export async function installAntigravityCliHooks(): Promise<number> {
       hooksConfig[antigravityEvent] = [createHookGroup(command)];
     }
 
-    const existingSettings = readAntigravitySettings();
-    const mergedSettings = mergeHooksIntoSettings(existingSettings, hooksConfig);
+    const existingHooks = readAntigravityHooksConfig();
+    const mergedHooks = mergeHooksIntoConfig(existingHooks, hooksConfig);
 
-    writeAntigravityHooksAndSetupContext(mergedSettings);
+    writeAntigravityHooksAndSetupContext(mergedHooks);
     registerAntigravityMcp();
     setupRulesContextFile();
 
     console.log(`
 Installation complete!
 
-Hooks installed to:    ${GEMINI_SETTINGS_PATH}
+Hooks installed to:    ${GEMINI_HOOKS_CONFIG_PATH}
 MCP config installed to:
   ${ANTIGRAVITY_MCP_CONFIG_PATHS.join('\n  ')}
 Using unified CLI: bun worker-service.cjs hook antigravity-cli <event>
@@ -274,9 +359,9 @@ Context Injection:
   }
 }
 
-function writeAntigravityHooksAndSetupContext(mergedSettings: AntigravitySettingsJson): void {
-  writeAntigravitySettings(mergedSettings);
-  console.log(`  Merged hooks into ${GEMINI_SETTINGS_PATH}`);
+function writeAntigravityHooksAndSetupContext(mergedHooks: AntigravityHooksConfig): void {
+  writeAntigravityHooksConfig(mergedHooks);
+  console.log(`  Merged hooks into ${GEMINI_HOOKS_CONFIG_PATH}`);
 
   setupGeminiMdContextSection();
   console.log(`  Setup context injection in ${GEMINI_MD_PATH}`);
@@ -328,10 +413,12 @@ export function uninstallAntigravityCliHooks(): number {
   console.log('\nUninstalling Claude-Mem Antigravity CLI hooks + MCP...\n');
 
   try {
+    removeAntigravityHooksFromHooksConfig();
+
+    // Legacy cleanup: strip hooks that pre-#4057 versions wrote into
+    // settings.json (agy never read them, but leave the user's file tidy).
     if (existsSync(GEMINI_SETTINGS_PATH)) {
       removeAntigravityHooksFromSettings();
-    } else {
-      console.log('  No Antigravity CLI (Gemini-shared) settings found — nothing to uninstall.');
     }
 
     for (const mcpConfigPath of ANTIGRAVITY_MCP_CONFIG_PATHS) {
@@ -355,10 +442,52 @@ export function uninstallAntigravityCliHooks(): number {
   }
 }
 
+function removeAntigravityHooksFromHooksConfig(): void {
+  if (!existsSync(GEMINI_HOOKS_CONFIG_PATH)) {
+    console.log('  No Antigravity CLI hooks.json found — nothing to uninstall.');
+    return;
+  }
+
+  let config: AntigravityHooksConfig;
+  try {
+    config = readAntigravityHooksConfig();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(`  Skipping hooks.json cleanup: ${message}`);
+    return;
+  }
+
+  let removedCount = 0;
+
+  for (const [eventName, groups] of Object.entries(config)) {
+    if (!Array.isArray(groups)) continue;
+    const filteredGroups = groups
+      .map(group => {
+        if (!group || !Array.isArray(group.hooks)) return group;
+        const remainingHooks = group.hooks.filter(hook => hook.name !== HOOK_NAME);
+        removedCount += group.hooks.length - remainingHooks.length;
+        return { ...group, hooks: remainingHooks };
+      })
+      .filter(group => !group || !Array.isArray(group.hooks) || group.hooks.length > 0);
+
+    if (filteredGroups.length > 0) {
+      config[eventName] = filteredGroups;
+    } else {
+      delete config[eventName];
+    }
+  }
+
+  writeAntigravityHooksConfig(config);
+  console.log(`  Removed ${removedCount} claude-mem hook(s) from ${GEMINI_HOOKS_CONFIG_PATH}`);
+
+  if (removeContextTagBlock(GEMINI_MD_PATH)) {
+    console.log(`  Removed context section from ${GEMINI_MD_PATH}`);
+  }
+}
+
 function removeAntigravityHooksFromSettings(): void {
   const settings = readAntigravitySettings();
   if (!settings.hooks) {
-    console.log('  No hooks found in Antigravity CLI settings — nothing to uninstall.');
     return;
   }
 
@@ -395,36 +524,31 @@ function removeAntigravityHooksFromSettings(): void {
 export function checkAntigravityCliHooksStatus(): number {
   console.log('\nClaude-Mem Antigravity CLI Status\n');
 
-  if (!existsSync(GEMINI_SETTINGS_PATH)) {
-    console.log('Antigravity CLI settings: Not found');
-    console.log(`  Expected at: ${GEMINI_SETTINGS_PATH}\n`);
+  if (!existsSync(GEMINI_HOOKS_CONFIG_PATH)) {
+    console.log('Antigravity CLI hooks.json: Not found');
+    console.log(`  Expected at: ${GEMINI_HOOKS_CONFIG_PATH}\n`);
     console.log('No hooks installed. Run: claude-mem install --ide antigravity\n');
     return 0;
   }
 
-  let settings: AntigravitySettingsJson;
+  let hooksConfig: AntigravityHooksConfig;
   try {
-    settings = readAntigravitySettings();
+    hooksConfig = readAntigravityHooksConfig();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    if (error instanceof Error) {
-      logger.error('WORKER', 'Failed to read Antigravity CLI settings', { path: GEMINI_SETTINGS_PATH }, error);
-    } else {
-      logger.error('WORKER', 'Failed to read Antigravity CLI settings', { path: GEMINI_SETTINGS_PATH }, new Error(String(error)));
-    }
-    console.log(`Antigravity CLI settings: ${message}\n`);
+    logger.error('WORKER', 'Failed to read Antigravity CLI hooks config', { path: GEMINI_HOOKS_CONFIG_PATH }, error instanceof Error ? error : new Error(String(error)));
+    console.log(`Antigravity CLI hooks.json: ${message}\n`);
     return 0;
   }
 
   const installedEvents: string[] = [];
-  if (settings.hooks) {
-    for (const [eventName, groups] of Object.entries(settings.hooks)) {
-      const hasClaudeMem = groups.some(group =>
-        group.hooks.some(hook => hook.name === HOOK_NAME)
-      );
-      if (hasClaudeMem) {
-        installedEvents.push(eventName);
-      }
+  for (const [eventName, groups] of Object.entries(hooksConfig)) {
+    if (!Array.isArray(groups)) continue;
+    const hasClaudeMem = groups.some(group =>
+      Array.isArray(group?.hooks) && group.hooks.some(hook => hook.name === HOOK_NAME)
+    );
+    if (hasClaudeMem) {
+      installedEvents.push(eventName);
     }
   }
 
@@ -432,7 +556,7 @@ export function checkAntigravityCliHooksStatus(): number {
     console.log('Hooks: Not installed');
     console.log('Run: claude-mem install --ide antigravity\n');
   } else {
-    console.log(`Settings: ${GEMINI_SETTINGS_PATH}`);
+    console.log(`Hooks config: ${GEMINI_HOOKS_CONFIG_PATH}`);
     console.log(`Mode: Unified CLI (bun worker-service.cjs hook antigravity-cli)`);
     console.log(`Events: ${installedEvents.length} of ${Object.keys(ANTIGRAVITY_EVENT_TO_INTERNAL_EVENT).length} mapped`);
     for (const event of installedEvents) {
@@ -485,7 +609,7 @@ Claude-Mem Antigravity CLI Integration
 Usage: claude-mem antigravity-cli <command>
 
 Commands:
-  install             Install hooks into ~/.gemini/settings.json + MCP config
+  install             Install hooks into ~/.gemini/config/hooks.json + MCP config
   uninstall           Remove claude-mem hooks/MCP entries (preserves other config)
   status              Check installation status
 

--- a/src/shared/transcript-parser.ts
+++ b/src/shared/transcript-parser.ts
@@ -74,11 +74,46 @@ export function extractLastAssistantTurn(
 }
 
 /**
+ * Antigravity CLI (`agy`) transcript node types → chat roles. Its
+ * `brain/<session>/.system_generated/logs/transcript.jsonl` lines are shaped
+ * `{step_index, source, type, content}` with the text at the TOP LEVEL
+ * (`content`), not under `message.content` (issue #4057). Only PLANNER_RESPONSE
+ * carries the assistant's final text — RUN_COMMAND / VIEW_FILE / etc. also
+ * carry `source: 'MODEL'`, so we discriminate on `type`, never on `source`.
+ */
+const ANTIGRAVITY_TYPE_TO_ROLE: Record<string, 'user' | 'assistant'> = {
+  USER_INPUT: 'user',
+  PLANNER_RESPONSE: 'assistant',
+};
+
+/**
+ * Reduce a message content value to plain text. Returns `null` for an unknown
+ * shape so callers can skip the line (rather than treating it as empty text).
+ * Handles a top-level string, a Claude-style content array (`{type:'text',text}`),
+ * and a generic `{text}` array (Antigravity, when content isn't a bare string).
+ */
+function contentToText(msgContent: unknown): string | null {
+  if (typeof msgContent === 'string') return msgContent;
+  if (Array.isArray(msgContent)) {
+    return msgContent
+      .filter(
+        (c: any): c is { text: string } =>
+          !!c && typeof c === 'object' && typeof c.text === 'string' &&
+          (c.type === undefined || c.type === 'text')
+      )
+      .map((c) => c.text)
+      .join('\n');
+  }
+  return null;
+}
+
+/**
  * Extract last message from a JSONL transcript.
  *
- * Supports two field conventions for the per-line role marker:
- * - Claude Code:  `{"type":"assistant",...}`
- * - Cursor:       `{"role":"assistant",...}`
+ * Supports three field conventions for the per-line role marker:
+ * - Claude Code:      `{"type":"assistant","message":{"content":...}}`
+ * - Cursor:           `{"role":"assistant","message":{"content":...}}`
+ * - Antigravity CLI:  `{"type":"PLANNER_RESPONSE","content":"..."}` (top-level)
  *
  * The most recent assistant turn is often a pure tool_use block with no text
  * content (especially in Cursor, where the agent's last action before the
@@ -95,32 +130,26 @@ export function extractLastMessageFromJsonl(
   let lastEmptyText: string | null = null;
 
   for (const line of parseJsonlLinesBackward(content)) {
-    const lineRole = line.type ?? line.role;
+    const antigravityRole = typeof line.type === 'string'
+      ? ANTIGRAVITY_TYPE_TO_ROLE[line.type]
+      : undefined;
+    const lineRole = antigravityRole ?? line.type ?? line.role;
     if (lineRole !== role) continue;
     foundMatchingRole = true;
 
-    if (!line.message?.content) continue;
+    // Antigravity nodes carry text at the top level; Claude/Cursor nest it under
+    // `message.content`.
+    const msgContent = antigravityRole !== undefined ? line.content : line.message?.content;
+    if (msgContent === undefined || msgContent === null) continue;
 
-    let text = '';
-    const msgContent = line.message.content;
-    if (typeof msgContent === 'string') {
-      text = msgContent;
-    } else if (Array.isArray(msgContent)) {
-      text = msgContent
-        .filter(
-          (c: any): c is { type: 'text'; text: string } =>
-            !!c && typeof c === 'object' && c.type === 'text' && typeof c.text === 'string'
-        )
-        .map((c) => c.text)
-        .join('\n');
-    } else {
-      // Unknown content shape (null, number, plain object, etc.) — skip rather
-      // than throw. A single weird line should not crash the entire summary
-      // pipeline; we already tolerate malformed JSONL in parseJsonlLinesBackward,
-      // and this is the same class of defensive forward compat
-      // (CodeRabbit / Greptile review on PR #2282).
-      continue;
-    }
+    // Unknown content shape (number, plain object, etc.) — skip rather than
+    // throw. A single weird line should not crash the entire summary pipeline;
+    // we already tolerate malformed JSONL in parseJsonlLinesBackward, and this
+    // is the same class of defensive forward compat (CodeRabbit / Greptile
+    // review on PR #2282).
+    const extracted = contentToText(msgContent);
+    if (extracted === null) continue;
+    let text = extracted;
 
     if (stripSystemReminders) {
       text = text.replace(SYSTEM_REMINDER_REGEX, '');

--- a/tests/antigravity-cli-compat.test.ts
+++ b/tests/antigravity-cli-compat.test.ts
@@ -1,42 +1,75 @@
 import { describe, it, expect } from 'bun:test';
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { readFileSync } from 'fs';
 import { antigravityCliAdapter } from '../src/cli/adapters/antigravity-cli.js';
+import { extractLastMessage } from '../src/shared/transcript-parser.js';
 
 const INSTALLER_PATH = 'src/services/integrations/AntigravityCliHooksInstaller.ts';
 
-describe('AntigravityCliHooksInstaller - event mapping (B0-confirmed 7-event map)', () => {
+// These assertions lock in the REAL agy 1.2.1 hook contract (issue #4057).
+// The prior version of this file asserted the legacy Gemini-CLI event map
+// (BeforeTool/AfterTool/BeforeAgent/SessionStart) written into settings.json —
+// none of which agy actually fires — so it "passed" while recording zero
+// observations. Do not reintroduce those names.
+describe('AntigravityCliHooksInstaller - agy 1.2.1 event map', () => {
   const src = readFileSync(INSTALLER_PATH, 'utf-8');
 
-  it('maps SessionStart to context', () => {
-    expect(src).toContain("'SessionStart': 'context'");
+  it('maps PreInvocation to context (the injectSteps context-injection point)', () => {
+    expect(src).toContain("'PreInvocation': 'context'");
   });
 
-  it('maps BeforeAgent to session-init, not user-message', () => {
-    expect(src).toContain("'BeforeAgent': 'session-init'");
+  it('maps PreToolUse and PostToolUse to observation', () => {
+    expect(src).toContain("'PreToolUse': 'observation'");
+    expect(src).toContain("'PostToolUse': 'observation'");
   });
 
-  it('maps AfterAgent, BeforeTool, AfterTool, and Notification to observation', () => {
-    expect(src).toContain("'AfterAgent': 'observation'");
-    expect(src).toContain("'BeforeTool': 'observation'");
-    expect(src).toContain("'AfterTool': 'observation'");
-    expect(src).toContain("'Notification': 'observation'");
+  it('maps PostInvocation to observation', () => {
+    expect(src).toContain("'PostInvocation': 'observation'");
   });
 
-  it('maps PreCompress to summarize', () => {
-    expect(src).toContain("'PreCompress': 'summarize'");
+  it('maps Stop to summarize', () => {
+    expect(src).toContain("'Stop': 'summarize'");
   });
 
-  it('should not map SessionEnd (session-complete has no handler; worker self-completes)', () => {
-    expect(src).not.toContain("'SessionEnd':");
+  it('does NOT register the legacy Gemini-CLI event names (0 occurrences in agy)', () => {
+    expect(src).not.toContain("'BeforeTool'");
+    expect(src).not.toContain("'AfterTool'");
+    expect(src).not.toContain("'BeforeAgent'");
+    expect(src).not.toContain("'AfterAgent'");
+    expect(src).not.toContain("'SessionStart':");
+    expect(src).not.toContain("'PreCompress'");
+    expect(src).not.toContain("'Notification':");
   });
 
   it('uses the antigravity-cli hook command string, not gemini-cli', () => {
     expect(src).toContain('hook antigravity-cli');
     expect(src).not.toContain('hook gemini-cli');
   });
+});
 
-  it('targets the shared ~/.gemini config tree (settings.json + GEMINI.md), not a separate Antigravity-only file', () => {
-    expect(src).toContain("path.join(GEMINI_CONFIG_DIR, 'settings.json')");
+describe('AntigravityCliHooksInstaller - hooks.json target (not settings.json)', () => {
+  const src = readFileSync(INSTALLER_PATH, 'utf-8');
+
+  it('writes hooks to ~/.gemini/config/hooks.json (the file agy loads)', () => {
+    expect(src).toContain("path.join(GEMINI_CONFIG_DIR, 'config', 'hooks.json')");
+    expect(src).toContain('writeAntigravityHooksConfig');
+  });
+
+  it('does not write hooks into settings.json on install', () => {
+    // settings.json is only referenced for LEGACY uninstall cleanup, never for
+    // writing hooks. Install must go through the hooks.json writer.
+    expect(src).toContain('writeAntigravityHooksAndSetupContext(mergedHooks)');
+    expect(src).toContain('writeAntigravityHooksConfig(mergedHooks)');
+  });
+
+  it('emits bare (unquoted) forward-slashed hook command paths (agy splits on spaces, keeps quotes)', () => {
+    expect(src).toContain('hook antigravity-cli ${internalEvent}');
+    expect(src).not.toContain('"${escapedBunPath}" "${escapedWorkerPath}"');
+  });
+
+  it('still targets the shared ~/.gemini GEMINI.md context file', () => {
     expect(src).toContain("path.join(GEMINI_CONFIG_DIR, 'GEMINI.md')");
   });
 
@@ -45,18 +78,38 @@ describe('AntigravityCliHooksInstaller - event mapping (B0-confirmed 7-event map
     expect(src).toContain("path.join(GEMINI_CONFIG_DIR, 'config', 'mcp_config.json')");
   });
 
-  it('reuses writeMcpJsonConfig from McpIntegrations.ts rather than reimplementing MCP config writing', () => {
-    expect(src).toContain("from './McpIntegrations.js'");
-    expect(src).toContain('writeMcpJsonConfig');
-  });
-
   it('writes the rules/context placeholder to the plural, home-relative .agents/rules path', () => {
     expect(src).toContain("path.join(homedir(), '.agents', 'rules', 'claude-mem-context.md')");
   });
 });
 
-describe('antigravityCliAdapter - normalizeInput', () => {
-  it('falls back to process.cwd() when no cwd and no GEMINI_*/CLAUDE_PROJECT_DIR env vars are set', () => {
+describe('antigravityCliAdapter - normalizeInput (camelCase protojson stdin)', () => {
+  it('reads cwd from workspacePaths[0]', () => {
+    const result = antigravityCliAdapter.normalizeInput({
+      workspacePaths: ['/tmp/agy-workspace'],
+      conversationId: 'conv-1',
+    });
+    expect(result.cwd).toBe('/tmp/agy-workspace');
+  });
+
+  it('reads sessionId from conversationId', () => {
+    const result = antigravityCliAdapter.normalizeInput({
+      workspacePaths: ['/tmp'],
+      conversationId: 'conv-abc',
+    });
+    expect(result.sessionId).toBe('conv-abc');
+  });
+
+  it('reads transcriptPath from the camelCase transcriptPath field', () => {
+    const result = antigravityCliAdapter.normalizeInput({
+      workspacePaths: ['/tmp'],
+      conversationId: 'c',
+      transcriptPath: '/tmp/does-not-exist.jsonl',
+    });
+    expect(result.transcriptPath).toBe('/tmp/does-not-exist.jsonl');
+  });
+
+  it('falls back to process.cwd() when nothing provides a cwd', () => {
     const savedCwd = process.env.GEMINI_CWD;
     const savedProjectDir = process.env.GEMINI_PROJECT_DIR;
     const savedClaudeDir = process.env.CLAUDE_PROJECT_DIR;
@@ -64,7 +117,7 @@ describe('antigravityCliAdapter - normalizeInput', () => {
     delete process.env.GEMINI_PROJECT_DIR;
     delete process.env.CLAUDE_PROJECT_DIR;
     try {
-      const result = antigravityCliAdapter.normalizeInput({});
+      const result = antigravityCliAdapter.normalizeInput({ conversationId: 'c' });
       expect(result.cwd).toBe(process.cwd());
     } finally {
       if (savedCwd !== undefined) process.env.GEMINI_CWD = savedCwd;
@@ -73,79 +126,172 @@ describe('antigravityCliAdapter - normalizeInput', () => {
     }
   });
 
-  it('prefers an explicit cwd over any env var fallback', () => {
-    const result = antigravityCliAdapter.normalizeInput({ cwd: '/tmp/explicit-cwd' });
-    expect(result.cwd).toBe('/tmp/explicit-cwd');
-  });
-
-  it('falls back to process.cwd() when cwd is an empty string (#3887)', () => {
-    const result = antigravityCliAdapter.normalizeInput({ cwd: '' });
-    expect(result.cwd).toBe(process.cwd());
-  });
-
-  it('maps AfterAgent prompt_response into toolName/toolInput/toolResponse', () => {
+  it('extracts toolName/toolInput from a PreToolUse toolCall and marks it pre-execution', () => {
     const result = antigravityCliAdapter.normalizeInput({
-      cwd: '/tmp',
-      hook_event_name: 'AfterAgent',
-      prompt: 'hi',
-      prompt_response: 'hello there',
+      workspacePaths: ['/tmp'],
+      conversationId: 'c',
+      toolCall: { name: 'Read', args: { path: '/tmp/x' } },
+      stepIdx: 3,
     });
-    expect(result.toolName).toBe('AntigravityProvider');
-    expect(result.toolInput).toEqual({ prompt: 'hi' });
-    expect(result.toolResponse).toEqual({ response: 'hello there' });
-  });
-
-  it('marks a BeforeTool call as pre-execution when no response is present', () => {
-    const result = antigravityCliAdapter.normalizeInput({
-      cwd: '/tmp',
-      hook_event_name: 'BeforeTool',
-      tool_name: 'Read',
-    });
+    expect(result.toolName).toBe('Read');
+    expect(result.toolInput).toEqual({ path: '/tmp/x' });
     expect(result.toolResponse).toEqual({ _preExecution: true });
   });
 
-  it('maps Notification fields into toolName/toolInput/toolResponse', () => {
+  it('records a PostToolUse error from the error key', () => {
     const result = antigravityCliAdapter.normalizeInput({
-      cwd: '/tmp',
-      hook_event_name: 'Notification',
-      notification_type: 'permission',
-      message: 'allow?',
-      details: { foo: 'bar' },
+      workspacePaths: ['/tmp'],
+      conversationId: 'c',
+      toolCall: { name: 'Bash', args: { command: 'boom' } },
+      error: 'command failed',
     });
-    expect(result.toolName).toBe('AntigravityNotification');
-    expect(result.toolInput).toEqual({ notification_type: 'permission', message: 'allow?' });
-    expect(result.toolResponse).toEqual({ details: { foo: 'bar' } });
+    expect(result.toolName).toBe('Bash');
+    expect(result.toolResponse).toEqual({ error: 'command failed' });
+  });
+
+  it('maps an invocation payload to the AntigravityProvider provider fields', () => {
+    const result = antigravityCliAdapter.normalizeInput({
+      workspacePaths: ['/tmp'],
+      conversationId: 'c',
+      invocationNum: 1,
+      initialNumSteps: 0,
+    });
+    expect(result.toolName).toBe('AntigravityProvider');
+    expect(result.toolInput).toEqual({ prompt: 'User Query' });
+    expect(result.toolResponse).toEqual({ response: 'Completed' });
+  });
+
+  it('pulls prompt (USER_INPUT) and response (PLANNER_RESPONSE) from the transcript on an invocation', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'agy-transcript-'));
+    const transcriptPath = join(dir, 'transcript.jsonl');
+    writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({ step_index: 0, source: 'USER_EXPLICIT', type: 'USER_INPUT', content: '<USER_REQUEST>fix the bug</USER_REQUEST>' }),
+        JSON.stringify({ step_index: 1, source: 'MODEL', type: 'RUN_COMMAND', content: 'ls' }),
+        JSON.stringify({ step_index: 2, source: 'MODEL', type: 'PLANNER_RESPONSE', content: 'I fixed it.' }),
+      ].join('\n') + '\n',
+    );
+
+    const result = antigravityCliAdapter.normalizeInput({
+      workspacePaths: [dir],
+      conversationId: 'c',
+      transcriptPath,
+      invocationNum: 1,
+      initialNumSteps: 0,
+    });
+
+    expect(result.prompt).toBe('fix the bug');
+    expect(result.toolInput).toEqual({ prompt: 'fix the bug' });
+    expect(result.toolResponse).toEqual({ response: 'I fixed it.' });
   });
 });
 
-describe('antigravityCliAdapter - formatOutput', () => {
-  it('strips ANSI escape codes from systemMessage (real bug fix carried over from Gemini CLI adapter)', () => {
-    const raw = '[31mRed text[0m';
-    const result = antigravityCliAdapter.formatOutput({ systemMessage: raw }) as Record<string, unknown>;
-    expect(result.systemMessage).toBe('Red text');
+describe('antigravityCliAdapter - formatOutput (strict protojson stdout)', () => {
+  it('emits {"decision":"allow"} for a PreToolUse (toolCall, no error)', () => {
+    antigravityCliAdapter.normalizeInput({
+      workspacePaths: ['/tmp'],
+      conversationId: 'c',
+      toolCall: { name: 'Read', args: {} },
+    });
+    const out = antigravityCliAdapter.formatOutput({ continue: true, suppressOutput: true }) as Record<string, unknown>;
+    expect(out).toEqual({ decision: 'allow' });
   });
 
-  it('defaults continue to true and passes through hookSpecificOutput.additionalContext', () => {
-    const result = antigravityCliAdapter.formatOutput({
-      hookSpecificOutput: { hookEventName: 'SessionStart', additionalContext: 'ctx' },
+  it('emits {} for a PostToolUse (toolCall + error key)', () => {
+    antigravityCliAdapter.normalizeInput({
+      workspacePaths: ['/tmp'],
+      conversationId: 'c',
+      toolCall: { name: 'Read', args: {} },
+      error: '',
+    });
+    const out = antigravityCliAdapter.formatOutput({ continue: true, suppressOutput: true }) as Record<string, unknown>;
+    expect(out).toEqual({});
+  });
+
+  it('emits injectSteps for a context-injection result and strips ANSI', () => {
+    antigravityCliAdapter.normalizeInput({
+      workspacePaths: ['/tmp'],
+      conversationId: 'c',
+      invocationNum: 1,
+    });
+    const out = antigravityCliAdapter.formatOutput({
+      hookSpecificOutput: { hookEventName: 'SessionStart', additionalContext: '\u001b[31mpast context\u001b[0m' },
     }) as Record<string, unknown>;
-    expect(result.continue).toBe(true);
-    expect(result.hookSpecificOutput).toEqual({ additionalContext: 'ctx' });
+    expect(out).toEqual({ injectSteps: [{ ephemeralMessage: 'past context' }] });
   });
 
-  it('passes through suppressOutput when explicitly set', () => {
-    const result = antigravityCliAdapter.formatOutput({ suppressOutput: true }) as Record<string, unknown>;
-    expect(result.suppressOutput).toBe(true);
+  it('emits {} for an invocation/Stop result with no context', () => {
+    antigravityCliAdapter.normalizeInput({
+      workspacePaths: ['/tmp'],
+      conversationId: 'c',
+      terminationReason: 'done',
+    });
+    const out = antigravityCliAdapter.formatOutput({ continue: true, suppressOutput: true }) as Record<string, unknown>;
+    expect(out).toEqual({});
+  });
+
+  it('emits a deny decision when the result blocks', () => {
+    antigravityCliAdapter.normalizeInput({
+      workspacePaths: ['/tmp'],
+      conversationId: 'c',
+      toolCall: { name: 'Read', args: {} },
+    });
+    const out = antigravityCliAdapter.formatOutput({ continue: false, reason: 'nope' }) as Record<string, unknown>;
+    expect(out).toEqual({ decision: 'deny', reason: 'nope' });
+  });
+
+  it('never emits Claude-style continue/systemMessage/hookSpecificOutput fields', () => {
+    antigravityCliAdapter.normalizeInput({
+      workspacePaths: ['/tmp'],
+      conversationId: 'c',
+      toolCall: { name: 'Read', args: {} },
+    });
+    const out = antigravityCliAdapter.formatOutput({
+      continue: true,
+      systemMessage: 'hi',
+      hookSpecificOutput: { hookEventName: 'PostToolUse', additionalContext: '' },
+    }) as Record<string, unknown>;
+    // Whatever protojson shape it picks, it MUST NOT carry the Claude-style
+    // continue/systemMessage/hookSpecificOutput fields that break agy's parser.
+    expect('continue' in out).toBe(false);
+    expect('systemMessage' in out).toBe(false);
+    expect('hookSpecificOutput' in out).toBe(false);
   });
 });
 
-// NOTE: an automated regression test for the B0 empty-mcp-config-file edge
-// case (see AntigravityCliHooksInstaller.ts's seedEmptyMcpConfigFile /
-// readMcpConfigTolerantly) was deliberately NOT added here. Bun's homedir()
-// does not re-read a runtime-reassigned process.env.HOME within a single
-// process, so a test attempting to redirect GEMINI_CONFIG_DIR that way
-// silently operates on the REAL ~/.gemini instead of an isolated temp dir.
-// That was verified by hand (as a one-off script run in a separate process
-// with HOME set before start, which bun DOES respect) rather than as a
-// committed test, specifically to avoid this footgun running unattended in
-// CI/local `bun test` and mutating a real, live ~/.gemini tree every run.
+describe('transcript-parser - Antigravity PLANNER_RESPONSE / USER_INPUT nodes', () => {
+  function writeTranscript(lines: object[]): string {
+    const dir = mkdtempSync(join(tmpdir(), 'agy-parser-'));
+    const p = join(dir, 'transcript.jsonl');
+    writeFileSync(p, lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+    return p;
+  }
+
+  it('extracts the last PLANNER_RESPONSE as the assistant message', () => {
+    const p = writeTranscript([
+      { type: 'USER_INPUT', source: 'USER_EXPLICIT', content: 'hello' },
+      { type: 'PLANNER_RESPONSE', source: 'MODEL', content: 'first answer' },
+      { type: 'RUN_COMMAND', source: 'MODEL', content: 'ls -la' },
+      { type: 'PLANNER_RESPONSE', source: 'MODEL', content: 'final answer' },
+    ]);
+    expect(extractLastMessage(p, 'assistant')).toBe('final answer');
+  });
+
+  it('extracts the last USER_INPUT as the user message', () => {
+    const p = writeTranscript([
+      { type: 'USER_INPUT', source: 'USER_EXPLICIT', content: 'first request' },
+      { type: 'PLANNER_RESPONSE', source: 'MODEL', content: 'ok' },
+      { type: 'USER_INPUT', source: 'USER_EXPLICIT', content: 'second request' },
+    ]);
+    expect(extractLastMessage(p, 'user')).toBe('second request');
+  });
+
+  it('does not treat MODEL-sourced tool nodes as assistant text', () => {
+    const p = writeTranscript([
+      { type: 'PLANNER_RESPONSE', source: 'MODEL', content: 'the real answer' },
+      { type: 'VIEW_FILE', source: 'MODEL', content: 'file contents that must be ignored' },
+    ]);
+    expect(extractLastMessage(p, 'assistant')).toBe('the real answer');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Antigravity CLI (`agy`) recorded **zero observations** with `--ide antigravity` because the installer, adapter, and transcript parser still spoke **Gemini CLI** contracts. Verified against the tree (issue [#4057](https://github.com/thedotmack/claude-mem/issues/4057)): hooks were written to `settings.json` under Gemini event names that don't exist in `agy`, the adapter emitted Claude-style JSON that `agy`'s protojson parser rejects, and the transcript parser only understood `type:"assistant"` + `message.content`.

This is a narrow, Antigravity-only fix reimplemented on current `main`. No second system, no OpenCode/provider/UI changes, no whole-PR cherry-picks (read #3397 for Antigravity-only ideas, reimplemented narrowly).

## The four contract fixes

1. **Hooks file** — write to `~/.gemini/config/hooks.json` (the file `agy` actually loads), not `~/.gemini/settings.json`. Uninstall still strips legacy `settings.json` entries so older installs clean up. MCP config + `GEMINI.md` context paths are unchanged.
2. **Event names** — register the events `agy` 1.2.1 fires: `PreInvocation` → `context`, `PreToolUse`/`PostToolUse` → `observation`, `PostInvocation` → `observation`, `Stop` → `summarize`. The Gemini names (`BeforeTool`/`AfterTool`/`BeforeAgent`/`SessionStart`/`PreCompress`/`Notification`) have 0 occurrences in the binary and never executed. Hook command paths are now bare + forward-slashed (agy splits on spaces and does not strip quotes; Windows paths with spaces fall back to 8.3 short paths).
3. **Hook I/O** — parse camelCase protojson stdin (`conversationId`, `workspacePaths`, `transcriptPath`, `toolCall`, …) and emit **strict protojson** stdout: `PreToolUse` → `{"decision":"allow"}`, `PreInvocation` (context) → `{"injectSteps":[…]}`, `PostToolUse`/`PostInvocation`/`Stop` → `{}`. No more Claude-style `{"continue":true,"systemMessage":…}` on the Antigravity path.
4. **Transcript** — read `PLANNER_RESPONSE` / `USER_INPUT` nodes with top-level `content` (and `<USER_REQUEST>` unwrapping) from `brain/<session>/.system_generated/logs/transcript.jsonl`, alongside the existing Claude/Cursor `message.content` handling.

## Files touched

- `src/services/integrations/AntigravityCliHooksInstaller.ts` — hooks.json target + event map + command formatting + uninstall/status.
- `src/cli/adapters/antigravity-cli.ts` — protojson stdin/stdout.
- `src/shared/transcript-parser.ts` — Antigravity node-type branch (`extractLastMessageFromJsonl`).
- `tests/antigravity-cli-compat.test.ts` — rewritten to assert the real `agy` 1.2.1 contract (the old file locked in the broken Gemini map).
- `docs/public/antigravity-cli/setup.mdx` — corrected event table + hooks path.

## Tests

`bun test tests/antigravity-cli-compat.test.ts` → 29 pass. Transcript/summarize consumers (`tests/transcripts/`, summarize handlers) still pass. `tsc --noEmit` clean.

## RCA-later

The exact internal `hooks.json` group schema (matcher-wrapped groups keyed by event name) is **provisional** — chosen for consistency with the existing Gemini/Cursor hook schema and to preserve user-authored hooks. Deeper live-CLI validation is deferred to the plan-23 [#3611](https://github.com/thedotmack/claude-mem/issues/3611) contract fixture. No version bump here — a clean fix PR the Prioritizer can bump after merge.

Closes #4057
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da7c1bd4-0aa8-4b91-8fb1-9fe513177f87?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da7c1bd4-0aa8-4b91-8fb1-9fe513177f87&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

