### PR TITLE
fix(logger): recompute the log filename when the UTC date changes

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -81,6 +81,7 @@ class Logger {
   private useColor: boolean;
   private logFilePath: string | null = null;
   private logFileInitialized: boolean = false;
+  private logFileDate: string | null = null;
 
   constructor() {
     this.useColor = process.stdout.isTTY ?? false;
@@ -88,8 +89,14 @@ class Logger {
   }
 
   private ensureLogFileInitialized(): void {
-    if (this.logFileInitialized) return;
+    // The date is computed BEFORE the latch is consulted, so a long-lived process rolls onto a new
+    // log file at UTC midnight. Latching on the boolean alone freezes logFilePath at the day the
+    // process started, and the daemon then writes entries stamped with today's date into a file
+    // named for a previous day.
+    const date = new Date().toISOString().split('T')[0];
+    if (this.logFileInitialized && this.logFileDate === date) return;
     this.logFileInitialized = true;
+    this.logFileDate = date;
 
     try {
       const logsDir = paths.logsDir();
@@ -98,7 +105,6 @@ class Logger {
         mkdirSync(logsDir, { recursive: true });
       }
 
-      const date = new Date().toISOString().split('T')[0];
       this.logFilePath = join(logsDir, `claude-mem-${date}.log`);
     } catch (error: unknown) {
       console.error('[LOGGER] Failed to initialize log file:', error instanceof Error ? error.message : String(error));


### PR DESCRIPTION
Fixes #4063.

`Logger.ensureLogFileInitialized()` computed the date **inside** the latch, so `logFilePath` was
frozen at the day the process started. The worker daemon runs for days, so it kept appending to the
file named for whichever UTC day it happened to start on, while every line it wrote carried the
current timestamp.

Short-lived hook processes recompute per spawn, so a correctly named file for today also exists and
grows, and the log directory looks right. **The tell is two files with recent mtimes.**

Measured on one machine: `claude-mem-2026-09-05.log` was still being written on Sep 7 and was by far
the largest file in the directory at 10.5 MB, because the daemon that opened it never let go.

## The change

8 lines including the comment. The date is computed before the latch is consulted and compared
against it, so the path is recomputed on the first write after UTC midnight.

```ts
const date = new Date().toISOString().split('T')[0];
if (this.logFileInitialized && this.logFileDate === date) return;
this.logFileInitialized = true;
this.logFileDate = date;
```

The early return is kept rather than restructured, so the diff is as small as the fix.

## A caveat for verifying it

`toISOString()` is UTC while the log *lines* are stamped in local time. On a UTC+2 machine the
filename rolls at 02:00 local, so between midnight and 02:00 a file correctly named with yesterday's
UTC date legitimately holds lines dated today. **Comparing a filename against the local date reports a
false positive for two hours every night.** Compare against `date -u +%F`.

## How this was checked

Not by looking at the log directory once after a restart: a fixed latch and a freshly latched broken
one both produce a file named with today's date. Both methods were extracted from the built bundles
and run against an advanced clock, asserting that the **original still latches** and the patched one
rolls. Asserting only the second half leaves you unable to tell a working fix from a harness that
never exercised the guard.