### PR TITLE
fix(worker): refresh all quota windows from unifiedWindows, drop reset snapshots

### DIFF
--- a/src/services/worker/RateLimitStore.ts
+++ b/src/services/worker/RateLimitStore.ts
@@ -9,7 +9,7 @@
  *
  *   {
  *     status: "allowed" | "allowed_warning" | "rejected",
- *     resetsAt?: number,                              // epoch ms
+ *     resetsAt?: number,                              // epoch ms or s
  *     rateLimitType?: "five_hour" | "seven_day"
  *                   | "seven_day_opus" | "seven_day_sonnet"
  *                   | "overage",
@@ -18,7 +18,19 @@
  *     overageResetsAt?: number,
  *     isUsingOverage?: boolean,
  *     surpassedThreshold?: number,
+ *     unifiedWindows?: {                              // every window's live
+ *       five_hour?: { utilization?, resetsAt? },       // reading, not just the
+ *       seven_day?: { utilization?, resetsAt? },       // binding one
+ *     },
  *   }
+ *
+ * A single event is keyed by its binding `rateLimitType` (almost always
+ * `five_hour`), but `unifiedWindows` carries the current reading of every
+ * window. set() fans that out to the per-window buckets so a window that is
+ * never the binding one still gets refreshed — otherwise a stale reading
+ * (e.g. seven_day at 98% from before an account switch) would sit in the
+ * store for the life of the process and trip the quota guard on every
+ * request. get() additionally drops snapshots whose `resetsAt` has passed.
  *
  * Pattern adapted from meridian's proxy/rateLimitStore.ts (last-write-wins
  * per `rateLimitType` bucket, in-memory only). State resets on worker
@@ -45,6 +57,13 @@ export interface RateLimitInfo {
   overageResetsAt?: number;
   isUsingOverage?: boolean;
   surpassedThreshold?: number;
+  unifiedWindows?: Partial<Record<RateLimitWindow, UnifiedWindowInfo>>;
+}
+
+export interface UnifiedWindowInfo {
+  status?: 'allowed' | 'allowed_warning' | 'rejected';
+  utilization?: number;
+  resetsAt?: number;
 }
 
 export interface RateLimitEntry extends RateLimitInfo {
@@ -65,14 +84,55 @@ export class RateLimitStore {
     if (!info || typeof info !== 'object') return false;
     const key: RateLimitBucketKey = info.rateLimitType ?? 'default';
     const previous = this.entries.get(key);
-    this.entries.set(key, { ...info, observedAt: Date.now() });
+    const observedAt = Date.now();
+    const unified = isRecord(info.unifiedWindows) ? info.unifiedWindows : undefined;
+
+    // The binding window's own payload may omit utilization; the same
+    // event's unifiedWindows entry for that window carries it.
+    const own = unified && key !== 'default' ? unified[key] : undefined;
+    const utilization =
+      typeof info.utilization === 'number'
+        ? info.utilization
+        : isRecord(own) && typeof own.utilization === 'number'
+          ? own.utilization
+          : undefined;
+    this.entries.set(key, {
+      ...info,
+      ...(utilization !== undefined ? { utilization } : {}),
+      observedAt,
+    });
+
+    // Refresh every other window the provider reported in this event. These
+    // readings are as current as the binding one, so they replace whatever
+    // the store held for those windows — including a `rejected` snapshot
+    // left over from a different account or an already-reset window.
+    if (unified) {
+      for (const [window, reading] of Object.entries(unified)) {
+        if (window === key || !isRecord(reading)) continue;
+        this.entries.set(window as RateLimitWindow, {
+          rateLimitType: window as RateLimitWindow,
+          ...(isRateLimitStatus(reading.status) ? { status: reading.status } : {}),
+          ...(typeof reading.utilization === 'number' ? { utilization: reading.utilization } : {}),
+          ...(typeof reading.resetsAt === 'number' ? { resetsAt: reading.resetsAt } : {}),
+          observedAt,
+        });
+      }
+    }
+
     return isNewRejection(previous, info);
   }
 
-  /** Snapshot a single bucket, or undefined if not yet seen. */
-  get(type: RateLimitWindow | undefined): RateLimitEntry | undefined {
-    if (!type) return this.entries.get('default');
-    return this.entries.get(type);
+  /**
+   * Snapshot a single bucket, or undefined if not yet seen or if its window
+   * has already reset (`resetsAt` in the past) — a reading from before the
+   * reset says nothing about the current window.
+   */
+  get(type: RateLimitWindow | undefined, now: number = Date.now()): RateLimitEntry | undefined {
+    const entry = this.entries.get(type ?? 'default');
+    if (!entry) return undefined;
+    const resetsAtMs = toEpochMs(entry.resetsAt);
+    if (resetsAtMs !== undefined && resetsAtMs <= now) return undefined;
+    return entry;
   }
 
   /** Latest snapshot per "interesting" window for health surface. */
@@ -84,11 +144,11 @@ export class RateLimitStore {
     overage?: RateLimitEntry;
   } {
     return {
-      five_hour: this.entries.get('five_hour'),
-      seven_day: this.entries.get('seven_day'),
-      seven_day_opus: this.entries.get('seven_day_opus'),
-      seven_day_sonnet: this.entries.get('seven_day_sonnet'),
-      overage: this.entries.get('overage'),
+      five_hour: this.get('five_hour'),
+      seven_day: this.get('seven_day'),
+      seven_day_opus: this.get('seven_day_opus'),
+      seven_day_sonnet: this.get('seven_day_sonnet'),
+      overage: this.get('overage'),
     };
   }
 
@@ -145,9 +205,27 @@ export function isNewRejection(
  * documents epoch ms, so anything too small to be ms is treated as seconds.
  */
 export function minutesUntilReset(resetsAt: number | undefined, now: number = Date.now()): number | undefined {
-  if (typeof resetsAt !== 'number' || !Number.isFinite(resetsAt)) return undefined;
-  const resetsAtMs = resetsAt < 1e12 ? resetsAt * 1000 : resetsAt;
+  const resetsAtMs = toEpochMs(resetsAt);
+  if (resetsAtMs === undefined) return undefined;
   return Math.max(0, Math.round((resetsAtMs - now) / 60_000));
+}
+
+/**
+ * Normalize a `resetsAt` value to epoch ms. The SDK documents epoch ms but
+ * live `rate_limit_event` payloads carry epoch seconds, so anything too
+ * small to be ms is treated as seconds.
+ */
+export function toEpochMs(resetsAt: number | undefined): number | undefined {
+  if (typeof resetsAt !== 'number' || !Number.isFinite(resetsAt)) return undefined;
+  return resetsAt < 1e12 ? resetsAt * 1000 : resetsAt;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isRateLimitStatus(value: unknown): value is NonNullable<RateLimitInfo['status']> {
+  return value === 'allowed' || value === 'allowed_warning' || value === 'rejected';
 }
 
 /**
@@ -214,7 +292,7 @@ export function shouldAbortForQuota(
   ];
 
   for (const window of windows) {
-    const entry = store.get(window);
+    const entry = store.get(window, now);
     if (!entry) continue;
 
     const util = entry.utilization;
@@ -251,13 +329,14 @@ export function shouldAbortForQuota(
     // Reset-grace buffer: only meaningful for the rolling 5h window where
     // a fresh bucket is imminent. Skip when utilization is low — no point
     // bailing on a window that just reset to ~0%.
+    const resetsAtMs = toEpochMs(entry.resetsAt);
     if (
       window === 'five_hour' &&
-      typeof entry.resetsAt === 'number' &&
+      resetsAtMs !== undefined &&
       typeof util === 'number' &&
       util >= RESET_GRACE_UTILIZATION_FLOOR
     ) {
-      const msUntilReset = entry.resetsAt - now;
+      const msUntilReset = resetsAtMs - now;
       if (msUntilReset > 0 && msUntilReset <= RESET_GRACE_MS) {
         return {
           abort: true,

--- a/tests/worker/rate-limit-store.test.ts
+++ b/tests/worker/rate-limit-store.test.ts
@@ -74,6 +74,97 @@ describe('RateLimitStore', () => {
   });
 });
 
+describe('RateLimitStore — unifiedWindows and window resets', () => {
+  // Real rate_limit_event payload shape: keyed by the binding window
+  // (five_hour), resetsAt in epoch seconds, utilization only inside
+  // unifiedWindows.
+  const nowSec = Math.floor(FIXED_NOW / 1000);
+  const liveEvent = (fiveHour: number, sevenDay: number): RateLimitInfo => ({
+    status: 'allowed',
+    resetsAt: nowSec + 3 * 3600,
+    rateLimitType: 'five_hour',
+    overageStatus: 'rejected',
+    isUsingOverage: false,
+    unifiedWindows: {
+      five_hour: { utilization: fiveHour, resetsAt: nowSec + 3 * 3600 },
+      seven_day: { utilization: sevenDay, resetsAt: nowSec + 4 * 86400 },
+    },
+  });
+
+  it('fans unifiedWindows out to the per-window buckets', () => {
+    const store = freshStore();
+    store.set(liveEvent(0.04, 0.24));
+    expect(store.get('five_hour', FIXED_NOW)?.utilization).toBe(0.04);
+    expect(store.get('seven_day', FIXED_NOW)?.utilization).toBe(0.24);
+    expect(store.get('seven_day', FIXED_NOW)?.resetsAt).toBe(nowSec + 4 * 86400);
+  });
+
+  it('replaces a stale seven_day reading whose window has not reset yet (account switch)', () => {
+    const store = freshStore();
+    // Previous account: seven_day exhausted, reset still days away.
+    store.set({ rateLimitType: 'seven_day', status: 'rejected', utilization: 0.98, resetsAt: nowSec + 4 * 86400 });
+    expect(shouldAbortForQuota('cli', store, FIXED_NOW).abort).toBe(true);
+    // New account: every event is keyed five_hour, but reports seven_day at 24%.
+    store.set(liveEvent(0.06, 0.24));
+    expect(store.get('seven_day', FIXED_NOW)?.utilization).toBe(0.24);
+    expect(store.get('seven_day', FIXED_NOW)?.status).toBeUndefined();
+    expect(shouldAbortForQuota('cli', store, FIXED_NOW)).toEqual({ abort: false });
+  });
+
+  it('still aborts when unifiedWindows reports a window over its threshold', () => {
+    const store = freshStore();
+    store.set(liveEvent(0.1, 0.95));
+    const d = shouldAbortForQuota('cli', store, FIXED_NOW);
+    expect(d.abort).toBe(true);
+    expect(d.window).toBe('seven_day');
+  });
+
+  it('does not let a unifiedWindows reading mask its own binding-window payload', () => {
+    const store = freshStore();
+    store.set({ ...liveEvent(0.1, 0.1), status: 'rejected' });
+    expect(store.get('five_hour', FIXED_NOW)?.status).toBe('rejected');
+    expect(shouldAbortForQuota('cli', store, FIXED_NOW).window).toBe('five_hour');
+  });
+
+  it('keeps an explicit top-level utilization over the unifiedWindows copy', () => {
+    const store = freshStore();
+    store.set({ ...liveEvent(0.1, 0.1), utilization: 0.5 });
+    expect(store.get('five_hour', FIXED_NOW)?.utilization).toBe(0.5);
+  });
+
+  it('ignores malformed unifiedWindows entries', () => {
+    const store = freshStore();
+    store.set({
+      rateLimitType: 'five_hour',
+      utilization: 0.1,
+      unifiedWindows: { seven_day: null, seven_day_opus: 'x', overage: [] } as any,
+    });
+    expect(store.size).toBe(1);
+    store.set({ rateLimitType: 'five_hour', utilization: 0.1, unifiedWindows: 'nope' as any });
+    expect(store.size).toBe(1);
+  });
+
+  it('drops a snapshot once its resetsAt has passed (epoch seconds and ms)', () => {
+    const store = freshStore();
+    store.set({ rateLimitType: 'seven_day', status: 'rejected', utilization: 0.99, resetsAt: nowSec - 60 });
+    store.set({ rateLimitType: 'five_hour', status: 'rejected', utilization: 0.99, resetsAt: FIXED_NOW - 60_000 });
+    expect(store.get('seven_day', FIXED_NOW)).toBeUndefined();
+    expect(store.get('five_hour', FIXED_NOW)).toBeUndefined();
+    expect(shouldAbortForQuota('cli', store, FIXED_NOW)).toEqual({ abort: false });
+    // Same snapshots are still live before their reset.
+    expect(store.get('seven_day', FIXED_NOW - 120_000)?.utilization).toBe(0.99);
+    expect(shouldAbortForQuota('cli', store, FIXED_NOW - 120_000).abort).toBe(true);
+  });
+
+  it('applies the five_hour reset-grace buffer to epoch-seconds resetsAt', () => {
+    const store = freshStore();
+    store.set({ rateLimitType: 'five_hour', utilization: 0.9, resetsAt: nowSec + 10 * 60 });
+    const d = shouldAbortForQuota('cli', store, FIXED_NOW);
+    expect(d.abort).toBe(true);
+    expect(d.reason).toContain('resets in 10m');
+  });
+});
+
 describe('isApiKeyAuth', () => {
   it('matches verbose getAuthMethodDescription() output', () => {
     expect(isApiKeyAuth('API key (from ~/.claude-mem/.env)')).toBe(true);


### PR DESCRIPTION
Refs #4068 · Refs #3870

## Problem

`RateLimitStore.set()` stores each `rate_limit_event` only under its binding `rateLimitType`, which is almost always `five_hour`. The `seven_day` bucket gets written only by the rare event whose binding window is `seven_day`, and entries never expire. So one high `seven_day` reading stays in worker memory for the life of the process. `shouldAbortForQuota` keeps tripping on it, and the persisted quota cooldown gets re-armed on every restart.

Reproduced on 13.24.23 after switching Claude Code to a different account:

- The store held `seven_day` at `utilization: 0.98` from the previous account, with `resetsAt` still ~4 days in the future.
- Every live event from the new account was keyed `five_hour` and reported, in the same payload, `unifiedWindows.seven_day.utilization: 0.24`.
- The observer aborted on every request (`quota:seven_day utilization 98.0% >= 93%`) until the process was replaced.

An expiry check alone would **not** have fixed this case, because `resetsAt` hadn't passed yet. The fix has to take the fresh reading that is already in every event.

A live payload, trimmed:

```json
{"status":"allowed","resetsAt":1789249800,"rateLimitType":"five_hour",
 "overageStatus":"rejected","isUsingOverage":false,
 "unifiedWindows":{"five_hour":{"utilization":0.04,"resetsAt":1789249800},
                   "seven_day":{"utilization":0.01,"resetsAt":1789563600}}}
```

Two details in this payload matter:

- The top-level payload has no `utilization`. It only appears inside `unifiedWindows`.
- `resetsAt` is epoch **seconds**, not the ms the SDK docs describe. `minutesUntilReset` already handles this.

## Change (`src/services/worker/RateLimitStore.ts`)

- **`set()`:** fans `unifiedWindows` out to the per-window buckets, so windows that are never the binding one stay current. A fresh reading replaces a stale `rejected` snapshot. The binding window's `utilization` is backfilled from the same map when the top-level payload omits it. The return value (new-rejection signal) is unchanged: it still reflects only the binding window.
- **`get(type, now)`:** returns `undefined` once a snapshot's `resetsAt` has passed. `shouldAbortForQuota` passes its `now` through, and `getMostRecentByWindow()` (the health surface) now goes through `get()`.
- **`toEpochMs()`:** one seconds-vs-ms normalizer, used by `minutesUntilReset`, the expiry check and the `five_hour` reset-grace check. The grace check used to compute `entry.resetsAt - now` directly. With live second-based values that is always hugely negative, so the grace buffer never fired.

The thresholds, the API-key bypass and the ordering are all unchanged.

## Tests (`tests/worker/rate-limit-store.test.ts`)

Eight new cases:

- the account-switch case (stale `seven_day` 0.98 with `resetsAt` in the future, then a live event with `seven_day` 0.24 → no abort)
- a hot control (`unifiedWindows.seven_day` 0.95 → still aborts on `seven_day`)
- the binding window's own `rejected` status is kept
- an explicit top-level utilization wins over the `unifiedWindows` copy
- malformed `unifiedWindows` is ignored
- expiry works for both seconds and ms
- the reset grace fires for second-based `resetsAt`

```
bun test tests/worker/rate-limit-store.test.ts
  main + new tests:  44 pass, 5 fail   (the 5 new behavior tests fail)
  this branch:       49 pass, 0 fail
```

`tsc --noEmit` is clean. Across all 11 test files that reference the store or `ClaudeProvider`, the results are the same as on `main` except for the new cases. The one remaining failure, `logger-usage-standards`, also fails on `main` on Windows; it flags `console.*` calls in unrelated `src\npx-cli\` files.

## Not in this PR

#4068 also reports that queued observations are lost across a restart during a cooldown. That is a separate defect and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
